### PR TITLE
Add back guide param to detailed routing

### DIFF
--- a/siliconcompiler/tools/openroad/sc_route.tcl
+++ b/siliconcompiler/tools/openroad/sc_route.tcl
@@ -55,7 +55,9 @@ check_antennas -report_file "reports/${sc_design}_antenna.rpt"
 
 set_thread_count $sc_threads
 
-detailed_route -output_drc "reports/${sc_design}_drc.rpt" \
+# Detailed routing must include -guide parameter!
+detailed_route -guide "route.guide" \
+               -output_drc "reports/${sc_design}_drc.rpt" \
                -output_maze "reports/${sc_design}_maze.log" \
                -output_guide "reports/${sc_design}_guide.mode" \
                -verbose 1


### PR DESCRIPTION
Getting rid of the guide param breaks routing with Skywater130 -- we need to make sure we keep passing this param in: https://gitter.im/The-OpenROAD-Project/community?at=610b9b93949a3d73861d6bf8