### PR TITLE
Make dynamic import error checking more specific

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -302,7 +302,7 @@ class Chip:
                 setup_design = getattr(module, "setup_design")
                 setup_design(self)
                 self.logger.info("Loaded platform '%s'", platform)
-            except:
+            except ModuleNotFoundError:
                 self.logger.critical("Platform %s not found.", platform)
                 sys.exit()
         else:
@@ -315,7 +315,7 @@ class Chip:
             setup_flow = getattr(module, "setup_flow")
             setup_flow(self, platform)
             self.logger.info("Loaded edaflow '%s'", edaflow)
-        except:
+        except ModuleNotFoundError:
             self.logger.critical("EDA flow %s not found.", edaflow)
             sys.exit()
 


### PR DESCRIPTION
Need to catch this exception in particular, or we get a confusing error message for syntax errors in the module.