### PR TITLE
Add a fusesoc target for Lattice's iCE40UP5K evaluation board.

### DIFF
--- a/fpga/boards/ice40up5k-evn/ice40up5k-evn.core
+++ b/fpga/boards/ice40up5k-evn/ice40up5k-evn.core
@@ -1,0 +1,21 @@
+CAPI=2:
+name: sc:ice40up5k-evn:1.0
+
+filesets:
+  rtl:
+    files:
+      - inputs/sc.v
+    file_type: verilogSource
+
+  constraints:
+    files:
+      - inputs/ice40up5k-evn.pcf
+    file_type: PCF
+
+targets:
+  default:
+    default_tool: icestorm
+    filesets: [rtl, constraints]
+    tools:
+      icestorm:
+        nextpnr_options: ['--up5k', '--package', 'sg48']

--- a/fpga/boards/ice40up5k-evn/ice40up5k-evn.pcf
+++ b/fpga/boards/ice40up5k-evn/ice40up5k-evn.pcf
@@ -1,0 +1,10 @@
+# Minimal constraint file for Lattice's iCE40UP5K evaluation board.
+
+# 12 MHz clock
+set_io -nowarn CLK        35
+set_frequency  CLK        12
+
+# RGB LED
+set_io -nowarn LED1       39
+set_io -nowarn LED2       40
+set_io -nowarn LED3       41

--- a/fpga/targets/ice40up5k-evn.py
+++ b/fpga/targets/ice40up5k-evn.py
@@ -1,0 +1,5 @@
+from . import fusesoc
+
+def setup_platform(chip):
+    # Configure board settings.
+    fusesoc.setup_board(chip, 'lattice', 'ice40up5k-evn', 'pcf')

--- a/tests/fpga/test_fusesoc.py
+++ b/tests/fpga/test_fusesoc.py
@@ -24,6 +24,26 @@ def test_icebreaker():
     assert os.path.isfile('build/blinky/job1/export/outputs/blinky.bit')
 
 ##################################
+def test_ice40up5k_evn():
+    '''Basic FPGA test: build the Blinky example by running `sc` as a command-line app.
+    '''
+
+    # Use subprocess to test running the `sc` scripts as a command-line program.
+    # Pipe stdout to /dev/null to avoid printing to the terminal.
+    blinky_ex_dir = os.path.abspath(__file__)
+    blinky_ex_dir = blinky_ex_dir[:blinky_ex_dir.rfind('/tests/fpga')] + '/examples/blinky/'
+
+    # Run the build command for an iCE40 board.
+    subprocess.run(['sc',
+                    blinky_ex_dir + '/blinky.v',
+                    '-design', 'blinky',
+                    '-target', 'ice40up5k-evn_fusesoc'],
+                   stdout = subprocess.DEVNULL)
+
+    # Verify that a bitstream was generated
+    assert os.path.isfile('build/blinky/job1/export/outputs/blinky.bit')
+
+##################################
 def test_orangecrab():
     '''Basic FPGA test: build the Blinky example by running `sc` as a command-line app.
     '''


### PR DESCRIPTION
Just realized that I forgot to submit this small change - it adds support for [Lattice's iCE40UP5K-B-EVN board,](https://www.latticesemi.com/products/developmentboardsandkits/ice40ultraplusbreakoutboard) and a matching CI test.