### PR TITLE
Fix Floorplan API integration

### DIFF
--- a/eda/openroad/openroad_setup.py
+++ b/eda/openroad/openroad_setup.py
@@ -63,7 +63,13 @@ def pre_process(chip, step):
         fp = setup_floorplan(fp, chip)
 
         topmodule = chip.get('design')[-1]
-        fp.save('inputs/' + topmodule + '.def')
+        def_file = 'inputs/' + topmodule + '.def'
+        fp.save(def_file)
+
+        chip.set('asic', 'def', def_file)
+        # a bit of a hack: have to regenerate schema TCL file so OpenROAD script
+        # finds our generated DEF file
+        chip.writecfg("sc_schema.tcl", abspath=True)
 
 def post_process(chip, step):
      ''' Tool specific function to run after step execution
@@ -108,8 +114,4 @@ def post_process(chip, step):
                     chip.set('real', step, 'cells', cells.group(1))
                elif nets:
                     chip.set('real', step, 'nets', nets.group(1))               
-          
 
-     
-                        
-   

--- a/eda/openroad/sc_apr.tcl
+++ b/eda/openroad/sc_apr.tcl
@@ -98,8 +98,8 @@ if {[dict exists $sc_cfg constraint]} {
 }
 
 # DEF
-if {[dict exists $sc_cfg def]} {    
-    set sc_def [dict get $sc_cfg def]
+if {[dict exists $sc_cfg asic def]} {
+    set sc_def [dict get $sc_cfg asic def]
 } else {
     set sc_def  ""
 }
@@ -174,4 +174,3 @@ source "$sc_refdir/sc_metrics.tcl"
 ###############################
 
 source "$sc_refdir/sc_write.tcl"
-

--- a/examples/counter/run.sh
+++ b/examples/counter/run.sh
@@ -6,6 +6,7 @@
 sc examples/counter/counter.v \
    -pdk_rev "1.0" \
    -target "freepdk45" \
+   -constraint "examples/counter/constraint.sdc" \
    -asic_diesize "0 0 100.13 100.8" \
    -asic_coresize "10.07 11.2 90.25 91" \
    -asic_floorplan examples/counter/counter_floorplan.py \


### PR DESCRIPTION
Some of the OpenROAD refactoring broke the Floorplan API integration, this PR gets it back to a working state. 

The main issue was that `sc_floorplan.tcl` now checks for an existing DEF in the schema, but when using the Python floorplan API, the DEF doesn't get generated until the floorplan `pre_process` step, at which point the schema has already been dumped to tcl. This PR includes a hack to regenerate `sc_schema.tcl` after adding the DEF file to the schema, but I'm definitely open for suggestions on how to handle this more cleanly!