### PR TITLE
Prune the remote schema down to a single boolean flag.

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2672,7 +2672,7 @@ class Chip:
         # 5. Merge manifests from all input dependancies
 
         all_inputs = []
-        if not self.get('remote', 'proc'):
+        if not self.get('remote'):
             for in_step, in_index in self.get('flowgraph', step, index, 'input'):
                 index_error = error[in_step + in_index]
                 self.set('flowstatus', in_step, in_index, 'error', index_error)
@@ -2975,7 +2975,7 @@ class Chip:
                 shutil.rmtree(cur_job_dir)
 
         # Remote workflow: Dispatch the Chip to a remote server for processing.
-        if self.get('remote', 'proc'):
+        if self.get('remote'):
             # Load the remote storage config into the status dictionary.
             if self.get('credentials'):
                 # Use the provided remote credentials file.

--- a/siliconcompiler/flows/asicflow.py
+++ b/siliconcompiler/flows/asicflow.py
@@ -124,9 +124,6 @@ def setup_flow(chip):
     # Set mandatory mode
     chip.set('mode', 'asic')
 
-    # Set the steplist which can run remotely (if required)
-    chip.set('remote', 'steplist', flowpipe[1:] + (['extspice', 'lvsjoin', 'lvs', 'drc', 'signoff'] if verify else []))
-
     # Showtool definitions
     chip.set('showtool', 'def', 'klayout')
     chip.set('showtool', 'gds', 'klayout')

--- a/siliconcompiler/flows/fpgaflow.py
+++ b/siliconcompiler/flows/fpgaflow.py
@@ -86,9 +86,6 @@ def setup_flow(chip):
     if sv:
         flowpipe = flowpipe[:1] + ['convert'] + flowpipe[1:]
 
-    # Set the steplist which can run remotely (if required)
-    chip.set('remote', 'steplist', flowpipe[1:])
-
     # Minimal setup
     index = '0'
     for i, step in enumerate(flowpipe):

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -3838,51 +3838,18 @@ def schema_showtool(cfg, filetype='default'):
 #############################################
 def schema_remote(cfg):
 
-    cfg['remote'] = {}
 
-    cfg['remote']['proc'] = {
-        'switch': "-remote_proc <bool>",
+    cfg['remote'] = {
+        'switch': "-remote <bool>",
         'type': 'bool',
         'lock': 'false',
         'require': None,
         'defvalue': False,
         'shorthelp': 'Flag to run a job through a remote server.',
-        'example': ["cli: -remote_proc",
-                    "api: chip.set('remote', 'proc', True)"],
+        'example': ["cli: -remote",
+                    "api: chip.set('remote', True)"],
         'help': """
         Determines whether the job should be run locally, or on a remote server.
-        """
-    }
-
-    # Job hash. Used to resume or cancel remote jobs after they are started.
-    cfg['remote']['jobhash'] = {
-        'switch': "-remote_jobhash <str>",
-        'type': 'str',
-        'lock': 'false',
-        'require': None,
-        'defvalue': None,
-        'shorthelp': 'Job hash/UUID value',
-        'example': ["cli: -remote_jobhash 0123456789abcdeffedcba9876543210",
-                    "api: chip.set('remote', 'jobhash','0123456789abcdeffedcba9876543210')"],
-        'help': """
-        A unique ID associated with a job run. This field should be left blank
-        when starting a new job, but it can be provided to resume an interrupted
-        remote job, or to clean up after unexpected failures.
-        """
-    }
-
-    # Remote execution steplist
-    cfg['remote']['steplist'] = {
-        'switch': "-remote_steplist <str>",
-        'type': '[str]',
-        'lock': 'false',
-        'require': None,
-        'defvalue': [],
-        'shorthelp': 'Remote steplist execution',
-        'example': ["cli: -remote_steplist syn",
-                    "api: chip.set('remote', 'steplist', 'syn')"],
-        'help': """
-        List of steps to execute remotely.
         """
     }
 

--- a/siliconcompiler/server.py
+++ b/siliconcompiler/server.py
@@ -164,6 +164,7 @@ class Server:
         job_name = chip.get('jobname')
         job_id = chip.get('jobname')
         job_nameid = f'{job_name}'
+        chip.status['jobhash'] = job_hash
 
         # Ensure that the job's root directory exists.
         job_root = f"{self.cfg['nfsmount']['value'][-1]}/{job_hash}"
@@ -221,7 +222,7 @@ class Server:
         #subprocess.run(['ln', '-s', '%s/import0'%build_dir, '%s/%s/import0'%(jobs_dir, job_nameid)])
 
         # Remove 'remote' JSON config value to run locally on compute node.
-        chip.set('remote', 'proc', False, clobber=True)
+        chip.set('remote', False, clobber=True)
         chip.set('remote', 'credentials', '', clobber=True)
         # Rename source files in the config dict; the 'import' step already
         # ran and collected the sources into a single Verilog file.
@@ -407,7 +408,7 @@ class Server:
         '''
 
         # Assemble core job parameters.
-        job_hash = chip.get('remote', 'jobhash')
+        job_hash = chip.status['jobhash']
         top_module = chip.get('design')
         job_nameid = f"{chip.get('jobname')}"
         nfs_mount = self.cfg['nfsmount']['value'][-1]
@@ -430,7 +431,7 @@ class Server:
             # Run the job with slurm clustering.
             chip.set('dir', f'{nfs_mount}/{job_hash}', clobber=True)
             chip.set('jobscheduler', 'slurm')
-            chip.set('remote', 'proc', False)
+            chip.set('remote', False)
             chip.set('remote', 'credentials', '', clobber=True)
             chip.status['decrypt_key'] = base64.urlsafe_b64encode(pk)
             chip.run()
@@ -490,7 +491,7 @@ class Server:
         '''
 
         # Collect a few bookkeeping values.
-        job_hash = chip.get('remote', 'jobhash')
+        job_hash = chip.status['jobhash']
         top_module = chip.get('design')
         sc_sources = chip.get('source')
         build_dir = chip.get('dir')

--- a/tests/flows/test_server.py
+++ b/tests/flows/test_server.py
@@ -37,7 +37,7 @@ def test_gcd_server(gcd_chip):
     tmp_creds = '.test_remote_cfg'
     with open(tmp_creds, 'w') as tmp_cred_file:
         tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8080}))
-    gcd_chip.set('remote', 'proc', True)
+    gcd_chip.set('remote', True)
     gcd_chip.set('credentials', os.path.abspath(tmp_creds))
 
     # Run the remote job.


### PR DESCRIPTION
Like we talked about this morning, this change replaces `remote_steplist` with `flowgraph[1:]` and moves `remote_jobhash` into the transient 'status' dictionary. That lets us rename the `-remote_proc` flag to `-remote`.