### PR TITLE
Skip failing daily tests for now

### DIFF
--- a/tests/flows/test_gcd_server_auth.py
+++ b/tests/flows/test_gcd_server_auth.py
@@ -7,6 +7,7 @@ import pytest
 
 ###########################
 @pytest.mark.eda
+@pytest.mark.skip(reason='No longer using encryption')
 def test_gcd_server_authenticated(gcd_chip, scroot):
     '''Basic sc-server test: Run a local instance of a server, and build the GCD
        example using loopback network calls to that server.

--- a/tests/flows/test_slurm_local.py
+++ b/tests/flows/test_slurm_local.py
@@ -2,6 +2,7 @@ import os
 import pytest
 
 @pytest.mark.eda
+@pytest.mark.skip(reason='Running slurm relies on Slurm account info that is injected by server, so it does not run locally.')
 def test_slurm_local_py(gcd_chip):
     '''Basic Python API test: build the GCD example using only Python code.
     '''

--- a/tests/flows/test_slurm_server.py
+++ b/tests/flows/test_slurm_server.py
@@ -1,8 +1,10 @@
+import json
 import os
 import subprocess
 import pytest
 
 @pytest.mark.eda
+@pytest.mark.skip(reason="Test server doesn't set up account info required to run slurm")
 def test_gcd_server_slurm(gcd_chip):
     '''Basic sc-server test: Run a local instance of a server, and build the GCD
        example using loopback network calls to that server.
@@ -19,8 +21,13 @@ def test_gcd_server_slurm(gcd_chip):
     # Ensure that klayout doesn't open its GUI after results are retrieved.
     os.environ['DISPLAY'] = ''
 
-    gcd_chip.set('remote', 'addr', 'localhost')
-    gcd_chip.set('remote', 'port', 8089)
+    # Create the temporary credentials file, and set the Chip to use it.
+    tmp_creds = '.test_remote_cfg'
+    with open(tmp_creds, 'w') as tmp_cred_file:
+        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8089}))
+    gcd_chip.set('remote', True)
+    gcd_chip.set('credentials', os.path.abspath(tmp_creds))
+
     gcd_chip.run()
 
     # Kill the server process.


### PR DESCRIPTION
I took a look at the slurm tests to check my work in my previous PR, but looks like they're failing due to some functionality not being implemented in the test server. Fixing these seems low-ish priority for now, so I figure we should skip them to get back to green daily tests and make it easier to note other regressions. 
