### PR TITLE
Specify OpenROAD tuning constants as tool options

### DIFF
--- a/siliconcompiler/tools/openroad/openroad_setup.py
+++ b/siliconcompiler/tools/openroad/openroad_setup.py
@@ -66,6 +66,53 @@ def setup_tool(chip, step, index):
 
     chip.set('eda', tool, step, index, 'option', 'cmdline', '-no_init')
 
+    target_tech = chip.get('target').split('_')[0]
+    if target_tech == 'freepdk45':
+        default_options = {
+            'place_density': ['0.3'],
+            'pad_global_place': ['2'],
+            'pad_detail_place': ['1'],
+            'macro_place_halo': ['22.4', '15.12'],
+            'macro_place_channel': ['18.8', '19.95']
+        }
+    elif target_tech == 'asap7':
+       default_options = {
+            'place_density': ['0.77'],
+            'pad_global_place': ['2'],
+            'pad_detail_place': ['1'],
+            'macro_place_halo': ['22.4', '15.12'],
+            'macro_place_channel': ['18.8', '19.95']
+        }
+    elif target_tech == 'skywater130':
+       default_options = {
+            'place_density': ['0.6'],
+            'pad_global_place': ['4'],
+            'pad_detail_place': ['2'],
+            'macro_place_halo': ['1', '1'],
+            'macro_place_channel': ['80', '80']
+        }
+    else:
+        default_options = None
+
+    generic_default_options = {
+        'place_density': ['0.3'],
+        'pad_global_place': ['1'],
+        'pad_detail_place': ['1'],
+        'macro_place_halo': ['22.4', '15.12'],
+        'macro_place_channel': ['18.8', '19.95']
+    }
+
+    for option in generic_default_options.keys():
+        if (option not in chip.getkeys('eda', tool,  step, index, 'option') or
+            chip.get('eda', tool, step,  index, 'option', option) is None):
+            if default_options is not None:
+                chip.set('eda', tool, step, index, 'option', option, default_options[option])
+            else:
+                chip.logger.warning(f'No tech-specific default for OpenROAD '
+                                    f'option {option} and target_tech {target_tech}. '
+                                    f'Using generic default value.')
+                chip.get('eda', tool, step, index, 'option', option, generic_default_options[option])
+
     # exit automatically unless bkpt
     if (step not in chip.get('bkpt')):
         chip.add('eda', tool, step, index, 'option', 'cmdline', '-exit')

--- a/siliconcompiler/tools/openroad/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/sc_apr.tcl
@@ -12,48 +12,19 @@ set openroad_overflow_iter 100
 set openroad_cluster_diameter 100
 set openroad_cluster_size 30
 
-# These are magic tuning constants that vary per-technology. We set their values
-# here since they're OpenROAD-specific, and therefore we don't want to define
-# them in the schema.
-
-set target [dict get $sc_cfg target]
-set targetlist [split $target _]
-set target_tech [lindex [lindex $targetlist 0] end]
-
-if {$target_tech eq "freepdk45"} {
-    set openroad_place_density 0.3
-    set openroad_pad_global_place 2
-    set openroad_pad_detail_place 1
-    set openroad_macro_place_halo "22.4 15.12"
-    set openroad_macro_place_channel "18.8 19.95"
-} elseif {$target_tech eq "asap7"} {
-    set openroad_place_density 0.77
-    set openroad_pad_global_place 2
-    set openroad_pad_detail_place 1
-    set openroad_macro_place_halo "22.4 15.12"
-    set openroad_macro_place_channel "18.8 19.95"
-} elseif {$target_tech eq "skywater130"} {
-    set openroad_place_density 0.6
-    set openroad_pad_global_place 4
-    set openroad_pad_detail_place 2
-    set openroad_macro_place_halo "1 1"
-    set openroad_macro_place_channel "80 80"
-} else {
-    puts "WARNING: OpenROAD tuning constants not set for $target_tech in sc_apr.tcl, using generic values."
-    set openroad_place_density 0.3
-    set openroad_pad_global_place 2
-    set openroad_pad_detail_place 1
-    set openroad_macro_place_halo "22.4 15.12"
-    set openroad_macro_place_channel "18.8 19.95"
-}
-
-###############################
+##############################
 # Schema Adapter
 ###############################
 
 set tool openroad
 set sc_step       [dict get $sc_cfg arg step]
 set sc_index      [dict get $sc_cfg arg index]
+
+set openroad_place_density [lindex [dict get $sc_cfg eda openroad $sc_step $sc_index option place_density] 0]
+set openroad_pad_global_place [lindex [dict get $sc_cfg eda openroad $sc_step $sc_index option pad_global_place] 0]
+set openroad_pad_detail_place [lindex [dict get $sc_cfg eda openroad $sc_step $sc_index option pad_detail_place] 0]
+set openroad_macro_place_halo [dict get $sc_cfg eda openroad $sc_step $sc_index option macro_place_halo]
+set openroad_macro_place_channel [dict get $sc_cfg eda openroad $sc_step $sc_index option macro_place_channel]
 
 #Handling remote/local script execution
 if {[dict get $sc_cfg eda $tool $sc_step $sc_index copy] eq True} {


### PR DESCRIPTION
I figured these things would all want to be pulled out as tool options (I currently adjust the default place density for ZeroSoC). I ended up moving the technology-dependent defaults from TCL into Python, let me know what you think about that. 