### PR TITLE
Adjust cli.py to match the recently-changed '-cfg[file]' command-line option.

### DIFF
--- a/siliconcompiler/cli.py
+++ b/siliconcompiler/cli.py
@@ -47,7 +47,7 @@ def cmdline():
     "Examples:                                                              ",
     "$ sc 'hello_world.v' -target freepdk45'                                ",
     "$ sc 'my_riscv_cpu.v' -target asap7 -design my_riscv_cpu               ",
-    "$ sc 'my_tpu.v' -cfgfile my_tpu_setup.json                             ",
+    "$ sc 'my_tpu.v' -cfg my_tpu_setup.json                                 ",
     "                                                                       ",  
     "-----------------------------------------------------------------------"])
 
@@ -207,8 +207,8 @@ def main():
     setup_target(chip)
     
     # Reading in config files specified at command line
-    if 'cfgfile' in  cmdlinecfg.keys():        
-        for cfgfile in cmdlinecfg['cfgfile']['value']:
+    if 'cfg' in  cmdlinecfg.keys():
+        for cfgfile in cmdlinecfg['cfg']['value']:
             chip.readcfg(cfgfile)
         
     #Override cfg with command line args


### PR DESCRIPTION
The command-line option for reading a configuration file was recently changed from `-cfgfile` to `-cfg`, [according to schema.py](https://github.com/zeroasiccorp/siliconcompiler/blob/50e978c5c29d2d9f7ed6843350a5481d19d1fd1a/siliconcompiler/schema.py#L1650)

This change updates the `cli.py` file to use that updated syntax, fixing the 'run job from a config file' functionality. Tested with an `sc_setup.json` file from a prior job:

`sc /dev/null -cfg sc_setup.json`

(The extra `/dev/null` input file prevents the argument parser from throwing a 'no source files' error.)