### PR TITLE
Fix unescaped '\' in strings

### DIFF
--- a/eda/openroad/openroad_setup.py
+++ b/eda/openroad/openroad_setup.py
@@ -75,12 +75,12 @@ def post_process(chip, step):
      design = chip.get('design')[-1]
      with open(exe + ".log") as f:
           for line in f:
-               area = re.search('^Design area (\d+)', line)
-               tns = re.search('^tns (.*)',line)
-               wns = re.search('^wns (.*)',line)
-               power = re.search('^Total(.*)',line)
-               vias = re.search('^total number of vias = (.*)',line)
-               wirelength = re.search('^total wire length = (.*) um',line)
+               area = re.search(r'^Design area (\d+)', line)
+               tns = re.search(r'^tns (.*)',line)
+               wns = re.search(r'^wns (.*)',line)
+               power = re.search(r'^Total(.*)',line)
+               vias = re.search(r'^total number of vias = (.*)',line)
+               wirelength = re.search(r'^total wire length = (.*) um',line)
 
                if area:
                     chip.set('real', step, 'area_cells', str(round(float(area.group(1)),2)))
@@ -103,9 +103,9 @@ def post_process(chip, step):
      #Getting cell count and net number from DEF
      with open("outputs/" + design + ".def") as f:
           for line in f:
-               cells = re.search('^COMPONENTS (\d+)', line)
-               nets = re.search('^NETS (\d+)',line)
-               pins = re.search('^PINS (\d+)',line)
+               cells = re.search(r'^COMPONENTS (\d+)', line)
+               nets = re.search(r'^NETS (\d+)',line)
+               pins = re.search(r'^PINS (\d+)',line)
                if cells:
                     chip.set('real', step, 'cells', cells.group(1))
                elif nets:

--- a/eda/verilator/verilator_setup.py
+++ b/eda/verilator/verilator_setup.py
@@ -99,7 +99,7 @@ def post_process(chip, step):
     '''
 
     # filtering out debug garbage
-    subprocess.run('egrep -h -v "\`begin_keywords" obj_dir/*.vpp > verilator.v',
+    subprocess.run('egrep -h -v "\\`begin_keywords" obj_dir/*.vpp > verilator.v',
                    shell=True)
 
     # setting top module of design

--- a/eda/yosys/yosys_setup.py
+++ b/eda/yosys/yosys_setup.py
@@ -61,9 +61,9 @@ def post_process(chip, step):
      exe = chip.get('flow',step,'exe')[-1]
      with open(exe + ".log") as f:
           for line in f:
-               area = re.search('Chip area for module.*\:\s+(.*)', line)
-               cells = re.search('Number of cells\:\s+(.*)', line)
-               warnings = re.search('Warnings.*\s(\d+)\s+total', line)
+               area = re.search(r'Chip area for module.*\:\s+(.*)', line)
+               cells = re.search(r'Number of cells\:\s+(.*)', line)
+               warnings = re.search(r'Warnings.*\s(\d+)\s+total', line)
                
                if area:
                     chip.set('real', step, 'area_cells', str(round(float(area.group(1)),2)))

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -171,11 +171,11 @@ class Chip:
 
         for item in sys.argv:
             #Split switches with one character and a number after (O0,O1,O2)            
-            opt = re.search('(\-\w)(\d+)',item)
+            opt = re.search(r'(\-\w)(\d+)',item)
             #Split assign switches (-DCFG_ASIC=1)
-            assign = re.search('(\-\w)(\w+\=\w+)',item)
+            assign = re.search(r'(\-\w)(\w+\=\w+)',item)
             #Split plusargs (+incdir+/path)
-            plusarg = re.search('(\+\w+\+)(.*)',item)
+            plusarg = re.search(r'(\+\w+\+)(.*)',item)
             if opt:
                 scargs.append(opt.group(1))
                 scargs.append(opt.group(2))
@@ -360,7 +360,7 @@ class Chip:
 
         #Refcard String
         #Need to escape dir to get pdf to print in pandoc?
-        outlst = [param.replace("<dir>", "\<dir\>"),
+        outlst = [param.replace("<dir>", "\\<dir\\>"),
                   description,
                   typestr,
                   requirement,
@@ -648,7 +648,7 @@ class Chip:
                 if mode == 'tcl':
                     for i, val in enumerate(cfg[k][field]):
                         #replace $VAR with env(VAR) for tcl
-                        m = re.match('\$(\w+)(.*)', val)
+                        m = re.match(r'\$(\w+)(.*)', val)
                         if m:
                             cfg[k][field][i] = ('$env(' +
                                                 m.group(1) +
@@ -1399,7 +1399,7 @@ class Chip:
             if schema_istrue(self.cfg['jobincr']['value']):
                 jobid = 0
                 for item in alljobs:
-                    m = re.match(jobname+'(\d+)', item)
+                    m = re.match(jobname+r'(\d+)', item)
                     if m:
                         jobid = max(jobid, int(m.group(1)))
                 jobid = jobid+1

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -75,7 +75,7 @@ def schema_path(filename):
             filename = abspath
             break
     #Replace $ Variables
-    varmatch = re.match('^\$(\w+)(.*)', filename)
+    varmatch = re.match(r'^\$(\w+)(.*)', filename)
     if varmatch:
         var = varmatch.group(1)
         varpath = os.getenv(var)
@@ -2904,12 +2904,12 @@ def schema_design(cfg):
         A list of source files to read in for elaboration. The files are read 
         in order from first to last entered. File type is inferred from the 
         file suffix:
-        (\*.v, \*.vh) = Verilog
-        (\*.vhd)      = VHDL
-        (\*.sv)       = SystemVerilog
-        (\*.c)        = C
-        (\*.cpp, .cc) = C++
-        (\*.py)       = Python
+        (\\*.v, \\*.vh) = Verilog
+        (\\*.vhd)      = VHDL
+        (\\*.sv)       = SystemVerilog
+        (\\*.c)        = C
+        (\\*.cpp, .cc) = C++
+        (\\*.py)       = Python
         """
     }
 
@@ -3207,7 +3207,7 @@ def schema_design(cfg):
         'help' : """
         Specifes the file extensions that should be used for finding modules. 
         For example, if -y is specified as ./lib", and '.v' is specified as 
-        libext then the files ./lib/\*.v ", will be searched for module matches.
+        libext then the files ./lib/\\*.v ", will be searched for module matches.
         """
     }
 


### PR DESCRIPTION
This cleans up the DeprecationWarnings we see when pytests fail. It turns out instances of `'\'` in Python strings should either be escaped with another slash: `'\\'`; or by using a "raw string literal" (`r'....'`), which seems to be commonly used for regexes. 

For more info: https://stackoverflow.com/questions/52335970/how-to-fix-string-deprecationwarning-invalid-escape-sequence-in-python

Closes #248. 