### PR TITLE
Integrate floorplan Python API with OpenROAD flow

### DIFF
--- a/eda/openroad/sc_floorplan.tcl
+++ b/eda/openroad/sc_floorplan.tcl
@@ -92,7 +92,7 @@ link_design $topmodule
 ########################################################
 
 if {[file exists $input_def]} {
-    read_def $input_def
+    read_def -floorplan_initialize $input_def
 } else {
     if {[llength $diesize] != "4"} {
 	#1. get cell area

--- a/examples/counter/constraint.sdc
+++ b/examples/counter/constraint.sdc
@@ -1,0 +1,1 @@
+create_clock [get_ports clk]  -name core_clock  -period 2

--- a/examples/counter/counter.v
+++ b/examples/counter/counter.v
@@ -1,0 +1,15 @@
+module counter # (
+  parameter W = 2
+  ) (
+  input wire clk,
+  output [W-1:0] c
+);
+
+  reg [W-1:0] counter;
+  always @(posedge clk) begin
+    counter <= counter + 1'b1;
+  end
+
+  assign c = counter;
+
+endmodule

--- a/examples/counter/counter_floorplan.py
+++ b/examples/counter/counter_floorplan.py
@@ -1,0 +1,13 @@
+def setup_floorplan(fp, chip):
+    w = fp.std_cell_width
+    h = fp.std_cell_height
+
+    fp.create_die_area(64 * w, 9 * h, core_area=(8 * w, 1 * h, 56 * w, 8 * h))
+
+    metal = 'm3'
+    width = 1
+    depth = 3
+    fp.place_pins(['clk'], 'w', width, depth, metal)
+    fp.place_pins(['c[0]', 'c[1]'], 'e', width, depth, metal)
+
+    return fp

--- a/examples/counter/run.sh
+++ b/examples/counter/run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Die size and core size are overwritten by floorplan file, but are required to
+# make build run without error
+
+sc examples/counter/counter.v \
+   -pdk_rev "1.0" \
+   -target "freepdk45" \
+   -asic_diesize "0 0 100.13 100.8" \
+   -asic_coresize "10.07 11.2 90.25 91" \
+   -asic_floorplan examples/counter/counter_floorplan.py \
+   -loglevel "INFO" \
+   -design counter \
+   -quiet

--- a/siliconcompiler/floorplan.py
+++ b/siliconcompiler/floorplan.py
@@ -127,8 +127,8 @@ class Floorplan:
         else:
             self.core_area = core_area
 
-        self.chip.set('asic', 'diesize', (0, 0, width, height))
-        self.chip.set('asic', 'coresize', self.core_area)
+        self.chip.set('asic', 'diesize', str((0, 0, width, height)))
+        self.chip.set('asic', 'coresize', str(self.core_area))
         self.chip.layout['diearea'] = self._def_scale([(0, 0), self.die_area])
 
         if generate_rows:
@@ -286,7 +286,7 @@ class Floorplan:
                 'use': use
             }
             port = {
-                'layer': layer,
+                'layer': self.layers[layer]['name'],
                 'box': self._def_scale(shape),
                 'status': 'fixed' if fixed else 'placed',
                 'point': self._def_scale(pos),
@@ -421,8 +421,11 @@ class Floorplan:
         elif isinstance(val, tuple):
             return tuple([self._def_scale(item) for item in val])
         else:
-            # make int (?)
-            return int(val * self.db_units)
+            # TODO: rounding and making this an int seems helpful for resolving
+            # floating point rounding issues, but could be problematic if we
+            # want to have floats in DEF file? Alternative could be to use
+            # Python decimal library for internally representing micron values
+            return int(round(val * self.db_units))
 
     def _snap_to_x_track(self, x, layer):
         offset = self.layers[layer]['xoffset']


### PR DESCRIPTION
This PR adds functionality to integrate the floorplanning API with OpenROAD! It's a cleaned-up version of the approach in #86, with the biggest difference being that library info is no longer hardcoded. 

I used the same counter example as before, here's the final gds produced with this design + floorplan: 
![Screen Shot 2021-04-14 at 12 54 03 PM](https://user-images.githubusercontent.com/4412459/114749027-7efdab00-9d20-11eb-9019-efa8f6fade0b.png)

One proposal for a future change I just thought of is to modify the `create_die_area` function to accept dimensions in terms of cell width/height by default (with a `units='absolute'` option to specify microns if a designer wishes). I think this would be consistent with the rest of the API, and I ended up applying this approach manually in the example here. How does that sound?
