### PR TITLE
Update OpenROAD scripts to use a more recent API.

### DIFF
--- a/eda/klayout/klayout.py
+++ b/eda/klayout/klayout.py
@@ -1,3 +1,5 @@
+import os
+
 ################################
 # Tool Setup
 ################################
@@ -16,11 +18,11 @@ def setup_tool(chip, step, tool):
           if step == 'gdsview':               
                chip.add('flow', step, 'option', '-nn')
           elif step == 'export':               
-               chip.add('flow', step, 'option', '-rm')
+               chip.add('flow', step, 'option', '-zz')
           
 def setup_options(chip,step , tool):
      
-     options = chip.get('flow', step, 'opt')
+     options = chip.get('flow', step, 'option')
      return options
 
 ################################
@@ -29,7 +31,48 @@ def setup_options(chip,step , tool):
 def pre_process(chip, step, tool):
     ''' Tool specific function to run before step execution
     '''
-    pass
+    sc_paths = os.getenv('SCPATH').split(' ')
+    sc_path = ''
+    for path in sc_paths:
+      if chip.cfg['pdk_foundry']['value'][-1] in path:
+        sc_path = path
+    sc_root = sc_path[:sc_path.find('/foundry')]
+    foundry_path = '%s/%s/pdk/%s'%(
+        sc_path,
+        chip.cfg['target']['value'][-1],
+        chip.cfg['pdk_rev']['value'][-1])
+    lefs_path = '%s/%s/libs/%s/%s/lef'%(
+        sc_path,
+        chip.cfg['target']['value'][-1],
+        chip.cfg['target_lib']['value'][0],
+        chip.cfg['pdk_rev']['value'][-1])
+    tech_file = '%s/setup/klayout/%s.lyt'%(
+        foundry_path,
+        chip.cfg['target']['value'][-1])
+    if step == 'export':
+         chip.add('flow', step, 'option', '-nn')
+         chip.add('flow', step, 'option', tech_file)
+         chip.add('flow', step, 'option', '-rd')
+         chip.add('flow', step, 'option', 'design_name=%s'%(
+             chip.cfg['design']['value'][-1]))
+         chip.add('flow', step, 'option', '-rd')
+         chip.add('flow', step, 'option', 'in_def=inputs/%s.def'%(
+             chip.cfg['design']['value'][-1]))
+         chip.add('flow', step, 'option', '-rd')
+         chip.add('flow', step, 'option', 'seal_gds=""')
+         chip.add('flow', step, 'option', '-rd')
+         chip.add('flow', step, 'option', 'in_gds=%s/%s'%(
+             sc_root,
+             chip.cfg['stdcell'][chip.cfg['target_lib']['value'][0]]['gds']['value'][-1]))
+         chip.add('flow', step, 'option', '-rd')
+         chip.add('flow', step, 'option', 'out_gds=outputs/%s.gds'%(
+             chip.cfg['design']['value'][-1]))
+         chip.add('flow', step, 'option', '-rd')
+         chip.add('flow', step, 'option', 'tech_file=%s'%tech_file)
+         chip.add('flow', step, 'option', '-rd')
+         chip.add('flow', step, 'option', 'foundry_lefs=%s'%lefs_path)
+         chip.add('flow', step, 'option', '-rm')
+         chip.add('flow', step, 'option', 'def2gds.py')
 
 def post_process(chip, step, tool):
     ''' Tool specific function to run after step execution

--- a/eda/openroad/sc_cts.tcl
+++ b/eda/openroad/sc_cts.tcl
@@ -29,8 +29,6 @@ set cts_buf      "BUF_X4"
 set fillcells    "FILLCELL_X1 FILLCELL_X2 FILLCELL_X4 FILLCELL_X8 FILLCELL_X16 FILLCELL_X32"
 set max_slew     1e-9
 set max_cap      1e-9
-set sqr_cap      1e-9
-set sqr_res      1e-9
 set wire_unit    20
 set parasitics_layer metal3
 
@@ -76,9 +74,7 @@ read_sdc $input_sdc
 repair_clock_inverters
 
 configure_cts_characterization -max_slew $max_slew \
-                               -max_cap $max_cap \
-                               -sqr_cap $sqr_cap \
-                               -sqr_res $sqr_res \
+                               -max_cap $max_cap
 
 # Run CTS
 clock_tree_synthesis -buf_list "$cts_buf" \
@@ -102,7 +98,7 @@ optimize_mirroring
 check_placement -verbose
 
 estimate_parasitics -placement
-repair_hold_violations -buffer_cell "$cts_buf"
+repair_timing -hold
 
 ################################################################
 # Reporting

--- a/eda/openroad/sc_route.tcl
+++ b/eda/openroad/sc_route.tcl
@@ -47,6 +47,7 @@ set output_verilog  "outputs/$topmodule.v"
 set output_tmp_def  "outputs/$topmodule\_tmp.def"
 set output_lef      "outputs/merged.lef"
 set output_def      "outputs/$topmodule.def"
+set output_drc      "outputs/$topmodule.drc"
 set output_sdc      "outputs/$topmodule.sdc"
 set output_guide    "outputs/$topmodule.guide"
 
@@ -96,10 +97,19 @@ exec ./mergeLef.py --inputLef \
                    $pdklef \
                    --outputLef $output_lef
 
-exec TritonRoute -lef $output_lef \
-                 -guide $output_guide \
-                 -def $output_tmp_def \
-                 -output $output_def
+set param_file [open "route.params" "w"]
+puts $param_file "lef:./$output_lef
+def:./$output_tmp_def
+guide:./$output_guide
+output:./$output_def
+outputDRC:./$output_drc
+verbose:1"
+close $param_file
+
+set param_filepath [file normalize "route.params"]
+puts $param_filepath
+
+detailed_route -param $param_filepath
 
 
 ################################################################


### PR DESCRIPTION
These are the changes that I was going to make as part of #44. Sorry about the delay, it's been a busy day and the detailed router's parameter file took a bit of figuring out.

The only remaining issue with these scripts is the `NangateOpenCellLibrary.mod.lef` file. I didn't commit it as part of this change because it is ~13kloc, but you can find it in the OpenROAD-flow-scripts repository:

[OpenROAD-flow-scripts/tools/OpenROAD/src/OpenDB/tests/data/Nangate45/NangateOpenCellLibrary.mod.lef](https://github.com/The-OpenROAD-Project/OpenROAD/blob/836c13607facf725d70edaa6713d593bc78c9511/src/OpenDB/test/data/Nangate45/NangateOpenCellLibrary.mod.lef)

We discussed the idea of replacing the `NangateOpenCellLibrary.macro.lef` file with the modified one, since the main difference is the use of `RECT` to define pad areas instead of `POLY`. But the `.mod.lef` file is [already referenced in our `freepdk45.lyt` file](https://github.com/zeroasiccorp/siliconcompiler/blob/main/foundry/virtual/freepdk45/pdk/r1p0/setup/klayout/freepdk45.lyt#L54).

So, do you think we should just add the `NangateOpenCellLibrary.mod.lef` file to the appropriate `foundry/virtual/...` directory with an attribution comment at the top?