### PR TITLE
Make specifying .lib optional

### DIFF
--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -30,7 +30,7 @@ set stat_libs ""
 foreach libname $sc_macrolibs {
     # TODO: we assume corner name is "typical" - this should probably be
     # documented somewhere?
-    if {[dict exists $sc_cfg library $libname]} {
+    if {[dict exists $sc_cfg library $libname nldm]} {
         set macro_lib [dict get $sc_cfg library $libname nldm typical lib]
         yosys read_liberty -lib $macro_lib
         append stat_libs "-liberty $macro_lib "


### PR DESCRIPTION
Tweaking this line makes it so that synthesis passes even if you don't have a .lib file for a specific macro. This comes up when building the ZeroSoC top level, where I want to treat the core as a macro itself (and I don't have a liberty file for it). However, if you think we should make a liberty file mandatory, I can try and make a dummy one as an alternate solution.