### PR TITLE
Floorplan API: add place_pin, place_pinlist, save

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ aiohttp >= 3.7.4.post0
 PyYAML >= 5.4.1
 defusedxml >= 0.7.1
 pandas >= 1.2.3
+Jinja2 >= 2.11.3

--- a/siliconcompiler/floorplan.py
+++ b/siliconcompiler/floorplan.py
@@ -1,201 +1,273 @@
-# Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
+# Copyright 2021 Silicon Compiler Authors. All Rights Reserved.
 
-import math
 import logging
-import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib.patches import Rectangle
+import jinja2
 
-from siliconcompiler.leflib import define_lef
-from siliconcompiler.leflib import read_lef
-from siliconcompiler.deflib import define_def
-from siliconcompiler.deflib import read_def
+# Set up Jinja
+env = jinja2.Environment(loader=jinja2.BaseLoader, trim_blocks=True, lstrip_blocks=True)
+
+# Jinja filter for rendering tuples in DEF style, e.g. (0, 0) becomes "( 0 0 )"
+def render_tuple(vals):
+    vals_str = ' '.join([str(val) for val in vals])
+    return f"( {vals_str} )"
+env.filters['render_tuple'] = render_tuple
+
+# Jinja template for outputting layout as DEF file
+DEF_TEMPLATE = """VERSION {{ layout.version }} ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN {{ layout.design }} ;
+UNITS DISTANCE MICRONS 2000 ;
+DIEAREA {% for coord in layout.diearea %}{{ coord | render_tuple }} {% endfor %};
+
+PINS {{ layout.pin | length }} ;
+{% for name, pin in layout.pin.items() %}
+    - {{ name }} + NET {{ pin.net }} + DIRECTION {{ pin.direction|upper }} + USE {{ pin.use|upper }}
+       + PORT
+         + LAYER {{ pin.port.layer }} {{ pin.port.box | map('render_tuple') | join(' ') }}
+         {% if pin.port.status %}
+         + {{ pin.port.status|upper }} {{ pin.port.point | render_tuple }} {{ pin.port.orientation }} ;
+         {% endif %}
+{% endfor %}
+END PINS
+
+END DESIGN
+"""
 
 class Floorplan:
-    """
-    Chip Layout Class
-    """
+    '''
+    Floorplan layout class
+    '''
 
-    def __init__(self, techlef):
+    def __init__(self, chip,
+                 # TODO: read from synthesis metrics
+                 die_area,
+                 # TODO: read from LEF/library files
+                 # layers,
+                 # std_cell_width,
+                 # std_cell_height,
+                 scale_factor):
         '''
-        Init method for Chip object
+        Initialize Floorplan
         '''
+        self.chip = chip
+        self.die_area = die_area
 
-        #Setup LEF-DEF Database
-        layout = {}
-        define_lef(layout)        
-        define_def(layout)
+        self.chip.layout['version'] = '5.8'
+        self.chip.layout['design'] = chip.get('design')[-1]
+        self.chip.layout['diearea'] = die_area
 
-        #Read lef  
-        read_lef(layout, techlef)
-        
-
-    def set(self, filename):     
-    #TODO
-        
-        
-    def load(self, filename):
-        '''
-        Read Lef file
-        '''
-        logging.info('Read LEF file')
-        pass
+        # self.layers = layers
+        # self.std_cell_width = std_cell_width
+        # self.std_cell_height = std_cell_height
+        self.scale_factor = scale_factor
 
     def save(self, filename):
         '''
-        Write DEF or JSON File
+        Write DEF file
         '''
         logging.info('Write DEF %s', filename)
 
-        pass
+        # TODO: come up with cleaner way to handle defaults
+        old_layout = self.chip.layout
+        del self.chip.layout['pin']['default']
 
-    def set_diearea(self, *args):
+        tmpl = env.from_string(DEF_TEMPLATE)
+        with open(filename, 'w') as f:
+            f.write(tmpl.render(layout=self.chip.layout))
+
+        self.chip.layout = old_layout
+
+    def place_pin(self, pin_name, net_name, pos, shape, layer, orientation,
+                  direction='input', use='signal', fixed=True, units='relative'):
         '''
-        Specifies the die area of the design. If two points are defined, 
-        specifies two corners of the bounding rectangle for the design. If
-        more than two points are defined, specifies the points of a 
-        polygon that forms the die area. All points are integers, 
-        specified as DEF database units.
+        Place pin on floorplan
+
+        Parameters:
+        - pin_name: name of pin
+        - net_name: name of connected net
+        - pos: position of pin, as tuple of 2 numbers
+        - shape: geometry of pin, as list of 2 or more tuples of 2 numbers
+        - layer: layer of pin
+        - orientation: orientation of pin (must be a valid LEF/DEF orientation)
+        - direction: I/O direction of pin (must be valid LEF/DEF direction)
+        - use: use of pin (must be valid LEF/DEF use)
+        - fixed: whether or not pin is fixed
+        - units: whether to use technology-independent ('relative') or absolute
+          ('absolute') units
         '''
-        logging.info('Set diearea to floorplan')
-        pass
+        logging.debug('Placing a pin: %s', pin_name)
 
-    def place_row(self, name, site, x, y, orientation, numx, numy, stepx, stepy):
+        if direction.upper() not in ('INPUT', 'OUTPUT', 'INOUT', 'FEEDTHRU'):
+            raise ValueError('Invalid direction')
+        if use.upper() not in ('SIGNAL', 'POWER', 'GROUND', 'CLOCK', 'TIEOFF',
+                               'ANALOG', 'SCAN', 'RESET'):
+            raise ValueError('Invalid use')
+        self._validate_orientation(orientation)
+        self._validate_units(units)
+
+        pin = {
+            'net': net_name,
+            'direction': direction,
+            'use': use
+        }
+
+        port = {
+            'layer': layer,
+            'box': self._scale(shape, units),
+            'status': 'fixed' if fixed else None,
+            'point': self._scale(pos, units),
+            'orientation': orientation
+        }
+
+        self.chip.layout['pin'][pin_name] = pin
+        self.chip.layout['pin'][pin_name]['port'] = port
+
+    def place_pinlist(self, pinlist, side, pin_width, pin_depth, layer,
+                      pitch=None, offset=2, halo=2, block_w=None, block_h=None,
+                      direction='input', units='relative'):
+
+        '''Place a list of pins along the side of a block
+
+        Parameters:
+        - pinlist: list of pin names (must be the same as the corresponding net
+          name)
+        - side: which side of the block to place the pins along. Options are
+          'n', 's', 'e', or 'w' (case insensitive)
+        - layer: the name of the layer to place the pins on
+        - pitch: the spacing between pins. If None, place pins equally spaced
+          along side (this overwrites provided offset, if any)
+        - block_w, block_h: the width and the height of the block defining the
+          sides the pins are to be placed along. If None, infers bounds from die
+          area
+        - direction: I/O direction of the pins
+        - units: whether to use technology-independent ('relative') or absolute
+          ('absolute') units
+
+        All other parameters specify dimensions as shown in this diagram (this
+        example is for the north side of the block):
+
+                          <----------pitch-------->
+        -----------+-----|-----+-------------------|-------- ...
+        |<-offset->|I halo     | ^
+        |          +-----------+ |           +-----------+
+        |          |           | pin         |           |
+        |          |    PIN    | depth       |    PIN    |
+        |          |           | |           |           |
+        |          +-----------+ |           +-----------+
+        |          |I halo     | |
+        |          +-----------+ v
+        |          <-pin width->
+        |
+        ...
+
         '''
-        Adding a placement row
-        '''
-        logging.info('Adding  row to floorplan')
-        pass
+        logging.debug('Placing pins: %s', ' '.join(pinlist))
 
-    def place_track(self, layer, direction, start, step, total):
-        '''
-        Add a routing track
-        '''
-        logging.info('Placing tracks')
-        pass
-     
-    def place_pin(self, pin, net, x, y, box, layer,
-               direction=None, use="signal", fixed=True):
-        '''
-        Place pin
-        '''
-        logging.info('Placing a pin')
-        pass
+        self._validate_units(units)
+        if side.upper() not in ('N', 'S', 'E', 'W'):
+            raise ValueError('Invalid side')
 
-    def place_cell(self):
-        '''
-        Place a cell
-        '''
-        logging.info('Placing a cell')
-        pass
+        pin_width = self._scale(pin_width, units)
+        pin_depth = self._scale(pin_depth, units)
+        halo = self._scale(halo, units)
 
-    def place_keepout(self):
-        '''
-        Place a keepout area
-        '''
-        logging.info('Placing a keepout area')
-        pass
+        if (block_w is None or block_h is None) and len(self.die_area) != 2:
+            raise ValueError('block_w and block_h must be set explicitly for '
+                             'non-rectangular die area')
+        if block_w is None:
+            block_w = self.die_area[1][0] - self.die_area[0][0]
+        else:
+            block_w = self._scale(block_w, units)
+        if block_h is None:
+            block_h = self.die_area[1][1] - self.die_area[0][1]
+        else:
+            block_h = self._scale(block_h, units)
 
- 
-    
-    
+        if pitch is None:
+            # no pitch provided => infer equal pin spacing
+            num_pins = len(pinlist)
+            pitch = block_w / (num_pins + 1)
+            offset = pitch - pin_width/2
+        else:
+            pitch = self._scale(pitch, units)
+            offset = self._scale(offset, units)
 
-#############################
-#Snaps value to routing grid
-def snap2grid (val, grid):
-    logging.debug('Executing fp.snap2grid', val,grid)
-    return(grid * math.ceil(val/grid))
+        if side.upper() == 'N':
+            x0    = offset
+            y0    = block_h - halo
+            x1    = x0 + pin_width
+            y1    = y0 - pin_depth + 2 * halo
+            xincr = pitch
+            yincr = 0.0
+        elif side.upper() == 'S':
+            x0    = offset
+            y0    = halo
+            x1    = x0 + pin_width
+            y1    = y0 + pin_depth - 2 * halo
+            xincr = pitch
+            yincr = 0.0
+        elif side.upper() == 'W':
+            x0    = halo
+            y0    = offset
+            x1    = x0 + pin_depth - 2 * halo
+            y1    = y0 + pin_width
+            xincr = 0.0
+            yincr = pitch
+        elif side.upper() == 'E':
+            x0    = block_w - halo
+            y0    = offset
+            x1    = x0 - pin_depth + 2 * halo
+            y1    = y0 + pin_width
+            xincr = 0.0
+            yincr = pitch
 
+        for name in pinlist:
+            shape = [(0, 0), (x1 - x0, y1 - y0)]
+            self.place_pin(name, name, (x0, y0), shape, layer, 'N',
+                           direction=direction, units='absolute')
+            #Update with new values
+            x0 += xincr
+            y0 += yincr
+            x1 += xincr
+            y1 += yincr
 
+    def _scale(self, val, units):
+        if isinstance(val, list):
+            return [self._scale(item, units) for item in val]
+        elif isinstance(val, tuple):
+            return tuple([self._scale(item, units) for item in val])
+        else:
+            if units == 'absolute':
+                return val
+            else:
+                return val * self.scale_factor
 
-#####################
-#Place a list of pins
-#Everything starts in the lower left corer (0,0) and counts up and to the right
+    def _validate_units(self, units):
+        if units not in ('relative', 'absolute'):
+            raise ValueError("Units must be 'relative' or 'absolute'")
 
-def pinlist (pinlist, side, block_w, block_h, offset, pinwidth, pindepth, pinhalo, pitch, metal):
+    def _validate_orientation(self, orientation):
+        if orientation not in ('N', 'S', 'W', 'E', 'FN', 'FS', 'FW', 'FE'):
+            raise ValueError("Illegal orientation")
 
-    logging.debug('Executing pinlist',pinlist, side, block_w, block_h, offset, pinwidth, pindepth, pinhalo, pitch, metal)
-    
-    if(side=='no'):
-        x0    = offset
-        y0    = block_h - halo
-        x1    = x0 + pinwidth
-        y1    = y0 - pindepth + 2 * halo
-        xincr = pitch
-        yincr = 0.0
-    elif (side == 'so'):
-        x0    = offset
-        y0    = halo
-        x1    = x0 + pinwidth
-        y1    = y0 + pindepth - 2 * halo
-        xincr = pitch
-        yincr = 0.0
-    elif (side == 'we'):
-        x0    = halo
-        y0    = offset
-        x1    = x0 + pindepth - 2 * halo
-        y1    = y0 + pinwidth
-        xincr = 0.0 
-        yincr = pitch
-    elif (side == 'ea'):
-        x0    = block_w - halo
-        y0    = offset
-        x1    = x0 - pindepth + 2 * halo
-        y1    = y0 + pinwidth
-        xincr = 0.0
-        yincr = pitch    
-    #loop through all pins
-    for name in pinlist:
-        box = [x0,y0,x1,y1]
-        pin (name, box, metal)
-        #Update with new values
-        x0 = x0 + xincr
-        y0 = y0 + yincr
-        x1 = x1 + xincr
-        y1 = y1 + yincr
+if __name__ == '__main__':
+    # Test: create floorplan with `n` equally spaced `width` x `depth` pins along
+    # each side
 
+    from siliconcompiler.core import *
+    c = Chip()
+    c.set('design', 'test')
+    fp = Floorplan(c, [(0, 0), (100, 100)], 1)
 
+    n = 4 # pins per side
+    width = 8
+    depth = 12
 
-#####################
-# Plot the design
-# Input=structure
-# Output=display | write to file
+    pins = [f"in[{i}]" for i in range(4 * n)]
+    fp.place_pinlist(pins[0:n], 'n', width, depth, 'metal1')
+    fp.place_pinlist(pins[n:2*n], 'e', width, depth, 'metal1')
+    fp.place_pinlist(pins[2*n:3*n], 'w', width, depth, 'metal1')
+    fp.place_pinlist(pins[3*n:4*n], 's', width, depth, 'metal1')
 
-def plot():
-    logging.debug('Display design')
-
-    design = "Floorplan"
-    width  = 1000
-    height = 1000
-    
-    fig, ax = plt.subplots()
-    ax.tick_params(labeltop=True,
-                   top=True,
-                   right=True,
-                   labelright=True)   # Put labels on both side for ease uf use
-    ax.grid(True)                     # Turn on grids
-    ax.set_xlim(0, width)
-    ax.set_ylim(0, height)
-    ax.set_xlabel('Width')            # x label
-    ax.set_ylabel('Height')           # y label
-    ax.set_title(design)              # Name of design
-    
-    for i in range(10):
-        for j in range(10):
-            print(i*100, j*100)
-            ax.add_patch(Rectangle((i*100,j*100), 50, 50,
-                           edgecolor = 'pink',
-                           facecolor = 'blue',
-                           fill=True,
-                           lw=1))
-    plt.savefig("test.svg", format="svg")
-    plt.show()                        # Display figure
-
-
-
-
-#####################
-# Test Program
-    
-#plot()
-   
+    fp.save('test.def')


### PR DESCRIPTION
@aolofsson I'm not sure at what granularity you want to review/merge my work on the Floorplan API, but I figured I'd open a PR with my work so far to make sure you can let me know if there are issues with my approach sooner rather than later.

So far, I've implemented functionality to place pins (both one-by-one, and as a pinlist). I also implemented your idea to automatically place pins evenly along a side if a pitch is not explicitly provided. I also have functionality to save the layout as a DEF file. 

Here's an example script using this API, showing off the automatic even spacing:
```python
c = Chip()                                                  
c.set('design', 'test')                                     
fp = Floorplan(c, [(0, 0), (100, 100)], 1)                  
                                                            
n = 4 # pins per side                                       
width = 8                                                   
depth = 12                                                  
                                                            
pins = [f"in[{i}]" for i in range(4 * n)]                   
fp.place_pinlist(pins[0:n], 'n', width, depth, 'metal1')    
fp.place_pinlist(pins[n:2*n], 'e', width, depth, 'metal1')  
fp.place_pinlist(pins[2*n:3*n], 'w', width, depth, 'metal1')
fp.place_pinlist(pins[3*n:4*n], 's', width, depth, 'metal1')
                                                            
fp.save('test.def')                                        
```

The resulting DEF looks like:
![Screen Shot 2021-04-06 at 11 32 19 AM](https://user-images.githubusercontent.com/4412459/113739121-7c220b00-96cd-11eb-94ee-e8353aa8eebe.png)

You can run this example by running `floorplan.py` directly. You can also play with the parameters to see the spacing and pin geometries change!

Note that this change adds [Jinja](https://palletsprojects.com/p/jinja/) as a dependency. I found it a pretty elegant way to create the output, since it separates out the actual look of the DEF file format from the Floorplan class logic (the single string `DEF_TEMPLATE` basically encodes all the logic for converting from our internal layout schema to a DEF file, and this could be refactored into a separate file as it gets longer). 
