### PR TITLE
Fix a small typo in user_guide/installation

### DIFF
--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -5,7 +5,7 @@ Installation
 Python
 ------
 
-Before installing the SiliconCompiler package you will need to set up a Python environment. Currently Python 3-6-3.10 is supported.
+Before installing the SiliconCompiler package you will need to set up a Python environment. Currently Python 3.6-3.10 is supported.
 
 Ubuntu (>=18.04)
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Just walked through the signup process again, and I think I found a small typo near the top of the installation instructions.