### PR TITLE
Add basic NextPNR flow with blinky example

### DIFF
--- a/eda/icepack/icepack.py
+++ b/eda/icepack/icepack.py
@@ -1,0 +1,44 @@
+################################
+# Setup icepack
+################################
+
+def setup_tool(chip, step, tool):
+    ''' Sets up default settings on a per step basis
+    '''
+
+    chip.add('flow', step, 'threads', '4')
+    chip.add('flow', step, 'format', 'cmdline')
+    chip.add('flow', step, 'copy', 'false')
+    chip.add('flow', step, 'vendor', 'icepack')
+    chip.add('flow', step, 'exe', 'icepack')
+    chip.add('flow', step, 'refdir', '')
+    chip.add('flow', step, 'option', '')
+
+################################
+# Set icepack Runtime Options
+################################
+
+def setup_options(chip, step, tool):
+    ''' Per tool/step function that returns a dynamic options string based on
+    the dictionary settings.
+    '''
+
+    #Get default opptions from setup
+    options = chip.get('flow', step, 'option')
+
+    topmodule = chip.get('design')[-1]
+
+    options.append("inputs/" + topmodule + ".asc")
+    options.append("outputs/" + topmodule + ".bit")
+
+    return options
+
+def pre_process(chip, step, tool):
+    ''' Tool specific function to run before step execution
+    '''
+    pass
+
+def post_process(chip, step, tool):
+    ''' Tool specific function to run after step execution
+    '''
+    pass

--- a/eda/nextpnr/nextpnr.py
+++ b/eda/nextpnr/nextpnr.py
@@ -1,0 +1,76 @@
+import os
+
+################################
+# Setup NextPNR
+################################
+
+def setup_tool(chip, step, tool):
+    ''' Sets up default settings on a per step basis
+    '''
+
+    refdir = 'eda/nextpnr'
+
+    chip.add('flow', step, 'threads', '4')
+    chip.add('flow', step, 'format', 'cmdline')
+    chip.add('flow', step, 'vendor', 'nextpnr')
+    chip.add('flow', step, 'refdir', refdir)
+    chip.add('flow', step, 'exe', 'nextpnr-ice40')
+    chip.add('flow', step, 'copy', 'true')
+
+    # hardcode settings for icebreaker dev board for now
+    chip.add('flow', step, 'option', '--up5k --package sg48 --freq 12')
+
+################################
+# Set NextPNR Runtime Options
+################################
+
+def setup_options(chip, step, tool):
+    ''' Per tool/step function that returns a dynamic options string based on
+    the dictionary settings.
+    '''
+
+    #Get default opptions from setup
+    options = chip.get('flow', step, 'option')
+
+    topmodule = chip.get('design')[-1]
+
+    pcf_file = None
+    for constraint_file in chip.get('constraint'):
+        if os.path.splitext(constraint_file)[-1] == '.pcf':
+            pcf_file = make_abs_path(constraint_file)
+
+    if pcf_file == None:
+        chip.logger.error('Pin constraint file required')
+        os.sys.exit()
+
+    options.append('--pcf ' + pcf_file)
+    options.append('--json inputs/' + topmodule + '.json')
+    options.append('--asc outputs/' + topmodule + '.asc')
+
+    return options
+
+def pre_process(chip, step, tool):
+    ''' Tool specific function to run before step execution
+    '''
+    pass
+
+def post_process(chip, step, tool):
+    ''' Tool specific function to run after step execution
+    '''
+    pass
+
+################################
+# Utilities
+################################
+
+def make_abs_path(path):
+    '''Helper for constructing absolute path, assuming `path` is relative to
+    directory `sc` was run from
+    '''
+
+    if os.path.isabs(path):
+        return path
+
+    cwd = os.getcwd()
+    run_dir = cwd + '/../../../' # directory `sc` was run from
+    return os.path.join(run_dir, path)

--- a/eda/yosys/sc_syn_ice40.tcl
+++ b/eda/yosys/sc_syn_ice40.tcl
@@ -1,5 +1,9 @@
 # Yosys synthesis script for ice40
 
 proc syn_ice40 {topmodule} {
-    # TODO
+    set output_json "outputs/$topmodule.json"
+
+    # Use built-in ice40 synthesis command:
+    # http://yosyshq.net/yosys/cmd_synth_ice40.html
+    yosys synth_ice40 -top $topmodule -json $output_json
 }

--- a/examples/blinky/README.md
+++ b/examples/blinky/README.md
@@ -1,0 +1,22 @@
+# Blinky ice40 Example
+
+This example tests support for the ice40 FPGA flow by generating a blinky
+bitstream for the [iCEBreaker](https://1bitsquared.com/products/icebreaker) dev
+board.
+
+## Prerequisites
+
+To run this flow, the following tools need to be installed (along with Verilator
+and Yosys):
+- The IceStorm Tools
+- NextPNR
+
+See this page for installation instructions: http://www.clifford.at/icestorm/.
+
+## How to run
+
+To run the example, call `./examples/blinky/run.sh` on the command line. This
+will produce an output bitstream at `build/export/job1/outputs/blinky.bit`.
+
+The resulting bitstream can be loaded onto a connected dev board with the
+command: `iceprog build/export/job1/outputs/blinky.bit`.

--- a/examples/blinky/blinky.v
+++ b/examples/blinky/blinky.v
@@ -1,0 +1,13 @@
+module blinky(
+  input  CLK,
+  output LED1
+);
+  // Blink LED 1 on/off for 2^22 clock cycles, or ~0.35 seconds at 12 Mhz
+  reg [22:0] count;
+
+  always @(posedge CLK) begin
+    count <= count + 1'b1;
+  end
+
+  assign LED1 = count[22];
+endmodule

--- a/examples/blinky/icebreaker.pcf
+++ b/examples/blinky/icebreaker.pcf
@@ -1,0 +1,66 @@
+## Source: https://github.com/icebreaker-fpga/icebreaker-examples/blob/master/icebreaker.pcf
+
+# 12 MHz clock
+set_io -nowarn CLK        35
+
+# RS232
+set_io -nowarn RX          6
+set_io -nowarn TX          9
+
+# LEDs and Button
+set_io -nowarn BTN_N      10
+set_io -nowarn LEDR_N     11
+set_io -nowarn LEDG_N     37
+
+# RGB LED Driver
+set_io -nowarn LED_RED_N  39
+set_io -nowarn LED_GRN_N  40
+set_io -nowarn LED_BLU_N  41
+
+# SPI Flash
+set_io -nowarn FLASH_SCK  15
+set_io -nowarn FLASH_SSB  16
+set_io -nowarn FLASH_IO0  14
+set_io -nowarn FLASH_IO1  17
+set_io -nowarn FLASH_IO2  12
+set_io -nowarn FLASH_IO3  13
+
+# PMOD 1A
+set_io -nowarn P1A1        4
+set_io -nowarn P1A2        2
+set_io -nowarn P1A3       47
+set_io -nowarn P1A4       45
+set_io -nowarn P1A7        3
+set_io -nowarn P1A8       48
+set_io -nowarn P1A9       46
+set_io -nowarn P1A10      44
+
+# PMOD 1B
+set_io -nowarn P1B1       43
+set_io -nowarn P1B2       38
+set_io -nowarn P1B3       34
+set_io -nowarn P1B4       31
+set_io -nowarn P1B7       42
+set_io -nowarn P1B8       36
+set_io -nowarn P1B9       32
+set_io -nowarn P1B10      28
+
+# PMOD 2
+set_io -nowarn P2_1       27
+set_io -nowarn P2_2       25
+set_io -nowarn P2_3       21
+set_io -nowarn P2_4       19
+set_io -nowarn P2_7       26
+set_io -nowarn P2_8       23
+set_io -nowarn P2_9       20
+set_io -nowarn P2_10      18
+
+# LEDs and Buttons (PMOD 2)
+set_io -nowarn LED1       26
+set_io -nowarn LED2       27
+set_io -nowarn LED3       25
+set_io -nowarn LED4       23
+set_io -nowarn LED5       21
+set_io -nowarn BTN1       20
+set_io -nowarn BTN2       19
+set_io -nowarn BTN3       18

--- a/examples/blinky/run.sh
+++ b/examples/blinky/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sc examples/blinky/blinky.v \
+    -target "ice40" \
+    -constraint "examples/blinky/icebreaker.pcf"


### PR DESCRIPTION
This commit adds a basic Icebreaker flow and a simple blinky example. I can demo it next time we meet!

I think there may be some ways to do this a bit better/clean it up, but I imagine it might be worth just skipping ahead to switching out NextPNR for VTR as a next step since that's where we want to go eventually.

If you have NextPNR/icestorm tools installed, you can run the example with:
`./examples/blinky/run.sh`

Which generates a bitstream at:
`build/export/job1/outputs/blinky.bit`