### PR TITLE
Fix user-provided modules via SCPATH

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -81,6 +81,9 @@ class Chip:
         #Getting environment path (highest priority)
         scpaths = str(os.environ['SCPATH']).split(':')
 
+        #Add the root Path
+        scpaths.append(rootdir)
+
         # Add the path where the builtin tools, foundries, and flows live.
         # By adding this path directly to sys.path, we can search both builtin
         # and user provided modules more easily, since we don't have to prefix


### PR DESCRIPTION
I tried a different approach here that seems a little simpler than enforcing a sclib vs siliconcompiler naming scheme, but let me know what you think. It worked in my testing, but I'm still not 100% sure why making my own directory structure look like siliconcompiler/... did not work before while this does now. 

What's nice about this approach though is it seems like it should make the import behavior analogous to how it was before we restructured the directory. The user just needs to provide a `tools/`, `flows/`, etc. under the directory(ies) specified on the SCPATH.

Explanation from commit message:

Since we reorganized the directory structure to put our build in tools,
flows, etc. under siliconcompiler/siliconcompiler, we had to prefix the
dynamic import searchdirs with `siliconcompiler.`. However, this seemed
to break the ability for user's to provide their own dynamic modules for
tools, etc.

By adding `siliconcompiler/siliconcompiler/` to the sys.path, and
removing `siliconcompiler.` from the loadtool/pdk/flow routines, we go
back to the old behavior where we'll search both the SC builtins and
user provided directories.