### PR TITLE
Add support for -I flag

### DIFF
--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -4723,7 +4723,7 @@ def schema_design(cfg):
     }
 
     cfg['idir'] = {
-        'switch': "+incdir+<dir>",
+        'switch': ['+incdir+<dir>', '-I <dir>'],
         'type': '[dir]',
         'lock': 'false',
         'require': None,

--- a/tests/core/test_create_cmdline.py
+++ b/tests/core/test_create_cmdline.py
@@ -1,9 +1,6 @@
 import siliconcompiler
 
-# TODO: find pytest-based way to do mocking
-import unittest.mock
-
-def test_cli_multi_source():
+def test_cli_multi_source(monkeypatch):
     ''' Regression test for bug where CLI parser wasn't handling multiple
     source files properly.
     '''
@@ -14,9 +11,25 @@ def test_cli_multi_source():
     args = ['sc', 'examples/ibex/ibex_alu.v', 'examples/ibex/ibex_branch_predict.v',
             '-target', 'asicflow_freepdk45']
 
-    with unittest.mock.patch('sys.argv', args):
-        chip.create_cmdline('sc')
+    monkeypatch.setattr('sys.argv', args)
+    chip.create_cmdline('sc')
 
     assert chip.get('source') == ['examples/ibex/ibex_alu.v',
                                   'examples/ibex/ibex_branch_predict.v']
     assert chip.get('target') == 'asicflow_freepdk45'
+
+def test_cli_include_flag(monkeypatch):
+    ''' Regression test for bug where CLI parser wasn't handling multiple
+    source files properly.
+    '''
+    chip = siliconcompiler.Chip()
+
+    # It doesn't matter that these files/dirs don't exist, since we're just
+    # checking that the CLI app parses them correctly
+    args = ['sc', 'source.v', '-I', 'include/inc1', '+incdir+include/inc2']
+
+    monkeypatch.setattr('sys.argv', args)
+    chip.create_cmdline('sc')
+
+    assert chip.get('source') == ['source.v']
+    assert chip.get('idir') == ['include/inc1', 'include/inc2']


### PR DESCRIPTION
This PR adds supports for the -I flag. 

I actually think we don't yet have any parameters with two switches (example from discussion earlier was `ydir`, but that only supports `-y`, not `-ydir`). This might be a bit much, but I decided to mock up a solution that makes the switch parameter an optional list. I'm not sure if this is worth it for the small, finite number of cases where we might want to do this, but the code change ended up being pretty minimal so I'm curious to get thoughts on this approach. 

Closes #632