### PR TITLE
Floorplan cleanup

### DIFF
--- a/siliconcompiler/floorplan.py
+++ b/siliconcompiler/floorplan.py
@@ -238,14 +238,14 @@ class Floorplan:
         with open(filename, 'w') as f:
             f.write(tmpl.render(fp=self))
 
-    def place_pins(self, pins, offset, pitch, side, width, depth, layer,
+    def place_pins(self, pins, offset, spacing, side, width, depth, layer,
                    pin_dir='inout', net_name=None, use='signal', fixed=True):
         '''Places pins along edge of floorplan.
 
         Args:
             pins (list of str): List of pin names to place.
             offset (int): How far to place first pin from edge, in microns.
-            pitch (int): Spacing between pins in microns.
+            spacing (int): Spacing between pins in microns.
             side (str): Which side of the block to place the pins along. Options
                 are 'n', 's', 'e', or 'w' (case insensitive).
             width (float): Width of pin.
@@ -280,26 +280,26 @@ class Floorplan:
         if side.upper() == 'N':
             x     = offset
             y     = block_h - depth/2
-            xincr = pitch
+            xincr = spacing
             yincr = 0.0
             shape = [(-width/2, -depth/2), (width/2, depth/2)]
         elif side.upper() == 'S':
             x     = offset
             y     = depth/2
-            xincr = pitch
+            xincr = spacing
             yincr = 0.0
             shape = [(-width/2, -depth/2), (width/2, depth/2)]
         elif side.upper() == 'W':
             x     = depth/2
             y     = offset
             xincr = 0
-            yincr = pitch
+            yincr = spacing
             shape = [(-depth/2, -width/2), (depth/2, width/2)]
         elif side.upper() == 'E':
             x     = block_w - depth/2
             y     = offset
             xincr = 0
-            yincr = pitch
+            yincr = spacing
             shape = [(-depth/2, -width/2), (depth/2, width/2)]
 
         for pin_name in pins:
@@ -324,7 +324,7 @@ class Floorplan:
             x += xincr
             y += yincr
 
-    def place_macros(self, macros, pos, pitch, direction, orientation,
+    def place_macros(self, macros, pos, spacing, direction, orientation,
                     halo=(0, 0, 0, 0), fixed=True):
         '''Places macros on floorplan.
 
@@ -333,7 +333,7 @@ class Floorplan:
                 (instance name, macro name).
             pos (tuple): x, y coordinate where to place first instance, in
                 microns.
-            pitch (int): Distance between this macro and previous, in microns.
+            spacing (int): Distance between this macro and previous, in microns.
             direction (str): Direction to place macros ('h' for east-west, 'v'
                 for north-south).
             orientation (str): Orientation of macros (must be valid LEF/DEF
@@ -367,18 +367,18 @@ class Floorplan:
             self.macros.append(macro)
 
             if direction.lower() == 'h':
-                x += pitch
+                x += spacing
             else:
-                y += pitch
+                y += spacing
 
-    def place_wires(self, nets, pos, pitch, direction, layer, width, length, shape):
+    def place_wires(self, nets, pos, spacing, direction, layer, width, length, shape):
         '''Place wires on floorplan.
 
         Args:
             nets (list of str): List of net names of wires to place.
             pos (tuple): x, y coordinate where to place first instance, in
                 microns.
-            pitch (int): Distance between this wire and previous, in microns.
+            spacing (int): Distance between this wire and previous, in microns.
             direction (str): Direction to place wires along ('h' for east-west,
                 'v' for north-south). Note that the wires themselves will run in
                 the opposite direction.
@@ -417,9 +417,9 @@ class Floorplan:
                     f'it by calling init_net()')
 
             if direction.lower() == 'h':
-                pos = x + pitch, y
+                pos = x + spacing, y
             elif direction.lower() == 'v':
-                pos = x, y + pitch
+                pos = x, y + spacing
 
     def generate_rows(self, site_name=None, flip_first_row=False, area=None):
         '''Auto-generates placement rows based on floorplan parameters and tech


### PR DESCRIPTION
This PR takes care of some small, miscellaneous cleanup things in floorplan.py, mostly regarding documentation. 

It should be ready for testing now! Some pointers to examples:
- [`siliconcompiler/tests/test_floorplan.py`](https://github.com/siliconcompiler/siliconcompiler/blob/main/siliconcompiler/test/test_floorplan.py#L70) has a function `test_padring` that shows how to use the API to replicate this [example](https://github.com/YosysHQ/padring/blob/master/example/mypadring.config). Running this test file will dump the padring as a DEF file, which you can look at in KLayout (as a heads up, to view the DEF with I/O pads shown properly, I think the iocells.lef needs to be in the same directory as the padring.def output).  
- [`examples/gcd/floorplan.py`](https://github.com/siliconcompiler/siliconcompiler/blob/main/examples/gcd/floorplan.py) shows how floorplans can be integrated into the flow. If you use the following CLI invocation, GCD will be built using this floorplan: 
```bash
sc examples/gcd/gcd.v \
   -target "freepdk45" \
   -constraint "examples/gcd/gcd.sdc" \
   -asic_floorplan "examples/gcd/floorplan.py" \
   -loglevel "INFO" \
   -quiet \
   -relax \
   -design gcd
```

Looking forward to hearing your feedback once you get a chance to play with the API!
 