### PR TITLE
Modified LEF file for nangate45/OpenROAD compatibility.

### DIFF
--- a/asic/virtual/freepdk45/libs/NangateOpenCellLibrary/r1p0/lef/NangateOpenCellLibrary.mod.lef
+++ b/asic/virtual/freepdk45/libs/NangateOpenCellLibrary/r1p0/lef/NangateOpenCellLibrary.mod.lef
@@ -1,0 +1,12289 @@
+# Modified freepdk45 LEF file, with 'RECT' pad areas instead of 'POLY'/etc.
+#
+# Source: The OpenROAD Project.
+#
+# License: BSD 3-Clause.
+#
+#Copyright (c) 2018, The Regents of the University of California
+#All rights reserved.
+#
+#Redistribution and use in source and binary forms, with or without
+#modification, are permitted provided that the following conditions are met:
+#
+#* Redistributions of source code must retain the above copyright notice, this
+#  list of conditions and the following disclaimer.
+#
+#* Redistributions in binary form must reproduce the above copyright notice,
+#  this list of conditions and the following disclaimer in the documentation
+#  and/or other materials provided with the distribution.
+#
+#* Neither the name of the copyright holder nor the names of its
+#  contributors may be used to endorse or promote products derived from
+#  this software without specific prior written permission.
+#
+#THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+VERSION 5.6 ;
+BUSBITCHARS "[]" ;
+DIVIDERCHAR "/" ;
+
+UNITS
+  DATABASE MICRONS 2000 ;
+END UNITS
+MANUFACTURINGGRID 0.005 ;
+LAYER poly
+  TYPE MASTERSLICE ;
+END poly
+
+LAYER active
+  TYPE MASTERSLICE ;
+END active
+
+LAYER metal1
+  TYPE ROUTING ;
+  DIRECTION HORIZONTAL ;
+  PITCH 0.19 0.14 ;
+  WIDTH 0.07 ;
+  OFFSET 0.095 0.07 ;
+  #SPACING 0.065 ;
+  SPACINGTABLE
+    PARALLELRUNLENGTH 0
+    WIDTH 0 0.065 ;
+  RESISTANCE RPERSQ 0.38 ;
+  CAPACITANCE CPERSQDIST 7.7161e-05 ;
+  HEIGHT 0.37 ;
+  THICKNESS 0.13 ;
+  EDGECAPACITANCE 2.7365e-05 ;
+END metal1
+
+LAYER via1
+  TYPE CUT ;
+  SPACING 0.08 ;
+  WIDTH 0.07 ;
+  RESISTANCE 5 ;
+END via1
+
+LAYER metal2
+  TYPE ROUTING ;
+  DIRECTION VERTICAL ;
+  PITCH 0.19 0.14 ;
+  WIDTH 0.07 ;
+  OFFSET 0.095 0.07 ;
+  SPACINGTABLE
+    PARALLELRUNLENGTH 0 0.3 0.9 1.8 2.7 4
+    WIDTH 0 0.07 0.07 0.07 0.07 0.07 0.07
+    WIDTH 0.09 0.07 0.09 0.09 0.09 0.09 0.09
+    WIDTH 0.27 0.07 0.09 0.27 0.27 0.27 0.27
+    WIDTH 0.5 0.07 0.09 0.27 0.5 0.5 0.5
+    WIDTH 0.9 0.07 0.09 0.27 0.5 0.9 0.9
+    WIDTH 1.5 0.07 0.09 0.27 0.5 0.9 1.5 ;
+  RESISTANCE RPERSQ 0.25 ;
+  CAPACITANCE CPERSQDIST 4.0896e-05 ;
+  HEIGHT 0.62 ;
+  THICKNESS 0.14 ;
+  EDGECAPACITANCE 2.5157e-05 ;
+END metal2
+
+LAYER via2
+  TYPE CUT ;
+  SPACING 0.09 ;
+  WIDTH 0.07 ;
+  RESISTANCE 5 ;
+END via2
+
+LAYER metal3
+  TYPE ROUTING ;
+  DIRECTION HORIZONTAL ;
+  PITCH 0.19 0.14 ;
+  WIDTH 0.07 ;
+  OFFSET 0.095 0.07 ;
+  SPACINGTABLE
+    PARALLELRUNLENGTH 0 0.3 0.9 1.8 2.7 4
+    WIDTH 0 0.07 0.07 0.07 0.07 0.07 0.07
+    WIDTH 0.09 0.07 0.09 0.09 0.09 0.09 0.09
+    WIDTH 0.27 0.07 0.09 0.27 0.27 0.27 0.27
+    WIDTH 0.5 0.07 0.09 0.27 0.5 0.5 0.5
+    WIDTH 0.9 0.07 0.09 0.27 0.5 0.9 0.9
+    WIDTH 1.5 0.07 0.09 0.27 0.5 0.9 1.5 ;
+  RESISTANCE RPERSQ 0.25 ;
+  CAPACITANCE CPERSQDIST 2.7745e-05 ;
+  HEIGHT 0.88 ;
+  THICKNESS 0.14 ;
+  EDGECAPACITANCE 2.5157e-05 ;
+END metal3
+
+LAYER via3
+  TYPE CUT ;
+  SPACING 0.09 ;
+  WIDTH 0.07 ;
+  RESISTANCE 5 ;
+END via3
+
+LAYER metal4
+  TYPE ROUTING ;
+  DIRECTION VERTICAL ;
+  PITCH 0.28 0.28 ;
+  WIDTH 0.14 ;
+  OFFSET 0.095 0.07 ;
+  SPACINGTABLE
+    PARALLELRUNLENGTH 0 0.9 1.8 2.7 4
+    WIDTH 0 0.14 0.14 0.14 0.14 0.14
+    WIDTH 0.27 0.14 0.27 0.27 0.27 0.27
+    WIDTH 0.5 0.14 0.27 0.5 0.5 0.5
+    WIDTH 0.9 0.14 0.27 0.5 0.9 0.9
+    WIDTH 1.5 0.14 0.27 0.5 0.9 1.5 ;
+  RESISTANCE RPERSQ 0.21 ;
+  CAPACITANCE CPERSQDIST 2.0743e-05 ;
+  HEIGHT 1.14 ;
+  THICKNESS 0.28 ;
+  EDGECAPACITANCE 3.0908e-05 ;
+END metal4
+
+LAYER via4
+  TYPE CUT ;
+  SPACING 0.16 ;
+  WIDTH 0.14 ;
+  RESISTANCE 3 ;
+END via4
+
+LAYER metal5
+  TYPE ROUTING ;
+  DIRECTION HORIZONTAL ;
+  PITCH 0.28 0.28 ;
+  WIDTH 0.14 ;
+  OFFSET 0.095 0.07 ;
+  SPACINGTABLE
+    PARALLELRUNLENGTH 0 0.9 1.8 2.7 4
+    WIDTH 0 0.14 0.14 0.14 0.14 0.14
+    WIDTH 0.27 0.14 0.27 0.27 0.27 0.27
+    WIDTH 0.5 0.14 0.27 0.5 0.5 0.5
+    WIDTH 0.9 0.14 0.27 0.5 0.9 0.9
+    WIDTH 1.5 0.14 0.27 0.5 0.9 1.5 ;
+  RESISTANCE RPERSQ 0.21 ;
+  CAPACITANCE CPERSQDIST 1.3527e-05 ;
+  HEIGHT 1.71 ;
+  THICKNESS 0.28 ;
+  EDGECAPACITANCE 2.3863e-06 ;
+END metal5
+
+LAYER via5
+  TYPE CUT ;
+  SPACING 0.16 ;
+  WIDTH 0.14 ;
+  RESISTANCE 3 ;
+END via5
+
+LAYER metal6
+  TYPE ROUTING ;
+  DIRECTION VERTICAL ;
+  PITCH 0.28 0.28 ;
+  WIDTH 0.14 ;
+  OFFSET 0.095 0.07 ;
+  SPACINGTABLE
+    PARALLELRUNLENGTH 0 0.9 1.8 2.7 4
+    WIDTH 0 0.14 0.14 0.14 0.14 0.14
+    WIDTH 0.27 0.14 0.27 0.27 0.27 0.27
+    WIDTH 0.5 0.14 0.27 0.5 0.5 0.5
+    WIDTH 0.9 0.14 0.27 0.5 0.9 0.9
+    WIDTH 1.5 0.14 0.27 0.5 0.9 1.5 ;
+  RESISTANCE RPERSQ 0.21 ;
+  CAPACITANCE CPERSQDIST 1.0036e-05 ;
+  HEIGHT 2.28 ;
+  THICKNESS 0.28 ;
+  EDGECAPACITANCE 2.3863e-05 ;
+END metal6
+
+LAYER via6
+  TYPE CUT ;
+  SPACING 0.16 ;
+  WIDTH 0.14 ;
+  RESISTANCE 3 ;
+END via6
+
+LAYER metal7
+  TYPE ROUTING ;
+  DIRECTION HORIZONTAL ;
+  PITCH 0.8 0.8 ;
+  WIDTH 0.4 ;
+  OFFSET 0.095 0.07 ;
+  SPACINGTABLE
+    PARALLELRUNLENGTH 0 1.8 2.7 4
+    WIDTH 0 0.4 0.4 0.4 0.4
+    WIDTH 0.5 0.4 0.5 0.5 0.5
+    WIDTH 0.9 0.4 0.5 0.9 0.9
+    WIDTH 1.5 0.4 0.5 0.9 1.5 ;
+  RESISTANCE RPERSQ 0.075 ;
+  CAPACITANCE CPERSQDIST 7.9771e-06 ;
+  HEIGHT 2.85 ;
+  THICKNESS 0.8 ;
+  EDGECAPACITANCE 3.2577e-05 ;
+END metal7
+
+LAYER via7
+  TYPE CUT ;
+  SPACING 0.44 ;
+  WIDTH 0.4 ;
+  RESISTANCE 1 ;
+END via7
+
+LAYER metal8
+  TYPE ROUTING ;
+  DIRECTION VERTICAL ;
+  PITCH 0.8 0.8 ;
+  WIDTH 0.4 ;
+  OFFSET 0.095 0.07 ;
+  SPACINGTABLE
+    PARALLELRUNLENGTH 0 1.8 2.7 4
+    WIDTH 0 0.4 0.4 0.4 0.4
+    WIDTH 0.5 0.4 0.5 0.5 0.5
+    WIDTH 0.9 0.4 0.5 0.9 0.9
+    WIDTH 1.5 0.4 0.5 0.9 1.5 ;
+  RESISTANCE RPERSQ 0.075 ;
+  CAPACITANCE CPERSQDIST 5.0391e-06 ;
+  HEIGHT 4.47 ;
+  THICKNESS 0.8 ;
+  EDGECAPACITANCE 2.3932e-05 ;
+END metal8
+
+LAYER via8
+  TYPE CUT ;
+  SPACING 0.44 ;
+  WIDTH 0.4 ;
+  RESISTANCE 1 ;
+END via8
+
+LAYER metal9
+  TYPE ROUTING ;
+  DIRECTION HORIZONTAL ;
+  PITCH 1.6 1.6 ;
+  WIDTH 0.8 ;
+  OFFSET 0.095 0.07 ;
+  SPACINGTABLE
+    PARALLELRUNLENGTH 0 2.7 4
+    WIDTH 0 0.8 0.8 0.8
+    WIDTH 0.9 0.8 0.9 0.9
+    WIDTH 1.5 0.8 0.9 1.5 ;
+  RESISTANCE RPERSQ 0.03 ;
+  CAPACITANCE CPERSQDIST 3.6827e-06 ;
+  HEIGHT 6.09 ;
+  THICKNESS 2 ;
+  EDGECAPACITANCE 3.0803e-05 ;
+END metal9
+
+LAYER via9
+  TYPE CUT ;
+  SPACING 0.88 ;
+  WIDTH 0.8 ;
+  RESISTANCE 0.5 ;
+END via9
+
+LAYER metal10
+  TYPE ROUTING ;
+  DIRECTION VERTICAL ;
+  PITCH 1.6 1.6 ;
+  WIDTH 0.8 ;
+  OFFSET 0.095 0.07 ;
+  SPACINGTABLE
+    PARALLELRUNLENGTH 0 2.7 4
+    WIDTH 0 0.8 0.8 0.8
+    WIDTH 0.9 0.8 0.9 0.9
+    WIDTH 1.5 0.8 0.9 1.5 ;
+  RESISTANCE RPERSQ 0.03 ;
+  CAPACITANCE CPERSQDIST 2.2124e-06 ;
+  HEIGHT 10.09 ;
+  THICKNESS 2 ;
+  EDGECAPACITANCE 2.3667e-05 ;
+END metal10
+
+LAYER OVERLAP
+  TYPE OVERLAP ;
+END OVERLAP
+
+VIARULE Via1Array-0 GENERATE
+  LAYER metal1 ;
+    ENCLOSURE 0.035 0.035 ;
+  LAYER metal2 ;
+    ENCLOSURE 0.035 0.035 ;
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+    SPACING 0.15 BY 0.15 ;
+END Via1Array-0
+
+VIARULE Via1Array-1 GENERATE
+  LAYER metal1 ;
+    ENCLOSURE 0 0.035 ;
+  LAYER metal2 ;
+    ENCLOSURE 0 0.035 ;
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+    SPACING 0.15 BY 0.15 ;
+END Via1Array-1
+
+VIARULE Via1Array-2 GENERATE
+  LAYER metal1 ;
+    ENCLOSURE 0.035 0 ;
+  LAYER metal2 ;
+    ENCLOSURE 0.035 0 ;
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+    SPACING 0.15 BY 0.15 ;
+END Via1Array-2
+
+VIARULE Via1Array-3 GENERATE
+  LAYER metal1 ;
+    ENCLOSURE 0 0.035 ;
+  LAYER metal2 ;
+    ENCLOSURE 0.035 0 ;
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+    SPACING 0.15 BY 0.15 ;
+END Via1Array-3
+
+VIARULE Via1Array-4 GENERATE
+  LAYER metal1 ;
+    ENCLOSURE 0.035 0 ;
+  LAYER metal2 ;
+    ENCLOSURE 0 0.035 ;
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+    SPACING 0.15 BY 0.15 ;
+END Via1Array-4
+
+VIARULE Via2Array-0 GENERATE
+  LAYER metal2 ;
+    ENCLOSURE 0.035 0.035 ;
+  LAYER metal3 ;
+    ENCLOSURE 0.035 0.035 ;
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+    SPACING 0.16 BY 0.16 ;
+END Via2Array-0
+
+VIARULE Via2Array-1 GENERATE
+  LAYER metal2 ;
+    ENCLOSURE 0 0.035 ;
+  LAYER metal3 ;
+    ENCLOSURE 0 0.035 ;
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+    SPACING 0.16 BY 0.16 ;
+END Via2Array-1
+
+VIARULE Via2Array-2 GENERATE
+  LAYER metal2 ;
+    ENCLOSURE 0.035 0 ;
+  LAYER metal3 ;
+    ENCLOSURE 0.035 0 ;
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+    SPACING 0.16 BY 0.16 ;
+END Via2Array-2
+
+VIARULE Via2Array-3 GENERATE
+  LAYER metal2 ;
+    ENCLOSURE 0 0.035 ;
+  LAYER metal3 ;
+    ENCLOSURE 0.035 0 ;
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+    SPACING 0.16 BY 0.16 ;
+END Via2Array-3
+
+VIARULE Via2Array-4 GENERATE
+  LAYER metal2 ;
+    ENCLOSURE 0.035 0 ;
+  LAYER metal3 ;
+    ENCLOSURE 0 0.035 ;
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+    SPACING 0.16 BY 0.16 ;
+END Via2Array-4
+
+VIARULE Via3Array-0 GENERATE
+  LAYER metal3 ;
+    ENCLOSURE 0.035 0.035 ;
+  LAYER metal4 ;
+    ENCLOSURE 0.035 0.035 ;
+  LAYER via3 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+    SPACING 0.16 BY 0.16 ;
+END Via3Array-0
+
+VIARULE Via3Array-1 GENERATE
+  LAYER metal3 ;
+    ENCLOSURE 0 0.035 ;
+  LAYER metal4 ;
+    ENCLOSURE 0.035 0.035 ;
+  LAYER via3 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+    SPACING 0.16 BY 0.16 ;
+END Via3Array-1
+
+VIARULE Via3Array-2 GENERATE
+  LAYER metal3 ;
+    ENCLOSURE 0.035 0 ;
+  LAYER metal4 ;
+    ENCLOSURE 0.035 0.035 ;
+  LAYER via3 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+    SPACING 0.16 BY 0.16 ;
+END Via3Array-2
+
+VIARULE Via4Array-0 GENERATE
+  LAYER metal4 ;
+    ENCLOSURE 0 0 ;
+  LAYER metal5 ;
+    ENCLOSURE 0 0 ;
+  LAYER via4 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+    SPACING 0.3 BY 0.3 ;
+END Via4Array-0
+
+VIARULE Via5Array-0 GENERATE
+  LAYER metal5 ;
+    ENCLOSURE 0 0 ;
+  LAYER metal6 ;
+    ENCLOSURE 0 0 ;
+  LAYER via5 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+    SPACING 0.3 BY 0.3 ;
+END Via5Array-0
+
+VIARULE Via6Array-0 GENERATE
+  LAYER metal6 ;
+    ENCLOSURE 0 0 ;
+  LAYER metal7 ;
+    ENCLOSURE 0.13 0.13 ;
+  LAYER via6 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+    SPACING 0.3 BY 0.3 ;
+END Via6Array-0
+
+VIARULE Via7Array-0 GENERATE
+  LAYER metal7 ;
+    ENCLOSURE 0 0 ;
+  LAYER metal8 ;
+    ENCLOSURE 0 0 ;
+  LAYER via7 ;
+    RECT -0.2 -0.2 0.2 0.2 ;
+    SPACING 0.84 BY 0.84 ;
+END Via7Array-0
+
+VIARULE Via8Array-0 GENERATE
+  LAYER metal8 ;
+    ENCLOSURE 0 0 ;
+  LAYER metal9 ;
+    ENCLOSURE 0.2 0.2 ;
+  LAYER via8 ;
+    RECT -0.2 -0.2 0.2 0.2 ;
+    SPACING 0.84 BY 0.84 ;
+END Via8Array-0
+
+VIARULE Via9Array-0 GENERATE
+  LAYER metal9 ;
+    ENCLOSURE 0 0 ;
+  LAYER metal10 ;
+    ENCLOSURE 0 0 ;
+  LAYER via9 ;
+    RECT -0.4 -0.4 0.4 0.4 ;
+    SPACING 1.68 BY 1.68 ;
+END Via9Array-0
+
+VIA via1_0 DEFAULT
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal1 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal2 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+END via1_0
+
+VIA via1_1 DEFAULT
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal1 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal2 ;
+    RECT -0.035 -0.07 0.035 0.07 ;
+END via1_1
+
+VIA via1_2 DEFAULT
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal1 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal2 ;
+    RECT -0.07 -0.035 0.07 0.035 ;
+END via1_2
+
+VIA via1_3 DEFAULT
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal1 ;
+    RECT -0.035 -0.07 0.035 0.07 ;
+  LAYER metal2 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+END via1_3
+
+VIA via1_4 DEFAULT
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal1 ;
+    RECT -0.035 -0.07 0.035 0.07 ;
+  LAYER metal2 ;
+    RECT -0.035 -0.07 0.035 0.07 ;
+END via1_4
+
+VIA via1_5 DEFAULT
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal1 ;
+    RECT -0.035 -0.07 0.035 0.07 ;
+  LAYER metal2 ;
+    RECT -0.07 -0.035 0.07 0.035 ;
+END via1_5
+
+VIA via1_6 DEFAULT
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal1 ;
+    RECT -0.07 -0.035 0.07 0.035 ;
+  LAYER metal2 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+END via1_6
+
+VIA via1_7 DEFAULT
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal1 ;
+    RECT -0.07 -0.035 0.07 0.035 ;
+  LAYER metal2 ;
+    RECT -0.035 -0.07 0.035 0.07 ;
+END via1_7
+
+VIA via1_8 DEFAULT
+  LAYER via1 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal1 ;
+    RECT -0.07 -0.035 0.07 0.035 ;
+  LAYER metal2 ;
+    RECT -0.07 -0.035 0.07 0.035 ;
+END via1_8
+
+VIA via2_0 DEFAULT
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal2 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal3 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+END via2_0
+
+VIA via2_1 DEFAULT
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal2 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal3 ;
+    RECT -0.035 -0.07 0.035 0.07 ;
+END via2_1
+
+VIA via2_2 DEFAULT
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal2 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal3 ;
+    RECT -0.07 -0.035 0.07 0.035 ;
+END via2_2
+
+VIA via2_3 DEFAULT
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal2 ;
+    RECT -0.035 -0.07 0.035 0.07 ;
+  LAYER metal3 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+END via2_3
+
+VIA via2_4 DEFAULT
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal2 ;
+    RECT -0.035 -0.07 0.035 0.07 ;
+  LAYER metal3 ;
+    RECT -0.035 -0.07 0.035 0.07 ;
+END via2_4
+
+VIA via2_5 DEFAULT
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal2 ;
+    RECT -0.035 -0.07 0.035 0.07 ;
+  LAYER metal3 ;
+    RECT -0.07 -0.035 0.07 0.035 ;
+END via2_5
+
+VIA via2_6 DEFAULT
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal2 ;
+    RECT -0.07 -0.035 0.07 0.035 ;
+  LAYER metal3 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+END via2_6
+
+VIA via2_7 DEFAULT
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal2 ;
+    RECT -0.07 -0.035 0.07 0.035 ;
+  LAYER metal3 ;
+    RECT -0.035 -0.07 0.035 0.07 ;
+END via2_7
+
+VIA via2_8 DEFAULT
+  LAYER via2 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal2 ;
+    RECT -0.07 -0.035 0.07 0.035 ;
+  LAYER metal3 ;
+    RECT -0.07 -0.035 0.07 0.035 ;
+END via2_8
+
+VIA via3_0 DEFAULT
+  LAYER via3 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal3 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal4 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+END via3_0
+
+VIA via3_1 DEFAULT
+  LAYER via3 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal3 ;
+    RECT -0.035 -0.07 0.035 0.07 ;
+  LAYER metal4 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+END via3_1
+
+VIA via3_2 DEFAULT
+  LAYER via3 ;
+    RECT -0.035 -0.035 0.035 0.035 ;
+  LAYER metal3 ;
+    RECT -0.07 -0.035 0.07 0.035 ;
+  LAYER metal4 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+END via3_2
+
+VIA via4_0 DEFAULT
+  LAYER via4 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal4 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal5 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+END via4_0
+
+VIA via5_0 DEFAULT
+  LAYER via5 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal5 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal6 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+END via5_0
+
+VIA via6_0 DEFAULT
+  LAYER via6 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal6 ;
+    RECT -0.07 -0.07 0.07 0.07 ;
+  LAYER metal7 ;
+    RECT -0.2 -0.2 0.2 0.2 ;
+END via6_0
+
+VIA via7_0 DEFAULT
+  LAYER via7 ;
+    RECT -0.2 -0.2 0.2 0.2 ;
+  LAYER metal7 ;
+    RECT -0.2 -0.2 0.2 0.2 ;
+  LAYER metal8 ;
+    RECT -0.2 -0.2 0.2 0.2 ;
+END via7_0
+
+VIA via8_0 DEFAULT
+  LAYER via8 ;
+    RECT -0.2 -0.2 0.2 0.2 ;
+  LAYER metal8 ;
+    RECT -0.2 -0.2 0.2 0.2 ;
+  LAYER metal9 ;
+    RECT -0.4 -0.4 0.4 0.4 ;
+END via8_0
+
+VIA via9_0 DEFAULT
+  LAYER via9 ;
+    RECT -0.4 -0.4 0.4 0.4 ;
+  LAYER metal9 ;
+    RECT -0.4 -0.4 0.4 0.4 ;
+  LAYER metal10 ;
+    RECT -0.4 -0.4 0.4 0.4 ;
+END via9_0
+
+SPACING
+  SAMENET metal1 metal1 0.065 ;
+  SAMENET via1 via1 0.08 ;
+  SAMENET metal2 metal2 0.07 ;
+  SAMENET via2 via2 0.09 ;
+  SAMENET metal3 metal3 0.07 ;
+  SAMENET via3 via3 0.09 ;
+  SAMENET metal4 metal4 0.14 ;
+  SAMENET via4 via4 0.16 ;
+  SAMENET metal5 metal5 0.14 ;
+  SAMENET via5 via5 0.16 ;
+  SAMENET metal6 metal6 0.14 ;
+  SAMENET via6 via6 0.16 ;
+  SAMENET metal7 metal7 0.4 ;
+  SAMENET via7 via7 0.44 ;
+  SAMENET metal8 metal8 0.4 ;
+  SAMENET via8 via8 0.44 ;
+  SAMENET metal9 metal9 0.8 ;
+  SAMENET via9 via9 0.88 ;
+  SAMENET metal10 metal10 0.8 ;
+  SAMENET via1 via2 0 STACK ;
+  SAMENET via2 via3 0 STACK ;
+  SAMENET via3 via4 0 STACK ;
+  SAMENET via4 via5 0 STACK ;
+  SAMENET via5 via6 0 STACK ;
+  SAMENET via6 via7 0 STACK ;
+  SAMENET via7 via8 0 STACK ;
+  SAMENET via8 via9 0 STACK ;
+END SPACING
+
+SITE FreePDK45_38x28_10R_NP_162NW_34O
+  CLASS CORE ;
+  SYMMETRY Y ;
+  SIZE 0.19 BY 1.4 ;
+END FreePDK45_38x28_10R_NP_162NW_34O
+
+MACRO AND2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND2_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.61 0.19 0.7 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.415 -0.085 0.485 0.325 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.235 0.84 0.305 1.25 ;
+      RECT 0.235 0.84 0.54 0.91 ;
+      RECT 0.47 0.39 0.54 0.91 ;
+      RECT 0.045 0.39 0.54 0.46 ;
+      RECT 0.045 0.19 0.115 0.46 ;
+  END
+END AND2_X1
+
+MACRO AND2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND2_X2 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.615 0.15 0.7 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.795 -0.085 0.865 0.425 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.235 0.84 0.305 1.25 ;
+      RECT 0.235 0.84 0.545 0.91 ;
+      RECT 0.475 0.39 0.545 0.91 ;
+      RECT 0.045 0.39 0.545 0.46 ;
+      RECT 0.045 0.15 0.115 0.46 ;
+  END
+END AND2_X2
+
+MACRO AND2_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND2_X4 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.42 0.38 0.66 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.725 0.76 0.795 ;
+        RECT 0.69 0.525 0.76 0.795 ;
+        RECT 0.06 0.42 0.185 0.795 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.365 0.15 1.435 1.25 ;
+        RECT 0.995 0.68 1.435 0.75 ;
+        RECT 0.995 0.15 1.08 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.555 0.995 1.625 1.485 ;
+        RECT 1.175 0.995 1.245 1.485 ;
+        RECT 0.795 0.995 0.865 1.485 ;
+        RECT 0.415 0.995 0.485 1.485 ;
+        RECT 0.04 0.995 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.555 -0.085 1.625 0.355 ;
+        RECT 1.175 -0.085 1.245 0.355 ;
+        RECT 0.795 -0.085 0.865 0.215 ;
+        RECT 0.04 -0.085 0.11 0.355 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.605 0.86 0.675 1.25 ;
+      RECT 0.235 0.86 0.305 1.25 ;
+      RECT 0.235 0.86 0.92 0.93 ;
+      RECT 0.85 0.285 0.92 0.93 ;
+      RECT 0.425 0.285 0.92 0.355 ;
+      RECT 0.425 0.22 0.495 0.355 ;
+  END
+END AND2_X4
+
+MACRO AND3_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND3_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.57 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.8 0.975 0.89 1.25 ;
+        RECT 0.82 0.15 0.89 1.25 ;
+        RECT 0.8 0.15 0.89 0.425 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.605 1 0.675 1.485 ;
+        RECT 0.225 1.04 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.415 0.865 0.485 1.25 ;
+      RECT 0.045 0.865 0.115 1.25 ;
+      RECT 0.045 0.865 0.705 0.935 ;
+      RECT 0.635 0.35 0.705 0.935 ;
+      RECT 0.635 0.525 0.755 0.66 ;
+      RECT 0.045 0.35 0.705 0.42 ;
+      RECT 0.045 0.15 0.115 0.42 ;
+  END
+END AND3_X1
+
+MACRO AND3_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND3_X2 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.57 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.805 0.15 0.89 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.99 0.975 1.06 1.485 ;
+        RECT 0.605 0.975 0.675 1.485 ;
+        RECT 0.225 0.975 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.99 -0.085 1.06 0.425 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.415 0.8 0.485 1.25 ;
+      RECT 0.045 0.8 0.115 1.25 ;
+      RECT 0.045 0.8 0.735 0.87 ;
+      RECT 0.665 0.355 0.735 0.87 ;
+      RECT 0.045 0.355 0.735 0.425 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+  END
+END AND3_X2
+
+MACRO AND3_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND3_X4 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.595 0.555 0.73 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.42 0.95 0.7 ;
+        RECT 0.34 0.42 0.95 0.49 ;
+        RECT 0.34 0.42 0.41 0.66 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.12 0.765 1.14 0.835 ;
+        RECT 1.07 0.525 1.14 0.835 ;
+        RECT 0.12 0.525 0.19 0.835 ;
+        RECT 0.06 0.525 0.19 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.745 0.15 1.815 1.25 ;
+        RECT 1.375 0.56 1.815 0.7 ;
+        RECT 1.375 0.15 1.445 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.935 1.035 2.005 1.485 ;
+        RECT 1.555 1.035 1.625 1.485 ;
+        RECT 1.175 1.035 1.245 1.485 ;
+        RECT 0.795 1.035 0.865 1.485 ;
+        RECT 0.415 1.035 0.485 1.485 ;
+        RECT 0.04 1.035 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.935 -0.085 2.005 0.425 ;
+        RECT 1.555 -0.085 1.625 0.425 ;
+        RECT 1.175 -0.085 1.245 0.195 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.985 0.9 1.055 1.25 ;
+      RECT 0.605 0.9 0.675 1.25 ;
+      RECT 0.235 0.9 0.305 1.25 ;
+      RECT 0.235 0.9 1.305 0.97 ;
+      RECT 1.235 0.26 1.305 0.97 ;
+      RECT 0.615 0.26 1.305 0.33 ;
+      RECT 0.615 0.15 0.685 0.33 ;
+  END
+END AND3_X4
+
+MACRO AND4_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND4_X1 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.76 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.99 0.15 1.08 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.795 -0.085 0.865 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.605 0.84 0.675 1.25 ;
+      RECT 0.235 0.84 0.305 1.25 ;
+      RECT 0.235 0.84 0.925 0.91 ;
+      RECT 0.855 0.35 0.925 0.91 ;
+      RECT 0.045 0.35 0.925 0.42 ;
+      RECT 0.045 0.15 0.115 0.42 ;
+  END
+END AND4_X1
+
+MACRO AND4_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND4_X2 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.76 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.995 0.15 1.08 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.18 0.975 1.25 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 1.18 -0.085 1.25 0.425 ;
+        RECT 0.795 -0.085 0.865 0.27 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.605 0.8 0.675 1.25 ;
+      RECT 0.235 0.8 0.305 1.25 ;
+      RECT 0.235 0.8 0.925 0.87 ;
+      RECT 0.855 0.355 0.925 0.87 ;
+      RECT 0.045 0.355 0.925 0.425 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+  END
+END AND4_X2
+
+MACRO AND4_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND4_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.8 0.56 0.935 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.065 0.425 1.135 0.66 ;
+        RECT 0.565 0.425 1.135 0.495 ;
+        RECT 0.565 0.425 0.7 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.355 0.77 1.345 0.84 ;
+        RECT 1.2 0.525 1.345 0.84 ;
+        RECT 0.355 0.525 0.425 0.84 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.135 0.905 1.535 0.975 ;
+        RECT 1.465 0.525 1.535 0.975 ;
+        RECT 0.135 0.525 0.205 0.975 ;
+        RECT 0.06 0.525 0.205 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.14 0.15 2.21 0.925 ;
+        RECT 1.77 0.56 2.21 0.7 ;
+        RECT 1.77 0.15 1.84 0.925 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.33 1.065 2.4 1.485 ;
+        RECT 1.95 1.065 2.02 1.485 ;
+        RECT 1.57 1.175 1.64 1.485 ;
+        RECT 1.19 1.175 1.26 1.485 ;
+        RECT 0.81 1.175 0.88 1.485 ;
+        RECT 0.43 1.175 0.5 1.485 ;
+        RECT 0.055 1.065 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.33 -0.085 2.4 0.425 ;
+        RECT 1.95 -0.085 2.02 0.425 ;
+        RECT 1.57 -0.085 1.64 0.195 ;
+        RECT 0.055 -0.085 0.125 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.215 1.04 1.705 1.11 ;
+      RECT 1.635 0.29 1.705 1.11 ;
+      RECT 0.785 0.29 1.705 0.36 ;
+  END
+END AND4_X4
+
+MACRO ANTENNA_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN ANTENNA_X1 0 0 ;
+  SIZE 0.19 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.42 0.13 0.75 ;
+    END
+  END A
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.19 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.19 0.085 ;
+    END
+  END VSS
+END ANTENNA_X1
+
+MACRO AOI211_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI211_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.525 0.89 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.41 0.525 0.51 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.21 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.275 0.355 0.905 0.425 ;
+        RECT 0.835 0.15 0.905 0.425 ;
+        RECT 0.44 0.15 0.525 0.425 ;
+        RECT 0.275 0.355 0.345 1.115 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.835 0.905 0.905 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.645 -0.085 0.715 0.285 ;
+        RECT 0.08 -0.085 0.15 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.085 1.18 0.525 1.25 ;
+      RECT 0.455 0.905 0.525 1.25 ;
+      RECT 0.085 0.905 0.155 1.25 ;
+  END
+END AOI211_X1
+
+MACRO AOI211_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI211_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.39 0.56 0.525 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.765 0.75 0.835 ;
+        RECT 0.68 0.525 0.75 0.835 ;
+        RECT 0.06 0.525 0.185 0.835 ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.19 0.56 1.325 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.54 0.425 1.65 0.7 ;
+        RECT 0.965 0.425 1.65 0.495 ;
+        RECT 0.965 0.425 1.035 0.66 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.405 0.765 1.475 1.055 ;
+        RECT 0.82 0.765 1.475 0.835 ;
+        RECT 0.2 0.285 1.32 0.355 ;
+        RECT 1.185 0.15 1.32 0.355 ;
+        RECT 1.025 0.765 1.095 1.055 ;
+        RECT 0.82 0.285 0.89 0.835 ;
+        RECT 0.2 0.15 0.335 0.355 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 0.42 1.035 0.49 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.595 -0.085 1.665 0.355 ;
+        RECT 0.825 -0.085 0.895 0.215 ;
+        RECT 0.43 -0.085 0.5 0.215 ;
+        RECT 0.045 -0.085 0.115 0.355 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.815 1.18 1.665 1.25 ;
+      RECT 1.595 0.975 1.665 1.25 ;
+      RECT 0.05 0.9 0.12 1.25 ;
+      RECT 1.22 0.975 1.29 1.25 ;
+      RECT 0.815 0.9 0.885 1.25 ;
+      RECT 0.05 0.9 0.885 0.97 ;
+  END
+END AOI211_X2
+
+MACRO AOI211_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI211_X4 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.76 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.75 0.15 1.82 1.175 ;
+        RECT 1.375 0.56 1.82 0.7 ;
+        RECT 1.375 0.15 1.445 1.175 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.935 0.9 2.005 1.485 ;
+        RECT 1.555 0.9 1.625 1.485 ;
+        RECT 1.175 0.9 1.245 1.485 ;
+        RECT 0.795 0.9 0.865 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.935 -0.085 2.005 0.425 ;
+        RECT 1.555 -0.085 1.625 0.425 ;
+        RECT 1.175 -0.085 1.245 0.425 ;
+        RECT 0.795 -0.085 0.865 0.285 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.995 0.15 1.065 1.175 ;
+      RECT 0.995 0.525 1.31 0.66 ;
+      RECT 0.235 0.765 0.305 1.115 ;
+      RECT 0.235 0.765 0.93 0.835 ;
+      RECT 0.86 0.39 0.93 0.835 ;
+      RECT 0.045 0.39 0.93 0.46 ;
+      RECT 0.605 0.15 0.675 0.46 ;
+      RECT 0.045 0.15 0.115 0.46 ;
+      RECT 0.045 1.18 0.485 1.25 ;
+      RECT 0.415 0.9 0.485 1.25 ;
+      RECT 0.045 0.9 0.115 1.25 ;
+  END
+END AOI211_X4
+
+MACRO AOI21_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI21_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.4 0.525 0.51 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.2 0.7 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.265 0.355 0.525 0.425 ;
+        RECT 0.44 0.15 0.525 0.425 ;
+        RECT 0.265 0.355 0.335 1.115 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.645 0.905 0.715 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.645 -0.085 0.715 0.355 ;
+        RECT 0.08 -0.085 0.15 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.085 1.18 0.525 1.25 ;
+      RECT 0.455 0.905 0.525 1.25 ;
+      RECT 0.085 0.905 0.155 1.25 ;
+  END
+END AOI21_X1
+
+MACRO AOI21_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI21_X2 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.215 0.56 0.35 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.56 0.9 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.77 1.18 0.84 ;
+        RECT 1.11 0.525 1.18 0.84 ;
+        RECT 0.63 0.525 0.7 0.84 ;
+        RECT 0.57 0.525 0.7 0.7 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.435 0.905 1.13 0.975 ;
+        RECT 0.25 0.355 0.905 0.425 ;
+        RECT 0.835 0.15 0.905 0.425 ;
+        RECT 0.435 0.355 0.505 0.975 ;
+        RECT 0.25 0.15 0.335 0.425 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 0.265 1.205 0.335 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 1.215 -0.085 1.285 0.425 ;
+        RECT 0.455 -0.085 0.525 0.285 ;
+        RECT 0.08 -0.085 0.15 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.215 0.975 1.285 1.25 ;
+      RECT 0.085 0.975 0.155 1.25 ;
+      RECT 0.085 1.07 1.285 1.14 ;
+  END
+END AOI21_X2
+
+MACRO AOI21_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI21_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.4 0.525 0.535 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.165 0.69 2.06 0.76 ;
+        RECT 1.925 0.56 2.06 0.76 ;
+        RECT 1.165 0.56 1.3 0.76 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.25 0.42 2.32 0.66 ;
+        RECT 0.925 0.42 2.32 0.49 ;
+        RECT 1.525 0.42 1.66 0.625 ;
+        RECT 0.925 0.42 0.995 0.66 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.14 0.825 2.21 1.115 ;
+        RECT 0.63 0.825 2.21 0.895 ;
+        RECT 0.63 0.26 2.055 0.33 ;
+        RECT 1.76 0.825 1.83 1.115 ;
+        RECT 1.38 0.825 1.45 1.115 ;
+        RECT 1 0.825 1.07 1.115 ;
+        RECT 0.63 0.15 0.7 0.895 ;
+        RECT 0.25 0.355 0.7 0.425 ;
+        RECT 0.25 0.15 0.32 0.425 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 0.62 1.205 0.69 1.485 ;
+        RECT 0.24 1.205 0.31 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.33 -0.085 2.4 0.35 ;
+        RECT 1.57 -0.085 1.64 0.195 ;
+        RECT 0.81 -0.085 0.88 0.195 ;
+        RECT 0.43 -0.085 0.5 0.195 ;
+        RECT 0.055 -0.085 0.125 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.81 1.18 2.4 1.25 ;
+      RECT 2.33 0.84 2.4 1.25 ;
+      RECT 0.43 0.965 0.5 1.24 ;
+      RECT 0.06 0.965 0.13 1.24 ;
+      RECT 1.95 0.96 2.02 1.25 ;
+      RECT 1.57 0.96 1.64 1.25 ;
+      RECT 1.19 0.96 1.26 1.25 ;
+      RECT 0.81 0.965 0.88 1.25 ;
+      RECT 0.06 0.965 0.88 1.035 ;
+  END
+END AOI21_X4
+
+MACRO AOI221_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI221_X1 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.955 0.525 1.08 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.74 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.355 1.055 0.425 ;
+        RECT 0.985 0.15 1.055 0.425 ;
+        RECT 0.805 0.355 0.89 1.115 ;
+        RECT 0.425 0.15 0.495 0.425 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.225 0.905 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.605 -0.085 0.675 0.215 ;
+        RECT 0.04 -0.085 0.11 0.355 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.615 1.18 1.055 1.25 ;
+      RECT 0.985 0.905 1.055 1.25 ;
+      RECT 0.615 0.905 0.685 1.25 ;
+      RECT 0.415 0.77 0.485 1.18 ;
+      RECT 0.045 0.77 0.115 1.18 ;
+      RECT 0.045 0.77 0.485 0.84 ;
+  END
+END AOI221_X1
+
+MACRO AOI221_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI221_X2 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.18 0.79 1.13 0.86 ;
+        RECT 1.06 0.525 1.13 0.86 ;
+        RECT 0.18 0.56 0.25 0.86 ;
+        RECT 0.06 0.56 0.25 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.42 0.945 0.7 ;
+        RECT 0.34 0.42 0.945 0.49 ;
+        RECT 0.34 0.42 0.41 0.66 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.585 0.56 0.725 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.57 0.525 1.66 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.77 0.525 1.91 0.7 ;
+        RECT 1.34 0.765 1.84 0.835 ;
+        RECT 1.77 0.525 1.84 0.835 ;
+        RECT 1.34 0.525 1.41 0.835 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.195 0.9 1.86 0.97 ;
+        RECT 0.2 0.28 1.675 0.35 ;
+        RECT 1.195 0.28 1.275 0.97 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 0.795 1.205 0.865 1.485 ;
+        RECT 0.415 1.205 0.485 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.945 -0.085 2.015 0.425 ;
+        RECT 1.175 -0.085 1.245 0.195 ;
+        RECT 0.605 -0.085 0.675 0.195 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 1.07 2.015 1.14 ;
+      RECT 1.945 0.865 2.015 1.14 ;
+      RECT 0.045 0.865 0.115 1.14 ;
+      RECT 0.2 0.93 1.09 1 ;
+  END
+END AOI221_X2
+
+MACRO AOI221_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI221_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.61 0.525 0.7 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.8 0.525 0.89 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.18 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.27 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.42 0.525 0.51 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.17 0.15 2.24 1.25 ;
+        RECT 1.795 0.56 2.24 0.7 ;
+        RECT 1.795 0.15 1.885 0.7 ;
+        RECT 1.795 0.15 1.865 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.355 0.975 2.425 1.485 ;
+        RECT 1.975 0.975 2.045 1.485 ;
+        RECT 1.6 1.005 1.67 1.485 ;
+        RECT 1.215 0.975 1.285 1.485 ;
+        RECT 0.875 1.035 0.945 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.355 -0.085 2.425 0.425 ;
+        RECT 1.975 -0.085 2.045 0.425 ;
+        RECT 1.605 -0.085 1.675 0.425 ;
+        RECT 1.215 -0.085 1.285 0.285 ;
+        RECT 0.495 -0.085 0.565 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.415 0.15 1.485 1.25 ;
+      RECT 1.415 0.525 1.73 0.66 ;
+      RECT 0.315 0.765 0.385 1.04 ;
+      RECT 0.315 0.765 1.35 0.835 ;
+      RECT 1.28 0.355 1.35 0.835 ;
+      RECT 0.125 0.355 1.35 0.425 ;
+      RECT 0.71 0.15 0.78 0.425 ;
+      RECT 0.125 0.15 0.195 0.425 ;
+      RECT 1.03 0.9 1.1 1.25 ;
+      RECT 0.695 0.9 0.765 1.25 ;
+      RECT 0.695 0.9 1.1 0.97 ;
+      RECT 0.495 0.975 0.565 1.25 ;
+      RECT 0.125 0.975 0.195 1.25 ;
+      RECT 0.125 1.105 0.565 1.175 ;
+  END
+END AOI221_X4
+
+MACRO AOI222_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI222_X1 0 0 ;
+  SIZE 1.52 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.315 0.525 1.46 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.995 0.525 1.08 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.62 0.525 0.72 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.525 0.91 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.525 0.51 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.215 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.5 0.375 1.46 0.45 ;
+        RECT 1.325 0.175 1.46 0.45 ;
+        RECT 1.145 0.375 1.215 1.115 ;
+        RECT 0.5 0.175 0.57 0.45 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.52 1.485 ;
+        RECT 0.415 0.905 0.485 1.485 ;
+        RECT 0.04 0.905 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.52 0.085 ;
+        RECT 0.945 -0.085 1.015 0.31 ;
+        RECT 0.04 -0.085 0.11 0.45 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.575 1.18 1.395 1.25 ;
+      RECT 1.325 0.905 1.395 1.25 ;
+      RECT 0.945 0.905 1.015 1.25 ;
+      RECT 0.575 0.905 0.645 1.25 ;
+      RECT 0.235 0.77 0.305 1.18 ;
+      RECT 0.755 0.77 0.825 1.115 ;
+      RECT 0.235 0.77 0.825 0.84 ;
+  END
+END AOI222_X1
+
+MACRO AOI222_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI222_X2 0 0 ;
+  SIZE 2.66 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.91 0.56 2.045 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.285 0.56 2.42 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.145 0.56 1.28 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.475 0.42 1.545 0.66 ;
+        RECT 0.91 0.42 1.545 0.49 ;
+        RECT 0.91 0.42 1.08 0.66 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.56 0.52 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.69 0.425 0.76 0.66 ;
+        RECT 0.06 0.425 0.76 0.495 ;
+        RECT 0.06 0.425 0.19 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.31 0.77 2.38 1.115 ;
+        RECT 1.77 0.77 2.38 0.84 ;
+        RECT 0.39 0.285 2.035 0.355 ;
+        RECT 1.94 0.77 2.01 1.115 ;
+        RECT 1.77 0.285 1.84 0.84 ;
+        RECT 1.145 0.15 1.28 0.355 ;
+        RECT 0.39 0.15 0.525 0.355 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.66 1.485 ;
+        RECT 0.605 0.905 0.675 1.485 ;
+        RECT 0.225 0.905 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.66 0.085 ;
+        RECT 2.31 -0.085 2.38 0.25 ;
+        RECT 1.555 -0.085 1.625 0.195 ;
+        RECT 0.765 -0.085 0.9 0.215 ;
+        RECT 0.04 -0.085 0.11 0.25 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.1 0.355 2.57 0.425 ;
+      RECT 2.5 0.15 2.57 0.425 ;
+      RECT 2.1 0.15 2.17 0.425 ;
+      RECT 1.715 0.15 2.17 0.22 ;
+      RECT 0.995 1.18 2.57 1.25 ;
+      RECT 2.5 0.905 2.57 1.25 ;
+      RECT 2.12 0.905 2.19 1.25 ;
+      RECT 1.745 0.905 1.815 1.25 ;
+      RECT 1.365 0.905 1.435 1.25 ;
+      RECT 0.995 0.905 1.065 1.25 ;
+      RECT 0.795 0.77 0.865 1.18 ;
+      RECT 0.415 0.77 0.485 1.18 ;
+      RECT 0.045 0.77 0.115 1.18 ;
+      RECT 1.555 0.77 1.625 1.115 ;
+      RECT 1.175 0.77 1.245 1.115 ;
+      RECT 0.045 0.77 1.625 0.84 ;
+  END
+END AOI222_X2
+
+MACRO AOI222_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI222_X4 0 0 ;
+  SIZE 2.66 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.235 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.525 0.51 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.525 0.89 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.135 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.525 1.335 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.33 0.15 2.41 1.205 ;
+        RECT 1.95 0.56 2.41 0.7 ;
+        RECT 2.325 0.15 2.41 0.7 ;
+        RECT 1.95 0.15 2.02 1.205 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.66 1.485 ;
+        RECT 2.51 0.93 2.58 1.485 ;
+        RECT 2.13 0.93 2.2 1.485 ;
+        RECT 1.75 0.93 1.82 1.485 ;
+        RECT 1.37 0.93 1.44 1.485 ;
+        RECT 0.995 1.065 1.065 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.66 0.085 ;
+        RECT 2.51 -0.085 2.58 0.425 ;
+        RECT 2.14 -0.085 2.21 0.425 ;
+        RECT 1.75 -0.085 1.82 0.425 ;
+        RECT 1.37 -0.085 1.44 0.285 ;
+        RECT 0.46 -0.085 0.53 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.57 0.15 1.64 1.205 ;
+      RECT 1.57 0.525 1.885 0.66 ;
+      RECT 0.28 0.765 0.35 1.04 ;
+      RECT 0.28 0.765 1.505 0.835 ;
+      RECT 1.435 0.355 1.505 0.835 ;
+      RECT 0.09 0.355 1.505 0.425 ;
+      RECT 0.84 0.15 0.91 0.425 ;
+      RECT 0.09 0.15 0.16 0.425 ;
+      RECT 1.18 0.93 1.25 1.205 ;
+      RECT 0.66 0.93 0.73 1.065 ;
+      RECT 0.66 0.93 1.25 1 ;
+      RECT 0.09 1.135 0.91 1.205 ;
+      RECT 0.84 1.07 0.91 1.205 ;
+      RECT 0.46 0.93 0.53 1.205 ;
+      RECT 0.09 0.93 0.16 1.205 ;
+  END
+END AOI222_X4
+
+MACRO AOI22_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI22_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.42 0.7 0.66 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.42 0.89 0.66 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.62 0.725 0.69 1.005 ;
+        RECT 0.44 0.725 0.69 0.795 ;
+        RECT 0.44 0.15 0.51 0.795 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.24 1.205 0.31 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.81 -0.085 0.88 0.355 ;
+        RECT 0.055 -0.085 0.125 0.355 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.06 1.07 0.88 1.14 ;
+      RECT 0.81 0.865 0.88 1.14 ;
+      RECT 0.435 0.865 0.505 1.14 ;
+      RECT 0.06 0.865 0.13 1.14 ;
+  END
+END AOI22_X1
+
+MACRO AOI22_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI22_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.155 0.56 1.29 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.48 0.425 1.55 0.66 ;
+        RECT 0.955 0.425 1.55 0.495 ;
+        RECT 0.955 0.425 1.08 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.395 0.56 0.53 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.765 0.755 0.835 ;
+        RECT 0.685 0.525 0.755 0.835 ;
+        RECT 0.06 0.525 0.195 0.835 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.375 0.765 1.445 1.065 ;
+        RECT 0.82 0.765 1.445 0.835 ;
+        RECT 0.395 0.28 1.285 0.355 ;
+        RECT 1.15 0.15 1.285 0.355 ;
+        RECT 0.99 0.765 1.06 1.065 ;
+        RECT 0.82 0.28 0.89 0.835 ;
+        RECT 0.395 0.15 0.53 0.355 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 0.61 1.035 0.68 1.485 ;
+        RECT 0.23 1.035 0.3 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.56 -0.085 1.63 0.36 ;
+        RECT 0.77 -0.085 0.905 0.205 ;
+        RECT 0.045 -0.085 0.115 0.39 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.8 1.18 1.63 1.25 ;
+      RECT 1.56 0.975 1.63 1.25 ;
+      RECT 0.42 0.9 0.49 1.25 ;
+      RECT 0.05 0.9 0.12 1.25 ;
+      RECT 1.18 0.975 1.25 1.25 ;
+      RECT 0.8 0.9 0.87 1.25 ;
+      RECT 0.05 0.9 0.87 0.97 ;
+  END
+END AOI22_X2
+
+MACRO AOI22_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI22_X4 0 0 ;
+  SIZE 3.23 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.915 0.69 2.79 0.76 ;
+        RECT 2.655 0.56 2.79 0.76 ;
+        RECT 1.915 0.56 2.05 0.76 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.91 0.42 3.045 0.66 ;
+        RECT 1.715 0.42 3.045 0.49 ;
+        RECT 2.295 0.42 2.43 0.625 ;
+        RECT 1.715 0.42 1.785 0.66 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.395 0.69 1.29 0.76 ;
+        RECT 1.155 0.56 1.29 0.76 ;
+        RECT 0.395 0.56 0.53 0.76 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.445 0.42 1.515 0.66 ;
+        RECT 0.125 0.42 1.515 0.49 ;
+        RECT 0.755 0.42 0.89 0.625 ;
+        RECT 0.125 0.42 0.195 0.66 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.89 0.825 2.96 1.115 ;
+        RECT 1.75 0.825 2.96 0.895 ;
+        RECT 0.395 0.26 2.805 0.33 ;
+        RECT 2.51 0.825 2.58 1.115 ;
+        RECT 2.13 0.825 2.2 1.115 ;
+        RECT 1.75 0.725 1.82 1.115 ;
+        RECT 1.58 0.725 1.82 0.795 ;
+        RECT 1.58 0.26 1.65 0.795 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.23 1.485 ;
+        RECT 1.37 1.065 1.44 1.485 ;
+        RECT 0.99 1.065 1.06 1.485 ;
+        RECT 0.61 1.065 0.68 1.485 ;
+        RECT 0.23 1.065 0.3 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.23 0.085 ;
+        RECT 3.08 -0.085 3.15 0.335 ;
+        RECT 2.29 -0.085 2.425 0.16 ;
+        RECT 1.53 -0.085 1.665 0.16 ;
+        RECT 0.77 -0.085 0.905 0.16 ;
+        RECT 0.045 -0.085 0.115 0.335 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.56 1.18 3.15 1.25 ;
+      RECT 3.08 0.84 3.15 1.25 ;
+      RECT 2.7 0.96 2.77 1.25 ;
+      RECT 2.32 0.96 2.39 1.25 ;
+      RECT 1.94 0.96 2.01 1.25 ;
+      RECT 1.56 0.87 1.63 1.25 ;
+      RECT 1.18 0.87 1.25 1.16 ;
+      RECT 0.8 0.87 0.87 1.16 ;
+      RECT 0.42 0.87 0.49 1.16 ;
+      RECT 0.05 0.87 0.12 1.16 ;
+      RECT 0.05 0.87 1.63 0.94 ;
+  END
+END AOI22_X4
+
+MACRO BUF_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN BUF_X1 0 0 ;
+  SIZE 0.57 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.19 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.42 0.19 0.51 1.24 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.57 1.485 ;
+        RECT 0.225 0.965 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.57 0.085 ;
+        RECT 0.225 -0.085 0.295 0.325 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.83 0.115 1.24 ;
+      RECT 0.045 0.83 0.355 0.9 ;
+      RECT 0.285 0.39 0.355 0.9 ;
+      RECT 0.045 0.39 0.355 0.46 ;
+      RECT 0.045 0.19 0.115 0.46 ;
+  END
+END BUF_X1
+
+MACRO BUF_X16
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN BUF_X16 0 0 ;
+  SIZE 4.75 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.715 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.42 0.15 4.49 0.925 ;
+        RECT 1.77 0.28 4.49 0.42 ;
+        RECT 4.05 0.28 4.12 0.925 ;
+        RECT 4.04 0.15 4.11 0.42 ;
+        RECT 3.66 0.15 3.73 0.925 ;
+        RECT 3.28 0.15 3.35 0.925 ;
+        RECT 2.9 0.15 2.97 0.925 ;
+        RECT 2.52 0.15 2.59 0.925 ;
+        RECT 2.14 0.15 2.21 0.925 ;
+        RECT 1.77 0.15 1.84 0.925 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.75 1.485 ;
+        RECT 4.61 1.205 4.68 1.485 ;
+        RECT 4.23 1.205 4.3 1.485 ;
+        RECT 3.85 1.205 3.92 1.485 ;
+        RECT 3.47 1.205 3.54 1.485 ;
+        RECT 3.09 1.205 3.16 1.485 ;
+        RECT 2.71 1.205 2.78 1.485 ;
+        RECT 2.33 1.205 2.4 1.485 ;
+        RECT 1.95 1.205 2.02 1.485 ;
+        RECT 1.57 1.205 1.64 1.485 ;
+        RECT 1.19 0.975 1.26 1.485 ;
+        RECT 0.81 0.975 0.88 1.485 ;
+        RECT 0.43 0.975 0.5 1.485 ;
+        RECT 0.055 0.975 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.75 0.085 ;
+        RECT 4.61 -0.085 4.68 0.2 ;
+        RECT 4.23 -0.085 4.3 0.2 ;
+        RECT 3.85 -0.085 3.92 0.2 ;
+        RECT 3.47 -0.085 3.54 0.2 ;
+        RECT 3.09 -0.085 3.16 0.2 ;
+        RECT 2.71 -0.085 2.78 0.2 ;
+        RECT 2.33 -0.085 2.4 0.2 ;
+        RECT 1.95 -0.085 2.02 0.2 ;
+        RECT 1.57 -0.085 1.64 0.34 ;
+        RECT 1.19 -0.085 1.26 0.34 ;
+        RECT 0.81 -0.085 0.88 0.34 ;
+        RECT 0.43 -0.085 0.5 0.34 ;
+        RECT 0.055 -0.085 0.125 0.34 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.38 0.15 1.45 1.25 ;
+      RECT 1 0.15 1.07 1.25 ;
+      RECT 0.62 0.15 0.69 1.25 ;
+      RECT 0.25 0.15 0.32 1.25 ;
+      RECT 1.635 1.05 4.63 1.12 ;
+      RECT 4.56 0.525 4.63 1.12 ;
+      RECT 3.45 0.525 3.52 1.12 ;
+      RECT 2.69 0.525 2.76 1.12 ;
+      RECT 1.635 0.525 1.705 1.12 ;
+      RECT 0.25 0.525 1.705 0.66 ;
+  END
+END BUF_X16
+
+MACRO BUF_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN BUF_X2 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.23 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.465 0.56 0.7 0.7 ;
+        RECT 0.465 0.15 0.535 1.25 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.645 0.975 0.715 1.485 ;
+        RECT 0.265 1.04 0.335 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.645 -0.085 0.715 0.425 ;
+        RECT 0.265 -0.085 0.335 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.085 0.82 0.155 1.25 ;
+      RECT 0.085 0.82 0.395 0.89 ;
+      RECT 0.325 0.39 0.395 0.89 ;
+      RECT 0.085 0.39 0.395 0.46 ;
+      RECT 0.085 0.15 0.155 0.46 ;
+  END
+END BUF_X2
+
+MACRO BUF_X32
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN BUF_X32 0 0 ;
+  SIZE 9.31 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.1 0.93 2.8 1 ;
+        RECT 2.665 0.56 2.8 1 ;
+        RECT 1.905 0.56 2.04 1 ;
+        RECT 1.12 0.56 1.255 1 ;
+        RECT 0.1 0.525 0.17 1 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 8.99 0.15 9.06 1.25 ;
+        RECT 3.3 0.28 9.06 0.42 ;
+        RECT 8.61 0.15 8.68 0.785 ;
+        RECT 8.23 0.15 8.3 0.785 ;
+        RECT 7.85 0.15 7.92 0.785 ;
+        RECT 7.47 0.15 7.54 0.785 ;
+        RECT 7.09 0.15 7.16 0.785 ;
+        RECT 6.71 0.15 6.78 0.785 ;
+        RECT 6.33 0.15 6.4 0.785 ;
+        RECT 5.95 0.15 6.02 0.785 ;
+        RECT 5.57 0.15 5.64 0.785 ;
+        RECT 5.19 0.15 5.26 0.785 ;
+        RECT 4.81 0.15 4.88 0.785 ;
+        RECT 4.43 0.15 4.5 0.785 ;
+        RECT 4.05 0.15 4.12 0.785 ;
+        RECT 3.67 0.15 3.74 0.785 ;
+        RECT 3.3 0.15 3.37 0.785 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 9.31 1.485 ;
+        RECT 9.18 1.065 9.25 1.485 ;
+        RECT 8.8 1.065 8.87 1.485 ;
+        RECT 8.42 1.065 8.49 1.485 ;
+        RECT 8.04 1.065 8.11 1.485 ;
+        RECT 7.66 1.065 7.73 1.485 ;
+        RECT 7.28 1.065 7.35 1.485 ;
+        RECT 6.9 1.065 6.97 1.485 ;
+        RECT 6.52 1.065 6.59 1.485 ;
+        RECT 6.14 1.065 6.21 1.485 ;
+        RECT 5.76 1.065 5.83 1.485 ;
+        RECT 5.38 1.065 5.45 1.485 ;
+        RECT 5 1.065 5.07 1.485 ;
+        RECT 4.62 1.065 4.69 1.485 ;
+        RECT 4.24 1.065 4.31 1.485 ;
+        RECT 3.86 1.065 3.93 1.485 ;
+        RECT 3.48 1.065 3.55 1.485 ;
+        RECT 3.08 1.065 3.15 1.485 ;
+        RECT 2.695 1.065 2.765 1.485 ;
+        RECT 2.315 1.065 2.385 1.485 ;
+        RECT 1.935 1.065 2.005 1.485 ;
+        RECT 1.555 1.065 1.625 1.485 ;
+        RECT 1.175 1.065 1.245 1.485 ;
+        RECT 0.795 1.065 0.865 1.485 ;
+        RECT 0.415 1.065 0.485 1.485 ;
+        RECT 0.04 1.065 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 9.31 0.085 ;
+        RECT 9.18 -0.085 9.25 0.2 ;
+        RECT 8.8 -0.085 8.87 0.2 ;
+        RECT 8.42 -0.085 8.49 0.2 ;
+        RECT 8.04 -0.085 8.11 0.2 ;
+        RECT 7.66 -0.085 7.73 0.2 ;
+        RECT 7.28 -0.085 7.35 0.2 ;
+        RECT 6.9 -0.085 6.97 0.2 ;
+        RECT 6.52 -0.085 6.59 0.2 ;
+        RECT 6.14 -0.085 6.21 0.2 ;
+        RECT 5.76 -0.085 5.83 0.2 ;
+        RECT 5.38 -0.085 5.45 0.2 ;
+        RECT 5 -0.085 5.07 0.2 ;
+        RECT 4.62 -0.085 4.69 0.2 ;
+        RECT 4.24 -0.085 4.31 0.2 ;
+        RECT 3.86 -0.085 3.93 0.2 ;
+        RECT 3.48 -0.085 3.55 0.2 ;
+        RECT 3.08 -0.085 3.15 0.22 ;
+        RECT 2.695 -0.085 2.765 0.34 ;
+        RECT 2.315 -0.085 2.385 0.34 ;
+        RECT 1.935 -0.085 2.005 0.34 ;
+        RECT 1.555 -0.085 1.625 0.34 ;
+        RECT 1.175 -0.085 1.245 0.34 ;
+        RECT 0.795 -0.085 0.865 0.34 ;
+        RECT 0.415 -0.085 0.485 0.34 ;
+        RECT 0.04 -0.085 0.11 0.36 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.165 0.85 8.88 0.92 ;
+      RECT 8.745 0.56 8.88 0.92 ;
+      RECT 2.885 0.405 2.955 0.865 ;
+      RECT 2.505 0.15 2.575 0.865 ;
+      RECT 2.13 0.15 2.2 0.865 ;
+      RECT 1.745 0.405 1.815 0.865 ;
+      RECT 1.365 0.15 1.435 0.865 ;
+      RECT 0.985 0.15 1.055 0.865 ;
+      RECT 0.615 0.405 0.685 0.865 ;
+      RECT 0.235 0.15 0.305 0.865 ;
+      RECT 7.605 0.56 7.74 0.92 ;
+      RECT 6.465 0.56 6.6 0.92 ;
+      RECT 5.325 0.56 5.46 0.92 ;
+      RECT 4.185 0.56 4.32 0.92 ;
+      RECT 3.165 0.405 3.235 0.92 ;
+      RECT 0.235 0.405 3.235 0.495 ;
+      RECT 2.89 0.15 2.96 0.495 ;
+      RECT 1.75 0.15 1.82 0.495 ;
+      RECT 0.605 0.15 0.675 0.495 ;
+  END
+END BUF_X32
+
+MACRO BUF_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN BUF_X4 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.17 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.995 0.15 1.065 1.25 ;
+        RECT 0.615 0.56 1.065 0.7 ;
+        RECT 0.615 0.15 0.685 1.25 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.175 0.975 1.245 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 1.175 -0.085 1.245 0.37 ;
+        RECT 0.795 -0.085 0.865 0.37 ;
+        RECT 0.415 -0.085 0.485 0.37 ;
+        RECT 0.04 -0.085 0.11 0.37 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.235 0.15 0.305 1.25 ;
+      RECT 0.235 0.525 0.55 0.66 ;
+  END
+END BUF_X4
+
+MACRO BUF_X8
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN BUF_X8 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.17 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.125 0.15 2.195 1.25 ;
+        RECT 0.995 0.56 2.195 0.7 ;
+        RECT 1.755 0.56 1.825 1.25 ;
+        RECT 1.745 0.15 1.815 0.7 ;
+        RECT 1.365 0.15 1.435 1.25 ;
+        RECT 0.995 0.15 1.065 1.25 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.315 0.975 2.385 1.485 ;
+        RECT 1.935 0.975 2.005 1.485 ;
+        RECT 1.555 0.975 1.625 1.485 ;
+        RECT 1.175 0.975 1.245 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.315 -0.085 2.385 0.425 ;
+        RECT 1.935 -0.085 2.005 0.425 ;
+        RECT 1.555 -0.085 1.625 0.425 ;
+        RECT 1.185 -0.085 1.255 0.425 ;
+        RECT 0.795 -0.085 0.865 0.425 ;
+        RECT 0.415 -0.085 0.485 0.425 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.605 0.15 0.675 1.25 ;
+      RECT 0.235 0.15 0.305 1.25 ;
+      RECT 0.235 0.525 0.925 0.66 ;
+  END
+END BUF_X8
+
+MACRO CLKBUF_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKBUF_X1 0 0 ;
+  SIZE 0.57 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.21 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.15 0.51 1.24 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.57 1.485 ;
+        RECT 0.245 0.965 0.315 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.57 0.085 ;
+        RECT 0.245 -0.085 0.315 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.065 0.83 0.135 1.24 ;
+      RECT 0.065 0.83 0.37 0.9 ;
+      RECT 0.3 0.35 0.37 0.9 ;
+      RECT 0.065 0.35 0.37 0.42 ;
+      RECT 0.065 0.15 0.135 0.42 ;
+  END
+END CLKBUF_X1
+
+MACRO CLKBUF_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKBUF_X2 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.19 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.15 0.51 1.25 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.605 0.975 0.675 1.485 ;
+        RECT 0.225 1.04 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.905 0.115 1.25 ;
+      RECT 0.045 0.905 0.36 0.975 ;
+      RECT 0.29 0.35 0.36 0.975 ;
+      RECT 0.045 0.35 0.36 0.42 ;
+      RECT 0.045 0.15 0.115 0.42 ;
+  END
+END CLKBUF_X2
+
+MACRO CLKBUF_X3
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKBUF_X3 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.19 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.795 0.18 0.865 1.175 ;
+        RECT 0.425 0.42 0.865 0.56 ;
+        RECT 0.425 0.18 0.495 1.175 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.605 0.9 0.675 1.485 ;
+        RECT 0.225 0.9 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.605 -0.085 0.675 0.235 ;
+        RECT 0.225 -0.085 0.295 0.235 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.765 0.115 1.175 ;
+      RECT 0.045 0.765 0.355 0.835 ;
+      RECT 0.285 0.38 0.355 0.835 ;
+      RECT 0.045 0.38 0.355 0.45 ;
+      RECT 0.045 0.18 0.115 0.45 ;
+  END
+END CLKBUF_X3
+
+MACRO CLKGATETST_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATETST_X1 0 0 ;
+  SIZE 2.85 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.075 0.7 2.22 0.84 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.7 0.38 0.84 ;
+    END
+  END E
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.7 0.185 0.84 ;
+    END
+  END SE
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.705 0.35 2.79 1.235 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.85 1.485 ;
+        RECT 2.48 1.045 2.615 1.485 ;
+        RECT 2.135 0.94 2.205 1.485 ;
+        RECT 1.755 0.94 1.825 1.485 ;
+        RECT 1.185 1.01 1.32 1.485 ;
+        RECT 0.385 1.04 0.52 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.85 0.085 ;
+        RECT 2.485 -0.085 2.62 0.385 ;
+        RECT 1.75 -0.085 1.82 0.42 ;
+        RECT 1.185 -0.085 1.32 0.38 ;
+        RECT 0.385 -0.085 0.52 0.385 ;
+        RECT 0.04 -0.085 0.11 0.42 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.33 0.525 2.4 1.005 ;
+      RECT 2.33 0.525 2.64 0.66 ;
+      RECT 2.14 0.525 2.64 0.595 ;
+      RECT 2.14 0.285 2.21 0.595 ;
+      RECT 1.935 0.15 2.005 1.21 ;
+      RECT 1.935 0.15 2.07 0.22 ;
+      RECT 1.565 0.93 1.69 1.205 ;
+      RECT 1.62 0.585 1.69 1.205 ;
+      RECT 1.105 0.585 1.69 0.655 ;
+      RECT 1.565 0.285 1.635 0.655 ;
+      RECT 0.805 0.285 0.875 1.095 ;
+      RECT 0.805 0.735 1.555 0.805 ;
+      RECT 1.405 0.875 1.475 1.235 ;
+      RECT 0.67 1.16 1.12 1.23 ;
+      RECT 1.05 0.875 1.12 1.23 ;
+      RECT 0.67 0.15 0.74 1.23 ;
+      RECT 1.05 0.875 1.475 0.945 ;
+      RECT 0.945 0.445 1.475 0.515 ;
+      RECT 1.405 0.285 1.475 0.515 ;
+      RECT 0.945 0.15 1.015 0.515 ;
+      RECT 0.67 0.15 1.015 0.22 ;
+      RECT 0.045 0.905 0.115 1.235 ;
+      RECT 0.045 0.905 0.57 0.975 ;
+      RECT 0.5 0.45 0.57 0.975 ;
+      RECT 0.235 0.45 0.57 0.52 ;
+      RECT 0.235 0.285 0.305 0.52 ;
+  END
+END CLKGATETST_X1
+
+MACRO CLKGATETST_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATETST_X2 0 0 ;
+  SIZE 3.04 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.18 0.85 2.825 0.92 ;
+        RECT 2.72 0.525 2.825 0.92 ;
+        RECT 2.18 0.525 2.25 0.92 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.56 0.375 0.725 ;
+    END
+  END E
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.56 0.545 0.725 ;
+    END
+  END SE
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.52 0.15 2.6 0.785 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.04 1.485 ;
+        RECT 2.675 1.24 2.81 1.485 ;
+        RECT 2.275 1.24 2.41 1.485 ;
+        RECT 1.83 1.24 1.965 1.485 ;
+        RECT 1.515 0.91 1.585 1.485 ;
+        RECT 0.73 1.115 0.865 1.485 ;
+        RECT 0.225 0.94 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.04 0.085 ;
+        RECT 2.7 -0.085 2.77 0.195 ;
+        RECT 2.325 -0.085 2.395 0.195 ;
+        RECT 1.765 -0.085 1.9 0.185 ;
+        RECT 1.45 -0.085 1.52 0.405 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.68 1.08 1.75 1.245 ;
+      RECT 2.895 0.15 2.965 1.24 ;
+      RECT 1.68 1.08 2.965 1.15 ;
+      RECT 2.045 0.39 2.115 0.925 ;
+      RECT 2.045 0.39 2.45 0.46 ;
+      RECT 2.17 0.325 2.45 0.46 ;
+      RECT 2.17 0.15 2.24 0.46 ;
+      RECT 1.38 0.76 1.775 0.83 ;
+      RECT 1.705 0.28 1.775 0.83 ;
+      RECT 1.61 0.28 1.775 0.35 ;
+      RECT 1.145 0.285 1.215 1.03 ;
+      RECT 1.145 0.525 1.63 0.66 ;
+      RECT 1.08 0.285 1.215 0.42 ;
+      RECT 0.045 0.15 0.115 1.125 ;
+      RECT 0.41 0.95 1.015 1.02 ;
+      RECT 0.945 0.15 1.015 1.02 ;
+      RECT 0.41 0.805 0.48 1.02 ;
+      RECT 0.045 0.805 0.48 0.875 ;
+      RECT 0.945 0.61 1.08 0.745 ;
+      RECT 0.945 0.15 1.285 0.22 ;
+      RECT 0.61 0.41 0.68 0.885 ;
+      RECT 0.61 0.41 0.87 0.545 ;
+      RECT 0.425 0.41 0.87 0.48 ;
+      RECT 0.425 0.15 0.495 0.48 ;
+  END
+END CLKGATETST_X2
+
+MACRO CLKGATETST_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATETST_X4 0 0 ;
+  SIZE 3.8 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.21 0.77 2.85 0.85 ;
+        RECT 2.72 0.525 2.85 0.85 ;
+        RECT 2.21 0.525 2.28 0.85 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.56 0.38 0.775 ;
+    END
+  END E
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.56 0.185 0.775 ;
+    END
+  END SE
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.455 0.18 3.525 0.925 ;
+        RECT 3.085 0.42 3.525 0.56 ;
+        RECT 3.085 0.18 3.155 0.925 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.8 1.485 ;
+        RECT 3.645 0.975 3.715 1.485 ;
+        RECT 3.265 0.975 3.335 1.485 ;
+        RECT 2.885 1.2 2.955 1.485 ;
+        RECT 2.505 1.2 2.575 1.485 ;
+        RECT 2.13 1.205 2.2 1.485 ;
+        RECT 1.49 1.165 1.625 1.485 ;
+        RECT 0.755 1.13 0.825 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.8 0.085 ;
+        RECT 3.645 -0.085 3.715 0.2 ;
+        RECT 3.265 -0.085 3.335 0.2 ;
+        RECT 2.885 -0.085 2.955 0.2 ;
+        RECT 2.125 -0.085 2.195 0.285 ;
+        RECT 1.53 -0.085 1.6 0.285 ;
+        RECT 0.755 -0.085 0.825 0.195 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.29 0.93 3.015 1 ;
+      RECT 2.945 0.35 3.015 1 ;
+      RECT 2.655 0.35 3.015 0.42 ;
+      RECT 2.655 0.185 2.725 0.42 ;
+      RECT 2.48 0.185 2.725 0.255 ;
+      RECT 1.13 1.03 1.205 1.25 ;
+      RECT 1.13 1.03 2.125 1.1 ;
+      RECT 2.055 0.39 2.125 1.1 ;
+      RECT 1.13 0.525 1.2 1.25 ;
+      RECT 2.425 0.39 2.495 0.66 ;
+      RECT 1.13 0.525 1.645 0.66 ;
+      RECT 1.39 0.185 1.46 0.66 ;
+      RECT 2.055 0.39 2.495 0.46 ;
+      RECT 1.11 0.185 1.46 0.255 ;
+      RECT 1.265 0.865 1.99 0.935 ;
+      RECT 1.92 0.15 1.99 0.935 ;
+      RECT 1.265 0.795 1.335 0.935 ;
+      RECT 1.405 0.725 1.78 0.795 ;
+      RECT 1.71 0.15 1.78 0.795 ;
+      RECT 0.575 0.975 0.645 1.25 ;
+      RECT 0.575 0.975 1.065 1.045 ;
+      RECT 0.975 0.39 1.065 1.045 ;
+      RECT 0.975 0.39 1.325 0.46 ;
+      RECT 0.975 0.26 1.045 1.045 ;
+      RECT 0.575 0.26 1.045 0.33 ;
+      RECT 0.575 0.15 0.645 0.33 ;
+      RECT 0.045 0.84 0.115 1.25 ;
+      RECT 0.045 0.84 0.91 0.91 ;
+      RECT 0.84 0.415 0.91 0.91 ;
+      RECT 0.235 0.415 0.91 0.485 ;
+      RECT 0.235 0.15 0.335 0.485 ;
+  END
+END CLKGATETST_X4
+
+MACRO CLKGATETST_X8
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATETST_X8 0 0 ;
+  SIZE 5.51 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.385 0.845 3.925 0.915 ;
+        RECT 3.855 0.56 3.925 0.915 ;
+        RECT 3.765 0.56 3.925 0.63 ;
+        RECT 3.1 0.56 3.17 0.915 ;
+        RECT 3.035 0.56 3.17 0.63 ;
+        RECT 2.385 0.525 2.455 0.915 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.33 0.7 0.51 0.84 ;
+    END
+  END E
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.7 0.25 0.84 ;
+    END
+  END SE
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 5.205 0.15 5.275 1.25 ;
+        RECT 4.12 0.56 5.275 0.7 ;
+        RECT 4.825 0.15 4.895 1.25 ;
+        RECT 4.445 0.15 4.515 1.25 ;
+        RECT 4.075 0.975 4.19 1.25 ;
+        RECT 4.12 0.15 4.19 1.25 ;
+        RECT 4.075 0.15 4.19 0.285 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 5.51 1.485 ;
+        RECT 5.395 0.975 5.465 1.485 ;
+        RECT 5.015 0.975 5.085 1.485 ;
+        RECT 4.635 0.975 4.705 1.485 ;
+        RECT 4.26 0.975 4.33 1.485 ;
+        RECT 3.845 1.01 3.98 1.485 ;
+        RECT 3.465 1.01 3.6 1.485 ;
+        RECT 3.085 1.01 3.22 1.485 ;
+        RECT 2.705 1.01 2.84 1.485 ;
+        RECT 2.365 1.06 2.435 1.485 ;
+        RECT 1.915 1.1 2.05 1.485 ;
+        RECT 1.535 1.1 1.67 1.485 ;
+        RECT 0.75 1.24 0.885 1.485 ;
+        RECT 0.41 1.215 0.545 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 5.51 0.085 ;
+        RECT 5.395 -0.085 5.465 0.285 ;
+        RECT 5.015 -0.085 5.085 0.285 ;
+        RECT 4.635 -0.085 4.705 0.285 ;
+        RECT 4.255 -0.085 4.325 0.285 ;
+        RECT 3.845 -0.085 3.98 0.25 ;
+        RECT 3.085 -0.085 3.22 0.16 ;
+        RECT 2.33 -0.085 2.465 0.16 ;
+        RECT 1.95 -0.085 2.02 0.425 ;
+        RECT 1.575 -0.085 1.645 0.265 ;
+        RECT 0.75 -0.085 0.885 0.175 ;
+        RECT 0.44 -0.085 0.51 0.285 ;
+        RECT 0.065 -0.085 0.135 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.235 0.71 3.79 0.78 ;
+      RECT 2.52 0.71 3.03 0.78 ;
+      RECT 3.235 0.705 3.7 0.78 ;
+      RECT 3.63 0.16 3.7 0.78 ;
+      RECT 2.9 0.425 2.97 0.78 ;
+      RECT 3.235 0.425 3.305 0.78 ;
+      RECT 2.71 0.425 3.305 0.495 ;
+      RECT 3.63 0.35 4.055 0.485 ;
+      RECT 3.47 0.16 3.7 0.23 ;
+      RECT 1.16 0.56 1.23 1.185 ;
+      RECT 1.16 0.965 2.305 1.035 ;
+      RECT 2.235 0.29 2.305 1.035 ;
+      RECT 2.575 0.56 2.735 0.63 ;
+      RECT 1.16 0.56 1.75 0.63 ;
+      RECT 3.37 0.555 3.52 0.625 ;
+      RECT 2.575 0.29 2.645 0.63 ;
+      RECT 1.435 0.18 1.505 0.63 ;
+      RECT 3.37 0.29 3.44 0.625 ;
+      RECT 2.235 0.29 3.44 0.36 ;
+      RECT 1.155 0.18 1.505 0.25 ;
+      RECT 1.315 0.83 2.17 0.9 ;
+      RECT 2.1 0.195 2.17 0.9 ;
+      RECT 1.315 0.715 1.385 0.9 ;
+      RECT 1.45 0.695 1.885 0.765 ;
+      RECT 1.815 0.185 1.885 0.765 ;
+      RECT 1.73 0.185 1.885 0.39 ;
+      RECT 0.565 1.065 1.085 1.135 ;
+      RECT 1.015 0.25 1.085 1.135 ;
+      RECT 1.015 0.425 1.37 0.495 ;
+      RECT 0.6 0.25 1.085 0.32 ;
+      RECT 0.6 0.15 0.67 0.32 ;
+      RECT 0.07 0.905 0.14 1.25 ;
+      RECT 0.07 0.905 0.95 0.975 ;
+      RECT 0.87 0.42 0.95 0.975 ;
+      RECT 0.26 0.42 0.95 0.49 ;
+      RECT 0.26 0.15 0.33 0.49 ;
+  END
+END CLKGATETST_X8
+
+MACRO CLKGATE_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATE_X1 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.54 0.42 1.895 0.56 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.91 0.525 1.08 0.7 ;
+    END
+  END E
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.31 0.175 2.41 1.09 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.03 0.915 2.1 1.485 ;
+        RECT 1.585 0.89 1.655 1.485 ;
+        RECT 0.955 0.9 1.09 1.485 ;
+        RECT 0.225 0.955 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.12 -0.085 2.19 0.225 ;
+        RECT 1.585 -0.085 1.655 0.195 ;
+        RECT 0.985 -0.085 1.055 0.32 ;
+        RECT 0.225 -0.085 0.295 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.785 0.765 1.855 1.09 ;
+      RECT 1.785 0.765 2.245 0.835 ;
+      RECT 2.175 0.35 2.245 0.835 ;
+      RECT 1.97 0.35 2.245 0.42 ;
+      RECT 1.97 0.185 2.04 0.42 ;
+      RECT 1.405 0.195 1.475 1.09 ;
+      RECT 1.145 0.525 1.475 0.66 ;
+      RECT 1.175 0.765 1.245 1.05 ;
+      RECT 0.695 0.765 1.245 0.835 ;
+      RECT 0.695 0.39 0.765 0.835 ;
+      RECT 0.695 0.39 1.245 0.46 ;
+      RECT 1.175 0.27 1.245 0.46 ;
+      RECT 0.51 0.98 0.715 1.05 ;
+      RECT 0.51 0.22 0.58 1.05 ;
+      RECT 0.175 0.59 0.58 0.725 ;
+      RECT 0.51 0.22 0.71 0.29 ;
+      RECT 0.04 0.265 0.11 1.04 ;
+      RECT 0.04 0.45 0.44 0.52 ;
+  END
+END CLKGATE_X1
+
+MACRO CLKGATE_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATE_X2 0 0 ;
+  SIZE 2.66 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.58 0.42 1.65 0.66 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.34 0.42 0.51 0.59 ;
+    END
+  END E
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.32 0.185 2.41 1.215 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.66 1.485 ;
+        RECT 2.505 0.94 2.575 1.485 ;
+        RECT 2.095 0.94 2.165 1.485 ;
+        RECT 1.725 0.89 1.795 1.485 ;
+        RECT 0.985 0.98 1.055 1.485 ;
+        RECT 0.225 0.94 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.66 0.085 ;
+        RECT 2.505 -0.085 2.575 0.22 ;
+        RECT 2.095 -0.085 2.165 0.22 ;
+        RECT 1.565 -0.085 1.635 0.235 ;
+        RECT 0.955 -0.085 1.09 0.285 ;
+        RECT 0.225 -0.085 0.295 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.915 0.805 1.985 1.215 ;
+      RECT 1.915 0.805 2.255 0.875 ;
+      RECT 2.185 0.39 2.255 0.875 ;
+      RECT 1.725 0.39 2.255 0.46 ;
+      RECT 1.725 0.185 1.795 0.46 ;
+      RECT 1.12 1.18 1.64 1.25 ;
+      RECT 1.57 0.755 1.64 1.25 ;
+      RECT 0.36 1.18 0.92 1.25 ;
+      RECT 0.85 0.79 0.92 1.25 ;
+      RECT 1.12 0.79 1.19 1.25 ;
+      RECT 0.36 0.805 0.43 1.25 ;
+      RECT 0.04 0.295 0.11 1.17 ;
+      RECT 0.04 0.805 0.43 0.875 ;
+      RECT 0.85 0.79 1.19 0.86 ;
+      RECT 1.57 0.755 1.785 0.825 ;
+      RECT 1.715 0.56 1.785 0.825 ;
+      RECT 1.715 0.56 2.095 0.63 ;
+      RECT 1.42 0.49 1.49 0.975 ;
+      RECT 1.065 0.49 1.49 0.56 ;
+      RECT 1.385 0.185 1.455 0.56 ;
+      RECT 1.255 0.65 1.325 1.115 ;
+      RECT 0.74 0.65 1.325 0.72 ;
+      RECT 0.74 0.585 0.99 0.72 ;
+      RECT 0.92 0.35 0.99 0.72 ;
+      RECT 0.92 0.35 1.28 0.42 ;
+      RECT 0.605 0.2 0.675 1.115 ;
+      RECT 0.175 0.655 0.675 0.725 ;
+      RECT 0.175 0.525 0.245 0.725 ;
+  END
+END CLKGATE_X2
+
+MACRO CLKGATE_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATE_X4 0 0 ;
+  SIZE 3.23 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.895 0.39 1.965 0.66 ;
+        RECT 1.535 0.39 1.965 0.46 ;
+        RECT 1.535 0.39 1.65 0.7 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.35 0.42 0.51 0.63 ;
+    END
+  END E
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.925 0.15 2.995 1.24 ;
+        RECT 2.555 0.42 2.995 0.56 ;
+        RECT 2.555 0.15 2.625 1.24 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.23 1.485 ;
+        RECT 3.115 0.965 3.185 1.485 ;
+        RECT 2.735 0.965 2.805 1.485 ;
+        RECT 2.355 1.065 2.425 1.485 ;
+        RECT 1.975 1.065 2.045 1.485 ;
+        RECT 1.57 1.24 1.705 1.485 ;
+        RECT 0.995 0.965 1.065 1.485 ;
+        RECT 0.235 0.965 0.305 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.23 0.085 ;
+        RECT 3.115 -0.085 3.185 0.215 ;
+        RECT 2.735 -0.085 2.805 0.215 ;
+        RECT 2.325 -0.085 2.46 0.185 ;
+        RECT 1.58 -0.085 1.65 0.285 ;
+        RECT 0.995 -0.085 1.065 0.32 ;
+        RECT 0.235 -0.085 0.305 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.165 0.905 2.235 1.24 ;
+      RECT 1.79 0.905 1.86 1.24 ;
+      RECT 1.79 0.905 2.49 0.975 ;
+      RECT 2.42 0.255 2.49 0.975 ;
+      RECT 1.95 0.255 2.49 0.325 ;
+      RECT 0.05 0.15 0.12 1.24 ;
+      RECT 0.37 1.165 0.885 1.235 ;
+      RECT 0.815 0.83 0.885 1.235 ;
+      RECT 1.13 1.105 1.64 1.175 ;
+      RECT 1.57 0.765 1.64 1.175 ;
+      RECT 0.37 0.83 0.44 1.235 ;
+      RECT 1.13 0.83 1.2 1.175 ;
+      RECT 0.815 0.83 1.2 0.9 ;
+      RECT 0.05 0.83 0.44 0.9 ;
+      RECT 1.57 0.765 2.32 0.835 ;
+      RECT 2.25 0.525 2.32 0.835 ;
+      RECT 0.92 0.56 0.99 0.9 ;
+      RECT 1.715 0.525 1.785 0.835 ;
+      RECT 1.4 0.15 1.47 1.04 ;
+      RECT 1.19 0.56 1.47 0.63 ;
+      RECT 1.265 0.695 1.335 0.87 ;
+      RECT 1.055 0.695 1.335 0.765 ;
+      RECT 1.055 0.39 1.125 0.765 ;
+      RECT 0.75 0.39 0.82 0.66 ;
+      RECT 0.75 0.39 1.255 0.46 ;
+      RECT 1.185 0.3 1.255 0.46 ;
+      RECT 0.615 0.2 0.685 1.095 ;
+      RECT 0.185 0.695 0.685 0.765 ;
+      RECT 0.185 0.525 0.255 0.765 ;
+  END
+END CLKGATE_X4
+
+MACRO CLKGATE_X8
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATE_X8 0 0 ;
+  SIZE 4.94 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.625 0.86 2.935 0.93 ;
+        RECT 2.865 0.525 2.935 0.93 ;
+        RECT 2.13 0.525 2.22 0.93 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.345 0.56 0.51 0.7 ;
+    END
+  END E
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.615 0.15 4.685 1.235 ;
+        RECT 3.485 0.42 4.685 0.56 ;
+        RECT 4.235 0.15 4.305 1.235 ;
+        RECT 3.855 0.15 3.925 1.235 ;
+        RECT 3.485 0.15 3.555 1.235 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.94 1.485 ;
+        RECT 4.805 0.96 4.875 1.485 ;
+        RECT 4.425 0.96 4.495 1.485 ;
+        RECT 4.045 0.96 4.115 1.485 ;
+        RECT 3.665 0.96 3.735 1.485 ;
+        RECT 3.275 0.96 3.345 1.485 ;
+        RECT 2.88 1.205 2.95 1.485 ;
+        RECT 2.5 1.205 2.57 1.485 ;
+        RECT 2.12 1.205 2.19 1.485 ;
+        RECT 1.725 1.065 1.795 1.485 ;
+        RECT 1.355 1.175 1.49 1.485 ;
+        RECT 1.005 0.995 1.075 1.485 ;
+        RECT 0.23 0.96 0.3 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.94 0.085 ;
+        RECT 4.805 -0.085 4.875 0.285 ;
+        RECT 4.425 -0.085 4.495 0.285 ;
+        RECT 4.045 -0.085 4.115 0.285 ;
+        RECT 3.67 -0.085 3.74 0.285 ;
+        RECT 3.245 -0.085 3.38 0.16 ;
+        RECT 2.47 -0.085 2.605 0.16 ;
+        RECT 1.715 -0.085 1.85 0.16 ;
+        RECT 1.355 -0.085 1.49 0.16 ;
+        RECT 1.005 -0.085 1.075 0.285 ;
+        RECT 0.2 -0.085 0.335 0.25 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.07 0.725 3.14 1.235 ;
+      RECT 2.66 0.995 2.795 1.2 ;
+      RECT 2.28 0.995 2.415 1.2 ;
+      RECT 1.905 0.995 2.04 1.2 ;
+      RECT 1.905 0.995 3.14 1.065 ;
+      RECT 3.005 0.725 3.42 0.795 ;
+      RECT 3.35 0.525 3.42 0.795 ;
+      RECT 2.31 0.725 2.74 0.795 ;
+      RECT 2.67 0.39 2.74 0.795 ;
+      RECT 3.005 0.39 3.075 0.795 ;
+      RECT 2.31 0.39 2.38 0.795 ;
+      RECT 2.67 0.39 3.075 0.46 ;
+      RECT 2.095 0.39 2.38 0.46 ;
+      RECT 0.87 0.725 1.275 0.795 ;
+      RECT 1.205 0.15 1.275 0.795 ;
+      RECT 3.155 0.255 3.225 0.66 ;
+      RECT 2.5 0.255 2.57 0.66 ;
+      RECT 1.825 0.255 1.895 0.66 ;
+      RECT 1.205 0.255 3.225 0.325 ;
+      RECT 0.44 1.15 0.94 1.22 ;
+      RECT 0.87 0.86 0.94 1.22 ;
+      RECT 0.44 0.765 0.51 1.22 ;
+      RECT 1.49 1.005 1.645 1.075 ;
+      RECT 1.49 0.43 1.56 1.075 ;
+      RECT 0.87 0.86 1.56 0.93 ;
+      RECT 0.18 0.765 0.51 0.835 ;
+      RECT 0.18 0.605 0.25 0.835 ;
+      RECT 1.49 0.43 1.645 0.5 ;
+      RECT 0.585 1.01 0.805 1.08 ;
+      RECT 0.735 0.525 0.805 1.08 ;
+      RECT 0.735 0.525 1.14 0.66 ;
+      RECT 0.865 0.18 0.935 0.66 ;
+      RECT 0.585 0.18 0.935 0.25 ;
+      RECT 0.045 0.15 0.115 1.235 ;
+      RECT 0.575 0.39 0.645 0.87 ;
+      RECT 0.045 0.39 0.8 0.46 ;
+  END
+END CLKGATE_X8
+
+MACRO DFFRS_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFFRS_X1 0 0 ;
+  SIZE 4.56 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.12 0.585 4.31 0.84 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.7 1.345 0.84 ;
+    END
+  END RN
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.8 0.7 0.89 0.84 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.24 0.28 4.385 0.495 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.4 0.51 0.875 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.185 0.13 1.075 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.56 1.485 ;
+        RECT 4.255 0.915 4.325 1.485 ;
+        RECT 3.325 1.03 3.46 1.485 ;
+        RECT 2.795 0.835 2.93 1.485 ;
+        RECT 2.415 0.89 2.55 1.485 ;
+        RECT 1.655 0.99 1.79 1.485 ;
+        RECT 1.345 0.925 1.415 1.485 ;
+        RECT 0.965 1.065 1.035 1.485 ;
+        RECT 0.56 1.095 0.695 1.485 ;
+        RECT 0.215 1.1 0.35 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.56 0.085 ;
+        RECT 4.225 -0.085 4.36 0.16 ;
+        RECT 3.135 -0.085 3.27 0.285 ;
+        RECT 2.415 -0.085 2.55 0.285 ;
+        RECT 1.47 -0.085 1.605 0.285 ;
+        RECT 0.935 -0.085 1.07 0.285 ;
+        RECT 0.215 -0.085 0.35 0.2 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.68 1.18 4.055 1.25 ;
+      RECT 3.985 0.15 4.055 1.25 ;
+      RECT 1.955 1.165 2.275 1.235 ;
+      RECT 2.205 0.35 2.275 1.235 ;
+      RECT 3.68 0.76 3.75 1.25 ;
+      RECT 3.02 0.76 3.09 1.07 ;
+      RECT 3.02 0.76 3.75 0.83 ;
+      RECT 3.62 0.15 3.69 0.46 ;
+      RECT 2.98 0.35 3.69 0.42 ;
+      RECT 2.205 0.35 2.76 0.42 ;
+      RECT 2.69 0.165 2.76 0.42 ;
+      RECT 2.98 0.165 3.05 0.42 ;
+      RECT 2.69 0.165 3.05 0.235 ;
+      RECT 3.62 0.15 4.055 0.22 ;
+      RECT 3.85 0.62 3.92 1.115 ;
+      RECT 2.5 0.62 3.92 0.69 ;
+      RECT 3.76 0.285 3.83 0.69 ;
+      RECT 3.545 0.895 3.615 1.115 ;
+      RECT 3.175 0.895 3.245 1.115 ;
+      RECT 3.175 0.895 3.615 0.965 ;
+      RECT 2.635 0.755 2.705 1.07 ;
+      RECT 2.345 0.755 2.705 0.825 ;
+      RECT 2.345 0.485 2.415 0.825 ;
+      RECT 2.345 0.485 3.545 0.555 ;
+      RECT 2.825 0.3 2.895 0.555 ;
+      RECT 2.065 0.185 2.135 1.085 ;
+      RECT 1.09 0.495 2.135 0.63 ;
+      RECT 1.875 0.855 1.945 1.075 ;
+      RECT 1.505 0.855 1.575 1.075 ;
+      RECT 1.505 0.855 1.945 0.925 ;
+      RECT 0.955 0.925 1.26 0.995 ;
+      RECT 0.955 0.35 1.025 0.995 ;
+      RECT 0.595 0.555 1.025 0.625 ;
+      RECT 0.95 0.35 1.025 0.625 ;
+      RECT 0.95 0.35 1.9 0.425 ;
+      RECT 0.2 0.96 0.88 1.03 ;
+      RECT 0.2 0.265 0.27 1.03 ;
+      RECT 0.2 0.265 0.695 0.335 ;
+      RECT 4.45 0.185 4.52 1.25 ;
+  END
+END DFFRS_X1
+
+MACRO DFFRS_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFFRS_X2 0 0 ;
+  SIZE 4.94 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.485 0.28 4.69 0.46 ;
+        RECT 4.485 0.28 4.555 0.575 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.39 0.545 1.46 0.7 ;
+    END
+  END RN
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.545 1.27 0.7 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.62 0.54 4.72 0.7 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.625 0.4 0.7 0.965 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.24 0.2 0.32 0.965 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.94 1.485 ;
+        RECT 4.59 0.765 4.66 1.485 ;
+        RECT 3.695 1.03 3.83 1.485 ;
+        RECT 3.195 0.765 3.265 1.485 ;
+        RECT 2.815 0.955 2.885 1.485 ;
+        RECT 2.055 0.955 2.125 1.485 ;
+        RECT 1.715 0.895 1.785 1.485 ;
+        RECT 1.335 1.08 1.405 1.485 ;
+        RECT 0.875 1.205 0.945 1.485 ;
+        RECT 0.425 1.205 0.495 1.485 ;
+        RECT 0.05 0.925 0.12 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.94 0.085 ;
+        RECT 4.56 -0.085 4.695 0.215 ;
+        RECT 3.505 -0.085 3.64 0.285 ;
+        RECT 2.785 -0.085 2.92 0.285 ;
+        RECT 1.87 -0.085 1.94 0.32 ;
+        RECT 1.335 -0.085 1.405 0.32 ;
+        RECT 0.805 -0.085 0.875 0.2 ;
+        RECT 0.425 -0.085 0.495 0.2 ;
+        RECT 0.05 -0.085 0.12 0.415 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 4.05 1.18 4.39 1.25 ;
+      RECT 4.32 0.15 4.39 1.25 ;
+      RECT 2.325 1.14 2.64 1.21 ;
+      RECT 2.57 0.35 2.64 1.21 ;
+      RECT 4.05 0.76 4.12 1.25 ;
+      RECT 3.39 0.76 3.46 1.04 ;
+      RECT 3.39 0.76 4.12 0.83 ;
+      RECT 3.985 0.15 4.055 0.46 ;
+      RECT 3.35 0.35 4.055 0.42 ;
+      RECT 2.57 0.35 3.13 0.42 ;
+      RECT 3.06 0.185 3.13 0.42 ;
+      RECT 3.35 0.185 3.42 0.42 ;
+      RECT 3.06 0.185 3.42 0.255 ;
+      RECT 3.985 0.15 4.39 0.22 ;
+      RECT 4.185 0.62 4.255 1.115 ;
+      RECT 2.895 0.62 4.255 0.69 ;
+      RECT 4.13 0.285 4.2 0.69 ;
+      RECT 3.915 0.895 3.985 1.115 ;
+      RECT 3.545 0.895 3.615 1.115 ;
+      RECT 3.545 0.895 3.985 0.965 ;
+      RECT 3.005 0.755 3.075 1.04 ;
+      RECT 2.76 0.755 3.075 0.825 ;
+      RECT 2.76 0.485 2.83 0.825 ;
+      RECT 2.76 0.485 3.915 0.555 ;
+      RECT 3.195 0.32 3.265 0.555 ;
+      RECT 2.425 0.2 2.505 1.075 ;
+      RECT 1.58 0.58 2.505 0.65 ;
+      RECT 2.245 0.82 2.315 1.075 ;
+      RECT 1.875 0.82 1.945 1.075 ;
+      RECT 1.875 0.82 2.315 0.89 ;
+      RECT 1.065 0.845 1.63 0.915 ;
+      RECT 1.065 0.41 1.135 0.915 ;
+      RECT 0.84 0.525 1.135 0.66 ;
+      RECT 1.065 0.41 2.27 0.48 ;
+      RECT 1.715 0.205 1.785 0.48 ;
+      RECT 0.49 1.035 1.225 1.105 ;
+      RECT 0.49 0.265 0.56 1.105 ;
+      RECT 0.385 0.525 0.56 0.66 ;
+      RECT 0.49 0.265 1.065 0.335 ;
+      RECT 4.785 0.25 4.855 1.24 ;
+  END
+END DFFRS_X2
+
+MACRO DFFR_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFFR_X1 0 0 ;
+  SIZE 3.8 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.6 0.56 0.72 0.745 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.455 0.64 2.89 0.71 ;
+        RECT 2.455 0.56 2.6 0.71 ;
+        RECT 2.105 1.18 2.525 1.25 ;
+        RECT 2.455 0.56 2.525 1.25 ;
+        RECT 2.105 0.93 2.175 1.25 ;
+        RECT 1.815 0.93 2.175 1 ;
+        RECT 1.495 1.165 1.885 1.235 ;
+        RECT 1.815 0.93 1.885 1.235 ;
+    END
+  END RN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.175 0.42 0.32 0.56 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.66 0.185 3.74 1.25 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.285 0.4 3.36 1.25 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.8 1.485 ;
+        RECT 3.465 0.975 3.535 1.485 ;
+        RECT 3.08 1.065 3.15 1.485 ;
+        RECT 2.7 0.98 2.77 1.485 ;
+        RECT 1.95 1.065 2.02 1.485 ;
+        RECT 1.295 1.03 1.43 1.485 ;
+        RECT 0.575 1.015 0.645 1.485 ;
+        RECT 0.23 1.065 0.3 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.8 0.085 ;
+        RECT 3.465 -0.085 3.535 0.195 ;
+        RECT 2.7 -0.085 2.77 0.32 ;
+        RECT 1.895 -0.085 2.03 0.285 ;
+        RECT 1.515 -0.085 1.585 0.41 ;
+        RECT 0.575 -0.085 0.645 0.32 ;
+        RECT 0.23 -0.085 0.3 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.89 0.81 2.96 1.25 ;
+      RECT 2.59 0.81 3.185 0.88 ;
+      RECT 3.115 0.265 3.185 0.88 ;
+      RECT 3.525 0.265 3.595 0.66 ;
+      RECT 3.05 0.265 3.595 0.335 ;
+      RECT 2.32 0.185 2.39 1.115 ;
+      RECT 2.98 0.425 3.05 0.66 ;
+      RECT 2.32 0.425 3.05 0.495 ;
+      RECT 1.68 0.76 1.75 0.96 ;
+      RECT 1.19 0.76 2.255 0.83 ;
+      RECT 2.185 0.35 2.255 0.83 ;
+      RECT 1.69 0.35 2.255 0.42 ;
+      RECT 1.69 0.185 1.76 0.42 ;
+      RECT 0.42 0.185 0.49 1.25 ;
+      RECT 0.82 0.15 0.89 0.785 ;
+      RECT 1.985 0.485 2.12 0.67 ;
+      RECT 1.09 0.485 2.12 0.555 ;
+      RECT 0.42 0.425 0.89 0.495 ;
+      RECT 1.09 0.15 1.16 0.555 ;
+      RECT 0.82 0.15 1.16 0.22 ;
+      RECT 0.955 0.29 1.025 1.125 ;
+      RECT 0.955 0.625 1.895 0.695 ;
+      RECT 1.135 0.895 1.205 1.125 ;
+      RECT 1.495 1.025 1.63 1.095 ;
+      RECT 1.495 0.895 1.565 1.095 ;
+      RECT 1.135 0.895 1.565 0.965 ;
+      RECT 0.04 0.185 0.11 1.25 ;
+      RECT 0.04 0.7 0.355 0.835 ;
+  END
+END DFFR_X1
+
+MACRO DFFR_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFFR_X2 0 0 ;
+  SIZE 4.18 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.52 0.74 0.7 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.52 0.56 2.905 0.7 ;
+        RECT 2.17 1.15 2.59 1.22 ;
+        RECT 2.52 0.56 2.59 1.22 ;
+        RECT 2.17 0.965 2.24 1.22 ;
+        RECT 1.835 0.965 2.24 1.035 ;
+        RECT 1.515 1.165 1.905 1.235 ;
+        RECT 1.835 0.965 1.905 1.235 ;
+    END
+  END RN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.42 0.32 0.56 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.86 0.185 3.935 1.08 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.41 0.645 3.55 0.785 ;
+        RECT 3.48 0.185 3.55 0.785 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.18 1.485 ;
+        RECT 4.05 1.065 4.12 1.485 ;
+        RECT 3.67 1.065 3.74 1.485 ;
+        RECT 3.19 1.065 3.26 1.485 ;
+        RECT 2.725 1 2.86 1.485 ;
+        RECT 1.97 1.1 2.105 1.485 ;
+        RECT 1.315 1.03 1.45 1.485 ;
+        RECT 0.59 1.015 0.66 1.485 ;
+        RECT 0.245 0.945 0.315 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.18 0.085 ;
+        RECT 4.05 -0.085 4.12 0.335 ;
+        RECT 3.67 -0.085 3.74 0.335 ;
+        RECT 3.295 -0.085 3.365 0.195 ;
+        RECT 2.69 -0.085 2.76 0.32 ;
+        RECT 1.9 -0.085 2.035 0.285 ;
+        RECT 1.535 -0.085 1.605 0.41 ;
+        RECT 0.59 -0.085 0.66 0.32 ;
+        RECT 0.245 -0.085 0.315 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.97 0.85 3.04 1.22 ;
+      RECT 2.655 0.85 3.79 0.92 ;
+      RECT 3.72 0.525 3.79 0.92 ;
+      RECT 3.07 0.4 3.14 0.92 ;
+      RECT 2.655 0.765 2.725 0.92 ;
+      RECT 2.375 0.215 2.445 1.085 ;
+      RECT 3.24 0.265 3.31 0.66 ;
+      RECT 2.375 0.385 2.95 0.455 ;
+      RECT 2.88 0.265 2.95 0.455 ;
+      RECT 2.88 0.265 3.31 0.335 ;
+      RECT 2.285 0.215 2.445 0.285 ;
+      RECT 1.7 0.76 1.77 0.96 ;
+      RECT 1.7 0.83 2.26 0.9 ;
+      RECT 2.19 0.35 2.26 0.9 ;
+      RECT 1.235 0.76 1.77 0.83 ;
+      RECT 1.75 0.35 2.26 0.42 ;
+      RECT 1.75 0.185 1.82 0.42 ;
+      RECT 0.44 0.185 0.51 0.98 ;
+      RECT 0.83 0.15 0.9 0.82 ;
+      RECT 2.055 0.485 2.125 0.705 ;
+      RECT 1.105 0.485 2.125 0.555 ;
+      RECT 1.105 0.15 1.175 0.555 ;
+      RECT 0.44 0.385 0.9 0.455 ;
+      RECT 0.83 0.15 1.175 0.22 ;
+      RECT 0.97 0.29 1.04 1.125 ;
+      RECT 1.85 0.625 1.925 0.765 ;
+      RECT 0.97 0.625 1.925 0.695 ;
+      RECT 1.155 0.895 1.225 1.125 ;
+      RECT 1.515 1.025 1.65 1.095 ;
+      RECT 1.515 0.895 1.585 1.095 ;
+      RECT 1.155 0.895 1.585 0.965 ;
+      RECT 0.06 0.185 0.13 1.22 ;
+      RECT 0.06 0.655 0.375 0.79 ;
+  END
+END DFFR_X2
+
+MACRO DFFS_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFFS_X1 0 0 ;
+  SIZE 3.8 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.34 0.56 0.51 0.7 ;
+    END
+  END D
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.625 0.7 2.79 0.84 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.77 0.59 1.84 0.84 ;
+        RECT 1.705 0.59 1.84 0.725 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.575 0.56 3.74 0.7 ;
+        RECT 3.575 0.185 3.645 1.16 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.195 0.56 3.36 0.7 ;
+        RECT 3.195 0.185 3.265 0.925 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.8 1.485 ;
+        RECT 3.38 1.205 3.45 1.485 ;
+        RECT 2.855 1.005 2.925 1.485 ;
+        RECT 2.48 1.065 2.615 1.485 ;
+        RECT 1.755 0.905 1.825 1.485 ;
+        RECT 1.41 0.885 1.48 1.485 ;
+        RECT 1.015 0.94 1.085 1.485 ;
+        RECT 0.225 0.9 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.8 0.085 ;
+        RECT 3.385 -0.085 3.455 0.46 ;
+        RECT 2.67 -0.085 2.805 0.34 ;
+        RECT 1.75 -0.085 1.82 0.375 ;
+        RECT 1.04 -0.085 1.11 0.32 ;
+        RECT 0.225 -0.085 0.295 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.01 0.995 3.505 1.065 ;
+      RECT 3.435 0.525 3.505 1.065 ;
+      RECT 3.01 0.42 3.08 1.065 ;
+      RECT 2.375 0.42 3.08 0.49 ;
+      RECT 2.905 0.185 2.975 0.49 ;
+      RECT 2.105 1.045 2.24 1.115 ;
+      RECT 2.17 0.29 2.24 1.115 ;
+      RECT 2.17 0.56 2.925 0.63 ;
+      RECT 2.105 0.29 2.24 0.36 ;
+      RECT 2.7 0.93 2.77 1.15 ;
+      RECT 2.33 0.93 2.4 1.15 ;
+      RECT 2.33 0.93 2.77 1 ;
+      RECT 1.57 0.815 1.67 1.09 ;
+      RECT 0.635 0.72 0.73 0.855 ;
+      RECT 1.57 0.15 1.64 1.09 ;
+      RECT 1.97 0.665 2.095 0.8 ;
+      RECT 0.635 0.42 0.705 0.855 ;
+      RECT 0.175 0.42 0.245 0.685 ;
+      RECT 1.97 0.15 2.04 0.8 ;
+      RECT 1.57 0.44 2.04 0.51 ;
+      RECT 0.175 0.42 0.705 0.49 ;
+      RECT 0.905 0.385 1.35 0.455 ;
+      RECT 1.28 0.15 1.35 0.455 ;
+      RECT 0.445 0.15 0.515 0.49 ;
+      RECT 0.905 0.15 0.975 0.455 ;
+      RECT 1.97 0.15 2.32 0.22 ;
+      RECT 1.28 0.15 1.64 0.22 ;
+      RECT 0.445 0.15 0.975 0.22 ;
+      RECT 1.22 0.75 1.29 1.09 ;
+      RECT 0.94 0.75 1.485 0.82 ;
+      RECT 1.415 0.285 1.485 0.82 ;
+      RECT 0.94 0.685 1.01 0.82 ;
+      RECT 0.59 0.975 0.865 1.045 ;
+      RECT 0.795 0.545 0.865 1.045 ;
+      RECT 1.28 0.545 1.35 0.685 ;
+      RECT 0.77 0.545 1.35 0.615 ;
+      RECT 0.77 0.285 0.84 0.615 ;
+      RECT 0.59 0.285 0.84 0.355 ;
+      RECT 0.04 0.185 0.11 1.16 ;
+      RECT 0.04 0.765 0.57 0.835 ;
+  END
+END DFFS_X1
+
+MACRO DFFS_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFFS_X2 0 0 ;
+  SIZE 3.99 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.35 0.56 0.51 0.7 ;
+    END
+  END D
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.675 0.56 2.79 0.7 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.75 0.59 1.84 0.84 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.1 0.4 3.17 0.925 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.48 0.4 3.55 0.925 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.99 1.485 ;
+        RECT 3.66 1.205 3.73 1.485 ;
+        RECT 3.285 1.205 3.355 1.485 ;
+        RECT 2.91 1.205 2.98 1.485 ;
+        RECT 2.53 1.065 2.665 1.485 ;
+        RECT 1.805 0.94 1.875 1.485 ;
+        RECT 1.46 0.94 1.53 1.485 ;
+        RECT 1.08 0.94 1.15 1.485 ;
+        RECT 0.235 0.94 0.305 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.99 0.085 ;
+        RECT 3.66 -0.085 3.73 0.195 ;
+        RECT 3.28 -0.085 3.35 0.195 ;
+        RECT 2.72 -0.085 2.855 0.34 ;
+        RECT 1.8 -0.085 1.87 0.32 ;
+        RECT 1.09 -0.085 1.16 0.37 ;
+        RECT 0.235 -0.085 0.305 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.85 0.26 3.92 1.215 ;
+      RECT 2.92 0.99 3.92 1.06 ;
+      RECT 3.235 0.525 3.305 1.06 ;
+      RECT 2.92 0.795 2.99 1.06 ;
+      RECT 2.45 0.795 2.99 0.865 ;
+      RECT 2.155 1.045 2.29 1.115 ;
+      RECT 2.22 0.29 2.29 1.115 ;
+      RECT 3.615 0.265 3.685 0.66 ;
+      RECT 2.22 0.405 3.035 0.475 ;
+      RECT 2.965 0.265 3.035 0.475 ;
+      RECT 2.155 0.29 2.29 0.36 ;
+      RECT 2.965 0.265 3.685 0.335 ;
+      RECT 2.75 0.93 2.82 1.15 ;
+      RECT 2.38 0.93 2.45 1.15 ;
+      RECT 2.38 0.93 2.82 1 ;
+      RECT 1.615 0.94 1.72 1.075 ;
+      RECT 1.615 0.15 1.685 1.075 ;
+      RECT 0.65 0.735 0.755 0.87 ;
+      RECT 2.02 0.665 2.145 0.8 ;
+      RECT 0.65 0.425 0.72 0.87 ;
+      RECT 0.19 0.425 0.26 0.695 ;
+      RECT 2.02 0.15 2.09 0.8 ;
+      RECT 1.615 0.455 2.09 0.525 ;
+      RECT 0.955 0.435 1.295 0.505 ;
+      RECT 1.225 0.15 1.295 0.505 ;
+      RECT 0.19 0.425 0.72 0.495 ;
+      RECT 0.955 0.15 1.025 0.505 ;
+      RECT 0.455 0.15 0.525 0.495 ;
+      RECT 2.02 0.15 2.395 0.22 ;
+      RECT 1.225 0.15 1.685 0.22 ;
+      RECT 0.455 0.15 1.025 0.22 ;
+      RECT 0.965 0.77 1.535 0.84 ;
+      RECT 1.465 0.285 1.535 0.84 ;
+      RECT 0.585 0.975 0.89 1.045 ;
+      RECT 0.82 0.285 0.89 1.045 ;
+      RECT 0.82 0.57 1.4 0.705 ;
+      RECT 0.59 0.285 0.89 0.355 ;
+      RECT 0.05 0.185 0.12 1.215 ;
+      RECT 0.05 0.765 0.585 0.835 ;
+  END
+END DFFS_X2
+
+MACRO DFF_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFF_X1 0 0 ;
+  SIZE 3.23 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.81 0.53 0.97 0.7 ;
+    END
+  END D
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.56 0.53 1.67 0.7 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.1 0.26 3.17 1.13 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.72 0.26 2.79 0.785 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.23 1.485 ;
+        RECT 2.905 0.985 2.975 1.485 ;
+        RECT 2.345 1.1 2.48 1.485 ;
+        RECT 1.61 0.9 1.68 1.485 ;
+        RECT 1.005 1.08 1.075 1.485 ;
+        RECT 0.24 0.98 0.31 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.23 0.085 ;
+        RECT 2.905 -0.085 2.975 0.46 ;
+        RECT 2.345 -0.085 2.48 0.37 ;
+        RECT 1.61 -0.085 1.68 0.36 ;
+        RECT 0.975 -0.085 1.11 0.3 ;
+        RECT 0.24 -0.085 0.31 0.405 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.57 0.225 2.64 1.115 ;
+      RECT 2.57 0.85 3.035 0.92 ;
+      RECT 2.965 0.525 3.035 0.92 ;
+      RECT 2.265 0.73 2.64 0.8 ;
+      RECT 2 0.285 2.07 1.2 ;
+      RECT 2 0.525 2.505 0.66 ;
+      RECT 1.14 1.18 1.495 1.25 ;
+      RECT 1.425 0.225 1.495 1.25 ;
+      RECT 0.485 1.18 0.94 1.25 ;
+      RECT 0.87 0.945 0.94 1.25 ;
+      RECT 1.14 0.945 1.21 1.25 ;
+      RECT 0.87 0.945 1.21 1.015 ;
+      RECT 1.425 0.765 1.925 0.835 ;
+      RECT 1.855 0.15 1.925 0.835 ;
+      RECT 1.855 0.15 2.205 0.22 ;
+      RECT 1.275 0.37 1.345 0.995 ;
+      RECT 0.38 0.15 0.45 0.545 ;
+      RECT 0.785 0.37 1.345 0.44 ;
+      RECT 1.2 0.27 1.27 0.44 ;
+      RECT 0.785 0.15 0.855 0.44 ;
+      RECT 0.38 0.15 0.855 0.22 ;
+      RECT 0.635 0.285 0.705 1.115 ;
+      RECT 0.635 0.765 1.19 0.835 ;
+      RECT 1.12 0.53 1.19 0.835 ;
+      RECT 0.06 0.27 0.13 1.13 ;
+      RECT 0.06 0.61 0.57 0.745 ;
+  END
+END DFF_X1
+
+MACRO DFF_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFF_X2 0 0 ;
+  SIZE 3.61 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.94 0.56 1.08 0.7 ;
+    END
+  END D
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.57 0.56 1.65 0.7 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.29 0.25 3.36 1.115 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.91 0.25 2.98 0.925 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.61 1.485 ;
+        RECT 3.485 0.84 3.555 1.485 ;
+        RECT 3.105 1.205 3.175 1.485 ;
+        RECT 2.73 1.205 2.8 1.485 ;
+        RECT 2.35 0.875 2.485 1.485 ;
+        RECT 1.62 0.9 1.69 1.485 ;
+        RECT 1.015 1.08 1.085 1.485 ;
+        RECT 0.255 0.965 0.325 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.61 0.085 ;
+        RECT 3.485 -0.085 3.555 0.46 ;
+        RECT 3.105 -0.085 3.175 0.46 ;
+        RECT 2.73 -0.085 2.8 0.46 ;
+        RECT 2.35 -0.085 2.485 0.45 ;
+        RECT 1.62 -0.085 1.69 0.385 ;
+        RECT 0.985 -0.085 1.12 0.215 ;
+        RECT 0.255 -0.085 0.325 0.385 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.575 1.045 3.215 1.115 ;
+      RECT 3.145 0.525 3.215 1.115 ;
+      RECT 2.575 0.2 2.645 1.115 ;
+      RECT 2.245 0.735 2.645 0.805 ;
+      RECT 2.01 0.35 2.08 0.975 ;
+      RECT 2.01 0.525 2.51 0.66 ;
+      RECT 1.15 1.18 1.505 1.25 ;
+      RECT 1.435 0.25 1.505 1.25 ;
+      RECT 0.5 1.18 0.935 1.25 ;
+      RECT 0.865 0.945 0.935 1.25 ;
+      RECT 1.15 0.945 1.22 1.25 ;
+      RECT 0.865 0.945 1.22 1.015 ;
+      RECT 1.435 0.765 1.945 0.835 ;
+      RECT 1.875 0.215 1.945 0.835 ;
+      RECT 1.875 0.215 2.215 0.285 ;
+      RECT 1.285 0.285 1.355 1.115 ;
+      RECT 0.39 0.15 0.46 0.7 ;
+      RECT 0.825 0.285 1.355 0.355 ;
+      RECT 0.825 0.15 0.895 0.355 ;
+      RECT 0.39 0.15 0.895 0.22 ;
+      RECT 0.61 1 0.76 1.07 ;
+      RECT 0.69 0.285 0.76 1.07 ;
+      RECT 0.69 0.765 1.215 0.835 ;
+      RECT 1.145 0.565 1.215 0.835 ;
+      RECT 0.61 0.285 0.76 0.355 ;
+      RECT 0.075 0.325 0.145 1.055 ;
+      RECT 0.075 0.765 0.625 0.835 ;
+      RECT 0.555 0.565 0.625 0.835 ;
+  END
+END DFF_X2
+
+MACRO DLH_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DLH_X1 0 0 ;
+  SIZE 1.9 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.95 0.525 1.08 0.7 ;
+    END
+  END D
+  PIN G
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.2 0.525 0.32 0.7 ;
+    END
+  END G
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.185 0.51 0.785 ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.9 1.485 ;
+        RECT 1.595 1.025 1.665 1.485 ;
+        RECT 0.845 0.965 0.915 1.485 ;
+        RECT 0.25 0.985 0.32 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.9 0.085 ;
+        RECT 1.595 -0.085 1.665 0.445 ;
+        RECT 0.805 -0.085 0.94 0.285 ;
+        RECT 0.25 -0.085 0.32 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.79 0.32 1.86 1.16 ;
+      RECT 1.485 0.525 1.86 0.595 ;
+      RECT 1.19 1.045 1.415 1.115 ;
+      RECT 1.345 0.35 1.415 1.115 ;
+      RECT 1.345 0.66 1.725 0.795 ;
+      RECT 0.785 0.35 0.855 0.66 ;
+      RECT 0.785 0.35 1.415 0.42 ;
+      RECT 1.025 1.18 1.43 1.25 ;
+      RECT 1.025 0.765 1.095 1.25 ;
+      RECT 0.65 0.185 0.72 1.115 ;
+      RECT 0.65 0.765 1.215 0.835 ;
+      RECT 1.145 0.49 1.215 0.835 ;
+      RECT 1.145 0.49 1.28 0.56 ;
+      RECT 0.505 1.18 0.78 1.25 ;
+      RECT 0.065 0.185 0.135 1.24 ;
+      RECT 0.505 0.85 0.575 1.25 ;
+      RECT 0.065 0.85 0.575 0.92 ;
+  END
+END DLH_X1
+
+MACRO DLH_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DLH_X2 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.135 0.525 1.27 0.7 ;
+    END
+  END D
+  PIN G
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.18 0.525 0.32 0.7 ;
+    END
+  END G
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.185 0.51 0.785 ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.78 1.08 1.85 1.485 ;
+        RECT 1.03 1.04 1.1 1.485 ;
+        RECT 0.62 1 0.69 1.485 ;
+        RECT 0.24 1.055 0.31 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.78 -0.085 1.85 0.32 ;
+        RECT 1.03 -0.085 1.1 0.32 ;
+        RECT 0.62 -0.085 0.69 0.255 ;
+        RECT 0.24 -0.085 0.31 0.255 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.975 0.185 2.045 1.215 ;
+      RECT 1.705 0.495 2.045 0.63 ;
+      RECT 1.4 0.78 1.47 1.2 ;
+      RECT 1.4 0.78 1.91 0.875 ;
+      RECT 1.545 0.74 1.91 0.875 ;
+      RECT 0.985 0.78 1.91 0.85 ;
+      RECT 0.985 0.525 1.055 0.85 ;
+      RECT 1.545 0.185 1.615 0.875 ;
+      RECT 1.41 0.185 1.615 0.32 ;
+      RECT 0.82 0.975 0.92 1.25 ;
+      RECT 0.85 0.175 0.92 1.25 ;
+      RECT 1.405 0.39 1.475 0.67 ;
+      RECT 0.85 0.39 1.475 0.46 ;
+      RECT 0.82 0.175 0.92 0.31 ;
+      RECT 0.045 0.185 0.115 1.24 ;
+      RECT 0.045 0.85 0.78 0.92 ;
+      RECT 0.71 0.375 0.78 0.92 ;
+  END
+END DLH_X2
+
+MACRO DLL_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DLL_X1 0 0 ;
+  SIZE 1.9 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.56 0.43 0.7 ;
+    END
+  END D
+  PIN GN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.58 0.525 1.705 0.7 ;
+    END
+  END GN
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.39 0.26 1.46 0.84 ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.9 1.485 ;
+        RECT 1.575 1.04 1.645 1.485 ;
+        RECT 1.035 0.95 1.105 1.485 ;
+        RECT 0.275 0.915 0.345 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.9 0.085 ;
+        RECT 1.575 -0.085 1.645 0.235 ;
+        RECT 1.035 -0.085 1.105 0.42 ;
+        RECT 0.275 -0.085 0.345 0.415 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.235 1.18 1.51 1.25 ;
+      RECT 1.44 0.905 1.51 1.25 ;
+      RECT 1.77 0.195 1.84 1.24 ;
+      RECT 1.44 0.905 1.84 0.975 ;
+      RECT 1.23 0.285 1.3 1.085 ;
+      RECT 0.9 0.775 1.3 0.845 ;
+      RECT 0.665 0.285 0.735 1.085 ;
+      RECT 0.665 0.525 1.165 0.66 ;
+      RECT 0.53 0.15 0.6 1.25 ;
+      RECT 0.095 0.28 0.165 1.085 ;
+      RECT 0.095 0.78 0.6 0.85 ;
+      RECT 0.53 0.15 0.845 0.22 ;
+  END
+END DLL_X1
+
+MACRO DLL_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DLL_X2 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.51 0.38 0.7 ;
+    END
+  END D
+  PIN GN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.77 0.525 1.89 0.7 ;
+    END
+  END GN
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.58 0.26 1.65 1.005 ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.76 1.205 1.83 1.485 ;
+        RECT 1.385 1.205 1.455 1.485 ;
+        RECT 0.985 0.875 1.055 1.485 ;
+        RECT 0.225 0.9 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.76 -0.085 1.83 0.195 ;
+        RECT 1.385 -0.085 1.455 0.395 ;
+        RECT 0.985 -0.085 1.055 0.46 ;
+        RECT 0.225 -0.085 0.295 0.37 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.185 1.07 1.32 1.25 ;
+      RECT 1.955 0.195 2.025 1.24 ;
+      RECT 1.185 1.07 2.025 1.14 ;
+      RECT 1.19 0.325 1.26 1.005 ;
+      RECT 0.85 0.73 1.26 0.8 ;
+      RECT 0.615 0.335 0.685 1.015 ;
+      RECT 0.615 0.525 1.125 0.66 ;
+      RECT 0.045 0.3 0.115 1.145 ;
+      RECT 0.045 0.765 0.55 0.835 ;
+      RECT 0.48 0.195 0.55 0.835 ;
+      RECT 0.48 0.195 0.82 0.265 ;
+  END
+END DLL_X2
+
+MACRO FA_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN FA_X1 0 0 ;
+  SIZE 3.04 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.905 0.825 2.66 0.895 ;
+        RECT 2.53 0.7 2.66 0.895 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.34 0.42 2.47 0.56 ;
+        RECT 1.41 0.42 2.47 0.49 ;
+    END
+  END B
+  PIN CI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.555 2.275 0.625 ;
+        RECT 0.63 0.42 0.7 0.625 ;
+    END
+  END CI
+  PIN CO
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.195 0.135 1.215 ;
+    END
+  END CO
+  PIN S
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.89 0.195 2.98 1.215 ;
+    END
+  END S
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.04 1.485 ;
+        RECT 2.695 1.205 2.765 1.485 ;
+        RECT 1.705 1.095 1.84 1.485 ;
+        RECT 1.36 0.965 1.43 1.485 ;
+        RECT 1.015 1.095 1.085 1.485 ;
+        RECT 0.25 0.94 0.32 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.04 0.085 ;
+        RECT 2.665 -0.085 2.8 0.16 ;
+        RECT 1.705 -0.085 1.84 0.16 ;
+        RECT 1.36 -0.085 1.43 0.195 ;
+        RECT 1.025 -0.085 1.095 0.33 ;
+        RECT 0.25 -0.085 0.32 0.33 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.13 0.96 2.2 1.24 ;
+      RECT 2.13 0.96 2.82 1.03 ;
+      RECT 2.75 0.225 2.82 1.03 ;
+      RECT 2.1 0.225 2.82 0.295 ;
+      RECT 0.63 0.69 0.7 1.215 ;
+      RECT 0.495 0.69 2.115 0.76 ;
+      RECT 0.495 0.23 0.565 0.76 ;
+      RECT 0.205 0.525 0.565 0.66 ;
+      RECT 0.495 0.23 0.735 0.3 ;
+      RECT 1.93 0.96 2 1.24 ;
+      RECT 1.555 0.96 1.625 1.24 ;
+      RECT 1.555 0.96 2 1.03 ;
+      RECT 0.835 0.395 1.275 0.465 ;
+      RECT 1.205 0.195 1.275 0.465 ;
+      RECT 0.835 0.195 0.905 0.465 ;
+      RECT 1.205 0.96 1.275 1.235 ;
+      RECT 0.8 0.96 0.935 1.215 ;
+      RECT 0.8 0.96 1.275 1.03 ;
+      RECT 1.52 0.225 2.03 0.295 ;
+  END
+END FA_X1
+
+MACRO FILLCELL_X1
+  #CLASS CORE ;
+  CLASS CORE SPACER ;
+  ORIGIN 0 0 ;
+  FOREIGN FILLCELL_X1 0 0 ;
+  SIZE 0.19 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.19 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.19 0.085 ;
+    END
+  END VSS
+END FILLCELL_X1
+
+MACRO FILLCELL_X16
+  #CLASS CORE ;
+  CLASS CORE SPACER ;
+  ORIGIN 0 0 ;
+  FOREIGN FILLCELL_X16 0 0 ;
+  SIZE 3.04 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.04 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.04 0.085 ;
+    END
+  END VSS
+END FILLCELL_X16
+
+MACRO FILLCELL_X2
+  #CLASS CORE ;
+  CLASS CORE SPACER ;
+  ORIGIN 0 0 ;
+  FOREIGN FILLCELL_X2 0 0 ;
+  SIZE 0.19 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.19 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.19 0.085 ;
+    END
+  END VSS
+END FILLCELL_X2
+
+MACRO FILLCELL_X32
+  #CLASS CORE ;
+  CLASS CORE SPACER ;
+  ORIGIN 0 0 ;
+  FOREIGN FILLCELL_X32 0 0 ;
+  SIZE 6.08 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 6.08 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 6.08 0.085 ;
+    END
+  END VSS
+END FILLCELL_X32
+
+MACRO FILLCELL_X4
+  #CLASS CORE ;
+  CLASS CORE SPACER ;
+  ORIGIN 0 0 ;
+  FOREIGN FILLCELL_X4 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+    END
+  END VSS
+END FILLCELL_X4
+
+MACRO FILLCELL_X8
+  #CLASS CORE ;
+  CLASS CORE SPACER ;
+  ORIGIN 0 0 ;
+  FOREIGN FILLCELL_X8 0 0 ;
+  SIZE 1.52 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.52 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.52 0.085 ;
+    END
+  END VSS
+END FILLCELL_X8
+
+MACRO HA_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN HA_X1 0 0 ;
+  SIZE 1.9 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.56 1.08 0.7 ;
+        RECT 0.67 0.56 1.08 0.63 ;
+        RECT 0.355 0.725 0.74 0.795 ;
+        RECT 0.67 0.56 0.74 0.795 ;
+        RECT 0.355 0.525 0.425 0.795 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.86 0.89 0.93 ;
+        RECT 0.805 0.7 0.89 0.93 ;
+        RECT 0.195 0.525 0.265 0.93 ;
+    END
+  END B
+  PIN CO
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.77 0.15 1.85 1.25 ;
+    END
+  END CO
+  PIN S
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.29 0.525 0.36 ;
+        RECT 0.455 0.15 0.525 0.36 ;
+        RECT 0.06 0.995 0.37 1.065 ;
+        RECT 0.06 0.29 0.13 1.065 ;
+    END
+  END S
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.9 1.485 ;
+        RECT 1.59 1.08 1.66 1.485 ;
+        RECT 1.22 0.94 1.29 1.485 ;
+        RECT 0.645 1.08 0.715 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.9 0.085 ;
+        RECT 1.59 -0.085 1.66 0.285 ;
+        RECT 1.03 -0.085 1.1 0.285 ;
+        RECT 0.645 -0.085 0.715 0.285 ;
+        RECT 0.08 -0.085 0.15 0.225 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.4 0.15 1.47 1.115 ;
+      RECT 1.4 0.525 1.705 0.66 ;
+      RECT 1.22 0.15 1.47 0.285 ;
+      RECT 1.035 0.765 1.105 1.115 ;
+      RECT 1.035 0.765 1.25 0.835 ;
+      RECT 1.18 0.425 1.25 0.835 ;
+      RECT 0.535 0.425 0.605 0.66 ;
+      RECT 0.535 0.425 1.25 0.495 ;
+      RECT 0.84 0.15 0.91 0.495 ;
+      RECT 0.05 1.13 0.56 1.2 ;
+  END
+END HA_X1
+
+MACRO INV_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN INV_X1 0 0 ;
+  SIZE 0.38 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.165 0.7 ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.23 0.15 0.325 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.38 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.38 0.085 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+END INV_X1
+
+MACRO INV_X16
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN INV_X16 0 0 ;
+  SIZE 3.23 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.095 1.05 3.095 1.12 ;
+        RECT 3.025 0.525 3.095 1.12 ;
+        RECT 2 0.525 2.07 1.12 ;
+        RECT 1.2 0.525 1.27 1.12 ;
+        RECT 0.095 0.525 0.165 1.12 ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.885 0.15 2.955 0.985 ;
+        RECT 0.235 0.28 2.955 0.42 ;
+        RECT 2.505 0.15 2.575 0.985 ;
+        RECT 2.135 0.28 2.205 0.985 ;
+        RECT 2.125 0.15 2.195 0.42 ;
+        RECT 1.745 0.15 1.815 0.985 ;
+        RECT 1.365 0.15 1.435 0.985 ;
+        RECT 0.985 0.15 1.055 0.985 ;
+        RECT 0.605 0.16 0.675 0.985 ;
+        RECT 0.235 0.18 0.305 0.985 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.23 1.485 ;
+        RECT 3.075 1.205 3.145 1.485 ;
+        RECT 2.695 1.205 2.765 1.485 ;
+        RECT 2.315 1.205 2.385 1.485 ;
+        RECT 1.935 1.205 2.005 1.485 ;
+        RECT 1.555 1.205 1.625 1.485 ;
+        RECT 1.175 1.205 1.245 1.485 ;
+        RECT 0.795 1.205 0.865 1.485 ;
+        RECT 0.415 1.205 0.485 1.485 ;
+        RECT 0.04 1.205 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.23 0.085 ;
+        RECT 3.075 -0.085 3.145 0.365 ;
+        RECT 2.695 -0.085 2.765 0.21 ;
+        RECT 2.315 -0.085 2.385 0.21 ;
+        RECT 1.935 -0.085 2.005 0.21 ;
+        RECT 1.555 -0.085 1.625 0.21 ;
+        RECT 1.175 -0.085 1.245 0.21 ;
+        RECT 0.795 -0.085 0.865 0.21 ;
+        RECT 0.415 -0.085 0.485 0.21 ;
+        RECT 0.04 -0.085 0.11 0.365 ;
+    END
+  END VSS
+END INV_X16
+
+MACRO INV_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN INV_X2 0 0 ;
+  SIZE 0.57 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.15 0.32 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.57 1.485 ;
+        RECT 0.43 0.975 0.5 1.485 ;
+        RECT 0.055 0.975 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.57 0.085 ;
+        RECT 0.43 -0.085 0.5 0.425 ;
+        RECT 0.055 -0.085 0.125 0.425 ;
+    END
+  END VSS
+END INV_X2
+
+MACRO INV_X32
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN INV_X32 0 0 ;
+  SIZE 6.27 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.115 0.93 5.85 1 ;
+        RECT 5.78 0.525 5.85 1 ;
+        RECT 4.62 0.525 4.69 1 ;
+        RECT 3.48 0.525 3.55 1 ;
+        RECT 2.34 0.525 2.41 1 ;
+        RECT 1.2 0.525 1.27 1 ;
+        RECT 0.115 0.525 0.185 1 ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 5.945 0.16 6.015 1.005 ;
+        RECT 0.25 0.28 6.015 0.42 ;
+        RECT 5.56 0.16 5.63 0.865 ;
+        RECT 5.18 0.16 5.25 0.865 ;
+        RECT 4.81 0.28 4.88 0.865 ;
+        RECT 4.8 0.16 4.87 0.42 ;
+        RECT 4.42 0.16 4.49 0.865 ;
+        RECT 4.04 0.16 4.11 0.865 ;
+        RECT 3.665 0.16 3.735 0.865 ;
+        RECT 3.28 0.16 3.35 0.865 ;
+        RECT 2.9 0.16 2.97 0.865 ;
+        RECT 2.525 0.16 2.595 0.865 ;
+        RECT 2.14 0.16 2.21 0.865 ;
+        RECT 1.76 0.16 1.83 0.865 ;
+        RECT 1.39 0.16 1.46 0.865 ;
+        RECT 1 0.16 1.07 0.865 ;
+        RECT 0.62 0.16 0.69 0.865 ;
+        RECT 0.25 0.16 0.32 0.865 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 6.27 1.485 ;
+        RECT 6.13 1.065 6.2 1.485 ;
+        RECT 5.75 1.065 5.82 1.485 ;
+        RECT 5.37 1.065 5.44 1.485 ;
+        RECT 4.99 1.065 5.06 1.485 ;
+        RECT 4.61 1.065 4.68 1.485 ;
+        RECT 4.23 1.065 4.3 1.485 ;
+        RECT 3.85 1.065 3.92 1.485 ;
+        RECT 3.47 1.065 3.54 1.485 ;
+        RECT 3.09 1.065 3.16 1.485 ;
+        RECT 2.71 1.065 2.78 1.485 ;
+        RECT 2.33 1.065 2.4 1.485 ;
+        RECT 1.95 1.065 2.02 1.485 ;
+        RECT 1.57 1.065 1.64 1.485 ;
+        RECT 1.19 1.065 1.26 1.485 ;
+        RECT 0.81 1.065 0.88 1.485 ;
+        RECT 0.43 1.065 0.5 1.485 ;
+        RECT 0.055 1.065 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 6.27 0.085 ;
+        RECT 6.13 -0.085 6.2 0.335 ;
+        RECT 5.75 -0.085 5.82 0.195 ;
+        RECT 5.37 -0.085 5.44 0.195 ;
+        RECT 4.99 -0.085 5.06 0.195 ;
+        RECT 4.61 -0.085 4.68 0.195 ;
+        RECT 4.23 -0.085 4.3 0.195 ;
+        RECT 3.85 -0.085 3.92 0.195 ;
+        RECT 3.47 -0.085 3.54 0.195 ;
+        RECT 3.09 -0.085 3.16 0.195 ;
+        RECT 2.71 -0.085 2.78 0.195 ;
+        RECT 2.33 -0.085 2.4 0.195 ;
+        RECT 1.95 -0.085 2.02 0.195 ;
+        RECT 1.57 -0.085 1.64 0.195 ;
+        RECT 1.19 -0.085 1.26 0.195 ;
+        RECT 0.81 -0.085 0.88 0.195 ;
+        RECT 0.43 -0.085 0.5 0.195 ;
+        RECT 0.055 -0.085 0.125 0.335 ;
+    END
+  END VSS
+END INV_X32
+
+MACRO INV_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN INV_X4 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.17 0.7 ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.615 0.15 0.685 1.04 ;
+        RECT 0.235 0.56 0.685 0.7 ;
+        RECT 0.61 0.15 0.685 0.7 ;
+        RECT 0.235 0.15 0.305 1.04 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.795 0.98 0.865 1.485 ;
+        RECT 0.415 0.98 0.485 1.485 ;
+        RECT 0.04 0.98 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.795 -0.085 0.865 0.425 ;
+        RECT 0.415 -0.085 0.485 0.425 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+END INV_X4
+
+MACRO INV_X8
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN INV_X8 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.17 0.7 ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.375 0.15 1.445 1.04 ;
+        RECT 0.235 0.56 1.445 0.7 ;
+        RECT 0.985 0.15 1.055 1.04 ;
+        RECT 0.605 0.15 0.675 1.04 ;
+        RECT 0.235 0.15 0.305 1.04 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.555 0.97 1.625 1.485 ;
+        RECT 1.175 0.97 1.245 1.485 ;
+        RECT 0.795 0.97 0.865 1.485 ;
+        RECT 0.415 0.97 0.485 1.485 ;
+        RECT 0.04 0.97 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.555 -0.085 1.625 0.36 ;
+        RECT 1.175 -0.085 1.245 0.36 ;
+        RECT 0.795 -0.085 0.865 0.36 ;
+        RECT 0.415 -0.085 0.485 0.36 ;
+        RECT 0.04 -0.085 0.11 0.36 ;
+    END
+  END VSS
+END INV_X8
+
+MACRO LOGIC0_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN LOGIC0_X1 0 0 ;
+  SIZE 0.38 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.15 0.13 0.84 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.38 1.485 ;
+        RECT 0.245 1.115 0.315 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.38 0.085 ;
+        RECT 0.24 -0.085 0.31 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.06 0.975 0.18 1.25 ;
+  END
+END LOGIC0_X1
+
+MACRO LOGIC1_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN LOGIC1_X1 0 0 ;
+  SIZE 0.38 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.56 0.13 1.25 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.38 1.485 ;
+        RECT 0.24 1.115 0.31 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.38 0.085 ;
+        RECT 0.245 -0.085 0.315 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.06 0.15 0.18 0.425 ;
+  END
+END LOGIC1_X1
+
+MACRO MUX2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN MUX2_X1 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.525 0.95 0.7 ;
+    END
+  END B
+  PIN S
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.765 0.595 0.835 ;
+        RECT 0.525 0.535 0.595 0.835 ;
+        RECT 0.06 0.525 0.185 0.835 ;
+    END
+  END S
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.18 0.19 1.27 1.23 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 0.985 0.975 1.055 1.485 ;
+        RECT 0.225 1.035 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 0.985 -0.085 1.055 0.24 ;
+        RECT 0.225 -0.085 0.295 0.24 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.58 1.07 0.92 1.14 ;
+      RECT 0.85 0.84 0.92 1.14 ;
+      RECT 0.85 0.84 1.115 0.91 ;
+      RECT 1.045 0.39 1.115 0.91 ;
+      RECT 0.83 0.39 1.115 0.46 ;
+      RECT 0.83 0.22 0.9 0.46 ;
+      RECT 0.58 0.22 0.9 0.29 ;
+      RECT 0.045 0.9 0.115 1.25 ;
+      RECT 0.045 0.9 0.755 0.97 ;
+      RECT 0.685 0.39 0.755 0.97 ;
+      RECT 0.045 0.39 0.755 0.46 ;
+      RECT 0.045 0.19 0.115 0.46 ;
+  END
+END MUX2_X1
+
+MACRO MUX2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN MUX2_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.225 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END B
+  PIN S
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.925 0.85 1.535 0.92 ;
+        RECT 1.465 0.525 1.535 0.92 ;
+        RECT 0.925 0.525 0.995 0.92 ;
+        RECT 0.77 0.525 0.995 0.7 ;
+    END
+  END S
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.15 1.29 0.785 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.405 1.205 1.475 1.485 ;
+        RECT 1.035 1.205 1.105 1.485 ;
+        RECT 0.24 1.24 0.375 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.405 -0.085 1.475 0.285 ;
+        RECT 1.03 -0.085 1.1 0.285 ;
+        RECT 0.46 -0.085 0.53 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.6 0.15 1.67 1.25 ;
+      RECT 0.79 0.985 1.67 1.055 ;
+      RECT 0.79 0.765 0.86 1.055 ;
+      RECT 0.425 0.765 0.86 0.835 ;
+      RECT 0.425 0.525 0.495 0.835 ;
+      RECT 0.655 0.9 0.725 1.075 ;
+      RECT 0.29 0.9 0.725 0.97 ;
+      RECT 0.29 0.385 0.36 0.97 ;
+      RECT 1.065 0.385 1.135 0.66 ;
+      RECT 0.09 0.385 1.135 0.455 ;
+      RECT 0.845 0.15 0.915 0.455 ;
+      RECT 0.09 0.15 0.16 0.455 ;
+      RECT 0.46 1.175 0.955 1.245 ;
+      RECT 0.46 1.065 0.53 1.245 ;
+      RECT 0.09 1.065 0.53 1.135 ;
+      RECT 0.09 0.86 0.16 1.135 ;
+  END
+END MUX2_X2
+
+MACRO NAND2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND2_X1 0 0 ;
+  SIZE 0.57 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.525 0.51 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.355 0.5 0.425 ;
+        RECT 0.43 0.15 0.5 0.425 ;
+        RECT 0.25 0.355 0.32 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.57 1.485 ;
+        RECT 0.43 0.975 0.5 1.485 ;
+        RECT 0.055 0.975 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.57 0.085 ;
+        RECT 0.055 -0.085 0.125 0.425 ;
+    END
+  END VSS
+END NAND2_X1
+
+MACRO NAND2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND2_X2 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.51 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.77 0.81 0.84 ;
+        RECT 0.74 0.525 0.81 0.84 ;
+        RECT 0.25 0.525 0.32 0.84 ;
+        RECT 0.175 0.525 0.32 0.66 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.905 0.7 1.25 ;
+        RECT 0.04 0.905 0.7 0.975 ;
+        RECT 0.04 0.39 0.51 0.46 ;
+        RECT 0.44 0.15 0.51 0.46 ;
+        RECT 0.25 0.905 0.32 1.25 ;
+        RECT 0.04 0.39 0.11 0.975 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.82 1.04 0.89 1.485 ;
+        RECT 0.44 1.04 0.51 1.485 ;
+        RECT 0.065 1.04 0.135 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.82 -0.085 0.89 0.425 ;
+        RECT 0.065 -0.085 0.135 0.285 ;
+    END
+  END VSS
+END NAND2_X2
+
+MACRO NAND2_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND2_X4 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.14 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.38 0.525 0.51 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.405 0.35 1.475 1.07 ;
+        RECT 0.275 0.785 1.475 0.855 ;
+        RECT 1.39 0.35 1.475 0.855 ;
+        RECT 1 0.35 1.475 0.42 ;
+        RECT 1.025 0.785 1.095 1.07 ;
+        RECT 0.645 0.785 0.715 1.07 ;
+        RECT 0.275 0.785 0.345 1.07 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.595 1.04 1.665 1.485 ;
+        RECT 1.215 1.04 1.285 1.485 ;
+        RECT 0.835 1.04 0.905 1.485 ;
+        RECT 0.455 1.04 0.525 1.485 ;
+        RECT 0.08 1.04 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 0.645 -0.085 0.715 0.285 ;
+        RECT 0.265 -0.085 0.335 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.595 0.15 1.665 0.425 ;
+      RECT 0.085 0.355 0.905 0.425 ;
+      RECT 0.835 0.15 0.905 0.425 ;
+      RECT 0.455 0.15 0.525 0.425 ;
+      RECT 0.085 0.15 0.155 0.425 ;
+      RECT 0.835 0.15 1.665 0.22 ;
+  END
+END NAND2_X4
+
+MACRO NAND3_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND3_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.54 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.605 0.15 0.675 1.25 ;
+        RECT 0.235 0.8 0.675 0.87 ;
+        RECT 0.235 0.8 0.32 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+END NAND3_X1
+
+MACRO NAND3_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND3_X2 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.595 0.56 0.73 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.95 0.42 1.08 0.7 ;
+        RECT 0.38 0.42 1.08 0.49 ;
+        RECT 0.38 0.42 0.45 0.66 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.77 1.215 0.84 ;
+        RECT 1.145 0.525 1.215 0.84 ;
+        RECT 0.195 0.7 0.32 0.84 ;
+        RECT 0.195 0.525 0.265 0.84 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.025 0.905 1.095 1.25 ;
+        RECT 0.06 0.905 1.095 0.975 ;
+        RECT 0.06 0.265 0.75 0.335 ;
+        RECT 0.645 0.905 0.715 1.25 ;
+        RECT 0.265 0.905 0.335 1.25 ;
+        RECT 0.06 0.265 0.13 0.975 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.215 1.04 1.285 1.485 ;
+        RECT 0.835 1.04 0.905 1.485 ;
+        RECT 0.455 1.04 0.525 1.485 ;
+        RECT 0.08 1.04 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 1.215 -0.085 1.285 0.335 ;
+        RECT 0.08 -0.085 0.15 0.195 ;
+    END
+  END VSS
+END NAND3_X2
+
+MACRO NAND3_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND3_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.66 0.555 1.89 0.625 ;
+        RECT 1.66 0.29 1.73 0.625 ;
+        RECT 0.82 0.29 1.73 0.36 ;
+        RECT 0.625 0.555 0.89 0.625 ;
+        RECT 0.82 0.29 0.89 0.625 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.525 0.69 2.13 0.76 ;
+        RECT 2.06 0.525 2.13 0.76 ;
+        RECT 1.525 0.425 1.595 0.76 ;
+        RECT 0.955 0.425 1.595 0.495 ;
+        RECT 0.38 0.69 1.08 0.76 ;
+        RECT 0.955 0.425 1.08 0.76 ;
+        RECT 0.38 0.525 0.45 0.76 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.19 0.825 2.3 0.895 ;
+        RECT 2.23 0.525 2.3 0.895 ;
+        RECT 1.19 0.56 1.325 0.895 ;
+        RECT 0.19 0.525 0.26 0.895 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.055 0.98 2.435 1.05 ;
+        RECT 2.365 0.355 2.435 1.05 ;
+        RECT 1.795 0.355 2.435 0.425 ;
+        RECT 2.165 0.98 2.235 1.22 ;
+        RECT 0.265 0.98 2.235 1.12 ;
+        RECT 1.795 0.15 1.865 0.425 ;
+        RECT 1.785 0.98 1.855 1.22 ;
+        RECT 1.405 0.98 1.475 1.22 ;
+        RECT 1.025 0.98 1.095 1.22 ;
+        RECT 0.645 0.98 0.715 1.22 ;
+        RECT 0.055 0.355 0.715 0.425 ;
+        RECT 0.645 0.15 0.715 0.425 ;
+        RECT 0.265 0.98 0.335 1.22 ;
+        RECT 0.055 0.355 0.125 1.05 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.355 1.17 2.425 1.485 ;
+        RECT 1.945 1.205 2.08 1.485 ;
+        RECT 1.565 1.205 1.7 1.485 ;
+        RECT 1.185 1.205 1.32 1.485 ;
+        RECT 0.805 1.195 0.94 1.485 ;
+        RECT 0.425 1.195 0.56 1.485 ;
+        RECT 0.08 1.16 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.355 -0.085 2.425 0.195 ;
+        RECT 1.215 -0.085 1.285 0.195 ;
+        RECT 0.08 -0.085 0.15 0.195 ;
+    END
+  END VSS
+END NAND3_X4
+
+MACRO NAND4_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND4_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.525 0.89 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.42 0.555 0.66 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.42 0.375 0.66 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.42 0.185 0.66 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.355 0.865 0.425 ;
+        RECT 0.795 0.15 0.865 0.425 ;
+        RECT 0.615 0.84 0.7 1.25 ;
+        RECT 0.63 0.355 0.7 1.25 ;
+        RECT 0.235 0.84 0.7 0.91 ;
+        RECT 0.235 0.84 0.305 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.04 -0.085 0.11 0.355 ;
+    END
+  END VSS
+END NAND4_X1
+
+MACRO NAND4_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND4_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.81 0.42 0.945 0.625 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.145 0.285 1.27 0.66 ;
+        RECT 0.575 0.285 1.27 0.355 ;
+        RECT 0.575 0.285 0.645 0.66 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.39 0.725 1.405 0.795 ;
+        RECT 1.335 0.525 1.405 0.795 ;
+        RECT 0.39 0.525 0.51 0.795 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.86 1.59 0.93 ;
+        RECT 1.52 0.525 1.59 0.93 ;
+        RECT 0.195 0.525 0.32 0.93 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.375 0.995 1.51 1.25 ;
+        RECT 0.06 0.995 1.51 1.065 ;
+        RECT 0.995 0.995 1.13 1.25 ;
+        RECT 0.285 0.15 0.94 0.22 ;
+        RECT 0.615 0.995 0.75 1.25 ;
+        RECT 0.235 0.995 0.37 1.25 ;
+        RECT 0.06 0.39 0.355 0.46 ;
+        RECT 0.285 0.15 0.355 0.46 ;
+        RECT 0.06 0.39 0.13 1.065 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.595 1.065 1.665 1.485 ;
+        RECT 1.215 1.13 1.285 1.485 ;
+        RECT 0.835 1.13 0.905 1.485 ;
+        RECT 0.455 1.13 0.525 1.485 ;
+        RECT 0.08 1.13 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.595 -0.085 1.665 0.39 ;
+        RECT 0.08 -0.085 0.15 0.25 ;
+    END
+  END VSS
+END NAND4_X2
+
+MACRO NAND4_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND4_X4 0 0 ;
+  SIZE 3.42 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.405 0.525 0.51 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.17 0.525 1.27 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.15 0.525 2.22 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.91 0.525 2.98 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.27 0.84 3.34 1.155 ;
+        RECT 0.09 0.84 3.34 0.98 ;
+        RECT 2.89 0.84 2.96 1.155 ;
+        RECT 2.51 0.84 2.58 1.155 ;
+        RECT 2.13 0.84 2.2 1.155 ;
+        RECT 1.68 0.84 1.75 1.155 ;
+        RECT 1.22 0.84 1.29 1.155 ;
+        RECT 0.84 0.84 0.91 1.155 ;
+        RECT 0.685 0.285 0.755 0.98 ;
+        RECT 0.225 0.285 0.755 0.355 ;
+        RECT 0.46 0.84 0.53 1.155 ;
+        RECT 0.09 0.84 0.16 1.155 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.42 1.485 ;
+        RECT 3.05 1.095 3.185 1.485 ;
+        RECT 2.67 1.095 2.805 1.485 ;
+        RECT 2.29 1.095 2.425 1.485 ;
+        RECT 1.91 1.095 2.045 1.485 ;
+        RECT 1.38 1.095 1.515 1.485 ;
+        RECT 1 1.095 1.135 1.485 ;
+        RECT 0.62 1.095 0.755 1.485 ;
+        RECT 0.24 1.095 0.375 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.42 0.085 ;
+        RECT 3.05 -0.085 3.185 0.3 ;
+        RECT 2.67 -0.085 2.805 0.3 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.51 0.39 3.34 0.46 ;
+      RECT 3.27 0.185 3.34 0.46 ;
+      RECT 1.76 0.15 1.83 0.46 ;
+      RECT 2.89 0.185 2.96 0.46 ;
+      RECT 2.51 0.15 2.58 0.46 ;
+      RECT 1.76 0.15 2.58 0.22 ;
+      RECT 1.38 0.525 2.045 0.595 ;
+      RECT 1.91 0.285 2.045 0.595 ;
+      RECT 1.38 0.285 1.515 0.595 ;
+      RECT 1.91 0.285 2.425 0.355 ;
+      RECT 1.005 0.285 1.515 0.355 ;
+      RECT 1.6 0.15 1.67 0.46 ;
+      RECT 0.84 0.15 0.91 0.46 ;
+      RECT 0.09 0.15 0.16 0.46 ;
+      RECT 0.09 0.15 1.67 0.22 ;
+  END
+END NAND4_X4
+
+MACRO NOR2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR2_X1 0 0 ;
+  SIZE 0.57 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.525 0.51 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.43 0.975 0.5 1.25 ;
+        RECT 0.25 0.975 0.5 1.045 ;
+        RECT 0.25 0.15 0.32 1.045 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.57 1.485 ;
+        RECT 0.055 0.975 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.57 0.085 ;
+        RECT 0.43 -0.085 0.5 0.425 ;
+        RECT 0.055 -0.085 0.125 0.425 ;
+    END
+  END VSS
+END NOR2_X1
+
+MACRO NOR2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR2_X2 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.42 0.51 0.66 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.725 0.89 0.795 ;
+        RECT 0.76 0.525 0.89 0.795 ;
+        RECT 0.195 0.525 0.265 0.795 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.26 0.75 0.33 ;
+        RECT 0.455 0.91 0.525 1.25 ;
+        RECT 0.06 0.91 0.525 0.98 ;
+        RECT 0.06 0.26 0.13 0.98 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.835 1.045 0.905 1.485 ;
+        RECT 0.08 1.045 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.835 -0.085 0.905 0.335 ;
+        RECT 0.455 -0.085 0.525 0.195 ;
+        RECT 0.08 -0.085 0.15 0.195 ;
+    END
+  END VSS
+END NOR2_X2
+
+MACRO NOR2_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR2_X4 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.09 0.42 1.16 0.66 ;
+        RECT 0.59 0.42 1.16 0.49 ;
+        RECT 0.59 0.42 0.7 0.66 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.215 0.91 1.535 0.98 ;
+        RECT 1.465 0.525 1.535 0.98 ;
+        RECT 0.805 0.56 0.94 0.98 ;
+        RECT 0.215 0.525 0.285 0.98 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.24 0.28 1.51 0.35 ;
+        RECT 1.225 0.28 1.295 0.845 ;
+        RECT 0.44 0.28 0.525 0.845 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.6 0.71 1.67 1.485 ;
+        RECT 0.835 1.045 0.905 1.485 ;
+        RECT 0.08 0.71 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.595 -0.085 1.665 0.39 ;
+        RECT 1.215 -0.085 1.285 0.195 ;
+        RECT 0.835 -0.085 0.905 0.195 ;
+        RECT 0.455 -0.085 0.525 0.195 ;
+        RECT 0.08 -0.085 0.15 0.39 ;
+    END
+  END VSS
+END NOR2_X4
+
+MACRO NOR3_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR3_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.545 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.175 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.61 0.15 0.7 1 ;
+        RECT 0.235 0.355 0.7 0.425 ;
+        RECT 0.235 0.15 0.305 0.425 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.415 -0.085 0.485 0.22 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+END NOR3_X1
+
+MACRO NOR3_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR3_X2 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.62 0.56 0.755 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.92 0.425 0.99 0.66 ;
+        RECT 0.39 0.425 0.99 0.495 ;
+        RECT 0.39 0.425 0.51 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.77 1.27 0.84 ;
+        RECT 1.145 0.525 1.27 0.84 ;
+        RECT 0.195 0.525 0.265 0.84 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.285 1.13 0.355 ;
+        RECT 0.645 0.905 0.715 1.18 ;
+        RECT 0.06 0.905 0.715 0.975 ;
+        RECT 0.06 0.285 0.13 0.975 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.215 1.065 1.285 1.485 ;
+        RECT 0.08 1.065 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 1.215 -0.085 1.285 0.335 ;
+        RECT 0.835 -0.085 0.905 0.195 ;
+        RECT 0.455 -0.085 0.525 0.195 ;
+        RECT 0.08 -0.085 0.15 0.195 ;
+    END
+  END VSS
+END NOR3_X2
+
+MACRO NOR3_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR3_X4 0 0 ;
+  SIZE 2.66 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.525 0.51 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.185 0.525 1.27 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.13 0.525 2.23 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.235 0.39 2.38 0.46 ;
+        RECT 2.31 0.15 2.38 0.46 ;
+        RECT 1.93 0.15 2 0.46 ;
+        RECT 1.365 0.15 1.435 0.46 ;
+        RECT 0.985 0.15 1.055 0.46 ;
+        RECT 0.605 0.765 0.675 1.115 ;
+        RECT 0.605 0.15 0.675 0.46 ;
+        RECT 0.235 0.765 0.675 0.835 ;
+        RECT 0.235 0.39 0.32 0.835 ;
+        RECT 0.235 0.15 0.305 1.115 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.66 1.485 ;
+        RECT 2.5 0.9 2.57 1.485 ;
+        RECT 2.09 0.935 2.225 1.485 ;
+        RECT 1.745 0.9 1.815 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.66 0.085 ;
+        RECT 2.505 -0.085 2.575 0.425 ;
+        RECT 2.09 -0.085 2.225 0.325 ;
+        RECT 1.525 -0.085 1.85 0.325 ;
+        RECT 1.145 -0.085 1.28 0.325 ;
+        RECT 0.765 -0.085 0.9 0.325 ;
+        RECT 0.385 -0.085 0.52 0.325 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.31 0.765 2.38 1.175 ;
+      RECT 1.93 0.765 2 1.175 ;
+      RECT 1.365 0.765 1.435 1.115 ;
+      RECT 0.995 0.765 1.065 1.115 ;
+      RECT 0.995 0.765 2.38 0.835 ;
+      RECT 0.045 1.18 1.625 1.25 ;
+      RECT 1.555 0.9 1.625 1.25 ;
+      RECT 1.175 0.9 1.245 1.25 ;
+      RECT 0.795 0.9 0.865 1.25 ;
+      RECT 0.415 0.9 0.485 1.25 ;
+      RECT 0.045 0.9 0.115 1.25 ;
+  END
+END NOR3_X4
+
+MACRO NOR4_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR4_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.525 0.89 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.795 0.975 0.865 1.25 ;
+        RECT 0.63 0.975 0.865 1.045 ;
+        RECT 0.63 0.15 0.7 1.045 ;
+        RECT 0.235 0.355 0.7 0.425 ;
+        RECT 0.61 0.15 0.7 0.425 ;
+        RECT 0.235 0.15 0.305 0.425 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.795 -0.085 0.865 0.425 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+END NOR4_X1
+
+MACRO NOR4_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR4_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.81 0.56 0.945 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.11 0.42 1.18 0.66 ;
+        RECT 0.57 0.42 1.18 0.49 ;
+        RECT 0.57 0.42 0.7 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.38 0.765 1.46 0.835 ;
+        RECT 1.33 0.525 1.46 0.835 ;
+        RECT 0.38 0.525 0.45 0.835 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.2 0.91 1.65 0.98 ;
+        RECT 1.525 0.84 1.65 0.98 ;
+        RECT 1.525 0.525 1.595 0.98 ;
+        RECT 0.2 0.525 0.27 0.98 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.405 0.15 1.475 0.425 ;
+        RECT 0.055 0.26 1.475 0.33 ;
+        RECT 0.055 1.055 0.94 1.125 ;
+        RECT 0.055 0.26 0.13 1.125 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.595 1.065 1.665 1.485 ;
+        RECT 0.08 1.205 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.595 -0.085 1.665 0.335 ;
+        RECT 1.185 -0.085 1.32 0.16 ;
+        RECT 0.805 -0.085 0.94 0.16 ;
+        RECT 0.425 -0.085 0.56 0.16 ;
+        RECT 0.08 -0.085 0.15 0.195 ;
+    END
+  END VSS
+END NOR4_X2
+
+MACRO NOR4_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR4_X4 0 0 ;
+  SIZE 3.42 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.525 0.51 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.18 0.525 1.27 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.15 0.525 2.245 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.91 0.525 3 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.235 0.39 3.375 0.46 ;
+        RECT 3.305 0.15 3.375 0.46 ;
+        RECT 2.925 0.15 2.995 0.46 ;
+        RECT 2.545 0.15 2.615 0.46 ;
+        RECT 2.165 0.15 2.235 0.46 ;
+        RECT 1.79 0.15 1.86 0.46 ;
+        RECT 1.37 0.15 1.44 0.46 ;
+        RECT 0.985 0.15 1.055 0.46 ;
+        RECT 0.605 0.765 0.675 1.115 ;
+        RECT 0.605 0.15 0.675 0.46 ;
+        RECT 0.235 0.765 0.675 0.835 ;
+        RECT 0.235 0.39 0.32 0.835 ;
+        RECT 0.235 0.15 0.305 1.115 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.42 1.485 ;
+        RECT 3.085 0.935 3.22 1.485 ;
+        RECT 2.705 0.935 2.84 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.42 0.085 ;
+        RECT 3.085 -0.085 3.22 0.325 ;
+        RECT 2.705 -0.085 2.84 0.325 ;
+        RECT 2.325 -0.085 2.46 0.325 ;
+        RECT 1.945 -0.085 2.08 0.325 ;
+        RECT 1.525 -0.085 1.66 0.325 ;
+        RECT 1.145 -0.085 1.28 0.325 ;
+        RECT 0.765 -0.085 0.9 0.325 ;
+        RECT 0.385 -0.085 0.52 0.325 ;
+        RECT 0.04 -0.085 0.11 0.36 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.305 0.765 3.375 1.175 ;
+      RECT 2.925 0.765 2.995 1.175 ;
+      RECT 2.545 0.765 2.615 1.175 ;
+      RECT 2.165 0.765 2.235 1.115 ;
+      RECT 1.795 0.765 1.865 1.115 ;
+      RECT 1.795 0.765 3.375 0.835 ;
+      RECT 0.995 1.18 2.425 1.25 ;
+      RECT 2.355 0.9 2.425 1.25 ;
+      RECT 1.975 0.9 2.045 1.25 ;
+      RECT 1.365 0.9 1.435 1.25 ;
+      RECT 0.995 0.9 1.065 1.25 ;
+      RECT 0.045 1.18 0.865 1.25 ;
+      RECT 0.795 0.765 0.865 1.25 ;
+      RECT 0.415 0.9 0.485 1.25 ;
+      RECT 0.045 0.9 0.115 1.25 ;
+      RECT 1.555 0.765 1.625 1.115 ;
+      RECT 1.175 0.765 1.245 1.115 ;
+      RECT 0.795 0.765 1.625 0.835 ;
+  END
+END NOR4_X4
+
+MACRO OAI211_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI211_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.79 0.525 0.89 0.7 ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.4 0.525 0.51 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.835 0.78 0.905 1.055 ;
+        RECT 0.25 0.78 0.905 0.85 ;
+        RECT 0.455 0.78 0.525 1.055 ;
+        RECT 0.25 0.78 0.525 0.855 ;
+        RECT 0.25 0.285 0.335 0.855 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.645 1.04 0.715 1.485 ;
+        RECT 0.08 1.04 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.835 -0.085 0.905 0.46 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.455 0.15 0.525 0.425 ;
+      RECT 0.085 0.15 0.155 0.425 ;
+      RECT 0.085 0.15 0.525 0.22 ;
+  END
+END OAI211_X1
+
+MACRO OAI211_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI211_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.185 0.765 0.755 0.835 ;
+        RECT 0.685 0.525 0.755 0.835 ;
+        RECT 0.185 0.525 0.32 0.835 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.53 0.7 ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.19 0.525 1.29 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.96 0.77 1.65 0.84 ;
+        RECT 1.525 0.525 1.65 0.84 ;
+        RECT 0.96 0.525 1.03 0.84 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.39 1.51 0.46 ;
+        RECT 1.215 0.905 1.285 1.25 ;
+        RECT 0.27 0.905 1.285 0.975 ;
+        RECT 0.82 0.39 0.89 0.975 ;
+        RECT 0.645 0.905 0.715 1.25 ;
+        RECT 0.27 0.905 0.34 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.595 1.04 1.665 1.485 ;
+        RECT 0.835 1.04 0.905 1.485 ;
+        RECT 0.455 1.04 0.525 1.485 ;
+        RECT 0.08 1.04 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 0.45 -0.085 0.52 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.595 0.185 1.665 0.46 ;
+      RECT 0.08 0.39 0.66 0.46 ;
+      RECT 0.59 0.185 0.66 0.46 ;
+      RECT 0.08 0.185 0.15 0.46 ;
+      RECT 0.59 0.185 1.665 0.255 ;
+  END
+END OAI211_X2
+
+MACRO OAI211_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI211_X4 0 0 ;
+  SIZE 3.23 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.39 0.39 1.52 0.66 ;
+        RECT 0.125 0.39 1.52 0.46 ;
+        RECT 0.805 0.39 0.875 0.66 ;
+        RECT 0.125 0.39 0.195 0.66 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.42 0.77 1.245 0.84 ;
+        RECT 1.175 0.525 1.245 0.84 ;
+        RECT 0.42 0.525 0.51 0.84 ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.91 0.77 2.8 0.84 ;
+        RECT 2.665 0.56 2.8 0.84 ;
+        RECT 1.91 0.56 2.045 0.84 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.965 0.425 3.035 0.66 ;
+        RECT 1.67 0.425 3.035 0.495 ;
+        RECT 2.31 0.425 2.41 0.7 ;
+        RECT 1.67 0.425 1.74 0.66 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.235 0.905 3.17 0.975 ;
+        RECT 3.1 0.29 3.17 0.975 ;
+        RECT 1.72 0.29 3.17 0.36 ;
+        RECT 2.695 0.905 2.765 1.25 ;
+        RECT 1.935 0.905 2.005 1.25 ;
+        RECT 1.365 0.905 1.435 1.25 ;
+        RECT 0.985 0.905 1.055 1.25 ;
+        RECT 0.605 0.905 0.675 1.25 ;
+        RECT 0.235 0.905 0.305 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.23 1.485 ;
+        RECT 3.075 1.04 3.145 1.485 ;
+        RECT 2.315 1.04 2.385 1.485 ;
+        RECT 1.555 1.04 1.625 1.485 ;
+        RECT 1.175 1.04 1.245 1.485 ;
+        RECT 0.795 1.04 0.865 1.485 ;
+        RECT 0.415 1.04 0.485 1.485 ;
+        RECT 0.04 1.04 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.23 0.085 ;
+        RECT 1.145 -0.085 1.28 0.16 ;
+        RECT 0.385 -0.085 0.52 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.225 1.625 0.295 ;
+      RECT 1.555 0.15 1.625 0.295 ;
+      RECT 0.045 0.15 0.115 0.295 ;
+      RECT 1.555 0.15 3.18 0.22 ;
+  END
+END OAI211_X4
+
+MACRO OAI21_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI21_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.525 0.51 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.765 0.51 1.25 ;
+        RECT 0.25 0.765 0.51 0.835 ;
+        RECT 0.25 0.285 0.32 0.835 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.63 0.975 0.7 1.485 ;
+        RECT 0.065 0.975 0.135 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.63 -0.085 0.7 0.46 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.44 0.15 0.51 0.425 ;
+      RECT 0.07 0.15 0.14 0.425 ;
+      RECT 0.07 0.15 0.51 0.22 ;
+  END
+END OAI21_X1
+
+MACRO OAI21_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI21_X2 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.19 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.805 0.525 0.89 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.77 1.135 0.84 ;
+        RECT 1.065 0.525 1.135 0.84 ;
+        RECT 0.44 0.525 0.57 0.84 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.235 0.905 1.27 0.975 ;
+        RECT 1.2 0.355 1.27 0.975 ;
+        RECT 0.58 0.355 1.27 0.425 ;
+        RECT 0.795 0.905 0.865 1.25 ;
+        RECT 0.235 0.905 0.305 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.175 1.04 1.245 1.485 ;
+        RECT 0.415 1.04 0.485 1.485 ;
+        RECT 0.04 1.04 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.355 0.485 0.425 ;
+      RECT 0.415 0.15 0.485 0.425 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+      RECT 0.415 0.15 1.28 0.22 ;
+  END
+END OAI21_X2
+
+MACRO OAI21_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI21_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.43 0.525 0.515 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.15 0.69 2.04 0.76 ;
+        RECT 1.905 0.56 2.04 0.76 ;
+        RECT 1.15 0.56 1.285 0.76 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.15 0.42 2.275 0.66 ;
+        RECT 0.91 0.42 2.275 0.49 ;
+        RECT 1.525 0.42 1.66 0.625 ;
+        RECT 0.91 0.42 0.98 0.66 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.235 0.845 2.41 0.915 ;
+        RECT 2.34 0.285 2.41 0.915 ;
+        RECT 0.96 0.285 2.41 0.355 ;
+        RECT 1.935 0.845 2.005 1.19 ;
+        RECT 1.175 0.845 1.245 1.19 ;
+        RECT 0.605 0.845 0.675 1.19 ;
+        RECT 0.235 0.845 0.305 1.19 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.315 1.04 2.385 1.485 ;
+        RECT 1.555 1.04 1.625 1.485 ;
+        RECT 0.795 1.04 0.865 1.485 ;
+        RECT 0.415 1.04 0.485 1.485 ;
+        RECT 0.04 1.04 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.355 0.83 0.425 ;
+      RECT 0.76 0.15 0.83 0.425 ;
+      RECT 0.42 0.15 0.49 0.425 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+      RECT 0.76 0.15 2.42 0.22 ;
+  END
+END OAI21_X4
+
+MACRO OAI221_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI221_X1 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.955 0.525 1.08 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.74 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.985 0.85 1.055 1.25 ;
+        RECT 0.425 0.85 1.055 0.92 ;
+        RECT 0.805 0.4 0.89 0.92 ;
+        RECT 0.425 0.85 0.495 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.605 1.04 0.675 1.485 ;
+        RECT 0.04 1.04 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.985 0.15 1.055 0.425 ;
+      RECT 0.615 0.15 0.685 0.425 ;
+      RECT 0.615 0.15 1.055 0.22 ;
+      RECT 0.045 0.355 0.485 0.425 ;
+      RECT 0.415 0.15 0.485 0.425 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+  END
+END OAI221_X1
+
+MACRO OAI221_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI221_X2 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.955 0.9 2.03 0.97 ;
+        RECT 1.93 0.525 2.03 0.97 ;
+        RECT 0.955 0.525 1.025 0.97 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.155 0.765 1.84 0.835 ;
+        RECT 1.715 0.525 1.84 0.835 ;
+        RECT 1.155 0.525 1.225 0.835 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.38 0.525 1.48 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.525 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.77 0.89 0.84 ;
+        RECT 0.76 0.525 0.89 0.84 ;
+        RECT 0.195 0.525 0.265 0.84 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.755 1.035 1.89 1.245 ;
+        RECT 0.06 1.035 1.89 1.105 ;
+        RECT 0.995 1.035 1.13 1.245 ;
+        RECT 0.06 0.39 0.75 0.46 ;
+        RECT 0.425 1.035 0.56 1.245 ;
+        RECT 0.06 0.39 0.13 1.105 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.975 1.065 2.045 1.485 ;
+        RECT 1.405 1.17 1.475 1.485 ;
+        RECT 0.835 1.17 0.905 1.485 ;
+        RECT 0.085 1.17 0.155 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.565 -0.085 1.7 0.19 ;
+        RECT 1.185 -0.085 1.32 0.19 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.975 0.15 2.045 0.425 ;
+      RECT 0.05 0.255 2.045 0.325 ;
+      RECT 1 0.39 1.89 0.46 ;
+  END
+END OAI221_X2
+
+MACRO OAI221_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI221_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.585 0.525 0.7 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.775 0.525 0.9 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.155 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.245 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.395 0.525 0.51 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.165 0.185 2.235 1.25 ;
+        RECT 1.795 0.7 2.235 0.84 ;
+        RECT 1.795 0.185 1.865 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.355 0.975 2.425 1.485 ;
+        RECT 1.975 0.975 2.045 1.485 ;
+        RECT 1.595 0.975 1.665 1.485 ;
+        RECT 1.19 1.04 1.26 1.485 ;
+        RECT 0.47 1.04 0.54 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.355 -0.085 2.425 0.46 ;
+        RECT 1.975 -0.085 2.045 0.46 ;
+        RECT 1.595 -0.085 1.665 0.335 ;
+        RECT 1.19 -0.085 1.26 0.2 ;
+        RECT 0.82 -0.085 0.955 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.415 0.185 1.485 1.25 ;
+      RECT 1.415 0.525 1.73 0.66 ;
+      RECT 0.66 0.775 0.73 1.12 ;
+      RECT 0.1 0.775 0.17 1.12 ;
+      RECT 0.1 0.775 1.35 0.845 ;
+      RECT 1.28 0.39 1.35 0.845 ;
+      RECT 0.29 0.39 1.35 0.46 ;
+      RECT 0.29 0.285 0.36 0.46 ;
+      RECT 0.67 0.255 1.11 0.325 ;
+      RECT 0.67 0.15 0.74 0.325 ;
+      RECT 0.47 0.15 0.54 0.285 ;
+      RECT 0.1 0.15 0.17 0.285 ;
+      RECT 0.1 0.15 0.54 0.22 ;
+  END
+END OAI221_X4
+
+MACRO OAI222_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI222_X1 0 0 ;
+  SIZE 1.52 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.34 0.525 1.46 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.115 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.755 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.525 0.945 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.35 0.525 0.51 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.2 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.36 0.795 1.43 1.14 ;
+        RECT 0.52 0.795 1.43 0.865 ;
+        RECT 1.18 0.4 1.27 0.865 ;
+        RECT 0.52 0.795 0.59 1.14 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.52 1.485 ;
+        RECT 0.98 1.04 1.05 1.485 ;
+        RECT 0.05 1.04 0.12 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.52 0.085 ;
+        RECT 0.395 -0.085 0.53 0.19 ;
+        RECT 0.05 -0.085 0.12 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.575 0.39 1.05 0.46 ;
+      RECT 0.98 0.15 1.05 0.46 ;
+      RECT 1.36 0.15 1.43 0.425 ;
+      RECT 0.98 0.265 1.43 0.335 ;
+      RECT 0.245 0.15 0.315 0.425 ;
+      RECT 0.245 0.255 0.86 0.325 ;
+      RECT 0.79 0.15 0.86 0.325 ;
+  END
+END OAI222_X1
+
+MACRO OAI222_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI222_X2 0 0 ;
+  SIZE 2.66 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.85 0.725 2.465 0.795 ;
+        RECT 2.34 0.525 2.465 0.795 ;
+        RECT 1.85 0.525 1.92 0.795 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.15 0.42 2.22 0.66 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.955 0.77 1.65 0.84 ;
+        RECT 1.525 0.525 1.65 0.84 ;
+        RECT 0.955 0.525 1.025 0.84 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.525 1.29 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.77 0.83 0.84 ;
+        RECT 0.76 0.525 0.83 0.84 ;
+        RECT 0.195 0.525 0.32 0.84 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.53 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.53 0.285 2.6 1.25 ;
+        RECT 0.09 0.905 2.6 0.975 ;
+        RECT 1.925 0.285 2.6 0.355 ;
+        RECT 1.605 0.905 1.675 1.25 ;
+        RECT 0.84 0.905 0.91 1.25 ;
+        RECT 0.09 0.905 0.16 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.66 1.485 ;
+        RECT 2.14 1.04 2.21 1.485 ;
+        RECT 1.22 1.04 1.29 1.485 ;
+        RECT 0.46 1.04 0.53 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.66 0.085 ;
+        RECT 0.65 -0.085 0.72 0.285 ;
+        RECT 0.27 -0.085 0.34 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.005 0.355 1.84 0.425 ;
+      RECT 1.77 0.15 1.84 0.425 ;
+      RECT 1.77 0.15 2.625 0.22 ;
+      RECT 0.09 0.355 0.91 0.425 ;
+      RECT 0.84 0.15 0.91 0.425 ;
+      RECT 0.465 0.15 0.535 0.425 ;
+      RECT 0.09 0.15 0.16 0.425 ;
+      RECT 0.84 0.15 1.705 0.22 ;
+  END
+END OAI222_X2
+
+MACRO OAI222_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI222_X4 0 0 ;
+  SIZE 2.66 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.56 0.9 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.495 0.56 0.7 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.995 0.56 1.13 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.195 0.56 1.33 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.29 0.15 2.36 1.25 ;
+        RECT 1.915 0.56 2.36 0.7 ;
+        RECT 1.915 0.15 1.985 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.66 1.485 ;
+        RECT 2.475 0.975 2.545 1.485 ;
+        RECT 2.095 0.975 2.165 1.485 ;
+        RECT 1.715 0.975 1.785 1.485 ;
+        RECT 1.335 1.04 1.405 1.485 ;
+        RECT 0.415 1.03 0.485 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.66 0.085 ;
+        RECT 2.475 -0.085 2.545 0.425 ;
+        RECT 2.095 -0.085 2.165 0.425 ;
+        RECT 1.715 -0.085 1.785 0.335 ;
+        RECT 1.335 -0.085 1.405 0.22 ;
+        RECT 0.965 -0.085 1.035 0.22 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.535 0.15 1.605 1.16 ;
+      RECT 1.535 0.525 1.85 0.66 ;
+      RECT 0.88 0.785 0.95 1.075 ;
+      RECT 0.045 0.785 0.115 1.075 ;
+      RECT 0.045 0.785 1.465 0.855 ;
+      RECT 1.395 0.285 1.465 0.855 ;
+      RECT 0.2 0.285 1.465 0.355 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+      RECT 0.045 0.15 0.9 0.22 ;
+      RECT 0.58 0.42 1.25 0.49 ;
+  END
+END OAI222_X4
+
+MACRO OAI22_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI22_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.525 0.89 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.39 0.725 0.46 ;
+        RECT 0.44 0.39 0.51 1.05 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.81 0.975 0.88 1.485 ;
+        RECT 0.055 0.975 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.21 -0.085 0.345 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.81 0.185 0.88 0.46 ;
+      RECT 0.06 0.185 0.13 0.46 ;
+      RECT 0.06 0.245 0.88 0.315 ;
+  END
+END OAI22_X1
+
+MACRO OAI22_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI22_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.185 0.525 1.27 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.765 1.515 0.835 ;
+        RECT 1.445 0.525 1.515 0.835 ;
+        RECT 0.82 0.525 0.95 0.835 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.525 0.525 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.765 0.75 0.835 ;
+        RECT 0.68 0.525 0.75 0.835 ;
+        RECT 0.06 0.525 0.185 0.835 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.9 1.65 0.97 ;
+        RECT 1.58 0.39 1.65 0.97 ;
+        RECT 0.96 0.39 1.65 0.46 ;
+        RECT 1.185 0.9 1.255 1.25 ;
+        RECT 0.425 0.9 0.495 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.555 1.035 1.625 1.485 ;
+        RECT 0.795 1.035 0.865 1.485 ;
+        RECT 0.04 1.035 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.355 0.865 0.425 ;
+      RECT 0.795 0.15 0.865 0.425 ;
+      RECT 0.415 0.15 0.485 0.425 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+      RECT 0.795 0.15 1.66 0.22 ;
+  END
+END OAI22_X2
+
+MACRO OAI22_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI22_X4 0 0 ;
+  SIZE 3.23 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.91 0.725 2.805 0.795 ;
+        RECT 2.67 0.56 2.805 0.795 ;
+        RECT 1.91 0.56 2.045 0.795 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.91 0.425 3.035 0.7 ;
+        RECT 1.645 0.425 3.035 0.495 ;
+        RECT 2.32 0.425 2.39 0.66 ;
+        RECT 1.645 0.425 1.715 0.66 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.725 1.28 0.795 ;
+        RECT 1.145 0.56 1.28 0.795 ;
+        RECT 0.385 0.56 0.52 0.795 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.39 0.425 1.52 0.7 ;
+        RECT 0.15 0.425 1.52 0.495 ;
+        RECT 0.795 0.425 0.865 0.66 ;
+        RECT 0.15 0.425 0.22 0.66 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.865 3.17 0.935 ;
+        RECT 3.1 0.29 3.17 0.935 ;
+        RECT 1.72 0.29 3.17 0.36 ;
+        RECT 2.695 0.865 2.765 1.21 ;
+        RECT 1.935 0.865 2.005 1.21 ;
+        RECT 1.175 0.865 1.245 1.21 ;
+        RECT 0.425 0.865 0.495 1.21 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.23 1.485 ;
+        RECT 3.075 1.04 3.145 1.485 ;
+        RECT 2.315 1.04 2.385 1.485 ;
+        RECT 1.555 1.04 1.625 1.485 ;
+        RECT 0.795 1.04 0.865 1.485 ;
+        RECT 0.04 1.04 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.23 0.085 ;
+        RECT 1.365 -0.085 1.435 0.195 ;
+        RECT 0.985 -0.085 1.055 0.195 ;
+        RECT 0.605 -0.085 0.675 0.195 ;
+        RECT 0.225 -0.085 0.295 0.195 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.26 1.595 0.33 ;
+      RECT 1.525 0.15 1.595 0.33 ;
+      RECT 0.045 0.185 0.115 0.33 ;
+      RECT 1.525 0.15 3.18 0.22 ;
+  END
+END OAI22_X4
+
+MACRO OAI33_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI33_X1 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.525 0.89 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.955 0.525 1.08 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.145 0.525 1.27 0.7 ;
+    END
+  END A3
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END B2
+  PIN B3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END B3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.365 1.26 0.435 ;
+        RECT 1.19 0.15 1.26 0.435 ;
+        RECT 0.63 0.365 0.7 1 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.19 0.975 1.26 1.485 ;
+        RECT 0.055 0.975 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 0.4 -0.085 0.535 0.16 ;
+        RECT 0.055 -0.085 0.125 0.335 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.215 0.225 1.105 0.295 ;
+  END
+END OAI33_X1
+
+MACRO OR2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR2_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.61 0.15 0.7 1.24 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.415 0.965 0.485 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.83 0.115 1.24 ;
+      RECT 0.045 0.83 0.54 0.9 ;
+      RECT 0.47 0.35 0.54 0.9 ;
+      RECT 0.235 0.35 0.54 0.42 ;
+      RECT 0.235 0.15 0.305 0.42 ;
+  END
+END OR2_X1
+
+MACRO OR2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR2_X2 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.615 0.15 0.7 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 1.04 0.485 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.795 -0.085 0.865 0.425 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.905 0.115 1.25 ;
+      RECT 0.045 0.905 0.545 0.975 ;
+      RECT 0.475 0.355 0.545 0.975 ;
+      RECT 0.235 0.355 0.545 0.425 ;
+      RECT 0.235 0.15 0.305 0.425 ;
+  END
+END OR2_X2
+
+MACRO OR2_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR2_X4 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.765 0.76 0.835 ;
+        RECT 0.69 0.525 0.76 0.835 ;
+        RECT 0.06 0.525 0.15 0.835 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.365 0.15 1.435 1.095 ;
+        RECT 0.995 0.56 1.435 0.7 ;
+        RECT 0.995 0.15 1.075 0.7 ;
+        RECT 0.995 0.15 1.065 1.095 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.555 1.035 1.625 1.485 ;
+        RECT 1.175 1.035 1.245 1.485 ;
+        RECT 0.795 1.035 0.865 1.485 ;
+        RECT 0.04 1.035 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.555 -0.085 1.625 0.425 ;
+        RECT 1.175 -0.085 1.245 0.425 ;
+        RECT 0.795 -0.085 0.865 0.285 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.425 0.9 0.495 1.25 ;
+      RECT 0.425 0.9 0.925 0.97 ;
+      RECT 0.855 0.355 0.925 0.97 ;
+      RECT 0.235 0.355 0.925 0.425 ;
+      RECT 0.605 0.15 0.675 0.425 ;
+      RECT 0.235 0.15 0.305 0.425 ;
+  END
+END OR2_X4
+
+MACRO OR3_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR3_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.57 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.8 0.15 0.89 1.24 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.605 0.965 0.675 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.83 0.115 1.24 ;
+      RECT 0.045 0.83 0.73 0.9 ;
+      RECT 0.66 0.35 0.73 0.9 ;
+      RECT 0.045 0.35 0.73 0.42 ;
+      RECT 0.415 0.15 0.485 0.42 ;
+      RECT 0.045 0.15 0.115 0.42 ;
+  END
+END OR3_X1
+
+MACRO OR3_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR3_X2 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.57 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.805 0.15 0.89 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.985 0.975 1.055 1.485 ;
+        RECT 0.605 0.975 0.675 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.985 -0.085 1.055 0.425 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.84 0.115 1.25 ;
+      RECT 0.045 0.84 0.73 0.91 ;
+      RECT 0.66 0.39 0.73 0.91 ;
+      RECT 0.045 0.39 0.73 0.46 ;
+      RECT 0.415 0.15 0.485 0.46 ;
+      RECT 0.045 0.15 0.115 0.46 ;
+  END
+END OR3_X2
+
+MACRO OR3_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR3_X4 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.61 0.56 0.745 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.915 0.42 0.985 0.66 ;
+        RECT 0.375 0.42 0.985 0.49 ;
+        RECT 0.375 0.42 0.51 0.66 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.185 0.77 1.2 0.84 ;
+        RECT 1.13 0.525 1.2 0.84 ;
+        RECT 0.185 0.7 0.32 0.84 ;
+        RECT 0.185 0.525 0.255 0.84 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.79 0.26 1.86 1.25 ;
+        RECT 1.415 0.56 1.86 0.7 ;
+        RECT 1.415 0.26 1.485 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.975 1.035 2.045 1.485 ;
+        RECT 1.595 1.035 1.665 1.485 ;
+        RECT 1.21 1.045 1.28 1.485 ;
+        RECT 0.075 1.035 0.145 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.975 -0.085 2.045 0.335 ;
+        RECT 1.595 -0.085 1.665 0.335 ;
+        RECT 1.21 -0.085 1.28 0.195 ;
+        RECT 0.83 -0.085 0.9 0.195 ;
+        RECT 0.45 -0.085 0.52 0.195 ;
+        RECT 0.075 -0.085 0.145 0.335 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.65 0.91 0.72 1.25 ;
+      RECT 0.65 0.91 1.35 0.98 ;
+      RECT 1.28 0.26 1.35 0.98 ;
+      RECT 0.235 0.26 1.35 0.33 ;
+  END
+END OR3_X4
+
+MACRO OR4_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR4_X1 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.76 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.99 0.15 1.08 1.24 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.795 0.965 0.865 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.795 -0.085 0.865 0.285 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.83 0.115 1.24 ;
+      RECT 0.045 0.83 0.92 0.9 ;
+      RECT 0.85 0.35 0.92 0.9 ;
+      RECT 0.235 0.35 0.92 0.42 ;
+      RECT 0.605 0.15 0.675 0.42 ;
+      RECT 0.235 0.15 0.305 0.42 ;
+  END
+END OR4_X1
+
+MACRO OR4_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR4_X2 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.76 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.995 0.15 1.08 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.175 0.975 1.245 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 1.175 -0.085 1.245 0.425 ;
+        RECT 0.795 -0.085 0.865 0.285 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.84 0.115 1.25 ;
+      RECT 0.045 0.84 0.925 0.91 ;
+      RECT 0.855 0.355 0.925 0.91 ;
+      RECT 0.235 0.355 0.925 0.425 ;
+      RECT 0.605 0.15 0.675 0.425 ;
+      RECT 0.235 0.15 0.305 0.425 ;
+  END
+END OR4_X2
+
+MACRO OR4_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR4_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.805 0.525 0.89 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.39 1.14 0.66 ;
+        RECT 0.505 0.39 1.14 0.46 ;
+        RECT 0.505 0.39 0.575 0.66 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.31 0.77 1.33 0.84 ;
+        RECT 1.26 0.525 1.33 0.84 ;
+        RECT 0.31 0.525 0.38 0.84 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.115 0.905 1.52 0.975 ;
+        RECT 1.45 0.525 1.52 0.975 ;
+        RECT 0.115 0.525 0.185 0.975 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.13 0.15 2.2 1.25 ;
+        RECT 1.755 0.56 2.2 0.7 ;
+        RECT 1.755 0.15 1.825 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.315 1.045 2.385 1.485 ;
+        RECT 1.935 1.045 2.005 1.485 ;
+        RECT 1.555 1.205 1.625 1.485 ;
+        RECT 0.04 1.045 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.315 -0.085 2.385 0.4 ;
+        RECT 1.905 -0.085 2.04 0.365 ;
+        RECT 1.525 -0.085 1.66 0.325 ;
+        RECT 1.145 -0.085 1.28 0.16 ;
+        RECT 0.765 -0.085 0.9 0.16 ;
+        RECT 0.385 -0.085 0.52 0.16 ;
+        RECT 0.04 -0.085 0.11 0.4 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.77 1.04 1.685 1.11 ;
+      RECT 1.615 0.39 1.685 1.11 ;
+      RECT 1.37 0.39 1.685 0.46 ;
+      RECT 0.235 0.15 0.305 0.425 ;
+      RECT 1.37 0.15 1.44 0.46 ;
+      RECT 0.235 0.225 1.44 0.295 ;
+  END
+END OR4_X4
+
+MACRO SDFFRS_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFFRS_X1 0 0 ;
+  SIZE 5.51 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 5.07 0.765 5.26 0.98 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.525 0.92 0.7 ;
+    END
+  END RN
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 5.19 0.39 5.335 0.56 ;
+        RECT 4.76 0.39 5.335 0.46 ;
+        RECT 4.76 0.765 5.005 0.835 ;
+        RECT 4.76 0.39 4.83 0.835 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.56 0.695 4.69 0.84 ;
+    END
+  END SI
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.11 0.7 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.575 0.7 1.67 0.84 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.045 0.26 0.13 1.105 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.36 0.51 0.8 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 5.51 1.485 ;
+        RECT 5.175 1.095 5.31 1.485 ;
+        RECT 4.415 1.13 4.55 1.485 ;
+        RECT 3.585 1.03 3.72 1.485 ;
+        RECT 3.045 0.865 3.18 1.485 ;
+        RECT 2.665 0.99 2.8 1.485 ;
+        RECT 1.945 0.83 2.015 1.485 ;
+        RECT 1.305 1.105 1.44 1.485 ;
+        RECT 0.925 1.105 1.06 1.485 ;
+        RECT 0.545 1.035 0.68 1.485 ;
+        RECT 0.195 1.18 0.33 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 5.51 0.085 ;
+        RECT 5.175 -0.085 5.31 0.225 ;
+        RECT 4.415 -0.085 4.55 0.225 ;
+        RECT 3.4 -0.085 3.535 0.285 ;
+        RECT 2.665 -0.085 2.8 0.285 ;
+        RECT 1.755 -0.085 1.825 0.32 ;
+        RECT 0.92 -0.085 1.055 0.285 ;
+        RECT 0.195 -0.085 0.33 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 5.4 0.215 5.47 1.235 ;
+      RECT 4.9 0.625 5.47 0.695 ;
+      RECT 4.9 0.56 4.975 0.695 ;
+      RECT 4.37 0.945 4.93 1.015 ;
+      RECT 4.37 0.41 4.44 1.015 ;
+      RECT 4.37 0.41 4.685 0.48 ;
+      RECT 4.615 0.22 4.685 0.48 ;
+      RECT 4.615 0.22 4.93 0.29 ;
+      RECT 3.94 1.18 4.28 1.25 ;
+      RECT 4.21 0.16 4.28 1.25 ;
+      RECT 3.94 0.76 4.01 1.25 ;
+      RECT 2.18 1.035 2.525 1.105 ;
+      RECT 2.455 0.35 2.525 1.105 ;
+      RECT 3.27 0.76 3.34 1.09 ;
+      RECT 3.27 0.76 4.01 0.83 ;
+      RECT 3.865 0.16 3.935 0.51 ;
+      RECT 3.265 0.35 3.935 0.42 ;
+      RECT 2.455 0.35 2.98 0.42 ;
+      RECT 2.91 0.16 2.98 0.42 ;
+      RECT 3.265 0.16 3.335 0.42 ;
+      RECT 3.865 0.16 4.28 0.23 ;
+      RECT 2.91 0.16 3.335 0.23 ;
+      RECT 4.075 0.295 4.145 1.115 ;
+      RECT 2.75 0.62 4.145 0.69 ;
+      RECT 4 0.295 4.145 0.69 ;
+      RECT 3.805 0.895 3.875 1.115 ;
+      RECT 3.435 0.895 3.505 1.115 ;
+      RECT 3.435 0.895 3.875 0.965 ;
+      RECT 2.615 0.755 2.99 0.825 ;
+      RECT 2.615 0.485 2.685 0.825 ;
+      RECT 2.615 0.485 3.8 0.555 ;
+      RECT 3.045 0.295 3.18 0.555 ;
+      RECT 2.315 0.2 2.385 0.965 ;
+      RECT 1.415 0.555 2.385 0.625 ;
+      RECT 2.125 0.695 2.195 0.965 ;
+      RECT 1.755 0.695 1.825 0.965 ;
+      RECT 1.755 0.695 2.195 0.765 ;
+      RECT 1.145 0.765 1.215 1.105 ;
+      RECT 0.61 0.765 1.215 0.835 ;
+      RECT 0.61 0.39 0.68 0.835 ;
+      RECT 0.61 0.39 1.19 0.46 ;
+      RECT 1.12 0.25 1.19 0.46 ;
+      RECT 1.62 0.385 2.15 0.455 ;
+      RECT 1.62 0.15 1.69 0.455 ;
+      RECT 1.12 0.25 1.4 0.32 ;
+      RECT 1.33 0.15 1.4 0.32 ;
+      RECT 1.33 0.15 1.69 0.22 ;
+      RECT 1.585 1.165 1.815 1.235 ;
+      RECT 1.585 0.905 1.655 1.235 ;
+      RECT 1.28 0.905 1.655 0.975 ;
+      RECT 1.28 0.41 1.35 0.975 ;
+      RECT 1.28 0.41 1.555 0.48 ;
+      RECT 1.485 0.285 1.555 0.48 ;
+      RECT 0.195 0.9 0.865 0.97 ;
+      RECT 0.195 0.225 0.265 0.97 ;
+      RECT 0.195 0.225 0.68 0.295 ;
+  END
+END SDFFRS_X1
+
+MACRO SDFFRS_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFFRS_X2 0 0 ;
+  SIZE 5.89 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 5.495 0.42 5.64 0.56 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.545 1.165 0.7 ;
+    END
+  END RN
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 5.57 0.675 5.7 0.84 ;
+        RECT 5.135 0.72 5.7 0.79 ;
+        RECT 5.135 0.385 5.205 0.79 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.925 0.56 5.07 0.7 ;
+    END
+  END SI
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.365 0.545 1.46 0.7 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.9 0.175 2.065 0.245 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.24 0.15 0.32 1.125 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.6 0.435 0.735 0.9 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 5.89 1.485 ;
+        RECT 5.54 1.195 5.675 1.485 ;
+        RECT 4.78 1.09 4.915 1.485 ;
+        RECT 3.95 1.09 4.085 1.485 ;
+        RECT 3.42 0.985 3.555 1.485 ;
+        RECT 3.04 0.985 3.175 1.485 ;
+        RECT 2.285 0.965 2.42 1.485 ;
+        RECT 1.64 1.115 1.775 1.485 ;
+        RECT 1.18 1.12 1.315 1.485 ;
+        RECT 0.79 1.1 0.925 1.485 ;
+        RECT 0.41 1.1 0.545 1.485 ;
+        RECT 0.065 0.85 0.135 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 5.89 0.085 ;
+        RECT 5.54 -0.085 5.675 0.18 ;
+        RECT 4.81 -0.085 4.88 0.27 ;
+        RECT 3.76 -0.085 3.895 0.285 ;
+        RECT 3.04 -0.085 3.175 0.285 ;
+        RECT 2.13 -0.085 2.2 0.32 ;
+        RECT 1.7 -0.085 1.835 0.285 ;
+        RECT 0.79 -0.085 0.925 0.16 ;
+        RECT 0.41 -0.085 0.545 0.16 ;
+        RECT 0.065 -0.085 0.135 0.41 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 5.765 0.15 5.835 1.09 ;
+      RECT 5.27 0.565 5.41 0.635 ;
+      RECT 5.34 0.285 5.41 0.635 ;
+      RECT 5.34 0.285 5.835 0.355 ;
+      RECT 4.74 0.95 5.295 1.02 ;
+      RECT 4.74 0.375 4.81 1.02 ;
+      RECT 4.74 0.375 5.045 0.445 ;
+      RECT 4.975 0.165 5.045 0.445 ;
+      RECT 4.975 0.165 5.295 0.235 ;
+      RECT 4.305 1.155 4.675 1.225 ;
+      RECT 4.605 0.15 4.675 1.225 ;
+      RECT 2.555 1.115 2.915 1.185 ;
+      RECT 2.845 0.35 2.915 1.185 ;
+      RECT 4.305 0.765 4.375 1.225 ;
+      RECT 3.615 0.765 4.375 0.835 ;
+      RECT 4.575 0.69 4.675 0.825 ;
+      RECT 3.61 0.355 4.34 0.425 ;
+      RECT 4.27 0.15 4.34 0.425 ;
+      RECT 2.845 0.35 3.39 0.42 ;
+      RECT 3.32 0.15 3.39 0.42 ;
+      RECT 3.61 0.15 3.68 0.425 ;
+      RECT 4.27 0.15 4.675 0.22 ;
+      RECT 3.32 0.15 3.68 0.22 ;
+      RECT 4.44 0.625 4.51 1.09 ;
+      RECT 3.125 0.625 4.51 0.695 ;
+      RECT 4.405 0.285 4.475 0.695 ;
+      RECT 4.405 0.285 4.54 0.355 ;
+      RECT 4.17 0.955 4.24 1.175 ;
+      RECT 3.8 0.955 3.87 1.175 ;
+      RECT 3.8 0.955 4.24 1.025 ;
+      RECT 2.99 0.765 3.37 0.835 ;
+      RECT 2.99 0.485 3.06 0.835 ;
+      RECT 2.99 0.49 4.17 0.56 ;
+      RECT 2.99 0.485 3.525 0.56 ;
+      RECT 3.455 0.32 3.525 0.56 ;
+      RECT 2.7 0.2 2.77 1.05 ;
+      RECT 1.665 0.485 1.735 0.68 ;
+      RECT 1.665 0.485 2.77 0.555 ;
+      RECT 1.53 0.84 2.04 0.91 ;
+      RECT 1.97 0.685 2.04 0.91 ;
+      RECT 1.53 0.35 1.6 0.91 ;
+      RECT 1.97 0.685 2.635 0.755 ;
+      RECT 2.565 0.62 2.635 0.755 ;
+      RECT 1.53 0.35 2.04 0.42 ;
+      RECT 2.5 0.83 2.57 1.05 ;
+      RECT 2.13 0.83 2.2 1.05 ;
+      RECT 2.13 0.83 2.57 0.9 ;
+      RECT 1.84 1.16 2.22 1.23 ;
+      RECT 1.84 0.975 1.91 1.23 ;
+      RECT 1.395 0.975 1.91 1.045 ;
+      RECT 1.395 0.765 1.465 1.045 ;
+      RECT 0.87 0.765 1.465 0.835 ;
+      RECT 0.87 0.41 0.94 0.835 ;
+      RECT 0.87 0.41 1.46 0.48 ;
+      RECT 0.39 0.965 1.12 1.035 ;
+      RECT 0.39 0.23 0.46 1.035 ;
+      RECT 0.39 0.23 1.305 0.3 ;
+  END
+END SDFFRS_X2
+
+MACRO SDFFR_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFFR_X1 0 0 ;
+  SIZE 4.75 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.24 0.56 4.365 0.7 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.84 0.925 0.98 ;
+    END
+  END RN
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.105 0.77 4.53 0.84 ;
+        RECT 4.43 0.56 4.53 0.84 ;
+        RECT 4.105 0.565 4.175 0.84 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.67 0.655 3.765 0.84 ;
+    END
+  END SI
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.77 0.66 1.995 0.84 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.435 0.185 0.51 1.015 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.185 0.13 1.065 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.75 1.485 ;
+        RECT 4.4 1.045 4.47 1.485 ;
+        RECT 3.64 1.08 3.71 1.485 ;
+        RECT 3.27 1.08 3.34 1.485 ;
+        RECT 2.4 0.995 2.47 1.485 ;
+        RECT 1.84 1.06 1.975 1.485 ;
+        RECT 1.15 1.205 1.22 1.485 ;
+        RECT 0.74 1.24 0.875 1.485 ;
+        RECT 0.21 1.24 0.345 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.75 0.085 ;
+        RECT 4.4 -0.085 4.47 0.32 ;
+        RECT 3.64 -0.085 3.71 0.32 ;
+        RECT 3.11 -0.085 3.18 0.32 ;
+        RECT 2.27 -0.085 2.34 0.425 ;
+        RECT 1.71 -0.085 1.845 0.285 ;
+        RECT 0.77 -0.085 0.84 0.32 ;
+        RECT 0.24 -0.085 0.31 0.46 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 4.595 0.185 4.665 1.22 ;
+      RECT 3.965 0.905 4.665 0.975 ;
+      RECT 3.965 0.715 4.035 0.975 ;
+      RECT 4.1 0.415 4.665 0.485 ;
+      RECT 3.83 1.04 4.125 1.11 ;
+      RECT 3.83 0.22 3.9 1.11 ;
+      RECT 3.12 0.52 3.9 0.59 ;
+      RECT 3.83 0.22 4.125 0.29 ;
+      RECT 2.54 1.18 3.205 1.25 ;
+      RECT 3.135 0.945 3.205 1.25 ;
+      RECT 3.45 0.945 3.52 1.2 ;
+      RECT 2.54 0.505 2.61 1.25 ;
+      RECT 3.135 0.945 3.585 1.015 ;
+      RECT 3.515 0.655 3.585 1.015 ;
+      RECT 2.985 0.655 3.585 0.725 ;
+      RECT 2.985 0.385 3.055 0.725 ;
+      RECT 2.985 0.385 3.335 0.455 ;
+      RECT 3.265 0.185 3.335 0.455 ;
+      RECT 2.69 1.015 3.065 1.085 ;
+      RECT 2.995 0.81 3.065 1.085 ;
+      RECT 2.69 0.305 2.76 1.085 ;
+      RECT 2.995 0.81 3.45 0.88 ;
+      RECT 2.22 0.855 2.29 1.13 ;
+      RECT 2.22 0.855 2.405 0.925 ;
+      RECT 2.335 0.49 2.405 0.925 ;
+      RECT 2.85 0.17 2.92 0.835 ;
+      RECT 1.43 0.49 1.5 0.7 ;
+      RECT 1.43 0.49 2.475 0.56 ;
+      RECT 2.405 0.17 2.475 0.56 ;
+      RECT 2.09 0.185 2.16 0.56 ;
+      RECT 2.405 0.17 2.92 0.24 ;
+      RECT 1.545 1.18 1.695 1.25 ;
+      RECT 1.625 0.765 1.695 1.25 ;
+      RECT 2.065 0.655 2.135 1.065 ;
+      RECT 1.625 0.905 2.135 0.975 ;
+      RECT 1.28 0.765 1.695 0.835 ;
+      RECT 2.065 0.655 2.26 0.79 ;
+      RECT 1.28 0.35 1.35 0.835 ;
+      RECT 1.28 0.35 2 0.42 ;
+      RECT 1.93 0.185 2 0.42 ;
+      RECT 1.49 0.905 1.56 1.04 ;
+      RECT 1.14 0.905 1.56 0.975 ;
+      RECT 1.14 0.215 1.21 0.975 ;
+      RECT 0.72 0.705 1.21 0.775 ;
+      RECT 0.72 0.525 0.79 0.775 ;
+      RECT 1.14 0.215 1.46 0.285 ;
+      RECT 0.585 0.185 0.655 1.24 ;
+      RECT 0.195 1.08 0.655 1.15 ;
+      RECT 0.195 0.525 0.265 1.15 ;
+      RECT 1.005 0.39 1.075 0.635 ;
+      RECT 0.585 0.39 1.075 0.46 ;
+      RECT 0.935 1.045 1.41 1.115 ;
+  END
+END SDFFR_X1
+
+MACRO SDFFR_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFFR_X2 0 0 ;
+  SIZE 4.94 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.565 0.42 4.69 0.625 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.145 0.84 1.27 0.98 ;
+    END
+  END RN
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.345 0.7 4.765 0.845 ;
+        RECT 4.345 0.565 4.415 0.845 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.86 0.67 4.005 0.84 ;
+    END
+  END SI
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.145 0.695 2.28 0.84 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.395 0.51 1.005 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.795 0.56 0.89 1.005 ;
+        RECT 0.795 0.395 0.865 1.005 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.94 1.485 ;
+        RECT 4.635 1.045 4.705 1.485 ;
+        RECT 3.875 1.08 3.945 1.485 ;
+        RECT 3.46 1.115 3.595 1.485 ;
+        RECT 2.66 0.995 2.73 1.485 ;
+        RECT 2.06 1.06 2.195 1.485 ;
+        RECT 1.37 1.205 1.44 1.485 ;
+        RECT 0.985 1.205 1.055 1.485 ;
+        RECT 0.575 1.24 0.71 1.485 ;
+        RECT 0.225 1.205 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.94 0.085 ;
+        RECT 4.635 -0.085 4.705 0.195 ;
+        RECT 3.875 -0.085 3.945 0.32 ;
+        RECT 3.295 -0.085 3.365 0.32 ;
+        RECT 2.535 -0.085 2.605 0.42 ;
+        RECT 2.005 -0.085 2.075 0.32 ;
+        RECT 1.065 -0.085 1.135 0.32 ;
+        RECT 0.575 -0.085 0.71 0.16 ;
+        RECT 0.195 -0.085 0.33 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 4.83 0.195 4.9 1.22 ;
+      RECT 4.205 0.91 4.9 0.98 ;
+      RECT 4.205 0.715 4.275 0.98 ;
+      RECT 4.36 0.415 4.495 0.485 ;
+      RECT 4.425 0.285 4.495 0.485 ;
+      RECT 4.425 0.285 4.9 0.355 ;
+      RECT 4.07 1.045 4.36 1.115 ;
+      RECT 4.07 0.23 4.14 1.115 ;
+      RECT 3.42 0.52 4.14 0.59 ;
+      RECT 4.07 0.23 4.36 0.3 ;
+      RECT 2.805 1.18 3.255 1.25 ;
+      RECT 3.185 0.975 3.255 1.25 ;
+      RECT 3.69 0.655 3.76 1.2 ;
+      RECT 2.805 0.5 2.875 1.25 ;
+      RECT 3.185 0.975 3.76 1.045 ;
+      RECT 3.285 0.655 3.76 0.725 ;
+      RECT 3.285 0.385 3.355 0.725 ;
+      RECT 3.285 0.385 3.57 0.455 ;
+      RECT 3.5 0.2 3.57 0.455 ;
+      RECT 3.04 0.84 3.11 1.115 ;
+      RECT 2.955 0.84 3.11 0.915 ;
+      RECT 2.955 0.84 3.625 0.91 ;
+      RECT 2.955 0.33 3.025 0.915 ;
+      RECT 2.89 0.33 3.025 0.4 ;
+      RECT 2.48 0.815 2.55 1.09 ;
+      RECT 2.48 0.815 2.74 0.885 ;
+      RECT 2.67 0.165 2.74 0.885 ;
+      RECT 3.15 0.165 3.22 0.775 ;
+      RECT 1.715 0.545 1.785 0.685 ;
+      RECT 1.715 0.545 2.74 0.615 ;
+      RECT 2.35 0.285 2.42 0.615 ;
+      RECT 2.67 0.165 3.22 0.235 ;
+      RECT 1.79 1.18 1.95 1.25 ;
+      RECT 1.88 0.75 1.95 1.25 ;
+      RECT 1.88 0.915 2.415 0.985 ;
+      RECT 2.345 0.68 2.415 0.985 ;
+      RECT 1.56 0.75 1.95 0.82 ;
+      RECT 2.345 0.68 2.56 0.75 ;
+      RECT 1.56 0.41 1.63 0.82 ;
+      RECT 1.56 0.41 2.265 0.48 ;
+      RECT 2.195 0.26 2.265 0.48 ;
+      RECT 1.425 0.885 1.815 0.955 ;
+      RECT 1.425 0.265 1.495 0.955 ;
+      RECT 0.29 0.26 0.36 0.66 ;
+      RECT 0.93 0.385 1.495 0.455 ;
+      RECT 0.93 0.26 1 0.455 ;
+      RECT 1.425 0.265 1.73 0.335 ;
+      RECT 0.29 0.26 1 0.33 ;
+      RECT 1.155 1.045 1.29 1.25 ;
+      RECT 1.155 1.045 1.63 1.115 ;
+      RECT 0.045 1.07 1.08 1.14 ;
+      RECT 1.01 0.64 1.08 1.14 ;
+      RECT 0.66 0.525 0.73 1.14 ;
+      RECT 0.045 0.26 0.115 1.14 ;
+      RECT 1.01 0.64 1.36 0.775 ;
+  END
+END SDFFR_X2
+
+MACRO SDFFS_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFFS_X1 0 0 ;
+  SIZE 4.75 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.55 0.38 0.7 ;
+    END
+  END D
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.765 0.57 0.835 ;
+        RECT 0.5 0.55 0.57 0.835 ;
+        RECT 0.06 0.55 0.185 0.835 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.91 0.42 1.08 0.56 ;
+    END
+  END SI
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.84 0.42 3.93 0.575 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.785 1.115 0.98 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.24 0.98 4.335 1.25 ;
+        RECT 4.265 0.4 4.335 1.25 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.62 0.98 4.705 1.25 ;
+        RECT 4.635 0.15 4.705 1.25 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.75 1.485 ;
+        RECT 4.445 0.975 4.515 1.485 ;
+        RECT 4.105 0.975 4.175 1.485 ;
+        RECT 3.735 1.07 3.805 1.485 ;
+        RECT 2.83 1.07 2.9 1.485 ;
+        RECT 2.3 1.155 2.37 1.485 ;
+        RECT 1.52 1.04 1.59 1.485 ;
+        RECT 0.985 1.045 1.055 1.485 ;
+        RECT 0.225 1.035 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.75 0.085 ;
+        RECT 4.445 -0.085 4.515 0.195 ;
+        RECT 3.735 -0.085 3.805 0.32 ;
+        RECT 2.805 -0.085 2.94 0.285 ;
+        RECT 2.485 -0.085 2.555 0.37 ;
+        RECT 1.49 -0.085 1.625 0.215 ;
+        RECT 0.985 -0.085 1.055 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.915 0.775 3.985 1.25 ;
+      RECT 3.69 0.775 3.985 0.915 ;
+      RECT 3.69 0.775 4.2 0.845 ;
+      RECT 4.13 0.265 4.2 0.845 ;
+      RECT 4.495 0.265 4.565 0.66 ;
+      RECT 4.075 0.265 4.565 0.335 ;
+      RECT 3.255 1.1 3.625 1.17 ;
+      RECT 3.555 0.215 3.625 1.17 ;
+      RECT 3.555 0.64 4.065 0.71 ;
+      RECT 3.995 0.525 4.065 0.71 ;
+      RECT 3.25 0.215 3.625 0.285 ;
+      RECT 2.615 0.93 3.49 1 ;
+      RECT 3.42 0.35 3.49 1 ;
+      RECT 2.615 0.805 2.685 1 ;
+      RECT 2.225 0.805 2.685 0.875 ;
+      RECT 2.65 0.35 3.49 0.42 ;
+      RECT 2.65 0.2 2.72 0.42 ;
+      RECT 1.34 0.905 1.41 1.25 ;
+      RECT 1.34 0.905 1.865 0.975 ;
+      RECT 1.795 0.74 1.865 0.975 ;
+      RECT 3.285 0.485 3.355 0.86 ;
+      RECT 1.795 0.74 2.025 0.81 ;
+      RECT 1.955 0.42 2.025 0.81 ;
+      RECT 2.225 0.485 3.355 0.555 ;
+      RECT 1.74 0.42 2.025 0.49 ;
+      RECT 2.225 0.15 2.295 0.555 ;
+      RECT 1.74 0.15 1.81 0.49 ;
+      RECT 1.34 0.28 1.81 0.35 ;
+      RECT 1.34 0.15 1.41 0.35 ;
+      RECT 1.74 0.15 2.295 0.22 ;
+      RECT 1.87 1.17 2.005 1.24 ;
+      RECT 1.935 0.88 2.005 1.24 ;
+      RECT 1.935 0.88 2.16 0.95 ;
+      RECT 2.09 0.285 2.16 0.95 ;
+      RECT 2.09 0.665 2.945 0.735 ;
+      RECT 1.875 0.285 2.16 0.355 ;
+      RECT 2.455 1.17 2.59 1.24 ;
+      RECT 2.07 1.17 2.205 1.24 ;
+      RECT 2.135 1.02 2.205 1.24 ;
+      RECT 2.455 1.02 2.525 1.24 ;
+      RECT 2.135 1.02 2.525 1.09 ;
+      RECT 1.18 0.77 1.25 1.25 ;
+      RECT 1.18 0.77 1.675 0.84 ;
+      RECT 1.605 0.415 1.675 0.84 ;
+      RECT 1.605 0.6 1.89 0.67 ;
+      RECT 1.18 0.415 1.675 0.485 ;
+      RECT 1.18 0.15 1.25 0.485 ;
+      RECT 0.58 1.035 0.715 1.24 ;
+      RECT 0.58 1.035 0.9 1.105 ;
+      RECT 0.83 0.625 0.9 1.105 ;
+      RECT 0.775 0.625 1.54 0.695 ;
+      RECT 0.775 0.15 0.845 0.695 ;
+      RECT 0.615 0.15 0.845 0.285 ;
+      RECT 0.045 0.9 0.115 1.25 ;
+      RECT 0.045 0.9 0.765 0.97 ;
+      RECT 0.635 0.835 0.765 0.97 ;
+      RECT 0.635 0.415 0.705 0.97 ;
+      RECT 0.045 0.415 0.705 0.485 ;
+      RECT 0.045 0.15 0.115 0.485 ;
+  END
+END SDFFS_X1
+
+MACRO SDFFS_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFFS_X2 0 0 ;
+  SIZE 5.13 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.67 0.375 0.84 ;
+    END
+  END D
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.91 0.595 0.98 ;
+        RECT 0.525 0.67 0.595 0.98 ;
+        RECT 0.06 0.795 0.185 0.98 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.965 0.42 1.08 0.64 ;
+    END
+  END SI
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.34 0.56 4.03 0.63 ;
+        RECT 3.34 0.28 3.41 0.63 ;
+        RECT 2.91 0.28 3.41 0.35 ;
+        RECT 2.42 0.425 2.98 0.495 ;
+        RECT 2.91 0.28 2.98 0.495 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.84 1.13 0.98 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.43 0.395 4.5 0.785 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.81 0.395 4.88 0.785 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 5.13 1.485 ;
+        RECT 4.99 1.125 5.06 1.485 ;
+        RECT 4.58 1.15 4.715 1.485 ;
+        RECT 4.2 1.15 4.335 1.485 ;
+        RECT 3.825 1.15 3.96 1.485 ;
+        RECT 3.51 1.12 3.58 1.485 ;
+        RECT 2.64 1.03 2.71 1.485 ;
+        RECT 2.265 1.165 2.4 1.485 ;
+        RECT 1.505 1.24 1.64 1.485 ;
+        RECT 0.99 1.115 1.06 1.485 ;
+        RECT 0.195 1.24 0.33 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 5.13 0.085 ;
+        RECT 4.99 -0.085 5.06 0.195 ;
+        RECT 4.58 -0.085 4.715 0.18 ;
+        RECT 4.2 -0.085 4.335 0.18 ;
+        RECT 3.475 -0.085 3.61 0.48 ;
+        RECT 2.475 -0.085 2.61 0.345 ;
+        RECT 1.51 -0.085 1.645 0.345 ;
+        RECT 0.96 -0.085 1.095 0.28 ;
+        RECT 0.2 -0.085 0.335 0.465 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.91 1.18 3.445 1.25 ;
+      RECT 3.375 0.985 3.445 1.25 ;
+      RECT 2.91 0.83 2.98 1.25 ;
+      RECT 3.375 0.985 5.015 1.055 ;
+      RECT 4.945 0.26 5.015 1.055 ;
+      RECT 2.26 0.83 2.98 0.965 ;
+      RECT 3.69 0.26 3.76 0.495 ;
+      RECT 3.69 0.26 5.015 0.33 ;
+      RECT 3.375 0.85 4.745 0.92 ;
+      RECT 4.675 0.525 4.745 0.92 ;
+      RECT 4.295 0.415 4.365 0.92 ;
+      RECT 3.825 0.415 4.365 0.485 ;
+      RECT 3.045 1.045 3.31 1.115 ;
+      RECT 3.24 0.695 3.31 1.115 ;
+      RECT 3.24 0.695 4.23 0.765 ;
+      RECT 4.095 0.56 4.23 0.765 ;
+      RECT 3.205 0.415 3.275 0.76 ;
+      RECT 3.045 0.415 3.275 0.485 ;
+      RECT 1.355 1.105 1.425 1.25 ;
+      RECT 1.355 1.105 1.855 1.175 ;
+      RECT 1.785 0.76 1.855 1.175 ;
+      RECT 3.07 0.845 3.175 0.98 ;
+      RECT 3.07 0.56 3.14 0.98 ;
+      RECT 1.785 0.76 2.05 0.83 ;
+      RECT 1.98 0.425 2.05 0.83 ;
+      RECT 2.285 0.56 3.14 0.63 ;
+      RECT 1.98 0.425 2.075 0.575 ;
+      RECT 2.285 0.155 2.355 0.63 ;
+      RECT 1.355 0.425 2.075 0.495 ;
+      RECT 1.75 0.155 1.82 0.495 ;
+      RECT 1.355 0.36 1.425 0.495 ;
+      RECT 1.75 0.155 2.355 0.225 ;
+      RECT 1.925 0.895 1.995 1.25 ;
+      RECT 1.925 0.895 2.195 0.965 ;
+      RECT 2.125 0.695 2.195 0.965 ;
+      RECT 2.125 0.695 2.825 0.765 ;
+      RECT 2.15 0.29 2.22 0.765 ;
+      RECT 1.895 0.29 2.22 0.36 ;
+      RECT 2.485 1.03 2.555 1.25 ;
+      RECT 2.115 1.03 2.185 1.25 ;
+      RECT 2.115 1.03 2.555 1.1 ;
+      RECT 1.195 0.87 1.265 1.25 ;
+      RECT 1.195 0.87 1.705 0.94 ;
+      RECT 1.635 0.56 1.705 0.94 ;
+      RECT 1.635 0.625 1.915 0.695 ;
+      RECT 1.195 0.56 1.705 0.63 ;
+      RECT 1.195 0.315 1.265 0.63 ;
+      RECT 0.585 1.18 0.9 1.25 ;
+      RECT 0.83 0.35 0.9 1.25 ;
+      RECT 0.83 0.705 1.57 0.775 ;
+      RECT 0.585 0.35 0.9 0.42 ;
+      RECT 0.045 1.045 0.115 1.25 ;
+      RECT 0.045 1.045 0.765 1.115 ;
+      RECT 0.695 0.535 0.765 1.115 ;
+      RECT 0.045 0.535 0.765 0.605 ;
+      RECT 0.045 0.38 0.115 0.605 ;
+  END
+END SDFFS_X2
+
+MACRO SDFF_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFF_X1 0 0 ;
+  SIZE 4.37 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.975 0.42 4.125 0.565 ;
+    END
+  END D
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.05 0.7 4.18 0.84 ;
+        RECT 3.75 0.7 4.18 0.77 ;
+        RECT 3.75 0.59 3.885 0.77 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.415 0.525 3.55 0.7 ;
+    END
+  END SI
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.02 0.42 2.225 0.58 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.15 0.51 0.785 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.15 0.135 1.215 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.37 1.485 ;
+        RECT 4.02 0.975 4.155 1.485 ;
+        RECT 3.295 1.04 3.365 1.485 ;
+        RECT 2.935 1.08 3.005 1.485 ;
+        RECT 2.07 0.94 2.14 1.485 ;
+        RECT 1.51 0.975 1.645 1.485 ;
+        RECT 0.75 1.165 0.885 1.485 ;
+        RECT 0.25 1.04 0.32 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.37 0.085 ;
+        RECT 4.02 -0.085 4.155 0.16 ;
+        RECT 3.295 -0.085 3.365 0.195 ;
+        RECT 2.905 -0.085 3.04 0.19 ;
+        RECT 2.04 -0.085 2.175 0.285 ;
+        RECT 1.51 -0.085 1.645 0.285 ;
+        RECT 0.75 -0.085 0.885 0.285 ;
+        RECT 0.25 -0.085 0.32 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 4.245 0.15 4.315 1.215 ;
+      RECT 3.615 0.45 3.685 0.84 ;
+      RECT 3.615 0.45 3.88 0.52 ;
+      RECT 3.81 0.28 3.88 0.52 ;
+      RECT 3.81 0.28 4.315 0.35 ;
+      RECT 3.67 0.905 3.74 1.215 ;
+      RECT 3.28 0.905 3.74 0.975 ;
+      RECT 3.28 0.285 3.35 0.975 ;
+      RECT 2.9 0.695 3.35 0.83 ;
+      RECT 3.28 0.285 3.74 0.355 ;
+      RECT 3.67 0.15 3.74 0.355 ;
+      RECT 3.125 0.92 3.195 1.215 ;
+      RECT 2.205 1.14 2.835 1.21 ;
+      RECT 2.765 0.545 2.835 1.21 ;
+      RECT 2.205 0.815 2.275 1.21 ;
+      RECT 2.765 0.92 3.195 0.99 ;
+      RECT 2.765 0.545 3.215 0.615 ;
+      RECT 3.145 0.15 3.215 0.615 ;
+      RECT 2.53 0.975 2.7 1.045 ;
+      RECT 2.63 0.215 2.7 1.045 ;
+      RECT 2.63 0.325 3.08 0.46 ;
+      RECT 2.53 0.215 2.7 0.285 ;
+      RECT 1.885 0.2 1.955 1.09 ;
+      RECT 2.37 0.68 2.44 0.95 ;
+      RECT 1.885 0.68 2.565 0.75 ;
+      RECT 2.495 0.35 2.565 0.75 ;
+      RECT 1.26 0.65 1.955 0.72 ;
+      RECT 1.73 0.84 1.8 1.215 ;
+      RECT 1.125 0.84 1.8 0.91 ;
+      RECT 1.125 0.475 1.195 0.91 ;
+      RECT 1.125 0.475 1.8 0.545 ;
+      RECT 1.73 0.32 1.8 0.545 ;
+      RECT 0.99 1.15 1.265 1.22 ;
+      RECT 0.99 0.23 1.06 1.22 ;
+      RECT 0.73 0.525 1.06 0.66 ;
+      RECT 0.99 0.23 1.265 0.3 ;
+      RECT 0.595 0.15 0.665 1.215 ;
+      RECT 0.2 0.885 0.665 0.955 ;
+      RECT 0.2 0.51 0.27 0.955 ;
+      RECT 0.595 0.73 0.925 0.865 ;
+  END
+END SDFF_X1
+
+MACRO SDFF_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFF_X2 0 0 ;
+  SIZE 4.56 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.165 0.42 4.33 0.56 ;
+    END
+  END D
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.95 0.7 4.355 0.84 ;
+        RECT 3.95 0.595 4.02 0.84 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.48 0.42 3.58 0.56 ;
+    END
+  END SI
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.225 0.42 2.41 0.58 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.4 0.51 0.785 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.805 0.185 0.89 0.84 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.56 1.485 ;
+        RECT 4.24 0.965 4.31 1.485 ;
+        RECT 3.455 1.24 3.59 1.485 ;
+        RECT 3.135 1.08 3.205 1.485 ;
+        RECT 2.275 0.91 2.345 1.485 ;
+        RECT 1.745 0.94 1.815 1.485 ;
+        RECT 0.985 1.04 1.055 1.485 ;
+        RECT 0.605 1.04 0.675 1.485 ;
+        RECT 0.225 1.04 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.56 0.085 ;
+        RECT 4.21 -0.085 4.345 0.16 ;
+        RECT 3.485 -0.085 3.555 0.255 ;
+        RECT 3.065 -0.085 3.2 0.165 ;
+        RECT 2.275 -0.085 2.345 0.32 ;
+        RECT 1.745 -0.085 1.815 0.32 ;
+        RECT 0.985 -0.085 1.055 0.32 ;
+        RECT 0.605 -0.085 0.675 0.195 ;
+        RECT 0.225 -0.085 0.295 0.195 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 4.43 0.195 4.5 1.24 ;
+      RECT 3.78 0.42 3.85 0.895 ;
+      RECT 3.78 0.42 4.05 0.49 ;
+      RECT 3.98 0.285 4.05 0.49 ;
+      RECT 3.98 0.285 4.5 0.355 ;
+      RECT 3.86 0.96 3.93 1.24 ;
+      RECT 3.645 0.96 3.93 1.03 ;
+      RECT 3.645 0.15 3.715 1.03 ;
+      RECT 3.105 0.64 3.715 0.775 ;
+      RECT 3.645 0.15 3.965 0.22 ;
+      RECT 3.33 0.89 3.4 1.185 ;
+      RECT 2.41 1.11 3.04 1.18 ;
+      RECT 2.97 0.505 3.04 1.18 ;
+      RECT 2.41 0.785 2.48 1.18 ;
+      RECT 2.97 0.89 3.4 0.96 ;
+      RECT 2.97 0.505 3.405 0.575 ;
+      RECT 3.335 0.185 3.405 0.575 ;
+      RECT 2.63 0.945 2.905 1.015 ;
+      RECT 2.835 0.215 2.905 1.015 ;
+      RECT 2.835 0.37 3.27 0.44 ;
+      RECT 2.635 0.215 2.905 0.285 ;
+      RECT 2.09 0.185 2.16 1.185 ;
+      RECT 2.575 0.65 2.645 0.88 ;
+      RECT 2.09 0.65 2.77 0.72 ;
+      RECT 2.7 0.35 2.77 0.72 ;
+      RECT 1.42 0.63 2.16 0.7 ;
+      RECT 1.935 0.79 2.005 1.185 ;
+      RECT 1.265 0.475 1.335 0.985 ;
+      RECT 1.265 0.79 2.005 0.86 ;
+      RECT 1.265 0.475 2.005 0.545 ;
+      RECT 1.935 0.185 2.005 0.545 ;
+      RECT 1.13 1.055 1.47 1.125 ;
+      RECT 1.13 0.22 1.2 1.125 ;
+      RECT 0.29 0.905 1.2 0.975 ;
+      RECT 0.29 0.525 0.36 0.975 ;
+      RECT 1.13 0.22 1.47 0.29 ;
+      RECT 0.045 0.185 0.115 1.185 ;
+      RECT 0.67 0.265 0.74 0.66 ;
+      RECT 0.045 0.265 0.74 0.335 ;
+  END
+END SDFF_X2
+
+MACRO TBUF_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TBUF_X1 0 0 ;
+  SIZE 1.52 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.495 0.89 0.73 ;
+        RECT 0.51 0.495 0.89 0.565 ;
+        RECT 0.51 0.495 0.58 0.63 ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.695 1.33 0.92 ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.035 0.97 0.14 1.245 ;
+        RECT 0.035 0.15 0.14 0.425 ;
+        RECT 0.035 0.15 0.105 1.245 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.52 1.485 ;
+        RECT 1.19 1.24 1.325 1.485 ;
+        RECT 0.69 1.145 0.76 1.485 ;
+        RECT 0.225 1.145 0.36 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.52 0.085 ;
+        RECT 1.15 -0.085 1.285 0.295 ;
+        RECT 0.77 -0.085 0.905 0.295 ;
+        RECT 0.225 -0.085 0.36 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.41 0.365 1.48 1.245 ;
+      RECT 0.875 1.105 1.48 1.175 ;
+      RECT 0.875 0.94 0.945 1.175 ;
+      RECT 0.65 0.94 0.945 1.01 ;
+      RECT 0.65 0.645 0.72 1.01 ;
+      RECT 1.345 0.365 1.48 0.435 ;
+      RECT 1.065 0.36 1.135 1.04 ;
+      RECT 0.17 0.495 0.305 0.565 ;
+      RECT 0.235 0.225 0.305 0.565 ;
+      RECT 0.615 0.36 1.135 0.43 ;
+      RECT 0.615 0.225 0.685 0.43 ;
+      RECT 0.235 0.225 0.685 0.295 ;
+      RECT 0.495 0.835 0.565 1.115 ;
+      RECT 0.37 0.835 0.565 0.905 ;
+      RECT 0.37 0.36 0.44 0.905 ;
+      RECT 0.17 0.645 0.44 0.715 ;
+      RECT 0.37 0.36 0.53 0.43 ;
+  END
+END TBUF_X1
+
+MACRO TBUF_X16
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TBUF_X16 0 0 ;
+  SIZE 4.94 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.265 0.39 4.335 0.66 ;
+        RECT 3.67 0.39 4.335 0.46 ;
+        RECT 3.475 0.555 3.74 0.625 ;
+        RECT 3.67 0.39 3.74 0.625 ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.05 0.725 4.6 0.795 ;
+        RECT 4.53 0.525 4.6 0.795 ;
+        RECT 4.05 0.56 4.12 0.795 ;
+        RECT 3.955 0.56 4.12 0.63 ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.895 0.36 3.03 1.005 ;
+        RECT 0.36 0.56 3.03 0.7 ;
+        RECT 2.515 0.36 2.65 1.005 ;
+        RECT 2.14 0.56 2.275 1.005 ;
+        RECT 2.135 0.36 2.27 0.7 ;
+        RECT 1.76 0.36 1.895 0.7 ;
+        RECT 1.755 0.56 1.89 1.005 ;
+        RECT 1.38 0.56 1.515 1.005 ;
+        RECT 1.375 0.36 1.51 0.7 ;
+        RECT 1 0.36 1.135 0.7 ;
+        RECT 0.995 0.56 1.13 1.005 ;
+        RECT 0.62 0.36 0.755 1.005 ;
+        RECT 0.24 0.86 0.43 0.93 ;
+        RECT 0.36 0.36 0.43 0.93 ;
+        RECT 0.24 0.36 0.43 0.43 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.94 1.485 ;
+        RECT 4.605 1.24 4.74 1.485 ;
+        RECT 3.845 1.24 3.98 1.485 ;
+        RECT 3.465 1.24 3.6 1.485 ;
+        RECT 3.085 1.24 3.22 1.485 ;
+        RECT 2.705 1.24 2.84 1.485 ;
+        RECT 2.325 1.24 2.46 1.485 ;
+        RECT 1.945 1.24 2.08 1.485 ;
+        RECT 1.565 1.24 1.7 1.485 ;
+        RECT 1.185 1.24 1.32 1.485 ;
+        RECT 0.805 1.24 0.94 1.485 ;
+        RECT 0.425 1.24 0.56 1.485 ;
+        RECT 0.05 1.24 0.185 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.94 0.085 ;
+        RECT 4.605 -0.085 4.74 0.16 ;
+        RECT 4.225 -0.085 4.36 0.16 ;
+        RECT 3.845 -0.085 3.98 0.16 ;
+        RECT 3.085 -0.085 3.22 0.16 ;
+        RECT 2.705 -0.085 2.84 0.16 ;
+        RECT 2.325 -0.085 2.46 0.16 ;
+        RECT 1.945 -0.085 2.08 0.16 ;
+        RECT 1.565 -0.085 1.7 0.16 ;
+        RECT 1.185 -0.085 1.32 0.16 ;
+        RECT 0.805 -0.085 0.94 0.16 ;
+        RECT 0.425 -0.085 0.56 0.16 ;
+        RECT 0.05 -0.085 0.185 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 4.825 0.26 4.895 1.25 ;
+      RECT 3.86 0.995 4.895 1.065 ;
+      RECT 3.86 0.83 3.93 1.065 ;
+      RECT 3.23 0.83 3.93 0.9 ;
+      RECT 3.805 0.525 3.875 0.9 ;
+      RECT 3.23 0.525 3.3 0.9 ;
+      RECT 4.23 0.86 4.735 0.93 ;
+      RECT 4.665 0.225 4.735 0.93 ;
+      RECT 0.105 0.495 0.29 0.565 ;
+      RECT 0.105 0.225 0.175 0.565 ;
+      RECT 0.105 0.225 4.735 0.295 ;
+      RECT 0.105 1.085 3.79 1.155 ;
+      RECT 3.095 0.36 3.165 1.155 ;
+      RECT 0.105 0.65 0.175 1.155 ;
+      RECT 0.105 0.65 0.295 0.72 ;
+      RECT 3.095 0.36 3.6 0.43 ;
+  END
+END TBUF_X16
+
+MACRO TBUF_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TBUF_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.56 0.965 0.7 ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.7 1.535 0.84 ;
+        RECT 1.2 0.285 1.27 0.84 ;
+        RECT 0.685 0.285 1.27 0.355 ;
+        RECT 0.685 0.285 0.755 0.66 ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.8 0.335 0.87 ;
+        RECT 0.06 0.35 0.33 0.42 ;
+        RECT 0.06 0.35 0.13 0.87 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.39 1.065 1.46 1.485 ;
+        RECT 0.975 1.065 1.045 1.485 ;
+        RECT 0.415 1.135 0.485 1.485 ;
+        RECT 0.04 0.995 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.405 -0.085 1.475 0.25 ;
+        RECT 0.91 -0.085 0.98 0.2 ;
+        RECT 0.415 -0.085 0.485 0.39 ;
+        RECT 0.04 -0.085 0.11 0.25 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.6 0.15 1.67 1.25 ;
+      RECT 1.335 0.56 1.67 0.63 ;
+      RECT 0.4 0.925 1.27 0.995 ;
+      RECT 1.065 0.43 1.135 0.995 ;
+      RECT 0.4 0.65 0.47 0.995 ;
+      RECT 0.235 0.65 0.47 0.72 ;
+      RECT 1 0.43 1.135 0.5 ;
+      RECT 0.55 0.725 0.705 0.795 ;
+      RECT 0.55 0.15 0.62 0.795 ;
+      RECT 0.235 0.495 0.62 0.565 ;
+      RECT 0.55 0.15 0.825 0.22 ;
+  END
+END TBUF_X2
+
+MACRO TBUF_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TBUF_X4 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.35 0.525 1.46 0.7 ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.75 0.525 1.84 0.7 ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.235 1.065 0.745 1.135 ;
+        RECT 0.235 0.33 0.745 0.4 ;
+        RECT 0.235 0.33 0.32 1.135 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.745 0.86 1.815 1.485 ;
+        RECT 1.21 1.205 1.28 1.485 ;
+        RECT 0.83 1.205 0.9 1.485 ;
+        RECT 0.45 1.205 0.52 1.485 ;
+        RECT 0.075 1.205 0.145 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.74 -0.085 1.81 0.195 ;
+        RECT 1.365 -0.085 1.435 0.195 ;
+        RECT 0.83 -0.085 0.9 0.195 ;
+        RECT 0.45 -0.085 0.52 0.195 ;
+        RECT 0.075 -0.085 0.145 0.335 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.935 0.15 2.005 0.995 ;
+      RECT 0.945 0.265 1.015 0.66 ;
+      RECT 0.945 0.265 2.005 0.335 ;
+      RECT 1.365 0.895 1.435 1.14 ;
+      RECT 0.59 0.895 1.63 0.965 ;
+      RECT 1.56 0.4 1.63 0.965 ;
+      RECT 0.59 0.465 0.66 0.965 ;
+      RECT 0.73 0.725 1.28 0.795 ;
+      RECT 1.21 0.4 1.28 0.795 ;
+      RECT 0.73 0.615 0.8 0.795 ;
+  END
+END TBUF_X4
+
+MACRO TBUF_X8
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TBUF_X8 0 0 ;
+  SIZE 3.42 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.72 0.39 2.79 0.66 ;
+        RECT 2.14 0.39 2.79 0.46 ;
+        RECT 1.95 0.56 2.21 0.63 ;
+        RECT 2.14 0.39 2.21 0.63 ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.465 0.725 3.08 0.795 ;
+        RECT 3.01 0.525 3.08 0.795 ;
+        RECT 2.465 0.525 2.6 0.795 ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.36 1.01 1.505 1.08 ;
+        RECT 1.355 0.375 1.505 0.445 ;
+        RECT 1.36 0.775 1.43 1.08 ;
+        RECT 0.265 0.7 1.425 0.84 ;
+        RECT 1.355 0.375 1.425 0.84 ;
+        RECT 1.02 0.2 1.095 0.84 ;
+        RECT 1.02 0.2 1.09 1.25 ;
+        RECT 0.645 0.2 0.715 1.25 ;
+        RECT 0.265 0.2 0.335 1.25 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.42 1.485 ;
+        RECT 3.085 1.13 3.22 1.485 ;
+        RECT 2.32 1.15 2.455 1.485 ;
+        RECT 1.97 0.995 2.04 1.485 ;
+        RECT 1.59 0.995 1.66 1.485 ;
+        RECT 1.21 0.975 1.28 1.485 ;
+        RECT 0.83 0.975 0.9 1.485 ;
+        RECT 0.415 1.01 0.55 1.485 ;
+        RECT 0.07 0.975 0.14 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.42 0.085 ;
+        RECT 3.09 -0.085 3.225 0.16 ;
+        RECT 2.7 -0.085 2.835 0.16 ;
+        RECT 2.32 -0.085 2.455 0.16 ;
+        RECT 1.56 -0.085 1.695 0.16 ;
+        RECT 1.18 -0.085 1.315 0.16 ;
+        RECT 0.8 -0.085 0.935 0.16 ;
+        RECT 0.415 -0.085 0.55 0.375 ;
+        RECT 0.07 -0.085 0.14 0.41 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.305 0.2 3.375 1.25 ;
+      RECT 2.295 0.995 3.375 1.065 ;
+      RECT 2.295 0.525 2.365 1.065 ;
+      RECT 1.705 0.725 2.365 0.795 ;
+      RECT 2.275 0.525 2.365 0.795 ;
+      RECT 1.705 0.525 1.775 0.795 ;
+      RECT 2.705 0.86 3.215 0.93 ;
+      RECT 3.145 0.225 3.215 0.93 ;
+      RECT 1.205 0.225 1.275 0.6 ;
+      RECT 1.205 0.225 3.215 0.295 ;
+      RECT 2.16 0.86 2.23 1.25 ;
+      RECT 1.78 0.86 1.85 1.25 ;
+      RECT 1.57 0.86 2.23 0.93 ;
+      RECT 1.57 0.39 1.64 0.93 ;
+      RECT 1.49 0.615 1.64 0.75 ;
+      RECT 1.57 0.39 2.075 0.46 ;
+  END
+END TBUF_X8
+
+MACRO TINV_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TINV_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN EN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.45 0.65 0.585 0.72 ;
+        RECT 0.175 0.84 0.52 0.98 ;
+        RECT 0.45 0.65 0.52 0.98 ;
+        RECT 0.175 0.625 0.245 0.98 ;
+    END
+  END EN
+  PIN I
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.31 0.42 0.38 0.6 ;
+        RECT 0.25 0.42 0.38 0.56 ;
+    END
+  END I
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.84 0.72 1.24 ;
+        RECT 0.65 0.155 0.72 1.24 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.225 1.065 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.225 -0.085 0.295 0.195 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.04 0.195 0.11 1.24 ;
+      RECT 0.45 0.495 0.585 0.565 ;
+      RECT 0.45 0.275 0.52 0.565 ;
+      RECT 0.04 0.275 0.52 0.345 ;
+  END
+END TINV_X1
+
+MACRO TLAT_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TLAT_X1 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.585 0.73 0.84 ;
+    END
+  END D
+  PIN G
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.185 0.745 0.32 0.98 ;
+    END
+  END G
+  PIN OE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.815 0.5 2.275 0.57 ;
+        RECT 1.815 0.5 2.03 0.7 ;
+    END
+  END OE
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.265 1.01 2.41 1.215 ;
+        RECT 2.34 0.22 2.41 1.215 ;
+        RECT 2.265 0.22 2.41 0.425 ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 1.87 0.975 1.94 1.485 ;
+        RECT 1.305 1.08 1.44 1.485 ;
+        RECT 0.585 1.04 0.655 1.485 ;
+        RECT 0.235 1.045 0.305 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 1.87 -0.085 1.94 0.32 ;
+        RECT 1.335 -0.085 1.405 0.32 ;
+        RECT 0.585 -0.085 0.655 0.46 ;
+        RECT 0.235 -0.085 0.305 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.68 0.185 1.75 1.245 ;
+      RECT 1.68 0.775 2.275 0.855 ;
+      RECT 2.14 0.65 2.275 0.855 ;
+      RECT 1.53 0.185 1.6 1.185 ;
+      RECT 1.26 0.515 1.6 0.65 ;
+      RECT 0.93 1.07 1.09 1.14 ;
+      RECT 1.02 0.22 1.09 1.14 ;
+      RECT 1.02 0.745 1.465 0.88 ;
+      RECT 0.93 0.22 1.09 0.29 ;
+      RECT 0.43 0.185 0.5 1.25 ;
+      RECT 0.43 0.905 0.945 0.975 ;
+      RECT 0.875 0.51 0.945 0.975 ;
+      RECT 0.05 0.185 0.12 1.25 ;
+      RECT 0.05 0.46 0.365 0.595 ;
+  END
+END TLAT_X1
+
+MACRO XNOR2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN XNOR2_X1 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.65 0.555 0.81 0.625 ;
+        RECT 0.65 0.39 0.72 0.625 ;
+        RECT 0.185 0.39 0.72 0.46 ;
+        RECT 0.185 0.39 0.32 0.56 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.35 0.84 0.965 0.91 ;
+        RECT 0.895 0.525 0.965 0.91 ;
+        RECT 0.35 0.84 0.51 0.98 ;
+    END
+  END B
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.98 1.1 1.05 ;
+        RECT 1.03 0.295 1.1 1.05 ;
+        RECT 0.785 0.295 1.1 0.365 ;
+        RECT 0.63 0.98 0.7 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 1 1.115 1.07 1.485 ;
+        RECT 0.43 1.115 0.5 1.485 ;
+        RECT 0.05 1.115 0.12 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.395 -0.085 0.53 0.25 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.21 1.145 0.345 1.215 ;
+      RECT 0.21 0.67 0.28 1.215 ;
+      RECT 0.05 0.67 0.585 0.74 ;
+      RECT 0.515 0.525 0.585 0.74 ;
+      RECT 0.05 0.15 0.12 0.74 ;
+      RECT 0.595 0.16 1.105 0.23 ;
+  END
+END XNOR2_X1
+
+MACRO XNOR2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN XNOR2_X2 0 0 ;
+  SIZE 1.9 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.08 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.77 1.65 0.84 ;
+        RECT 1.58 0.525 1.65 0.84 ;
+        RECT 0.82 0.56 0.89 0.84 ;
+        RECT 0.505 0.56 0.89 0.63 ;
+    END
+  END B
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.21 0.905 1.84 0.975 ;
+        RECT 1.77 0.19 1.84 0.975 ;
+        RECT 0.975 0.36 1.84 0.43 ;
+        RECT 1.765 0.19 1.84 0.43 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.9 1.485 ;
+        RECT 1.54 1.24 1.675 1.485 ;
+        RECT 0.805 1.065 0.875 1.485 ;
+        RECT 0.425 1.065 0.495 1.485 ;
+        RECT 0.05 1.065 0.12 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.9 0.085 ;
+        RECT 0.395 -0.085 0.53 0.16 ;
+        RECT 0.05 -0.085 0.12 0.325 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.245 0.725 0.72 0.795 ;
+      RECT 0.245 0.39 0.315 0.795 ;
+      RECT 0.245 0.39 0.91 0.46 ;
+      RECT 0.975 1.095 1.865 1.165 ;
+      RECT 0.21 0.225 1.675 0.295 ;
+  END
+END XNOR2_X2
+
+MACRO XOR2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN XOR2_X1 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.755 0.66 ;
+        RECT 0.175 0.73 0.7 0.8 ;
+        RECT 0.63 0.525 0.7 0.8 ;
+        RECT 0.175 0.665 0.245 0.8 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.525 0.945 0.66 ;
+        RECT 0.305 0.875 0.89 0.945 ;
+        RECT 0.82 0.525 0.89 0.945 ;
+    END
+  END B
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.775 1.04 1.08 1.11 ;
+        RECT 1.01 0.35 1.08 1.11 ;
+        RECT 0.62 0.35 1.08 0.42 ;
+        RECT 0.62 0.15 0.69 0.42 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.42 1.15 0.49 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.99 -0.085 1.06 0.285 ;
+        RECT 0.42 -0.085 0.49 0.285 ;
+        RECT 0.04 -0.085 0.11 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.04 0.525 0.11 1.25 ;
+      RECT 0.495 0.525 0.565 0.66 ;
+      RECT 0.04 0.525 0.565 0.595 ;
+      RECT 0.225 0.15 0.295 0.595 ;
+      RECT 0.585 1.175 1.095 1.245 ;
+  END
+END XOR2_X1
+
+MACRO XOR2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN XOR2_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.255 0.395 1.325 0.66 ;
+        RECT 0.745 0.395 1.325 0.465 ;
+        RECT 0.745 0.285 0.82 0.66 ;
+        RECT 0.06 0.285 0.82 0.355 ;
+        RECT 0.06 0.285 0.165 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.365 0.77 1.125 0.84 ;
+        RECT 0.99 0.56 1.125 0.84 ;
+        RECT 0.365 0.56 0.5 0.84 ;
+    END
+  END B
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.8 0.905 1.465 0.975 ;
+        RECT 1.39 0.26 1.465 0.975 ;
+        RECT 0.885 0.26 1.465 0.33 ;
+        RECT 0.885 0.15 0.955 0.33 ;
+        RECT 0.61 0.15 0.955 0.22 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.585 1.205 1.655 1.485 ;
+        RECT 0.445 1.205 0.515 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.585 -0.085 1.655 0.335 ;
+        RECT 1.025 -0.085 1.095 0.195 ;
+        RECT 0.445 -0.085 0.515 0.195 ;
+        RECT 0.07 -0.085 0.14 0.21 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.04 1.04 1.6 1.11 ;
+      RECT 1.53 0.525 1.6 1.11 ;
+      RECT 0.23 0.425 0.3 1.11 ;
+      RECT 0.575 0.425 0.645 0.66 ;
+      RECT 0.23 0.425 0.645 0.495 ;
+      RECT 0.61 1.175 1.5 1.245 ;
+  END
+END XOR2_X2
+
+END LIBRARY


### PR DESCRIPTION
This is the modified LEF file which lets the freepdk45 PDK work with the OpenROAD tools.

OpenROAD does not support non-rectangular pad areas, and apparently the nangate45 PDK is one of the only PDKs to use polygonal definitions for those areas. The actual shapes are still rectangles, so I believe that the OpenROAD team created this modified version to work with their tools.