### PR TITLE
Fix typo in sc-configure app

### DIFF
--- a/siliconcompiler/apps/sc_configure.py
+++ b/siliconcompiler/apps/sc_configure.py
@@ -27,7 +27,7 @@ def main():
         overwrite = False
         while not overwrite:
             oin = input('Overwrite existing remote configuration? (y/N)')
-            if (not oin) or (oin == 'n') or (on == 'N'):
+            if (not oin) or (oin == 'n') or (oin == 'N'):
                 print('Exiting.')
                 return
             elif (oin == 'y') or (oin == 'Y'):


### PR DESCRIPTION
Sorry for not testing this more thoroughly; there's a misnamed variable in the logic which asks the user if it's okay to overwrite the config file.

I would add a unit test for this app, but that will take a bit of effort to implement without overwriting the user's existing remote configuration file.