### PR TITLE
Fix exception that is thrown when we get() a list that's None

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -987,6 +987,8 @@ class Chip:
                     if bool(re.match(r'\[', cfg[param]['type'])):
                         sctype = re.sub(r'[\[\]]', '', cfg[param]['type'])
                         return_list = []
+                        if selval is None:
+                            return None
                         for item in selval:
                             if sctype == 'int':
                                 return_list.append(int(item))


### PR DESCRIPTION
This quick PR is meant to fix a hard-to-debug error that I occasionally get that looks like:

```
  File "/home/noah/zeroasic/siliconcompiler/siliconcompiler/core.py", line 3018, in run
    self.check_manifest()
  File "/home/noah/zeroasic/siliconcompiler/siliconcompiler/core.py", line 1454, in check_manifest
    key_empty = self._keypath_empty(key)
  File "/home/noah/zeroasic/siliconcompiler/siliconcompiler/core.py", line 1404, in _keypath_empty
    value = self.get(*key)
  File "/home/noah/zeroasic/siliconcompiler/siliconcompiler/core.py", line 710, in get
    return self._search(cfg, keypathstr, *keypath, field=field, mode='get')
  File "/home/noah/zeroasic/siliconcompiler/siliconcompiler/core.py", line 1041, in _search
    return self._search(cfg[param], keypath, *all_args, field=field, mode=mode, clobber=clobber)
  File "/home/noah/zeroasic/siliconcompiler/siliconcompiler/core.py", line 1041, in _search
    return self._search(cfg[param], keypath, *all_args, field=field, mode=mode, clobber=clobber)
  File "/home/noah/zeroasic/siliconcompiler/siliconcompiler/core.py", line 990, in _search
    for item in selval:
TypeError: 'NoneType' object is not iterable
```

It comes up when we call `chip.get()` on a list that's value is set to `None`.

This PR fixes the problem by returning `None` if a list type is set to `None`. However, I'm not sure if we want to support `None` as a valid value for list types -- I think an alternative approach could be to enforce that unset lists are always `[]`. I'm not sure what the spec is intended to be (if we've even thought about this yet)? If we do want to enforce that unset lists are always `[]`, then I'll update this PR to fix some default values instead (which is how this came up originally). 