### PR TITLE
Schema docs tweaks

### DIFF
--- a/docs/_ext/schemagen.py
+++ b/docs/_ext/schemagen.py
@@ -1,4 +1,6 @@
 from docutils import nodes
+from sphinx.util.nodes import nested_parse_with_titles
+from docutils.statemachine import ViewList
 from docutils.parsers.rst import Directive
 from siliconcompiler.schema import schema_cfg
 
@@ -81,7 +83,8 @@ class SchemaGen(Directive):
                 entries.append([strong(f'Example ({name.upper()})'), code(ex.strip())])
 
             table = build_table(entries)
-            body = para(schema['help'])
+            body = self.parse_rst(schema['help'])
+
             return [table, body]
         else:
             sections = []
@@ -101,6 +104,16 @@ class SchemaGen(Directive):
             # entry that's a leaf. In this case, we sort this as an empty string
             # in order to put this node at the beginning of the list.
             return sorted(sections, key=lambda s: s[0][0] if isinstance(s, nodes.section) else '')
+
+    def parse_rst(self, content):
+        rst = ViewList()
+        # use fake filename 'inline' and fake line number '1' for error reporting
+        rst.append(content, 'inline', 1)
+        body = nodes.paragraph()
+        nested_parse_with_titles(self.state, rst, body)
+
+        return body
+
 
 def setup(app):
     app.add_directive('schemagen', SchemaGen)

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -201,7 +201,7 @@ def schema_fpga(cfg):
         Provides an XML-based architecture description for the target FPGA
         architecture to be used in VTR, allowing targeting a large number of 
         virtual and commercial architectures.
-        [More information...](https://verilogtorouting.org)
+        `More information... <https://verilogtorouting.org>`_
         """
     }
 
@@ -2912,12 +2912,12 @@ def schema_design(cfg):
         A list of source files to read in for elaboration. The files are read 
         in order from first to last entered. File type is inferred from the 
         file suffix:
-        (*.v, *.vh)  = Verilog
-        (*.vhd)      = VHDL
-        (*.sv)       = SystemVerilog
-        (*.c)        = C
-        (*.cpp, .cc) = C++
-        (*.py)       = Python
+        (\*.v, \*.vh) = Verilog
+        (\*.vhd)      = VHDL
+        (\*.sv)       = SystemVerilog
+        (\*.c)        = C
+        (\*.cpp, .cc) = C++
+        (\*.py)       = Python
         """
     }
 
@@ -3177,7 +3177,7 @@ def schema_design(cfg):
                     "api: chip.add('idir','./mylib')"],
         'help' : """
         Provides a search paths to look for files included in the design using
-        the `include statement.
+        the ```include`` statement.
         """
     }
 
@@ -3215,7 +3215,7 @@ def schema_design(cfg):
         'help' : """
         Specifes the file extensions that should be used for finding modules. 
         For example, if -y is specified as ./lib", and '.v' is specified as 
-        libext then the files ./lib/*.v ", will be searched for module matches.
+        libext then the files ./lib/\*.v ", will be searched for module matches.
         """
     }
 


### PR DESCRIPTION
This PR contains three commits that affect the schema documentation:

- I changed the generator to address the points brought up in #196. 
- I fixed multiline schema examples that were introducing additional whitespace (see attached before and after). I think the thing to do here is to use Python's automatic concatenation of adjacent strings (in Python, `"qwerty" "uiop"` becomes `"qwertyuiop"`). 
- I made the schema generator parse the help strings as reStructuredText. If you don't like this change I'm happy to remove it from the PR, but it was an easy way to get the link in the fpga_xml help text to render. The only cost is I had to change a few schema help strings to escape characters that were confusing the parser.

Extra whitespace (before):
<img width="750" alt="Screen Shot 2021-06-09 at 3 51 34 PM" src="https://user-images.githubusercontent.com/4412459/121428532-ea8c7f00-c943-11eb-8f1f-880246e18a08.png">

Extra whitespace (after):
<img width="775" alt="Screen Shot 2021-06-09 at 3 51 56 PM" src="https://user-images.githubusercontent.com/4412459/121428541-eceed900-c943-11eb-992f-c316436b417a.png">

This PR closes #196. 

