### PR TITLE
Update `Chip.set` to support a 'field' kwarg, and start using the 'lock' schema bit to guard `setup_tool` calls.

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -591,7 +591,7 @@ class Chip:
         return keys
 
     ###########################################################################
-    def set(self, *args, cfg=None, clobber=True):
+    def set(self, *args, cfg=None, clobber=True, field='value'):
         '''
         Sets a Chip dictionary value based on key-sequence and data provided.
 
@@ -633,7 +633,7 @@ class Chip:
         all_args = list(args)
 
         self.logger.debug(f"Setting [{keypath}] to {args[-1]}")
-        return self._search(cfg, keypath, *all_args, field='value', mode='set', clobber=clobber)
+        return self._search(cfg, keypath, *all_args, field=field, mode='set', clobber=clobber)
 
     ###########################################################################
     def add(self, *args, cfg=None):

--- a/siliconcompiler/tools/openroad/openroad_setup.py
+++ b/siliconcompiler/tools/openroad/openroad_setup.py
@@ -53,6 +53,12 @@ def setup_tool(chip, step, index, mode='batch'):
     tool = 'openroad'
     refdir = 'siliconcompiler/tools/openroad'
 
+    # If the 'lock' bit is set, don't reconfigure.
+    configured = chip.get('eda', tool, step, index, 'exe', field='lock')
+    if configured and (configured != 'false'):
+        chip.logger.warning('Tool already configured: ' + tool)
+        return
+
     if mode == 'show':
         clobber = True
         script = '/sc_display.tcl'
@@ -126,6 +132,9 @@ def setup_tool(chip, step, index, mode='batch'):
             chip.logger.error('Missing option %s for OpenROAD.', option)
         else:
             chip.set('eda', tool, step, index, 'option', option, default_options[option], clobber=clobber)
+
+    # Set the 'lock' bit for this tool.
+    chip.set('eda', tool, step, index, 'exe', 'true', field='lock')
 
 
 ################################

--- a/siliconcompiler/tools/verilator/verilator_setup.py
+++ b/siliconcompiler/tools/verilator/verilator_setup.py
@@ -16,8 +16,14 @@ def setup_tool(chip, step, index):
     the dictionary settings.
     '''
 
-    # Standard Setup
+    # If the 'lock' bit is set, don't reconfigure.
     tool = 'verilator'
+    configured = chip.get('eda', tool, step, index, 'exe', field='lock')
+    if configured and (configured != 'false'):
+        chip.logger.warning('Tool already configured: ' + tool)
+        return
+
+    # Standard Setup
     chip.set('eda', tool, step, index, 'exe', 'verilator', clobber=False)
     chip.set('eda', tool, step, index, 'vswitch', '--version', clobber=False)
     chip.set('eda', tool, step, index, 'version', '4.211', clobber=False)
@@ -56,6 +62,9 @@ def setup_tool(chip, step, index):
     #Make warnings non-fatal in relaxed mode
     if chip.get('relax'):
         chip.add('eda', tool, step, index, 'option', 'cmdline', '-Wno-fatal')
+
+    # Set the 'lock' bit for this tool.
+    chip.set('eda', tool, step, index, 'exe', 'true', field='lock')
 
 ################################
 # Post_process (post executable)

--- a/siliconcompiler/tools/yosys/yosys_setup.py
+++ b/siliconcompiler/tools/yosys/yosys_setup.py
@@ -14,8 +14,15 @@ def setup_tool(chip, step, index):
     ''' Tool specific function to run before step execution
     '''
 
+    # If the 'lock' bit is set, don't reconfigure.
     tool = 'yosys'
     refdir = 'siliconcompiler/tools/yosys'
+    configured = chip.get('eda', tool, step, index, 'exe', field='lock')
+    if configured and (configured != 'false'):
+        chip.logger.warning('Tool already configured: ' + tool)
+        return
+
+    # Standard Setup
     chip.set('eda', tool, step, index, 'copy', 'true', clobber=False)
     chip.set('eda', tool, step, index, 'vendor', 'yosys', clobber=False)
     chip.set('eda', tool, step, index, 'exe', 'yosys', clobber=False)


### PR DESCRIPTION
Like we talked about today, this change uses the schema's `lock` bits to guard the `setup_tool()` methods. The `get` and `set` methods only work nicely with leaf nodes, so I used the `exe` parameter as a consistent field to lock.

It also slightly tweaks the `Chip.set` call to support a 'field' keyword argument similar to `Chip.get`, so that we can lock a field by calling `Chip.set([parameter...], 'true', field='lock')`