### PR TITLE
Get rid of hard requirement to provide sources on CLI

### DIFF
--- a/siliconcompiler/apps/sc.py
+++ b/siliconcompiler/apps/sc.py
@@ -46,7 +46,13 @@ def main():
 
     # Set design if none specified
     if not chip.get('design'):
-        topfile = chip.get('source')[0]
+        sources = chip.get('source')
+        if len(sources) > 0:
+            topfile = chip.get('source')[0]
+        else:
+            chip.logger.error('Invalid arguments: either specify -design or provide sources.')
+            sys.exit(1)
+
         topmodule = os.path.splitext(os.path.basename(topfile))[0]
         chip.set('design', topmodule)
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -291,7 +291,7 @@ class Chip:
         if ((switchlist == []) &
             (not '-cfg' in scargs)) | ('source' in switchlist) :
             parser.add_argument('source',
-                                nargs='+',
+                                nargs='*',
                                 help=self.get('source', field='shorthelp'))
 
         #Grab argument from pre-process sysargs

--- a/siliconcompiler/tools/bambu/bambu.py
+++ b/siliconcompiler/tools/bambu/bambu.py
@@ -41,6 +41,9 @@ def setup_tool(chip):
     # Input/Output requirements
     chip.add('eda', tool, 'output', step, index, chip.get('design') + '.v')
 
+    # Schema requirements
+    chip.add('eda', tool, 'require', step, index, 'source')
+
 def parse_version(stdout):
     # Long multiline output, but second-to-last line looks like:
     # Version: PandA 0.9.6 - Revision 5e5e306b86383a7d85274d64977a3d71fdcff4fe-main

--- a/siliconcompiler/tools/bluespec/bluespec.py
+++ b/siliconcompiler/tools/bluespec/bluespec.py
@@ -58,6 +58,9 @@ def setup_tool(chip):
     # Input/Output requirements
     chip.add('eda', tool, 'output', step, index, chip.get('design') + '.v')
 
+    # Schema requirements
+    chip.add('eda', tool, 'require', step, index, 'source')
+
 def parse_version(stdout):
     # Bluespec Compiler, version 2021.12.1-27-g9a7d5e05 (build 9a7d5e05)
 

--- a/siliconcompiler/tools/ghdl/ghdl.py
+++ b/siliconcompiler/tools/ghdl/ghdl.py
@@ -50,6 +50,9 @@ def setup_tool(chip):
     chip.set('eda', tool, 'threads', step, index, '4', clobber=clobber)
     chip.set('eda', tool, 'option', step, index, '', clobber=clobber)
 
+    # Schema requirements
+    chip.add('eda', tool, 'require', step, index, 'source')
+
 ################################
 #  Custom runtime options
 ################################

--- a/siliconcompiler/tools/icarus/icarus.py
+++ b/siliconcompiler/tools/icarus/icarus.py
@@ -57,6 +57,9 @@ def setup_tool(chip):
     else:
         chip.logger.error(f"Step '{step}' not supported in Icarus tool")
 
+    # Schema requirements
+    chip.add('eda', tool, 'require', step, index, 'source')
+
 ################################
 #  Custom runtime options
 ################################

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -67,6 +67,9 @@ def setup_tool(chip):
     # Input/Output requirements
     chip.add('eda', tool, 'output', step, index, chip.get('design') + '.v')
 
+    # Schema requirements
+    chip.add('eda', tool, 'require', step, index, 'source')
+
     # We package SC wheels with a precompiled copy of Surelog installed to
     # tools/surelog/bin. If the user doesn't have Surelog installed on their
     # system path, set the path to the bundled copy in the schema.

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -74,6 +74,9 @@ def setup_tool(chip):
         design = chip.get('design')
         chip.set('eda', tool, 'output', step, index, f'{design}.v')
 
+    # Schema requirements
+    chip.add('eda', tool, 'require', step, index, 'source')
+
 ################################
 #  Custom runtime options
 ################################

--- a/tests/core/test_env_schema.py
+++ b/tests/core/test_env_schema.py
@@ -10,6 +10,9 @@ import multiprocessing
 def test_env(monkeypatch):
     chip = siliconcompiler.Chip()
     chip.set('design', 'test')
+    # File doesn't need to resolve, just need to put something in the schema so
+    # we don't fail the initial static check_manifest().
+    chip.add('source', 'fake.v')
     chip.target('asicflow_freepdk45')
     chip.set('steplist', 'import')
 


### PR DESCRIPTION
This PR makes it so providing sources is no longer a hard requirement when using the CLI. Instead, individual tools that ingest sources are responsible for marking it as a tool-specific requirement. I also had to add a bit of logic to sc.py to gracefully handle an error that occurs if we try to infer 'design' when no sources are provided. I think the error messages for these invalid invocations are pretty clear:

```
$ sc
| INFO    | job0    | ---          | -   | Setting commandline arguments
| ERROR   | job0    | ---          | -   | Invalid arguments: either specify -design or provide sources.
```

```
$ sc -design gcd
| INFO    | job0    | ---          | -   | Setting commandline arguments
| INFO    | job0    | ---          | -   | Loading target 'asicflow_freepdk45'
| INFO    | job0    | ---          | -   | Loading function 'setup_flow' from module 'asicflow'
| INFO    | job0    | ---          | -   | Loading function 'setup_pdk' from module 'freepdk45'
| INFO    | job0    | ---          | -   | Operating in 'asic' mode
| ERROR   | job0    | ---          | -   | Value empty for [['source']].
| ERROR   | job0    | ---          | -   | Check failed. See previous errors.
```