### PR TITLE
Use fancy Sphinx warnings to mark WIP stuff

### DIFF
--- a/siliconcompiler/foundries/asap7.py
+++ b/siliconcompiler/foundries/asap7.py
@@ -34,13 +34,14 @@ def make_docs():
 
     * http://asap.asu.edu/asap
     * L.T. Clark, V. Vashishtha, L. Shifren, A. Gujja, S. Sinha, B. Cline,
-    C. Ramamurthya, and G. Yeric, “ASAP7: A 7-nm FinFET Predictive Process
-    Design Kit,” Microelectronics Journal, vol. 53, pp. 105-115, July 2016.
+      C. Ramamurthya, and G. Yeric, “ASAP7: A 7-nm FinFET Predictive Process
+      Design Kit,” Microelectronics Journal, vol. 53, pp. 105-115, July 2016.
 
 
     Sources: https://github.com/The-OpenROAD-Project/asap
 
-    Status: Work in progress (not ready for use)
+    .. warning::
+       Work in progress (not ready for use)
 
     '''
 

--- a/siliconcompiler/tools/openfpga/openfpga.py
+++ b/siliconcompiler/tools/openfpga/openfpga.py
@@ -22,8 +22,8 @@ def make_docs():
 
     Installation: https://github.com/lnis-uofu/OpenFPGA
 
-    Status: SC integration WIP
-
+    .. warning::
+       Work in progress (not ready for use)
     '''
 
     chip = siliconcompiler.Chip()

--- a/siliconcompiler/tools/vpr/vpr.py
+++ b/siliconcompiler/tools/vpr/vpr.py
@@ -23,8 +23,8 @@ def make_docs():
 
     Installation: https://github.com/verilog-to-routing/vtr-verilog-to-routing
 
-    Status: SC integration WIP
-
+    .. warning::
+       Work in progress (not ready for use)
     '''
 
     chip = siliconcompiler.Chip()


### PR DESCRIPTION
I was looking at the changes you made and remembered I read at one point about how to add little Note/Warning boxes in Sphinx docs. I decided to try using those for the status messages to make them more visible:

<img width="761" alt="Screen Shot 2021-09-22 at 5 55 06 PM" src="https://user-images.githubusercontent.com/4412459/134427419-123d7b5b-6359-4d65-92ef-0f108ec74565.png">

Feel free not to merge if you don't want this, just wanted to propose it!

This also uncovered a general bug in dynamicgen.py regarding parsing fancy stuff like this in the docstrings, I added the fix for that to PR #542 since we'll want that regardless.