### PR TITLE
Run daily tests across all versions of Python

### DIFF
--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 8 * * *'
 
 name: 'Daily CI Tests'
 
@@ -27,9 +27,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - run: |
-          python -m pip install --upgrade pip
           python -m venv create $GITHUB_WORKSPACE/clean_env --clear
           source $GITHUB_WORKSPACE/clean_env/bin/activate
           echo $VIRTUAL_ENV
-          pip install -r $GITHUB_WORKSPACE/requirements.txt $GITHUB_WORKSPACE/.
+          python -m pip install --upgrade pip
+          python -m pip install -r $GITHUB_WORKSPACE/requirements.txt $GITHUB_WORKSPACE/.
           pytest -n 4 --import-mode=append


### PR DESCRIPTION
This PR adds a build matrix to our daily tests so that we can test our full suite against all supported Python versions each night. I tested this out with a few manual runs - the runs themselves aren't currently passing since we have some broken tests, but the build matrix itself seems to be working fine (and we have consistent failures across all Python versions). 

I also set the cron job to run later at night, since this will make the daily tests take much longer (5 -> 30 mins) and I didn't want to tie up the test runner in case someone happens to be working late. 


