### PR TITLE
Tweak the way FPGA target is configured

### DIFF
--- a/fpga/targets/ice40.py
+++ b/fpga/targets/ice40.py
@@ -1,2 +1,4 @@
 def setup_platform(chip):
     chip.add('mode', 'fpga')
+    chip.set('fpga', 'vendor', 'lattice')
+    chip.set('fpga', 'device', 'ice40up5k-sg48')

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -210,14 +210,14 @@ def schema_fpga(cfg):
         'requirement' : '!fpga_xml',
         'type' : 'str',
         'lock' : 'false',
-        'defvalue' : ['lattice'],
+        'defvalue' : [],
         'short_help' : 'FPGA Vendor Name',
         'param_help' : "fpga vendor <str>",
         'example': ["cli: -fpga_vendor acme",                    
                     "api:  chip.set('fpga', 'vendor', 'acme')"],
         'help' : """
-        Name of the FPGA vendor for non-VTR based compilation. Only currently
-        supported value is 'lattice'.
+        Name of the FPGA vendor for non-VTR based compilation. This value is
+        generally set by the FPGA platform target.
         """
     }
 
@@ -226,14 +226,14 @@ def schema_fpga(cfg):
         'requirement' : '!fpga_xml',
         'type' : 'str',
         'lock' : 'false',
-        'defvalue' : ['ice40up5k-sg48'],
+        'defvalue' : [],
         'short_help' : 'FPGA Device Name',
         'param_help' : "fpga device <str>",
         'example': ["cli: -fpga_device fpga64k",                    
                     "api:  chip.set('fpga', 'device', 'fpga64k')"],
         'help' : """
-        Name of the FPGA device for non-VTR based compilation. Only currently
-        supported value is 'ice40up5k-sg48'.
+        Name of the FPGA device for non-VTR based compilation. This value is
+        generally set by the FPGA platform target.
         """
     }
 


### PR DESCRIPTION
RE our discussion the other day, cleaned up the way selecting an FPGA device for the NextPNR flow is handled. 

Summary: 
Instead of having people manually set vendor/device, we want that set by the target. We'll then document the targets instead of documenting the specific supported values in the schema (to avoid including vendor-specific options in the schema).