### PR TITLE
Add a 'CI tests' badge to the README.

### DIFF
--- a/.github/workflows/gcd_test.yml
+++ b/.github/workflows/gcd_test.yml
@@ -1,5 +1,7 @@
 on: [workflow_dispatch, pull_request, pull_request_review, push]
 
+name: 'CI Tests'
+
 jobs:
   gcd_test_job:
     timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Silicon Compiler Collection (SCC)
 
+![CI Tests](https://github.com/zeroasiccorp/siliconcompiler/workflows/CI%20Tests/badge.svg)
+
 ## Introduction
 
 * schema.py defines the silicon compiler architecture


### PR DESCRIPTION
Add a name to the GitHub Action that runs the CI tests, and add a 'passing/failing' badge to the top of the README.

At the moment, the CI test workflow does not have a name, [so the filename is used in the badge URL and display](https://github.com/zeroasiccorp/siliconcompiler/actions/workflows/gcd_test.yml/badge.svg). But it will probably look better if our CI test badge says "CI Tests" instead of "gcd_test.yml".