### PR TITLE
Fix command line argument parsing bugs

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -169,7 +169,9 @@ class Chip:
         #Preprocess sys.argv to enable legacy GCC/SV switches with no space
         scargs = []
 
-        for item in sys.argv:
+        # Iterate from index 1, otherwise we end up with script name as a
+        # 'source' positional argument
+        for item in sys.argv[1:]:
             #Split switches with one character and a number after (O0,O1,O2)            
             opt = re.search('(\-\w)(\d+)',item)
             #Split assign switches (-DCFG_ASIC=1)
@@ -194,9 +196,13 @@ class Chip:
         #Stuff command line values into dynamic dict
         for key, val in cmdargs.items():
             for item in val:
-                strlist = item.split()
                 args = schema_reorder_keys(argmap[key], item)
-                self._search(self.cfg, *args, mode='set')
+                # TODO: we should annotate each schema item as list or scalar,
+                # and then use that annotation to determine how to set the value
+                if key in ('source'):
+                    self._search(self.cfg, *args, mode='add')
+                else:
+                    self._search(self.cfg, *args, mode='set')
                 if key == 'cfg':
                     self.readcfg(item)
 
@@ -261,7 +267,7 @@ class Chip:
         # <process/device>
         # <process/device>_<eda>
 
-        targetlist = str(self.get('target')[0]).split('_')
+        targetlist = str(self.get('target')[-1]).split('_')
         platform = targetlist[0]
 
         #Load Platform (PDK or FPGA)

--- a/siliconcompiler/test/test_core.py
+++ b/siliconcompiler/test/test_core.py
@@ -1,4 +1,5 @@
 import unittest
+import unittest.mock
 from siliconcompiler.core import Chip
 
 class TestCore(unittest.TestCase):
@@ -7,3 +8,16 @@ class TestCore(unittest.TestCase):
         chip = Chip()
         chip.set('target', 'freepdk45')
         self.assertEqual(chip.get('target'), ['freepdk45'])
+
+    def test_cli_multi_source(self):
+        ''' Regression test for bug where CLI parser wasn't handling multiple
+        source files properly.
+        '''
+        chip = Chip()
+
+        args = ['sc', 'foo.v', 'bar.v', '-target', 'freepdk45']
+        with unittest.mock.patch('sys.argv', args):
+            chip.cmdline()
+
+        assert chip.get('source') == ['foo.v', 'bar.v']
+        assert chip.get('target')[-1] == 'freepdk45'


### PR DESCRIPTION
- Should add values instead of setting them: otherwise list items (like `source`) are just set to the value of the last element in the list specified on the command line.
- Need to take index -1 of chip.get('target') to get latest value.
- Need to parse arguments starting from sys.argv[1:] since sys.argv[0] contains the name of the script being run.

Note that I think we can determine whether to use a single `set` vs a loop and `add` once #201 is resolved, since I think the solution to that issue will involve annotating each parameter with whether it's a list or scalar. (Also, the fact that there was a latent issue with `chip.get('target')[0]` is more motivation to fix `chip.get`!)

This PR also adds a unit test that fails if any of these bugs remain.

Closes #244 