### PR TITLE
Fix `tar` import step warning

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -132,6 +132,8 @@ def request_remote_run(chip):
     subprocess.run(['tar',
                     '-cf',
                     'import.zip',
+                    '--exclude',
+                    'import.zip',
                     '.'],
                    cwd=local_build_dir)
     upload_file = os.path.abspath(os.path.join(local_build_dir, 'import.zip'))


### PR DESCRIPTION
This change fixes the "`tar: ./import.zip: file is the archive; not dumped`" message which is currently printed right before a remote job is submitted.

The warning is printed because the import archive is located within the directory that `tar` is trying to compress. By excluding `[dir]/import.zip` from the list of files to archive, we avoid the attempt at recursive zipping.