### PR TITLE
Fix steplist bug in check_manifest()

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -62,8 +62,13 @@ def remote_preprocess(chip):
             chip.set('arg', 'index', index)
             func = chip.find_function(tool, 'tool', 'setup_tool')
             func(chip)
-            # Run the actual import step locally.
-            chip._runtask(local_step, index, active, error)
+
+        # Need to override steplist here to make sure check_manifest() doesn't
+        # check steps that haven't been setup.
+        chip.set('steplist', local_step)
+
+        # Run the actual import step locally.
+        chip._runtask(local_step, index, active, error)
 
     # Set 'steplist' to only the remote steps, for the future server-side run.
     remote_steplist = remote_steplist[1:]

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1582,7 +1582,7 @@ class Chip:
         '''
 
         steplist = self.get('steplist')
-        if steplist is None:
+        if not steplist:
             steplist = self.list_steps()
 
         #1. Checking that flowgraph is legal

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -12,7 +12,8 @@ def test_check_manifest():
     chip.set('source', 'examples/gcd/gcd.v')
 
     index = "0"
-    for step in ('import', 'syn'):
+    steps = ['import', 'syn']
+    for step in steps:
         tool = chip.get('flowgraph', step, index, 'tool')
         chip.set('arg', 'step', step)
         chip.set('arg', 'index', index)
@@ -21,6 +22,8 @@ def test_check_manifest():
         setup_tool = chip.find_function(tool, 'tool', 'setup_tool')
         assert setup_tool is not None
         setup_tool(chip)
+
+    chip.set('steplist', steps)
 
     chip.set('arg', 'step', None)
     chip.set('arg', 'index', None)


### PR DESCRIPTION
Steplist defvalue is [], so we shouldn't compare to None to check if it's unset.

This change uncovered a few other hidden bugs which I've fixed:

1. Need to set the steplist in test_check_manifest(): since we're only setting up two steps here, we need to set the steplist accordingly.

2. Setting a steplist before calling the local _runtask() in remote_preprocess() - this one's a bit more complex. From the commit message body:
Another bug hidden by the check_manifest() steplist issue. In this case,
only the local step is set up before remote_preprocess() calls
_runtask(), so we need to override the steplist to force it to only
check the local step. This feels a bit hacky, but it shouldn't be
dangerous since we already overwrite the steplist for the remote run
immediately after.
I also snuck in a separate bugfix - it seems like the _runtask() call
needs to be outside of the if statement, otherwise the local step will
not run if the local step runs a builtin function.

