### PR TITLE
Update EDA scripts for OpenROAD March stable release.

### DIFF
--- a/eda/openroad/sc_cts.tcl
+++ b/eda/openroad/sc_cts.tcl
@@ -27,9 +27,9 @@ set techlef      [dict get $sc_cfg pdk_aprtech $stackup $libarch openroad]
 set clock_nets   "clk"
 set cts_buf      "BUF_X4"
 set fillcells    "FILLCELL_X1 FILLCELL_X2 FILLCELL_X4 FILLCELL_X8 FILLCELL_X16 FILLCELL_X32"
-set max_slew     1e-9
-set max_cap      1e-9
-set wire_unit    20
+set max_slew     .198e-9
+set max_cap      .242e-12
+set clk_layer    metal5
 set parasitics_layer metal3
 
 #Inputs
@@ -73,13 +73,15 @@ read_sdc $input_sdc
 # Clone clock tree inverters.
 repair_clock_inverters
 
+# Set clock layer wire RC.
+set_wire_rc -clock  -layer $clk_layer
+
 configure_cts_characterization -max_slew $max_slew \
                                -max_cap $max_cap
 
 # Run CTS
 clock_tree_synthesis -buf_list "$cts_buf" \
-                     -clk_nets "$clock_nets" \
-                     -wire_unit $wire_unit
+                     -clk_nets "$clock_nets"
 
 set_propagated_clock [all_clocks]
 

--- a/eda/openroad/sc_route.tcl
+++ b/eda/openroad/sc_route.tcl
@@ -98,10 +98,8 @@ exec ./mergeLef.py --inputLef \
                    --outputLef $output_lef
 
 set param_file [open "route.params" "w"]
-puts $param_file "lef:./$output_lef
-def:./$output_tmp_def
-guide:./$output_guide
-output:./$output_def
+puts $param_file \
+"guide:./$output_guide
 outputDRC:./$output_drc
 verbose:1"
 close $param_file
@@ -123,6 +121,6 @@ sc_write_reports $topmodule
 ################################################################
 
 #sc_write_outputs $topmodule
-#write_def $output_def
+write_def $output_def
 write_verilog $output_verilog
 write_sdc $output_sdc


### PR DESCRIPTION
The detailed router deprecated several parameters in the most recent release, including the one that made it possible to write out a DEF file after the routing command.

I also updated the CTS script to remove an unnecessary option and change the slew/capacitance values to the freepdk45 defaults. (Pending their inclusion in the config dictionary.)