### PR TITLE
Dynamically check that all required file/dir-type parameters resolve correctly in check_manifest()

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1654,8 +1654,16 @@ class Chip:
                     self.logger.error(f'Required input {filename} not received for {step}{index}.')
                     self.error = 1
 
-            # TODO: loop through all param requirements, and check that any file
-            # reqs resolve successfuly.
+            if (not tool in self.builtin) and self.valid('eda', tool, 'require', step, index):
+                all_required = self.get('eda', tool, 'require', step, index)
+                for item in all_required:
+                    keypath = item.split(',')
+                    paramtype = self.get(*keypath, field='type')
+                    if ('file' in paramtype) or ('dir' in paramtype):
+                        abspath = self.find_files(*keypath)
+                        if abspath is None or (isinstance(abspath, list) and None in abspath):
+                            self.logger.error(f"Required file keypath {keypath} can't be resolved.")
+                            self.error = 1
 
         return self.error
 
@@ -3138,7 +3146,7 @@ class Chip:
         self.set('arg', 'index', index, clobber=True)
 
         if self.check_manifest():
-            self.logger.error(f"Fatal error in check()! See previous errors.")
+            self.logger.error(f"Fatal error in check_manifest()! See previous errors.")
             self._haltstep(step, index, active)
 
 

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -85,6 +85,14 @@ def setup_tool(chip):
         chip.add('eda', tool, 'require', step, index, ",".join(['pdk', 'process']))
         chip.add('eda', tool, 'require', step, index, ",".join(['design']))
         chip.add('eda', tool, 'require', step, index, ",".join(['asic', 'targetlib']))
+
+        mainlib = chip.get('asic', 'targetlib')[0]
+        chip.add('eda', tool, 'require', step, index, ",".join(['library', mainlib, 'nldm', 'typical', 'lib']))
+
+        macrolibs = chip.get('asic', 'macrolib')
+        for lib in macrolibs:
+            if 'nldm' in chip.getkeys('library', lib):
+                chip.add('eda', tool, 'require', step, index, ",".join(['library', lib, 'nldm', 'typical', 'lib']))
     else:
         chip.add('eda', tool, 'require', step, index, ",".join(['fpga','partname']))
 

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -70,6 +70,26 @@ def test_check_allowed_filepaths_fail(scroot, monkeypatch):
 
     assert chip.check_manifest() == 1
 
+def test_check_missing_file_param():
+    chip = siliconcompiler.Chip()
+    chip.set('design', 'gcd')
+    chip.target('asicflow_freepdk45')
+
+    chip.set('arg', 'step', 'syn')
+    chip.set('arg', 'index', '0')
+    setup_tool = chip.find_function('yosys', 'tool', 'setup_tool')
+    setup_tool(chip)
+
+    chip.set('eda', 'yosys', 'input', 'syn', '0', [])
+    chip.set('eda', 'yosys', 'output', 'syn', '0',[])
+
+    # not real file, will cause error
+    libname = 'NangateOpenCellLibrary'
+    corner = 'typical'
+    chip.add('library', libname, 'nldm', corner, 'lib', '/fake/timing/file.lib')
+
+    assert chip.check_manifest() == 1
+
 #########################
 if __name__ == "__main__":
     test_check_manifest()


### PR DESCRIPTION
This check ensures that as long as the tool spec is written correctly, we should never fail during TCL execution due to a filepath being resolved to None. 