### PR TITLE
Updated permutations workflow, addressing CR comments from last week.

### DIFF
--- a/examples/gcd/2jobs.py
+++ b/examples/gcd/2jobs.py
@@ -1,0 +1,8 @@
+import numpy
+
+# Example Python generator to create two permutations of a design with
+# different clock periods.
+def permutations(cfg):
+  for i in numpy.arange(0.5, 1.5, 0.5):
+      cfg['clock']['default']['period']['value'] = [str(i)]
+      yield cfg

--- a/siliconcompiler/cli.py
+++ b/siliconcompiler/cli.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 
 #Standard Modules
+import asyncio
 import sys
 import logging
 import argparse
@@ -15,7 +16,10 @@ from argparse import RawTextHelpFormatter
 #Shorten siliconcompiler as sc
 import siliconcompiler
 from siliconcompiler.schema import schema_cfg
+from siliconcompiler.client import fetch_results
+from siliconcompiler.client import remote_preprocess
 from siliconcompiler.client import remote_run
+from siliconcompiler.core   import get_permutations
 
 ###########################
 def cmdline():
@@ -225,50 +229,71 @@ def main():
     else:
         loglevel = "INFO"
         
-    #Create one (or many...) instances of Chip class
-    chip = siliconcompiler.Chip(loglevel=loglevel)
+    # Create a 'job hash' and base Chip class.
+    job_hash = uuid.uuid4().hex
+    base_chip = siliconcompiler.Chip(loglevel=loglevel)
+    base_chip.status['job_hash'] = job_hash
 
     # Checing for illegal combination
     if ('target' in cmdlinecfg.keys()) & ('cfg' in cmdlinecfg.keys()):
-        chip.logger.error("Options -target and -cfg are mutually exlusive")
+        base_chip.logger.error("Options -target and -cfg are mutually exlusive")
         sys.exit()
     # Reading in config files specified at command line
     elif 'cfg' in  cmdlinecfg.keys():
         for cfgfile in cmdlinecfg['cfg']['value']:
-            chip.readcfg(cfgfile)
+            base_chip.readcfg(cfgfile)
     # Reading in automated target
     else:
         if 'target' in cmdlinecfg.keys():
-            chip.set('target', cmdlinecfg['target']['value'][0])
+            base_chip.set('target', cmdlinecfg['target']['value'][0])
         else:
-            chip.logger.info('No target set, setting to %s','freepdk45')
-            chip.set('target', 'freepdk45_asic')
+            base_chip.logger.info('No target set, setting to %s','freepdk45')
+            base_chip.set('target', 'freepdk45_asic')
         if 'optmode' in cmdlinecfg.keys():
-            chip.set('optmode', cmdlinecfg['optmode']['value'])
+            base_chip.set('optmode', cmdlinecfg['optmode']['value'])
         #Load values based on target name
-        chip.target()
+        base_chip.target()
 
     # 4. Override cfg with command line args
-    chip.mergecfg(cmdlinecfg)   
+    base_chip.mergecfg(cmdlinecfg)
 
-    #Checks settings and fills in missing values
-    chip.check()
+    # Create one (or many...) instances of Chip class
+    chips = get_permutations(base_chip, cmdlinecfg)
 
-    #Creating hashes for all sourced files
-    chip.hash()
+    # Check and lock each permutation.
+    for chip in chips:
+        #Checks settings and fills in missing values
+        chip.check()
 
-    # Create a 'job hash'.
-    job_hash = uuid.uuid4().hex
-    chip.status['job_hash'] = job_hash
+        #Creating hashes for all sourced files
+        chip.hash()
 
-    #Lock chip configuration
-    chip.lock()
+        #Lock chip configuration
+        chip.lock()
 
-    # Running compilation pipeline
-    chip.run()
-    
-    # Print Summary
-    chip.summary()
+    # Perform preprocessing for remote jobs, if necessary.
+    remote_preprocess(chips, cmdlinecfg)
+
+    # Run each job in parallel (remote) or serially (local).
+    # The Chip.run() method is not thread-safe, so no parallel local runs.
+    for chip in chips:
+        # Running compilation pipeline
+        chip.start_async_run()
+
+    # Wait for threads to complete.
+    loop = asyncio.get_event_loop()
+    for chip in chips:
+        while chip.active_thread and (not chip.active_thread.done()):
+            # Sleep asynchronously so that background threads can run.
+            loop.run_until_complete(asyncio.sleep(1.0))
+
+        # Print Summary
+        # TODO: Currently causes errors due to jobid keys.
+        #chip.summary()
+
+    # For remote jobs, fetch results.
+    if 'remote' in cmdlinecfg.keys():
+        fetch_results(chips[-1])
         
 #########################
 if __name__ == "__main__":    

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -17,7 +17,9 @@ import copy
 import importlib
 import glob
 import pandas
+from importlib.machinery import SourceFileLoader
 
+from siliconcompiler.client import remote_run
 from siliconcompiler.schema import schema_cfg
 from siliconcompiler.schema import schema_layout
 from siliconcompiler.schema import schema_path
@@ -58,7 +60,12 @@ class Chip:
         self.handler.setFormatter(self.formatter)
         self.logger.addHandler(self.handler)
         self.logger.setLevel(str(loglevel))
-        
+
+        # Special tracking variable for async run status. This could
+        # go in the config dictionary, but internal thread states don't
+        # need to be exposed to TCL scripts / etc.
+        self.active_thread = None
+
         # Set Environment Variable if not already set
         scriptdir = os.path.dirname(os.path.abspath(__file__))
         rootdir =  re.sub('siliconcompiler/siliconcompiler',
@@ -778,7 +785,17 @@ class Chip:
           error = subprocess.run(cmd, shell=True)
 
     ###################################
-    def run(self, start=None, stop=None, jobid=None):
+    def start_async_run(self, start=None, stop=None, jobid=None):
+        '''Helper method to start an asynchronous 'run' command, and update
+           a tracking semaphore when it starts/finishes.
+        '''
+        loop = asyncio.get_event_loop()
+        self.active_thread = loop.create_task(self.run(start=start,
+                                                       stop=stop,
+                                                       jobid=jobid))
+
+    ###################################
+    async def run(self, start=None, stop=None, jobid=None):
 
         '''The common execution method for all compilation steps compilation
         flow. The job executes on the local machine by default, but can be
@@ -826,16 +843,23 @@ class Chip:
             # Job-ID and Step
             #####################
             
-            #Automatic updating of jobids when argument is missing
-            if (jobid is None ) | importstep:
-                #Initialize jobid first time around
+            if not remote:
+                #Automatic updating of jobids when argument is missing
+                if (jobid is None ) | importstep:
+                    #Initialize jobid first time around
+                    if not step in self.cfg['status'].keys():
+                        self.set('status', step, 'jobid', '0')
+                    jobid = int(self.cfg['status'][step]['jobid']['value'][-1])
+                    jobid = jobid + 1
+
+                #Update JOBID in dictionary!
+                self.set('status', step, 'jobid', str(jobid))
+            else:
+                # Remote job IDs are set ahead of time.
                 if not step in self.cfg['status'].keys():
                     self.set('status', step, 'jobid', '0')
                 jobid = int(self.cfg['status'][step]['jobid']['value'][-1])
-                jobid = jobid + 1
-
-            #Update JOBID in dictionary!
-            self.set('status', step, 'jobid', str(jobid))
+                self.set('status', step, 'jobid', str(jobid))
       
             if stepindex==0:
                 jobdir = buildroot + '/import/job'
@@ -870,8 +894,8 @@ class Chip:
             else:
                 self.logger.info("Running step '%s' with jobid '%s'", step, jobid)  
 
-                # Copying in Files
-                if os.path.isdir(jobdir):
+                # Copying in Files (local only)
+                if os.path.isdir(jobdir) and (not remote):
                     shutil.rmtree(jobdir)
                 os.makedirs(jobdir, exist_ok=True)
                 os.chdir(jobdir)
@@ -881,7 +905,8 @@ class Chip:
                 if stepindex==0:
                     pass
                 elif stepindex == 1:
-                    shutil.copytree("../../import/job/outputs", 'inputs')
+                    if not remote:
+                        shutil.copytree("../../import/job/outputs", 'inputs')
                 else:
                     lastjobid = self.get('status', laststep, 'jobid')[-1]                    
                     #check if job was run before, if not use current step ID
@@ -892,7 +917,8 @@ class Chip:
                                         steplist[stepindex-1],
                                         'job'+str(lastjobid),
                                         'outputs'])
-                    shutil.copytree(lastdir, 'inputs')
+                    if not remote:
+                        shutil.copytree(lastdir, 'inputs')
                 
                 #Copy Reference Scripts
                 refdir = schema_path(self.cfg['flow'][step]['refdir']['value'][-1])
@@ -950,10 +976,12 @@ class Chip:
                 #####################
                 # Execute
                 #####################
-                if remote:
+                if (stepindex != 0) and remote:
                     self.logger.info('Remote server call')
-                    pass
+                    await remote_run(self, step)
                 else:
+                    # Local builds must be processed synchronously, because
+                    # they use calls such as os.chdir which are not thread-safe.
                     # Tool Pre Process
                     pre_process = getattr(module,"pre_process")
                     pre_process(self,step)
@@ -975,6 +1003,8 @@ class Chip:
             ########################       
             os.chdir(cwd)
 
+        # Mark completion of async run if applicable.
+        self.active_thread = None
  
 
 ############################################
@@ -984,6 +1014,37 @@ class YamlIndentDumper(yaml.Dumper):
     def increase_indent(self, flow=False, indentless=False):
         return super(YamlIndentDumper, self).increase_indent(flow, False)
 
+########################
+def get_permutations(base_chip, cmdlinecfg):
+    '''Helper method to generate one or more Chip objects depending on
+       whether a permutations file was passed in.
+    '''
 
+    chips = []
+    if 'permutations' in cmdlinecfg.keys():
+        perm_path = os.path.abspath(cmdlinecfg['permutations']['value'][-1])
+        perm_script = SourceFileLoader('job_perms', perm_path).load_module()
+        jobid = 0
+        loglevel = cmdlinecfg['loglevel']['value'][-1] \
+            if 'loglevel' in cmdlinecfg.keys() else "INFO"
+        # Create a new Chip object with the same job hash for each permutation.
+        for chip_cfg in perm_script.permutations(base_chip.cfg):
+            new_chip = Chip(loglevel=loglevel)
+            # JSON dump/load is a simple way to deep-copy a Python
+            # dictionary which does not contain custom classes/objects.
+            new_chip.status = json.loads(json.dumps(base_chip.status))
+            new_chip.cfg = json.loads(json.dumps(chip_cfg))
+            # set incrementing job IDs to avoid overwriting other jobs.
+            for step in new_chip.cfg['steplist']['value']:
+                new_chip.set('status', step, 'jobid', str(jobid))
+            if 'remote' in cmdlinecfg.keys():
+                new_chip.set('start', 'syn')
+            chips.append(new_chip)
+            jobid = jobid + 1
+    else:
+        # If no permutations script is configured, simply run the design once.
+        chips.append(base_chip)
 
-    
+    # Done; return the list of Chips.
+    return chips
+

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2109,6 +2109,21 @@ def schema_options(cfg):
         """
     }
 
+    # Path to a config file defining multiple remote jobs to run.
+    cfg['permutations'] = {
+        'switch' : '-permutations',
+        'type' : ['str'],
+        'requirement' : 'optional',
+        'defvalue' : [],
+        'short_help' : "Python file containing configuration generator for parallel runs.",
+        'param_help' : "'permutations' <str>",
+        'help' : """
+        Sets the path to a Python file containing a generator which yields
+        multiple configurations of a job to run in parallel. This lets you
+        'sweep' various configurations such as die size or clock speed.
+        """
+    }
+
     return cfg
 
 

--- a/siliconcompiler/server.py
+++ b/siliconcompiler/server.py
@@ -45,7 +45,7 @@ class Server:
         self.app.add_routes([
             web.post('/remote_run/{job_hash}/{stage}', self.handle_remote_run),
             web.post('/import/{job_hash}', self.handle_import),
-            web.get('/check_progress/{job_hash}/{stage}', self.handle_check_progress),
+            web.get('/check_progress/{job_hash}/{stage}/{jobid}', self.handle_check_progress),
             web.get('/delete_job/{job_hash}', self.handle_delete_job),
         ])
         # TODO: Put zip files in a different directory.
@@ -77,26 +77,30 @@ class Server:
 
         # Reset 'build' directory in NFS storage.
         build_dir = '%s/%s'%(self.cfg['nfsmount']['value'][0], job_hash)
-        cfg['build']['value'] = [build_dir]
+        cfg['dir']['value'] = [build_dir]
         # Remove 'remote' JSON config value to run locally on compute node.
         cfg['remote']['value'] = []
         # Rename source files in the config dict; the 'import' step already
-        # ran and collected the sources into a single 'verilator.v' file.
+        # ran and collected the sources into a single 'verilator.sv' file.
         # TODO: Use 'jobid'
-        cfg['source']['value'] = ['%s/%s/import/job1/verilator.v'%(self.cfg['nfsmount']['value'][0], job_hash)]
+        cfg['source']['value'] = ['%s/%s/import/job/verilator.sv'%(self.cfg['nfsmount']['value'][0], job_hash)]
         # Write JSON config to shared compute storage.
-        with open('%s/chip.json'%build_dir, 'w') as f:
+        cur_id = cfg['status'][stage]['jobid']['value'][-1]
+        subprocess.run(['mkdir', '-p', '%s/configs'%build_dir])
+        with open('%s/configs/chip%s.json'%(build_dir, cur_id), 'w') as f:
           f.write(json.dumps(cfg))
+        # Symlink the appropriate import directory.
+        subprocess.run(['ln', '-s', '%s/import/job'%build_dir, '%s/import/job%s'%(build_dir, str(int(cur_id)+1))])
 
         # Issue an 'srun' command depending on the given config JSON.
         sc_sources = ''
         for filename in cfg['source']['value']:
           sc_sources += filename + " "
         # (Non-blocking)
-        asyncio.create_task(self.remote_sc(job_hash, cfg['design']['value'][0], cfg['source']['value'], build_dir, stage))
+        asyncio.create_task(self.remote_sc(job_hash, cfg['design']['value'][0], cfg['source']['value'], build_dir, stage, cur_id))
 
         # Return a response to the client.
-        response_text = "Starting step: %s"%stage
+        response_text = "Starting job stage: %s (%s)"%(job_hash, stage)
         return web.Response(text=response_text)
 
     ####################
@@ -134,7 +138,8 @@ class Server:
                         f.write(chunk)
 
         # Un-zip the archive file.
-        subprocess.run(['unzip', '-o', '%s/import.zip'%(job_root)], cwd=job_root)
+        subprocess.run(['mkdir', '-p', '%s/import/job'%job_root])
+        subprocess.run(['unzip', '-o', '%s/import.zip'%(job_root)], cwd='%s/import/job'%job_root)
 
         # Done.
         return web.Response(text="Successfully imported project %s."%job_hash)
@@ -170,6 +175,8 @@ class Server:
             #print('Deleting: %s.zip'%build_dir)
             os.remove('%s.zip'%build_dir)
 
+        return web.Response(text="Job deleted.")
+
     ####################
     async def handle_check_progress(self, request):
         '''
@@ -187,23 +194,31 @@ class Server:
         stage = request.match_info.get('stage', None)
         if not stage:
           return web.Response(text="Error: no stage provided.")
+        jobid = request.match_info.get('jobid', None)
+        if not jobid:
+          return web.Response(text="Error: no job ID provided.")
 
         # Determine if the job is running.
-        if "%s_%s"%(job_hash, stage) in self.sc_jobs:
+        if "%s_%s_%s"%(job_hash, stage, jobid) in self.sc_jobs:
             return web.Response(text="Job is currently running on the cluster.")
         else:
             return web.Response(text="Job has no running steps.")
 
     ####################
-    async def remote_sc(self, job_hash, top_module, sc_sources, build_dir, stage):
+    async def remote_sc(self, job_hash, top_module, sc_sources, build_dir, stage, jobid):
         '''
         Async method to delegate an 'sc' command to a slurm host,
         and send an email notification when the job completes.
 
         '''
 
+        # Read config JSON, for multi-job configuration.
+        jobs_cfg = {}
+        with open('%s/configs/chip%s.json'%(build_dir, jobid), 'r') as cfgf:
+            jobs_cfg = json.load(cfgf)
+
         # Mark the job hash as being busy.
-        self.sc_jobs["%s_%s"%(job_hash, stage)] = 'busy'
+        self.sc_jobs["%s_%s_%s"%(job_hash, stage, jobid)] = 'busy'
 
         # Assemble the 'sc' command. The host must be running slurmctld.
         # TODO: Avoid using a hardcoded $PATH variable for the compute node.
@@ -214,8 +229,7 @@ class Server:
         # Send JSON config instead of using subset of flags.
         # TODO: Use slurmpy SDK?
         srun_cmd  = 'srun %s sc /dev/null '%(export_path)
-        srun_cmd += '-cfg %s/chip.json '%(build_dir)
-        srun_cmd += '-start %s -stop %s'%(stage, stage)
+        srun_cmd += '-cfg %s/configs/chip%s.json '%(build_dir, jobid)
 
         # Create async subprocess shell, and block this thread until it finishes.
         proc = await asyncio.create_subprocess_shell(srun_cmd)
@@ -227,12 +241,13 @@ class Server:
         if stage == 'export':
             subprocess.run(['zip',
                             '-r',
+                            '-y',
                             '%s.zip'%job_hash,
                             '%s'%job_hash],
                            cwd=self.cfg['nfsmount']['value'][0])
 
         # Mark the job hash as being done.
-        self.sc_jobs.pop("%s_%s"%(job_hash, stage))
+        self.sc_jobs.pop("%s_%s_%s"%(job_hash, stage, jobid))
 
     ####################
     def writecfg(self, filename, mode="all"):


### PR DESCRIPTION
This PR includes the parallel workflow from #95 and #96, rebased onto the main branch and with changes to address code review comments.

Before merging this, please take a look at the way that I wrapped the asynchronous 'run' method, and let me know if it looks like what you had in mind. I added a synchronous `start_async_run()` method and an `active_thread` class variable which can be polled to check on the run status.

If you would prefer, I could try to take the opposite approach and find a way to make the `run()` call synchronous by adding asynchronous helper methods. But that would be challenging, because the asynchronous `remote_run()` method is called from `run()`, and it is difficult to cleanly yield from a synchronous method in Python.