### PR TITLE
Update builtin PDK file paths to ensure editable install works

### DIFF
--- a/examples/gcd/run.sh
+++ b/examples/gcd/run.sh
@@ -11,5 +11,4 @@ sc examples/gcd/gcd.v \
    -loglevel "INFO" \
    -quiet \
    -relax \
-   -scpath "third_party/pdks/" \
    -design gcd  $OPT

--- a/siliconcompiler/pdks/asap7.py
+++ b/siliconcompiler/pdks/asap7.py
@@ -70,7 +70,7 @@ def setup_pdk(chip):
     rev = 'r1p7'
     stackup = '10M'
     libtype = '7p5t'
-    pdkdir = os.path.join(foundry, process, 'pdk', rev)
+    pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
 
     # If you got here,  you are in asic mode
     chip.set('mode', 'asic', clobber=True)
@@ -162,7 +162,7 @@ def setup_pdk(chip):
     rev = 'r1p7'
     corner = 'typical'
     objectives = ['setup']
-    libdir = os.path.join(foundry, process, 'libs', libname, rev)
+    libdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'libs', libname, rev)
 
     # rev
     chip.set('library',libname,'version',rev)

--- a/siliconcompiler/pdks/freepdk45.py
+++ b/siliconcompiler/pdks/freepdk45.py
@@ -60,7 +60,7 @@ def setup_pdk(chip):
     edgemargin = 2
     d0 = 1.25
 
-    pdkdir = os.path.join(foundry, process, 'pdk', rev)
+    pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
 
     # If you got here,  you are in asic mode
     chip.set('mode', 'asic', clobber=True)
@@ -145,7 +145,7 @@ def setup_pdk(chip):
     corner = 'typical'
     objectives = ['setup']
 
-    libdir = os.path.join(foundry, process, 'libs', libname, rev)
+    libdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'libs', libname, rev)
 
     # standard cell typ
     chip.set('library',libname,'type','stdcell')

--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -67,7 +67,7 @@ def setup_pdk(chip):
     vscribe = 0.1
     edgemargin = 2
 
-    pdkdir = os.path.join(foundry, process, 'pdk', rev)
+    pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
 
     #if you are calling this file, you are in asic mode
     chip.set('mode','asic', clobber = True)
@@ -156,7 +156,7 @@ def setup_pdk(chip):
     # TODO: should I be using a different name for the corner
     corner = 'typical'
 
-    libdir = os.path.join(foundry, process, 'libs', libname, rev)
+    libdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'libs', libname, rev)
 
 
     chip.set('library', libname, 'type', 'stdcell')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def pytest_addoption(parser):
     )
 
 def pytest_generate_tests(metafunc):
-    os.environ['SCPATH'] = os.path.join(fixtures.scroot(), 'third_party', 'pdks')
+    os.environ['SCPATH'] = os.path.join(fixtures.scroot(), 'siliconcompiler')
 
 @pytest.fixture(autouse=True)
 def test_wrapper(tmp_path, request):


### PR DESCRIPTION
RE: our discussion, this preserves the same behavior as before when installing SC via `pip install -e`. Users that install SC via the wheel will have to set up their SC path to point to `<path-to-sc>/siliconcompiler`. 

@WRansohoff Andreas suggested this small change, and as a consequence the server the SCPATH env variable now needs to point to `<path-to-sc>/siliconcompiler` (rather than what I said before, which was`<path-to-sc>/third_party/pdks`). 

