### PR TITLE
Cast the 'vias' metric value to an integer to fix an error in 'summary()'

### DIFF
--- a/siliconcompiler/tools/openroad/openroad_setup.py
+++ b/siliconcompiler/tools/openroad/openroad_setup.py
@@ -142,7 +142,7 @@ def post_process(chip, step, index):
                elif wirelength:
                     chip.set('metric', step, index, 'real', 'wirelength', round(float(wirelength.group(1)),2))
                elif vias:
-                    chip.set('metric', step, index, 'real', 'vias', round(float(vias.group(1)),2))
+                    chip.set('metric', step, index, 'real', 'vias', int(round(float(vias.group(1)),2)))
                elif slack:
                     chip.set('metric', step, index, 'real', metric, round(float(slack.group(1)),2))
                elif metric == "power":


### PR DESCRIPTION
Since the flowgraph update, the command-line interface has started to raise exceptions during the final `summary()` step.

This hasn't made the tests fail, because the failure occurs after the final GDS file is generated. But it makes the `sc` commaned exit with an error code, which caused some minor issues for the remote workflow.

It looks like the root cause was one of the `int`-typed metrics parameters being set to a `float` value in the OpenROAD setup script; casting the value to an int appears to fix the bug.