### PR TITLE
Handle unset metrics more gracefully in summary()

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2225,7 +2225,7 @@ class Chip:
                         value = self.get('metric', step, index, metric, 'real')
 
                     if value is None:
-                        value = '-'
+                        value = 'ERR'
                     else:
                         value = str(value)
 


### PR DESCRIPTION
I noticed that when steps fail with the remote flow, the summary function logs a bunch of errors due to attempts to read schema entries that do not exist, and the table is printed with a bunch of entries that say `None`. 

This PR fixes up this behavior by checking if metrics exist before calling `get()`, and displaying unset values as `-`s, which I think look cleaner than None.
