### PR TITLE
Specify die area based on cell height

### DIFF
--- a/examples/counter/counter_floorplan.py
+++ b/examples/counter/counter_floorplan.py
@@ -1,8 +1,5 @@
 def setup_floorplan(fp, chip):
-    w = fp.std_cell_width
-    h = fp.std_cell_height
-
-    fp.create_die_area(64 * w, 9 * h, core_area=(8 * w, 1 * h, 56 * w, 8 * h))
+    fp.create_die_area(9, 9)
 
     metal = 'm3'
     width = 1

--- a/siliconcompiler/floorplan.py
+++ b/siliconcompiler/floorplan.py
@@ -98,7 +98,7 @@ class Floorplan:
         self.db_units = db_units
 
     def create_die_area(self, width, height, core_area=None, generate_rows=True,
-                        generate_tracks=True):
+                        generate_tracks=True, units='relative'):
         '''Initializes die.
 
         Initializes the area of the die and generates placement rows and routing
@@ -107,23 +107,34 @@ class Floorplan:
         already present in the chip config.
 
         Args:
-            width (float): Width of die in microns.
-            height (float): Height of die in microns.
+            width (float): Width of die in terms of standard cell height if
+                using technology-independent units, otherwise microns.
+            height (float): Height of die in terms of standard cell height if
+                using technology-independent units, otherwise microns.
             core_area (tuple of float): The core cell area of the physical
                 design. This is provided as a tuple (x0 y0 x1 y1), where (x0,
                 y0), specifes the lower left corner of the block and (x1, y1)
                 specifies the upper right corner. If `None`, core_area is set to
-                be equivalent to the die area.
+                be equivalent to the die area minus the standard cell height on
+                each side.
             generate_rows (bool): Automatically generate rows to fill entire
                 core area.
             generate_tracks (bool): Automatically generate tracks to fill entire
                 core area.
-
+            units (str): whether to use technology-relative ('relative') or
+                absolute ('absolute') units.
         '''
         # store die_area as 2-tuple since bottom left corner is always 0,0
+        if units == 'relative':
+            width *= self.std_cell_height
+            height *= self.std_cell_height
+
         self.die_area = (width, height)
         if core_area == None:
-            self.core_area = (0, 0, width, height)
+            self.core_area = (self.std_cell_height,
+                              self.std_cell_height,
+                              width - self.std_cell_height,
+                              height - self.std_cell_height)
         else:
             self.core_area = core_area
 


### PR DESCRIPTION
This implements the relative die area discussed in #97.

One question about this: is there any need to require that the die/core sizes are multiples of standard cell dimensions? For some reason I think I recall this being a constraint documented somewhere (perhaps in some OpenROAD code I looked at), but I can't find it/remember if I read it correctly. Of course, this wouldn't be a problem for the height if we constrain the input to an int, but I wonder if it'd be important to round the die width to the nearest multiple of a cell width. 