### PR TITLE
Update Python API test to account for its build directory.

### DIFF
--- a/tests/asic/test_gcd_py.py
+++ b/tests/asic/test_gcd_py.py
@@ -11,10 +11,10 @@ def test_gcd_local_py():
     chip = siliconcompiler.Chip(loglevel='NOTSET')
 
     # Inserting value into configuration
-    chip.add('source', 'examples/gcd/gcd.v')
+    chip.add('source', '../examples/gcd/gcd.v')
     chip.add('design', 'gcd')
     chip.add('clock', 'clock_name', 'pin', 'clk')
-    chip.add('constraint', "examples/gcd/constraint.sdc")
+    chip.add('constraint', "../examples/gcd/constraint.sdc")
     chip.set('target', "freepdk45")
     chip.set('asic', 'diesize', "0 0 100.13 100.8")
     chip.set('asic', 'coresize', "10.07 11.2 90.25 91")


### PR DESCRIPTION
The tests run in a temporary `[siliconcompiler/]pytest_tmp/` directory, and we should probably make our tests' file paths relative to the directory that the `sc` command is run in.

I noticed this [when I tried adding logic to copy the constraint files in the import step](https://github.com/zeroasiccorp/siliconcompiler/runs/2604755601); I think that we've been getting away with it because the `SCPATH` environment variable is automatically populated with the root `siliconcompiler/` path in `cli.py`.