### PR TITLE
Add back pre_process method to tools

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1778,6 +1778,20 @@ class Chip:
                 refdir = schema_path(self.get('eda', tool, step, index, 'refdir'))
                 shutil.copytree(refdir, ".", dirs_exist_ok=True)
 
+        # If it exists, run pre_process in stepdir
+        try:
+            tool = self.get('flowgraph', step, 'tool')
+            searchdir = "siliconcompiler.tools." + tool
+            modulename = '.'+tool+'_setup'
+            module = importlib.import_module(modulename, package=searchdir)
+            if hasattr(module, "pre_process"):
+                pre_process = getattr(module, "pre_process")
+                pre_process(self, step, index)
+        except:
+            traceback.print_exc()
+            self.logger.error(f"Pre-processing failed for '{tool}' in step '{step}'")
+            self._haltstep(step, index, error, active)
+
         # Construct command line
         logfile = exe + ".log"
         options = self.get('eda', tool, step, index, 'option', 'cmdline')

--- a/siliconcompiler/tools/magic/magic_setup.py
+++ b/siliconcompiler/tools/magic/magic_setup.py
@@ -48,6 +48,7 @@ def setup_tool(chip, step, index):
 
     chip.add('eda', tool, step, index, 'option', 'cmdline', options)
 
+def pre_process(chip, step, index):
     # Dumps path to PDK to tcl file so that .magicrc can find tech file
     with open('pdkpath.tcl', 'w') as f:
         f.write(f'set PDKPATH {pdk_path(chip)}')

--- a/siliconcompiler/tools/openfpga/openfpga_setup.py
+++ b/siliconcompiler/tools/openfpga/openfpga_setup.py
@@ -31,6 +31,7 @@ def setup_tool(chip, step, index):
         chip.add('eda', tool, step, index, 'option', 'cmdline', ' -r inputs/ outputs/')
     chip.set('eda', tool, step, index, 'copy', 'true')
 
+def pre_process(chip, step, index):
     topmodule = chip.get('design')
 
     input_blif = 'inputs/' + topmodule + '.blif'
@@ -51,15 +52,14 @@ def setup_tool(chip, step, index):
         elif root_tag == 'openfpga_simulation_setting':
             openfpga_sim_file = path
 
+    # Raising exceptions here ensures the issue is caught by runstep() and
+    # everything is killed safely with regards to parallel processing.
     if vpr_arch_file == None:
-        chip.logger.error('No VPR architecture file was specified')
-        os.sys.exit()
+        raise ValueError('No VPR architecture file was specified')
     if openfpga_arch_file == None:
-        chip.logger.error('No OpenFPGA architecture file was specified')
-        os.sys.exit()
+        raise ValueError('No OpenFPGA architecture file was specified')
     if openfpga_sim_file == None:
-        chip.logger.error('No OpenFPGA simulation file was specified')
-        os.sys.exit()
+        raise ValueError('No OpenFPGA simulation file was specified')
 
     # Fill in OpenFPGA shell script template
     scriptdir = os.path.dirname(os.path.abspath(__file__))

--- a/siliconcompiler/tools/yosys/yosys_setup.py
+++ b/siliconcompiler/tools/yosys/yosys_setup.py
@@ -38,11 +38,12 @@ def setup_tool(chip, step, index):
         chip.add('eda', tool, step, index, 'req', 'constraint')
         chip.add('eda', tool, step, index, 'req', ",".join(['fpga','partname']))
 
+def pre_process(chip, step, index):
     #TODO: remove special treatment for fpga??
-    if chip.get('target'):
-        targetlist = chip.get('target').split('_')
-    else:
-        targetlist = ['no','no']
+    if chip.get('target') is None:
+        return
+    targetlist = chip.get('target').split('_')
+
     if targetlist[0] == 'openfpga':
         # Synthesis for OpenFPGA/VPR needs to know the size of the LUTs in the
         # FPGA architecture. We infer this from the VPR architecture file, then


### PR DESCRIPTION
As discussed in the meeting today, this PR adds back the ability to specify a pre_process function which gets called in the step directory. Specifying it in a tool setup file is optional -- runstep() checks if it exists before attempting to call it.

Closes #424