### PR TITLE
Add a 'new_hosts' parameter to the authenticated import request.

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -330,6 +330,7 @@ async def upload_import_dir(chip):
                 'job_hash': chip.status['job_hash'],
                 'job_name': chip.get('jobname')[-1],
                 'job_ids': chip.status['perm_ids'],
+                'new_hosts': int(chip.get('remote', 'hosts')[-1]),
             }
             with open(os.path.abspath('import.crypt'), 'rb') as f:
                 async with session.post("http://%s:%s/import/"%(


### PR DESCRIPTION
The lets the `-remote_hosts` config setting spin up temporary compute nodes, although the functionality is only supported by the `scserver` repository at the moment.

The temporary hosts get terminated by the `delete_job` call, so we still need logic to unwind the changes if there is a failure partway through, a keyboard interrupt, etc.