### PR TITLE
Addding asic/fpga mode to cmdline interface

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -268,6 +268,10 @@ class Chip:
         if 'loglevel' in cmdargs.keys():
             self.logger.setLevel(cmdargs['loglevel'])
 
+        # set mode (needed for target)
+        if 'mode' in cmdargs.keys():
+            self.set('mode', cmdargs['mode'])
+
         # read in target if set
         if 'target' in cmdargs.keys():
             self.target(cmdargs['target'])


### PR DESCRIPTION
-asic/fpga is used to select the target platform in the target routine. The default is ASIC,  so we need to override from the commandline before calling target
-Any command line argument that is needed by a target needs to be called here.
NOTE: the list of overrides should be very limited, otherwise it defeats the purpose of the target and the user might as well copy past the target code over and create their own flow/tech target.
-The flow/platform targets should NOT have dependencies/assumptions on self.get()