### PR TITLE
Remove fpga tests section from daily_tests.yml

### DIFF
--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -18,16 +18,3 @@ jobs:
           echo $VIRTUAL_ENV
           pip3 install -r $GITHUB_WORKSPACE/requirements.txt -e $GITHUB_WORKSPACE/.
           pytest -n 4 $GITHUB_WORKSPACE/tests/daily_tests/asic/
-  fpga_tests_job:
-    timeout-minutes: 10
-    runs-on: self-hosted
-    name: 'FPGA test builds'
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          python3 -m venv create $GITHUB_WORKSPACE/clean_env --clear
-          source $GITHUB_WORKSPACE/clean_env/bin/activate
-          echo $VIRTUAL_ENV
-          pip3 install -r $GITHUB_WORKSPACE/requirements.txt -e $GITHUB_WORKSPACE/.
-          PATH="$HOME/OpenFPGA/openfpga:$PATH"
-          pytest -n 4 $GITHUB_WORKSPACE/tests/daily_tests/fpga/


### PR DESCRIPTION
Apparently this is the only reason our daily CI test are still failing -- pytest returns a nonzero exit code when it can't find any tests, and we don't have daily FPGA tests anymore!