### PR TITLE
Remove schema hack in Floorplan API integration

### DIFF
--- a/eda/openroad/openroad_setup.py
+++ b/eda/openroad/openroad_setup.py
@@ -66,11 +66,6 @@ def pre_process(chip, step):
         def_file = 'inputs/' + topmodule + '.def'
         fp.save(def_file)
 
-        chip.set('asic', 'def', def_file)
-        # a bit of a hack: have to regenerate schema TCL file so OpenROAD script
-        # finds our generated DEF file
-        chip.writecfg("sc_schema.tcl", abspath=True)
-
 def post_process(chip, step):
      ''' Tool specific function to run after step execution
      '''

--- a/eda/openroad/sc_apr.tcl
+++ b/eda/openroad/sc_apr.tcl
@@ -105,8 +105,8 @@ if {[dict exists $sc_cfg asic def]} {
 }
 
 # FLOORPLAN
-if {[dict exists $sc_cfg floorplan]} {    
-    set sc_floorplan [dict get $sc_cfg floorplan]
+if {[dict exists $sc_cfg asic floorplan]} {
+    set sc_floorplan [dict get $sc_cfg asic floorplan]
 } else {
     set sc_floorplan  ""
 }

--- a/eda/openroad/sc_floorplan.tcl
+++ b/eda/openroad/sc_floorplan.tcl
@@ -2,11 +2,13 @@
 # FLOORPLANNING
 ########################################################
 
-if {[llength $sc_def] > 0 | [llength $sc_floorplan] > 0} {
+if {[llength $sc_def] > 0} {
     #TODO: Only one def supported for now
     read_def -floorplan_initialize $sc_def
+} elseif {[llength $sc_floorplan] > 0} {
+    read_def -floorplan_initialize "inputs/$sc_design.def"
 } else {
-  
+
     #########################
     #Init Floorplan
     #########################


### PR DESCRIPTION
Looks like you merged #113 before I got a chance to remove the schema dump hack :) But what you said there about not doing this makes sense, so fixing it here. I think the change in b347f5624a0da0c8992343f1b56fc01cde00e2d6 doesn't quite do the trick, since it still tries to read`$sc_def`, which would be undefined. I modified `sc_floorplan.tcl` here to read `$topmodule.def` instead if a floorplan file is defined. 