### PR TITLE
Add logic to write_manifest to replace build dir with local dir

### DIFF
--- a/tests/core/test_write_manifest.py
+++ b/tests/core/test_write_manifest.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 import siliconcompiler
+import os
 
 def test_write_manifest():
 
@@ -18,6 +19,30 @@ def test_write_manifest():
     chip.write_manifest('top.csv')
     chip.write_manifest('top.tcl')
     chip.write_manifest('top.yaml')
+
+def test_write_manifest_dir_sanitize():
+
+    chip = siliconcompiler.Chip()
+
+    chip.status['local_dir'] = 'build'
+    chip.set('dir', 'remote_build_dir')
+
+    chip.add('constraint', 'top.sdc')
+    chip.set('description', 'A dummy project')
+    chip.add('cfg', os.path.join(chip.get('dir'), 'mycfg.json'))
+    chip.add('source', 'top.v')
+    chip.add('source', 'a.v')
+    chip.add('source', 'b.v')
+    chip.add('source', 'c.v')
+    chip.set('design', 'top')
+
+    chip.write_manifest('top.pkg.json')
+
+    new_chip = siliconcompiler.Chip()
+    new_chip.read_manifest('top.pkg.json')
+
+    assert new_chip.get('dir') == chip.status['local_dir']
+    assert new_chip.get('cfg')[0] == os.path.join(chip.status['local_dir'], 'mycfg.json')
 
 #########################
 if __name__ == "__main__":


### PR DESCRIPTION
This PR addresses sanitizing remote build directories from the schema. I added some logic to `write_manifest()` to loop through every file/dict param, check for paths that are under `self.get('dir')`, and re-write those paths to be under `chip.status['local_dir']`. 

This additional logic only runs if `chip.status['local_dir']` exists, and if the `abspath` param is False in the `write_manifest()` call. The abspath check makes sure that we don't perform this replacement on the TCL manifests dumped for tool consumption, which will rely on having the actual remote paths during runtime. 

It feels a little ugly to me to put all this in `write_manifest()`, although at the same time it seems to me like a logical place for it. Very much open to any other ideas you have though @WRansohoff, just thought I'd try this out. 