### PR TITLE
Fix bug in _allpaths()

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2740,23 +2740,28 @@ class Chip:
         return list(sorted_dict.keys())
 
     ###########################################################################
-    def _allpaths(self, cfg, flow, step, index, path=None, allpaths=None):
+    def _allpaths(self, cfg, flow, step, index, path=None):
+        '''Recursive helper for finding all paths from provided step, index to
+        root node(s) with no inputs.
+
+        Returns a list of lists.
+        '''
 
         if path is None:
             path = []
-            allpaths = []
 
         inputs = self.get('flowgraph', flow, step, index, 'input', cfg=cfg)
 
         if not self.get('flowgraph', flow, step, index, 'input', cfg=cfg):
-            allpaths.append(path)
+            return [path]
         else:
+            allpaths = []
             for in_step, in_index in inputs:
                 newpath = path.copy()
                 newpath.append(in_step + in_index)
-                return self._allpaths(cfg, flow, in_step, in_index, path=newpath, allpaths=allpaths)
+                allpaths.extend(self._allpaths(cfg, flow, in_step, in_index, path=newpath))
 
-        return list(allpaths)
+        return allpaths
 
     ###########################################################################
     def clock(self, *, name, pin, period, jitter=0):

--- a/tests/core/test_list_steps.py
+++ b/tests/core/test_list_steps.py
@@ -1,0 +1,22 @@
+import siliconcompiler
+
+def test_list_steps():
+    chip = siliconcompiler.Chip()
+    flow = 'test'
+    chip.node(flow, 'A', 'join')
+
+    chip.node(flow, 'B', 'join')
+    chip.edge(flow, 'A', 'B')
+
+    chip.node(flow, 'C', 'join')
+    chip.edge(flow, 'B', 'C')
+
+    chip.node(flow, 'D', 'join')
+    chip.edge(flow, 'A', 'D')
+    chip.edge(flow, 'C', 'D')
+
+    chip.set('flow', flow)
+
+    chip.write_flowgraph('test_list_steps.png')
+
+    assert chip.list_steps() == ['A', 'B', 'C', 'D']


### PR DESCRIPTION
This PR fixes a bug I caught in the `_allpaths()` function today. The issue is that it had a `return` statement inside the for loop that loops over all inputs to the current task, meaning that it wouldn't actually generate all paths (just one of them).

Depending on the order in which you set up your flowgraph, this meant that `list_steps()` could give you an incorrect ordering, resulting in a confusing summary table. I demonstrated this with a new test, `tests/core/test_list_steps.py`. The simple flowgraph in the test looks like this:

![test_list_steps](https://user-images.githubusercontent.com/4412459/154529467-4b82a521-7cf6-457b-8619-3a33090c3432.png)

Without this fix, `list_steps()` returns `['A', 'B', 'D', 'C']`, because it only considers the path from A->D. With this fix, you get the correct order of `['A', 'B', 'C', 'D']`.

