### PR TITLE
Add morty tool

### DIFF
--- a/eda/morty/morty_setup.py
+++ b/eda/morty/morty_setup.py
@@ -1,0 +1,92 @@
+import os
+import subprocess
+import re
+import sys
+import siliconcompiler
+
+from siliconcompiler.schema import schema_istrue
+from siliconcompiler.schema import schema_path
+
+################################
+# Setup Tool (pre executable)
+################################
+
+def setup_tool(chip, step):
+    ''' Per tool function that returns a dynamic options string based on
+    the dictionary settings.
+    '''
+
+    # Standard Setup
+    tool = 'morty'
+    chip.add('eda', tool, step, 'threads', '4')
+    chip.add('eda', tool, step, 'format', 'cmdline')
+    chip.add('eda', tool, step, 'copy', 'false')
+    chip.add('eda', tool, step, 'exe', 'morty')
+    chip.add('eda', tool, step, 'vendor', 'morty')
+
+    # output single file to `morty.v`
+    chip.add('eda', tool, step, 'option', '-o morty.v')
+    # write list of undefined modules to `undefined.morty`
+    chip.add('eda', tool, step, 'option', '--write-undefined')
+    chip.add('eda', tool, step, 'option', '-I ../../../')
+
+    for value in chip.cfg['ydir']['value']:
+        chip.add('eda', tool, step, 'option', '--library-dir ' + schema_path(value))
+    for value in chip.cfg['vlib']['value']:
+        chip.add('eda', tool, step, 'option', '--library-file ' + schema_path(value))
+    for value in chip.cfg['idir']['value']:
+        chip.add('eda', tool, step, 'option', '-I ' + schema_path(value))
+    for value in chip.cfg['define']['value']:
+        chip.add('eda', tool, step, 'option', '-D ' + schema_path(value))
+    for value in chip.cfg['source']['value']:
+        # only pickle Verilog or SystemVerilog files
+        if value.endswith('.v') or value.endswith('.vh') or \
+                value.endswith('.sv') or value.endswith('.svh'):
+            chip.add('eda', tool, step, 'option', schema_path(value))
+
+################################
+# Post_process (post executable)
+################################
+
+def post_process(chip, step):
+    ''' Tool specific function to run after step execution
+    '''
+
+    # detect top module
+    modules = 0
+    if len(chip.cfg['design']['value']) < 1:
+        with open("morty.v", "r") as open_file:
+            for line in open_file:
+                modmatch = re.match(r'^module\s+(\w+)', line)
+                if modmatch:
+                    modules = modules + 1
+                    topmodule = modmatch.group(1)
+        if (modules > 1) & (chip.cfg['design']['value'] == ""):
+            chip.logger.error('Multiple modules found during import, \
+            but sc_design was not set')
+            sys.exit()
+        else:
+            chip.logger.info('Setting design (topmodule) to %s', topmodule)
+            chip.cfg['design']['value'].append(topmodule)
+    else:
+        topmodule = chip.cfg['design']['value'][-1]
+
+    # Hand off `morty.v` and `undefined.morty` to the next step
+    subprocess.run("cp morty.v " + "outputs/" + topmodule + ".v", shell=True)
+    subprocess.run("cp undefined.morty " + "outputs/", shell=True)
+
+    return 0
+
+##################################################
+if __name__ == "__main__":
+
+    # File being executed
+    prefix = os.path.splitext(os.path.basename(__file__))[0]
+    output = prefix + '.json'
+
+    # create a chip instance
+    chip = siliconcompiler.Chip(defaults=False)
+    # load configuration
+    setup_tool(chip, step='import')
+    # write out results
+    chip.writecfg(output)


### PR DESCRIPTION
Adds an EDA tool for running morty for importing SystemVerilog input files. The tool will preprocess the input files and pickle them into a single output SystemVerilog file called `morty.v`, along with a list of undefined modules in a file called `undefined.morty`. The library options are supported, but the `-f` command is not (I think it makes more sense to support `-f` at the SC level rather than in morty/other import tools, and it is also very inconvenient to implement in morty, since the flag syntax needed by `-f` is a little inconsistent and does not follow Rust's flag syntax).

Currently Verilator is still the default in the default flows, and the user can opt in to morty by modifying the flowgraph themselves. Morty is needed for import when the inputs are full SystemVerilog (more than Verilator's support), or VHDL (so that undefined modules can be detected).