### PR TITLE
docs: fix PDF build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ author = 'Zero ASIC Corporation'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
+    'sphinx.ext.imgconverter',
     'schemagen',
     'toolgen',
     'targetgen',


### PR DESCRIPTION
Turns out all we needed was the addition of this extension. The images do turn out kind of big, but I want to revisit the look/feel of this autogenerated stuff anyways, and I'll be sure to look at the PDF outputs when I do that.  

closes #363