### PR TITLE
Adding arg,mode parameter to schema

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3307,7 +3307,7 @@ class Chip:
                 self.logger.error(f'{tool} does not implement parse_version.')
                 self._haltstep(step, index, active)
             version = parse_version(proc.stdout)
-            self.logger.info(f"Checking executable. Tool '{tool}' found with version '{version}'")
+            self.logger.info(f"Checking executable. Tool '{exe}' found with version '{version}'")
             if vercheck:
                 allowed_versions = self.get('eda', tool, 'version')
                 if allowed_versions and version not in allowed_versions:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3289,8 +3289,7 @@ class Chip:
 
         for item in self.getkeys('eda', tool, 'licenseserver'):
             license_file = self.get('eda', tool, 'licenseserver', item)
-            if license_file:
-                os.environ[item] = license_file
+            os.environ[item] = ':'.join(license_file)
 
         ##################
         # 14. Check exe version

--- a/siliconcompiler/projects/project_template.py
+++ b/siliconcompiler/projects/project_template.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import re
+import siliconcompiler
+
+############################################################################
+# DOCS
+############################################################################
+
+def make_docs():
+    '''
+    Template project file.
+    '''
+
+    chip = siliconcompiler.Chip()
+    setup_project(chip)
+    return chip
+
+
+####################################################
+# PDK Setup
+####################################################
+
+def setup_project(chip):
+    '''
+    Template project file.
+    '''
+
+    #1. Load a PDK
+    chip.target('freepdk45')
+
+    #2. Specify PDK Stackup
+    chip.set('asic', 'stackup', '10M')
+
+    #3. Specify targetlibs
+    chip.add('asic', 'targetlib', 'NangateOpenCellLibrary')
+
+    #4. Specify the flow/methodology
+    chip.set('asic', 'flowname', 'asicflow')
+    chip.set('asic', 'stackup', chip.get('pdk', 'stackup')[0])
+    chip.add('asic', 'targetlib', libname)
+    chip.set('asic', 'minlayer', "m1")
+    chip.set('asic', 'maxlayer', "m10")
+    chip.set('asic', 'maxfanout', 64)
+    chip.set('asic', 'maxlength', 1000)
+    chip.set('asic', 'maxslew', 0.2e-9)
+    chip.set('asic', 'maxcap', 0.2e-12)
+    chip.set('asic', 'rclayer', 'clk', "m5")
+    chip.set('asic', 'rclayer', 'data',"m3")
+    chip.set('asic', 'hpinlayer', "m3")
+    chip.set('asic', 'vpinlayer', "m2")
+    chip.set('asic', 'density', 10)
+    chip.set('asic', 'aspectratio', 1)
+    chip.set('asic', 'coremargin', 1.9)
+
+    # Timing corners
+    corner = 'typical'
+    chip.set('mcmm','worst','libcorner', corner)
+    chip.set('mcmm','worst','pexcorner', corner)
+    chip.set('mcmm','worst','mode', 'func')
+    chip.set('mcmm','worst','check', ['setup','hold'])
+
+#########################
+if __name__ == "__main__":
+
+    chip = make_docs()

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -17,7 +17,7 @@ def schema_cfg():
 
     # SC version number (bump on every non trivial change)
     # Version number following semver standard.
-    SCHEMA_VERSION = '0.5.2'
+    SCHEMA_VERSION = '0.5.3'
 
     # Basic schema setup
     cfg = {}
@@ -2392,7 +2392,7 @@ def schema_arg(cfg):
         'require': None,
         'signature': None,
         'defvalue': None,
-        'shorthelp': 'Current execution step',
+        'shorthelp': 'Current step',
         'example': ["cli: -arg_step 'route'",
                     "api: chip.set('arg', 'step', 'route')"],
         'help': """
@@ -2411,12 +2411,29 @@ def schema_arg(cfg):
         'require': None,
         'signature': None,
         'defvalue': '0',
-        'shorthelp': 'Current step Index',
+        'shorthelp': 'Current index',
         'example': ["cli: -arg_index 0",
                     "api: chip.set('arg','index','0')"],
         'help': """
         Dynamic variable passed in by the sc runtime as an argument to
         an EDA tool to indicate the index of the step being worked on.
+        """
+    }
+
+    cfg['arg']['mode'] = {
+        'switch': "-arg_mode <str>",
+        'type': 'str',
+        'lock': 'false',
+        'require': None,
+        'signature': None,
+        'defvalue': '0',
+        'shorthelp': 'Current operating mode',
+        'example': ["cli: -arg_mode batch",
+                    "api: chip.set('arg','mode','batch')"],
+        'help': """
+        Dynamic variable passed in by the sc runtime as an argument to
+        an EDA tool to indicate the operating mode of the step being
+        worked on.
         """
     }
 

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2420,23 +2420,6 @@ def schema_arg(cfg):
         """
     }
 
-    cfg['arg']['mode'] = {
-        'switch': "-arg_mode <str>",
-        'type': 'str',
-        'lock': 'false',
-        'require': None,
-        'signature': None,
-        'defvalue': '0',
-        'shorthelp': 'Current operating mode',
-        'example': ["cli: -arg_mode batch",
-                    "api: chip.set('arg','mode','batch')"],
-        'help': """
-        Dynamic variable passed in by the sc runtime as an argument to
-        an EDA tool to indicate the operating mode of the step being
-        worked on.
-        """
-    }
-
     return cfg
 
 


### PR DESCRIPTION
- Some tools may have major modes that control the executable name, options used
- Other times it might completely change the setup path within a <tool>.py in terms of reference script.
- The mode lets use control the setup dynamically on a per step/index basis.
