### PR TITLE
Fix typo in timing results parsing

### DIFF
--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -186,7 +186,7 @@ def post_process(chip):
                warnmatch = re.match(r'^\[WARNING', line)
                area = re.search(r'^Design area (\d+)', line)
                tns = re.search(r'^tns (.*)',line)
-               wns = re.search(r'^tns (.*)',line)
+               wns = re.search(r'^wns (.*)',line)
                vias = re.search(r'^Total number of vias = (.*).',line)
                wirelength = re.search(r'^Total wire length = (.*) um',line)
                power = re.search(r'^Total(.*)',line)


### PR DESCRIPTION
Very small fix :)

I did have a question about how the timing metrics are recorded - not sure if there's any issue here, I think it might be a problem with my understanding.

It looks like openroad.py currently stores the total negative slack and worst negative slack in `setuptns` and `setupwns` respectively. There are also `holdtns` and `holdwns` metrics, which are currently ignored. Is there any guarantee that the TNS and WNS reported by OpenROAD are related to setup time violations, or could they be related to hold violations as well? I looked and didn't really see a way to distinguish between the two with the OpenROAD `report_*` commands. 