### PR TITLE
Add client-side logic to fetch and display remote results.

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -18,10 +18,10 @@ def remote_run(chip, stage):
     '''
 
     #Looking up stage numbers
-    stages = (chip.cfg['compile_steps']['value'] +
-              chip.cfg['dv_steps']['value'])
+    stages = (chip.cfg['design_steps']['value'] +
+              chip.cfg['signoff_steps']['value'])
     current = stages.index(stage)
-    laststage = stages[current-1]
+    laststep = stages[current-1]
     start = stages.index(chip.cfg['start']['value'][-1]) #scalar
     stop = stages.index(chip.cfg['stop']['value'][-1]) #scalar
     #Check if stage should be explicitly skipped
@@ -53,6 +53,28 @@ def remote_run(chip, stage):
       time.sleep(1)
       is_busy = loop.run_until_complete(is_job_busy(chip, stage))
     print("%s stage completed!"%stage)
+
+    # Increment the stage's jobid value.
+    next_id = str(int(chip.cfg['flow'][stage]['jobid']['value'][-1])+1)
+    chip.cfg['flow'][stage]['jobid']['value'] = [next_id]
+
+    # Fetch the remote archive after the export stage.
+    # TODO: Use aiohttp client methods, but wget is simpler for accessing
+    # a server endpoint that returns a file object.
+    if stage == 'export':
+        subprocess.run(['wget',
+                        "http://%s:%s/get_results/%s.zip"%(
+                            chip.cfg['remote']['value'][0],
+                            chip.cfg['remoteport']['value'][0],
+                            chip.status['job_hash'])])
+        # Unzip the result and run klayout to display the GDS file.
+        subprocess.run(['unzip', '%s.zip'%chip.status['job_hash']])
+        gds_loc = '%s/export/job%s/outputs/%s.gds'%(
+            chip.status['job_hash'],
+            next_id,
+            chip.cfg['design']['value'][0],
+        )
+        subprocess.run(['klayout', gds_loc])
 
 ###################################
 async def request_remote_run(chip, stage):


### PR DESCRIPTION
This small change should let a local client run remote jobs.

The compute nodes and server are on a different branch, and I'd like to do a code review of those more involved changes when we meet. But in addition to the AWS settings that we'll talk about tomorrow, this update to the `remote_run` method should be enough to let you submit jobs and view the results from your laptop.

This commit should also be properly attributed to my GitHub account; if it isn't, I can continue investigating that issue.