### PR TITLE
Fix encrypted remote workflow

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1318,15 +1318,15 @@ def get_permutations(base_chip, cmdlinecfg):
             # Set values for the new Chip's PDK/target.
             new_chip.target()
 
-            # Skip the 'import' stage for remote jobs; it will be run locally and uploaded.
-            if len(new_chip.get('remote', 'addr')) > 0:
-                new_chip.set('start', new_chip.get('remote', 'start')[-1])
-            elif len(new_chip.get('remote', 'key')) > 0:
-                # If 'remote_key' exists without 'remote_addr', it represents an
-                # encoded key string in an ongoing remote job. It should be
-                # moved from the config dictionary to the status one to avoid logging.
-                new_chip.status['decrypt_key'] = new_chip.get('remote', 'key')[-1]
-                new_chip.cfg['remote']['key']['value'] = []
+        # Skip the 'import' stage for remote jobs; it will be run locally and uploaded.
+        if len(new_chip.get('remote', 'addr')) > 0:
+            new_chip.set('start', new_chip.get('remote', 'start')[-1])
+        elif len(new_chip.get('remote', 'key')) > 0:
+            # If 'remote_key' exists without 'remote_addr', it represents an
+            # encoded key string in an ongoing remote job. It should be
+            # moved from the config dictionary to the status one to avoid logging.
+            new_chip.status['decrypt_key'] = new_chip.get('remote', 'key')[-1]
+            new_chip.cfg['remote']['key']['value'] = []
 
         # Set and increment the "job ID" so multiple chips don't share the same directory.
         new_chip.set('jobid', cur_jobid)


### PR DESCRIPTION
This is a good example of why I need to add functional tests to the scserver repository. I accidentally broke the encrypted workflow with a recent change, and we aren't testing that at the moment because encryption is not supported by the lightweight server included in the 'siliconcompiler' project.

This change fixes the encrypted workflow, but I also think it's time for me to get around to adding a few 'scserver' pytests to help prevent this sort of thing in the future.