### PR TITLE
Handle duplicate file basenames

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1304,7 +1304,7 @@ class Chip:
 
         for path in paths:
             if (copyall or copy) and ('file' in paramtype):
-                name = os.path.basename(path)
+                name = self._get_imported_filename(path)
                 abspath = os.path.join(self._getworkdir(step='import'), 'outputs', name)
                 if os.path.isfile(abspath):
                     # if copy is True and file is found in import outputs,
@@ -1919,7 +1919,6 @@ class Chip:
 
         self.logger.info('Collecting input sources')
 
-        copied_filenames = set()
         #copy all parameter take from self dictionary
         copyall = self.get('copyall')
         for key in self.getkeys():
@@ -1928,16 +1927,11 @@ class Chip:
                 value = self.get(*key)
                 if copyall or copy:
                     for item in value:
-                        filename = os.path.basename(item)
-                        if filename in copied_filenames:
-                            self.logger.error(f'Filename {filename} already copied into inputs/ directory. Make sure all copied files have unique names')
-                            self._haltstep(step,index,active)
-                        copied_filenames.add(filename)
-
+                        filename = self._get_imported_filename(item)
                         filepath = self._find_sc_file(item)
                         if filepath:
                             self.logger.info(f"Copying {filepath} to 'inputs' directory")
-                            shutil.copy(filepath, indir)
+                            shutil.copy(filepath, os.path.join(indir, filename))
                         else:
                             self._haltstep(step,index,active)
 
@@ -3558,6 +3552,14 @@ class Chip:
             filepath = filepath.replace("$"+item, varpath)
 
         return filepath
+
+    #######################################
+    def _get_imported_filename(self, path):
+        ''' Utility to map collected files to an unambigious name based on their path.'''
+
+        basename = os.path.basename(path)
+        pathhash = hashlib.md5(path.encode('utf-8')).hexdigest()
+        return f'{basename}.{pathhash}'
 
 ###############################################################################
 # Package Customization classes

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -10,6 +10,7 @@ import traceback
 import asyncio
 from subprocess import run, PIPE
 import os
+import pathlib
 import sys
 import gzip
 import re
@@ -1930,7 +1931,7 @@ class Chip:
                         filename = self._get_imported_filename(item)
                         filepath = self._find_sc_file(item)
                         if filepath:
-                            self.logger.info(f"Copying {filepath} to 'inputs' directory")
+                            self.logger.info(f"Copying {filepath} to '{indir}' directory")
                             shutil.copy(filepath, os.path.join(indir, filename))
                         else:
                             self._haltstep(step,index,active)
@@ -3554,12 +3555,17 @@ class Chip:
         return filepath
 
     #######################################
-    def _get_imported_filename(self, path):
-        ''' Utility to map collected files to an unambigious name based on their path.'''
+    def _get_imported_filename(self, pathstr):
+        ''' Utility to map collected file to an unambigious name based on its path.
 
-        basename = os.path.basename(path)
-        pathhash = hashlib.md5(path.encode('utf-8')).hexdigest()
-        return f'{basename}.{pathhash}'
+        The mapping looks like:
+        path/to/file.ext => file_<md5('path/to/file.ext')>.ext
+        '''
+        path = pathlib.Path(pathstr)
+        oldstem = path.stem
+        pathhash = hashlib.md5(pathstr.encode('utf-8')).hexdigest()
+
+        return str(path.with_stem(f'{oldstem}_{pathhash}').name)
 
 ###############################################################################
 # Package Customization classes

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3562,10 +3562,16 @@ class Chip:
         path/to/file.ext => file_<md5('path/to/file.ext')>.ext
         '''
         path = pathlib.Path(pathstr)
-        oldstem = path.stem
+        ext = ''.join(path.suffixes)
+
+        # strip off all file suffixes to get just the bare name
+        while path.suffix:
+            path = pathlib.Path(path.stem)
+        filename = str(path)
+
         pathhash = hashlib.md5(pathstr.encode('utf-8')).hexdigest()
 
-        return str(path.with_stem(f'{oldstem}_{pathhash}').name)
+        return f'{filename}_{pathhash}{ext}'
 
 ###############################################################################
 # Package Customization classes

--- a/siliconcompiler/tools/klayout/def2stream.py
+++ b/siliconcompiler/tools/klayout/def2stream.py
@@ -219,11 +219,9 @@ sc_libtype = sc_cfg['library'][sc_mainlib]['arch']['value']
 tech_file = sc_cfg['pdk']['layermap'][sc_stackup]['def']['gds']['value'][0]
 
 design = sc_cfg['design']['value']
-if ('def' in sc_cfg['read'] and
-    sc_step in sc_cfg['read']['def'] and
-    sc_index in sc_cfg['read']['def'][sc_step]):
+try:
   in_def = sc_cfg['read']['def'][sc_step][sc_index]['value'][0]
-else:
+except (KeyError, IndexError):
   in_def = os.path.join('inputs', f'{design}.def')
 out_gds = os.path.join('outputs', f'{design}.gds')
 

--- a/siliconcompiler/tools/klayout/def2stream.py
+++ b/siliconcompiler/tools/klayout/def2stream.py
@@ -209,6 +209,9 @@ with open('sc_manifest.json', 'r') as f:
     sc_cfg = json.load(f)
 
 # Extract info from manifest
+sc_step = sc_cfg['arg']['step']['value']
+sc_index = sc_cfg['arg']['index']['value']
+
 sc_stackup = sc_cfg['pdk']['stackup']['value'][0]
 sc_mainlib = sc_cfg['asic']['targetlib']['value'][0]
 sc_libtype = sc_cfg['library'][sc_mainlib]['arch']['value']
@@ -216,7 +219,12 @@ sc_libtype = sc_cfg['library'][sc_mainlib]['arch']['value']
 tech_file = sc_cfg['pdk']['layermap'][sc_stackup]['def']['gds']['value'][0]
 
 design = sc_cfg['design']['value']
-in_def = os.path.join('inputs', f'{design}.def')
+if ('def' in sc_cfg['read'] and
+    sc_step in sc_cfg['read']['def'] and
+    sc_index in sc_cfg['read']['def'][sc_step]):
+  in_def = sc_cfg['read']['def'][sc_step][sc_index]['value'][0]
+else:
+  in_def = os.path.join('inputs', f'{design}.def')
 out_gds = os.path.join('outputs', f'{design}.gds')
 
 libs = sc_cfg['asic']['targetlib']['value']

--- a/siliconcompiler/tools/openroad/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/sc_apr.tcl
@@ -119,13 +119,14 @@ foreach lib $sc_macrolibs {
 }
 
 # Read Verilog
-if {[dict exists $sc_cfg "read" netlist $sc_step $sc_index]} {
-    foreach netlist [dict get $sc_cfg "read" netlist $sc_step $sc_index] {
-	read_verilog $netlist
+if {$sc_step == "floorplan"} {
+    if {[dict exists $sc_cfg "read" netlist $sc_step $sc_index]} {
+        foreach netlist [dict get $sc_cfg "read" netlist $sc_step $sc_index] {
+            read_verilog $netlist
+        }
+    } else {
+        read_verilog "inputs/$sc_design.vg"
     }
-    link_design $sc_design
-} elseif {$sc_step == "floorplan"} {
-    read_verilog "inputs/$sc_design.vg"
     link_design $sc_design
 }
 

--- a/siliconcompiler/tools/yosys/sc_lec.tcl
+++ b/siliconcompiler/tools/yosys/sc_lec.tcl
@@ -30,7 +30,12 @@ if {[dict exists $sc_cfg eda $sc_tool $sc_step $sc_index variable induction_step
 
 # Gold netlist
 yosys read_liberty -ignore_miss_func $sc_liberty
-yosys read_verilog "inputs/$sc_design.v"
+if {[file exists "inputs/$sc_design.v"]} {
+    set source "inputs/$sc_design.v"
+} else {
+    set source [lindex [dict get $sc_cfg source] 0]
+}
+yosys read_verilog $source
 
 yosys proc
 yosys rmports
@@ -45,7 +50,12 @@ yosys design -stash gold
 
 # Gate netlist
 yosys read_liberty -ignore_miss_func $sc_liberty
-yosys read_verilog "inputs/$sc_design.vg"
+if {[dict exists $sc_cfg read netlist $sc_step $sc_index]} {
+    set netlist [lindex [dict get $sc_cfg read netlist $sc_step $sc_index] 0]
+} else {
+    set netlist "inputs/$design.vg"
+}
+yosys read_verilog $netlist
 
 yosys proc
 yosys rmports

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -57,15 +57,14 @@ def chip(scroot):
     '''
 
     datadir = os.path.join(scroot, 'tests', 'data')
-    netlist = os.path.join(datadir, 'oh_fifo_sync_freepdk45.vg')
     def_file = os.path.join(datadir, 'oh_fifo_sync.def')
 
     design = "oh_fifo_sync"
 
     chip = siliconcompiler.Chip()
     chip.set('design', design)
-    chip.set('read', 'netlist', 'floorplan', '0', netlist)
-    chip.set('read', 'def', 'floorplan', '0', def_file)
+    chip.set('read', 'def', 'place', '0', def_file)
+    chip.set('read', 'def', 'place', '1', def_file)
     chip.set('mode', 'asic')
     chip.set('quiet', True)
     chip.target('freepdk45')

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -13,7 +13,7 @@ def test_klayout(datadir):
 
     chip = siliconcompiler.Chip()
     chip.set('design', 'heartbeat_wrapper')
-    chip.set('read', 'def', 'floorplan', '0', in_def)
+    chip.set('read', 'def', 'export', '0', in_def)
 
     chip.add('asic', 'macrolib', 'heartbeat')
     chip.set('library', 'heartbeat', 'lef', library_lef)

--- a/tests/tools/test_yosys.py
+++ b/tests/tools/test_yosys.py
@@ -15,7 +15,7 @@ def test_yosys_lec(datadir):
     chip.target('yosys_freepdk45')
 
     chip.add('source', os.path.join(lec_dir, 'foo.v'))
-    chip.add('source', os.path.join(lec_dir, 'foo.vg'))
+    chip.add('read', 'netlist', 'lec', '0', os.path.join(lec_dir, 'foo.vg'))
 
     chip.run()
 
@@ -31,12 +31,12 @@ def test_yosys_lec_broken(datadir):
     chip = siliconcompiler.Chip()
 
     chip.set('arg', 'step', 'lec')
-    chip.set('design', 'foo_broken')
+    chip.set('design', 'foo')
     chip.set('mode', 'asic')
     chip.target('yosys_freepdk45')
 
     chip.add('source', os.path.join(lec_dir, 'foo_broken.v'))
-    chip.add('source', os.path.join(lec_dir, 'foo_broken.vg'))
+    chip.add('read', 'netlist', 'lec', '0', os.path.join(lec_dir, 'foo_broken.vg'))
 
     chip.run()
 


### PR DESCRIPTION
This PR implements the change we discussed to append a hash to collected filenames to make sure they can be unambiguously identified after being placed in a single directory. The actual changes to the core logic are fairly minimal, although this did reveal a few bugs elsewhere that needed fixing. 