### PR TITLE
Augment wheels workflow to automate PyPI release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -76,3 +76,19 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: wheelhouse/*.whl
+
+  publish:
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifact
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,6 @@ include setup.py
 include README.md
 
 include CMakeLists.txt
-include siliconcompiler/AUTHORS
 
 graft siliconcompiler/leflib
 graft siliconcompiler/templates


### PR DESCRIPTION
This PR adds logic to our wheels CI workflow to automatically build and upload the wheels to PyPI whenever we publish a new Github Release.