### PR TITLE
Fix logger bug

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -885,7 +885,7 @@ class Chip:
         all_args = list(args)
 
         # Special case to ensure loglevel is updated ASAP
-        if len(args) == 2 and args[0] == 'loglevel':
+        if len(args) == 2 and args[0] == 'loglevel' and field == 'value':
             self.logger.setLevel(args[1])
 
         self.logger.debug(f"Setting [{keypathstr}] to {args[-1]}")


### PR DESCRIPTION
This PR fixes the logger bug we discussed this morning. It's a fun one, that came about as a combination of two things:

- The change to override the loglevel on `chip.set('loglevel', ...)`
- The change to set the `lock`, `copy`, etc. fields in `read_manifest()`

The problem is I forgot a check that `field` is `'value'` in the special loglevel set() codepath, which means that the `read_manifest()` call that begins each task would originally set the value of the log correctly, then overwrite it with the value 'False' since all the additional boolean fields in the 'loglevel' parameter are False. Turns out setting the loglevel to False silences the log.

This small patch fixes it, I'll look into adding a regression test now.