### PR TITLE
Update the `-read_def/gds` sc-show options to work with `-cfg`

### DIFF
--- a/siliconcompiler/apps/sc_show.py
+++ b/siliconcompiler/apps/sc_show.py
@@ -32,8 +32,11 @@ def main():
     gds_mode = chip.valid('read', 'gds', 'show', '0') and bool(chip.get('read', 'gds', 'show', '0'))
     def_mode = chip.valid('read', 'def', 'show', '0') and bool(chip.get('read', 'def', 'show', '0'))
 
-    if (def_mode + gds_mode + design) != 1:
-        chip.logger.error('Exactly one of -read_gds, -read_def, or -design must be provided.')
+    if def_mode and gds_mode:
+        chip.logger.error('Exclusive options -read_gds and -read_def cannot both be defined.')
+        sys.exit(1)
+    if not (design or def_mode or gds_mode):
+        chip.logger.error('Nothing to load: please define a target with -cfg, -design, -read_def, and/or -read_gds.')
         sys.exit(1)
 
     if gds_mode:

--- a/tests/apps/test_sc_show.py
+++ b/tests/apps/test_sc_show.py
@@ -33,7 +33,7 @@ def heartbeat_dir(tmpdir_factory):
     ['-read_def', 'show 0 build/heartbeat/job0/dfm/0/outputs/heartbeat.def'],
     ['-read_gds', 'show 0 build/heartbeat/job0/export/0/outputs/heartbeat.gds'],
     ['-design', 'heartbeat'],
-    ['-read_def', '"show 0 build/heartbeat/job0/export/0/inputs/heartbeat.def"',
+    ['-read_def', 'show 0 build/heartbeat/job0/export/0/inputs/heartbeat.def',
         '-cfg', 'build/heartbeat/job0/export/0/outputs/heartbeat.pkg.json']
     ])
 @pytest.mark.eda


### PR DESCRIPTION
Our recent schema changes may have introduced a small bug in how `sc-show` parses its command-line options. I started following [the ZeroSoC tutorial](https://docs.siliconcompiler.com/en/latest/tutorials/zerosoc.html) to get a feel for the Python floorplanning API, and I got the following error when I tried to view the first .def file:

    $ sc-show -read_def "show 0 asic_core.def" -cfg core_manifest.json
    [...]
    | ERROR   | job0    | ---          | -   | Exactly one of -read_gds, -read_def, or -design must be provided.

It looks like the `sc-show` app expects that the `-design` parameter could only have been set from command line arguments [at the point where this error is thrown](https://github.com/siliconcompiler/siliconcompiler/blob/ced8e2b35127ae8f22efa2d8499fd451d5a13a51/siliconcompiler/apps/sc_show.py#L35). But if the `-cfg` parameter is passed in, the `Chip.create_cmdline(...)` method will call `Chip.read_manifest(...)` and set the `-design` parameter early.

This PR gives the `-read_def` and `-read_gds` CLI options priority over `-cfg`, and updates the `sc-show` CI test to catch this in the future.