### PR TITLE
Restoring verilator as default import tool in asic.py

### DIFF
--- a/eda/targets/asic.py
+++ b/eda/targets/asic.py
@@ -8,8 +8,7 @@ import siliconcompiler
 def setup_eda(chip, name=None):
 
     # Define Compilation Flow
-    chip.cfg['steplist']['value'] = ['validate',
-                                     'import',
+    chip.cfg['steplist']['value'] = ['import',
                                      'syn',
                                      'floorplan',
                                      'place',
@@ -20,10 +19,8 @@ def setup_eda(chip, name=None):
 
     # Setup tool based on flow step
     for step in chip.cfg['steplist']['value']:
-        if step == 'validate':
-            vendor = 'surelog'
-        elif step == 'import':
-            vendor = 'sv2v'
+        if step == 'import':
+            vendor = 'verilator'
         elif step == 'syn':
             vendor = 'yosys'
         elif step == 'export':

--- a/eda/verilator/verilator_setup.py
+++ b/eda/verilator/verilator_setup.py
@@ -42,7 +42,7 @@ def setup_options(chip, step):
     options = chip.set('flow', step, 'option', [])
 
     if step == 'import':
-        options.append('--lint-only --debug')
+        options.append('--lint-only --debug -sv')
     else:
         options.append('--cc')
 


### PR DESCRIPTION
For now we can have a separate experimental target for sv2v and surelog, but we can't let it get in the way of the rest of the flow.
Verilator remains the default for now.