### PR TITLE
Clone OpenROAD submodule in test workflow

### DIFF
--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -12,6 +12,7 @@ jobs:
     name: 'ASIC test builds'
     steps:
       - uses: actions/checkout@v2
+      - run: git submodule update --init --recursive third_party/tools/openroad
       - run: |
           python3 -m venv create $GITHUB_WORKSPACE/clean_env --clear
           source $GITHUB_WORKSPACE/clean_env/bin/activate

--- a/.github/workflows/on_push_tests.yml
+++ b/.github/workflows/on_push_tests.yml
@@ -9,6 +9,7 @@ jobs:
     name: 'ASIC test builds'
     steps:
       - uses: actions/checkout@v2
+      - run: git submodule update --init --recursive third_party/tools/openroad
       - run: |
           python3 -m venv create $GITHUB_WORKSPACE/clean_env --clear
           source $GITHUB_WORKSPACE/clean_env/bin/activate
@@ -21,6 +22,7 @@ jobs:
     name: 'FPGA test builds'
     steps:
       - uses: actions/checkout@v2
+      - run: git submodule update --init --recursive third_party/tools/openroad
       - run: |
           python3 -m venv create $GITHUB_WORKSPACE/clean_env --clear
           source $GITHUB_WORKSPACE/clean_env/bin/activate
@@ -34,6 +36,7 @@ jobs:
     name: 'Python unit tests'
     steps:
       - uses: actions/checkout@v2
+      - run: git submodule update --init --recursive third_party/tools/openroad
       - run: |
           python3 -m venv create $GITHUB_WORKSPACE/clean_env --clear
           source $GITHUB_WORKSPACE/clean_env/bin/activate


### PR DESCRIPTION
Not sure why this is breaking all of a sudden, but noticed we need to do this after #536 failed. 

(Update: actually, I think this broke because I accidentally pushed an old branch prior to the OpenROAD submodule being updated, which may have wiped a copy of the submodule that was sitting around between runs. Another thing to think about going forward is seeing what we can do further increase isolation between runs on the self-hosted test runner). 