### PR TITLE
Clean up tech-specific variables in OpenROAD

### DIFF
--- a/siliconcompiler/pdks/asap7.py
+++ b/siliconcompiler/pdks/asap7.py
@@ -136,11 +136,11 @@ def setup(chip):
         chip.set('pdk','grid', stackup, layer, 'adj',     0.4)
 
     # Defaults for OpenROAD tool variables
-    chip.set('pdk', 'variable', stackup, 'openroad', 'place_density', ['0.77'])
-    chip.set('pdk', 'variable', stackup, 'openroad', 'pad_global_place', ['2'])
-    chip.set('pdk', 'variable', stackup, 'openroad', 'pad_detail_place', ['1'])
-    chip.set('pdk', 'variable', stackup, 'openroad', 'macro_place_halo', ['22.4', '15.12'])
-    chip.set('pdk', 'variable', stackup, 'openroad', 'macro_place_channel', ['18.8', '19.95'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'place_density', ['0.77'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'pad_global_place', ['2'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'pad_detail_place', ['1'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'macro_place_halo', ['22.4', '15.12'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'macro_place_channel', ['18.8', '19.95'])
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/pdks/asap7.py
+++ b/siliconcompiler/pdks/asap7.py
@@ -135,6 +135,13 @@ def setup(chip):
         chip.set('pdk','grid', stackup, layer, 'ypitch',  0.08)
         chip.set('pdk','grid', stackup, layer, 'adj',     0.4)
 
+    # Defaults for OpenROAD tool variables
+    chip.set('pdk', 'variable', stackup, 'openroad', 'place_density', ['0.77'])
+    chip.set('pdk', 'variable', stackup, 'openroad', 'pad_global_place', ['2'])
+    chip.set('pdk', 'variable', stackup, 'openroad', 'pad_detail_place', ['1'])
+    chip.set('pdk', 'variable', stackup, 'openroad', 'macro_place_halo', ['22.4', '15.12'])
+    chip.set('pdk', 'variable', stackup, 'openroad', 'macro_place_channel', ['18.8', '19.95'])
+
 #########################
 if __name__ == "__main__":
 

--- a/siliconcompiler/pdks/freepdk45.py
+++ b/siliconcompiler/pdks/freepdk45.py
@@ -154,6 +154,13 @@ def setup(chip):
         else:
             chip.set('pdk','grid', stackup, layer, 'dir', 'horizontal')
 
+    # Defaults for OpenROAD tool variables
+    chip.set('pdk', 'variable', 'openroad', stackup, 'place_density', ['0.3'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'pad_global_place', ['2'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'pad_detail_place', ['1'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'macro_place_halo', ['22.4', '15.12'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'macro_place_channel', ['18.8', '19.95'])
+
 #########################
 if __name__ == "__main__":
 

--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -143,6 +143,13 @@ def setup(chip):
     chip.set('pdk','grid', stackup, 'met5', 'ypitch',  3.4)
     chip.set('pdk','grid', stackup, 'met5', 'adj', 0.5)
 
+    # Defaults for OpenROAD tool variables
+    chip.set('pdk', 'variable', stackup, 'openroad', 'place_density', ['0.6'])
+    chip.set('pdk', 'variable', stackup, 'openroad', 'pad_global_place', ['4'])
+    chip.set('pdk', 'variable', stackup, 'openroad', 'pad_detail_place', ['2'])
+    chip.set('pdk', 'variable', stackup, 'openroad', 'macro_place_halo', ['1', '1'])
+    chip.set('pdk', 'variable', stackup, 'openroad', 'macro_place_channel', ['80', '80'])
+
 #########################
 if __name__ == "__main__":
 

--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -144,11 +144,11 @@ def setup(chip):
     chip.set('pdk','grid', stackup, 'met5', 'adj', 0.5)
 
     # Defaults for OpenROAD tool variables
-    chip.set('pdk', 'variable', stackup, 'openroad', 'place_density', ['0.6'])
-    chip.set('pdk', 'variable', stackup, 'openroad', 'pad_global_place', ['4'])
-    chip.set('pdk', 'variable', stackup, 'openroad', 'pad_detail_place', ['2'])
-    chip.set('pdk', 'variable', stackup, 'openroad', 'macro_place_halo', ['1', '1'])
-    chip.set('pdk', 'variable', stackup, 'openroad', 'macro_place_channel', ['80', '80'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'place_density', ['0.6'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'pad_global_place', ['4'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'pad_detail_place', ['2'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'macro_place_halo', ['1', '1'])
+    chip.set('pdk', 'variable', 'openroad', stackup, 'macro_place_channel', ['80', '80'])
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -602,7 +602,7 @@ def schema_pdk(cfg, stackup='default'):
             "api: chip.set('pdk','directory','xyce','M10','rfmodel','rftechdir')"],
         'help': """
         List of named directories specified on a per tool and per stackup basis.
-        The parameter is useful for specifying files that are not directly
+        The parameter is useful for specifying directories that are not directly
         covered by the rest of the PDK schema.
         """
 
@@ -624,7 +624,7 @@ def schema_pdk(cfg, stackup='default'):
             "api: chip.set('pdk','variable','xyce', 'M10','modeltype','bsim4')"],
         'help': """
         List of key/value strings specified on a per tool and per stackup basis.
-        The parameter is useful for specifying files that are not directly
+        The parameter is useful for specifying values that are not directly
         covered by the rest of the PDK schema.
         """
     }

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -1,8 +1,6 @@
 import os
-import importlib
 import re
 import shutil
-import sys
 import siliconcompiler
 from siliconcompiler.floorplan import _infer_diearea
 
@@ -13,7 +11,7 @@ from siliconcompiler.floorplan import _infer_diearea
 def make_docs():
     '''
     OpenROAD is an automated physical design platform for
-    integreated circuit design with a complete set of features
+    integrated circuit design with a complete set of features
     needed to translate a synthesized netlist to a tapeout ready
     GDSII.
 
@@ -56,7 +54,7 @@ def setup(chip, mode='batch'):
         option = "-no_init"
 
     # exit automatically in batch mode and not bkpt
-    if (mode=='batch') & (step not in chip.get('bkpt')):
+    if (mode=='batch') and (step not in chip.get('bkpt')):
         option += " -exit"
 
     chip.set('eda', tool, 'exe', tool, clobber=clobber)
@@ -86,11 +84,10 @@ def setup(chip, mode='batch'):
     # openroad makes use of these parameters
     targetlibs = chip.get('asic', 'logiclib')
     stackup = chip.get('asic', 'stackup')
-    if bool(stackup) & bool(targetlibs):
+    if stackup and targetlibs:
         mainlib = targetlibs[0]
         macrolibs = chip.get('asic', 'macrolib')
         libtype = str(chip.get('library', mainlib, 'arch'))
-        techlef = chip.get('pdk', 'aprtech', 'openroad', stackup, libtype, 'lef')
 
         chip.add('eda', tool, 'require', step, index, ",".join(['asic', 'logiclib']))
         chip.add('eda', tool, 'require', step, index, ",".join(['asic', 'stackup']))
@@ -99,13 +96,11 @@ def setup(chip, mode='batch'):
 
         for lib in (targetlibs + macrolibs):
             for corner in chip.getkeys('library', lib, 'nldm'):
-                nldm = chip.get('library', lib, 'nldm', corner, 'lib')
                 chip.add('eda', tool, 'require', step, index, ",".join(['library', lib, 'nldm', corner, 'lib']))
-            lef = chip.get('library', lib, 'lef')
             chip.add('eda', tool, 'require', step, index, ",".join(['library', lib, 'lef']))
     else:
         chip.error = 1
-        chip.logger.error(f'Stackup and targetlib paremeters required for OpenROAD.')
+        chip.logger.error(f'Stackup and logiclib parameters required for OpenROAD.')
 
 
     # defining default dictionary

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -102,66 +102,26 @@ def setup(chip, mode='batch'):
         chip.error = 1
         chip.logger.error(f'Stackup and logiclib parameters required for OpenROAD.')
 
+    variables = (
+        'place_density',
+        'pad_global_place',
+        'pad_detail_place',
+        'macro_place_halo',
+        'macro_place_channel'
+    )
+    for variable in variables:
+        # For each OpenROAD tool variable, read default from PDK and write it
+        # into schema. If PDK doesn't contain a default, the value must be set
+        # by the user, so we add the variable keypath as a requirement.
+        if chip.valid('pdk', 'variable', tool, stackup, variable):
+            value = chip.get('pdk', 'variable', tool, stackup, variable)
+            # Clobber needs to be False here, since a user might want to
+            # overwrite these.
+            chip.set('eda', tool, 'variable', step, index, variable, value,
+                     clobber=False)
 
-    # defining default dictionary
-    default_options = {
-        'place_density': [],
-        'pad_global_place': [],
-        'pad_detail_place': [],
-        'macro_place_halo': [],
-        'macro_place_channel': []
-    }
-
-    # Setting up technologies with default values
-    # NOTE: no reasonable defaults, for halo and channel.
-    # TODO: Could possibly scale with node number for default, but safer to error out?
-    # perhaps we should use node as comp instead?
-    if chip.get('pdk', 'process'):
-        process = chip.get('pdk', 'process')
-        if process == 'freepdk45':
-            default_options = {
-                'place_density': ['0.3'],
-                'pad_global_place': ['2'],
-                'pad_detail_place': ['1'],
-                'macro_place_halo': ['22.4', '15.12'],
-                'macro_place_channel': ['18.8', '19.95']
-            }
-        elif process == 'asap7':
-            default_options = {
-                'place_density': ['0.77'],
-                'pad_global_place': ['2'],
-                'pad_detail_place': ['1'],
-                'macro_place_halo': ['22.4', '15.12'],
-                'macro_place_channel': ['18.8', '19.95']
-            }
-        elif process == 'skywater130':
-            default_options = {
-                'place_density': ['0.6'],
-                'pad_global_place': ['4'],
-                'pad_detail_place': ['2'],
-                'macro_place_halo': ['1', '1'],
-                'macro_place_channel': ['80', '80']
-            }
-        else:
-            chip.error = 1
-            chip.logger.error(f'Process {process} not supported with OpenROAD.')
-    else:
-        default_options = {
-            'place_density': ['1'],
-            'pad_global_place': ['<space>'],
-            'pad_detail_place': ['<space>'],
-            'macro_place_halo': ['<xspace>', '<yspace>'],
-            'macro_place_channel': ['<xspace>', '<yspace>']
-        }
-
-    for option in default_options:
-        if chip.valid('eda', tool, 'variable', step, index, option, quiet=True, default_valid=False):
-            chip.logger.info('User provided variable %s OpenROAD flow detected.', option)
-        elif not default_options[option]:
-            chip.error = 1
-            chip.logger.error('Missing variable %s for OpenROAD.', option)
-        else:
-            chip.set('eda', tool, 'variable', step, index, option, default_options[option], clobber=clobber)
+        keypath = ','.join(['eda', tool, 'variable', step, index, variable])
+        chip.add('eda', tool, 'require', step, index, keypath)
 
     for clock in chip.getkeys('clock'):
         chip.add('eda', tool, 'require', step, index, ','.join(['clock', clock, 'period']))

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -27,6 +27,9 @@ def make_docs():
     chip.set('arg', 'step', '<step>')
     chip.set('arg', 'index', '<index>')
     chip.set('design', '<design>')
+    # TODO: how to make it clear in docs that certain settings are
+    # target-dependent?
+    chip.load_target('freepdk45_demo')
     setup(chip)
 
     return chip


### PR DESCRIPTION
This PR removes the tech-specific variable default values from openroad.py. It now drives the defaults through the PDK. 

Also included some misc cleanup of the file.