### PR TITLE
Remove main routines from setup files

### DIFF
--- a/siliconcompiler/flows/asicflow.py
+++ b/siliconcompiler/flows/asicflow.py
@@ -97,18 +97,3 @@ def setup_flow(chip, process):
         chip.set('flowgraph', step, 'tool', tool)
         if showtool:
             chip.set('flowgraph', step, 'showtool', showtool)
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_flow(chip, "freepdk45")
-    # write out results
-    chip.writecfg(output)
-    chip.write_flowgraph(prefix + ".svg")

--- a/siliconcompiler/flows/fpgaflow.py
+++ b/siliconcompiler/flows/fpgaflow.py
@@ -68,18 +68,3 @@ def setup_flow(chip, partname):
             else:
                 tool = 'openfpga'
         chip.set('flowgraph', step, 'tool', tool)
-            
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_flow(chip, "partname")
-    # write out results
-    chip.writecfg(output)
-    chip.write_flowgraph(prefix + ".svg")

--- a/siliconcompiler/foundries/asap7.py
+++ b/siliconcompiler/foundries/asap7.py
@@ -197,18 +197,3 @@ def setup_design(chip):
     chip.set('mcmm','worst','pexcorner', corner)
     chip.set('mcmm','worst','mode', 'func')
     chip.set('mcmm','worst','check', ['setup','hold'])
-
-#########################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip()
-    # load configuration
-    setup_platform(chip)
-    setup_libs(chip)
-    # write out result
-    chip.writecfg(output)

--- a/siliconcompiler/foundries/freepdk45.py
+++ b/siliconcompiler/foundries/freepdk45.py
@@ -208,18 +208,3 @@ def setup_design(chip):
     chip.set('mcmm','worst','pexcorner', corner)
     chip.set('mcmm','worst','mode', 'func')
     chip.set('mcmm','worst','check', ['setup','hold'])
-
-#########################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip()
-    # load configuration
-    setup_platform(chip)
-    setup_libs(chip)
-    # write out result
-    chip.writecfg(output)

--- a/siliconcompiler/foundries/lambda.py
+++ b/siliconcompiler/foundries/lambda.py
@@ -223,20 +223,3 @@ def setup_design(chip):
     chip.set('mcmm','worst','pexcorner', corner)
     chip.set('mcmm','worst','mode', 'func')
     chip.set('mcmm','worst','check', ['setup','hold'])
-
-#########################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip()
-    chip.set('pdk','node','1')
-    chip.set('pdk','stackup','m10')
-    # load configuration
-    setup_platform(chip)
-    setup_libs(chip)
-    # write out result
-    chip.writecfg(output)

--- a/siliconcompiler/foundries/skywater130.py
+++ b/siliconcompiler/foundries/skywater130.py
@@ -242,20 +242,3 @@ def setup_design(chip):
     chip.set('mcmm','worst','pexcorner', corner)
     chip.set('mcmm','worst','mode', 'func')
     chip.set('mcmm','worst','check', ['setup','hold'])
-    
-#########################
-if __name__ == "__main__":    
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip()
-    # load configuration
-    setup_platform(chip)
-    setup_libs(chip)
-    # write out result
-    chip.writecfg(output)
-
-   

--- a/siliconcompiler/tools/fusesoc/fusesoc_setup.py
+++ b/siliconcompiler/tools/fusesoc/fusesoc_setup.py
@@ -83,17 +83,3 @@ def post_process(chip, step):
 
     #TODO: return error code
     return 0
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='apr')
-    # write out results
-    chip.writecfg(output)

--- a/siliconcompiler/tools/ghdl/ghdl_setup.py
+++ b/siliconcompiler/tools/ghdl/ghdl_setup.py
@@ -90,17 +90,3 @@ def post_process(chip, step):
         subprocess.run("cp inputs/import/" + topmodule + ".v" + " outputs/", shell=True)
 
     return 0
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='import')
-    # write out results
-    chip.writecfg(output)

--- a/siliconcompiler/tools/icepack/icepack_setup.py
+++ b/siliconcompiler/tools/icepack/icepack_setup.py
@@ -35,17 +35,3 @@ def post_process(chip, step):
     ''' Tool specific function to run after step execution
     '''
     return 0
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='bitstream')
-    # write out results
-    chip.writecfg(output)

--- a/siliconcompiler/tools/magic/magic_setup.py
+++ b/siliconcompiler/tools/magic/magic_setup.py
@@ -102,17 +102,3 @@ def pdk_path(chip):
         sc_path,
         chip.get('pdk', 'foundry'),
         target_tech)
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='drc')
-    # write out results
-    chip.writecfg(output)

--- a/siliconcompiler/tools/morty/morty_setup.py
+++ b/siliconcompiler/tools/morty/morty_setup.py
@@ -72,17 +72,3 @@ def post_process(chip, step):
     subprocess.run("cp manifest.json " + "outputs/", shell=True)
 
     return 0
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='import')
-    # write out results
-    chip.writecfg(output)

--- a/siliconcompiler/tools/nextpnr/nextpnr_setup.py
+++ b/siliconcompiler/tools/nextpnr/nextpnr_setup.py
@@ -59,17 +59,3 @@ def post_process(chip, step):
     '''
     #TODO: return error code
     return 0
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='syn')
-    # write out results
-    chip.writecfg(output)

--- a/siliconcompiler/tools/openfpga/openfpga_setup.py
+++ b/siliconcompiler/tools/openfpga/openfpga_setup.py
@@ -81,17 +81,3 @@ def post_process(chip, step):
 
     # Return 0 if successful
     return 0
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='apr')
-    # write out results
-    chip.writecfg(output)

--- a/siliconcompiler/tools/openroad/openroad_setup.py
+++ b/siliconcompiler/tools/openroad/openroad_setup.py
@@ -181,17 +181,3 @@ def post_process(chip, step):
 
      #Return 0 if successful
      return 0
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='apr')
-    # write out results
-    chip.writecfg(output)

--- a/siliconcompiler/tools/surelog/surelog_setup.py
+++ b/siliconcompiler/tools/surelog/surelog_setup.py
@@ -86,17 +86,3 @@ def post_process(chip, step):
 
     #TODO: return error code
     return 0
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='lint')
-    # write out results
-    chip.writecfg(output)

--- a/siliconcompiler/tools/sv2v/sv2v_setup.py
+++ b/siliconcompiler/tools/sv2v/sv2v_setup.py
@@ -48,17 +48,3 @@ def post_process(chip, step):
     ''' Tool specific function to run after step execution
     '''
     return 0
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='transalate')
-    # write out results
-    chip.writecfg(output)

--- a/siliconcompiler/tools/verilator/verilator_setup.py
+++ b/siliconcompiler/tools/verilator/verilator_setup.py
@@ -98,17 +98,3 @@ def post_process(chip, step):
 
     #Return 0 if successful
     return 0
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='import')
-    # write out results
-    chip.writecfg(output)

--- a/siliconcompiler/tools/vpr/vpr_setup.py
+++ b/siliconcompiler/tools/vpr/vpr_setup.py
@@ -43,17 +43,3 @@ def post_process(chip, step ):
 
     #TODO: return error code
     return 0
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='apr')
-    # write out results
-    chip.writecfg(output)

--- a/siliconcompiler/tools/xyce/xyce_setup.py
+++ b/siliconcompiler/tools/xyce/xyce_setup.py
@@ -29,17 +29,3 @@ def post_process(chip, step):
 
     #TODO: return error code
     return 0
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='spice')
-    # write out results
-    chip.writecfg(output)

--- a/siliconcompiler/tools/yosys/yosys_setup.py
+++ b/siliconcompiler/tools/yosys/yosys_setup.py
@@ -74,17 +74,3 @@ def post_process(chip, step):
 
     #Return 0 if successful
     return 0
-
-##################################################
-if __name__ == "__main__":
-
-    # File being executed
-    prefix = os.path.splitext(os.path.basename(__file__))[0]
-    output = prefix + '.json'
-
-    # create a chip instance
-    chip = siliconcompiler.Chip(defaults=False)
-    # load configuration
-    setup_tool(chip, step='syn')
-    # write out results
-    chip.writecfg(output)


### PR DESCRIPTION
Not sure if you still want these for another reason, but since my approach for generating the docs calls each file's setup function directly, these aren't needed for Sphinx. 