### PR TITLE
Fix setup_cmd import path

### DIFF
--- a/siliconcompiler/setup.py
+++ b/siliconcompiler/setup.py
@@ -108,7 +108,7 @@ def setup_cmd(chip,step):
     #Dynamically generate options
     vendor = chip.cfg['flow'][step]['vendor']['value'][-1]
     tool  = chip.cfg['flow'][step]['exe']['value'][-1]
-    module = importlib.import_module('.'+tool,
+    module = importlib.import_module('.'+vendor,
                                      package="eda." + vendor)
     setup_options = getattr(module,"setup_options")
     options = setup_options(chip, step, tool)


### PR DESCRIPTION
I think this small change is also needed to fix #42. Otherwise, I get a similar to before with nextpnr, since this function will try to import eda.vendor.nextpnr-ice40. 