### PR TITLE
Add test for mixed-source example

### DIFF
--- a/examples/microwatt/build.py
+++ b/examples/microwatt/build.py
@@ -64,7 +64,17 @@ def configure_fpga(chip):
     chip.add('define', 'CLK_INPUT=50000000')
     chip.add('define', 'CLK_FREQUENCY=40000000')
 
-    chip.set("target", "freepdk45_asicflow")
+    chip.target("freepdk45")
+
+    flow = [
+        ('importvhdl', 'ghdl'),
+        ('syn', 'yosys')
+    ]
+
+    for i, (step, tool) in enumerate(flow):
+        if i > 0:
+            chip.add('flowgraph', step, 'input', flow[i-1][0])
+        chip.add('flowgraph', step, 'tool', tool)
 
 def main():
     chip = sc.Chip()

--- a/examples/mixed-source/build.py
+++ b/examples/mixed-source/build.py
@@ -10,10 +10,21 @@ def main():
 
     chip.add('design', 'eq2')
     add_sources(chip)
-    chip.set('stop', 'export')
 
     chip.set_jobid()
-    chip.target("freepdk45_asicflow")
+    chip.target("freepdk45")
+
+    flow = [
+        ('import', 'morty'),
+        ('importvhdl', 'ghdl'),
+        ('syn', 'yosys')
+    ]
+
+    for i, (step, tool) in enumerate(flow):
+        if i > 0:
+            chip.add('flowgraph', step, 'input', flow[i-1][0])
+        chip.add('flowgraph', step, 'tool', tool)
+
     chip.run()
 
 if __name__ == '__main__':

--- a/tests/quick_tests/asic/test_mixedsource.py
+++ b/tests/quick_tests/asic/test_mixedsource.py
@@ -1,0 +1,39 @@
+import os
+import siliconcompiler
+from tests.fixtures import test_wrapper
+
+##################################
+def test_mixedsrc_local_py():
+    '''Basic Python API test: build the mixed-source example using only Python code.
+    '''
+
+    # Create instance of Chip class
+    chip = siliconcompiler.Chip(loglevel='NOTSET')
+
+    ex_dir = os.path.abspath(__file__)
+    ex_dir = ex_dir[:ex_dir.rfind('/tests/quick_tests/asic')] + '/examples/mixed-source/'
+
+    # Inserting value into configuration
+    chip.add('source', ex_dir + 'eq1.vhd')
+    chip.add('source', ex_dir + 'eq2.v')
+    chip.add('design', 'eq2')
+
+    chip.target("freepdk45")
+
+    flow = [
+        ('import', 'morty'),
+        ('importvhdl', 'ghdl'),
+        ('syn', 'yosys')
+    ]
+
+    for i, (step, tool) in enumerate(flow):
+        if i > 0:
+            chip.add('flowgraph', step, 'input', flow[i-1][0])
+        chip.add('flowgraph', step, 'tool', tool)
+    chip.set_jobid()
+
+    # Run the chip's build process synchronously.
+    chip.run()
+
+    # Verify that the Verilog netlist is generated
+    assert os.path.isfile('build/eq2/job1/syn/outputs/eq2.v')


### PR DESCRIPTION
This adds a test using the simple mixed-source 2-bit equality example. The test just runs up to synthesis and checks that the verilog netlist gets generated. This PR also updates the examples using vhdl to create their own flowgraph.