### PR TITLE
Integrate floorplan Python API with OpenROAD flow

### DIFF
--- a/eda/openroad/openroad_setup.py
+++ b/eda/openroad/openroad_setup.py
@@ -1,3 +1,8 @@
+import os
+import importlib
+
+from siliconcompiler.floorplan import *
+
 ################################
 # Tool Setup
 ################################
@@ -28,9 +33,85 @@ def setup_options(chip, step):
 def pre_process(chip, step):
     ''' Tool specific function to run before step execution
     '''
-    pass
+    if step == 'floorplan':
+        floorplan_file = chip.get('asic', 'floorplan')
+
+        if len(floorplan_file) == 0:
+             return
+
+        floorplan_file = make_abs_path(floorplan_file[-1])
+
+        if os.path.splitext(floorplan_file)[-1] != '.py':
+             return
+
+        # Harcode tech lib
+        # TODO: initialize floorplan by passing in the actual library files
+        # and/or data
+
+        # For now, check that we use freepdk45, because we're hardcoding for
+        # this library
+        if chip.get('target')[-1] != 'freepdk45':
+             return
+
+        # Initialize floorplan according to freepdk45 library, with equivalent
+        # die/core size to GCD. Set scale factor fo 1, so all units are in
+        # microns
+        offset = (0.095 * 2000, 0.07 * 2000)
+        layers = [
+             {'name': 'metal1', 'offset': offset, 'pitch': 0.14 * 2000},
+             {'name': 'metal2', 'offset': offset, 'pitch': 0.19 * 2000},
+             {'name': 'metal3', 'offset': offset, 'pitch': 0.14 * 2000},
+             {'name': 'metal4', 'offset': offset, 'pitch': 0.28 * 2000},
+             {'name': 'metal5', 'offset': offset, 'pitch': 0.28 * 2000},
+             {'name': 'metal6', 'offset': offset, 'pitch': 0.28 * 2000},
+             {'name': 'metal7', 'offset': offset, 'pitch': 0.8 * 2000},
+             {'name': 'metal8', 'offset': offset, 'pitch': 0.8 * 2000},
+             {'name': 'metal9', 'offset': offset, 'pitch': 0.8 * 2000},
+             {'name': 'metal10', 'offset': offset, 'pitch': 1.6 * 2000},
+        ]
+
+        fp = Floorplan(chip,
+                        [(0, 0), (200260, 201600)],
+                        [(20140, 22400), (180500, 182000)],
+                        layers,
+                        "FreePDK45_38x28_10R_NP_162NW_34O",
+                        380,
+                        2800,
+                        1)
+
+        # Import user's floorplan file, call setup_floorplan to set up their
+        # floorplan, and save it as an input DEF
+
+        mod_name = os.path.splitext(os.path.basename(floorplan_file))[0]
+        mod_spec = importlib.util.spec_from_file_location(mod_name, floorplan_file)
+        module = importlib.util.module_from_spec(mod_spec)
+        mod_spec.loader.exec_module(module)
+        setup_floorplan = getattr(module, "setup_floorplan")
+
+        fp = setup_floorplan(fp)
+        fp.generate_rows()
+        fp.generate_tracks()
+
+        topmodule = chip.get('design')[-1]
+        fp.save('inputs/' + topmodule + '.def')
 
 def post_process(chip, step):
     ''' Tool specific function to run after step execution
     '''
     pass
+
+################################
+# Utilities
+################################
+
+def make_abs_path(path):
+    '''Helper for constructing absolute path, assuming `path` is relative to
+    directory `sc` was run from
+    '''
+
+    if os.path.isabs(path):
+        return path
+
+    cwd = os.getcwd()
+    run_dir = cwd + '/../../../' # directory `sc` was run from
+    return os.path.join(run_dir, path)

--- a/eda/openroad/sc_floorplan.tcl
+++ b/eda/openroad/sc_floorplan.tcl
@@ -83,7 +83,7 @@ link_design $topmodule
 ########################################################
 
 if {[file exists $input_def]} {
-    read_def $input_def
+    read_def -floorplan_initialize $input_def
 } else {
     if {[llength $diesize] != "4"} {
 	#1. get cell area

--- a/examples/counter/constraint.sdc
+++ b/examples/counter/constraint.sdc
@@ -1,0 +1,1 @@
+create_clock [get_ports clk]  -name core_clock  -period 2

--- a/examples/counter/counter.v
+++ b/examples/counter/counter.v
@@ -1,0 +1,15 @@
+module counter # (
+  parameter W = 2
+  ) (
+  input wire clk,
+  output [W-1:0] c
+);
+
+  reg [W-1:0] counter;
+  always @(posedge clk) begin
+    counter <= counter + 1'b1;
+  end
+
+  assign c = counter;
+
+endmodule

--- a/examples/counter/counter_floorplan.py
+++ b/examples/counter/counter_floorplan.py
@@ -1,0 +1,7 @@
+def setup_floorplan(fp):
+    pin_width = 560
+    pin_depth = 760
+    fp.place_pinlist(['clk'], 'w', pin_width, pin_depth, 'metal3')
+    fp.place_pinlist(['c[0]', 'c[1]'], 'e', pin_width, pin_depth, 'metal3', direction='output')
+
+    return fp

--- a/examples/counter/run.sh
+++ b/examples/counter/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+sc examples/counter/counter.v \
+   -pdk_rev "1.0" \
+   -target "freepdk45" \
+   -asic_diesize "0 0 100.13 100.8" \
+   -asic_coresize "10.07 11.2 90.25 91" \
+   -asic_floorplan examples/counter/counter_floorplan.py \
+   -loglevel "INFO" \
+   -design counter \
+   -quiet

--- a/siliconcompiler/floorplan.py
+++ b/siliconcompiler/floorplan.py
@@ -61,6 +61,9 @@ class Floorplan:
         Initialize Floorplan
         '''
         self.chip = chip
+        # TODO: assert that die_area/core_area are valid multiples of placement
+        # site size. maybe I should also constrain die_area to be rectangle
+        # TODO: look into the fact that diesize and coresize are in schema
         self.die_area = die_area
 
         self.chip.layout['version'] = '5.8'


### PR DESCRIPTION
This is a basic pass at integrating the floorplan Python API into the OpenROAD flow. It's still a bit hacky and has limitations, but it's helpful for testing that the floorplan API produces valid output (and I wanted to demonstrate my progress so far!)

I'm using an example of a 2-bit counter, since this was the simplest example I could actually get to build with OpenROAD. You can see the simple floorplan in `counter_floorplan.py`, which is passed in using the `-asic_floorplan` switch. It sets up the `clk` input on the left, and the two counter outputs on the right. It uses the default arguments to evenly space the pins. Here's the result of running `./examples/counter/run.sh`:

![Screen Shot 2021-04-07 at 6 23 55 PM](https://user-images.githubusercontent.com/4412459/113942175-6b0cf300-97ce-11eb-8eac-46dd3e738ba1.png)

(the die is a bit oversized since I hardcoded it to be the size of the GCD example for now). 

I think we could either merge this as-is (I included some checks to make sure it hopefully doesn't break anything), or I can clean it up a bit (e.g. don't have hardcoded die size, maybe use a more finalized example) before merging. 

NOTE: this PR relies on #85, so that one should be merged first!