### PR TITLE
Add OpenFPGA flow

### DIFF
--- a/eda/openfpga/openfpga.py
+++ b/eda/openfpga/openfpga.py
@@ -1,0 +1,107 @@
+import os
+from string import Template
+import defusedxml.ElementTree as ET
+
+################################
+# Setup OpenFPGA
+################################
+
+OPENFPGA_SCRIPT = 'openfpga_script.openfpga'
+
+def setup_tool(chip, step, tool):
+    ''' Sets up default settings on a per step basis
+    '''
+
+    refdir = 'eda/openfpga'
+
+    chip.add('flow', step, 'threads', '4')
+    chip.add('flow', step, 'format', 'cmdline')
+
+    chip.add('flow', step, 'vendor', 'openfpga')
+    chip.add('flow', step, 'refdir', refdir)
+    chip.add('flow', step, 'option', '-batch -f ' + OPENFPGA_SCRIPT)
+    chip.add('flow', step, 'exe', 'openfpga')
+    chip.add('flow', step, 'copy', 'true')
+
+################################
+# Set OpenFPGA Runtime Options
+################################
+
+def setup_options(chip, step, tool):
+    ''' Per tool/step function that returns a dynamic options string based on
+    the dictionary settings.
+    '''
+
+    options = chip.get('flow', step, 'option')
+    return options
+
+################################
+# Pre and Post Run Commands
+################################
+
+def pre_process(chip, step, tool):
+    '''Tool specific function to run before step execution that fills out shell
+    script template
+
+    OpenFPGA doesn't have a rich command line interface or a tcl interface, so
+    we use a template script in OpenFPGA's scripting language and fill it in
+    with relevant variables, similar to how the OpenFPGA flow itself works
+    '''
+
+    topmodule = chip.cfg['design']['value'][-1]
+
+    input_blif = 'inputs/' + topmodule + '.blif'
+
+    # Search through and parse architecture XML files to find VPR and OpenFPGA
+    # files
+    vpr_arch_file = None
+    openfpga_arch_file = None
+
+    for arch_file in chip.get('fpga_xml'):
+        path = make_abs_path(arch_file)
+        root_tag = ET.parse(path).getroot().tag
+        if root_tag == 'architecture':
+            vpr_arch_file = path
+        elif root_tag == 'openfpga_architecture':
+            openfpga_arch_file = path
+
+    if vpr_arch_file == None:
+        chip.logger.error('No VPR architecture file was specified')
+        os.sys.exit()
+    if openfpga_arch_file == None:
+        chip.logger.error('No OpenFPGA architecture file was specified')
+        os.sys.exit()
+
+    # Fill in OpenFPGA shell script template
+    openfpga_script_template = 'openfpga_script_template.openfpga'
+
+    tmpl_vars = {'VPR_ARCH_FILE': vpr_arch_file,
+                 'VPR_TESTBENCH_BLIF': input_blif,
+                 'OPENFPGA_ARCH_FILE': openfpga_arch_file,
+                 'TOP': topmodule
+                 }
+
+    tmpl = Template(open(openfpga_script_template, encoding='utf-8').read())
+    with open(OPENFPGA_SCRIPT, 'w') as f:
+        f.write(tmpl.safe_substitute(tmpl_vars))
+
+def post_process(chip, step, tool):
+    ''' Tool specific function to run after step execution
+    '''
+    pass
+
+################################
+# Utilities
+################################
+
+def make_abs_path(path):
+    '''Helper for constructing absolute path, assuming `path` is relative to
+    directory `sc` was run from
+    '''
+
+    if os.path.isabs(path):
+        return path
+
+    cwd = os.getcwd()
+    run_dir = cwd + '/../../../' # directory `sc` was run from
+    return os.path.join(run_dir, path)

--- a/eda/openfpga/openfpga_script_template.openfpga
+++ b/eda/openfpga/openfpga_script_template.openfpga
@@ -1,0 +1,54 @@
+# This file is adapted from an OpenFPGA example script:
+# https://github.com/lnis-uofu/OpenFPGA/blob/master/openfpga_flow/openfpga_shell_scripts/generate_bitstream_example_script.openfpga
+
+# Run VPR for the 'and' design
+#--write_rr_graph example_rr_graph.xml
+vpr ${VPR_ARCH_FILE} ${VPR_TESTBENCH_BLIF} --clock_modeling route --absorb_buffer_luts off
+
+# Read OpenFPGA architecture definition
+read_openfpga_arch -f ${OPENFPGA_ARCH_FILE}
+
+# Read OpenFPGA simulation settings
+read_openfpga_simulation_setting -f sim_settings.xml
+
+# Annotate the OpenFPGA architecture to VPR data base
+# to debug use --verbose options
+link_openfpga_arch --sort_gsb_chan_node_in_edges
+
+# Check and correct any naming conflicts in the BLIF netlist
+check_netlist_naming_conflict --fix --report ./netlist_renaming.xml
+
+# Apply fix-up to clustering nets based on routing results
+pb_pin_fixup --verbose
+
+# Apply fix-up to Look-Up Table truth tables based on packing results
+lut_truth_table_fixup
+
+# Build the module graph
+#  - Enabled compression on routing architecture modules
+#  - Enabled frame view creation to save runtime and memory
+#    Note that this is turned on when bitstream generation 
+#    is the ONLY purpose of the flow!!!
+build_fabric --compress_routing --frame_view #--verbose
+
+# Repack the netlist to physical pbs
+# This must be done before bitstream generator and testbench generation
+# Strongly recommend it is done after all the fix-up have been applied
+repack #--verbose
+
+# Build the bitstream
+#  - Output the fabric-independent bitstream to a file
+build_architecture_bitstream --verbose --write_file outputs/${TOP}_fabric_independent_bitstream.xml
+
+# Build fabric-dependent bitstream
+build_fabric_bitstream --verbose 
+
+# Write fabric-dependent bitstream
+write_fabric_bitstream --file outputs/${TOP}_fabric_bitstream.txt --format plain_text
+write_fabric_bitstream --file outputs/${TOP}_fabric_bitstream.xml --format xml
+
+# Finish and exit OpenFPGA
+exit
+
+# Note :
+# To run verification at the end of the flow maintain source in ./SRC directory

--- a/eda/openfpga/sim_settings.xml
+++ b/eda/openfpga/sim_settings.xml
@@ -1,0 +1,41 @@
+<!-- Source:
+     https://github.com/lnis-uofu/OpenFPGA/blob/master/openfpga_flow/openfpga_simulation_settings/fixed_sim_openfpga.xml
+-->
+
+<!-- Simulation Setting for OpenFPGA framework
+     This file will use
+     - a fixed simulation clock frequency
+  -->
+<openfpga_simulation_setting>
+  <clock_setting>
+    <operating frequency="500e6" num_cycles="10" slack="0.2"/>
+    <programming frequency="300e6"/>
+  </clock_setting>
+  <simulator_option>
+    <operating_condition temperature="25"/>
+    <output_log verbose="false" captab="false"/>
+    <accuracy type="abs" value="1e-13"/>
+    <runtime fast_simulation="true"/>
+  </simulator_option>
+  <monte_carlo num_simulation_points="2"/>
+  <measurement_setting>
+    <slew>
+      <rise upper_thres_pct="0.95" lower_thres_pct="0.05"/>
+      <fall upper_thres_pct="0.05" lower_thres_pct="0.95"/>
+    </slew>
+    <delay>
+      <rise input_thres_pct="0.5" output_thres_pct="0.5"/>
+      <fall input_thres_pct="0.5" output_thres_pct="0.5"/>
+    </delay>
+  </measurement_setting>
+  <stimulus>
+    <clock>
+      <rise slew_type="abs" slew_time="20e-12" />
+      <fall slew_type="abs" slew_time="20e-12" />
+    </clock>
+    <input>
+      <rise slew_type="abs" slew_time="25e-12" />
+      <fall slew_type="abs" slew_time="25e-12" />
+    </input>
+  </stimulus>
+</openfpga_simulation_setting>

--- a/eda/yosys/sc_syn.tcl
+++ b/eda/yosys/sc_syn.tcl
@@ -23,6 +23,8 @@ set input_verilog   "inputs/$topmodule.v"
 set input_def       "inputs/$topmodule.def"
 set input_sdc       "inputs/$topmodule.sdc"
 
+# TODO: the original OpenFPGA synth script used read_verilog with -nolatches. Is
+# that a flag we might want here?
 yosys read_verilog $input_verilog
 
 if {$mode eq "asic"} {
@@ -77,6 +79,8 @@ if {$mode eq "asic"} {
     if {$target eq "ice40"} {
         syn_ice40 $topmodule
     } elseif {$target eq "openfpga"} {
-        syn_openfpga $topmodule
+        # TODO: use LUT size inferred from XML
+        set lutsize 6
+        syn_openfpga $topmodule $lutsize
     }
 }

--- a/eda/yosys/sc_syn_openfpga.tcl
+++ b/eda/yosys/sc_syn_openfpga.tcl
@@ -1,5 +1,25 @@
 # Yosys synthesis script for OpenFPGA
+# Based on https://github.com/lnis-uofu/OpenFPGA/blob/master/openfpga_flow/misc/ys_tmpl_yosys_vpr_flow.ys
 
-proc syn_openfpga {topmodule} {
-    # TODO
+proc syn_openfpga {topmodule lut_size} {
+    set output_blif "outputs/$topmodule.blif"
+
+    # Technology mapping
+    yosys hierarchy -top $topmodule
+    yosys proc
+    yosys techmap -D NO_LUT -map +/adff2dff.v
+
+    # Synthesis
+    yosys synth -top $topmodule -flatten
+    yosys clean
+
+    # LUT mapping
+    yosys abc -lut $lut_size
+
+    # Check
+    yosys synth -run check
+
+    # Clean and output blif
+    yosys opt_clean -purge
+    yosys write_blif $output_blif
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ numpy >= 1.19
 ply >= 3.11
 aiohttp >= 3.7.4.post0
 PyYAML >= 5.4.1
+defusedxml >= 0.7.1

--- a/siliconcompiler/setup.py
+++ b/siliconcompiler/setup.py
@@ -66,14 +66,10 @@ def setup_target(chip):
         else:
             chip.cfg['design_flow']['value'] = ['import',
                                                 'syn',
-                                                'floorplan',
-                                                'place',
-                                                'route',
-                                                'export']
+                                                'apr']
             setup_step(chip, 'import', 'verilator', 'verilator')
             setup_step(chip, 'syn', 'yosys', 'yosys')
-            for step in (['floorplan', 'place', 'route', 'export']):
-                setup_step(chip, step, 'vpr', 'vpr')
+            setup_step(chip, 'apr', 'openfpga', 'openfpga')
     else:
         module = importlib.import_module('sc_target')
         setup_target = getattr(module, "setup_target")


### PR DESCRIPTION
I'm opening up this new PR to replace #39, since this one's significantly cleaned up. However, I'm marking this as a draft since I don't think it's quite ready to merge, there are a few things I wanted to discuss first. 

As an update, the OpenFPGA people got back to me and gave me a trick for how to get around running ace2 by using a certain set of simulation settings. They did confirm that simulation settings in general shouldn't be required for the FPGA->bitstream flow, and it's a limitation of OpenFPGA that it makes you provide them in the first place. They're planning to patch this, but in the meantime I've added a dummy simulation settings file to eda/openfpga, which ensures that you don't have to run ace2 and that the user doesn't have to provide one. (See the discussion [here](https://github.com/lnis-uofu/OpenFPGA/issues/276) for more details)

There are two things I wanted to ask about before finalizing this PR:

- How should we pass in the OpenFPGA architecture file? This PR currently has an addition to the schema, but I recognize we want to think carefully before doing something like that. One thing I considered is passing both the VPR and OpenFPGA arch file in using -fpga_xml, and then parsing the top-level XML element to distinguish between the two. Does that sound reasonable?
- The LUT size defined in the architecture is currently hardcoded in the Yosys synthesis script. In the OpenFPGA flow, the LUT size is inferred from the VPR xml file, so we could do something like this as well. That still leaves the question of how to pass it along to Yosys, though. I assume this isn't something we'd necessarily want to add to the schema either, so we need some other way to pass data along to the TCL script. One way could be to rewrite the OpenFPGA TCL script as a template (much like the OpenFPGA shell script), and then as preprocessing step SC could copy the template and fill it in. Do you have any thoughts on this? 



