### PR TITLE
Update sv2v version to 0.0.9

### DIFF
--- a/setup/install-sv2v-pkg.sh
+++ b/setup/install-sv2v-pkg.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 mkdir -p deps
 cd deps
-wget -q https://github.com/zachjs/sv2v/releases/download/v0.0.7/sv2v-Linux.zip
+wget -q https://github.com/zachjs/sv2v/releases/download/v0.0.9/sv2v-Linux.zip
 unzip sv2v-Linux
 sudo mv sv2v-Linux/sv2v /usr/bin
 rm -rf sv2v-Linux


### PR DESCRIPTION
The new asicflow requires a newer version of sv2v, which can write to files instead of stdout. It looks like the required functionality is included in the 0.0.9 release.