### PR TITLE
gds2svg: Change type of literals (fixes #203)

### DIFF
--- a/eda/klayout/gds2svg.py
+++ b/eda/klayout/gds2svg.py
@@ -18,7 +18,7 @@ ctrans = pya.CplxTrans(1.0, 0.0, True, -bb.left, bb.top)
 
 # Set a basic layer-colors array, since we won't have a KLayout QT display.
 # Use the cube root of the number of layers to find how many colors are needed.
-num_pri_cols = math.ceil(math.pow(ly.layers(), 1/3))
+num_pri_cols = math.ceil(math.pow(ly.layers(), 1.0 / 3.0))
 col_step = int(0xff / num_pri_cols)
 primary_vals = []
 for c in range(col_step, 0x100, col_step):


### PR DESCRIPTION
In the Python version I've tried (3.8.3) the line would evaluate
`1.0` even if the amount of layers was more than `1`. The cast to
float prevents this from happening. Fixes #203.