### PR TITLE
Fix client.py for authenticated/encrypted jobs

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -164,7 +164,7 @@ def request_remote_run(chip):
         pkpath = chip.get('remote', 'key')
         job_path = os.path.join(chip.get('dir'),
                                 chip.get('design'),
-                                chip.get('job_nameid'))
+                                chip.get('jobname'))
 
         # AES-encrypt the job data prior to uploading.
         # TODO: This assumes a common OpenSSL convention of using similar file


### PR DESCRIPTION
Sorry if my use of 'job_nameid' as a variable name has become confusing; it came from when we separated job names and IDs in the schema, but I might need to clean up the `client.py` file a bit.

This bug probably didn't show up in our CI tests because we run the authenticated remote flow during the daily tests, not the quick tests.

Maybe we should consider running the authenticated remote flow as a quick test instead of the unauthenticated one. After all, server.siliconcompiler.com will reject unauthenticated job submissions when we launch.