### PR TITLE
Change ASIC CI test name to match the FPGA one.

### DIFF
--- a/.github/workflows/gcd_test.yml
+++ b/.github/workflows/gcd_test.yml
@@ -3,7 +3,7 @@ on: [workflow_dispatch, pull_request, pull_request_review]
 jobs:
   gcd_test_job:
     runs-on: self-hosted
-    name: 'ASIC tests'
+    name: 'ASIC test builds'
     steps:
       - uses: actions/checkout@v2
       - run: |


### PR DESCRIPTION
Sorry: this change is kind of silly, but the CI tests show up on every pull request, so we'd may as well use consistent names for the test suites.