### PR TITLE
Add layer width to schema

### DIFF
--- a/asic/targets/freepdk45.py
+++ b/asic/targets/freepdk45.py
@@ -58,6 +58,7 @@ def setup_platform(chip):
         chip.set('pdk','aprlayer', stackup, sc_name, 'xpitch',  '0.19')
         chip.set('pdk','aprlayer', stackup, sc_name, 'yoffset', '0.07')
         chip.set('pdk','aprlayer', stackup, sc_name, 'ypitch',  '0.14')
+        chip.set('pdk','aprlayer', stackup, sc_name, 'width',   '0.07')
         chip.set('pdk','aprlayer', stackup, sc_name, 'adjustment', '1.0')   
         
     for sc_name, pdk_name in [('m2', 'metal2')]:
@@ -66,6 +67,7 @@ def setup_platform(chip):
         chip.set('pdk','aprlayer', stackup, sc_name, 'xpitch',  '0.19')
         chip.set('pdk','aprlayer', stackup, sc_name, 'yoffset', '0.07')
         chip.set('pdk','aprlayer', stackup, sc_name, 'ypitch',  '0.14')
+        chip.set('pdk','aprlayer', stackup, sc_name, 'width',   '0.07')
         chip.set('pdk','aprlayer', stackup, sc_name, 'adjustment', '0.8')   
         
     for sc_name, pdk_name in [('m3', 'metal3')]:
@@ -74,6 +76,7 @@ def setup_platform(chip):
         chip.set('pdk','aprlayer', stackup, sc_name, 'xpitch',  '0.19')
         chip.set('pdk','aprlayer', stackup, sc_name, 'yoffset', '0.07')
         chip.set('pdk','aprlayer', stackup, sc_name, 'ypitch',  '0.14')
+        chip.set('pdk','aprlayer', stackup, sc_name, 'width',   '0.07')
         chip.set('pdk','aprlayer', stackup, sc_name, 'adjustment',  '0.7')   
 
     for sc_name, pdk_name in [('m4', 'metal4'), ('m5', 'metal5'), ('m6', 'metal6')]:
@@ -82,6 +85,7 @@ def setup_platform(chip):
         chip.set('pdk','aprlayer', stackup, sc_name, 'xpitch',  '0.28')
         chip.set('pdk','aprlayer', stackup, sc_name, 'yoffset', '0.07')
         chip.set('pdk','aprlayer', stackup, sc_name, 'ypitch',  '0.28')
+        chip.set('pdk','aprlayer', stackup, sc_name, 'width',   '0.14')
         chip.set('pdk','aprlayer', stackup, sc_name, 'adjustment', '0.4')   
 
     for sc_name, pdk_name in [('m7', 'metal7'), ('m8', 'metal8')]:
@@ -90,6 +94,7 @@ def setup_platform(chip):
         chip.set('pdk','aprlayer', stackup, sc_name, 'xpitch',  '0.8')
         chip.set('pdk','aprlayer', stackup, sc_name, 'yoffset', '0.07')
         chip.set('pdk','aprlayer', stackup, sc_name, 'ypitch',  '0.8')
+        chip.set('pdk','aprlayer', stackup, sc_name, 'width',   '0.4')
         chip.set('pdk','aprlayer', stackup, sc_name, 'adjustment', '0.4')   
 
     for sc_name, pdk_name in [('m9', 'metal9'), ('m10', 'metal10')]:
@@ -98,6 +103,7 @@ def setup_platform(chip):
         chip.set('pdk','aprlayer', stackup, sc_name, 'xpitch',  '1.6')
         chip.set('pdk','aprlayer', stackup, sc_name, 'yoffset', '0.07')
         chip.set('pdk','aprlayer', stackup, sc_name, 'ypitch',  '1.6')
+        chip.set('pdk','aprlayer', stackup, sc_name, 'width',   '0.8')
         chip.set('pdk','aprlayer', stackup, sc_name, 'adjustment', '0.4')   
 
 ####################################################

--- a/examples/counter/run.sh
+++ b/examples/counter/run.sh
@@ -4,7 +4,6 @@
 # make build run without error
 
 sc examples/counter/counter.v \
-   -pdk_rev "1.0" \
    -target "freepdk45" \
    -constraint "examples/counter/constraint.sdc" \
    -asic_diesize "0 0 100.13 100.8" \

--- a/siliconcompiler/floorplan.py
+++ b/siliconcompiler/floorplan.py
@@ -94,6 +94,7 @@ class Floorplan:
             self.layers[name]['ypitch'] = float(layer['ypitch']['value'][-1])
             self.layers[name]['xoffset'] = float(layer['xoffset']['value'][-1])
             self.layers[name]['yoffset'] = float(layer['yoffset']['value'][-1])
+            self.layers[name]['width'] = float(layer['width']['value'][-1])
 
         self.db_units = db_units
 
@@ -215,11 +216,10 @@ class Floorplan:
 
         # Convert all received dimensions to microns
         if units == 'relative':
+            pin_scale_factor = self.layers[layer]['width']
             if side.upper() in ('N', 'S'):
-                pin_scale_factor = self.layers[layer]['xpitch'] / 2
                 pos_scale_factor = self.layers[layer]['xoffset']
             else: # E, W
-                pin_scale_factor = self.layers[layer]['ypitch'] / 2
                 pos_scale_factor = self.layers[layer]['yoffset']
 
             width *= pin_scale_factor

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -689,6 +689,24 @@ def schema_pdk(cfg):
         """
     }
 
+    # Routing width
+    cfg['pdk']['aprlayer']['default']['default']['width'] = {
+        'switch' : '-pdk_aprlayer_width',
+        'requirement' : 'optional',
+        'type' : ['num'],
+        'lock' : 'false',
+        'defvalue' : [],
+        'short_help' : 'APR Layer Routing Width',
+        'param_help' : "'pdk' 'aprlayer' stackup layer 'width'",
+        'example': ["""cli: -pdk_aprlayer_xoffset 'stack10 m2 0.5'""",
+                    """api: chip.add('pdk','aprlayer','stack10','m2','width',
+                    '0.5')"""],
+        'help' : """
+        Defines the default routing width for all wiring on a metal layer,
+        specified on a per stackup and per metal basis. Values are specified in um.
+        """
+    }
+
     # Routing Layer Adjustment
     cfg['pdk']['aprlayer']['default']['default']['adjustment'] = {
         'switch' : '-pdk_aprlayer_adjustment',


### PR DESCRIPTION
re: our discussion the other day, I'm adding the layer default routing width to the schema since the floorplan API relies on it, and Skywater doesn't have the same width = pitch/2 relationship that FreePDK45 does.  

Also, something I noticed while making this PR: looks like you changed the pitches for the first 3 layers in a recent commit. Is there a source you're using for why it should be that way? It doesn't seem to match what's in the tech lef (each of the layers only has a single pitch value), but I was wondering if it has to do with some sort of override OpenROAD uses or something like that.  