### PR TITLE
Bump Surelog Version

### DIFF
--- a/tests/tools/data/test_preproc.v
+++ b/tests/tools/data/test_preproc.v
@@ -1,0 +1,6 @@
+module test_preproc();
+`define MAKE_MEM_PATH(filename) `"`MEM_ROOT/filename`"
+    initial begin
+    $display(`MAKE_MEM_PATH(rom.mem));
+    end
+endmodule

--- a/tests/tools/test_surelog.py
+++ b/tests/tools/test_surelog.py
@@ -21,6 +21,31 @@ def test_surelog(scroot):
 
     assert chip.find_result('v', step=step) is not None
 
+@pytest.mark.eda
+@pytest.mark.quick
+def test_surelog_preproc_regression(datadir):
+    src = os.path.join(datadir, 'test_preproc.v')
+    design = 'test_preproc'
+    step = "import"
+
+    chip = siliconcompiler.Chip(loglevel="INFO")
+
+    chip.add('source', src)
+    chip.add('define', 'MEM_ROOT=test')
+    chip.set('design', design)
+    chip.set('mode', 'sim')
+    chip.set('arg', 'step', step)
+    chip.target('surelog')
+
+    chip.run()
+
+    result = chip.find_result('v', step=step)
+
+    assert result is not None
+
+    with open(result, 'r') as vlog:
+        assert "`MEM_ROOT" not in vlog.read()
+
 if __name__ == "__main__":
     from tests.fixtures import scroot
     test_surelog(scroot())


### PR DESCRIPTION
I noticed that the Surelog submodule version accidentally got decreased at some point, so our wheels bundle a version with this bug: https://github.com/chipsalliance/Surelog/issues/2176.

This PR brings Surelog back to a working version, and also adds a regression test for this bug that should prevent this from happening again. 