### PR TITLE
Fix bug where flowstatus error values get lost

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3046,8 +3046,7 @@ class Chip:
                     else:
                         indexlist = self.getkeys('flowgraph', step)
                     if (step in steplist) & (index in indexlist):
-                        self.set('flowstatus', step, str(index), 'error', 1)
-                        error[stepstr] = self.get('flowstatus', step, str(index), 'error')
+                        error[stepstr] = 1
                         active[stepstr] = 1
                         # Setting up tool is optional
                         tool = self.get('flowgraph', step, index, 'tool')
@@ -3062,8 +3061,7 @@ class Chip:
                             self.set('arg','step', None)
                             self.set('arg','index', None)
                     else:
-                        self.set('flowstatus', step, str(index), 'error', 0)
-                        error[stepstr] = self.get('flowstatus', step, str(index), 'error')
+                        error[stepstr] = 0
                         active[stepstr] = 0
 
             # Implement auto-update of jobincrement

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -99,6 +99,11 @@ def test_failed_branch_min(chip):
     chip.set('flowgraph', 'placemin', '0', 'tool', 'minimum')
     chip.set('flowgraph', 'placemin', '0', 'input', [('place','0'), ('place','1')])
 
+    # Don't need CTS for what this test is focused on, but this lets it double
+    # as a regression test for issue #651.
+    chip.set('flowgraph', 'cts', '0', 'tool', 'openroad')
+    chip.set('flowgraph', 'cts', '0', 'input', [('placemin', '0')])
+
     chip.run()
 
     assert chip.get('flowstatus', 'place', '0', 'error') == 1


### PR DESCRIPTION
This PR fixes issue #651, where it seemed like flowstatus error values weren't being propagated between steps. It turns out there's a simple fix: I don't think we should be setting 'flowstatus', 'error' for every task to 1 in the schema in `run()`. This prevents these values from being updated by the `read_manifest()` call we make on all input dependencies in step 5 of `_runtask()`.