### PR TITLE
Add more info about running tests to tests/README.md

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -5,14 +5,75 @@ the pytest framework. This README documents how our tests are organized and
 describes some of our project-specific practices and standards for writing
 tests.
 
-## Directory contents and structure
+## Running tests
 
-### `conftest.py`
+Running `pytest` in the SC root directory will by default discover and run all
+tests under `tests/`.
+
+To select specific tests, you can pass in paths to specific directories or
+files, for example:
+
+- `pytest tests/core`: runs all core tests
+- `pytest tests/flows/test_asicflow.py`: runs any tests in test_asicflow.py
+- `pytest tests/core/test_target.py::test_target_valid`: run individual
+  `test_target_valid` test among the multiple defined in `test_target.py`
+
+In addition, some tests are annotated with pytest "markers", which specify
+specific properties (in our case, generally how often and what machines are used
+to run them within our CI system). You can select tests using the `-m` flag and
+providing generic Python-style boolean expressions based on these markers. For
+example:
+
+- `pytest -m eda`: runs all tests with "eda" marker
+- `pytest -m "not quick"`: runs all tests without the "quick" marker
+
+### Running all tests run by CI on push
+
+Run `pytest -m "not eda or quick"`.
+
+### Debugging tests
+
+By default, pytest will swallow test output (unless it fails), and run each test
+in a unique temporary directory. This can make it tough to get insight into
+what a test is doing.
+
+Some of our test files end in a block
+```python
+if __name__ == '__main__':
+  ...
+```
+that calls a test function directly in order to easily run and debug tests
+directly using Python. This works around these pytest features.
+
+#### Running through pytest
+
+For tests without the above boilerplate, you can  approximate the default Python
+behavior while executing a test with `pytest`. Use the `-s` flag to disable
+output capture, and use the custom `--cwd` flag to run it from the current
+working directory. For example, to run the OpenROAD test:
+
+`pytest -s --cwd tests/tools/test_openroad.py`
+
+To select a single test in a file, you can use `::` and specify the name of the test:
+
+`pytest -s --cwd tests/tools/test_yosys.py::test_yosys_lec`
+
+You can also use the `-k` flag to select the test without specifying a filename
+(note this will select partial matches as well, so `-k test_yosys_lec` will
+select `test_yosys_lec` and `test_yosys_lec_broken`):
+
+`pytest -s --cwd -k test_openroad`
+
+## Writing tests
+
+### Directory contents and structure
+
+#### `conftest.py`
 
 This file contains the definitions of our custom fixtures as well as
 additional pytest configuration.
 
-### `fixtures.py`
+#### `fixtures.py`
 
 All of the non-"autouse" fixtures defined in conftest.py have a pure Python
 implementation in this file. This allows us to implement a pattern where we can
@@ -35,7 +96,7 @@ All of these fixture implementations take no arguments except `datadir`, which
 takes in the full path to the current test file (so you should always pass in
 `__file__`).
 
-### `data/`
+#### `data/`
 
 This directory contains common data used by tests across multiple test
 directories. To access files in this directory, we suggest making a test depend
@@ -48,7 +109,7 @@ datadir = os.path.join(scroot, 'tests', 'data')
 This may change in the future if we add a dedicated fixture for accessing this
 directory.
 
-### Test directories
+#### Test directories
 
 The remaining directories all contain test files. Use the following rules to
 decide where a test should go:
@@ -72,11 +133,11 @@ Each of these directories can contain a `data/` directory which holds data files
 specific to those tests in particular. To access this directory, make your test
 depend on the `datadir` fixture, which provides an absolute path to this directory.
 
-## Custom Fixtures
+### Custom Fixtures
 
 To view our globally available custom fixtures, run `pytest --fixtures tests/conftest.py`.
 
-## Markers
+### Markers
 
 We've defined the following markers:
 
@@ -84,35 +145,3 @@ We've defined the following markers:
 - `@pytest.mark.eda`: this test requires EDA tools installed to run. By default these tests will be run nightly, not on push.
 
 To view documentation for these and builtin markers, run `pytest --markers`.
-
-## Debugging failing tests
-
-Some of our test files have a block
-```python
-if __name__ == '__main__':
-```
-that calls a test function directly in order to easily run tests directly in a
-Python interpreter and debug it.
-
-We've kept this pattern around, but going forward it would probably be best to
-move away from this method. Using pytest directly would allow us to take
-advantage of more pytest features (such as fixtures that depend on other
-fixtures), as well as make it easier for us to include multiple tests in a
-single file.
-
-To run tests through pytest as if they were running in the Python interpreter,
-use the `-s` flag to disable output capture, and use the custom `--cwd` flag to
-run it from the current working directory. For example, to run the OpenROAD
-test:
-
-`pytest -s --cwd tests/tools/test_openroad.py`
-
-To select a single test in a file, you can use `::` and specify the name of the test:
-
-`pytest -s --cwd tests/tools/test_yosys.py::test_yosys_lec`
-
-You can also use the `-k` flag to select the test without specifying a filename
-(note this will select partial matches as well, so `-k test_yosys_lec` will
-select `test_yosys_lec` and `test_yosys_lec_broken`):
-
-`pytest -s --cwd -k test_openroad`


### PR DESCRIPTION
This PR splits up the test README into two sections for running and developing tests, and I put more info clarifying how to select specific tests with markers etc. into the first section. 