### PR TITLE
Add '-y' flag to verilator apt-get install script.

### DIFF
--- a/setup/install-verilator-pkg.sh
+++ b/setup/install-verilator-pkg.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-sudo apt-get install verilator
+sudo apt-get install -y verilator


### PR DESCRIPTION
This is the only install script in our `setup/` directory that calls `apt-get install` without a `-y` flag, which means that it will prompt the user before installing the package's dependencies. That makes it a bit harder to use in an automated 'system setup' script.