### PR TITLE
Set out-of-bounds layer colors to a default value in SVG output.

### DIFF
--- a/eda/klayout/gds2svg.py
+++ b/eda/klayout/gds2svg.py
@@ -45,7 +45,7 @@ with open('outputs/' + design_name + '.svg', 'w') as svg:
     # Write all relevant paths.
     for layer in range(ly.layers()):
         # Set the fill color for this layer.
-        fill_color = "%X"%colors[layer]
+        fill_color = "%X"%(colors[layer] if (len(colors) > layer) else 0xABCDEF40)
 
         # Using <g> ('group') tags should let us write a viewer which can
         # selectively show and hide different GDS layers.


### PR DESCRIPTION
If we can't figure out a precise cause for #203, this should at least prevent the error from bubbling up and making the `export` step fail.