### PR TITLE
Initial example for setting environment variables via a shell/python combo.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,20 @@ setup(
         "graphviz >=0.17"
     ],
     entry_points={"console_scripts": entry_points},
+    scripts=['siliconcompiler/apps/sc_env'],
     cmake_install_dir="siliconcompiler/leflib",
     cmake_args=cmake_args
 )
+
+# Attempt to set an alias for 'sc_env' on supported platforms.
+try:
+    with open('/etc/bash.bashrc', 'r') as f:
+        cur_bashrc = f.read()
+    if not 'alias sc_env=' in cur_bashrc:
+        cur_bashrc += '''
+alias sc_env=". sc_env"'''
+    with open('/etc/bash.bashrc', 'w') as f:
+        f.write(cur_bashrc)
+except:
+    # This alias is not required, but it is convenient for apps that depend on it.
+    pass

--- a/siliconcompiler/apps/sc_env
+++ b/siliconcompiler/apps/sc_env
@@ -1,0 +1,3 @@
+#!/bin/bash
+sc-env-gen
+source test.sh

--- a/siliconcompiler/apps/sc_env_gen.py
+++ b/siliconcompiler/apps/sc_env_gen.py
@@ -3,7 +3,7 @@ import sys
 import siliconcompiler
 
 def main():
-    progname = "sc-env"
+    progname = "sc-env-gen"
     chip = siliconcompiler.Chip()
     switchlist = ['cfg',
                   'project',
@@ -21,8 +21,10 @@ def main():
 
     #Error checking
     if bool(not chip.get('cfg')) and bool(not chip.get('project')):
-        print(progname+": error: the following arguments are required: [-cfg | -project]")
-        sys.exit()
+        #print(progname+": error: the following arguments are required: [-cfg | -project]")
+        #sys.exit()
+        with open('test.sh', 'w') as test_env:
+            test_env.write('export SC_TEST_VAR="test_val2"')
     else:
         chip.create_env()
 


### PR DESCRIPTION
This change adds a shell command which calls a Python-based entry point, and sets environment variables based on the Python script's outputs. It's just a proof-of-concept, though; I modified the `sc_env_gen.py` script to set a test environment variable if no options are provided.

Unfortunately, shell scripts are also launched in their own processes, so we can't just create an `sc_env` script which calls `export VAR="val"`. Instead, we need to call `. sc_env` or `source sc_env` to propagate the changes to the parent process.

I don't think we want to ask users to remember the `source ` or `. ` prefix, so I tried adding an alias to the system-wide `bashrc` file in the `setup.py` script. This is the only solution I've found so far which seems to work cleanly, but modifying a system file like that requires root privileges, so we might want to update the logic a bit to make it work with user-level `~/.bashrc` files if the setup script is not run with `sudo`.

Also, after running `sudo setup.py install`, the user needs to either open a new terminal or run `exec bash` before the new alias will take effect.

But despite the workarounds, this change makes the `sc_env` shell command set the `SC_TEST_VAR` environment variable in the calling shell.