### PR TITLE
Add logic to auto-generate a core size if only the die size is configured.

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -448,6 +448,18 @@ class Chip:
         #1. Check for missing combinations
         #!(def-file | floorplan | (diesze & coresize)
 
+        # If die size is set and core size is missing, auto-generate a core size.
+        if (len(self.cfg['asic']['diesize']['value']) > 0) and \
+           (len(self.cfg['asic']['coresize']['value']) == 0):
+            die_sizes = self.cfg['asic']['diesize']['value'][-1].split(' ')
+            # TODO: Use placement site multiples.
+            core_size = '%.2f %.2f %.2f %.2f'%(
+                float(die_sizes[0])+10,
+                float(die_sizes[1])+10,
+                float(die_sizes[2])-10,
+                float(die_sizes[3])-10)
+            self.cfg['asic']['coresize']['value'] = [core_size]
+
         # notechlef
         # no site
         # no targetlib        


### PR DESCRIPTION
Currently, the user needs to pass in a die area and a core area for an ASIC design.

This change lets `sc` auto-generate a core size from the die size, to reduce the number of required parameters and make it easier to create multiple runs with varying die areas.