### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,10 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
-   formats:
-    - pdf
+  configuration: docs/conf.py
+
+formats:
+  - pdf
 
 python:
     install:

--- a/docs/_ext/dynamicgen.py
+++ b/docs/_ext/dynamicgen.py
@@ -177,6 +177,8 @@ class DynamicGen(SphinxDirective):
         directory.'''
         modules = []
         for importer, modname, _ in pkgutil.iter_modules([module_dir]):
+            if modname in ('sc_floorplan'):
+                continue
             module = importer.find_module(modname).load_module(modname)
             modules.append((module, modname))
 
@@ -341,7 +343,7 @@ class AppGen(DynamicGen):
 
     def document_module(self, module, modname, path):
         # TODO: Auto-documentation does not work with apps that use 'input(...)'
-        if modname == 'sc_configure':
+        if modname in ('sc_configure'):
             return
 
         cmd_name = modname.replace('_', '-')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,3 +107,7 @@ html_css_files = [
 latex_elements = {
   'extraclassoptions': 'openany,oneside'
 }
+
+# -- Options for autodoc -----------------------------------------------------
+
+autodoc_mock_imports = ['siliconcompiler.leflib._leflib']


### PR DESCRIPTION
* Fix .readthedocs.yaml
* Skip leflib build on RTD
* Mock up leflib import/skip sc_floorplan for now
* Fix a sneaky typo in setup.py that caused pip-licenses not to get installed

I want to look into cleaner ways to handle some of these things going forward, but I think this should be good for now!