### PR TITLE
set() targetlib instead of add() in PDK setup files

### DIFF
--- a/siliconcompiler/pdks/freepdk45.py
+++ b/siliconcompiler/pdks/freepdk45.py
@@ -208,7 +208,7 @@ def setup_pdk(chip):
     ###############################################
 
     chip.set('asic', 'stackup', chip.get('pdk', 'stackup')[0])
-    chip.add('asic', 'targetlib', libname)
+    chip.set('asic', 'targetlib', libname)
     chip.set('asic', 'minlayer', "m1")
     chip.set('asic', 'maxlayer', "m10")
     chip.set('asic', 'maxfanout', 64)

--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -254,7 +254,7 @@ def setup_pdk(chip):
     # Methodology
     ###############################################
 
-    chip.add('asic', 'targetlib', libname)
+    chip.set('asic', 'targetlib', libname)
     chip.set('asic', 'stackup', chip.get('pdk', 'stackup')[0])
     # TODO: how does LI get taken into account?
     chip.set('asic', 'minlayer', "m1")


### PR DESCRIPTION
Otherwise we get duplicate targetlibs on remote run.