### PR TITLE
Use requests instead of aiohttp for client-side web requests.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ matplotlib >= 3.3
 numpy >= 1.19
 ply >= 3.11
 aiohttp >= 3.7.4.post0
+requests >= 2.22.0
 pyfiglet >= 0.8
 PyYAML >= 5.4.1
 pytest >= 6.2.4

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -5,8 +5,6 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives import hashes, serialization
 
-import aiohttp
-import asyncio
 import base64
 import glob
 import math
@@ -14,6 +12,7 @@ import multiprocessing
 import importlib
 import json
 import os
+import requests
 import shutil
 import subprocess
 import sys
@@ -78,8 +77,7 @@ def remote_preprocess(chip):
                        cwd=local_build_dir)
 
         # Upload the archive to the 'import/' server endpoint.
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(upload_import_dir(chip))
+        upload_import_dir(chip)
 
 ###################################
 def client_decrypt(chip):
@@ -184,7 +182,7 @@ def client_encrypt(chip):
     os.remove('%s/%s.zip'%(root_dir, job_nameid))
 
 ###################################
-async def remote_run(chip):
+def remote_run(chip):
     '''Helper method to run a job stage on a remote compute cluster.
     Note that files will not be copied to the remote stage; typically
     the source files will be copied into the cluster's storage before
@@ -200,16 +198,16 @@ async def remote_run(chip):
     step_start = time.monotonic()
 
     # Ask the remote server to start processing the requested step.
-    await request_remote_run(chip)
+    request_remote_run(chip)
 
     # Check the job's progress periodically until it finishes.
     is_busy = True
     while is_busy:
       chip.logger.info("Job is still running. (%d seconds)"%(
                        int(time.monotonic() - step_start)))
-      await asyncio.sleep(3)
+      time.sleep(3)
       try:
-          is_busy = await is_job_busy(chip)
+          is_busy = is_job_busy(chip)
       except:
           # Sometimes an exception is raised if the request library cannot
           # reach the server due to a transient network issue.
@@ -219,283 +217,274 @@ async def remote_run(chip):
     chip.logger.info("Remote job run completed!")
 
 ###################################
-async def request_remote_run(chip):
-    '''Helper method to make an async request to start a job stage.
-
+def request_remote_run(chip):
+    '''Helper method to make a web request to start a job stage.
     '''
-    async with aiohttp.ClientSession() as session:
-        # Set the request URL.
-        remote_run_url = get_base_url(chip) + '/remote_run/'
 
-        # Use authentication if necessary.
-        post_params = {'chip_cfg': chip.cfg}
-        if (('user' in chip.getkeys('remote') and chip.get('remote', 'user')) and \
-            ('key' in chip.getkeys('remote') and chip.get('remote', 'key'))):
-            # Read the key and encode it in base64 format.
-            with open(os.path.abspath(chip.get('remote', 'key')), 'rb') as f:
-                key = f.read()
-            b64_key = base64.urlsafe_b64encode(key).decode()
-            post_params['params'] = {
-                'username': chip.get('remote', 'user'),
-                'key': b64_key,
-                'job_hash': chip.get('remote', 'jobhash'),
-            }
+    # Set the request URL.
+    remote_run_url = get_base_url(chip) + '/remote_run/'
+
+    # Use authentication if necessary.
+    post_params = {'chip_cfg': chip.cfg}
+    if (('user' in chip.getkeys('remote') and chip.get('remote', 'user')) and \
+        ('key' in chip.getkeys('remote') and chip.get('remote', 'key'))):
+        # Read the key and encode it in base64 format.
+        with open(os.path.abspath(chip.get('remote', 'key')), 'rb') as f:
+            key = f.read()
+        b64_key = base64.urlsafe_b64encode(key).decode()
+        post_params['params'] = {
+            'username': chip.get('remote', 'user'),
+            'key': b64_key,
+            'job_hash': chip.get('remote', 'jobhash'),
+        }
+    else:
+        post_params['params'] = {
+            'job_hash': chip.get('remote', 'jobhash'),
+        }
+
+    # Make the actual request.
+    # Redirected POST requests are translated to GETs. This is actually
+    # part of the HTTP spec, so we need to manually follow the trail.
+    redirect_url = remote_run_url
+    while redirect_url:
+        resp = requests.post(redirect_url,
+                             data=json.dumps(post_params),
+                             allow_redirects=False)
+        if resp.status_code == 302:
+            redirect_url = resp.headers['Location']
         else:
-            post_params['params'] = {
-                'job_hash': chip.get('remote', 'jobhash'),
-            }
-
-        # Make the actual request.
-        # Redirected POST requests are translated to GETs. This is actually
-        # part of the HTTP spec, so we need to manually follow the trail.
-        redirect_url = remote_run_url
-        while redirect_url:
-            async with session.post(redirect_url,
-                                    json=post_params,
-                                    allow_redirects=False) as resp:
-                if resp.status == 302:
-                    redirect_url = resp.headers['Location']
-                else:
-                    chip.logger.info(await resp.text())
-                    return
+            chip.logger.info(resp.text)
+            return
 
 ###################################
-async def is_job_busy(chip):
+def is_job_busy(chip):
     '''Helper method to make an async request asking the remote server
     whether a job is busy, or ready to accept a new step.
     Returns True if the job is busy, False if not.
-
     '''
 
-    async with aiohttp.ClientSession() as session:
-        # Set the request URL.
-        remote_run_url = get_base_url(chip) + '/check_progress/'
+    # Set the request URL.
+    remote_run_url = get_base_url(chip) + '/check_progress/'
 
-        # Set common parameters.
-        post_params = {
-            'job_hash': chip.get('remote', 'jobhash'),
-            'job_id': '0',
-        }
+    # Set common parameters.
+    post_params = {
+        'job_hash': chip.get('remote', 'jobhash'),
+        'job_id': chip.get('jobid'),
+    }
 
-        # Set authentication parameters if necessary.
-        if (('user' in chip.getkeys('remote') and chip.get('remote', 'user')) and \
-            ('key' in chip.getkeys('remote') and chip.get('remote', 'key'))):
-            with open(os.path.abspath(chip.get('remote', 'key')), 'rb') as f:
-                key = f.read()
-            b64_key = base64.urlsafe_b64encode(key).decode()
-            post_params['username'] = chip.get('remote', 'user')
-            post_params['key'] = b64_key
+    # Set authentication parameters if necessary.
+    if (('user' in chip.getkeys('remote') and chip.get('remote', 'user')) and \
+        ('key' in chip.getkeys('remote') and chip.get('remote', 'key'))):
+        with open(os.path.abspath(chip.get('remote', 'key')), 'rb') as f:
+            key = f.read()
+        b64_key = base64.urlsafe_b64encode(key).decode()
+        post_params['username'] = chip.get('remote', 'user')
+        post_params['key'] = b64_key
 
-        # Make the request and print its response.
-        redirect_url = remote_run_url
-        while redirect_url:
-            async with session.post(redirect_url,
-                                    json=post_params,
-                                    allow_redirects=False) as resp:
-                if resp.status == 302:
-                    redirect_url = resp.headers['Location']
-                else:
-                    response = await resp.text()
-                    return (response != "Job has no running steps.")
+    # Make the request and print its response.
+    redirect_url = remote_run_url
+    while redirect_url:
+        resp = requests.post(redirect_url,
+                             data=json.dumps(post_params),
+                             allow_redirects=False)
+        if resp.status_code == 302:
+            redirect_url = resp.headers['Location']
+        else:
+            return (resp.text != "Job has no running steps.")
 
 ###################################
-async def delete_job(chip):
+def delete_job(chip):
     '''Helper method to delete a job from shared remote storage.
     '''
 
-    async with aiohttp.ClientSession() as session:
-        # Set the request URL.
-        remote_run_url = get_base_url(chip) + '/delete_job/'
+    # Set the request URL.
+    remote_run_url = get_base_url(chip) + '/delete_job/'
 
-        # Set common parameter.
-        post_params = {
-            'job_hash': chip.get('remote', 'jobhash'),
-        }
+    # Set common parameter.
+    post_params = {
+        'job_hash': chip.get('remote', 'jobhash'),
+    }
 
-        # Set authentication parameters if necessary.
-        if (('user' in chip.getkeys('remote') and chip.get('remote', 'user')) and \
-            ('key' in chip.getkeys('remote') and chip.get('remote', 'key'))):
-            with open(os.path.abspath(chip.get('remote', 'key')), 'rb') as f:
-                key = f.read()
-            b64_key = base64.urlsafe_b64encode(key).decode()
-            post_params['username'] = chip.get('remote', 'user')
-            post_params['key'] = b64_key
+    # Set authentication parameters if necessary.
+    if (('user' in chip.getkeys('remote') and chip.get('remote', 'user')) and \
+        ('key' in chip.getkeys('remote') and chip.get('remote', 'key'))):
+        with open(os.path.abspath(chip.get('remote', 'key')), 'rb') as f:
+            key = f.read()
+        b64_key = base64.urlsafe_b64encode(key).decode()
+        post_params['username'] = chip.get('remote', 'user')
+        post_params['key'] = b64_key
 
-        # Make the request.
-        redirect_url = remote_run_url
-        while redirect_url:
-            async with session.post(redirect_url,
-                                    json=post_params,
-                                    allow_redirects=False) as resp:
-                if resp.status == 302:
-                    redirect_url = resp.headers['Location']
-                else:
-                    response = await resp.text()
-                    return response
+    # Make the request.
+    redirect_url = remote_run_url
+    while redirect_url:
+        resp = requests.post(redirect_url,
+                             data=json.dumps(post_params),
+                             allow_redirects=False)
+        if resp.status_code == 302:
+                redirect_url = resp.headers['Location']
+        else:
+            response = resp.text
+            return response
 
 ###################################
-async def upload_import_dir(chip):
+def upload_import_dir(chip):
     '''Helper method to make an async request uploading the post-import
     files to the remote compute cluster.
     '''
 
-    async with aiohttp.ClientSession() as session:
-        # Set the request URL.
-        remote_run_url = get_base_url(chip) + '/import/'
+    # Set the request URL.
+    remote_run_url = get_base_url(chip) + '/import/'
 
-        # Set common parameters.
-        post_params = {
-            'job_hash': chip.get('remote', 'jobhash'),
-            'job_name': chip.get('jobname'),
-        }
+    # Set common parameters.
+    post_params = {
+        'job_hash': chip.get('remote', 'jobhash'),
+        'job_name': chip.get('jobname'),
+    }
 
-        # Set authentication parameters and encrypt data if necessary.
-        if (('user' in chip.getkeys('remote') and chip.get('remote', 'user')) and \
-            ('key' in chip.getkeys('remote') and chip.get('remote', 'key'))):
-            # Encrypt the .zip archive with the user's public key.
-            # Asymmetric key cryptography is good at signing values, but bad at
-            # encrypting bulk data. One common approach is to generate a random
-            # symmetric encryption key, which can be encrypted using the asymmetric
-            # keys. Then the data itself can be encrypted with the symmetric cipher.
-            # We'll use AES-256-CTR, because the Python 'cryptography' module's
-            # recommended 'Fernet' algorithm only works on files that fit in memory.
+    # Set authentication parameters and encrypt data if necessary.
+    # TODO-review: Should an error be thrown if only 'user' or 'key' is present?
+    if (('user' in chip.getkeys('remote') and chip.get('remote', 'user')) and \
+        ('key' in chip.getkeys('remote') and chip.get('remote', 'key'))):
+        # Encrypt the .zip archive with the user's public key.
+        # Asymmetric key cryptography is good at signing values, but bad at
+        # encrypting bulk data. One common approach is to generate a random
+        # symmetric encryption key, which can be encrypted using the asymmetric
+        # keys. Then the data itself can be encrypted with the symmetric cipher.
+        # We'll use AES-256-CTR, because the Python 'cryptography' module's
+        # recommended 'Fernet' algorithm only works on files that fit in memory.
 
-            # Generate AES key and iv nonce.
-            aes_key = os.urandom(32)
-            aes_iv  = os.urandom(16)
+        # Generate AES key and iv nonce.
+        aes_key = os.urandom(32)
+        aes_iv  = os.urandom(16)
 
-            # Read in the user's public key.
-            # TODO: This assumes a common OpenSSL convention of using similar file
-            # paths for private and public keys: /path/to/key and /path/to/key.pub
-            # If the user has the account's private key, it is assumed that they
-            # will also have the matching public key in the same locale.
-            with open('%s.pub'%os.path.abspath(chip.get('remote', 'key')), 'r') as f:
-                encrypt_key = serialization.load_ssh_public_key(
-                    f.read().encode(),
-                    backend=default_backend())
-            # Encrypt the AES key using the user's public key.
-            # (The IV nonce can be stored in plaintext)
-            aes_key_enc = encrypt_key.encrypt(
-                aes_key,
-                padding.OAEP(
-                    mgf=padding.MGF1(algorithm=hashes.SHA512()),
-                    algorithm=hashes.SHA512(),
-                    label=None,
-                ))
+        # Read in the user's public key.
+        # TODO: This assumes a common OpenSSL convention of using similar file
+        # paths for private and public keys: /path/to/key and /path/to/key.pub
+        # If the user has the account's private key, it is assumed that they
+        # will also have the matching public key in the same locale.
+        with open('%s.pub'%os.path.abspath(chip.get('remote', 'key')), 'r') as f:
+            encrypt_key = serialization.load_ssh_public_key(
+                f.read().encode(),
+                backend=default_backend())
+        # Encrypt the AES key using the user's public key.
+        # (The IV nonce can be stored in plaintext)
+        aes_key_enc = encrypt_key.encrypt(
+            aes_key,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA512()),
+                algorithm=hashes.SHA512(),
+                label=None,
+            ))
 
-            # Create the AES cipher.
-            cipher = Cipher(algorithms.AES(aes_key), modes.CTR(aes_iv))
-            encryptor = cipher.encryptor()
+        # Create the AES cipher.
+        cipher = Cipher(algorithms.AES(aes_key), modes.CTR(aes_iv))
+        encryptor = cipher.encryptor()
 
-            # Open both 'import.zip' and 'import.crypt' files.
-            # We're using a stream cipher to support large files which may not fit
-            # in memory, so we'll read and write data one 'chunk' at a time.
-            local_build_dir = stepdir = '/'.join([chip.get('dir'),
-                                                  chip.get('design'),
-                                                  f"{chip.get('jobname')}0",
-                                                  'import0'])
-            with open(local_build_dir + '/import.crypt', 'wb') as wf:
-                with open(local_build_dir + '/import.zip', 'rb') as rf:
-                    while True:
-                        chunk = rf.read(1024)
-                        if not chunk:
-                            break
-                        wf.write(encryptor.update(chunk))
-                # Write out any remaining data; CTR mode does not require padding.
-                wf.write(encryptor.finalize())
+        # Open both 'import.zip' and 'import.crypt' files.
+        # We're using a stream cipher to support large files which may not fit
+        # in memory, so we'll read and write data one 'chunk' at a time.
+        local_build_dir = stepdir = '/'.join([chip.get('dir'),
+                                              chip.get('design'),
+                                              f"{chip.get('jobname')}0",
+                                              'import0'])
+        with open(local_build_dir + '/import.crypt', 'wb') as wf:
+            with open(local_build_dir + '/import.zip', 'rb') as rf:
+                while True:
+                    chunk = rf.read(1024)
+                    if not chunk:
+                        break
+                    wf.write(encryptor.update(chunk))
+            # Write out any remaining data; CTR mode does not require padding.
+            wf.write(encryptor.finalize())
 
-            # Set up encryption and authentication parameters in the request body.
-            with open(os.path.abspath(chip.get('remote', 'key')), 'rb') as f:
-                key = f.read()
-            b64_key = base64.urlsafe_b64encode(key).decode()
-            post_params['username'] = chip.get('remote', 'user')
-            post_params['key'] = b64_key
-            post_params['aes_key'] = base64.urlsafe_b64encode(aes_key_enc).decode()
-            post_params['aes_iv'] = base64.urlsafe_b64encode(aes_iv).decode()
+        # Set up encryption and authentication parameters in the request body.
+        with open(os.path.abspath(chip.get('remote', 'key')), 'rb') as f:
+            key = f.read()
+        b64_key = base64.urlsafe_b64encode(key).decode()
+        post_params['username'] = chip.get('remote', 'user')
+        post_params['key'] = b64_key
+        post_params['aes_key'] = base64.urlsafe_b64encode(aes_key_enc).decode()
+        post_params['aes_iv'] = base64.urlsafe_b64encode(aes_iv).decode()
 
-            # Set up 'temporary cloud host' parameters.
-            num_temp_hosts = int(chip.get('remote', 'hosts'))
-            if num_temp_hosts > 0:
-                post_params['new_hosts'] = num_temp_hosts
-                if len(chip.get('remote', 'ram')) > 0:
-                    post_params['new_host_ram'] = int(chip.get('remote', 'ram'))
-                if len(chip.get('remote', 'threads')) > 0:
-                    post_params['new_host_threads'] = int(chip.get('remote', 'threads'))
+        # Set up 'temporary cloud host' parameters.
+        num_temp_hosts = int(chip.get('remote', 'hosts'))
+        if num_temp_hosts > 0:
+            post_params['new_hosts'] = num_temp_hosts
+            if len(chip.get('remote', 'ram')) > 0:
+                post_params['new_host_ram'] = int(chip.get('remote', 'ram'))
+            if len(chip.get('remote', 'threads')) > 0:
+                post_params['new_host_threads'] = int(chip.get('remote', 'threads'))
 
-            # Upload the encrypted file.
-            upload_file = os.path.abspath(local_build_dir + '/import.crypt')
+        # Upload the encrypted file.
+        upload_file = os.path.abspath(local_build_dir + '/import.crypt')
 
-        else:
-            # No authorizaion configured; upload the unencrypted archive.
-            import_loc = '/'.join([chip.get('dir'),
-                                   chip.get('design'),
-                                   f"{chip.get('jobname')}0",
-                                   'import0',
-                                   'import.zip'])
-            upload_file = os.path.abspath(import_loc)
+    # (If '-remote_user' and '-remote_key' are not both specified:)
+    else:
+        # No authorizaion configured; upload the unencrypted archive.
+        import_loc = '/'.join([chip.get('dir'),
+                               chip.get('design'),
+                               f"{chip.get('jobname')}0",
+                               'import0',
+                               'import.zip'])
+        upload_file = os.path.abspath(import_loc)
 
-        # Make the 'import' API call and print the response.
-        redirect_url = remote_run_url
-        while redirect_url:
-            with open(upload_file, 'rb') as f:
-                async with session.post(redirect_url,
-                                        data={'import': f,
-                                              'params': json.dumps(post_params)},
-                                        allow_redirects=False) as resp:
-                    if resp.status == 302:
-                        redirect_url = resp.headers['Location']
-                    elif resp.status >= 400:
-                        chip.logger.info(await resp.text())
-                        chip.logger.error('Error importing project data; quitting.')
-                        sys.exit(1)
-                    else:
-                        chip.logger.info(await resp.text())
-                        return
+    # Make the 'import' API call and print the response.
+    redirect_url = remote_run_url
+    while redirect_url:
+        with open(upload_file, 'rb') as f:
+            resp = requests.post(redirect_url,
+                                 files={'import': f,
+                                        'params': json.dumps(post_params)},
+                                 allow_redirects=False)
+            if resp.status_code == 302:
+                redirect_url = resp.headers['Location']
+            elif resp.status_code >= 400:
+                chip.logger.info(resp.text)
+                chip.logger.error('Error importing project data; quitting.')
+                sys.exit(1)
+            else:
+                chip.logger.info(resp.text)
+                return
 
 ###################################
-async def fetch_results_request(chip):
+def fetch_results_request(chip):
     '''Helper method to fetch job results from a remote compute cluster.
     '''
 
-    async with aiohttp.ClientSession() as session:
-        # Set the request URL.
-        job_hash = chip.get('remote', 'jobhash')
-        remote_run_url = get_base_url(chip) + '/get_results/' + job_hash + '.zip'
+    # Set the request URL.
+    job_hash = chip.get('remote', 'jobhash')
+    remote_run_url = get_base_url(chip) + '/get_results/' + job_hash + '.zip'
 
+    # Set authentication parameters if necessary.
+    if (('user' in chip.getkeys('remote') and chip.get('remote', 'user')) and \
+        ('key' in chip.getkeys('remote') and chip.get('remote', 'key'))):
+        with open(os.path.abspath(chip.get('remote', 'key')), 'rb') as f:
+            key = f.read()
+        b64_key = base64.urlsafe_b64encode(key).decode()
+        post_params = {
+            'username': chip.get('remote', 'user'),
+            'key': b64_key,
+        }
+    else:
+        post_params = {}
 
-        # Set authentication parameters if necessary.
-        if (('user' in chip.getkeys('remote') and chip.get('remote', 'user')) and \
-            ('key' in chip.getkeys('remote') and chip.get('remote', 'key'))):
-            with open(os.path.abspath(chip.get('remote', 'key')), 'rb') as f:
-                key = f.read()
-            b64_key = base64.urlsafe_b64encode(key).decode()
-            post_params = {
-                'username': chip.get('remote', 'user'),
-                'key': b64_key,
-            }
-        else:
-            post_params = {}
-
-        # Make the web request, and stream the results archive in chunks.
-        redirect_url = remote_run_url
-        can_redirect = False
-        while redirect_url:
-            with open('%s.zip'%job_hash, 'wb') as zipf:
-                async with session.post(redirect_url,
-                                        json=post_params,
-                                        allow_redirects=can_redirect) as resp:
-                    if resp.status == 302:
-                        redirect_url = resp.headers['Location']
-                    elif resp.status == 303:
-                        redirect_url = resp.headers['Location']
-                        can_redirect = True
-                    else:
-                        while True:
-                            chunk = await resp.content.read(1024)
-                            if not chunk:
-                                break
-                            zipf.write(chunk)
-                        return
+    # Make the web request, and stream the results archive in chunks.
+    redirect_url = remote_run_url
+    can_redirect = False
+    while redirect_url:
+        with open('%s.zip'%job_hash, 'wb') as zipf:
+            resp = requests.post(redirect_url,
+                                 data=json.dumps(post_params),
+                                 allow_redirects=can_redirect,
+                                 stream=True)
+            if resp.status_code == 302:
+                redirect_url = resp.headers['Location']
+            elif resp.status_code == 303:
+                redirect_url = resp.headers['Location']
+                can_redirect = True
+            else:
+                shutil.copyfileobj(resp.raw, zipf)
+                return
 
 ###################################
 def fetch_results(chip):
@@ -503,9 +492,7 @@ def fetch_results(chip):
     '''
 
     # Fetch the remote archive after the export stage.
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(fetch_results_request(chip))
+    fetch_results_request(chip)
 
     # Unzip the results.
     top_design = chip.get('design')
@@ -515,7 +502,7 @@ def fetch_results(chip):
     os.remove('%s.zip'%job_hash)
 
     # Call 'delete_job' to remove the run from the server.
-    loop.run_until_complete(delete_job(chip))
+    delete_job(chip)
 
     # For encrypted jobs each permutation's result is encrypted in its own archive.
     # For unencrypted jobs, results are simply stored in the archive.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1916,8 +1916,8 @@ class Chip:
             # run remote process
             remote_preprocess(self)
 
-            # Run the async 'remote_run' method.
-            asyncio.get_event_loop().run_until_complete(remote_run(self))
+            # Run the job on the remote server, and wait for it to finish.
+            remote_run(self)
 
             # Fetch results (and delete the job's data from the server).
             fetch_results(self)

--- a/siliconcompiler/server.py
+++ b/siliconcompiler/server.py
@@ -395,7 +395,8 @@ class Server:
                             to_dir)
 
             # Run the generated command.
-            subprocess.run(run_cmd, shell = True)
+            proc = await asyncio.create_subprocess_shell(run_cmd)
+            await proc.wait()
 
             # Ensure that the private key file was deleted.
             # (The whole directory should already be gone,


### PR DESCRIPTION
You can see that these two HTTP libraries share a very similar API. The asynchronous `aiohttp` framework is certainly more efficient if many parallel network requests need to be made, but as we discussed today, our client-side API calls are mostly synchronous and infrequent.

Using the `requests` library lets us drop a level of indentation, and avoid the potentially-confusing `async` / `await` keywords. The parallel parts of the workflow are run on the server(s) after the client calls the `remote_run/` endpoint, so we shouldn't see a major performance impact.