### PR TITLE
Update client script to avoid wildcards when it calls klayout to display the results

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -8,6 +8,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 import aiohttp
 import asyncio
 import base64
+import glob
 import math
 import json
 import os
@@ -472,16 +473,12 @@ def fetch_results(chips):
     os.environ['QT_QPA_PLATFORM'] = ''
     # Find a list of GDS files to open.
     klayout_cmd = []
-    for chip in chips:
-        job_gds = '%s/%s/%s%s/export/outputs/%s.gds'%(
-            job_hash,
-            chip.cfg['design']['value'][-1],
-            chip.cfg['jobname']['value'][-1],
-            chip.cfg['jobid']['value'][-1],
-            chip.cfg['design']['value'][-1],
-        )
-        klayout_cmd.append(os.path.abspath(job_gds))
+    for gds_file in glob.iglob(os.path.abspath(job_hash) + '/**/*.[gG][dD][sS]',
+                               recursive=True):
+        klayout_cmd.append(gds_file)
 
     # Done; display the results using klayout.
-    klayout_cmd.insert(0, 'klayout')
-    subprocess.run(klayout_cmd)
+    # TODO: Raise an exception or print an error message if no GDS files exist?
+    if klayout_cmd:
+        klayout_cmd.insert(0, 'klayout')
+        subprocess.run(klayout_cmd)


### PR DESCRIPTION
It sounds like trying to call `klayout *.gds` in a Python subprocess call may not work on all platforms; I think it might rely on the glob being expanded in the execution environment before KLayout actually gets run.

This change assembles a list of absolute file paths for KLayout to open, which I hope will be a bit more compatible.