### PR TITLE
Add a Pip requirements file for easy dependency installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 * openroad:  netlist to GDSII
 * klayout :  general gui, file conversion
 
+Python3 libraries (`pip3 install -r requirements.txt`):
+* numpy:      linear algebra
+* matploblib: graphing / SVG processing
+* ply:        generic lexer / parser
+
 
 ## Examples
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Pip3 requirements file. To install Python library dependencies, run:
+# > pip3 install -r requirements.txt
+
+matplotlib >= 3.3
+numpy >= 1.19
+ply >= 3.11


### PR DESCRIPTION
`requirements.txt` files are a simple way for the Pip package manager to install a package's Python library dependencies.

I asked for the latest versions of each library, but you can remove the suffixes like `>= 3.3` if the library version doesn't matter.