### PR TITLE
Process CLI args before setting up target

### DIFF
--- a/siliconcompiler/cli.py
+++ b/siliconcompiler/cli.py
@@ -231,12 +231,12 @@ def main():
         for cfgfile in cmdlinecfg['cfg']['value']:
             chip.readcfg(cfgfile)
 
+    #Override cfg with command line args
+    chip.mergecfg(cmdlinecfg)
+
     #Load target
     if len(cmdlinecfg['target']['value']) > 0:
         chip.target(cmdlinecfg['target']['value'][0])
-
-    #Override cfg with command line args
-    chip.mergecfg(cmdlinecfg)   
 
     #Resolve absolute paths
 


### PR DESCRIPTION
I think these two routines need to be reordered -- otherwise the `mode` flag doesn't get set before the target is set up (meaning, for example, even if I specify `-mode fpga -target ice40` on the command line, SC will try to find an ASIC target called "ice40", since ASIC is the default mode). 