### PR TITLE
Clean up Sphinx warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,8 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'friendly'
 
+suppress_warnings = ['autosectionlabel.*']
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/tutorials/zerosoc.rst
+++ b/docs/tutorials/zerosoc.rst
@@ -61,8 +61,8 @@ submodules to pull down the required third-party design files:
   $ git submodule update --init --recursive
 
 In order to follow along, you should also :ref:`install
-SiliconCompiler<Installation from PyPI>` and the :ref:`KLayout layout
-viewer<Layout viewer>`.
+SiliconCompiler<SiliconCompiler Setup>` and the :ref:`KLayout layout
+viewer<Tool Setup>`.
 
 If you install SC from PyPI rather than from source, you'll need to clone the
 SiliconCompiler repository and configure your SC path to point to the repo in

--- a/docs/user_guide/programming_model.rst
+++ b/docs/user_guide/programming_model.rst
@@ -82,7 +82,6 @@ For complete information, see the :ref:`Core API` section of the reference manua
     ~siliconcompiler.core.Chip.calc_area
     ~siliconcompiler.core.Chip.calc_yield
     ~siliconcompiler.core.Chip.calc_dpw
-    ~siliconcompiler.core.Chip.calc_diecost
     ~siliconcompiler.core.Chip.check_manifest
     ~siliconcompiler.core.Chip.clock
     ~siliconcompiler.core.Chip.create_cmdline

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -714,7 +714,7 @@ class Chip:
         Returns a schema parameter field.
 
         Returns a schema parameter filed based on the keypath and value provided
-        in the *args. The returned type is consistent with the type field of
+        in the ``*args``. The returned type is consistent with the type field of
         the parameter. Fetching parameters with empty or undefined value files
         returns None for scalar types and [] (empty list) for list types.
         Accessing a non-existent keypath produces a logger error message and
@@ -824,7 +824,7 @@ class Chip:
         Sets a schema parameter field.
 
         Sets a schema parameter field based on the keypath and value provided
-        in the *args. New schema dictionaries are automatically created for
+        in the ``*args``. New schema dictionaries are automatically created for
         keypaths that overlap with 'default' dictionaries. The write action
         is ignored if the parameter value is non-empty and the clobber
         option is set to False.
@@ -869,7 +869,7 @@ class Chip:
         Adds item(s) to a schema parameter list.
 
         Adds item(s) to schema parameter list based on the keypath and value
-        provided in the *args. New schema dictionaries are
+        provided in the ``*args``. New schema dictionaries are
         automatically created for keypaths that overlap with 'default'
         dictionaries.
 
@@ -1814,7 +1814,7 @@ class Chip:
                         border=True, landscape=False):
         '''Renders and saves the compilation flowgraph to a file.
 
-        The chip object flowgraph is traversed to create a graphviz (*.dot)
+        The chip object flowgraph is traversed to create a graphviz (\*.dot)
         file comprised of node, edges, and labels. The dot file is a
         graphical representation of the flowgraph useful for validating the
         correctness of the execution flow graph. The dot file is then

--- a/siliconcompiler/flows/fpgaflow.py
+++ b/siliconcompiler/flows/fpgaflow.py
@@ -11,7 +11,7 @@ import sys
 def make_docs():
     '''
     A configurable FPGA compilation flow.
-.
+
     The 'fpgaflow' module is a configurable FPGA flow with support for
     open source and commercial tool flows. The fpgaflow relies on the
     FPGA partname to determine which design tools to use for RTL to


### PR DESCRIPTION
This PR gets our Sphinx warnings down to a much more manageable number :) 

First of all, I suppressed the "duplicate label" warnings, which takes care of the bulk of it. These shouldn't matter unless we want to link to a section that has a duplicated name. In that case, we'll have to add an [explicit target](https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html#explicit-targets). I think there also might be an option that will deduplicate the section labels for us, but I think this might break existing links by adding a prefix to everything.
 
After the warnings were cleaned up, I cleaned up some of them by fixing a few rst style issues in docstrings and fixing some broken links in the ZeroSoC tutorial.

The remaining warnings are these, they don't seem particularly problematic at the moment:

```
/home/noah/zeroasic/siliconcompiler/docs/user_guide/glossary.rst:10: WARNING: duplicate term description of default, other instance in reference_manual/schema
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/noah/zeroasic/siliconcompiler/docs/reference_manual/environment.rst: WARNING: document isn't included in any toctree
/home/noah/zeroasic/siliconcompiler/docs/reference_manual/examples.rst: WARNING: document isn't included in any toctree
/home/noah/zeroasic/siliconcompiler/docs/resources/primer.rst: WARNING: document isn't included in any toctree
/home/noah/zeroasic/siliconcompiler/docs/tutorials/asicflow.rst: WARNING: document isn't included in any toctree
```