### PR TITLE
Add buffer insertion to synth script

### DIFF
--- a/siliconcompiler/foundries/freepdk45.py
+++ b/siliconcompiler/foundries/freepdk45.py
@@ -163,6 +163,8 @@ def setup_pdk(chip):
     chip.add('library',libname,'cells','tie', ["LOGIC1_X1/Z",
                                                "LOGIC0_X1/Z"])
 
+    # buffer cell
+    chip.add('library', libname, 'cells', 'buf', ['BUF_X1/A/Z'])
 
     # hold cells
     chip.add('library',libname,'cells','hold', "BUF_X1")

--- a/siliconcompiler/foundries/skywater130.py
+++ b/siliconcompiler/foundries/skywater130.py
@@ -215,6 +215,9 @@ def setup_pdk(chip):
     #driver
     chip.add('library', libname, 'driver', '')
 
+    # buffer cell
+    chip.add('library', libname, 'cells', 'buf', ['sky130_fd_sc_hd__buf_4/A/X'])
+
     # tie cells
     chip.add('library', libname, 'cells', 'tie', ['sky130_fd_sc_hd__conb_1/HI',
                                                   'sky130_fd_sc_hd__conb_1/LO'])

--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -7,6 +7,7 @@ set sc_process     [dict get $sc_cfg pdk process]
 set sc_mainlib     [lindex [dict get $sc_cfg asic targetlib] 0]
 set sc_targetlibs  [dict get $sc_cfg asic targetlib]
 set sc_tie         [dict get $sc_cfg library $sc_mainlib cells tie]
+set sc_buf         [dict get $sc_cfg library $sc_mainlib cells buf]
 
 #TODO: fix to handle multiple libraries
 # (note that ABC and dfflibmap can only accept one library from Yosys, so
@@ -71,6 +72,11 @@ if {[llength $sc_tie] == 2} {
     set sc_tielo [split [lindex $sc_tie 1] /]
 
     yosys hilomap -hicell {*}$sc_tiehi -locell {*}$sc_tielo
+}
+
+if {[llength $sc_buf] == 1} {
+    set sc_buf_split [split $sc_buf /]
+    yosys insbuf -buf {*}$sc_buf_split
 }
 
 yosys splitnets


### PR DESCRIPTION
I just encountered an LVS failure in ZeroSoC that seemed to be related to missing this synthesis step -- Yosys left some assigns in the synthesis netlist, which then get dropped by OpenROAD after it processes the netlist and outputs another one. Adding this buffer insertion step (which is in the OpenROAD synth script) seems to fix the problem.

I did want to check about how these cells should be specified. For the tie cells we were able to specify the cell and port using `/` as the separator, which made sense since it seems to be a standard notation. In this case we need to specify 2 ports, so I used `cell/input/output` as placeholder for now, but I think that might be misusing the notation. Also, is `buf` an appropriate key for this cell? I noticed the PDK setup files all specify a 'hold' cell that seems to be a buffer, but I'm not sure if that's the same thing. 