### PR TITLE
Add timing repair steps to CTS

### DIFF
--- a/siliconcompiler/tools/openroad/sc_cts.tcl
+++ b/siliconcompiler/tools/openroad/sc_cts.tcl
@@ -33,4 +33,9 @@ if {[llength [all_clocks]] > 0} {
 
     check_placement
 
+    repair_timing -setup
+    repair_timing -hold
+
+    detailed_placement
+    check_placement
 }


### PR DESCRIPTION
This PR adds `repair_timing` calls after running CTS.