### PR TITLE
Add a 'workflow_dispatch' trigger to allow manual runs on branches.

### DIFF
--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
We might want to test whether a proposed change fixes or breaks a daily test on the CI runner - this change should let us manually start a `daily_test` run on a specific branch from the 'Actions' tab.