### PR TITLE
Delete build directory contents before "start-to-finish" job runs.

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2599,7 +2599,7 @@ class Chip:
             # If no step(list) was specified, the whole flow is being run
             # start-to-finish. Delete the build dir to clear stale results.
             cur_job_dir = f'{self.get("dir")}/{self.get("design")}/'\
-                          f'{self.get("jobname")}{self.get("jobid")}'
+                          f'{self.get("jobname")}'
             if os.path.isdir(cur_job_dir):
                 shutil.rmtree(cur_job_dir)
 


### PR DESCRIPTION
This change adds logic to delete the local build directory before starting a new local or remote job run.

If `-arg_step` or `-steplist` are specified, the build directory will not be deleted. This is for two reasons: the requested step(s) may depend on prior steps' outputs, and the remote compute nodes should not delete their local build directories before they start working on their assigned step.