### PR TITLE
Add autogenerated license list to docs

### DIFF
--- a/docs/_ext/common.py
+++ b/docs/_ext/common.py
@@ -8,9 +8,9 @@ def build_table(items):
 
     group = nodes.tgroup(cols=len(items[0]))
     table += group
-    # not sure how colwidth affects things - columns seem to adjust to contents
-    group += nodes.colspec(colwidth=50)
-    group += nodes.colspec(colwidth=100)
+    for _ in items[0]:
+        # not sure how colwidth affects things - columns seem to adjust to contents
+        group += nodes.colspec(colwidth=100)
 
     body = nodes.tbody()
     group += body

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Welcome to SiliconCompiler's documentation!
    user_guide/metric
    user_guide/remoteflow
    user_guide/faq
+   user_guide/licenses
 
 .. toctree::
    :maxdepth: 3

--- a/docs/user_guide/licenses.rst
+++ b/docs/user_guide/licenses.rst
@@ -1,0 +1,30 @@
+License
+==========
+
+SiliconCompiler is licensed under [TODO before launch]
+
+Dependency Licenses
+++++++++++++++++++++++
+
+SC relies on the following Python dependencies, which are licensed as shown.
+Note this table includes dependencies of the dependencies directly declared by
+SiliconCompiler.
+
+.. requirements_licenses::
+    :version:
+
+The precompiled SiliconCompiler wheels distributed on PyPI include the following
+bundled dependencies:
+
+.. table::
+    :widths: 300 300
+
+    ============================================ ========================
+    Name                                         License
+    ============================================ ========================
+    `Si2 LEF parser`_ (distributed by OpenROAD)  Apache Software License
+    `Surelog`_                                   Apache Software License
+    ============================================ ========================
+
+.. _Si2 LEF parser: https://github.com/The-OpenROAD-Project/OpenROAD/tree/cf744a3734204ef12378150d429acf32af385ea4/src/OpenDB/src/lef
+.. _Surelog: https://github.com/chipsalliance/Surelog/tree/0fb03574502b99f3a0ba64c9f881dd464646dcc4

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ cmake
 # Docs dependencies
 Sphinx >= 3.5.4
 sphinx-rtd-theme >= 0.5.2
+pip-licenses
 
 # Testing dependencies
 pytest >= 6.2.4


### PR DESCRIPTION
This PR adds an extra page to the docs with an autogenerated list of Python dependency licenses + the Surelog and LEF parser licenses (this seemed relevant to me as well).

Preview:

<img width="766" alt="Screen Shot 2021-11-04 at 5 06 10 PM" src="https://user-images.githubusercontent.com/4412459/140420067-0ff6a50f-2fa2-4fab-94b3-269579fd976b.png">
