### PR TITLE
Implement 'eda', ..., 'path' parameter

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3230,17 +3230,6 @@ class Chip:
             Runs the execution flow defined by the flowgraph dictionary.
         '''
 
-        # We package SC wheels with a precompiled copy of Surelog installed to
-        # tools/surelog/bin. Add this path to the system path before attempting to
-        # execute Surelog so the system checks here.
-        surelog_path = f'{os.path.dirname(__file__)}/tools/surelog/bin'
-        try:
-            ospath = os.environ['PATH'] + os.pathsep
-        except KeyError:
-            ospath = ''
-        ospath += f'{surelog_path}'
-        os.environ['PATH'] = ospath
-
         # Run steps if set, otherwise run whole graph
         if self.get('arg', 'step'):
             steplist = [self.get('arg', 'step')]

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1875,11 +1875,11 @@ def schema_eda(cfg, tool='default', step='default', index='default'):
 
     cfg['eda'][tool]['path'] = {
         'switch': "-eda_path 'tool <dir>'",
-        'type': '[dir]',
+        'type': 'dir',
         'lock': 'false',
         'require': None,
         'signature' : [],
-        'defvalue': [],
+        'defvalue': None,
         'shorthelp': 'Tool executable path',
         'example': [
             "cli: -eda_path 'openroad /usr/local/bin'",

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -53,9 +53,9 @@ def setup_tool(chip, mode="batch"):
                                       'Program Files (x86)',
                                       'KLayout')
             if os.path.isdir(loc_dir):
-                os.environ['PATH'] = os.environ['PATH'] + ';' + loc_dir
+                chip.set('eda', tool, 'path', loc_dir)
             elif os.path.isdir(global_dir):
-                os.environ['PATH'] = os.environ['PATH'] + ';' + global_dir
+                chip.set('eda', tool, 'path', global_dir)
     else:
         klayout_exe = 'klayout'
 

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -67,6 +67,12 @@ def setup_tool(chip):
     # Input/Output requirements
     chip.add('eda', tool, 'output', step, index, chip.get('design') + '.v')
 
+    # We package SC wheels with a precompiled copy of Surelog installed to
+    # tools/surelog/bin. If the user doesn't have Surelog installed on their
+    # system path, set the path to the bundled copy in the schema.
+    if shutil.which('surelog') is None:
+        surelog_path = os.path.join(os.path.dirname(__file__), 'bin')
+        chip.set('eda', tool, 'path', surelog_path, clobber=False)
 
 def parse_version(stdout):
     # Surelog --version output looks like:


### PR DESCRIPTION
This PR implements the 'eda', ..., 'path' parameter and uses it to refactor the $PATH hacks we added for Surelog and KLayout. This seems like a slightly cleaner way to handle these hacks: for example, now the user can check the manifest to see where the executables are being found. 

I tested that the changes to these hacks work on all platforms by rebasing this PR on PR #823 and manually running a wheel build/test: https://github.com/siliconcompiler/siliconcompiler/actions/runs/1650785417. 

