### PR TITLE
Add padding to the detailed placement step

### DIFF
--- a/eda/openroad/sc_apr.tcl
+++ b/eda/openroad/sc_apr.tcl
@@ -23,22 +23,26 @@ set target_tech [lindex $targetlist 0]
 if {$target_tech eq "freepdk45"} {
     set openroad_place_density 0.3
     set openroad_pad_global_place 2
+    set openroad_pad_detail_place 1
     set openroad_macro_place_halo "22.4 15.12"
     set openroad_macro_place_channel "18.8 19.95"
 } elseif {$target_tech eq "asap7"} {
     set openroad_place_density 0.77
     set openroad_pad_global_place 2
+    set openroad_pad_detail_place 1
     set openroad_macro_place_halo "22.4 15.12"
     set openroad_macro_place_channel "18.8 19.95"
 } elseif {$target_tech eq "skywater130"} {
     set openroad_place_density 0.6
     set openroad_pad_global_place 4
+    set openroad_pad_detail_place 2
     set openroad_macro_place_halo "1 1"
     set openroad_macro_place_channel "80 80"
 } else {
     puts "WARNING: OpenROAD tuning constants not set for $target_tech in sc_apr.tcl, using generic values."
     set openroad_place_density 0.3
     set openroad_pad_global_place 2
+    set openroad_pad_detail_place 1
     set openroad_macro_place_halo "22.4 15.12"
     set openroad_macro_place_channel "18.8 19.95"
 }

--- a/eda/openroad/sc_place.tcl
+++ b/eda/openroad/sc_place.tcl
@@ -39,6 +39,10 @@ repair_design
 # DETAILED PLACEMENT
 #######################
 
+set_placement_padding -global \
+                      -left $openroad_pad_detail_place \
+                      -right $openroad_pad_detail_place
+
 detailed_placement
 
 optimize_mirroring


### PR DESCRIPTION
Currently, our OpenROAD flow only adds cell padding in the global placement step. This change adds a similar option to the detailed placement step, which seems to be enabled for most PDKs in the official OpenROAD flow.