### PR TITLE
Add setup scripts and vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.vagrant/
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/focal64"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/home/vagrant/siliconcompiler/"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "8192"
+    vb.cpus = 4
+    vb.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
+    vb.customize ["modifyvm", :id, "--uartmode1", "file", File::NULL]
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    systemctl disable apt-daily.service
+    systemctl disable apt-daily.timer
+  SHELL
+  config.vm.provision "shell", inline: "sudo apt-get update", privileged: false
+  config.vm.provision "shell", path: "setup/install-verilator.sh", privileged: false
+  config.vm.provision "shell", path: "setup/install-klayout.sh", privileged: false
+  config.vm.provision "shell", path: "setup/install-openroad.sh", privileged: false
+  config.vm.provision "shell", path: "setup/install-ice40.sh", privileged: false
+  config.vm.provision "shell", path: "setup/install-openfpga.sh", privileged: false
+  config.vm.provision "shell", path: "setup/install-py.sh", privileged: false
+end

--- a/setup/install-ice40.sh
+++ b/setup/install-ice40.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+sudo apt-get install -y build-essential clang bison flex libreadline-dev \
+                        gawk tcl-dev libffi-dev git mercurial graphviz   \
+                        xdot pkg-config python python3 libftdi-dev \
+                        qt5-default python3-dev libboost-all-dev cmake libeigen3-dev
+
+git clone https://github.com/YosysHQ/icestorm.git icestorm
+cd icestorm
+make -j$(nproc)
+sudo make install
+cd -
+
+git clone https://github.com/YosysHQ/nextpnr nextpnr
+cd nextpnr
+cmake -DARCH=ice40 -DCMAKE_INSTALL_PREFIX=/usr/local .
+make -j$(nproc)
+sudo make install
+cd -

--- a/setup/install-klayout.sh
+++ b/setup/install-klayout.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+sudo apt-get install -y klayout
+export QT_QPA_PLATFORM=offscreen
+echo 'export QT_QPA_PLATFORM=offscreen' >> ~/.bashrc

--- a/setup/install-openfpga.sh
+++ b/setup/install-openfpga.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+git clone https://github.com/LNIS-Projects/OpenFPGA.git
+cd OpenFPGA
+make all -j$(nproc)
+cd -

--- a/setup/install-openroad.sh
+++ b/setup/install-openroad.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+sudo apt-get install -y pkg-config build-essential libatomic-ops-dev python3 bison flex libreadline-dev gawk libffi-dev git graphviz tcl xdot libboost-system-dev libboost-python-dev libboost-filesystem-dev zlib1g-dev cmake swig libeigen3-dev
+sudo apt-get install -y libboost-test-dev libspdlog-dev libqt5opengl5-dev
+
+wget -q http://lemon.cs.elte.hu/pub/sources/lemon-1.3.1.tar.gz
+tar -xf lemon-1.3.1.tar.gz
+cd lemon-1.3.1
+cmake -B build .
+sudo cmake --build build -j $(nproc) --target install
+cd -
+
+wget -q https://prdownloads.sourceforge.net/tcl/tcl8.6.10-src.tar.gz
+tar -xf tcl8.6.10-src.tar.gz
+cd tcl8.6.10/unix
+./configure
+make
+sudo make install
+cd -
+
+sudo ln -s /usr/bin/python3 /usr/bin/python
+sudo ln -s /usr/local/lib/libtcl8.6.so /usr/local/lib/libtcl.so
+
+git clone https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts
+cd OpenROAD-flow-scripts
+./build_openroad.sh -o
+cd -
+
+echo 'source /home/vagrant/OpenROAD-flow-scripts/setup_env.sh' >> ~/.bashrc

--- a/setup/install-py.sh
+++ b/setup/install-py.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+sudo apt-get install -y python3-pip
+cd siliconcompiler
+pip3 install -r requirements.txt
+python3 -m pip install -e .
+cd -
+
+echo 'export PATH=~/.local/bin:$PATH' >> ~/.bashrc

--- a/setup/install-verilator-pkg.sh
+++ b/setup/install-verilator-pkg.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+sudo apt-get install verilator

--- a/setup/install-verilator.sh
+++ b/setup/install-verilator.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+sudo apt-get install -y git perl python3 make autoconf g++ flex bison ccache
+sudo apt-get install -y libgoogle-perftools-dev numactl perl-doc
+sudo apt-get install -y libfl2
+sudo apt-get install -y libfl-dev
+sudo apt-get install -y zlibc zlib1g zlib1g-dev
+
+git clone https://github.com/verilator/verilator
+
+unset VERILATOR_ROOT
+cd verilator
+
+autoconf
+./configure
+make -j$(nproc)
+sudo make install
+
+cd -


### PR DESCRIPTION
During the installation process I created some setup scripts to install each dependency, as well as a Vagrantfile to manage a VirtualBox VM where all the dependencies along with SC can be automatically installed in a reproducible way.

With Vagrant and VirtualBox installed, you can run `vagrant up` from the repo root, which will boot up a Ubuntu focal VM and install everything (takes about an hour). Then you can run `vagrant ssh` to connect to the VM and run `sc`. The `siliconcompiler` directory is a shared folder, so build results can be directly accessed from the host machine. Changes from the host will also be reflected in the VM. The VM will persist and be saved unless you run `vagrant destroy`, in which case everything will be reinstalled from scratch next time `vagrant up` runs.

This is similar to using Docker (#38), and also useful internally to make sure everything works from a fresh install, and to set up a clean development environment.

Even if we don't want to use Vagrant, the setup scripts are useful as documentation for how to install all the dependencies.

For full reproducibility we may want to change the scripts so that dependencies from github checkout specific versions instead of installing from master.