### PR TITLE
Generate manifest file with morty

### DIFF
--- a/siliconcompiler/tools/morty/morty_setup.py
+++ b/siliconcompiler/tools/morty/morty_setup.py
@@ -26,9 +26,9 @@ def setup_tool(chip, step):
 
     # output single file to `morty.v`
     chip.add('eda', tool, step, 'option', '-o morty.v')
-    # write list of undefined modules to `undefined.morty`
-    chip.add('eda', tool, step, 'option', '--write-undefined')
-    chip.add('eda', tool, step, 'option', '--write-filelist')
+    # write additional information to `manifest.json`
+    chip.add('eda', tool, step, 'option', '--manifest manifest.json')
+
     chip.add('eda', tool, step, 'option', '-I ../../../')
 
     for value in chip.cfg['ydir']['value']:


### PR DESCRIPTION
Make sure to use the latest version of github.com/zyedidia/morty. This generates a bender "sources manifest" plus a list of undefined modules and a list of top-level modules as additional information. The sources part of the manifest is a list of bundles, each containing files, include dirs, and defines. In our case we should only ever have one bundle in the list (the only way to get multiple bundles is to pass a bender source manifest already with multiple bundles to morty as an input, and we are not doing this).

Here is an example manifest file:

```json
{
  "sources": [
    {
      "include_dirs": [
        "hdl"
      ],
      "defines": {
        "SYNTHESIS": null
      },
      "files": [
        "hdl/cpu_top.sv",
        "hdl/rw_ram.sv",
        "hdl/cpu.sv",
        "hdl/control.sv",
        "hdl/reg_reset.sv",
        "hdl/reg_file.sv",
        "hdl/alu.sv",
      ]
    }
  ],
  "tops": [
    "cpu_top"
  ],
  "undefined": []
}
```