### PR TITLE
Prepare encryption logic for use with slurm

### DIFF
--- a/siliconcompiler/crypto.py
+++ b/siliconcompiler/crypto.py
@@ -1,0 +1,137 @@
+# Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives import hashes, serialization
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+
+def encrypt_job(job_dir, job_nameid, design, pk_file):
+    # Create cipher for decryption.
+    with open(pk_file, 'r') as keyin:
+        dk = keyin.read().encode()
+    decrypt_key = serialization.load_ssh_private_key(dk, None, backend=default_backend())
+
+    # Decrypt the block cipher key.
+    with open(f'{job_dir}/import.bin', 'rb') as f:
+        aes_key = decrypt_key.decrypt(
+            f.read(),
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA512()),
+                algorithm=hashes.SHA512(),
+                label=None,
+            ))
+
+    # Zip the new job results.
+    subprocess.run(['zip',
+                    '-r',
+                    f'{job_nameid}.zip',
+                    '.'],
+                   cwd=f'{job_dir}/{design}/{job_nameid}')
+
+    # Create a new initialization vector and write it to a file for future decryption.
+    # The iv does not need to be secret, but using the same iv and key to encrypt
+    # different data can provide an attack surface to potentially decrypt some data.
+    aes_iv  = os.urandom(16)
+    with open(f'{job_dir}/{job_nameid}.iv', 'wb') as f:
+        f.write(aes_iv)
+
+    # Encrypt the new zip file.
+    cipher = Cipher(algorithms.AES(aes_key), modes.CTR(aes_iv))
+    encryptor = cipher.encryptor()
+    with open(f'{job_dir}/{job_nameid}.crypt', 'wb') as wf:
+        with open(f'{job_dir}/{design}/{job_nameid}/{job_nameid}.zip', 'rb') as rf:
+            while True:
+                chunk = rf.read(1024)
+                if not chunk:
+                    break
+                wf.write(encryptor.update(chunk))
+        # Write out any remaining data; CTR mode does not require padding.
+        wf.write(encryptor.finalize())
+
+    # Delete decrypted data.
+    shutil.rmtree(f'{job_dir}/{design}/{job_nameid}')
+    if os.path.isfile(f'{job_dir}/{job_nameid}.zip'):
+        os.remove(f'{job_dir}/{job_nameid}.zip')
+
+def decrypt_job(job_dir, job_nameid, design, pk_file):
+    # Create cipher for decryption.
+    with open(pk_file, 'r') as keyin:
+        dk = keyin.read().encode()
+    decrypt_key = serialization.load_ssh_private_key(dk, None, backend=default_backend())
+
+    # Decrypt the block cipher key.
+    with open(f'{job_dir}/import.bin', 'rb') as f:
+        aes_key = decrypt_key.decrypt(
+            f.read(),
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA512()),
+                algorithm=hashes.SHA512(),
+                label=None,
+            ))
+
+    # Read in the iv nonce.
+    with open(f'{job_dir}/{job_nameid}.iv', 'rb') as f:
+        aes_iv = f.read()
+
+    # Decrypt .crypt file using the decrypted block cipher key.
+    job_crypt = f'{job_dir}/{job_nameid}.crypt'
+    cipher = Cipher(algorithms.AES(aes_key), modes.CTR(aes_iv))
+    decryptor = cipher.decryptor()
+    # Same approach as encrypting: open both files, read/decrypt/write individual chunks.
+    with open(f'{job_dir}/{job_nameid}.zip', 'wb') as wf:
+        with open(job_crypt, 'rb') as rf:
+            while True:
+                chunk = rf.read(1024)
+                if not chunk:
+                    break
+                wf.write(decryptor.update(chunk))
+        wf.write(decryptor.finalize())
+
+    # Unzip the decrypted file to prepare for running the job (if necessary).
+    subprocess.run(['mkdir',
+                    '-p',
+                    f'{job_dir}/{design}/{job_nameid}'])
+    subprocess.run(['unzip',
+                    '-o',
+                    os.path.abspath(f'{job_dir}/{job_nameid}.zip')],
+                   cwd=f'{job_dir}/{design}/{job_nameid}')
+
+# Provide a way to encrypt/decrypt from the command line. (With the correct key)
+# This is mostly intended to make it easier to run individual job steps in an
+# HPC cluster when the data needs to be encrypted 'at rest'. It should not be
+# necessary to run these steps manually in a normal workflow.
+if __name__ == "__main__":
+    #Argument Parser
+    parser = argparse.ArgumentParser(prog='sc-crypt',
+                                     formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=50),
+                                     prefix_chars='-+',
+                                     description="Silicon Compiler Collection Encrypt / Decrypt Utility")
+
+    # Command-line options (all required):
+    parser.add_argument('-mode', required=True)
+    parser.add_argument('-job_dir', required=True)
+    parser.add_argument('-job_nameid', required=True)
+    parser.add_argument('-design', required=True)
+    parser.add_argument('-key_file', required=True)
+
+    # Parse arguments.
+    cmdargs = vars(parser.parse_args())
+
+    # Check for invalid parameters.
+    if (not cmdargs['mode'] in ['encrypt', 'decrypt']) or \
+       (not os.path.isdir(cmdargs['job_dir'])) or \
+       (not os.path.isfile(cmdargs['key_file'])):
+        print('Error: Invalid command-line parameters.', file=sys.stderr)
+        sys.exit(1)
+
+    # Perform the encryption or decryption.
+    if cmdargs['mode'] == 'encrypt':
+        encrypt_job(cmdargs['job_dir'], cmdargs['job_nameid'], cmdargs['design'], cmdargs['key_file'])
+    elif cmdargs['mode'] == 'decrypt':
+        decrypt_job(cmdargs['job_dir'], cmdargs['job_nameid'], cmdargs['design'], cmdargs['key_file'])

--- a/tests/quick_tests/python/test_crypto.py
+++ b/tests/quick_tests/python/test_crypto.py
@@ -1,0 +1,57 @@
+# Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
+
+import os
+
+from siliconcompiler import Chip
+from siliconcompiler.client import *
+from siliconcompiler.crypto import *
+
+if __name__ != "__main__":
+    from tests.fixtures import test_wrapper
+
+def test_crypto():
+    mydir = os.path.dirname(os.path.abspath(__file__))
+    sc_root = f'{mydir}/../../..'
+    crypto_key = f'{sc_root}/tests/insecure_ci_keypair'
+
+    # Create a directory structure representing a job run.
+    os.mkdir('build')
+    os.mkdir('build/test')
+    os.mkdir('build/test/job0')
+    os.mkdir('build/test/job0/import0')
+    os.mkdir('build/test/job0/syn0')
+    test_msg = 'This file will be encrypted.'
+    with open('build/test/job0/import0/test_file', 'w') as f:
+        f.write(test_msg)
+
+    # Create and encrypt AES cipher key for the encryption logic.
+    aes_key = os.urandom(32)
+    # Use the test public key to encrypt the cipher key.
+    with open(f'{crypto_key}.pub', 'r') as f:
+        encrypt_key = serialization.load_ssh_public_key(
+            f.read().encode(),
+            backend=default_backend())
+    aes_key_enc = encrypt_key.encrypt(
+        aes_key,
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA512()),
+            algorithm=hashes.SHA512(),
+            label=None,
+        ))
+    # Write the encrypted key where the sc client would put it.
+    with open('build/import.bin', 'wb') as f:
+        f.write(aes_key_enc)
+
+    # Encrypt the example data, and ensure that it is no longer on disk.
+    encrypt_job('build', 'job0', 'test', crypto_key)
+    assert not os.path.isfile('build/test/job0/import0/test_file')
+    assert not os.path.isdir('build/gcd/job0/import0')
+
+    # Ensure that the example data can be decrypted successfully.
+    decrypt_job('build', 'job0', 'test', crypto_key)
+    assert os.path.isfile('build/test/job0/import0/test_file')
+    with open('build/test/job0/import0/test_file', 'r') as f:
+        assert test_msg == f.read()
+
+if __name__ == "__main__":
+    test_crypto()


### PR DESCRIPTION
I've been thinking about how we can make a server-side `Chip.run()` call use `srun` for its executable steps. It won't be quite as simple as prepending `srun` to the shell command, because we'll also need to decrypt and re-encrypt the data on the compute node.

Slurm commands are essentially shell scripts, so we can pass in a few extra commands surrounding the step's main command-line executable. This change moves the bulk of the encryption and decryption logic into a `crypto.py` file which can be run on its own. That should let us pass something like this to `srun`:

    python siliconcompiler/crypto.py -mode decrypt -design gcd -job_dir build -job_nameid job0 -key_file key ;
    yosys [...] ;
    python siliconcompiler/crypto.py -mode encrypt -design gcd -job_dir build -job_nameid job0 -key_file key ;

There's also a CI test for the encrypt / decrypt logic - isolating these functions made it easier to write a unit test.