### PR TITLE
Fix the KLayout init script's root directory discovery.

### DIFF
--- a/eda/klayout/klayout_setup.py
+++ b/eda/klayout/klayout_setup.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 ################################
 # Tool Setup
@@ -31,11 +32,10 @@ def setup_options(chip,step):
 def pre_process(chip, step):
     ''' Tool specific function to run before step execution
     '''
-    sc_paths = os.getenv('SCPATH').split(':')
-    sc_root = ''
-    for path in sc_paths:
-      if 'siliconcompiler' in path:
-        sc_root = path
+    scriptdir = os.path.dirname(os.path.abspath(__file__))
+    sc_root   =  re.sub('siliconcompiler/eda/klayout',
+                        'siliconcompiler',
+                        scriptdir)
     sc_path = sc_root + '/asic'
     foundry_path = '%s/%s/%s/pdk/r1p0'%(
         sc_path,


### PR DESCRIPTION
Use the same method as `core.py` to find the root `siliconcompiler` directory in the KLayout setup script, instead of checking the `SCPATH` environment variable.

I think that this should fix issue #69. But long-term, we might want to iterate through the `SCPATH` variable to find the appropriate PDK directory for the given configuration.

Also, I just finished upgrading the version of the OpenROAD tools on the GitHub runner, so hopefully the GCD test will pass this time.