### PR TITLE
Remove 'push' trigger to reduce test frequency with multiple active runners.

### DIFF
--- a/.github/workflows/gcd_test.yml
+++ b/.github/workflows/gcd_test.yml
@@ -1,4 +1,4 @@
-on: [pull_request, pull_request_review]
+on: [workflow_dispatch, pull_request, pull_request_review]
 
 jobs:
   gcd_test_job:


### PR DESCRIPTION
Running a full test suite on every 'push' action might be a bit excessive, especially with multiple runners active on a single host.

Until we can set up separate hosts running a synchronized environment, it might be a good idea to replace the 'push' trigger with the `workflow_dispatch` one; that should let us run the flow manually from the 'Actions' menu whenever that is necessary.