### PR TITLE
Dynamic import modules directly from paths

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -459,13 +459,14 @@ class Chip:
             else:
                 self.logger.info(f"Loading function '{funcname}' from module '{modulename}'")
             try:
-                sys.path.append(os.path.dirname(fullpath))
-                imported = importlib.import_module(modulename)
+                spec = importlib.util.spec_from_file_location(modulename, fullpath)
+                imported = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(imported)
+
                 if hasattr(imported, funcname):
                     function = getattr(imported, funcname)
                 else:
                     function = None
-                sys.path.pop()
                 return function
             except:
                 traceback.print_exc()
@@ -3156,6 +3157,9 @@ class Chip:
                             self.set('arg','step', step)
                             self.set('arg','index', index)
                             func = self.find_function(tool, 'tool', 'setup_tool')
+                            if func is None:
+                                self.logger.error(f'setup_tool() not found for tool {tool}')
+                                sys.exit(1)
                             func(self)
                             # Need to clear index, otherwise we will skip
                             # setting up other indices. Clear step for good


### PR DESCRIPTION
@WRansohoff and I ran into a funky issue where a Python package globally installed alongside KLayout got imported here instead of the SC tool module.

This PR tweaks the import logic to load a module directly from a path to its Python source file, using the same pattern I use in the documentation generators. This seems safer in terms of conflicts to me, although another possible solution if we want to use importlib in the same way as before would be to prepend `fullpath` to `sys.path` instead of appending it (so it takes highest precedence). 