### PR TITLE
Allow pytests to be run as ordinary Python scripts.

### DIFF
--- a/tests/quick_tests/asic/test_asicflow.py
+++ b/tests/quick_tests/asic/test_asicflow.py
@@ -1,6 +1,8 @@
 import os
 import siliconcompiler
-from tests.fixtures import test_wrapper
+
+if __name__ != "__main__":
+    from tests.fixtures import test_wrapper
 
 ##################################
 def test_gcd_local_py():
@@ -8,7 +10,7 @@ def test_gcd_local_py():
     '''
 
     # Create instance of Chip class
-    chip = siliconcompiler.Chip(loglevel='NOTSET')
+    chip = siliconcompiler.Chip()
 
     gcd_ex_dir = os.path.abspath(__file__)
     gcd_ex_dir = gcd_ex_dir[:gcd_ex_dir.rfind('/tests/quick_tests/asic')] + '/examples/gcd/'
@@ -32,3 +34,6 @@ def test_gcd_local_py():
 
     # Verify that GDS and SVG files were generated.
     assert os.path.isfile('build/gcd/job0/export0/outputs/gcd.gds')
+
+if __name__ == "__main__":
+    test_gcd_local_py()

--- a/tests/quick_tests/asic/test_mixedsource.py
+++ b/tests/quick_tests/asic/test_mixedsource.py
@@ -1,7 +1,9 @@
 import os
 import pytest
 import siliconcompiler
-from tests.fixtures import test_wrapper
+
+if __name__ != "__main__":
+    from tests.fixtures import test_wrapper
 
 ##################################
 @pytest.mark.skip(reason="Mixed-source functionality is still a work-in-progress.")
@@ -10,7 +12,7 @@ def test_mixedsrc_local_py():
     '''
 
     # Create instance of Chip class
-    chip = siliconcompiler.Chip(loglevel='NOTSET')
+    chip = siliconcompiler.Chip()
 
     ex_dir = os.path.abspath(__file__)
     ex_dir = ex_dir[:ex_dir.rfind('/tests/quick_tests/asic')] + '/examples/mixed-source/'
@@ -38,3 +40,6 @@ def test_mixedsrc_local_py():
 
     # Verify that the Verilog netlist is generated
     assert os.path.isfile('build/eq2/job0/syn0/outputs/eq2.v')
+
+if __name__ == "__main__":
+    test_mixedsrc_local_py()

--- a/tests/quick_tests/asic/test_server.py
+++ b/tests/quick_tests/asic/test_server.py
@@ -1,7 +1,9 @@
 import os
 import re
 import subprocess
-from tests.fixtures import test_wrapper
+
+if __name__ != "__main__":
+    from tests.fixtures import test_wrapper
 
 ###########################
 def test_gcd_server():
@@ -13,8 +15,7 @@ def test_gcd_server():
     os.mkdir('local_server_work')
     srv_proc = subprocess.Popen(['sc-server',
                                  '-nfs_mount', './local_server_work',
-                                 '-cluster', 'local'],
-                                stdout = subprocess.DEVNULL)
+                                 '-cluster', 'local'])
 
     # Use subprocess to test running the `sc` scripts as a command-line program.
     # Pipe stdout to /dev/null to avoid printing to the terminal.
@@ -31,12 +32,13 @@ def test_gcd_server():
                     '-constraint', gcd_ex_dir + '/gcd.sdc',
                     '-remote_addr', 'localhost',
                     '-remote_port', '8080',
-                    '-relax',
-                    '-loglevel', 'NOTSET'],
-                   stdout = subprocess.DEVNULL)
+                    '-relax'])
 
     # Kill the server process.
     srv_proc.kill()
 
     # Verify that GDS and SVG files were generated and returned.
     assert os.path.isfile('build/gcd/job0/export0/outputs/gcd.gds')
+
+if __name__ == "__main__":
+    test_gcd_server()

--- a/tests/quick_tests/fpga/test_fpgaflow.py
+++ b/tests/quick_tests/fpga/test_fpgaflow.py
@@ -1,7 +1,9 @@
 import os
 import subprocess
-# fixture automatically used when imported to create clean build dir
-from tests.fixtures import test_wrapper
+
+if __name__ != "__main__":
+    # fixture automatically used when imported to create clean build dir
+    from tests.fixtures import test_wrapper
 
 ##################################
 def test_icebreaker():
@@ -19,8 +21,10 @@ def test_icebreaker():
                     '-mode', 'fpga',
                     '-constraint', blinky_ex_dir + '/icebreaker.pcf',
                     '-design', 'blinky',
-                    '-target', 'ice40up5k-sg48_fpgaflow'],
-                   stdout = subprocess.DEVNULL)
+                    '-target', 'ice40up5k-sg48_fpgaflow'])
 
     # Verify that a bitstream was generated
     assert os.path.isfile('build/blinky/job0/bitstream0/outputs/blinky.bit')
+
+if __name__ == "__main__":
+    test_icebreaker()

--- a/tests/quick_tests/fpga/test_openfpga.py
+++ b/tests/quick_tests/fpga/test_openfpga.py
@@ -1,7 +1,9 @@
 import os
 import subprocess
-# fixture automatically used when imported to create clean build dir
-from tests.fixtures import test_wrapper
+
+if __name__ != "__main__":
+    # fixture automatically used when imported to create clean build dir
+    from tests.fixtures import test_wrapper
 
 ##################################
 def test_openfpga():
@@ -20,10 +22,12 @@ def test_openfpga():
                     '-fpga_arch', openfpga_ex_dir + '/k6_frac_N10_40nm_openfpga.xml',
                     '-fpga_arch', openfpga_ex_dir + '/k6_frac_N10_40nm_vpr.xml', 
                     '-mode', 'fpga',
-                    '-target', 'openfpga_fpgaflow'],
-                   stdout = subprocess.DEVNULL)
+                    '-target', 'openfpga_fpgaflow'])
 
     # Verify that a bitstream was generated
     assert os.path.isfile('build/and2/job0/apr0/outputs/and2_fabric_bitstream.txt')
     assert os.path.isfile('build/and2/job0/apr0/outputs/and2_fabric_bitstream.xml')
     assert os.path.isfile('build/and2/job0/apr0/outputs/and2_fabric_independent_bitstream.xml')
+
+if __name__ == "__main__":
+    test_openfpga()


### PR DESCRIPTION
Like we talked about earlier today, this change will let us run out Pytests as ordinary Python scripts:

`python3 tests/quick_tests/asic/test_asicflow.py`

If these changes to the quick tests look good, I'll do the same to the daily tests.