### PR TITLE
Refactor `chip.target()` for better error messages

### DIFF
--- a/tests/api_tests/test_target.py
+++ b/tests/api_tests/test_target.py
@@ -1,0 +1,36 @@
+import siliconcompiler
+import pytest
+
+def test_target_valid():
+    '''Basic test of target function.'''
+    chip = siliconcompiler.Chip()
+    chip.target('asicflow_freepdk45')
+
+    assert chip.get('mode') == 'asic'
+
+def test_target_flipped_error():
+    '''Ensure that we error out if the user mixes up PDK name and flow.'''
+    chip = siliconcompiler.Chip()
+
+    # Test that call triggers a system exit with status code 1
+    # source: https://medium.com/python-pandemonium/testing-sys-exit-with-pytest-10c6e5f7726f
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        chip.target('freepdk45_asicflow')
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 1
+
+def test_target_fpga_valid():
+    '''Ensure that the FPGA flow allows an arbitrary partname and sets mode
+    correctly.'''
+    chip = siliconcompiler.Chip()
+    chip.target('fpgaflow_myfpga')
+
+    assert chip.get('mode') == 'fpga'
+
+def test_target_pdk_error():
+    '''Ensure that we error out in ASIC mode if given an invalid PDK name.'''
+    chip = siliconcompiler.Chip()
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        chip.target('asicflow_fakepdk')
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 1


### PR DESCRIPTION
While I was working on fixing up the broken API tests, I noticed some were using the old target order of `<pdkname>_<flowname>`. This error seems a bit tricky for an inexperienced user to catch, since the target function successfully loads both files (and prints out log messages to that effect), but doesn't actually apply the flow setup. Therefore, the flowgraph is silently left uninitialized, resulting in errors further downstream when check_manifest gets called:

```
>>> import siliconcompiler
>>> chip = siliconcompiler.Chip(design='test')
>>> chip.target('freepdk45_asicflow')
| INFO    | job0    | ---          | -   | Loading target 'freepdk45_asicflow'
| INFO    | job0    | ---          | -   | Loading function 'setup_pdk' from module 'freepdk45'
| INFO    | job0    | ---          | -   | Loading function 'setup_flow' from module 'asicflow'
| INFO    | job0    | ---          | -   | Operating in 'None' mode
>>> chip.run()
| INFO    | job0    | ---          | -   | Computing file hashes with hashmode = OFF
| ERROR   | job0    | ---          | -   | No flowgraph defined.
| ERROR   | job0    | ---          | -   | Global requirement missing for [mode].
| ERROR   | job0    | ---          | -   | Check failed. See previous errors.
```

This restructuring makes it so `chip.target()` itself will error out:
```
>>> import siliconcompiler
>>> chip = siliconcompiler.Chip(design='test')
>>> chip.target('freepdk45_asicflow')
| INFO    | job0    | ---          | -   | Loading target 'freepdk45_asicflow'
| INFO    | job0    | ---          | -   | Loading function 'setup_pdk' from module 'freepdk45'
| ERROR   | job0    | ---          | -   | Target string beginning with a PDK name must only have one entry
```

I also added some tests for a few valid and invalid target combinations.