### PR TITLE
Initial OpenFPGA/ASIC flow.

### DIFF
--- a/examples/k4n4_L124/LICENSE
+++ b/examples/k4n4_L124/LICENSE
@@ -1,0 +1,25 @@
+Example design from the OpenFPGA project:
+https://github.com/lnis-uofu/OpenFPGA
+Path: openfpga_flow/tasks/basic_tests/k4_series/
+
+MIT License
+
+Copyright (c) 2018 LNIS - The University of Utah
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/k4n4_L124/config/task.conf
+++ b/examples/k4n4_L124/config/task.conf
@@ -1,0 +1,38 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=vpr_blif
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fix_device_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_frac_N4_adder_chain_mem1K_L124_40nm_frame_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=4x4
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_frac_N4_tileable_adder_chain_mem1K_L124_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.blif
+
+[SYNTHESIS_PARAM]
+bench0_top = and2
+bench0_act = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.act
+bench0_verilog = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+bench0_chan_width = 300
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/examples/k4n4_tileableio/LICENSE
+++ b/examples/k4n4_tileableio/LICENSE
@@ -1,0 +1,25 @@
+Example design from the OpenFPGA project:
+https://github.com/lnis-uofu/OpenFPGA
+Path: openfpga_flow/tasks/basic_tests/k4_series/
+
+MIT License
+
+Copyright (c) 2018 LNIS - The University of Utah
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/k4n4_tileableio/config/task.conf
+++ b/examples/k4n4_tileableio/config/task.conf
@@ -1,0 +1,38 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=vpr_blif
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_shell_scripts/fix_device_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_frame_ccff_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+openfpga_vpr_device_layout=2x2
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileableIO_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.blif
+
+[SYNTHESIS_PARAM]
+bench0_top = and2
+bench0_act = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.act
+bench0_verilog = ${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+bench0_chan_width = 300
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=
+vpr_fpga_verilog_formal_verification_top_netlist=

--- a/siliconcompiler/cli.py
+++ b/siliconcompiler/cli.py
@@ -53,6 +53,11 @@ def main():
         #Checks settings and fills in missing values
         chip.check()
 
+        #Process absolute file paths for sources.
+        for i, v in enumerate(list(chip.cfg['source']['value'])):
+            #Look for relative paths in search path
+            chip.cfg['source']['value'][i] = schema_path(v)
+
         #Creating hashes for all sourced files
         chip.hash()
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -677,11 +677,11 @@ ss
             #print("abspath", k,v)
             if isinstance(v, dict):
                 #indicates leaf cell
-                if 'value' in cfg[k].keys():
+                if ('value' in cfg[k].keys()) and (cfg[k]['value']):
                     #print(cfg[k]['value'])
                     #print("dict=",cfg[k])
                     #only do something if type is file
-                    if re.search('file|dir', cfg[k]['type']):
+                    if re.search('file|dir|path', cfg[k]['type']):
                         #iterate if list
                         if re.match(r'\[', cfg[k]['type']):
                             for i, v in enumerate(list(cfg[k]['value'])):

--- a/siliconcompiler/flows/openfpgaflow.py
+++ b/siliconcompiler/flows/openfpgaflow.py
@@ -1,0 +1,112 @@
+import os
+import siliconcompiler
+
+####################################################
+# Flowgraph Setup
+####################################################
+def setup_flow(chip, process):
+    '''
+    This is a standard open source ASIC flow based on high quality tools.
+    The flow supports SystemVerilog, VHDL, and mixed SystemVerilog/VHDL
+    flows. The asic flow is a linera pipeline that includes the
+    stages below. To skip the last three verification steps, you can
+    specify "-stop export" at the command line.
+
+    rtlgen: Generates RTL netlist for the OpenFPGA architecture.
+
+    import: Sources are collected and packaged for compilation.
+            A design manifest is created to simplify design sharing.
+
+    syn: Translates RTL to netlist using Yosys
+
+    synopt: Timing driven synthesis
+
+    floorplan: Floorplanning
+
+    place: Gloal placement
+
+    cts: Clock tree synthesis
+
+    route: Global and detailed routing
+
+    dfm: Metal fill, atenna fixes and any other post routing steps
+
+    export: Merge library GDS files with design DEF to produce a single GDS
+
+    sta: Signoff static timing analysis
+
+    lvs: Layout versus schematic check
+
+    drc: Design rule check
+
+    Args:
+        process (string): Specifies the the process of the compilation.
+            Used in complex flows and reserved for future use.
+
+    '''
+
+
+    # A simple linear flow
+    flowpipe = ['rtlgen',
+                'import',
+                'syn',
+                'synopt',
+                'floorplan',
+                'place',
+                'cts',
+                'route',
+                'dfm',
+                'export',
+                # TODO: sta is currently broken, don't include in flow
+                # 'sta'
+                ]
+
+    # TODO: implement these steps for processes other than Skywater
+    verification_steps = [ 'lvs', 'drc']
+    if process == 'skywater130':
+        flowpipe += verification_steps
+
+    for i in range(len(flowpipe)-1):
+        chip.add('flowgraph', flowpipe[i], 'output', flowpipe[i+1])
+
+    # Per step tool selection
+    for step in flowpipe:
+        if step == 'import':
+            #tool = 'morty'
+            #tool = 'surelog'
+            tool = 'verilator'
+            showtool = None
+        elif step == 'rtlgen':
+            tool = 'python3'
+            # TODO: Should yosys be the show tool? (Output is .v sources)
+            showtool = None
+        elif step == 'syn':
+            tool = 'yosys'
+            showtool = 'yosys'
+        elif step == 'export':
+            tool = 'klayout'
+            showtool = 'klayout'
+        elif step in ('lvs', 'drc'):
+            tool = 'magic'
+            showtool = 'klayout'
+        else:
+            tool = 'openroad'
+            showtool = 'openroad'
+        chip.set('flowgraph', step, 'tool', tool)
+        if showtool:
+            chip.set('flowgraph', step, 'showtool', showtool)
+
+##################################################
+if __name__ == "__main__":
+
+    # File being executed
+    prefix = os.path.splitext(os.path.basename(__file__))[0]
+    output = prefix + '.json'
+
+    # create a chip instance
+    chip = siliconcompiler.Chip(defaults=False)
+    # load configuration
+    setup_flow(chip, "freepdk45")
+    # write out results
+    chip.writecfg(output)
+    chip.write_flowgraph(prefix + ".svg")

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -129,6 +129,11 @@ def schema_typecheck(chip, cfg, leafkey, value):
                     if not item in ['true', 'false']:
                         errormsg = "Valid boolean values are True/False/'true'/'false'"
                         ok = False
+                elif cfgtype == 'path':
+                    if (not os.path.isfile(schema_path(item)) and
+                        not os.path.isdir(schema_path(item))):
+                        errormsg = "Invalid path."
+                        ok = False
                 elif cfgtype == 'file':
                     if not os.path.isfile(schema_path(item)):
                         errormsg = "Invalid path or missing file."
@@ -3084,7 +3089,7 @@ def schema_design(cfg):
 
     cfg['source'] = {
         'switch': 'None',
-        'type': '[file]',
+        'type': '[path]',
         'lock': 'false',
         'copy': 'true',
         'requirement': 'all',
@@ -3235,16 +3240,16 @@ def schema_design(cfg):
     cfg['clock']['default'] = {}
     cfg['clock']['default']['pin'] = {
         'switch': '-clock_pin',
-        'type': 'str',
+        'type': '[str]',
         'lock': 'false',
         'requirement': 'optional',
-        'defvalue': None,
-        'short_help': 'Design Clock Driver',
+        'defvalue': ['clk'],
+        'short_help': 'Design Clock Drivers',
         'param_help': "clock clkvar pin <str>",
         'example': ["cli: -clock_pin 'clk top.pll.clkout'",
                     "api: chip.add('clock', 'clk','pin','top.pll.clkout')"],
         'help': """
-        Defines a clock name alias to assign to a clock source.
+        Defines clock name aliases to assign to a clock source.
         """
     }
 

--- a/siliconcompiler/tools/openroad/sc_cts.tcl
+++ b/siliconcompiler/tools/openroad/sc_cts.tcl
@@ -11,11 +11,27 @@ if {[llength [all_clocks]] > 0} {
     # so cts does not try to buffer the inverted clocks.
     repair_clock_inverters
 
-    clock_tree_synthesis -root_buf $sc_clkbuf -buf_list $sc_clkbuf \
-	-sink_clustering_enable \
-	-sink_clustering_size $openroad_cluster_size \
-	-sink_clustering_max_diameter $openroad_cluster_diameter \
-	-distance_between_buffers $openroad_cluster_diameter
+    # Allow CTS to fail without interrupting the flow.
+    # Sometimes it decides to skip the specified nets, do nothing, and error out.
+    catch {
+        if {[dict exists $sc_cfg clock] && [dict exists $sc_cfg clock clk]} {
+            set sc_clkpins [join [dict get $sc_cfg clock clk pin] " "]
+            clock_tree_synthesis -root_buf $sc_clkbuf -buf_list $sc_clkbuf \
+                -sink_clustering_enable \
+                -sink_clustering_size $openroad_cluster_size \
+                -sink_clustering_max_diameter $openroad_cluster_diameter \
+                -clk_nets "$sc_clkpins" \
+                -distance_between_buffers $openroad_cluster_diameter
+        }
+        # (Try to infer clock net[s] if none are specified)
+        else {
+            clock_tree_synthesis -root_buf $sc_clkbuf -buf_list $sc_clkbuf \
+                -sink_clustering_enable \
+                -sink_clustering_size $openroad_cluster_size \
+                -sink_clustering_max_diameter $openroad_cluster_diameter \
+                -distance_between_buffers $openroad_cluster_diameter
+        }
+    } err
 
     set_propagated_clock [all_clocks]
 

--- a/siliconcompiler/tools/python3/python3_setup.py
+++ b/siliconcompiler/tools/python3/python3_setup.py
@@ -1,0 +1,64 @@
+import glob
+import os
+import shutil
+import subprocess
+
+################################
+# Setup Tool (pre executable)
+################################
+
+def setup_tool(chip, step):
+    ''' Per tool function that returns a dynamic options string based on
+    the dictionary settings.
+    '''
+
+    # Standard Setup
+    tool = 'python3'
+    chip.set('eda', tool, step, 'threads', 4)
+    chip.set('eda', tool, step, 'format', 'cmdline')
+    chip.set('eda', tool, step, 'copy', 'false')
+
+    if step == 'rtlgen':
+        chip.set('eda', tool, step, 'exe', 'python3')
+        chip.set('eda', tool, step, 'vendor', 'openfpga')
+
+        # Cannot run if $OPENFPGA_PATH is not set.
+        if not 'OPENFPGA_PATH' in os.environ:
+            chip.logger.error('OpenFPGA script installation directory not found.')
+            sys.exit()
+
+        # OpenFPGA 'source' argument is the directory containing the OpenFPGA task.
+        chip.add('eda', tool, step, 'option', f'{os.environ["OPENFPGA_PATH"]}/openfpga_flow/scripts/run_fpga_task.py')
+        chip.add('eda', tool, step, 'option', os.path.abspath(chip.get('source')[0]))
+
+################################
+# Post_process (post executable)
+################################
+
+def post_process(chip, step):
+    ''' Tool specific function to run after step execution
+    '''
+
+    # Copy generated sources and relevant SDC file[s].
+    src_glob = f'{os.path.abspath(chip.get("source")[0])}/latest/*/*/*/'
+    # There should only be one generated-code directory.
+    src_dir = next(glob.iglob(src_glob))
+    shutil.copytree(os.path.realpath(src_dir + "/SRC"), os.path.abspath("outputs/SRC"))
+    shutil.copy(src_dir + "/SDC/global_ports.sdc", os.path.abspath("outputs/global_ports.sdc"))
+
+    # Modify the top-level file to use absolute file paths.
+    # TODO: Python file open/close instead of sed dependency?
+    subprocess.run(['sed', '-i', f's;\./SRC;{os.path.abspath("outputs/SRC")};g', os.path.abspath("outputs/SRC/fabric_netlists.v")])
+
+    # Modify the 'inv_buf_passgate.v' file to remove '$random' directives.
+    # TODO: These calls cause errors because Verilator does not support tri-state
+    # logic, but to my untrained eye they look like they exist for simulation.
+    # I believe it should be safe to remove them from the physical design.
+    subprocess.run(['sed', '-i', 's/(in === 1\'bz)? $random : //g', os.path.abspath('outputs/SRC/sub_module/inv_buf_passgate.v')])
+
+    # Modify the config dictionary to setup the ASIC flow's "import" step.
+    chip.set('source', os.path.abspath('outputs/SRC/fabric_netlists.v'))
+    chip.set('constraint', os.path.abspath('outputs/global_ports.sdc'))
+
+    # Return 0 if successful.
+    return 0

--- a/siliconcompiler/tools/verilator/verilator_setup.py
+++ b/siliconcompiler/tools/verilator/verilator_setup.py
@@ -24,6 +24,7 @@ def setup_tool(chip, step):
     chip.set('eda', tool, step, 'exe', 'verilator')
     chip.set('eda', tool, step, 'vendor', 'verilator')
     chip.add('eda', tool, step, 'option', '-sv')
+    chip.add('eda', tool, step, 'option', f'--top-module {chip.get("design")}')
 
     # Differentiate between import step and compilation
     if step in ['import', 'lint']:
@@ -34,6 +35,8 @@ def setup_tool(chip, step):
         chip.logger.error('Step %s not supported for verilator', step)
         sys.exit()
 
+    #Allow relative '`include' paths.
+    chip.add('eda', tool, step, 'option', '--relative-includes')
     #Include cwd in search path (verilator default)
     chip.add('eda', tool, step, 'option', '-I../../../')
 


### PR DESCRIPTION
This PR implements a flow to generate a netlist from an OpenFPGA design, and run it through the ASIC workflow to generate a GDS file.

We should probably talk about this in our meeting today before it is merged, because I needed to make a few small but significant changes which we might want to work around in other ways:

* I added a `'path'` schema type in addition to `'file'` and `'dir'`; OpenFPGA projects are directories rather than files, so I made the `'source'` entry for the OpenFPGA flow point to the directory containing the OpenFPGA `config/` dir. Another option would to be pass in the relevant `config/task.conf` file as a source, and evaluate the path from there.

* I made the `cli.py` script convert relative source file paths to absolute paths early in the process. This allows the `setup_tool(...)` functions to easily get the absolute path of a source file, even after the `os.chdir` calls which precede them.

* The `-design` option must always be set to `'fpga_top'` for this flow, and it's not an optional parameter in `sc`. This might be difficult to work around, because the design name is used very early on to set up the build directory structure.

* The OpenFPGA flow is run via a Python script, so I made the `'rtlgen'` step use `python3` as a tool. This works, but may not be ideal.

* I added a TCL `catch {}` block to allow CTS failures. Nets with only one sink don't get processed as a "clock tree", and the CTS step returns an error if no clock trees are processed. This may be addressed in newer versions of the OpenROAD tools; the maintainers have said that CTS should not produce an error code when it doesn't find any clock nets to process.

Finally, I need to make a quick PR to the OpenFPGA project for this flow to work. Currently, it does not accept absolute file paths to project directories, but that is a simple addition and I hope that Xifan et al will be amenable to it.