### PR TITLE
Print where the credentials are stored after running 'sc-configure'

### DIFF
--- a/siliconcompiler/apps/sc_configure.py
+++ b/siliconcompiler/apps/sc_configure.py
@@ -48,7 +48,7 @@ def main():
 }'''%(srv_addr, username, user_pass))
 
     # Let the user know that we finished successfully.
-    print('Configuration saved.')
+    print(f'Remote configuration saved to: {cfg_file}')
 
 #########################
 if __name__ == "__main__":


### PR DESCRIPTION
This is the small change to `sc-configure`'s output that we discussed earlier today.