### PR TITLE
Fix klayout options setup

### DIFF
--- a/eda/klayout/klayout_setup.py
+++ b/eda/klayout/klayout_setup.py
@@ -22,8 +22,51 @@ def setup_tool(chip, step):
                chip.add('flow', step, 'option', '-zz')
           
 def setup_options(chip,step):
-     
+
      options = chip.get('flow', step, 'option')
+
+     scriptdir = os.path.dirname(os.path.abspath(__file__))
+     sc_root   =  re.sub('siliconcompiler/eda/klayout',
+                         'siliconcompiler',
+                         scriptdir)
+     sc_path = sc_root + '/asic'
+     foundry_path = '%s/%s/%s/pdk/r1p0'%(
+          sc_path,
+          chip.cfg['pdk']['foundry']['value'][-1],
+          chip.cfg['target']['value'][-1])
+     lefs_path = '%s/%s/%s/libs/NangateOpenCellLibrary/r1p0/lef'%(
+          sc_path,
+          chip.cfg['pdk']['foundry']['value'][-1],
+          chip.cfg['target']['value'][-1])
+     tech_file = '%s/setup/klayout/%s.lyt'%(
+          foundry_path,
+          chip.cfg['target']['value'][-1])
+
+     if step == 'export':
+          options.append('-nn')
+          options.append(tech_file)
+          options.append('-rd')
+          options.append('design_name=%s'%(
+               chip.cfg['design']['value'][-1]))
+          options.append('-rd')
+          options.append('in_def=inputs/%s.def'%(
+               chip.cfg['design']['value'][-1]))
+          options.append('-rd')
+          options.append('seal_gds=""')
+          options.append('-rd')
+          options.append('in_gds=%s/%s'%(
+               sc_root,
+               chip.cfg['stdcell']['NangateOpenCellLibrary']['gds']['value'][-1]))
+          options.append('-rd')
+          options.append('out_gds=outputs/%s.gds'%(
+               chip.cfg['design']['value'][-1]))
+          options.append('-rd')
+          options.append('tech_file=%s'%tech_file)
+          options.append('-rd')
+          options.append('foundry_lefs=%s'%lefs_path)
+          options.append('-rm')
+          options.append('def2gds.py')
+
      return options
 
 ################################
@@ -32,46 +75,7 @@ def setup_options(chip,step):
 def pre_process(chip, step):
     ''' Tool specific function to run before step execution
     '''
-    scriptdir = os.path.dirname(os.path.abspath(__file__))
-    sc_root   =  re.sub('siliconcompiler/eda/klayout',
-                        'siliconcompiler',
-                        scriptdir)
-    sc_path = sc_root + '/asic'
-    foundry_path = '%s/%s/%s/pdk/r1p0'%(
-        sc_path,
-        chip.cfg['pdk']['foundry']['value'][-1],
-        chip.cfg['target']['value'][-1])
-    lefs_path = '%s/%s/%s/libs/NangateOpenCellLibrary/r1p0/lef'%(
-        sc_path,
-        chip.cfg['pdk']['foundry']['value'][-1],
-        chip.cfg['target']['value'][-1])
-    tech_file = '%s/setup/klayout/%s.lyt'%(
-        foundry_path,
-        chip.cfg['target']['value'][-1])
-    if step == 'export':
-         chip.add('flow', step, 'option', '-nn')
-         chip.add('flow', step, 'option', tech_file)
-         chip.add('flow', step, 'option', '-rd')
-         chip.add('flow', step, 'option', 'design_name=%s'%(
-             chip.cfg['design']['value'][-1]))
-         chip.add('flow', step, 'option', '-rd')
-         chip.add('flow', step, 'option', 'in_def=inputs/%s.def'%(
-             chip.cfg['design']['value'][-1]))
-         chip.add('flow', step, 'option', '-rd')
-         chip.add('flow', step, 'option', 'seal_gds=""')
-         chip.add('flow', step, 'option', '-rd')
-         chip.add('flow', step, 'option', 'in_gds=%s/%s'%(
-             sc_root,
-             chip.cfg['stdcell']['NangateOpenCellLibrary']['gds']['value'][-1]))
-         chip.add('flow', step, 'option', '-rd')
-         chip.add('flow', step, 'option', 'out_gds=outputs/%s.gds'%(
-             chip.cfg['design']['value'][-1]))
-         chip.add('flow', step, 'option', '-rd')
-         chip.add('flow', step, 'option', 'tech_file=%s'%tech_file)
-         chip.add('flow', step, 'option', '-rd')
-         chip.add('flow', step, 'option', 'foundry_lefs=%s'%lefs_path)
-         chip.add('flow', step, 'option', '-rm')
-         chip.add('flow', step, 'option', 'def2gds.py')
+    pass
 
 def post_process(chip, step):
     ''' Tool specific function to run after step execution


### PR DESCRIPTION
I was trying to run OpenROAD through SC to test some floorplanning-related things, and noticed a bug in the klayout setup script. I think it may be due to the recent run command refactor -  since pre_process isn't called till after setup_options now, the options set there don't actually get used. I fixed this by setting up all the options in setup_options itself. 