### PR TITLE
Test show() on Windows CI

### DIFF
--- a/.github/workflows/bin/install_klayout_win.bat
+++ b/.github/workflows/bin/install_klayout_win.bat
@@ -1,0 +1,3 @@
+curl https://www.klayout.org/downloads/Windows/klayout-0.26.11-win64.zip --output klayout.zip
+7z x klayout.zip
+xcopy /E klayout-0.26.11-win64 "C:\Program Files (x86)\KLayout\"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,6 +42,7 @@ jobs:
       run: |
         choco install -y graphviz winflexbison3
         vcpkg install zlib zlib:x64-windows
+        .github/workflows/bin/install_klayout_win.bat
 
     - name: Setup env (macOS)
       if: matrix.os == 'macos-latest'
@@ -70,6 +71,10 @@ jobs:
         CIBW_TEST_COMMAND: >
           pytest --import-mode=append {package}/tests/ -m "not eda" &&
           pytest --import-mode=append {package}/tests/tools/test_surelog.py
+        CIBW_TEST_COMMAND_WINDOWS: >
+          pytest --import-mode=append {package}/tests/ -m "not eda" &&
+          pytest --import-mode=append {package}/tests/tools/test_surelog.py &&
+          pytest --import-mode=append {package}/tests/core/test_show.py
     - name: Verify clean directory
       run: git diff --exit-code
       shell: bash

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -50,6 +50,7 @@ def setup_tool(chip, mode="batch"):
         if not shutil.which(klayout_exe):
             loc_dir = os.path.join(Path.home(), 'AppData', 'Roaming', 'KLayout')
             global_dir = os.path.join(os.path.splitdrive(Path.home())[0],
+                                      os.path.sep,
                                       'Program Files (x86)',
                                       'KLayout')
             if os.path.isdir(loc_dir):

--- a/tests/core/test_show.py
+++ b/tests/core/test_show.py
@@ -3,16 +3,19 @@ import siliconcompiler
 import os
 import pytest
 from pyvirtualdisplay import Display
-from unittest import mock
+import sys
 
 from unittest import mock
 
 @pytest.fixture
 def display():
-    display = Display(visible=False)
-    display.start()
-    yield display
-    display.stop()
+    if sys.platform != 'win32':
+        display = Display(visible=False)
+        display.start()
+        yield display
+        display.stop()
+    else:
+        yield False
 
 @pytest.mark.eda
 @pytest.mark.quick


### PR DESCRIPTION
This PR adds support for testing `show()` functionality after building Windows wheels on our CI system. 

I verified this with a manual wheel build run: https://github.com/siliconcompiler/siliconcompiler/actions/runs/1616295030, although I've since rebased this to catch up to main.