### PR TITLE
Add OpenROAD tool option to not fail on GRT congestion

### DIFF
--- a/siliconcompiler/tools/openroad/sc_route.tcl
+++ b/siliconcompiler/tools/openroad/sc_route.tcl
@@ -24,9 +24,17 @@ set_routing_layers -signal $sc_minmetal-$sc_maxmetal
 
 set_macro_extension 2
 
+if {[dict exists $sc_cfg eda $sc_tool $sc_step $sc_index option grt_allow_congestion] &&
+    [dict get $sc_cfg eda $sc_tool $sc_step $sc_index option grt_allow_congestion] == "true"} {
+    set additional_grt_args "-allow_congestion"
+} else {
+    set additional_grt_args ""
+}
+
 global_route -guide_file "./route.guide" \
     -overflow_iterations $openroad_overflow_iter \
-    -verbose 2
+    -verbose 2 \
+    $additional_grt_args
 
 ######################
 # Report Antennas


### PR DESCRIPTION
This PR adds an option to OpenROAD that lets us pass in -allow_congestion to the global router. I've gotten back to a situation where I'm seeing routing congestion with ZeroSoC, so I think it's finally time to add an option that will let us bypass this issue. 