### PR TITLE
Add jobname to logger

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -24,6 +24,7 @@ import pandas
 import yaml
 import graphviz
 import time
+import uuid
 from timeit import default_timer as timer
 from siliconcompiler.client import *
 from siliconcompiler.schema import *
@@ -67,11 +68,7 @@ class Chip:
 
     ###########################################################################
     def _init_logger(self, step=None, index=None):
-        # Give each step, index pair its own unique logger
-        logger = None
-        if step is not None and index is not None:
-            logger = f'{step}.{index}'
-        self.logger = logging.getLogger(logger)
+        self.logger = logging.getLogger(uuid.uuid4().hex)
 
         # Don't propagate log messages to "root" handler (we get duplicate
         # messages without this)


### PR DESCRIPTION
This PR adds the jobname to the logger header, and also instantiates each logger with a unique uuid, which should fix the problem you noticed, @WRansohoff.

Example of log appearance:
```
| INFO    | job0    | ---          | -   | Loading target 'asicflow_freepdk45'
| INFO    | job0    | ---          | -   | Loading function 'setup_flow' from module 'asicflow'
| INFO    | job0    | ---          | -   | Loading function 'setup_pdk' from module 'freepdk45'
| INFO    | job0    | ---          | -   | Operating in 'asic' mode
| INFO    | job0    | ---          | -   | Computing file hashes with hashmode = OFF
| INFO    | job0    | import       | 0   | Waiting for inputs...
| INFO    | job0    | import       | 0   | Collecting input sources
| INFO    | job0    | syn          | 0   | Waiting for inputs...
| INFO    | job0    | import       | 0   | Copying /home/noah/zeroasic/siliconcompiler/examples/gcd/gcd.v to step inputs/ directory
| INFO    | job0    | import       | 0   | Copying /home/noah/zeroasic/siliconcompiler/examples/gcd/gcd.sdc to step inputs/ directory
| INFO    | job0    | synmin       | 0   | Waiting for inputs...
| INFO    | job0    | floorplan    | 0   | Waiting for inputs...
```