### PR TITLE
Implement command timeout feature

### DIFF
--- a/tests/flows/test_timeout.py
+++ b/tests/flows/test_timeout.py
@@ -1,0 +1,11 @@
+import pytest
+
+@pytest.mark.eda
+def test_timeout(gcd_chip):
+    # 0 seconds guarantees a timeout
+    gcd_chip.set('flowgraph', 'import', '0', 'timeout', 0)
+
+    # Expect that command exits early
+    # TODO: automated check that run timed out vs failed for a different reason
+    with pytest.raises(SystemExit):
+        gcd_chip.run()


### PR DESCRIPTION
This PR implements functionality to terminate a command if the 'timeout' schema parameter is set. I implemented this last week while working on the experiments and finally got around to adding a test case and submitting it.

Unfortunately I couldn't find a super easy but clean way to both do this and handle live-logging at once. I ended up using a hack based on a Stack Overflow post (linked in comments), that works like this:

1) pipe the subprocess output directly to your log file, so it gets written asynchronously
2) in a loop that runs until the process stops running, read from the log file using a separate file object, and write contents back to stdout as they arrive

This approach seems to work just as well in my testing!

I was also able to get rid of the final `terminate()` call, since the `poll()` command used in the loop should set the return code on the final call (once the process has finished). 
