### PR TITLE
Conslidate the ASIC tests into a single CI workflow step?

### DIFF
--- a/.github/workflows/gcd_test.yml
+++ b/.github/workflows/gcd_test.yml
@@ -3,7 +3,7 @@ on: [workflow_dispatch, pull_request, pull_request_review]
 jobs:
   gcd_test_job:
     runs-on: self-hosted
-    name: 'GCD test build'
+    name: 'ASIC tests'
     steps:
       - uses: actions/checkout@v2
       - run: |
@@ -11,47 +11,7 @@ jobs:
           source $GITHUB_WORKSPACE/clean_env/bin/activate
           echo $VIRTUAL_ENV
           pip3 install -r $GITHUB_WORKSPACE/requirements.txt -e $GITHUB_WORKSPACE/.
-          pytest $GITHUB_WORKSPACE/tests/asic/test_gcd.py
-  gcd_loopback_test:
-    runs-on: self-hosted
-    name: 'GCD "local server" test build'
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          python3 -m venv create $GITHUB_WORKSPACE/clean_env --clear
-          source $GITHUB_WORKSPACE/clean_env/bin/activate
-          pip3 install -r $GITHUB_WORKSPACE/requirements.txt -e $GITHUB_WORKSPACE/.
-          pytest $GITHUB_WORKSPACE/tests/asic/test_gcd_server.py
-  gcd_permutations_test:
-    runs-on: self-hosted
-    name: 'GCD test build with two permutations'
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          python3 -m venv create $GITHUB_WORKSPACE/clean_env --clear
-          source $GITHUB_WORKSPACE/clean_env/bin/activate
-          pip3 install -r $GITHUB_WORKSPACE/requirements.txt -e $GITHUB_WORKSPACE/.
-          pytest $GITHUB_WORKSPACE/tests/asic/test_gcd_perms.py
-  gcd_loopback_permutations_test:
-    runs-on: self-hosted
-    name: 'GCD "local server" test build with two permutations'
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          python3 -m venv create $GITHUB_WORKSPACE/clean_env --clear
-          source $GITHUB_WORKSPACE/clean_env/bin/activate
-          pip3 install -r $GITHUB_WORKSPACE/requirements.txt -e $GITHUB_WORKSPACE/.
-          pytest $GITHUB_WORKSPACE/tests/asic/test_gcd_server_perms.py
-  gcd_python_api_test:
-    runs-on: self-hosted
-    name: 'GCD test build using the Python API (no shell calls)'
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          python3 -m venv create $GITHUB_WORKSPACE/clean_env --clear
-          source $GITHUB_WORKSPACE/clean_env/bin/activate
-          pip3 install -r $GITHUB_WORKSPACE/requirements.txt -e $GITHUB_WORKSPACE/.
-          pytest $GITHUB_WORKSPACE/tests/asic/test_gcd_py.py
+          pytest $GITHUB_WORKSPACE/tests/asic/
   fpga_test_job:
     runs-on: self-hosted
     name: 'FPGA test builds'


### PR DESCRIPTION
Now that the ASIC tests are compatible with the `pytest` framework, we have the option of running them all in a single GitHub Actions step.

Take a look at the difference between [the results from this PR's CI tests](https://github.com/zeroasiccorp/siliconcompiler/actions/runs/821705724), and [the previous ones](https://github.com/zeroasiccorp/siliconcompiler/actions/runs/821638748). Feel free to close this PR without merging it if you think that the existing run steps are easier to read.

I think that this option might run a bit faster because it doesn't need to create a new Python environment for each test case, but it also means that we'll need to look at the run logs to see which individual tests pass or fail.