### PR TITLE
Update the 'check progress' calls to retry after low-level network issues

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -390,7 +390,7 @@ async def upload_import_dir(chip):
                                         allow_redirects=False) as resp:
                     if resp.status == 302:
                         redirect_url = resp.headers['Location']
-                    elif resp.status > 400:
+                    elif resp.status >= 400:
                         print(await resp.text())
                         print('Error importing project data; quitting.')
                         sys.exit(1)


### PR DESCRIPTION
Since we moved to HTTPS and put the server behind a load balancer, I've seen a few random dropped connections. It's very rare, but when the client makes hundreds of 'check progress' requests over the course of a brief job, it can happen.

If we don't retry after a low-level network exception, the client script can exit prematurely, leaving a half-finished job to clean up after.

I am also planning to add a '-remote_resume' or '-remote_cleanup' flag to make these client-side failures less problematic, but I don't quite have a clear idea of what that should look like yet.