### PR TITLE
Add custom style to highlight Python methods more

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,4 @@
+dl.method.py > dt {
+    background-color: rgb(235, 241, 245) !important;
+    border-color: rgb(155, 190, 213) !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,3 +61,7 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+html_css_files = [
+    'css/custom.css',
+]


### PR DESCRIPTION
@aolofsson this PR implements the style change you suggested. Turns out it's not too hard to tweak things like colors - Sphinx lets you include custom CSS files, so it's just a matter of figuring out how to select the elements you want to override.

I ended up coloring the methods something in between the blue of the class names and the gray that they were before, but it should be pretty easy to tweak this further. Here's a before and after:

Before
<img width="483" alt="Screen Shot 2021-06-08 at 3 19 15 PM" src="https://user-images.githubusercontent.com/4412459/121245268-d6764e00-c86d-11eb-8a60-8b85d9336c43.png">

After
<img width="496" alt="Screen Shot 2021-06-08 at 3 22 20 PM" src="https://user-images.githubusercontent.com/4412459/121245273-d8d8a800-c86d-11eb-9c55-febbadfbcd34.png">
