### PR TITLE
Fix typo in sc_apr.tcl

### DIFF
--- a/siliconcompiler/tools/openroad/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/sc_apr.tcl
@@ -112,7 +112,7 @@ foreach lib $sc_targetlibs {
 
 # Read Macrolibs
 foreach lib $sc_macrolibs {
-    if {[dict exists $sc_cfg library $lib model]} {
+    if {[dict exists $sc_cfg library $lib nldm]} {
         read_liberty [dict get $sc_cfg library $lib nldm typical lib]
     }
     read_lef [dict get $sc_cfg library $lib lef]


### PR DESCRIPTION
'model' here should be 'nldm'