### PR TITLE
Add 'quiet' flags to the client zip/unzip commands.

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -341,9 +341,9 @@ def fetch_results(chip):
     top_design = chip.get('design')
     job_hash = chip.get('remote', 'jobhash')
     job_nameid = f"{chip.get('jobname')}{chip.get('jobid')}"
-    subprocess.run(['unzip', '-q', '%s.zip'%job_hash])
+    subprocess.run(['unzip', '-q', f'{job_hash}.zip'])
     # Remove the results archive after it is extracted.
-    os.remove('%s.zip'%job_hash)
+    os.remove(f'{job_hash}.zip')
 
     # Call 'delete_job' to remove the run from the server.
     delete_job(chip)


### PR DESCRIPTION
We can avoid cluttering the console output of remote jobs by using the 'quiet' flags when we pack and unpack the files for uploading/downloading.

Long-term, we should probably use library calls to tar/gzip these files, but the `zip` and `unzip` commands are a convenient and simple solution.