### PR TITLE
Tweak setup.py and __main__.py to install the core script as 'sc'.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
 
 from setuptools import setup
-project_dir = Path(__file__).parent
+
+with open("README.md", "r", encoding="utf-8") as readme:
+  long_desc = readme.read()
 
 setup(
     name="siliconcompiler",
     description="Silicon Compiler Collection (SCC)",
-    long_description=project_dir.joinpath("README.md").read_text(encoding="utf-8"),
     keywords=["HDL", "ASIC", "FPGA", "hardware design"],
+    long_description=long_desc,
+    long_description_content_type="text/markdown",
     author="Andreas Olofsson",
     url="https://github.com/aolofsson/siliconcompiler",
     version="0.0.0",
     packages=["siliconcompiler"],
     python_requires=">=3.6",
-    entry_points={"console_scripts": ["siliconcompiler=siliconcompiler.__main__:main"]},
+    entry_points={"console_scripts": ["sc=siliconcompiler.__main__:main"]},
     
 )

--- a/siliconcompiler/__main__.py
+++ b/siliconcompiler/__main__.py
@@ -3,7 +3,9 @@
 
 from siliconcompiler import cli
 
-if __name__ == '__main__':
+def main():
     cli.main()
 
-  
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
This fixes a missing `main()` method in `__main__.py`. It also changes the `setup.py` file to install the core script as a command-line utility called `sc`.