### PR TITLE
Add macro placement step to sc_floorplan.tcl

### DIFF
--- a/eda/openroad/sc_apr.tcl
+++ b/eda/openroad/sc_apr.tcl
@@ -23,10 +23,14 @@ set target_tech [lindex $targetlist 0]
 if {$target_tech eq "freepdk45"} {
     set openroad_place_density 0.3
     set openroad_pad_global_place 2
+    set openroad_macro_place_halo "22.4 15.12"
+    set openroad_macro_place_channel "18.8 19.95"
 } else {
     puts "WARNING: OpenROAD tuning constants not set for $target_tech in sc_apr.tcl, using generic values."
     set openroad_place_density 0.3
     set openroad_pad_global_place 2
+    set openroad_macro_place_halo "22.4 15.12"
+    set openroad_macro_place_channel "18.8 19.95"
 }
 
 ###############################


### PR DESCRIPTION
NOTE: This PR is dependent on #208, so that one should be merged first!
(Now that we're opening PRs from branches on this repo, I'm trying something new to handle chains of PR dependencies. This PR is showing changes relative to #208, but will switch to being relative to main once that one is merged. This means smaller diffs per PR, but the workflow from your end for merging should not change as long as the order is correct.)

Anyway, the error I mentioned during sync today was occurring because my FakeRAM macro wasn't getting placed! With this step added to the OpenROAD flow,  the routing problem goes away. I based it off of the OpenROAD scripts. 
