### PR TITLE
Remove redundant 'pull request' CI test targets.

### DIFF
--- a/.github/workflows/gcd_test.yml
+++ b/.github/workflows/gcd_test.yml
@@ -1,4 +1,4 @@
-on: [workflow_dispatch, pull_request, pull_request_review, push]
+on: [workflow_dispatch, push]
 
 name: 'CI Tests'
 


### PR DESCRIPTION
Now that we're pushing to branches on the main repository and making PRs from those, the `pull_request` and `pull_request_review` CI test targets are redundant.

We end up running the test suite twice for each PR, and the ASIC tests take several minutes to run, so this should help speed up the tests during busy times.