### PR TITLE
Automate most submodule management

### DIFF
--- a/.github/workflows/bin/setup_wheel_env_linux.sh
+++ b/.github/workflows/bin/setup_wheel_env_linux.sh
@@ -4,6 +4,7 @@
 yum install -y libuuid-devel zlib-devel java-1.8.0-openjdk-devel graphviz
 
 # Build surelog (install prefix defined outside file)
+git submodule update --init --recursive third_party/tools/surelog
 cd third_party/tools/surelog
 
 export LDFLAGS="-lrt"

--- a/.github/workflows/bin/setup_wheel_env_macos.sh
+++ b/.github/workflows/bin/setup_wheel_env_macos.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Install Surelog
+git submodule update --init --recursive third_party/tools/surelog
 cd third_party/tools/surelog
 make
 make install PREFIX=$GITHUB_WORKSPACE/siliconcompiler/tools/surelog

--- a/.github/workflows/bin/setup_wheel_env_win.bat
+++ b/.github/workflows/bin/setup_wheel_env_win.bat
@@ -26,6 +26,7 @@ where java && java -version
 where python && python --version
 where ninja && ninja --version
 
+git submodule update --init --recursive third_party/tools/surelog
 chdir third_party/tools/surelog
 
 make

--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -17,10 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: git submodule update --init --recursive third_party/tools/openroad
-      - run: git submodule update --init --recursive third_party/designs/oh
-      - run: git submodule update --init --recursive third_party/designs/picorv32
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/docs_test.yml
+++ b/.github/workflows/docs_test.yml
@@ -10,14 +10,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies
-        run: | 
+        run: |
           sudo apt-get update
           sudo apt-get install graphviz
       - run: |
           python3 -m venv create $GITHUB_WORKSPACE/clean_env --clear
           source $GITHUB_WORKSPACE/clean_env/bin/activate
           echo $VIRTUAL_ENV
-          git submodule update --init --recursive third_party/tools/openroad
           pip3 install -r $GITHUB_WORKSPACE/requirements.txt -e $GITHUB_WORKSPACE/.
           cd docs
           make html

--- a/.github/workflows/on_push_tests.yml
+++ b/.github/workflows/on_push_tests.yml
@@ -9,9 +9,6 @@ jobs:
     name: 'Tool-based tests'
     steps:
       - uses: actions/checkout@v2
-      - run: git submodule update --init --recursive third_party/tools/openroad
-      - run: git submodule update --init --recursive third_party/designs/oh
-      - run: git submodule update --init --recursive third_party/designs/picorv32
       - run: |
           python3 -m venv create $GITHUB_WORKSPACE/clean_env --clear
           source $GITHUB_WORKSPACE/clean_env/bin/activate
@@ -29,8 +26,6 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
-
-      - run: git submodule update --init --recursive third_party/tools/openroad
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,9 +20,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Clone tool submodules
-      run: git submodule update --init --recursive third_party/tools
-
     - name: Get Surelog version
       id: get-surelog
       run: |

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import glob
 import os
 import shutil
 import sys
+import subprocess
 from setuptools import find_packages
 
 # Hack to get version number since it's considered bad practice to import your
@@ -56,10 +57,8 @@ def parse_reqs():
 
     return install_reqs, extras_reqs
 
-if not on_rtd and not os.path.isdir('third_party/tools/openroad/tools/OpenROAD/src/odb/src/lef'):
-    print('Source for LEF parser library not found! Install OpenROAD submodule before continuing with install:\n'
-          'git submodule update --init --recursive third_party/tools/openroad')
-    sys.exit(1)
+if not on_rtd:
+    subprocess.run(['git', 'submodule', 'update', '--init', '--recursive', 'third_party/tools/openroad'])
 
 # Let us pass in generic arguments to CMake via an environment variable, since
 # our automated build servers need to pass in a certain argument when building

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import pytest
 
 from tests import fixtures
@@ -46,3 +47,25 @@ def gcd_chip():
     '''Returns a fully configured chip object that will compile the GCD example
     design using freepdk45 and the asicflow.'''
     return fixtures.gcd_chip()
+
+# Submodule fixtures
+# Tests that rely on data from design submodules should use this pattern to
+# create a fixture for the submodule, which will clone it if needed (and will
+# not attempt to do so more than once per session). This prevents us from having
+# to separately document which tests require submodules, and makes it easier to
+# specify tests in CI systems.
+
+def clone_submodule(dir):
+    scroot = fixtures.scroot()
+    subprocess.run(['git', 'submodule', 'update', '--init', '--recursive', dir], cwd=scroot)
+    return os.path.join(scroot, dir)
+
+@pytest.fixture(scope='session')
+def picorv32_dir():
+    dir = os.path.join('third_party', 'designs', 'picorv32')
+    return clone_submodule(dir)
+
+@pytest.fixture(scope='session')
+def oh_dir():
+    dir = os.path.join('third_party', 'designs', 'oh')
+    return clone_submodule(dir)

--- a/tests/core/test_archive.py
+++ b/tests/core/test_archive.py
@@ -3,14 +3,8 @@ import siliconcompiler
 import os
 import pytest
 @pytest.mark.skip(reason="broken file path")
-def test_archive():
-    scroot = os.path.abspath(os.path.join(os.path.dirname(__file__),"..",".."))
-    srcdir = os.path.join(scroot,
-                          'third_party',
-                          'designs',
-                          'oh',
-                          'stdlib',
-                          'hdl')
+def test_archive(oh_dir):
+    srcdir = os.path.join(oh_dir, 'stdlib', 'hdl')
 
     chip = siliconcompiler.Chip()
     chip.set('design', 'oh_add')

--- a/tests/designs/test_picorv32.py
+++ b/tests/designs/test_picorv32.py
@@ -6,8 +6,8 @@ import pytest
 # sc ../../third_party/designs/picorv32/picorv32.v -design picorv32 -mode sim -target "surelog" -arg_step "import" -quiet
 
 @pytest.mark.eda
-def test_picorv32(scroot):
-    source = os.path.join(scroot, 'third_party', 'designs', 'picorv32', 'picorv32.v')
+def test_picorv32(picorv32_dir):
+    source = os.path.join(picorv32_dir, 'picorv32.v')
     design = "picorv32"
     step = "import"
 

--- a/tests/flows/test_doe.py
+++ b/tests/flows/test_doe.py
@@ -19,11 +19,11 @@ def run_design(datadir, design, N, job):
 
 @pytest.mark.eda
 @pytest.mark.quick
-def test_doe(scroot):
+def test_doe(oh_dir):
     '''Test running multiple experiments sweeping different parameters in
     parallel using multiprocessing library.'''
 
-    datadir = os.path.join(scroot, 'third_party', 'designs', 'oh', 'stdlib', 'hdl')
+    datadir = os.path.join(oh_dir, 'stdlib', 'hdl')
     design = 'oh_add'
     N = [4, 8, 16, 32, 64, 128]
 
@@ -57,5 +57,5 @@ def test_doe(scroot):
         prev_area = area
 
 if __name__ == "__main__":
-    from tests.fixtures import scroot
-    test_doe(scroot())
+    oh_dir = os.path.join('third_party', 'designs', 'oh')
+    test_doe(oh_dir)

--- a/tests/tools/test_icarus.py
+++ b/tests/tools/test_icarus.py
@@ -5,10 +5,8 @@ import pytest
 
 @pytest.mark.eda
 @pytest.mark.quick
-def test_icarus(scroot):
-    ydir = os.path.join(scroot, 'third_party', 'designs', 'oh', 'stdlib', 'hdl')
-
-    assert os.path.isdir(ydir), 'third_party/designs/oh submodule not cloned!'
+def test_icarus(oh_dir):
+    ydir = os.path.join(oh_dir, 'stdlib', 'hdl')
 
     design = "oh_fifo_sync"
     topfile = os.path.join(ydir, f'{design}.v')
@@ -27,5 +25,5 @@ def test_icarus(scroot):
 
 #########################
 if __name__ == "__main__":
-    from tests.fixtures import scroot
-    test_icarus(scroot())
+    oh_dir = os.path.join('third_party', 'designs', 'oh')
+    test_icarus(oh_dir)

--- a/tests/tools/test_verilator.py
+++ b/tests/tools/test_verilator.py
@@ -5,8 +5,8 @@ import pytest
 
 @pytest.mark.eda
 @pytest.mark.quick
-def test_verilator(scroot):
-    ydir = os.path.join(scroot, 'third_party', 'designs', 'oh', 'stdlib', 'hdl')
+def test_verilator(oh_dir):
+    ydir = os.path.join(oh_dir, 'stdlib', 'hdl')
 
     design = "oh_fifo_sync"
     topfile = os.path.join(ydir, f'{design}.v')
@@ -28,5 +28,5 @@ def test_verilator(scroot):
 
 #########################
 if __name__ == "__main__":
-    from tests.fixtures import scroot
-    test_verilator(scroot())
+    oh_dir = os.path.join('third_party', 'designs', 'oh')
+    test_verilator(oh_dir)


### PR DESCRIPTION
This PR might seem a little random, but it was a refactor I started before the holidays related to a test I was thinking of adding then scrapped. I kind of like this cleanup though, so figured I'd suggest it anyways. Long description from commit message:

This automates clones of design/tool submodules by coupling them to the
places where the submodules are actually needed. This prevents us from
having to do a fine-grained selection of which submodules are needed in
CI scripts, while still avoiding a complete download of our many
submodules.

The most intricate part are the new test fixtures: these will clone
design submodules as needed by tests and return a path to the submodule.
If the submodule is already cloned there will be no effect, and the
fixture will not attempt to clone the submodule more than once per test
session, since the 'session' scope is set.