### PR TITLE
Skip missing liberty files

### DIFF
--- a/siliconcompiler/tools/openroad/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/sc_apr.tcl
@@ -173,7 +173,9 @@ if {$sc_step == "route"} {
 
 # Macrolibs
 foreach lib $sc_macrolibs {
-    read_liberty [dict get $sc_cfg macro $lib model typical nldm lib]
+    if {[dict exists $sc_cfg macro $lib model]} {
+        read_liberty [dict get $sc_cfg macro $lib model typical nldm lib]
+    }
     read_lef [dict get $sc_cfg macro $lib lef]
 }
 

--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -24,9 +24,13 @@ if {[dict exists $sc_cfg asic macrolib]} {
 # on (for area estimation).
 set stat_libs ""
 foreach libname $sc_macrolibs {
-    set macro_lib [dict get $sc_cfg macro $libname model typical nldm lib]
-    yosys read_liberty -lib $macro_lib
-    append stat_libs "-liberty $macro_lib "
+    # TODO: we assume corner name is "typical" - this should probably be
+    # documented somewhere?
+    if {[dict exists $sc_cfg macro $libname model]} {
+        set macro_lib [dict get $sc_cfg macro $libname model typical nldm lib]
+        yosys read_liberty -lib $macro_lib
+        append stat_libs "-liberty $macro_lib "
+    }
 }
 
 ########################################################


### PR DESCRIPTION
I've had this in a private branch for a while to work around errors that popped up back when I was working with the dummy IO cell library without a liberty file. I don't think I need it anymore, but I'm curious if you think this is worth merging, or should we just assume there's always a need for liberty files for every library (not necessarily sure what the implications of this would be)?