### PR TITLE
Proposal for a Python-based permutations configuration.

### DIFF
--- a/examples/gcd/2jobs.py
+++ b/examples/gcd/2jobs.py
@@ -1,0 +1,8 @@
+import numpy
+
+# Example Python generator to create two permutations of a design with
+# different clock periods.
+def permutations(cfg):
+  for i in numpy.arange(0.5, 1.5, 0.5):
+      cfg['clock']['default']['period']['value'] = [str(i)]
+      yield cfg

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2122,6 +2122,21 @@ def schema_options(cfg):
         """
     }
 
+    # Path to a config file defining multiple remote jobs to run.
+    cfg['permutations'] = {
+        'switch' : '-permutations',
+        'type' : ['str'],
+        'requirement' : 'optional',
+        'defvalue' : [],
+        'short_help' : "Python file containing configuration generator for parallel runs.",
+        'param_help' : "'permutations' <str>",
+        'help' : """
+        Sets the path to a Python file containing a generator which yields
+        multiple configurations of a job to run in parallel. This lets you
+        'sweep' various configurations such as die size or clock speed.
+        """
+    }
+
     return cfg
 
 ############################################


### PR DESCRIPTION
After rebasing the parallel remote logic onto your changes from late last week, and incorporating your feedback to use Python instead of JSON for configuring multiple runs, I ended up with some non-trivial modifications to the CLI script.

There's also an extra schema parameter which accepts a file location for the user's Python configuration script, so I thought that I should submit the 'parallel workflow' changes separately from the 'remote workflow' ones.

This minimal PR demonstrates the core idea of using a [Python generator](https://docs.python.org/3/howto/functional.html#generators) to generate design permutations. I will submit a follow-up PR soon with the server-side changes to run these permutations in parallel. I like this solution because it is easy to integrate with the 'remote_run' calls, but I would also understand if you feel that it adds too much dense logic to the `main()` method.