### PR TITLE
Fix build directory dict value in cli.py

### DIFF
--- a/siliconcompiler/cli.py
+++ b/siliconcompiler/cli.py
@@ -35,7 +35,7 @@ def main():
     chip.lock()
     
     #Printing out run-config
-    chip.writejson(chip.cfg['sc_build_dir']['values'][0] + "/setup.json")
+    chip.writejson(chip.cfg['sc_build']['values'][0] + "/setup.json")
     
     #Compiler
     chip.run("import")


### PR DESCRIPTION
The `defaults()` method in core.py uses the 'sc_build' key, so I figured that was probably correct.

This, along with your recent addition of the '-constraints' flag, lets me run `sc` on OpenROAD's nangate45 gcd example. It looks like some of the build steps might be placeholders for now, but the script itself runs without errors.