### PR TITLE
Document that 'eda', ... 'variable' is legal for remote

### DIFF
--- a/docs/user_guide/remote_processing.rst
+++ b/docs/user_guide/remote_processing.rst
@@ -94,3 +94,5 @@ For security reasons, only a subset of the full Schema parameters is currently s
      - None
    * - ``checkonly``
      - None
+   * - ``eda, ..., variable, ...``
+     - None


### PR DESCRIPTION
Had to add this for ZeroSoC to work. 