### PR TITLE
Use urljoin to construct urls in client.py

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 import time
+import urllib.parse
 import uuid
 
 from siliconcompiler.crypto import *
@@ -108,7 +109,7 @@ def request_remote_run(chip):
     '''
 
     # Set the request URL.
-    remote_run_url = get_base_url(chip) + '/remote_run/'
+    remote_run_url = urllib.parse.urljoin(get_base_url(chip), '/remote_run/')
 
     # Use authentication if necessary.
     job_nameid = f"{chip.get('jobname')}"
@@ -166,7 +167,7 @@ def is_job_busy(chip):
     '''
 
     # Set the request URL.
-    remote_run_url = get_base_url(chip) + '/check_progress/'
+    remote_run_url = urllib.parse.urljoin(get_base_url(chip), '/check_progress/')
 
     # Set common parameters.
     post_params = {
@@ -197,7 +198,7 @@ def delete_job(chip):
     '''
 
     # Set the request URL.
-    remote_run_url = get_base_url(chip) + '/delete_job/'
+    remote_run_url = urllib.parse.urljoin(get_base_url(chip), '/delete_job/')
 
     # Set common parameter.
     post_params = {
@@ -229,7 +230,7 @@ def fetch_results_request(chip):
 
     # Set the request URL.
     job_hash = chip.status['jobhash']
-    remote_run_url = get_base_url(chip) + '/get_results/' + job_hash + '.tar.gz'
+    remote_run_url = urllib.parse.urljoin(get_base_url(chip), '/get_results/' + job_hash + '.tar.gz')
 
     # Set authentication parameters if necessary.
     rcfg = chip.status['remote_cfg']


### PR DESCRIPTION
I noticed a bug similar to the spaces-in-passwords one: if you set up the server URL with a trailing slash, the client will try to hit invalid endpoints and result in an odd crash. (this happened to me after I right-clicked the URL in the intro email and selected "Copy Link Address" instead of copy-pasting the text itself).

This small PR concatenates the URLs using Python's urllib, which is able to handle the presence of a trailing slash. 