### PR TITLE
Add support for the 'remote_ram' and 'remote_threads' config values.

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -168,12 +168,15 @@ def get_remote_hostclass(chip):
     # Prioritise threads when comparing.
     cur_host = ''
     for host_key, host in hosts.items():
+        # Does the host match the requested configuration?
         if (host['ram'] >= ram_min) and (host['ram'] <= ram_max) and \
            (host['threads'] >= threads_min) and (host['threads'] <= threads_max):
+            # Is the host smaller than the current host (if any)?
             if (cur_host == '') or \
                (hosts[cur_host]['threads'] < host['threads']) or \
                ((hosts[cur_host]['threads'] == host['threads']) and \
                 (hosts[cur_host]['ram'] < host['ram'])):
+                # If so, mark the current host type as the smallest so far.
                 cur_host = host_key
 
     # Done, return the generated host type.


### PR DESCRIPTION
This enables the `remote_ram` and `remote_threads` schema entries for authenticated calls.

It goes along with [an `scserver` change](https://github.com/zeroasiccorp/scserver/commit/1ac310bef619e7d31487e32353b5a9e6b81f6700) which was surprisingly simple, thanks to the automated schema validations. But maybe we should talk tomorrow about whether the logic to select a cloud host type should be performed by the client or the server.