### PR TITLE
Update documentation for 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Intrigued? Check out the extensive [documentation!](https://docs.siliconcompiler
 ```python
 import siliconcompiler                    # import python package
 chip = siliconcompiler.Chip()             # create chip object
-chip.target('asicflow_freepdk45')         # load pre-defined flow
+chip.load_target('freepdk45_demo')        # load pre-defined flow
 chip.set('source', 'heartbeat.v')         # define list of sources
 chip.set('design', 'heartbeat')           # set top module name
 chip.set('constraint', 'heartbeat.sdc')   # define constraints
@@ -58,7 +58,7 @@ sc flipflop.v -remote
 More complex designs are handled by simply adding more options.
 
 ```bash
-sc hello.v add.v -remote -constraint hello.sdc -target "asicflow_skywater130"
+sc hello.v add.v -remote -constraint hello.sdc -target "skywater130_demo"
 ```
 
 ## Installation

--- a/docs/_ext/common.py
+++ b/docs/_ext/common.py
@@ -58,6 +58,19 @@ def link(url, text=None):
         text = url
     return nodes.reference(internal=False, refuri=url, text=text)
 
+def build_list(items, enumerated=False):
+    if enumerated:
+        list = nodes.enumerated_list()
+    else:
+        list = nodes.bullet_list()
+
+    for item in items:
+        docutils_item = nodes.list_item()
+        docutils_item += item
+        list += docutils_item
+
+    return list
+
 # SC schema helpers
 def is_leaf(schema):
     if 'defvalue' in schema:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,6 +57,7 @@ Welcome to SiliconCompiler's documentation!
    reference_manual/flows
    reference_manual/tools
    reference_manual/pdks
+   reference_manual/libs
 
 .. toctree::
    :maxdepth: 3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,7 @@ Welcome to SiliconCompiler's documentation!
    reference_manual/tools
    reference_manual/pdks
    reference_manual/libs
+   reference_manual/targets
 
 .. toctree::
    :maxdepth: 3

--- a/docs/reference_manual/libs.rst
+++ b/docs/reference_manual/libs.rst
@@ -1,0 +1,4 @@
+Libraries directory
+====================
+
+.. libgen::

--- a/docs/reference_manual/targets.rst
+++ b/docs/reference_manual/targets.rst
@@ -1,0 +1,4 @@
+Targets directory
+====================
+
+.. targetgen::

--- a/docs/tutorials/asicflow.rst
+++ b/docs/tutorials/asicflow.rst
@@ -195,7 +195,7 @@ We have now set up the basic execution flow and metrics, but we haven't specifie
           tool = 'openroad'
       chip.set('flowgraph', step, 'tool', tool)
 
-The 'magic' of setting up these tools happens at runtime when calling the run() function, at which point point the <tool>.py module is loaded and a a fixed name function "setup_tool()" is exeucted. The setup of these tools is beyond the scope o this tutorial, but if you curious about the process, you can take a look at one of the setup files here. [TODO: Add link]
+The 'magic' of setting up these tools happens at runtime when calling the run() function, at which point point the <tool>.py module is loaded and a fixed name function "setup()" is exeucted. The setup of these tools is beyond the scope o this tutorial, but if you curious about the process, you can take a look at one of the setup files here. [TODO: Add link]
 
 
 Check

--- a/docs/tutorials/bambu.rst
+++ b/docs/tutorials/bambu.rst
@@ -71,7 +71,7 @@ Or using Python::
         chip.set('design', 'gcd')
         # default Bambu clock pin is 'clock'
         chip.clock(name='clock', pin='clock', period=5)
-        chip.target('asicflow_freepdk45')
+        chip.load_target('freepdk45_demo')
         chip.run()
         chip.summary()
         chip.show()

--- a/docs/tutorials/bluespec.rst
+++ b/docs/tutorials/bluespec.rst
@@ -60,7 +60,7 @@ Or using Python::
         chip.set('design', 'mkFibOne')
         # default Bluespec clock pin is 'CLK'
         chip.clock(name='clock', pin='CLK', period=5)
-        chip.target('asicflow_freepdk45')
+        chip.load_target('freepdk45_demo')
         chip.run()
         chip.summary()
         chip.show()

--- a/docs/tutorials/chisel.rst
+++ b/docs/tutorials/chisel.rst
@@ -70,7 +70,7 @@ Or using Python::
         chip.set('design', 'GCD')
         # default Chisel clock pin is 'clock'
         chip.clock(name='clock', pin='clock', period=5)
-        chip.target('asicflow_freepdk45')
+        chip.load_target('freepdk45_demo')
         chip.run()
         chip.summary()
         chip.show()

--- a/docs/tutorials/contribution.rst
+++ b/docs/tutorials/contribution.rst
@@ -41,8 +41,8 @@ The process for target contributions is as follows:
        |    └── ...
        └── <...>
 
-3.) Test the new target by calling it from a the target() function. For example. ::
+3.) Test the new target by calling it using the appropriate "load" function. For example. ::
 
-  chip.target('asicflow_<newpdk>')
+  chip.load_pdk('<newpdk>')
 
 4.) Read the `CONTRIBUTING <https://github.com/siliconcompiler/siliconcompiler/blob/main/CONTRIBUTING.md>`_ guide to learn how to submit a PR.

--- a/docs/tutorials/examples/migen_heartbeat.py
+++ b/docs/tutorials/examples/migen_heartbeat.py
@@ -22,7 +22,7 @@ def main():
     chip.set('design', 'heartbeat')
     # default Migen clock pin is named 'sys_clk'
     chip.clock(name='sys', pin='sys_clk', period=1)
-    chip.target('asicflow_freepdk45')
+    chip.load_target('freepdk45_demo')
     chip.run()
     chip.summary()
     chip.show()

--- a/docs/tutorials/examples/parallel.py
+++ b/docs/tutorials/examples/parallel.py
@@ -19,7 +19,7 @@ def run_design(design, M, job):
     chip.set('flowarg','syn_place', str(M))
     chip.set('flowarg','syn_cts', str(M))
     chip.set('flowarg','syn_route', str(M))
-    chip.target("asicflow_freepdk45")
+    chip.load_target("freepdk45_demo")
     chip.run()
 
 def main():

--- a/docs/tutorials/zerosoc.rst
+++ b/docs/tutorials/zerosoc.rst
@@ -130,10 +130,10 @@ configured in the provided chip object:
 
 Let's fill out ``configure_chip()`` to accomplish these tasks one-by-one. First,
 we instantiate a new chip and set its target to Skywater 130, an open-source PDK
-that has its configuration bundled with SC::
+that has a demo build target bundled with SC::
 
   chip = Chip()
-  chip.load_pdk('skywater130')
+  chip.load_target('skywater130_demo')
 
 Next, we'll provide the design name as a parameter so that we can reuse this
 configuration function for testing both the core and top padring::
@@ -180,7 +180,7 @@ library, your definition of ``configure_chip()`` should look like this::
 
   def configure_chip(design):
       chip = Chip()
-      chip.load_pdk('skywater130')
+      chip.load_target('skywater130_demo')
 
       chip.set('design', design)
 

--- a/docs/tutorials/zerosoc.rst
+++ b/docs/tutorials/zerosoc.rst
@@ -133,7 +133,7 @@ we instantiate a new chip and set its target to Skywater 130, an open-source PDK
 that has its configuration bundled with SC::
 
   chip = Chip()
-  chip.target('skywater130')
+  chip.load_pdk('skywater130')
 
 Next, we'll provide the design name as a parameter so that we can reuse this
 configuration function for testing both the core and top padring::
@@ -180,7 +180,7 @@ library, your definition of ``configure_chip()`` should look like this::
 
   def configure_chip(design):
       chip = Chip()
-      chip.target('skywater130')
+      chip.load_pdk('skywater130')
 
       chip.set('design', design)
 

--- a/docs/user_guide/examples/heartbeat.py
+++ b/docs/user_guide/examples/heartbeat.py
@@ -5,7 +5,7 @@ def main():
     chip.set('source', 'heartbeat.v')             # define list of source files
     chip.set('design', 'heartbeat')               # set top module
     chip.set('constraint', 'heartbeat.sdc')       # set constraints file
-    chip.target('asicflow_freepdk45')             # load predefined target
+    chip.load_target('freepdk45_demo')            # load predefined target
     chip.run()                                    # run compilation
     chip.summary()                                # print results summary
     chip.show()                                   # show layout file

--- a/docs/user_guide/examples/heartbeat_flowgraph.py
+++ b/docs/user_guide/examples/heartbeat_flowgraph.py
@@ -3,7 +3,7 @@ chip = siliconcompiler.Chip()              # create chip object
 chip.set('source', 'heartbeat.v')          # define list of source files
 chip.set('design', 'heartbeat')            # set top module
 chip.set('constraint', 'heartbeat.sdc')    # set constraints file
-chip.target('freepdk45')                   # load freepdk45
+chip.load_pdk('freepdk45')                 # load freepdk45
 # start of flowgraph setup
 chip.node('import', 'surelog')             # use surelog for import
 chip.node('syn', 'yosys')                  # use yosys for synthesis

--- a/docs/user_guide/flows.rst
+++ b/docs/user_guide/flows.rst
@@ -15,7 +15,7 @@ SiliconCompiler flows are created by configuring the 'flowgraph' parameters with
      - Used by
      - Required
 
-   * - **setup_flow**
+   * - **setup**
      - PDK setup function
      - chip
      - chip
@@ -30,7 +30,7 @@ SiliconCompiler flows are created by configuring the 'flowgraph' parameters with
      - yes
 
 
-setup_flow(chip)
+setup(chip)
 -----------------
 
 A SiliconCompiler flowgraph consists of a set of connected nodes and edges, where a node is an executable tool performing some ("task"), and an edge is the connection between those tasks. The first task in the flowgraph must be named 'import'. ::
@@ -56,7 +56,7 @@ For a complete working example, see the `asicflow <https://github.com/siliconcom
 
 make_docs()
 -----------------
-The make_docs() function is used by the projects auto-doc generation. The function should include a descriptive docstring and a call to the setup_flow function that populates the appropriate schema settings. ::
+The make_docs() function is used by the projects auto-doc generation. The function should include a descriptive docstring and a call to the setup function that populates the appropriate schema settings. ::
 
   def make_docs():
     '''
@@ -64,5 +64,5 @@ The make_docs() function is used by the projects auto-doc generation. The functi
     '''
 
     chip = siliconcompiler.Chip()
-    setup_flow(chip)
+    setup(chip)
     return chip

--- a/docs/user_guide/flows.rst
+++ b/docs/user_guide/flows.rst
@@ -1,7 +1,7 @@
 Flows
 ===================================
 
-SiliconCompiler flows are created by configuring the 'flowgraph' parameters within the schema. To simplify reuse of complex flows, the project includes standardized interfaces for bundling flowgraph settings as reusable named modules. These flow modules get loaded by the target() function during compilation setup. A complete set of supported open PDKs can be found in the :ref:`Flows Directory`. The table below shows the function interfaces required in setting up flows.
+SiliconCompiler flows are created by configuring the 'flowgraph' parameters within the schema. To simplify reuse of complex flows, the project includes standardized interfaces for bundling flowgraph settings as reusable named modules. These flow modules get loaded by the load_flow() function during compilation setup. A complete set of supported open PDKs can be found in the :ref:`Flows Directory`. The table below shows the function interfaces required in setting up flows.
 
 
 .. list-table::

--- a/docs/user_guide/flows.rst
+++ b/docs/user_guide/flows.rst
@@ -19,7 +19,7 @@ SiliconCompiler flows are created by configuring the 'flowgraph' parameters with
      - PDK setup function
      - chip
      - chip
-     - target()
+     - load_flow()
      - yes
 
    * - **make_docs**

--- a/docs/user_guide/introduction.rst
+++ b/docs/user_guide/introduction.rst
@@ -1,6 +1,6 @@
 Introduction
 ===================================
-SiliconCompiler is an open source compiler framework that aims to enable automated translation from source code to silicon.
+SiliconCompiler is an open source build system that automates translation from source code to silicon.
 
 Motivation
 -----------

--- a/docs/user_guide/libraries.rst
+++ b/docs/user_guide/libraries.rst
@@ -12,6 +12,37 @@ The following code snippet shows how library gds and lef files can be set up in 
     chip.add('library','NangateOpenCellLibrary','lef','$FREEPDK45/lef/NangateOpenCellLibrary.lef')
     chip.add('library','NangateOpenCellLibrary','gds','$FREEPDK45/gds/NangateOpenCellLibrary.gds')
 
-To enable simple 'target' based access, it is recommended that fundamental physical foundry sponsored IP (stdcells, GPIO, memory macros) are set up as part of the setup_pdk function.
-
 SiliconCompiler also supports referencing soft libraries (RTL, C-code, etc), in which case many of the physical IP parameters can be omitted.
+
+Library Modules
+----------------
+To enable simple 'target' based access, it is recommended that fundamental physical foundry sponsored IP (stdcells, GPIO, memory macros) are set up as part of reusable library modules.
+
+Similarly to :ref:`PDKs<PDKs>`, library modules must implement the following functions.
+
+.. list-table::
+   :widths: 10 10 10 10 10 10
+   :header-rows: 1
+
+   * - Function
+     - Description
+     - Arg
+     - Returns
+     - Used by
+     - Required
+
+   * - **setup**
+     - Library setup function
+     - chip
+     - chip
+     - load_flow()
+     - yes
+
+   * - **make_docs**
+     - Doc generator
+     - None
+     - chip
+     - sphinx
+     - yes
+
+A complete set of supported standard cell libraries for SC's included open PDKs can be found in the :ref:`Libraries Directory`.

--- a/docs/user_guide/pdks.rst
+++ b/docs/user_guide/pdks.rst
@@ -1,7 +1,7 @@
 PDKs
 ===================================
 
-Process Design Kits (PDKs) for leading process nodes generally include hundreds of files, documents, and configuration parameters, resulting in significant startup times in porting a design to a new node. The SiliconCompiler project minimizes per design PDK setup efforts by packaging PDKs as standardized reusable objects and making them available as named modules by the target() function. A complete set of supported open PDKs can be found in the :ref:`PDK Directory`. The table below shows the function interfaces supported in setting up PDKs.
+Process Design Kits (PDKs) for leading process nodes generally include hundreds of files, documents, and configuration parameters, resulting in significant startup times in porting a design to a new node. The SiliconCompiler project minimizes per design PDK setup efforts by packaging PDKs as standardized reusable objects and making them available as named modules by the load_pdk() function. A complete set of supported open PDKs can be found in the :ref:`PDK Directory`. The table below shows the function interfaces supported in setting up PDKs.
 
 
 .. list-table::
@@ -19,7 +19,7 @@ Process Design Kits (PDKs) for leading process nodes generally include hundreds 
      - PDK setup function
      - chip
      - chip
-     - target()
+     - load_pdk()
      - yes
 
    * - **make_docs**
@@ -49,11 +49,9 @@ The following Schema parameters are mandatory in setting up PDKs for SiliconComp
     chip.set('pdk','lvs',<tool>, <stackup>, 'runset', <file>)
     chip.set('pdk','devmodel', <stackup>, <modeltype>, <tool>, <file>)
 
-To support standard RTL2GDS flows, the PDK setup will also need to specify pointers to routing technology rules, timing libraries, layout abstractions, layer maps, and routing grids as shown in the below example. For a complete set of available PDK parameters, see the :ref:`Schema<SiliconCompiler Schema>`. ::
+To support standard RTL2GDS flows, the PDK setup will also need to specify pointers to routing technology rules, layout abstractions, layer maps, and routing grids as shown in the below example. For a complete set of available PDK parameters, see the :ref:`Schema<SiliconCompiler Schema>`. ::
 
     chip.set('pdk','aprtech', <stackup>, <libtype>, 'lef', <file>)
-    chip.add('library',<libname>, 'nldm', <corner>, <libformat>, <file>)
-    chip.add('library',<libname>, 'lef', <file>)
     chip.set('pdk','layermap',<stackup>, 'def', 'gds', <file>)
 
     #Per layer grid setup

--- a/docs/user_guide/pdks.rst
+++ b/docs/user_guide/pdks.rst
@@ -15,7 +15,7 @@ Process Design Kits (PDKs) for leading process nodes generally include hundreds 
      - Used by
      - Required
 
-   * - **setup_pdk**
+   * - **setup**
      - PDK setup function
      - chip
      - chip
@@ -30,7 +30,7 @@ Process Design Kits (PDKs) for leading process nodes generally include hundreds 
      - yes
 
 
-setup_pdk(chip)
+setup(chip)
 -----------------
 
 A minimally viable PDK will include a simulation device model and a set of codified manufacturing rules ("drc").
@@ -68,7 +68,7 @@ Note that the 'techarg' dictionary in the schema can be used to pass named argum
 
 make_docs()
 -----------------
-The make_docs() function is used by the projects auto-doc generation. The function should include a descriptive docstring and a call to the setup_pdk function to populate the schema with all settings::
+The make_docs() function is used by the projects auto-doc generation. The function should include a descriptive docstring and a call to the setup function to populate the schema with all settings:
 
   def make_docs():
     '''
@@ -76,6 +76,6 @@ The make_docs() function is used by the projects auto-doc generation. The functi
     '''
 
     chip = siliconcompiler.Chip()
-    setup_pdk(chip)
+    setup(chip)
 
     return chip

--- a/docs/user_guide/programming_model.rst
+++ b/docs/user_guide/programming_model.rst
@@ -17,7 +17,7 @@ Compilation is based on a single chip object that follows the design from start 
 Setup
 ----------------
 
-Once the chip object has been created, functions and data are all contained within that object. A compilation is set up by accessing methods and parameters from the chip object. Parameters can generally be configured in any order during setup. The exceptions are flowarg and techarg parameters, which must be set before calling chip.target().
+Once the chip object has been created, functions and data are all contained within that object. A compilation is set up by accessing methods and parameters from the chip object. Parameters can generally be configured in any order during setup. The exceptions are flowarg and techarg parameters, which must be set before calling chip.load_flow() or chip.load_pdk(), respectively.
 
 The snippet of code below shows the basic principles. ::
 

--- a/docs/user_guide/quickstart.rst
+++ b/docs/user_guide/quickstart.rst
@@ -36,13 +36,13 @@ copy paste the code into your text editor and save it to disk as "heartbeat.py".
 .. literalinclude:: examples/heartbeat.py
 
 Much of the complexity of setting up a hardware compilation flow is abstracted away
-from the user through the target() function which sets up a large number of PDK,
-flow, and tool parameters based on a "tuple" of strings separated by underscore
-('_'). To understand the complete target configuration, see the
-:ref:`Flows Directory` and :ref:`PDK Directory` sections of the reference manual and
-read the source code for
-`asicflow <https://github.com/siliconcompiler/siliconcompiler/blob/main/siliconcompiler/flows/asicflow.py>`_ and
-`freepdk45 <https://github.com/siliconcompiler/siliconcompiler/blob/main/siliconcompiler/pdks/freepdk45.py>`_.
+from the user through the load_target() function which sets up a large number of PDK,
+flow, and tool parameters based on a target setup module. To understand the
+complete target configuration, see the :ref:`Flows Directory`, :ref:`PDK
+Directory`, and :ref:`Target Directory` sections of the reference manual and read the source code for
+`asicflow <https://github.com/siliconcompiler/siliconcompiler/blob/main/siliconcompiler/flows/asicflow.py>`_,
+`freepdk45 <https://github.com/siliconcompiler/siliconcompiler/blob/main/siliconcompiler/pdks/freepdk45.py>`_, and
+`freepdk45_demo <https://github.com/siliconcompiler/siliconcompiler/blob/main/siliconcompiler/targets/freepdk45_demo.py>`_.
 
 .. note::
 

--- a/docs/user_guide/remote_processing.rst
+++ b/docs/user_guide/remote_processing.rst
@@ -19,7 +19,7 @@ Remote processing is also supported from the Python interface when the 'remote' 
 
   chip.set('remote', True)
 
-For security reasons, only a subset of the full Schema parameters is currently supported. Values for disallowed keypaths will be silently dropped by the server. In addition, note that the target() function will be re-run on the server, to ensure targets are set up with their default configurations. The following table documents the list of supported remote parameters and any associated restrictions.
+For security reasons, only a subset of the full Schema parameters is currently supported. Values for disallowed keypaths will be silently dropped by the server. In addition, note that the load_target() function will be re-run on the server, to ensure targets are set up with their default configurations. The following table documents the list of supported remote parameters and any associated restrictions.
 
 .. list-table::
    :widths: 10 10

--- a/docs/user_guide/targets.rst
+++ b/docs/user_guide/targets.rst
@@ -36,9 +36,9 @@ See the :ref:`PDK<PDKs>`, :ref:`Library<Libraries>`, and :ref:`Flow<Flows>` User
 
 Generally, these functions will be called by targets, and then a user will only have to call ``load_target()`` in their build script.  However, the ``run()`` function requires all mandatory flowgraph, pdk, and tool settings to be defined prior to execution, so if a partial target is loaded, additional setup may be required.
 
-The following example calls the target function to load the built-in :ref:`freepdk45_demo` target. ::
+The following example calls the ``load_target()`` function to load the built-in :ref:`freepdk45_demo` target. ::
 
-  chip.target('freepdk45_dmeo')
+  chip.load_target('freepdk45_demo')
 
 The following example demonstrates the functional equivalent at the command line:
 

--- a/docs/user_guide/targets.rst
+++ b/docs/user_guide/targets.rst
@@ -1,13 +1,9 @@
 Targets
 ===================================
 
-To facilitate grouping and encapsulation of schema parameters, SiliconCompiler implements a target() function that operates on string based names similar to `LLVM <https://clang.llvm.org/docs/CrossCompilation.html>`_. The target() function searches for Python modules that match strings extracted from a "_" delimited target string. Depending on the target type, target() will construct a relative path as follows:
+To facilitate encapsulation and reuse of schema parameters related to design targets, SiliconCompiler implements a ``load_target()`` function that dynamically loads Python modules located in special places on the filesystem.
 
-  * **Tools**: ``tools/<modulename>/<modulename>.py``
-  * **Flows**: ``flows/<modulename>.py``
-  * **PDKs**: ``pdks/<modulname>.py``
-
-target() will then search for these relative paths in the following locations, in this order:
+``load_target()`` takes in a string ``targetname``, and it will search for the path ``targets/<targetname>.py`` in the following locations, in this order:
 
   #. The root of the SiliconCompiler Python package, wherever it is installed.
   #. The working directory from where the CLI app was called or the Chip() object instantiated.
@@ -16,28 +12,38 @@ target() will then search for these relative paths in the following locations, i
 
 The ability to configure the search paths via a schema parameter or environment variable enables users to create custom targets and place them anywhere on their filesystem. Note that this file resolution scheme is also used by SC for resolving all other relative paths, not just target modules.
 
-The run() function requires all mandatory flowgraph, pdk, and tool settings to be defined prior to execution, so if a partial target is loaded, additional parameter set() calls may be required. The following example calls the target function to load the setup_flow() function for asicflow and setup_pdk function for freepdk45. ::
+All target modules must contain a function ``setup()`` that takes in a chip object and can modify its schema parameters in any way. It's common for targets to load at least one flow, a PDK and at least one standard cell library if an ASIC target, and sometimes set up default design parameters. Targets should also include a ``make_docs()`` function which provides a descriptive docstring and returns a chip object with the target loaded.
 
-  chip.target('asicflow_freepdk45')
+SC supports additional levels of encapsulation through PDK, library, and flow modules. These are loaded similarly to targets, but with their own respective load functions and directories, as shown below:
+
+.. list-table::
+   :widths: 40 40
+   :header-rows: 1
+
+   * - Function
+     - Module location
+
+   * - ``load_pdk(name)``
+     - ``pdks/<name>.py``
+
+   * - ``load_lib(name)``
+     - ``libs/<name>.py``
+
+   * - ``load_flow(name)``
+     - ``flows/<name>.py``
+
+See the :ref:`PDK<PDKs>`, :ref:`Library<Libraries>`, and :ref:`Flow<Flows>` User Guide pages to learn more about what is expected to be configured in each of these modules.
+
+Generally, these functions will be called by targets, and then a user will only have to call ``load_target()`` in their build script.  However, the ``run()`` function requires all mandatory flowgraph, pdk, and tool settings to be defined prior to execution, so if a partial target is loaded, additional setup may be required.
+
+The following example calls the target function to load the built-in :ref:`freepdk45_demo` target. ::
+
+  chip.target('freepdk45_dmeo')
 
 The following example demonstrates the functional equivalent at the command line:
 
 .. code-block:: bash
 
-   sc hello.v -target "asicflow_freepdk45"
+   sc hello.v -target "freepdk45_demo"
 
-The following target target string combinations are supported:
-
- * <flowname>
- * <flowname>_<pdkname>
- * <flowname>_<partname> (for fpga flows)
- * <pdk>
- * <tool>
- * <tool>_<pdkname>
- * <projname>
-
-Loading tools through the target requires setting a step argument since tools are set up on a per step and per index basis. The example below illustrates the use of target to load tools individually. ::
-
-  chip.set('arg','step', 'floorplan')
-  chip.target("openroad_freepdk45")
-  chip.run()
+A full list of built-in demo targets can be found on the :ref:`Targets directory` page.

--- a/docs/user_guide/tools.rst
+++ b/docs/user_guide/tools.rst
@@ -14,7 +14,7 @@ SiliconCompiler execution depends on implementing adapter code "drivers" for eac
      - Used by
      - Required
 
-   * - **setup_tool**
+   * - **setup**
      - Configures tool
      - chip
      - chip
@@ -59,7 +59,7 @@ SiliconCompiler execution depends on implementing adapter code "drivers" for eac
 For a complete example of a tool setup module, see `OpenROAD <https://github.com/siliconcompiler/siliconcompiler/blob/main/siliconcompiler/tools/openroad/openroad.py>`_. For more in depth information about the various 'eda' parameters, see the :ref:`Schema <SiliconCompiler Schema>` section of the reference manual.
 
 
-setup_tool(chip)
+setup(chip)
 -----------------
 
 Tool setup is done for each step and index within the run() function prior to launching each individual task. Tools can be configured independently for different steps (ie. the place step is different from the route step), so we need a method for passing information about the current step and index to the setup function. This is accomplished with the reserved 'scratch' parameters shown below. ::
@@ -89,14 +89,14 @@ To leverage the run() function's internal setup checking logic, it is highly rec
 
 parse_version(stdout)
 -----------------------
-The run() function includes built in executable version checking, which can be enabled or disabled with the 'vercheck' parameter. The executable option to use for printing out the version number is specified with the 'vswitch' parameter within the setup_tool() function. Commonly used options include '-v', '\-\-version', '-version'. The executable output varies widely, so we need a parsing function that processes the output and returns a single uniform version string. The example shows how this function is implemented for the Yosys tool. ::
+The run() function includes built in executable version checking, which can be enabled or disabled with the 'vercheck' parameter. The executable option to use for printing out the version number is specified with the 'vswitch' parameter within the setup() function. Commonly used options include '-v', '\-\-version', '-version'. The executable output varies widely, so we need a parsing function that processes the output and returns a single uniform version string. The example shows how this function is implemented for the Yosys tool. ::
 
   def parse_version(stdout):
       # Yosys 0.9+3672 (git sha1 014c7e26, gcc 7.5.0-3ubuntu1~18.04 -fPIC -Os)
       version = stdout.split()[1]
       return version.split('+')[0]
 
-The run() function compares the returned parsed version against the 'version' parameter specified in the setup_tool() function to ensure that a qualified executable version is being used.
+The run() function compares the returned parsed version against the 'version' parameter specified in the setup() function to ensure that a qualified executable version is being used.
 
 pre_process(chip)
 -----------------------
@@ -144,7 +144,7 @@ Note that the return value of the post_process() function is interpreted as an i
 
 runtime_options(chip)
 -----------------------
-The distributed execution model of SiliconCompiler mandates that absolute paths be resolved at task run time. The setup_tool() function is run at run() launch to check flow validity, so we need a second function interface (runtime_options) to create the final commandline options. The runtime_options() function inspects the Schema and returns a cmdlist to be used by the 'exe' during task execution. The sequence of items used to generate the final command line invocation is as follows:
+The distributed execution model of SiliconCompiler mandates that absolute paths be resolved at task run time. The setup() function is run at run() launch to check flow validity, so we need a second function interface (runtime_options) to create the final commandline options. The runtime_options() function inspects the Schema and returns a cmdlist to be used by the 'exe' during task execution. The sequence of items used to generate the final command line invocation is as follows:
 
 ::
 
@@ -209,7 +209,7 @@ The SiliconCompiler includes automated document generators that search all tool 
     chip.set('arg','step','import')
     chip.set('arg','index','0')
     chip.set('design', '<design>')
-    setup_tool(chip)
+    setup(chip)
     return chip
 
 

--- a/examples/gcd/gcd.py
+++ b/examples/gcd/gcd.py
@@ -12,7 +12,7 @@ def main():
     chip.set('quiet', True)
     chip.set('asic', 'diearea', [(0,0), (100.13,100.8)])
     chip.set('asic', 'corearea', [(10.07,11.2), (90.25,91)])
-    chip.target("asicflow_freepdk45")
+    chip.load_target("freepdk45_demo")
     chip.run()
     chip.summary()
 

--- a/siliconcompiler/_metadata.py
+++ b/siliconcompiler/_metadata.py
@@ -1,5 +1,5 @@
 # Version number following semver standard.
-version = '0.5.0'
+version = '0.6.0'
 
 # This is the list of significant contributors to SiliconCompiler in
 # chronological order.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -91,6 +91,12 @@ class Chip:
 
         self._init_logger()
 
+        self._loaded_modules = {
+            'flows': [],
+            'pdks': [],
+            'libs': []
+        }
+
     ###########################################################################
     def _init_logger(self, step=None, index=None):
 
@@ -517,6 +523,7 @@ class Chip:
 
         func = self.find_function(name, 'setup', 'pdks')
         if func is not None:
+            self._loaded_modules['pdks'].append(name)
             func(self)
         else:
             self.logger.error(f'Module {name} not found.')
@@ -541,6 +548,7 @@ class Chip:
 
         func = self.find_function(name, 'setup', 'flows')
         if func is not None:
+            self._loaded_modules['flows'].append(name)
             func(self)
         else:
             self.logger.error(f'Module {name} not found.')
@@ -565,6 +573,7 @@ class Chip:
 
         func = self.find_function(name, 'setup', 'libs')
         if func is not None:
+            self._loaded_modules['libs'].append(name)
             func(self)
         else:
             self.logger.error(f'Module {name} not found.')

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -155,9 +155,11 @@ class Chip:
          1. design
          2. loglevel
          3. mode
-         4. target('target')
-         5. read_manifest([cfg])
-         6. all other switches
+         4. arg_step
+         5. fpga_partname
+         6. load_target('target')
+         7. read_manifest([cfg])
+         8. all other switches
 
         The cmdline interface is implemented using the Python argparse package
         and the following use restrictions apply.

--- a/siliconcompiler/libs/asap7sc7p5t.py
+++ b/siliconcompiler/libs/asap7sc7p5t.py
@@ -1,15 +1,9 @@
 import os
-import sys
-import re
 import siliconcompiler
 
 def make_docs():
     '''
-    Library description
-
-    Documentation: https://
-    Sources: https://
-    Installation: https://
+    ASAP 7 7.5-track standard cell library.
     '''
 
     chip = siliconcompiler.Chip()
@@ -37,6 +31,8 @@ def setup(chip):
 
         # rev
         chip.set('library',libname, 'package', 'version',rev)
+
+        chip.set('library', libname, 'pdk', 'asap7')
 
         # timing
         chip.add('library', libname, 'nldm', corner, 'lib',

--- a/siliconcompiler/libs/nangate45.py
+++ b/siliconcompiler/libs/nangate45.py
@@ -1,20 +1,13 @@
-
 import os
-import sys
-import re
 import siliconcompiler
 
 def make_docs():
     '''
-    Library description
-
-    Documentation: https://
-    Sources: https://
-    Installation: https://
+    Nangate open standard cell library for FreePDK45.
     '''
 
     chip = siliconcompiler.Chip()
-    setup_lib(chip)
+    setup(chip)
     return chip
 
 def setup(chip):
@@ -41,6 +34,8 @@ def setup(chip):
 
     # rev
     chip.set('library',libname, 'package', 'version',rev)
+
+    chip.set('library', libname, 'pdk', 'freepdk45')
 
     # timing
     chip.add('library',libname, 'nldm', corner, 'lib',

--- a/siliconcompiler/libs/sky130.py
+++ b/siliconcompiler/libs/sky130.py
@@ -1,19 +1,13 @@
 import os
-import sys
-import re
 import siliconcompiler
 
 def make_docs():
     '''
-    Library description
-
-    Documentation: https://
-    Sources: https://
-    Installation: https://
+    Skywater130 standard cell library.
     '''
 
     chip = siliconcompiler.Chip()
-    setup_lib(chip)
+    setup(chip)
     return chip
 
 def setup(chip):
@@ -34,6 +28,8 @@ def setup(chip):
 
     # rev
     chip.set('library', libname, 'package', 'version', rev)
+
+    chip.set('library', libname, 'pdk', 'skywater130')
 
     # timing
     chip.add('library', libname, 'nldm', corner, 'lib',

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -3472,7 +3472,7 @@ def schema_options(cfg):
                     "api: chip.set('techarg','mimcap', 'true')"],
         'help': """
         Parameter passed in as key/value pair to the technology target
-        referenced in the target() API call. See the target technology
+        referenced in the load_pdk() API call. See the target technology
         for specific guidelines regarding configuration parameters.
         """
     }
@@ -3490,7 +3490,7 @@ def schema_options(cfg):
                     "api: chip.set('flowarg','n', '100')"],
         'help': """
         Parameter passed in as key/value pair to the technology target
-        referenced in the target() API call. See the target flow for
+        referenced in the load_flow() API call. See the target flow for
         specific guidelines regarding configuration parameters.
         """
     }
@@ -3976,7 +3976,7 @@ def schema_options(cfg):
         Specifies the frontend that flows should use for importing and
         processing source files. Default option is 'verilog', also supports
         'systemverilog' and 'chisel'. When using the Python API, this parameter
-        must be configured before calling target().
+        must be configured before calling load_target().
         """
     }
 

--- a/siliconcompiler/targets/asap7_demo.py
+++ b/siliconcompiler/targets/asap7_demo.py
@@ -1,11 +1,9 @@
-import os
-import sys
-import re
 import siliconcompiler
 
 def make_docs():
     '''
-    Documentation
+    Demonstration target for compiling ASICs with ASAP7 and the open-source
+    asicflow.
     '''
 
     chip = siliconcompiler.Chip()

--- a/siliconcompiler/targets/fpgaflow_demo.py
+++ b/siliconcompiler/targets/fpgaflow_demo.py
@@ -1,14 +1,12 @@
-import os
-import sys
-import re
 import siliconcompiler
 
 def make_docs():
     '''
-    Documentation
+    Demonstration target for running the open-source fpgaflow.
     '''
 
     chip = siliconcompiler.Chip()
+    chip.set('fpga', 'partname', 'ice40up5k-sg48')
     setup(chip)
     return chip
 

--- a/siliconcompiler/targets/freepdk45_demo.py
+++ b/siliconcompiler/targets/freepdk45_demo.py
@@ -1,6 +1,3 @@
-import os
-import sys
-import re
 import siliconcompiler
 
 ############################################################################
@@ -9,7 +6,8 @@ import siliconcompiler
 
 def make_docs():
     '''
-    Template project file.
+    Demonstration target for compiling ASICs with FreePDK45 and the open-source
+    asicflow.
     '''
 
     chip = siliconcompiler.Chip()

--- a/siliconcompiler/targets/skywater130_demo.py
+++ b/siliconcompiler/targets/skywater130_demo.py
@@ -1,6 +1,3 @@
-import os
-import sys
-import re
 import siliconcompiler
 
 ############################################################################
@@ -9,11 +6,12 @@ import siliconcompiler
 
 def make_docs():
     '''
-    Template project file.
+    Demonstration target for compiling ASICs with Skywater130 and the
+    open-source asicflow.
     '''
 
     chip = siliconcompiler.Chip()
-    setup_project(chip)
+    setup(chip)
     return chip
 
 


### PR DESCRIPTION
This PR updates docs for our big change to the target interface in SC 0.6.

The main changes:
- Added autogeneration of library and target module documentation
- Updates to examples/prose to get rid of references to the old target() method (this ended up being substantial!)

The only change that might be controversial: I added a private variable `_loaded_modules` to the chip object that tracks which PDKs, flows, and libraries have been loaded into that chip. I wanted to display a nice concise list of these in the autogenerated target docs, but I realized we don't have a way to get this info from the schema. I think modifying the schema to enable this might be a better solution, which we can discuss, but for now this was a quick way to mock up my idea.