### PR TITLE
Add support for KLayout .lyp files to sc-show

### DIFF
--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -19,12 +19,14 @@ sc_libtype = sc_cfg['library'][sc_mainlib]['arch']['value']
 # or in the standalone format (.lyp).
 tech_filename = sc_cfg['pdk']['layermap']['klayout'][sc_stackup]['def']['gds']['value'][0]
 tech_file = None
-if tech_filename[-4:] == '.lyt':
-    # 'lyp_path' will be read out of the .lyt file later.
-    tech_file = tech_filename
-elif tech_filename[-4:] == '.lyp':
-    # Tech file will not be imported, only layermap properties.
-    lyp_path = tech_filename
+lyp_path = None
+if tech_filename:
+    if tech_filename[-4:] == '.lyt':
+        # 'lyp_path' will be read out of the .lyt file later.
+        tech_file = tech_filename
+    elif tech_filename[-4:] == '.lyp':
+        # Tech file will not be imported, only layermap properties.
+        lyp_path = tech_filename
 
 macro_lefs = []
 if 'macrolib' in sc_cfg['asic']:

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -37,11 +37,11 @@ if 'macrolib' in sc_cfg['asic']:
 # Tech / library LEF files are optional.
 try:
     tech_lef = sc_cfg['pdk']['aprtech']['klayout'][sc_stackup][sc_libtype]['lef']['value'][0]
-except:
+except KeyError:
     tech_lef = None
 try:
     lib_lef = sc_cfg['library'][sc_mainlib]['lef']['value'][0]
-except:
+except KeyError:
     lib_lef = None
 
 # Load KLayout technology file

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -15,7 +15,16 @@ sc_stackup = sc_cfg['pdk']['stackup']['value'][0]
 sc_mainlib = sc_cfg['asic']['targetlib']['value'][0]
 sc_libtype = sc_cfg['library'][sc_mainlib]['arch']['value']
 
-tech_file = sc_cfg['pdk']['layermap']['klayout'][sc_stackup]['def']['gds']['value'][0]
+# The layermap may be provided as part of a KLayout tech file (.lyt),
+# or in the standalone format (.lyp).
+tech_filename = sc_cfg['pdk']['layermap']['klayout'][sc_stackup]['def']['gds']['value'][0]
+tech_file = None
+if tech_filename[-4:] == '.lyt':
+    # 'lyp_path' will be read out of the .lyt file later.
+    tech_file = tech_filename
+elif tech_filename[-4:] == '.lyp':
+    # Tech file will not be imported, only layermap properties.
+    lyp_path = tech_filename
 
 macro_lefs = []
 if 'macrolib' in sc_cfg['asic']:
@@ -23,8 +32,15 @@ if 'macrolib' in sc_cfg['asic']:
     for lib in sc_macrolibs:
         macro_lefs.append(sc_cfg['library'][lib]['lef']['value'][0])
 
-tech_lef = sc_cfg['pdk']['aprtech']['klayout'][sc_stackup][sc_libtype]['lef']['value'][0]
-lib_lef = sc_cfg['library'][sc_mainlib]['lef']['value'][0]
+# Tech / library LEF files are optional.
+try:
+    tech_lef = sc_cfg['pdk']['aprtech']['klayout'][sc_stackup][sc_libtype]['lef']['value'][0]
+except:
+    tech_lef = None
+try:
+    lib_lef = sc_cfg['library'][sc_mainlib]['lef']['value'][0]
+except:
+    lib_lef = None
 
 # Load KLayout technology file
 tech = pya.Technology()
@@ -71,6 +87,7 @@ if tech_file and os.path.isfile(tech_file):
     tech_file_dir = os.path.dirname(tech_file)
     lyp_path = tech_file_dir + '/' + tech.layer_properties_file
 
+if lyp_path:
     # Set layer properties -- setting second argument to True ensures things like
     # KLayout's extra outline, blockage, and obstruction layers appear.
     layout_view.load_layer_props(lyp_path, True)

--- a/tests/core/test_show.py
+++ b/tests/core/test_show.py
@@ -38,6 +38,29 @@ def test_show(pdk, testfile, datadir, display, headless=True):
 
 @pytest.mark.eda
 @pytest.mark.quick
+def test_show_lyp(datadir, display, headless=True):
+    ''' Test sc-show with only a KLayout .lyp file for layer properties '''
+
+    chip = siliconcompiler.Chip()
+    chip.set('design', 'heartbeat')
+    chip.target(f'asicflow_freepdk45')
+    chip.set("quiet", True)
+
+    # Replace the '.lyt' file with the corresponding '.lyp'
+    stackup = chip.get('pdk', 'stackup')[0]
+    klayout_techfile = chip.get('pdk', 'layermap', 'klayout', stackup, 'def', 'gds')[0]
+    klayout_layerprops = klayout_techfile[:-4] + '.lyp'
+    chip.set('pdk', 'layermap', 'klayout', stackup, 'def', 'gds', klayout_layerprops, clobber=True)
+
+    if headless:
+        # Adjust command line options to exit KLayout after run
+        chip.set('eda', 'klayout', 'option', 'showdef', '0', ['-z', '-r'])
+
+    path = os.path.join(datadir, 'heartbeat_freepdk45.def')
+    assert chip.show(path)
+
+@pytest.mark.eda
+@pytest.mark.quick
 def test_show_nopdk(datadir, display):
     chip = siliconcompiler.Chip()
     chip.set('design', 'heartbeat')


### PR DESCRIPTION
This change allows us to use either `.lyt` or `.lyp` files to configure display properties in `sc-show`.

The `.lyp` file contains layer display properties such as color/pattern/etc, and we currently read its location from the `.lyt` file which is passed into the `klayout_show.py` script. This change allows us to specify either a `.lyp` or `.lyt` file in the `['pdk']['layermap']['klayout'][...]` parameter.