### PR TITLE
Fix sc-show on Windows after recent schema changes

### DIFF
--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -68,7 +68,7 @@ def setup_tool(chip, mode="batch"):
         script = '/klayout_export.py'
         option = ['-zz', '-r']
 
-    chip.set('eda', tool, 'exe', klayout_exe, clobber=clobber)
+    chip.set('eda', tool, 'exe', klayout_exe, clobber=True)
     chip.set('eda', tool, 'vswitch', '-zz -v', clobber=clobber)
     chip.set('eda', tool, 'version', '0.26.11', clobber=clobber)
     chip.set('eda', tool, 'format', 'json', clobber=clobber)


### PR DESCRIPTION
After the v0.3.0 changes, we need to override the KLayout executable name which `sc-show` loads out of the post-export manifest step. Without this change, the script tries to run `klayout` instead of `klayout_app.exe` on Windows platforms.