### PR TITLE
Add an initial Dockerfile and setup script

### DIFF
--- a/docs/_ext/installgen.py
+++ b/docs/_ext/installgen.py
@@ -16,13 +16,15 @@ class InstallScripts(SphinxDirective):
         scripts = {}
 
         for script in os.listdir(setup_dir):
-            components = script.split('.')[0].split('-')
-            tool = components[1]
+            # Ignore directories such as 'setup/docker/'.
+            if os.path.isfile(script):
+                components = script.split('.')[0].split('-')
+                tool = components[1]
 
-            if tool not in scripts:
-                scripts[tool] = [script]
-            else:
-                scripts[tool].append(script)
+                if tool not in scripts:
+                    scripts[tool] = [script]
+                else:
+                    scripts[tool].append(script)
 
         bullet_list = docutils.nodes.bullet_list()
         for tool, scripts in scripts.items():

--- a/setup/docker/Dockerfile
+++ b/setup/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && apt-get upgrade -y && apt-get -y install python3 cmake wget
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install git python3-pip lsb-core libqt5designer5 libqt5multimedia5 libqt5multimediawidgets5 libqt5xmlpatterns5 libruby2.7
+
+RUN git clone https://github.com/siliconcompiler/siliconcompiler.git
+
+COPY container_init.py /siliconcompiler/container_init.py
+RUN cd siliconcompiler && python3 container_init.py
+RUN echo 'source /siliconcompiler/third_party/tools/openroad/setup_env.sh' >> ~/.bashrc
+RUN echo 'export PYTHONPATH=$PYTHONPATH:/siliconcompiler' >> ~/.bashrc

--- a/setup/docker/Dockerfile
+++ b/setup/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && apt-get upgrade -y && apt-get -y install python3 cmake wget
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install git python3-pip lsb-core libqt5designer5 libqt5multimedia5 libqt5multimediawidgets5 libqt5xmlpatterns5 libruby2.7
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install git python3-pip lsb-core libqt5designer5 libqt5multimedia5 libqt5multimediawidgets5 libqt5xmlpatterns5 libqt5printsupport5 libqt5sql5 libruby2.7
 
 RUN git clone https://github.com/siliconcompiler/siliconcompiler.git
 

--- a/setup/docker/README.md
+++ b/setup/docker/README.md
@@ -1,0 +1,20 @@
+# SiliconCompiler Docker Image Setup
+
+Please note that Docker support is experimental at this time.
+
+To build a Docker image with `sc` and the minimum required EDA tools, use the `Dockerfile` in this directory:
+
+    docker build -t sc_tools .
+
+Once the image is built, you can create a container and log into it:
+
+    docker run --name my_sc_container -dit sc_tools
+    docker start my_sc_container
+    docker attach my_sc_container
+
+Once you are logged into the container, you can test the installation by building a small example design:
+
+    cd /siliconcompiler
+    sc examples/gcd/gcd.v
+
+The default keyboard sequence to detach from a running Docker container is Ctrl+P followed by Ctrl+Q (^P, ^Q). If you type `exit` into the container's shell, the container will stop and you'll need to restart it before you can attach to it again.

--- a/setup/docker/container_init.py
+++ b/setup/docker/container_init.py
@@ -1,0 +1,11 @@
+# Initialization script for siliconcompiler docker containers.
+# This installs some open-source EDA tools using scripts from the sc repository.
+
+import subprocess
+
+installs = ['surelog', 'klayout', 'magic', 'openroad', 'python']
+for i in installs:
+    script_path = 'setup/install-'+i+'.sh'
+    # Commands run as root from the Docker setup script; no 'sudo' required.
+    subprocess.run('sed -i "s/sudo //g" ' + script_path, shell=True)
+    subprocess.run(script_path, shell=True)


### PR DESCRIPTION
This PR adds a simple Dockerfile for an Ubuntu 20.04 image with sc and the core open-source EDA tools installed.

Next steps: X11 forwarding isn't set up for GUI apps like KLayout yet, and it might be a good idea to add instructions for mounting local directories in the container.