### PR TITLE
Removing spaces from user inputs in sc-configure

### DIFF
--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -108,7 +108,7 @@ To create the credentials file, use a text editor to create the credentials file
 
 .. code-block:: console
 
-  (siliconcompiler) $ sc-configure
+  $ sc-configure
   Remote server address: "your-server"
   Remote username: "your-username"
   Remote password: "your-key"

--- a/siliconcompiler/apps/sc_configure.py
+++ b/siliconcompiler/apps/sc_configure.py
@@ -34,9 +34,9 @@ def main():
                 overwrite = True
 
     # Get parameters from user input.
-    srv_addr = input('Remote server address: ')
-    username = input('Remote username: ')
-    user_pass = input('Remote password: ')
+    srv_addr = input('Remote server address: ').replace(" ","")
+    username = input('Remote username: ').replace(" ","")
+    user_pass = input('Remote password: ').replace(" ","")
 
     # Save the values to the target config file in JSON format.
     with open(cfg_file, 'w') as f:


### PR DESCRIPTION
- If folks are copy pasting from emails, it's easy to add a leading/trailing space by mistake.
-Leading/trailing spaces not allowed anyway.