### PR TITLE
Add scikit-build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,9 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "pybind11>=2.7.1",
     "cython",
     "scikit-build>=0.12",
+    "cmake"
 ]
 
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,10 @@ pandas >= 1.2.3
 Jinja2 >= 2.11.3
 Sphinx >= 3.5.4
 cryptography >= 3.4.7
-scikit-build >= 0.12
 sphinx-rtd-theme >= 0.5.2
 graphviz >=0.17
+
+# Build dependencies
+scikit-build >= 0.12
+cython
+cmake

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,26 @@
 #!/usr/bin/env python3
 
-from skbuild import setup
+import os
+import sys
+
+try:
+    from skbuild import setup
+except ImportError:
+    print(
+        "Error finding build dependencies!\n"
+        "If you're installing this project using pip, make sure you're using pip version 10 or greater.\n"
+        "If you're installing this project by running setup.py, manually install all dependencies listed in requirements.txt.",
+        file=sys.stderr,
+    )
+    raise
 
 with open("README.md", "r", encoding="utf-8") as readme:
   long_desc = readme.read()
+
+if not os.path.isdir('third_party/tools/openroad/tools/OpenROAD/src/OpenDB/src/lef'):
+    print('Source for LEF parser library not found! Install OpenROAD submodule before continuing with install:\n'
+          'git submodule update --init --recursive third_party/tools/openroad')
+    sys.exit(1)
 
 setup(
     name="siliconcompiler",


### PR DESCRIPTION
This appears to be part of fixing the `setup.py` script, but it looks like the user will also have to perform some manual steps which I'm still figuring out.