### PR TITLE
Cleaner error message when attempting to get() invalid multi-entry keypaths

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1108,8 +1108,12 @@ class Chip:
         #if not leaf cell descend tree
         else:
             ##copying in default tree for dynamic trees
-            if not param in cfg:
+            if not param in cfg and 'default' in cfg:
                 cfg[param] = copy.deepcopy(cfg['default'])
+            elif not param in cfg:
+                self.error = 1
+                self.logger.error(f"Get keypath [{keypath}] does not exist.")
+                return None
             all_args.pop(0)
             return self._search(cfg[param], keypath, *all_args, field=field, mode=mode, clobber=clobber)
 


### PR DESCRIPTION
I factored out this small error check from the big file checking PR since it's completely independent.

Before:
```
>>> chip.get('fake', 'keypath')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/noah/zeroasic/siliconcompiler/siliconcompiler/core.py", line 757, in get
    return self._search(cfg, keypathstr, *keypath, field=field, mode='get')
  File "/home/noah/zeroasic/siliconcompiler/siliconcompiler/core.py", line 1112, in _search
    cfg[param] = copy.deepcopy(cfg['default'])
KeyError: 'default'
```

After:
```
>>> chip.get('fake', 'keypath')
| ERROR   | job0    | ---          | -   | Get keypath [fake,keypath] does not exist.
```