### PR TITLE
Reduce reliance on start/stop configs.

### DIFF
--- a/eda/targets/asic.py
+++ b/eda/targets/asic.py
@@ -16,10 +16,7 @@ def setup_eda(chip, name=None):
                                      'route',
                                      'dfm',
                                      'export']
-    
-    chip.cfg['start']['value'] = ['import']
-    chip.cfg['stop']['value'] = ['export']
-        
+
     # Setup tool based on flow step
     for step in chip.cfg['steplist']['value']:            
         if step == 'import':

--- a/eda/targets/fpga.py
+++ b/eda/targets/fpga.py
@@ -16,9 +16,6 @@ def setup_eda(chip, name=None):
                                       'apr',
                                       'export']
 
-        chip.cfg['start']['value'] = [chip.cfg['steplist']['value'][0]]
-        chip.cfg['stop']['value'] = [chip.cfg['steplist']['value'][-1]]
-
         for step in chip.cfg['steplist']['value']:         
             if step == 'import':
                 vendor = 'verilator'

--- a/eda/targets/nextpnr.py
+++ b/eda/targets/nextpnr.py
@@ -14,9 +14,6 @@ def setup_eda(chip, name=None):
                                   'apr',
                                   'export']
 
-    chip.cfg['start']['value'] = [chip.cfg['steplist']['value'][0]]
-    chip.cfg['stop']['value'] = [chip.cfg['steplist']['value'][-1]]
-
     for step in chip.cfg['steplist']['value']:
         if step == 'import':
             vendor = 'verilator'

--- a/eda/targets/vpr.py
+++ b/eda/targets/vpr.py
@@ -13,9 +13,6 @@ def setup_eda(chip, name=None):
                                   'syn',
                                   'apr']
 
-    chip.cfg['start']['value'] = [chip.cfg['steplist']['value'][0]]
-    chip.cfg['stop']['value'] = [chip.cfg['steplist']['value'][-1]]
-
     for step in chip.cfg['steplist']['value']:
         if step == 'import':
             vendor = 'verilator'

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1055,8 +1055,10 @@ class Chip:
         '''
 
         steplist = self.get('steplist')
-        start = self.get('start')[-1]
-        stop = self.get('stop')[-1]
+        start = self.get('start')[-1] if self.get('start') \
+                                      else self.get('steplist')[0]
+        stop = self.get('stop')[-1] if self.get('stop') \
+                                    else self.get('steplist')[-1]
         design = self.get('design')[-1]
         startindex = steplist.index(start)
         stopindex = steplist.index(stop)
@@ -1167,9 +1169,11 @@ class Chip:
         ###########################
 
         if start is None:
-            start = self.get('start')[-1]
+            start = self.get('start')[-1] if self.get('start') \
+                                          else self.get('steplist')[0]
         if stop is None:
-            stop = self.get('stop')[-1]
+            stop = self.get('stop')[-1] if self.get('stop') \
+                                        else self.get('steplist')[-1]
 
         startindex = steplist.index(start)
         stopindex = steplist.index(stop)


### PR DESCRIPTION
We could allow blank `-start` / `-stop` values fairly easily. This change would address #198, but it would also allow calls like `chip.get('start')[-1]` to raise an exception.