### PR TITLE
Set jobid to 1 if design build dir not found

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1129,16 +1129,20 @@ class Chip:
         dirname = self.cfg['dir']['value'][-1]
         jobname = self.cfg['jobname']['value'][-1]
 
-        alljobs = os.listdir(dirname + "/" + design)
+        try:
+            alljobs = os.listdir(dirname + "/" + design)
 
-        if len(self.cfg['jobid']['value']) < 1:
-            jobid = 0
-            for item in alljobs:
-                m = re.match(jobname+'(\d+)', item)
-                if m:
-                    jobid = max(jobid, int(m.group(1)))
-            jobid = jobid+1
-            self.set('jobid', str(jobid))
+            if len(self.cfg['jobid']['value']) < 1:
+                jobid = 0
+                for item in alljobs:
+                    m = re.match(jobname+'(\d+)', item)
+                    if m:
+                        jobid = max(jobid, int(m.group(1)))
+                jobid = jobid+1
+                self.set('jobid', str(jobid))
+        except FileNotFoundError:
+            # if no existing build directory, set jobid to 1
+            self.set('jobid', '1')
             
 ################################################################################        
 # Annoying helper class b/c yaml..


### PR DESCRIPTION
This fixes a bug where SC would crash with a FileNotFoundError if a design's build directory doesn't exist yet (since it traverses this directory to compute the jobid). If the build directory doesn't exist yet, the jobid defaults to 1 (and the directory gets created by SC later on).

This should hopefully *actually* fix the FPGA CI, it was still failing in #113 due to this issue. 