### PR TITLE
Fix bug that prevents you from re-running steps

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1724,10 +1724,13 @@ class Chip:
             event = multiprocessing.Event()
             active = manager.dict()
             # Set all procs to active
-            for step in steplist:
+            for step in self.getkeys('flowgraph'):
                 for index in range(self.get('flowgraph', step, 'nproc')):
                     stepstr = step + str(index)
-                    active[stepstr] = 1
+                    if step in steplist:
+                        active[stepstr] = 1
+                    else:
+                        active[stepstr] = 0
 
             # Create procs
             processes = []


### PR DESCRIPTION
I noticed a bug that prevents you from being able to re-run steps. I think this PR fixes it, although I'm not 100% sure if this solution is best.

To reproduce the bug, you can first run through the GCD example:
```
sc examples/gcd/gcd.v \                 
     -target "freepdk45_asicflow" \
      -constraint "examples/gcd/gcd.sdc" \
      -asic_diesize "0 0 100.13 100.8" \
      -asic_coresize "10.07 11.2 90.25 91" \
      -loglevel "INFO" \
      -quiet \
      -relax \
      -jobid 0 \
      -design gcd
```

And then attempt to re-run synthesis using `-steplist` (note jobid explicitly set to ensure we're in the same directory):
```
sc examples/gcd/gcd.v \          
     -target "freepdk45_asicflow" \
     -constraint "examples/gcd/gcd.sdc" \
     -asic_diesize "0 0 100.13 100.8" \
     -asic_coresize "10.07 11.2 90.25 91" \
     -loglevel "INFO" \
     -quiet \
     -relax \
     -jobid 0 \
     -design gcd \
     -steplist syn
```

This fails with
```
Process Process-2:
Traceback (most recent call last):
  File "/usr/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/noah/zeroasic/siliconcompiler/siliconcompiler/core.py", line 1540, in runstep
    pending = pending + active[input_str]
  File "<string>", line 2, in __getitem__
  File "/usr/lib/python3.9/multiprocessing/managers.py", line 824, in _callmethod
    raise convert_to_error(kind, result)
KeyError: 'import0'
---------------------------------------------------------------------------------------------------------------------------------------
```

because the key corresponding to the previous step, import0, isn't present in the active dictionary. However, I think this should work since the files needed for synthesis are there.

To fix it, I made a small change to the logic to put entries in `active` for each step in the flowgraph, but only mark them as active if the corresponding step is in the steplist. 
