### PR TITLE
Run CI tests on pushes

### DIFF
--- a/.github/workflows/gcd_test.yml
+++ b/.github/workflows/gcd_test.yml
@@ -1,4 +1,4 @@
-on: [workflow_dispatch, pull_request, pull_request_review]
+on: [workflow_dispatch, pull_request, pull_request_review, push]
 
 jobs:
   gcd_test_job:


### PR DESCRIPTION
I think that Noah might have proposed including 'push' in the list of when to run CI tests when we first set things up, and it would probably be a good idea since Andreas often makes direct pushes to the repository without creating PRs.