### PR TITLE
Adding ability to feed arguments to tech and flow targets

### DIFF
--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2628,6 +2628,40 @@ def schema_options(cfg):
         """
     }
 
+    cfg['techarg'] = {}
+    cfg['techarg']['default'] = {
+        'switch': "-techarg 'arg <str>",
+        'type': 'str',
+        'lock': 'false',
+        'requirement': None,
+        'defvalue': None,
+        'short_help': 'Target technology setup parameter',
+        'example': ["cli: -techarg 'mimcap true",
+                    "api: chip.set('techarg','mimcap', 'true')"],
+        'help': """
+        Parameter passed in as key/value pair to the technology target
+        referenced in the target() API call. See the target technolgy
+        for specific guidelines regarding configuration parameters.
+        """
+    }
+
+    cfg['flowarg'] = {}
+    cfg['flowarg']['default'] = {
+        'switch': "-flowarg 'arg <str>",
+        'type': 'str',
+        'lock': 'false',
+        'requirement': None,
+        'defvalue': None,
+        'short_help': 'Target flow setup parameter',
+        'example': ["cli: -flowarg 'n 100",
+                    "api: chip.set('flowarg','n', '100')"],
+        'help': """
+        Parameter passed in as key/value pair to the technology target
+        referenced in the target() API call. See the target flow
+        for specific guidelines regarding configuration parameters.
+        """
+    }
+
     cfg['cfg'] = {
         'switch': "-cfg <file>",
         'type': '[file]',


### PR DESCRIPTION
 - This fixes a fundemental flaw in the approach so far. Targets have so far been fixed, but this is causing problems, because everything needs to be configurabla/programmable to be generally useful.
 - This bubbled up from the flows, b/c the user will want the ability to easily parallelize steps without having to get into creating a graph. This is easy to do by feeding in parameters to the execution graph generation, much harder and clumsier to do as a post creation step.
 - We want the tech and flow targets to be as free to operate as practical and the way to do this is to pass in an arbitrary set of key / value pair through the schema.
 - Adding these two entries lets us do that!