### PR TITLE
Run CI on push

### DIFF
--- a/.github/workflows/gcd_test.yml
+++ b/.github/workflows/gcd_test.yml
@@ -1,4 +1,4 @@
-on: [pull_request, pull_request_review]
+on: [push, pull_request, pull_request_review]
 
 jobs:
   gcd_test_job:


### PR DESCRIPTION
Quick change to run CI on direct pushes to the branch as well as PRs. Not sure if there was a particular reason for not doing this, but could be useful to ensure we cover Andreas' commits too!