### PR TITLE
Fix and clean up parallel clustered runs.

### DIFF
--- a/siliconcompiler/crypto.py
+++ b/siliconcompiler/crypto.py
@@ -6,6 +6,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives import hashes, serialization
 
 import argparse
+import json
 import os
 import shutil
 import subprocess
@@ -30,6 +31,49 @@ def gen_cipher_key(gen_dir, pubk_file):
 
     with open(f'{gen_dir}/import.bin', 'wb') as f:
         f.write(aes_key_enc)
+
+def write_encrypted_cfgfile(cfg, job_dir, pk_bytes, file_prefix):
+    # Helper method to write an encrypted config file to disk.
+    # Unlike most of these methods, this accepts the private key's bytes
+    # instead of a filename. It is intended to be used on a server with a shared
+    # disk, to help ensure that sensitive decrypted data is kept in RAM.
+
+    # Collect some basic values.
+    top_dir = os.path.abspath(f'{job_dir}/../..')
+
+    # Create cipher for decryption.
+    decrypt_key = serialization.load_ssh_private_key(pk_bytes, None, backend=default_backend())
+
+    # Decrypt the block cipher key.
+    with open(f'{job_dir}/import.bin', 'rb') as f:
+        aes_key = decrypt_key.decrypt(
+            f.read(),
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA512()),
+                algorithm=hashes.SHA512(),
+                label=None,
+            ))
+
+    # Create the 'configs/' directory to write into, if it doesn't exist already.
+    if not os.path.isdir(f'{job_dir}/configs'):
+        os.mkdir(f'{job_dir}/configs')
+
+    # Create a new initialization vector and write it to a file for future decryption.
+    # The iv does not need to be secret, but using the same iv and key to encrypt
+    # different data can provide an attack surface to potentially decrypt some data.
+    aes_iv  = os.urandom(16)
+    with open(f'{job_dir}/configs/{file_prefix}.iv', 'wb') as f:
+        f.write(aes_iv)
+
+    # Encrypt the JSON config and write it to disk under a 'configs/' directory.
+    cipher = Cipher(algorithms.AES(aes_key), modes.CTR(aes_iv))
+    encryptor = cipher.encryptor()
+    with open(f'{job_dir}/configs/{file_prefix}.crypt', 'wb') as wf:
+        # Write the config dictionary's JSON contents through the encryptor.
+        cfg_bytes = json.dumps(cfg, indent=4, sort_keys=True).encode()
+        wf.write(encryptor.update(cfg_bytes))
+        # Write out any remaining data; CTR mode does not require padding.
+        wf.write(encryptor.finalize())
 
 def encrypt_job(job_dir, pk_file):
     # Find a list of {step}{index} directories. Use 'next' to avoid recursion.
@@ -62,6 +106,7 @@ def encrypt_dir(enc_dir, pk_file):
     # Zip the step directory.
     subprocess.run(['zip',
                     '-r',
+                    '-q',
                     f'{stepname}.zip',
                     '.'],
                    cwd=enc_dir)
@@ -90,6 +135,45 @@ def encrypt_dir(enc_dir, pk_file):
     shutil.rmtree(f'{enc_dir}')
     if os.path.isfile(f'{job_dir}/{stepname}.zip'):
         os.remove(f'{job_dir}/{stepname}.zip')
+
+def decrypt_cfgfile(crypt_file, pk_file):
+    # Helper method to decrypt an encrypted Chip configuration file.
+    job_dir = os.path.dirname(crypt_file)
+    top_dir = os.path.abspath(f'{job_dir}/../..')
+    file_prefix = crypt_file.split('/')[-1].split('.crypt')[0]
+
+    # Create cipher for decryption.
+    with open(pk_file, 'r') as keyin:
+        dk = keyin.read().encode()
+    decrypt_key = serialization.load_ssh_private_key(dk, None, backend=default_backend())
+
+    # Decrypt the block cipher key, which should be one dir up from the cfg file.
+    with open(f'{job_dir}/../import.bin', 'rb') as f:
+        aes_key = decrypt_key.decrypt(
+            f.read(),
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA512()),
+                algorithm=hashes.SHA512(),
+                label=None,
+            ))
+
+    # Read in the iv nonce.
+    with open(f'{job_dir}/{file_prefix}.iv', 'rb') as f:
+        aes_iv = f.read()
+
+    # Decrypt .crypt file using the decrypted block cipher key.
+    job_crypt = f'{job_dir}/{file_prefix}.crypt'
+    cipher = Cipher(algorithms.AES(aes_key), modes.CTR(aes_iv))
+    decryptor = cipher.decryptor()
+    # Same approach as encrypting: open both files, read/decrypt/write individual chunks.
+    with open(f'{job_dir}/{file_prefix}.json', 'wb') as wf:
+        with open(job_crypt, 'rb') as rf:
+            while True:
+                chunk = rf.read(1024)
+                if not chunk:
+                    break
+                wf.write(decryptor.update(chunk))
+        wf.write(decryptor.finalize())
 
 def decrypt_job(job_dir, pk_file):
     # Find a list of {step}{index} encrypted dirs. Use 'next' to avoid recursion.
@@ -146,6 +230,7 @@ def decrypt_dir(crypt_file, pk_file):
                     step_dir])
     subprocess.run(['unzip',
                     '-o',
+                    '-q',
                     os.path.abspath(f'{job_dir}/{stepname}.zip')],
                    cwd=step_dir)
 
@@ -162,24 +247,26 @@ def main():
 
     # Command-line options (all required):
     parser.add_argument('-mode', required=True)
-    parser.add_argument('-job_dir', required=True)
+    parser.add_argument('-target', required=True)
     parser.add_argument('-key_file', required=True)
 
     # Parse arguments.
     cmdargs = vars(parser.parse_args())
 
     # Check for invalid parameters.
-    if (not cmdargs['mode'] in ['encrypt', 'decrypt']) or \
-       (not os.path.isdir(cmdargs['job_dir'])) or \
+    if (not cmdargs['mode'] in ['encrypt', 'decrypt', 'decrypt_config']) or \
+       (not os.path.exists(cmdargs['target'])) or \
        (not os.path.isfile(cmdargs['key_file'])):
         print('Error: Invalid command-line parameters.', file=sys.stderr)
         sys.exit(1)
 
     # Perform the encryption or decryption.
     if cmdargs['mode'] == 'encrypt':
-        encrypt_job(cmdargs['job_dir'], cmdargs['key_file'])
+        encrypt_job(cmdargs['target'], cmdargs['key_file'])
     elif cmdargs['mode'] == 'decrypt':
-        decrypt_job(cmdargs['job_dir'], cmdargs['key_file'])
+        decrypt_job(cmdargs['target'], cmdargs['key_file'])
+    elif cmdargs['mode'] == 'decrypt_config':
+        decrypt_cfgfile(cmdargs['target'], cmdargs['key_file'])
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR contains the fixes that we talked about this morning, to change how encrypted clustered jobs copy their `Chip` object's state into the compute nodes before each step. In a nutshell, it changes the `srun` commands to propagate the server-side schema dictionary to the compute nodes using an encrypted JSON file as an intermediary.

It also updates the `run()` method to read in error bits from the schema if they are available, and the `_deferstep()` logic now tracks flowgraph errors using the return code of the `sc` commands which run on the compute nodes. The goal is to maintain a consistent `Chip` object between the cluster's control node which manages the flowgraph, and the compute nodes which execute the actual `_runstep` logic.

With these changes, the `gcd_doe.py` script works with encrypted and unencrypted jobs on our cloud slurm cluster, even when a subset of the parallel steps fail. So I should be able to move on to adding some test cases and documentation for the clustering logic.