### PR TITLE
Fix duplicate logs in Linux

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -74,6 +74,16 @@ class Chip:
 
     ###########################################################################
     def _init_logger(self, step=None, index=None):
+        # Give each step, index pair its own unique logger
+        logger = None
+        if step is not None and index is not None:
+            logger = f'{step}.{index}'
+        self.logger = logging.getLogger(logger)
+
+        # Don't propagate log messages to "root" handler (we get duplicate
+        # messages without this)
+        self.logger.propagate = False
+
         if step == None:
             step = '---'
         if index == None:
@@ -86,19 +96,22 @@ class Chip:
         else:
             logformat = '| %(levelname)-7s | ' + step_index + ' | %(message)s'
 
-        self.logger = logging.getLogger()
-        self.handler = logging.StreamHandler()
-        self.formatter = logging.Formatter(logformat)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(logformat)
 
-        self.handler.setFormatter(self.formatter)
-        self.logger.addHandler(self.handler)
+        handler.setFormatter(formatter)
+
+        # Clear any existing handlers so we don't end up with duplicate messages
+        # if repeat calls to _init_logger are made
+        if len(self.logger.handlers) > 0:
+            self.logger.handlers.clear()
+
+        self.logger.addHandler(handler)
         self.logger.setLevel(self.loglevel)
 
     ###########################################################################
     def _deinit_logger(self):
         self.logger = None
-        self.handler = None
-        self.formatter = None
 
     ###########################################################################
     def cmdline(self, progname, description=None, switchlist=[]):


### PR DESCRIPTION
I tweaked the logging initialization a bit since I noticed duplicate messages in Linux (must be a difference between fork vs spawn for multiprocessing). 

The key was adding `logger.propagate=False` (source: https://jdhao.github.io/2020/06/20/python_duplicate_logging_messages/), but I also did a couple things that seemed like better practice:
- made sure each thread is using a unique logger object by constructing a logger name from step and index to pass into logging.get_logger()
- cleared any existing handlers before setting a new one, since I think multiple handlers can also result in duplicate messages (this could happen if we screw up and call _init_logger() twice)

this fixes #574 

