### PR TITLE
Fix bug in diearea inference

### DIFF
--- a/siliconcompiler/tools/openroad/sc_floorplan.tcl
+++ b/siliconcompiler/tools/openroad/sc_floorplan.tcl
@@ -50,8 +50,8 @@ if {[llength $sc_def] > 0} {
     #########################
     #Init Floorplan
     #########################
-    if {[dict exists $sc_cfg asic diearea] &&
-        [dict exists $sc_cfg asic corearea]} {
+    if {[llength [dict get $sc_cfg asic diearea]] > 0 &&
+        [llength [dict get $sc_cfg asic corearea]] > 0} {
 	#NOTE: assuming a two tuple value as lower left, upper right
         set sc_diearea   [dict get $sc_cfg asic diearea]
         set sc_corearea  [dict get $sc_cfg asic corearea]


### PR DESCRIPTION
This was introduced by my change keeping empty TCL lists around. We now can't check the existence of the list to see if we can infer the die area, but rather need to check that these lists have contents.

Daily tests were so close to passing today, this was the only issue! Hopefully they'll go green tomorrow :) 