### PR TITLE
Use FPGA schema to determine NextPNR target

### DIFF
--- a/eda/nextpnr/nextpnr_setup.py
+++ b/eda/nextpnr/nextpnr_setup.py
@@ -18,8 +18,23 @@ def setup_tool(chip, step):
     chip.add('flow', step, 'exe', 'nextpnr-ice40')
     chip.add('flow', step, 'copy', 'false')
 
-    # hardcode settings for icebreaker dev board for now
-    chip.add('flow', step, 'option', '--up5k --package sg48 --freq 12')
+    # Check FPGA schema to determine which device to target
+    if len(chip.get('fpga', 'vendor')) == 0 or len(chip.get('fpga', 'device')) == 0:
+        chip.logger.error(f"FPGA device and/or vendor unspecified!")
+        os.sys.exit()
+
+    vendor = chip.get('fpga', 'vendor')[-1]
+    device = chip.get('fpga', 'device')[-1]
+
+    if vendor == 'lattice' and device == 'ice40up5k-sg48':
+        options = '--up5k --package sg48'
+    else:
+        chip.logger.error(f"Unsupported vendor option '{vendor}' and device option "
+            f"'{device}'. NextPNR flow currently only supports vendor 'lattice' and device "
+            f"'ice40up5k-sg48'.")
+        os.sys.exit()
+
+    chip.add('flow', step, 'option', options)
 
 ################################
 # Set NextPNR Runtime Options

--- a/examples/blinky/icebreaker.pcf
+++ b/examples/blinky/icebreaker.pcf
@@ -2,6 +2,7 @@
 
 # 12 MHz clock
 set_io -nowarn CLK        35
+set_frequency  CLK        12
 
 # RS232
 set_io -nowarn RX          6

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -210,13 +210,14 @@ def schema_fpga(cfg):
         'requirement' : '!fpga_xml',
         'type' : 'str',
         'lock' : 'false',
-        'defvalue' : [],
+        'defvalue' : ['lattice'],
         'short_help' : 'FPGA Vendor Name',
         'param_help' : "fpga vendor <str>",
         'example': ["cli: -fpga_vendor acme",                    
                     "api:  chip.set('fpga', 'vendor', 'acme')"],
         'help' : """
-        Name of the FPGA vendor for non-VTR based compilation
+        Name of the FPGA vendor for non-VTR based compilation. Only currently
+        supported value is 'lattice'.
         """
     }
 
@@ -225,13 +226,14 @@ def schema_fpga(cfg):
         'requirement' : '!fpga_xml',
         'type' : 'str',
         'lock' : 'false',
-        'defvalue' : [],
+        'defvalue' : ['ice40up5k-sg48'],
         'short_help' : 'FPGA Device Name',
         'param_help' : "fpga device <str>",
         'example': ["cli: -fpga_device fpga64k",                    
                     "api:  chip.set('fpga', 'device', 'fpga64k')"],
         'help' : """
-        Name of the FPGA device for non-VTR based compilation
+        Name of the FPGA device for non-VTR based compilation. Only currently
+        supported value is 'ice40up5k-sg48'.
         """
     }
 


### PR DESCRIPTION
Although we still only support one FPGA target with NextPNR, this
documents that fact and lays explicit groundwork to potentially support more.

Closes #204