### PR TITLE
Add a remote schema entry for the 'job hash' value.

### DIFF
--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2609,6 +2609,24 @@ def schema_remote(cfg):
         """
     }
 
+    # Job hash. Used to resume or cancel remote jobs after they are started.
+    cfg['remote']['hash'] = {
+        'switch' : '-remote_hash',
+        'type' : 'str',
+        'lock' : 'false',
+        'requirement' : 'optional',
+        'defvalue' : [],
+        'short_help' : 'Job hash/UUID value',
+        'param_help' : "'remote_hash' <str>",
+        'example': ["cli: -remote_hash 0123456789abcdeffedcba9876543210",
+                    "api: chip.set('remote_hash','0123456789abcdeffedcba9876543210'"],
+        'help' : """
+        A unique ID associated with a job run. This field should be left blank
+        when starting a new job, but it can be provided to resume an interrupted
+        remote job, or to clean up after unexpected failures.
+        """
+    }
+
     # Remote start step
     cfg['remote']['start'] = {
         'switch': '-remote_start',


### PR DESCRIPTION
After thinking a bit about how to resume or clean up after a remote job, I think that I found a simple solution: move the `job_hash` value into a `cfg['remote']['hash']` schema entry.

With this schema change, and a few small changes to `cli.py` and `client.py` that I can submit in a follow-up PR, we'll be able to resume interrupted jobs by adding the following flags to an interrupted remote `sc` command:

    -remote_hash [job_hash] -remote_start [interrupted_step]

It's a little bit hack-y, and I still need to test the behavior with temporary slurm hosts, but it seems to work in my local testing. Plus, if you want to cancel the job early, you can pass in `-remote_start export` to fetch the in-progress results and delete them from the server.