### PR TITLE
Make the private key config a string, so that it is not logged.

### DIFF
--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2762,7 +2762,7 @@ def schema_remote(cfg):
     # Remote private key file.
     cfg['remote']['key'] = {
         'switch' : '-remote_key',
-        'type' : 'file',
+        'type' : 'str',
         'lock' : 'false',
         'copy' : 'false',
         'requirement' : 'remote',


### PR DESCRIPTION
With encrypted remote jobs, the user's private decryption key value is passed in to slurm compute nodes as a command-line config, because slurm's network communications are encrypted and we don't want to save it to disk at any point.

But the `sc` app will print warnings when schema configs have a "file" type and the provided value does not correspond to a valid file. This can cause the private key to be printed to the stdout of some `subprocess.run` calls, and while I don't think it actually gets logged, we really want to avoid printing the private key to any unnecessary output streams.

Changing the '-remote_key' schema type to "string" prevents the warnings, and it does not appear to cause any issues. I just tested it on the test cluster and with the `scserver` CI tests, and passing in a non-existent file path causes a self-explanatory 'file not found' error.