### PR TITLE
Fix "['value'][0]" calls in client.py

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -66,8 +66,8 @@ async def is_job_busy(chip, stage):
 
     async with aiohttp.ClientSession() as session:
         async with session.get("http://%s:%s/check_progress/%s/%s/%s"%(
-                               chip.cfg['remote']['addr']['value'][0],
-                               chip.cfg['remote']['port']['value'][0],
+                               chip.cfg['remote']['addr']['value'][-1],
+                               chip.cfg['remote']['port']['value'][-1],
                                chip.status['job_hash'],
                                stage,
                                chip.cfg['jobid']['value'][-1])) \
@@ -82,8 +82,8 @@ async def delete_job(chip):
 
     async with aiohttp.ClientSession() as session:
         async with session.get("http://%s:%s/delete_job/%s"%(
-                               chip.cfg['remote']['addr']['value'][0],
-                               chip.cfg['remote']['port']['value'][0],
+                               chip.cfg['remote']['addr']['value'][-1],
+                               chip.cfg['remote']['port']['value'][-1],
                                chip.status['job_hash'])) \
         as resp:
             response = await resp.text()


### PR DESCRIPTION
I noticed that using [0] instead of [-1] can result in the default value being used instead of one which was passed in at the command line. I noticed this while testing the `-remote_port` flag.

Going forwards, should I be replacing these config value accesses with `chip.get` calls, like `chip.get('remote', 'port')[-1]`?