### PR TITLE
Fix collected filename mangling on FIPS compliant systems

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3901,7 +3901,7 @@ class Chip:
             path = pathlib.Path(path.stem)
         filename = str(path)
 
-        pathhash = hashlib.md5(pathstr.encode('utf-8')).hexdigest()
+        pathhash = utils.insecure_md5(pathstr)
 
         return f'{filename}_{pathhash}{ext}'
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3901,7 +3901,7 @@ class Chip:
             path = pathlib.Path(path.stem)
         filename = str(path)
 
-        pathhash = utils.insecure_md5(pathstr)
+        pathhash = hashlib.sha1(pathstr.encode('utf-8')).hexdigest()
 
         return f'{filename}_{pathhash}{ext}'
 

--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -25,19 +25,3 @@ def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
             os.link(srcfile, dstfile)
         else:
             shutil.copy2(srcfile, dstfile)
-
-def insecure_md5(data):
-    '''Wrapper around hashlib md5 function to enable use on FIPS compliant
-    platforms.
-
-    This function SHOULD NOT be used for cryptography/security-related purposes.
-    '''
-    encoded_data = data.encode('utf-8')
-
-    if sys.version_info[0] == 3 and sys.version_info[1] >= 9:
-        # usedforsecurity flag added in Python 3.9
-        return hashlib.md5(encoded_data, usedforsecurity=False).hexdigest()
-    else:
-        # Regular md5 call seems to work on FIPS systems when using Python
-        # versions older than 3.9.
-        return hashlib.md5(encoded_data).hexdigest()

--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -1,5 +1,7 @@
 import os
+import hashlib
 import shutil
+import sys
 
 def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
     '''Simple implementation of shutil.copytree to give us a dirs_exist_ok
@@ -23,3 +25,19 @@ def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
             os.link(srcfile, dstfile)
         else:
             shutil.copy2(srcfile, dstfile)
+
+def insecure_md5(data):
+    '''Wrapper around hashlib md5 function to enable use on FIPS compliant
+    platforms.
+
+    This function SHOULD NOT be used for crypotgraphy/security-related purposes.
+    '''
+    encoded_data = data.encode('utf-8')
+
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 9:
+        # usedforsecurity flag added in Python 3.9
+        return hashlib.md5(encoded_data, usedforsecurity=False).hexdigest()
+    else:
+        # Regular md5 call seems to work on FIPS systems when using Python
+        # versions older than 3.9.
+        return hashlib.md5(encoded_data).hexdigest()

--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -30,7 +30,7 @@ def insecure_md5(data):
     '''Wrapper around hashlib md5 function to enable use on FIPS compliant
     platforms.
 
-    This function SHOULD NOT be used for crypotgraphy/security-related purposes.
+    This function SHOULD NOT be used for cryptography/security-related purposes.
     '''
     encoded_data = data.encode('utf-8')
 

--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -1,7 +1,5 @@
 import os
-import hashlib
 import shutil
-import sys
 
 def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
     '''Simple implementation of shutil.copytree to give us a dirs_exist_ok


### PR DESCRIPTION
This PR adds a wrapper around the hashlib md5 function that adds the `usedforsecurity=False` keyword argument when supported. Since using MD5 to deduplicate filenames isn't security related, this is safe.

Closes #845. 