### PR TITLE
Specify an explicit targetlib in targets

### DIFF
--- a/siliconcompiler/foundries/asap7.py
+++ b/siliconcompiler/foundries/asap7.py
@@ -226,7 +226,7 @@ def setup_pdk(chip):
     ###############################################
 
     chip.set('asic', 'stackup', chip.get('pdk', 'stackup')[0])
-    chip.add('asic', 'targetlib', chip.getkeys('library'))
+    chip.add('asic', 'targetlib', libname)
     chip.set('asic', 'minlayer', "m2")
     chip.set('asic', 'maxlayer', "m7")
     chip.set('asic', 'maxfanout', 64)

--- a/siliconcompiler/foundries/freepdk45.py
+++ b/siliconcompiler/foundries/freepdk45.py
@@ -220,7 +220,7 @@ def setup_pdk(chip):
     ###############################################
 
     chip.set('asic', 'stackup', chip.get('pdk', 'stackup')[0])
-    chip.add('asic', 'targetlib', chip.getkeys('library'))
+    chip.add('asic', 'targetlib', libname)
     chip.set('asic', 'minlayer', "m1")
     chip.set('asic', 'maxlayer', "m10")
     chip.set('asic', 'maxfanout', 64)

--- a/siliconcompiler/foundries/skywater130.py
+++ b/siliconcompiler/foundries/skywater130.py
@@ -267,7 +267,7 @@ def setup_pdk(chip):
     # Methodology
     ###############################################
 
-    chip.add('asic', 'targetlib', chip.getkeys('library'))
+    chip.add('asic', 'targetlib', libname)
     chip.set('asic', 'stackup', chip.get('pdk', 'stackup')[0])
     # TODO: how does LI get taken into account?
     chip.set('asic', 'minlayer', "m1")


### PR DESCRIPTION
Using `chip.getkeys()` here breaks when we have macro libraries set up. Code in SC looks at the first entry in targetlibs to find the standard cell library for PNR, but that first library may end up being a macro library if we set it equal to all keys in the dict.