### PR TITLE
Some sc-show enhancements

### DIFF
--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -45,7 +45,7 @@ def setup_tool(chip, mode="batch"):
     if mode == 'show':
         clobber = False
         script = '/klayout_show.py'
-        option = ['-rm']
+        option = ['-nc', '-rm']
     else:
         clobber = False
         script = '/klayout_export.py'

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -50,6 +50,14 @@ layoutOptions.lefdef_config.produce_blockages = True
 layoutOptions.lefdef_config.produce_cell_outlines = True
 layoutOptions.lefdef_config.produce_obstructions = True
 
+app = pya.Application.instance()
+# show all cells
+app.set_config('full-hierarchy-new-cell', 'true')
+# no tip pop-ups
+app.set_config('tip-window-hidden', 'only-top-level-shown-by-default=3,editor-mode=4,editor-mode=0')
+# hide text
+app.set_config('text-visible', 'false')
+
 # Display the file!
 cell_view = pya.MainWindow.instance().load_layout(filename, layoutOptions, 0)
 layout_view = cell_view.view()

--- a/third_party/pdks/virtual/freepdk45/pdk/r1p0/setup/klayout/freepdk45.lyp
+++ b/third_party/pdks/virtual/freepdk45/pdk/r1p0/setup/klayout/freepdk45.lyp
@@ -563,7 +563,7 @@
    <source>63/63@1</source>
   </properties>
   <properties>
-   <frame-color>#ffffff</frame-color>
+   <frame-color>#ffae00</frame-color>
    <fill-color/>
    <frame-brightness>0</frame-brightness>
    <fill-brightness>0</fill-brightness>


### PR DESCRIPTION
This PR implements some of the sc-show enhancements we discussed during sync today:
- Don't use KLayout config file (this means setting changes during the session won't be cached)
- Programmatically set up some reasonable defaults: hide tips, display full hierarchy, hide text

I also made the cell outline visible in FreePDK45 using the same color as the Skywater layer mapping.