### PR TITLE
Prettify remote_run error message

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -151,7 +151,7 @@ def request_remote_run(chip):
             if resp.status_code == 302:
                 redirect_url = resp.headers['Location']
             elif resp.status_code >= 400:
-                chip.logger.info(resp.text)
+                chip.logger.error(resp.json()['message'])
                 chip.logger.error('Error starting remote job run; quitting.')
                 sys.exit(1)
             else:


### PR DESCRIPTION
Good news, looks like the sanitizer is working as intended (and we'll either need to loosen it or I need to get rid of the underscore in the ZeroSoC's top-level module, which is currently `asic_core`...)

This quick change just cleans up the logging on error, so we go from:

```
| INFO    | job0    | ---          | -   | {"message": "Error: value for ['design'] must contain only alphanumeric characters."}
| ERROR   | job0    | ---          | -   | Error starting remote job run; quitting.
```

to:

```
| ERROR   | job0    | ---          | -   | Error: value for ['design'] must contain only alphanumeric characters.
| ERROR   | job0    | ---          | -   | Error starting remote job run; quitting.
```

I checked and seems like the server consistently supplies a JSON response with a 'message' field on error for this endpoint. 
