### PR TITLE
Add Migen tutorial

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ Welcome to SiliconCompiler's documentation!
    tutorials/contribution
    tutorials/parallel
    tutorials/slurmsetup
+   tutorials/frontends
 
 .. toctree::
    :maxdepth: 3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,7 @@ Welcome to SiliconCompiler's documentation!
    tutorials/contribution
    tutorials/parallel
    tutorials/slurmsetup
-   tutorials/frontends
+   tutorials/migen
 
 .. toctree::
    :maxdepth: 3

--- a/docs/tutorials/examples/migen_heartbeat.py
+++ b/docs/tutorials/examples/migen_heartbeat.py
@@ -1,0 +1,31 @@
+from migen import *
+from migen.fhdl.verilog import convert
+
+import siliconcompiler
+
+class Heartbeat(Module):
+  def __init__(self, N=8):
+    self.out = Signal()
+    self.counter_reg = Signal(N)
+
+    ###
+
+    self.sync += self.counter_reg.eq(self.counter_reg + 1)
+    self.sync += self.out.eq(self.counter_reg == Cat(Replicate(0, N-1), 1))
+
+def main():
+    heartbeat = Heartbeat()
+    convert(heartbeat, ios={heartbeat.out}, name='heartbeat').write('heartbeat.v')
+
+    chip = siliconcompiler.Chip()
+    chip.set('source', 'heartbeat.v')
+    chip.set('design', 'heartbeat')
+    # default Migen clock pin is named 'sys_clk'
+    chip.clock(name='sys', pin='sys_clk', period=1)
+    chip.target('asicflow_freepdk45')
+    chip.run()
+    chip.summary()
+    chip.show()
+
+if __name__ == '__main__':
+    main()

--- a/docs/tutorials/frontends.rst
+++ b/docs/tutorials/frontends.rst
@@ -1,0 +1,19 @@
+Alternate frontends
+========================================
+
+Along with Verilog and SystemVerilog, SiliconCompiler can be used with several other frontends that allow you to describe designs in a higher-level language.
+
+Migen (Python)
+---------------------------
+
+Since SC itself is a Python library, it can be used as-is in an end-to-end build script with any Python-based HDL that can be scripted to export designs to Verilog.
+
+For example, if you have SC installed already, you can quickly get started building designs written in the Migen HDL. To install Migen, run ``pip install migen``. Then, paste the following into a file called "migen_heartbeat.py".
+
+.. literalinclude:: examples/migen_heartbeat.py
+
+Run this file with ``python migen_heartbeat.py`` to compile your Migen design down to a GDS and automatically display it in KLayout.
+
+In this example, the ``Heartbeat`` class describes a design as a Migen module, and the ``main()`` function implements the build flow. The flow begins by using Migen's built-in functionality for exporting the design as a file named "heartbeat.v". The rest of the flow uses SC's core API to take this Verilog file and feed it into a basic asicflow build, as described in the :ref:`Quickstart guide`. For more info on how Migen works, see the `Migen docs <https://m-labs.hk/migen/manual/>`_.
+
+Although we wrote this example using Migen in particular, the concepts apply to other Python-based HDLs, such as `MyHDL  <https://www.myhdl.org/>`_ or `Amaranth <https://github.com/amaranth-lang/amaranth>`_ (note that Amaranth's Verilog backend requires Yosys installed locally).

--- a/docs/tutorials/migen.rst
+++ b/docs/tutorials/migen.rst
@@ -1,10 +1,5 @@
-Alternate frontends
-========================================
-
-Along with Verilog and SystemVerilog, SiliconCompiler can be used with several other frontends that allow you to describe designs in a higher-level language.
-
-Migen (Python)
----------------------------
+Python-based frontends
+===========================
 
 Since SC itself is a Python library, it can be used as-is in an end-to-end build script with any Python-based HDL that can be scripted to export designs to Verilog.
 


### PR DESCRIPTION
This PR adds a short example of how to use Migen with SC to a new page in the tutorials section. I figure we can fill this page out as SC gets support for additional frontends.