### PR TITLE
Add method summary table to core API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,8 @@ extensions = [
     'sphinx.ext.imgconverter',
     'schemagen',
     'clientservergen',
-    'dynamicgen'
+    'dynamicgen',
+    'sphinx.ext.autosummary'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/reference_manual/core_api.rst
+++ b/docs/reference_manual/core_api.rst
@@ -8,17 +8,41 @@ uses. For reference on concepts repeated across the API, see :ref:`glossary`.
 
 Listed in rough order of importance
 
-.. list-table::
-   :widths: 25 40
-   :header-rows: 1
+.. currentmodule:: siliconcompiler
+   
+.. autosummary::
+    :nosignatures:
 
-   * - Method
-     - Description
-
-   * - add(*args, cfg=None)
-     - Appends an item to the parameter value specified by args keypath.
-
-
+    ~siliconcompiler.core.Chip.create_commandline
+    ~siliconcompiler.core.Chip.find_function
+    ~siliconcompiler.core.Chip.target
+    ~siliconcompiler.core.Chip.list_outputs
+    ~siliconcompiler.core.Chip.help
+    ~siliconcompiler.core.Chip.get
+    ~siliconcompiler.core.Chip.getkeys
+    ~siliconcompiler.core.Chip.getdict
+    ~siliconcompiler.core.Chip.set
+    ~siliconcompiler.core.Chip.add
+    ~siliconcompiler.core.Chip.find_file
+    ~siliconcompiler.core.Chip.merge_manifest
+    ~siliconcompiler.core.Chip.check_manifest
+    ~siliconcompiler.core.Chip.read_manifest
+    ~siliconcompiler.core.Chip.write_manifest
+    ~siliconcompiler.core.Chip.write_flowgraph
+    ~siliconcompiler.core.Chip.hash_files
+    ~siliconcompiler.core.Chip.audit_manifest
+    ~siliconcompiler.core.Chip.calc_yield
+    ~siliconcompiler.core.Chip.calc_dpw
+    ~siliconcompiler.core.Chip.calc_diecost
+    ~siliconcompiler.core.Chip.summary
+    ~siliconcompiler.core.Chip.list_steps
+    ~siliconcompiler.core.Chip.step_join
+    ~siliconcompiler.core.Chip.step_minimum
+    ~siliconcompiler.core.Chip.step_maximum
+    ~siliconcompiler.core.Chip.step_verify
+    ~siliconcompiler.core.Chip.step_mux
+    ~siliconcompiler.core.Chip.run
+    ~siliconcompiler.core.Chip.show
 
 .. automodule:: siliconcompiler.core
     :members:


### PR DESCRIPTION
This PR adds a method summary table to the top of the core API docs page, similar to scikit-learn's. Turns out this is pretty easy to do using the Sphinx [autosummary](https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html) directive.

I added all the methods listed in order they appear in core.py -- since it seemed like you wanted them listed based on order of importance, I figured I'd leave the final ordering decision to you. The tilde (`~`) in front of each entry prevents the entire module prefix from being included, and makes it so the table just shows the bare method name.

I also included an option `:nosignatures:`, which means the parameter list for each function isn't displayed. I thought the way Sphinx styles this by default doesn't look great, but you can re-enable it by deleting that line if you'd like.

Here's part of the table right now:

<img width="760" alt="Screen Shot 2021-10-12 at 12 19 55 PM" src="https://user-images.githubusercontent.com/4412459/136994232-70682ee7-fb8b-4714-bcc6-323b3562c5ee.png">

And for reference, here it is with the `:nosignatures:` option removed:

<img width="747" alt="Screen Shot 2021-10-12 at 12 20 21 PM" src="https://user-images.githubusercontent.com/4412459/136994277-019c9f04-d5c4-4517-8290-d29a952507f7.png">


