### PR TITLE
Add a call to 'delete_job' at the end of the remote workflow.

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -333,6 +333,12 @@ def fetch_results(chips):
                         job_hash)])
     subprocess.run(['unzip', '%s.zip'%job_hash])
 
+    # Call 'delete_job' to remove the run from the server.
+    # This deletes a job_hash, so separate calls for each permutation are not required.
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(delete_job(chips[-1]))
+
     # For encrypted jobs each permutation's result is encrypted in its own archive.
     # For unencrypted jobs, results are simply stored in the archive.
     if len(chips[-1].get('remote', 'key')) > 0:


### PR DESCRIPTION
This adds a call to the `delete_job` endpoint after the remote client script finishes fetching results, to delete the job from the server's storage.

I had previously removed this for debugging purposes, but deleting the finished results is an important part of the remote workflow.