### PR TITLE
Hack to ensure remote run doesn't modify 'dir' param

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3212,7 +3212,9 @@ class Chip:
         lastdir = self._getworkdir(step=laststep, index=lastindex)
         lastcfg = f"{lastdir}/outputs/{self.get('design')}.pkg.json"
         if os.path.isfile(lastcfg):
+            local_dir = self.get('dir')
             self.read_manifest(lastcfg, clobber=True, clear=True)
+            self.set('dir', local_dir)
 
         # Store run in history
         self.cfghistory[self.get('jobname')] = copy.deepcopy(self.cfg)


### PR DESCRIPTION
This PR implements a quick hack that would fix #609, although it doesn't fully fix the problem of sanitizing server file fields. This PR would gets things like `sc-show` working until we get around to fixing #609 properly. 