### PR TITLE
Use external link for SC logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-![alt text](docs/_images/sc_logo_with_text.png)
+![SC logo](https://raw.githubusercontent.com/siliconcompiler/siliconcompiler/main/docs/_images/sc_logo_with_text.png)
 
 [![Quick CI Tests](https://github.com/siliconcompiler/siliconcompiler/actions/workflows/on_push_tests.yml/badge.svg)](https://github.com/siliconcompiler/siliconcompiler/actions/workflows/on_push_tests.yml)
 [![Daily CI Tests](https://github.com/siliconcompiler/siliconcompiler/actions/workflows/daily_tests.yml/badge.svg)](https://github.com/siliconcompiler/siliconcompiler/actions/workflows/daily_tests.yml)


### PR DESCRIPTION
Very teeny detail, but I noticed that our logo doesn't load on our PyPI package page:

![Screen Shot 2021-12-21 at 3 31 08 PM](https://user-images.githubusercontent.com/4412459/146993712-38f49135-23be-4037-bfd5-52103650c1c6.png)

This PR should fix this whenever we deploy our next release: https://stackoverflow.com/questions/41983209/how-do-i-add-images-to-a-pypi-readme-that-works-on-github/46875147, and will make the page a little prettier. 