### PR TITLE
Correct layer width in freepdk45 target

### DIFF
--- a/asic/targets/freepdk45.py
+++ b/asic/targets/freepdk45.py
@@ -39,7 +39,7 @@ def setup_platform(chip):
     # Layer Definitions
     for metal in ('metal1', 'metal2', 'metal3'):
         chip.set('pdk','aprlayer', stackup, metal, 'xoffset', '0.095')
-        chip.set('pdk','aprlayer', stackup, metal, 'xpitch',  '0.19')
+        chip.set('pdk','aprlayer', stackup, metal, 'xpitch',  '0.14')
         chip.set('pdk','aprlayer', stackup, metal, 'yoffset', '0.07')
         chip.set('pdk','aprlayer', stackup, metal, 'ypitch',  '0.14')
 


### PR DESCRIPTION
A small thing, but I think 0.19 might be a typo here (unless I'm misunderstanding something). The layer definition in  `asic/virtual/freepdk45/pdk/r1p0/apr/freepdk45.tech.lef` looks like:
```
LAYER metal1
  TYPE ROUTING ;
  SPACING 0.065 ;
  WIDTH 0.07 ;
  PITCH 0.14 ;
 .... 
END metal1
```

and based on the LEF spec it seems like one value specified for the pitch applies to both x and y.