### PR TITLE
Use 'flow' parameter to specify standalone tool run

### DIFF
--- a/docs/reference_manual/core_api.rst
+++ b/docs/reference_manual/core_api.rst
@@ -58,7 +58,6 @@ This chapter describes all public methods in the SiliconCompiler core Python API
     ~siliconcompiler.core.Chip.load_lib
     ~siliconcompiler.core.Chip.load_pdk
     ~siliconcompiler.core.Chip.load_target
-    ~siliconcompiler.core.Chip.load_tool
     ~siliconcompiler.core.Chip.merge_manifest
     ~siliconcompiler.core.Chip.package
     ~siliconcompiler.core.Chip.publish

--- a/docs/user_guide/tools.rst
+++ b/docs/user_guide/tools.rst
@@ -224,7 +224,7 @@ Schema configuration handoff from SiliconCompiler to script based tools is accom
 
 .. code-block:: tcl
 
-   dict set sc_cfg asic targetlib [list  NangateOpenCellLibrary ]
+   dict set sc_cfg asic logiclib [list  NangateOpenCellLibrary ]
    dict set sc_cfg asic maxfanout [list  64 ]
    dict set sc_cfg design [list  gcd ]
    dict set sc_cfg constraint [list gcd.sdc ]
@@ -240,8 +240,8 @@ It is the responsibility of the tool reference flow developer to bind the standa
    set sc_optmode    [dict get $sc_cfg optmode]
 
    # APR Parameters
-   set sc_mainlib     [lindex [dict get $sc_cfg asic targetlib] 0]
-   set sc_targetlibs  [dict get $sc_cfg asic targetlib]
+   set sc_mainlib     [lindex [dict get $sc_cfg asic logiclib] 0]
+   set sc_targetlibs  [dict get $sc_cfg asic logiclib]
    set sc_stackup     [dict get $sc_cfg asic stackup]
    set sc_density     [dict get $sc_cfg asic density]
    set sc_hpinlayer   [dict get $sc_cfg asic hpinlayer]

--- a/tests/tools/test_ghdl.py
+++ b/tests/tools/test_ghdl.py
@@ -15,8 +15,7 @@ def test_ghdl(datadir):
     chip.set('design', design)
     chip.set('mode', 'sim')
     chip.set('arg','step','import')
-    chip.set('flow', 'test')
-    chip.load_tool('ghdl', standalone=True)
+    chip.set('flow', 'ghdl')
 
     chip.run()
 

--- a/tests/tools/test_icarus.py
+++ b/tests/tools/test_icarus.py
@@ -18,8 +18,7 @@ def test_icarus(oh_dir):
     chip.set('source', topfile)
     chip.set('mode', 'sim')
     chip.set('arg','step','compile')
-    chip.set('flow', 'test')
-    chip.load_tool('icarus', standalone=True)
+    chip.set('flow', 'icarus')
     chip.run()
 
     # check that compilation succeeded

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -22,11 +22,9 @@ def test_klayout(datadir):
     chip.set('library', 'heartbeat', 'gds', library_gds)
 
     chip.set('arg', 'step', 'export')
-    chip.set('flow', 'test')
+    chip.set('flow', 'klayout')
 
     chip.set('eda', 'klayout', 'variable', 'export', '0', 'timestamps', 'false')
-
-    chip.load_tool('klayout', standalone=True)
 
     chip.run()
 

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -24,9 +24,8 @@ def test_openroad(scroot):
     chip.load_target("freepdk45_demo")
 
     # set up tool for floorplan
-    chip.set('flow', 'test')
+    chip.set('flow', 'openroad')
     chip.set('arg', 'step', 'floorplan')
-    chip.load_tool("openroad", standalone=True)
 
     chip.run()
 

--- a/tests/tools/test_surelog.py
+++ b/tests/tools/test_surelog.py
@@ -16,8 +16,7 @@ def test_surelog(scroot):
     chip.set('design', design)
     chip.set('mode', 'sim')
     chip.set('arg', 'step', step)
-    chip.set('flow', 'test')
-    chip.load_tool('surelog', standalone=True)
+    chip.set('flow', 'surelog')
 
     chip.run()
 
@@ -38,8 +37,7 @@ def test_surelog_preproc_regression(datadir):
     chip.set('design', design)
     chip.set('mode', 'asicflow')
     chip.set('arg', 'step', step)
-    chip.set('flow', 'test')
-    chip.load_tool('surelog', standalone=True)
+    chip.set('flow', 'surelog')
 
     chip.run()
 

--- a/tests/tools/test_surelog.py
+++ b/tests/tools/test_surelog.py
@@ -41,8 +41,6 @@ def test_surelog_preproc_regression(datadir):
     chip.set('flow', 'test')
     chip.load_tool('surelog', standalone=True)
 
-    chip.write_manifest("/home/aolofsson/tmp.json")
-
     chip.run()
 
     result = chip.find_result('v', step=step)

--- a/tests/tools/test_verilator.py
+++ b/tests/tools/test_verilator.py
@@ -21,8 +21,7 @@ def test_verilator(oh_dir):
     chip.set('quiet', True)
     chip.set('mode', 'sim')
     chip.set('arg','step',step)
-    chip.set('flow','test')
-    chip.load_tool('verilator', standalone=True)
+    chip.set('flow','verilator')
     chip.run()
 
     # check that compilation succeeded

--- a/tests/tools/test_yosys.py
+++ b/tests/tools/test_yosys.py
@@ -13,8 +13,7 @@ def test_yosys_lec(datadir):
     chip.set('arg', 'step', 'lec')
     chip.set('design', 'foo')
     chip.set('mode', 'asic')
-    chip.set('flow', 'test')
-    chip.load_tool('yosys', standalone=True)
+    chip.set('flow', 'yosys')
 
     chip.add('source', os.path.join(lec_dir, 'foo.v'))
     chip.add('read', 'netlist', 'lec', '0', os.path.join(lec_dir, 'foo.vg'))
@@ -36,8 +35,7 @@ def test_yosys_lec_broken(datadir):
     chip.set('arg', 'step', 'lec')
     chip.set('design', 'foo')
     chip.set('mode', 'asic')
-    chip.set('flow', 'test')
-    chip.load_tool('yosys', standalone=True)
+    chip.set('flow', 'yosys')
 
     chip.add('source', os.path.join(lec_dir, 'foo_broken.v'))
     chip.add('read', 'netlist', 'lec', '0', os.path.join(lec_dir, 'foo_broken.vg'))


### PR DESCRIPTION
This PR builds on top of #862 and fixes its failing tests. The main change is adjusting the way that standalone tool runs are set up. It gets rid of `load_tool()` -- we don't need this function since each tool's `setup()` function is called automatically inside of `run()`, and giving the user the ability to call it earlier can be problematic since it introduces ordering issues.

I chose overriding the 'flow' schema parameter as the new way to specify a standalone tool run. Now, if the user specifies a flow that doesn't have a configured flowgraph, `run()` will automatically set up a basic flowgraph to run that tool. I considered making a separate helper function for loading a standalone tool, but I realized using a schema parameter is necessary to support running tools in standalone mode from the CLI. Instead of adding an additional parameter, reusing `flow` seemed logical since the standalone tool is effectively the flow you want to run.

@aolofsson I'm opening this PR as relative to your PR's branch rather than committing directly to make it easier for you to review these changes. Once you're ready, you can merge this PR and these commits should show up in your original PR, which you can then merge into main.