### PR TITLE
Use try/except when creating the temporary test directory, to fix a race condition

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import shutil
 @pytest.fixture(autouse=True, scope='session')
 def test_session_wrapper():
     # Create and enter a temporary build directory.
-    if not os.path.isdir('pytest_tmp'):
+    try:
         os.mkdir('pytest_tmp')
+    except FileExistsError:
+        pass
     os.chdir('pytest_tmp')


### PR DESCRIPTION
I believe that the tests for PRs #259 and #261 failed because of a race condition in the parallel test setup code.

It is possible that the `pytest_tmp` directory gets created in between an individual thread's `if os.path.isdir(...):` check and their call to `os.mkdir(...)`. Using a try / except should solve that issue.