### PR TITLE
Use hard links when copying files around build directory

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2747,7 +2747,7 @@ class Chip:
             # Skip copying pkg.json files here, since we write the current chip
             # configuration into inputs/{design}.pkg.json earlier in _runstep.
             utils.copytree(f"../../../{job}/{in_step}/{in_index}/outputs", 'inputs/', dirs_exist_ok=True,
-                ignore=[f'{design}.pkg.json'])
+                ignore=[f'{design}.pkg.json'], link=True)
 
 
         ##################
@@ -2858,7 +2858,7 @@ class Chip:
                     self._haltstep(step, index, active)
         else:
             #for builtins, copy selected inputs to outputs
-            utils.copytree(f"inputs", 'outputs', dirs_exist_ok=True)
+            utils.copytree(f"inputs", 'outputs', dirs_exist_ok=True, link=True)
 
         ##################
         # 17. Post process (could fail)

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -123,11 +123,6 @@ def post_process(chip):
     if step != 'import':
         return 0
 
-    # Copy files from inputs to outputs. Need to do this before pickling since
-    # we may otherwise overwrite the pickled file with one of the Verilog
-    # sources.
-    utils.copytree("inputs", "outputs", dirs_exist_ok=True)
-
     # Look in slpp_all/file_elab.lst for list of Verilog files included in
     # design, read these and concatenate them into one pickled output file.
     with open('slpp_all/file_elab.lst', 'r') as filelist, \
@@ -140,6 +135,11 @@ def post_process(chip):
                 outfile.write(infile.read())
             # in case end of file is missing a newline
             outfile.write('\n')
+
+    # Copy files from inputs to outputs. Need to skip pickled Verilog and
+    # manifest since new versions of those are written.
+    utils.copytree("inputs", "outputs", dirs_exist_ok=True, link=True,
+                   ignore=[f'{design}.v', f'{design}.pkg.json'])
 
     # Clean up
     shutil.rmtree('slpp_all')

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -152,11 +152,12 @@ def post_process(chip):
     else:
         topmodule = chip.cfg['design']['value']
 
-    # Copy files from inputs to outputs
-    utils.copytree("inputs", "outputs", dirs_exist_ok=True)
-
     # Moving pickled file to outputs
     os.rename("verilator.v", "outputs/" + topmodule + ".v")
+
+    # Copy files from inputs to outputs
+    utils.copytree("inputs", "outputs", dirs_exist_ok=True, link=True,
+                   ignore=[f'{topmodule}.v', f'{topmodule}.pkg.json'])
 
     # Clean up
     shutil.rmtree('obj_dir')

--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -1,9 +1,13 @@
 import os
 import shutil
 
-def copytree(src, dst, ignore=[], dirs_exist_ok=False):
+def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
     '''Simple implementation of shutil.copytree to give us a dirs_exist_ok
-    option in Python < 3.8.'''
+    option in Python < 3.8.
+
+    If link is True, create hard links in dst pointing to files in src
+    instead of copying them.
+    '''
     os.makedirs(dst, exist_ok=dirs_exist_ok)
 
     for name in os.listdir(src):
@@ -15,5 +19,7 @@ def copytree(src, dst, ignore=[], dirs_exist_ok=False):
 
         if os.path.isdir(srcfile):
             copytree(srcfile, dstfile, ignore=ignore, dirs_exist_ok=dirs_exist_ok)
+        elif link:
+            os.link(srcfile, dstfile)
         else:
             shutil.copy2(srcfile, dstfile)


### PR DESCRIPTION
This PR changes our file-copying logic to use hard links when copying files around the build directory. Overall the change was pretty small, and seems to result in big savings - previously, the ZeroSoC build directory (core-only, no verification) was 1.2 GB, with this change it goes down to 400 MB (3x smaller!)

