### PR TITLE
Fix multiprocessing bug

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -32,10 +32,8 @@ from siliconcompiler.schema import *
 
 # Fix for multprocessing bug on MacOS
 # Source: https://github.com/Koed00/django-q/issues/389#issuecomment-699481976
-import platform
-if platform.system() != "Linux":
-    from multiprocessing import set_start_method
-    set_start_method("fork")
+from multiprocessing import set_start_method
+set_start_method("fork")
 
 class Chip:
     """Object for configuring and executing hardware design flows.


### PR DESCRIPTION
Turns out there's actually a pretty simple fix for this, borrowed from this Github issue: https://github.com/Koed00/django-q/issues/389#issuecomment-699481976. This is working on MacOS now, still to be tested on Windows.

I also fixed an unrelated bug in the summary() function in this PR, it came up while I was testing out my fix.

fixes #553

