### PR TITLE
Don't duplicate CLI options for netgen and magic

### DIFF
--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -70,7 +70,7 @@ def setup_tool(chip):
     options.append('-dnull')
     options.append('-rcfile')
     options.append('sc.magicrc')
-    chip.add('eda', tool, step, index, 'option', options)
+    chip.set('eda', tool, step, index, 'option', options, clobber=False)
 
 ################################
 # Version Check

--- a/siliconcompiler/tools/netgen/netgen.py
+++ b/siliconcompiler/tools/netgen/netgen.py
@@ -58,7 +58,7 @@ def setup_tool(chip):
     options = []
     options.append('-batch')
     options.append('source')
-    chip.add('eda', tool, step, index, 'option', options)
+    chip.set('eda', tool, step, index, 'option', options, clobber=False)
 
 ################################
 # Version Check


### PR DESCRIPTION
I noticed that `setup_tool()` gets called twice with the remote flow, so I needed to adjust the Magic and Netgen setup scripts to ensure their CLI options aren't duplicated. This happens since we have one top-level SC run that then calls `_deferstep()`, which re-runs SC for each particular step. It might be nice to get rid of this duplicate setup in the future, but for now this should eliminate issues running the verification part of the flow remotely. 