### PR TITLE
First pass at allowing multiple 'version switch' parameters for tools

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3173,7 +3173,8 @@ class Chip:
         exe = self._getexe(tool)
         version = None
         if (veropt is not None) and (exe is not None):
-            cmdlist = [exe] + veropt.split()
+            cmdlist = [exe]
+            cmdlist.extend(veropt)
             self.logger.info("Checking version of tool '%s'", tool)
             proc = subprocess.run(cmdlist, stdout=PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
             parse_version = self.find_function(tool, 'tool', 'parse_version')

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -17,7 +17,7 @@ def schema_cfg():
 
     # SC version number (bump on every non trivial change)
     # Version number following semver standard.
-    SCHEMA_VERSION = '0.5.0'
+    SCHEMA_VERSION = '0.5.1'
 
     # Basic schema setup
     cfg = {}
@@ -1938,7 +1938,7 @@ def schema_eda(cfg, tool='default', step='default', index='default'):
 
     cfg['eda'][tool]['vswitch'] = {
         'switch': "-eda_vswitch 'tool <str>'",
-        'type': 'str',
+        'type': '[str]',
         'lock': 'false',
         'require': None,
         'signature' : None,
@@ -1950,7 +1950,7 @@ def schema_eda(cfg, tool='default', step='default', index='default'):
         'help': """
         Command line switch to use with executable used to print out
         the version number. Common switches include -v, -version,
-        --version.
+        --version. Some tools may require extra flags to run in batch mode.
         """
     }
 

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -89,7 +89,7 @@ def setup_tool(chip, mode="batch"):
         option = ['-zz', '-r']
 
     chip.set('eda', tool, 'exe', klayout_exe, clobber=True)
-    chip.set('eda', tool, 'vswitch', '-zz -v', clobber=clobber)
+    chip.set('eda', tool, 'vswitch', ['-zz', '-v'], clobber=clobber)
     chip.set('eda', tool, 'version', '0.26.11', clobber=clobber)
     chip.set('eda', tool, 'format', 'json', clobber=clobber)
     chip.set('eda', tool, 'copy', 'true', clobber=clobber)


### PR DESCRIPTION
This change updates the schema's `vswitch` parameter to allow multiple command-line options for version checks.

Some tools (such as KLayout) require more than one CLI flag to produce output without trying to open GUI windows. Like we discussed earlier, `vswitch` is conceptually similar to the generic CLI `option` parameter, so it makes sense to store it as a list of strings.