### PR TITLE
Update sv2v for use with Morty import

### DIFF
--- a/eda/sv2v/sv2v_setup.py
+++ b/eda/sv2v/sv2v_setup.py
@@ -34,20 +34,6 @@ def setup_tool(chip, step):
     for value in chip.cfg['define']['value']:
         chip.add('eda', tool, step, 'option', '-D ' + schema_path(value))
 
-    #Source Level Controls
-    for value in chip.cfg['ydir']['value']:
-        chip.add('eda', tool, step, 'option', '-y ' + schema_path(value))
-    for value in chip.cfg['vlib']['value']:
-        chip.add('eda', tool, step, 'option', '-v ' + schema_path(value))
-    for value in chip.cfg['idir']['value']:
-        chip.add('eda', tool, step, 'option', '-I' + schema_path(value))
-    for value in chip.cfg['define']['value']:
-        chip.add('eda', tool, step, 'option', '-D' + schema_path(value))
-    for value in chip.cfg['cmdfile']['value']:
-        chip.add('eda', tool, step, 'option', '-f ' + schema_path(value))
-    for value in chip.cfg['source']['value']:
-        chip.add('eda', tool, step, 'option', schema_path(value))
-
     # since this step should run after import, the top design module should be
     # set and we can read the pickled Verilog without accessing the original
     # sources


### PR DESCRIPTION
This updates the `sv2v` tool so that it doesn't directly access the source files. Instead it is now meant to be used after the import step to convert a single pickled SystemVerilog file to a Verilog file.

This also updates the sv2v tool to the new eda tool format.