### PR TITLE
Chip class copy constructor: deep-copy the config dict.

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -39,10 +39,10 @@ class Chip:
         self.cfg = {}
         for key in default_cfg.keys():
             self.cfg[key] = {}
-            if type(self.cfg[key]['values']) in [dict, list]:
+            if ('values' in self.cfg[key]) and (type(self.cfg[key]['values']) in [dict, list]):
               self.cfg[key]['values'] = default_cfg[key]['values'].copy()
             else:
-              self.cfg[key]['values'] = default_cfg[key]['switch']
+              self.cfg[key]['values'] = default_cfg[key]['values']
             self.cfg[key]['help'] = default_cfg[key]['help']
             self.cfg[key]['switch'] = default_cfg[key]['switch']
 


### PR DESCRIPTION
Python copies arrays by reference, so I don't think the current 'copy constructor' will make new copies of values like `sc_process`, which are stored as arrays.

This probably won't cause problems with the nominal "create Chip[s] -> configure Chip[s] -> run job[s]" flow, but better safe than sorry.

This change will only deep-copy Array/List and Dictionary values, so it would need updating if you ever decided to use custom classes to store command-line arguments.