### PR TITLE
Implement the 'remote_steplist' parameter.

### DIFF
--- a/siliconcompiler/flows/asicflow.py
+++ b/siliconcompiler/flows/asicflow.py
@@ -59,6 +59,8 @@ def setup_flow(chip, process):
                 # TODO: sta is currently broken, don't include in flow
                 # 'sta'
                 ]
+    # Set the steplist which can run remotely (if required)
+    chip.set('remote', 'steplist', flowpipe[1:])
 
     # TODO: implement these steps for processes other than Skywater
     verification_steps = [ 'lvs', 'drc']

--- a/siliconcompiler/flows/fpgaflow.py
+++ b/siliconcompiler/flows/fpgaflow.py
@@ -42,6 +42,8 @@ def setup_flow(chip, partname):
                 'syn',
                 'apr',
                 'bitstream']
+    # Set the steplist which can run remotely (if required)
+    chip.set('remote', 'steplist', flowpipe[1:])
 
     #TODO: add 'program' stage
 

--- a/siliconcompiler/server.py
+++ b/siliconcompiler/server.py
@@ -355,7 +355,7 @@ class Server:
 
         # Rename source files in the config dict; the 'import' step already
         # ran and collected the sources into a single Verilog file.
-        chip.set('source', f"${build_dir}/{top_module}/{job_nameid}/import0/outputs/{top_module}.v", clobber=True)
+        chip.set('source', f"{build_dir}/{top_module}/{job_nameid}/import0/outputs/{top_module}.v", clobber=True)
 
         run_cmd = ''
         if self.cfg['cluster']['value'][-1] == 'slurm':


### PR DESCRIPTION
The `-remote_steplist` parameter was already present in the schema, so I implemented it like we talked about yesterday. Each `setup_flow` method sets the parameter based on their individual flow graphs, and it is ignored on local runs.

Also, should I set `clobber` to `False` in the `chip.set('remote', 'steplist', ...)` calls?