### PR TITLE
Reenable missing_ok for _abspath()

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1359,7 +1359,7 @@ class Chip:
 
             #only do something if type is file or dir
             if 'file' in paramtype or 'dir' in paramtype:
-                abspaths = self.find_files(*keypath, cfg=cfg)
+                abspaths = self.find_files(*keypath, cfg=cfg, missing_ok=True)
                 self.set(*keypath, abspaths, cfg=cfg)
 
     ###########################################################################


### PR DESCRIPTION
I think we used to have this and got rid of it, but I realized that setting `missing_ok` to True is important in this context. When dumping a tool manifest, we call `_abspath()`, which iterates through all files in the schema. However, depending on the runtime context, certain paths may not be resolvable. Without `missing_ok=True`, this results in spurious errors.

For example, running heartbeat example in a clean environment with SC installed from the wheel, we get the following errors on import:
```
| ERROR   | job0    | ---          | -   | File ../third_party/pdks/virtual/freepdk45/pdk/r1p0/setup/klayout/freepdk45.lyt was not found
| ERROR   | job0    | ---          | -   | File ../third_party/pdks/virtual/freepdk45/pdk/r1p0/apr/freepdk45.tech.lef was not found
| ERROR   | job0    | ---          | -   | File ../third_party/pdks/virtual/freepdk45/libs/NangateOpenCellLibrary/r1p0/lib/NangateOpenCellLibrary_typical.lib was not found
| ERROR   | job0    | ---          | -   | File ../third_party/pdks/virtual/freepdk45/libs/NangateOpenCellLibrary/r1p0/lef/NangateOpenCellLibrary.macro.mod.lef was not found
| ERROR   | job0    | ---          | -   | File ../third_party/pdks/virtual/freepdk45/libs/NangateOpenCellLibrary/r1p0/gds/NangateOpenCellLibrary.gds was not found
```

This shouldn't matter though, since these files are not required for import, and will be present on the remote.

Another example are the ZeroSoC logs - on each remote step I noticed there was an error printed about not being able to find the ydir, idir, etc. directories. However, that's okay since these are only used locally on import.

I think it's safe not to do error-checking here since I think the dynamic `check_manifest()` call could eventually be made to look at every file parameter requirement for a tool and make sure it resolves to a correct path. That way the error checking is done in the context in which that task is run, and it only checks files that need to be present for that particular task.