### PR TITLE
Remove extraneous remote check from the _runstep method.

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1724,7 +1724,7 @@ class Chip:
 
         # Directory manipulation
         cwd = os.getcwd()
-        if os.path.isdir(stepdir) and (not self.get('remote', 'addr')):
+        if os.path.isdir(stepdir):
             shutil.rmtree(stepdir)
         os.makedirs(stepdir, exist_ok=True)
         os.chdir(stepdir)


### PR DESCRIPTION
Andreas pointed out that we have a check for the `-remote_addr` parameter which is probably extraneous at this point.

In some earlier versions of the remote workflow, we had special logic to prevent results or early import files from being deleted. This may have been copied from that logic, but with the current `_runstep()` logic, I can't see a reason to avoid refreshing the step directories before a step runs if the remote flags are set.