### PR TITLE
Make EDA tool version optional in check

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2905,7 +2905,7 @@ class Chip:
 
             version = parse_version(proc.stdout)
             allowed_versions = self.get('eda', tool, step, index, 'version')
-            if version not in allowed_versions:
+            if allowed_versions and version not in allowed_versions:
                 allowedstr = ', '.join(allowed_versions)
                 self.logger.error(f"Version check failed for {tool}. Check installation.")
                 self.logger.error(f"Found version {version}, expected one of [{allowedstr}].")


### PR DESCRIPTION
Looks like the problem with the FPGA flow on the server arises because no tool version is specified for the 'icepack' tool. I think we can get rid of this check in `check_manifest()`, and just make it so a tool without any versions specified always passes the version check. This tool has no version number, so it seems like there's not much choice except to make it optional in those cases.