### PR TITLE
Fix Yosys requirements specification

### DIFF
--- a/siliconcompiler/_metadata.py
+++ b/siliconcompiler/_metadata.py
@@ -1,5 +1,5 @@
 # Version number following semver standard.
-version = '0.4.0'
+version = '0.4.1'
 
 # This is the list of significant contributors to SiliconCompiler in
 # chronological order.

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -91,7 +91,7 @@ def setup_tool(chip):
 
         macrolibs = chip.get('asic', 'macrolib')
         for lib in macrolibs:
-            if 'nldm' in chip.getkeys('library', lib):
+            if chip.valid('library', lib, 'nldm', 'typical', 'lib'):
                 chip.add('eda', tool, 'require', step, index, ",".join(['library', lib, 'nldm', 'typical', 'lib']))
     else:
         chip.add('eda', tool, 'require', step, index, ",".join(['fpga','partname']))


### PR DESCRIPTION
This PR is a quick fix to the Yosys requirements specification - this new check accidentally broke the ZeroSoC top-level build. I figure we can put out a patch with this at some point soon. 