### PR TITLE
Search both ASIC and FPGA targets for platform

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -113,11 +113,17 @@ class Chip:
         
         targetlist = name.split('_')
         platform = targetlist[0]
-      
+
         #Load Platform (PDK or FPGA)
-        packdir = mode+".targets"
-        self.logger.debug("Loading platform module %s from %s", platform, packdir)        
-        module = importlib.import_module('.'+platform, package=packdir)
+        try:
+            packdir = "asic.targets"
+            self.logger.debug("Loading platform module %s from %s", platform, packdir)
+            module = importlib.import_module('.'+platform, package=packdir)
+        except ImportError:
+            packdir = "fpga.targets"
+            self.logger.debug("Loading platform module %s from %s", platform, packdir)
+            module = importlib.import_module('.'+platform, package=packdir)
+
         setup_platform = getattr(module,"setup_platform")
         setup_platform(self)
 


### PR DESCRIPTION
I think this is the shortest way to check both locations for the platform. It defaults to the ASIC location, so if there's a duplicate it'll go with that one. Let me know if you want me to add in better error checking (so that it'd complain if there was a duplicate across both locations place). 