### PR TITLE
Add assert for number of _'s in CLI switch

### DIFF
--- a/siliconcompiler/cli.py
+++ b/siliconcompiler/cli.py
@@ -85,6 +85,8 @@ def cmdline():
     for key,all_vals in cmdargs.items():
        
         switch = key.split('_')
+        assert len(switch) <= 2, "CLI switches must not have more than 1 underscore"
+
         param = switch[0]
         if len(switch) > 1 :
             param = param + "_" + switch[1]            


### PR DESCRIPTION
I ran into an issue where introducing a command line switch with more than 1 underscore results in the config setting being stored with the second underscore and everything after removed. This is due to the switch being split by '_', then reconstructed with only the first and second pieces on line 92 of `cli.py`. 

I wasn't sure if there's some reason for this limitation (if not, perhaps a better fix is to generalize the parser), but in the meantime I think adding an assertion here might be useful: I had to find out what was wrong the hard way, and this would have saved a bit of time!