### PR TITLE
Add configuration file for Read-the-Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+   formats:
+    - pdf
+
+python:
+    install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - build
+        - docs

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,18 @@ setup(
         "cryptography >= 3.4.7",
         "graphviz >=0.17"
     ],
+    extras_require = {
+        "docs": [
+            "Sphinx >= 3.5.4",
+            "sphinx-rtd-theme >= 0.5.2"
+            "pip-licenses"
+        ],
+        "build": [
+            "scikit-build >= 0.12",
+            "cython",
+            "cmake"
+        ]
+    },
     entry_points={"console_scripts": entry_points},
     cmake_install_dir="siliconcompiler/leflib",
     cmake_args=cmake_args


### PR DESCRIPTION
This PR adds a configuration file for Read the Docs, which will help make sure we're ready to go when we want to release them.

The file specifies the following info:
- Root of our Sphinx configuration
- Build PDF as well as default HTML docs
- Install our package using Pip before building the docs (necessary for all our autogeneration extensions), and install the required additional dependencies needed for this