### PR TITLE
Fix typo in OpenROAD TCL script

### DIFF
--- a/eda/openroad/sc_apr.tcl
+++ b/eda/openroad/sc_apr.tcl
@@ -91,7 +91,7 @@ dict for {key value} [dict get $sc_cfg pdk aprlayer $sc_stackup] {
 ###############################
 
 # MACROS
-if {[dict exists $sc_cfg macrolib]} {    
+if {[dict exists $sc_cfg asic macrolib]} {
     set sc_macrolibs [dict get $sc_cfg asic macrolib]
 } else {
     set sc_macrolibs    ""


### PR DESCRIPTION
Was missing 'asic' key when checking for macrolibs.

Also, for some reason git is misinterpreting sc_apr.tcl as a binary file-- this commit adds a line to .gitattributes to fix that.