### PR TITLE
Skip test_env on macOS/Windows

### DIFF
--- a/tests/core/test_env_schema.py
+++ b/tests/core/test_env_schema.py
@@ -1,6 +1,12 @@
 import siliconcompiler
 import os
+import pytest
+import multiprocessing
 
+@pytest.mark.skipif(
+    multiprocessing.get_start_method() != 'fork',
+    reason="Mocking _runtask() does not work with the multiprocessing 'spawn' start method"
+)
 def test_env(monkeypatch):
     chip = siliconcompiler.Chip()
     chip.set('design', 'test')


### PR DESCRIPTION
This PR skips a failing test on macOS and Windows to get the wheels CI back to green. Verified here: https://github.com/siliconcompiler/siliconcompiler/actions/runs/1685871529. 

These platforms use the multiprocessing "spawn" start method by default, which doesn't propagate the mocked _runtask(), breaking this test. I manually verified that the environment gets set in _runtask() in macOS. Going forward, it might be a good idea to find another way to write this test to ensure we don't have regressions on these platforms.

There was also a different issue with the wheel builds last night, related to https://github.com/chipsalliance/Surelog/pull/2422. Resolving it requires updating Surelog, but the issue (which was related to a Github security setting) seems to have resolved itself. I'll revisit the Surelog update if this becomes an issue again.