### PR TITLE
Set the SCPATH environment variable if it does not exist.

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -65,6 +65,9 @@ class Chip:
                           'siliconcompiler',
                           scriptdir)
 
+        # Set SCPATH to an empty string if it does not exist.
+        if not 'SCPATH' in os.environ:
+            os.environ['SCPATH'] = ''
         #Getting environment path (highest priority)
         scpaths = str(os.environ['SCPATH']).split(':')
 


### PR DESCRIPTION
Pulling a recent version and trying to run `sc` without having `SCPATH` set in your environment causes a KeyError. [See this test run.](https://github.com/zeroasiccorp/siliconcompiler/runs/2255280978)

Setting the environment variable to an empty string if it does not exist seems to fix that particular issue on my machine; let's see if this change causes the tests to pass.