### PR TITLE
Add asic-sv2v EDA target

### DIFF
--- a/eda/targets/asic-sv2v.py
+++ b/eda/targets/asic-sv2v.py
@@ -1,0 +1,53 @@
+import importlib
+import os
+import siliconcompiler
+
+####################################################
+# EDA Setup
+####################################################
+def setup_eda(chip, name=None):
+
+    # Define Compilation Flow
+    chip.cfg['steplist']['value'] = ['validate',
+                                     'import',
+                                     'syn',
+                                     'floorplan',
+                                     'place',
+                                     'cts',
+                                     'route',
+                                     'dfm',
+                                     'export']
+
+    # Setup tool based on flow step
+    for step in chip.cfg['steplist']['value']:
+        if step == 'validate':
+            vendor = 'surelog'
+        elif step == 'import':
+            vendor = 'sv2v'
+        elif step == 'syn':
+            vendor = 'yosys'
+        elif step == 'export':
+            vendor = 'klayout'
+        else:
+            vendor = 'openroad'
+
+        #load module dynamically on each step
+        packdir = "eda." + vendor
+        modulename = '.'+vendor+'_setup'
+        module = importlib.import_module(modulename, package=packdir)
+        setup_tool = getattr(module, 'setup_tool')
+        setup_tool(chip, step)
+        
+#########################
+if __name__ == "__main__":    
+
+    # File being executed
+    prefix = os.path.splitext(os.path.basename(__file__))[0]
+    output = prefix + '.json'
+
+    # create a chip instance
+    chip = siliconcompiler.Chip()
+    # load configuration
+    setup_eda(chip)
+    # write out result
+    chip.writecfg(output)


### PR DESCRIPTION
We decided we didn't want sv2v used in the default ASIC target since it doesn't provide the right interface, but it'd still be nice to have the ability to use sv2v through SC in order to support ZeroSoC (unless using a separate Makefile that calls sv2v first is preferred). This PR adds another target that can be used to opt into using sv2v. 