### PR TITLE
Fix an edge case where the client script could raise an exception

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -544,10 +544,11 @@ def fetch_results(chips):
             subprocess.run(['mkdir', '-p', perm_dir], cwd=job_hash)
             subprocess.run(['unzip', '-d', perm_dir, '%s.zip'%job_nameid], cwd=job_hash)
 
-    # Remove dangling 'import' symlinks.
+    # Remove dangling 'import' symlinks if necessary.
     for import_link in glob.iglob(job_hash + '/' + top_design + '/**/import',
                                recursive=True):
-        os.remove(import_link)
+        if os.path.islink(import_link):
+            os.remove(import_link)
     # Copy the results into the local build directory, and remove the
     # unzipped directory (including encrypted archives).
     local_dir = chips[-1].get('dir')[-1]


### PR DESCRIPTION
If the 'import' directory is not a symlink, calling `os.remove(...)` on it causes an exception.

This change will fix [the failing `scserver` CI test](https://github.com/zeroasiccorp/scserver/runs/2721749446?check_suite_focus=true) for the encrypted workflow. On the bright side, the deploy key setup worked and the server repository's CI tests are now running.

In the future, would you be comfortable with me pushing small changes like this directly to `main` if the CI tests pass locally?