### PR TITLE
Fix jobinput/record bug

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3170,10 +3170,11 @@ class Chip:
 
         # support for sharing data across jobs
         job = self.get('jobname')
+        in_job = job
         if job in self.getkeys('jobinput'):
             if step in self.getkeys('jobinput',job):
                 if index in self.getkeys('jobinput',job,step):
-                    job = self.get('jobinput', job, step, index)
+                    in_job = self.get('jobinput', job, step, index)
 
         workdir = self._getworkdir(step=step,index=index)
         cwd = os.getcwd()
@@ -3194,7 +3195,7 @@ class Chip:
                 index_error = error[in_step + in_index]
                 self.set('flowstatus', in_step, in_index, 'error', index_error)
                 if not index_error:
-                    cfgfile = f"../../../{job}/{in_step}/{in_index}/outputs/{design}.pkg.json"
+                    cfgfile = f"../../../{in_job}/{in_step}/{in_index}/outputs/{design}.pkg.json"
                     self.read_manifest(cfgfile, clobber=False)
 
         ##################
@@ -3264,7 +3265,7 @@ class Chip:
 
             # Skip copying pkg.json files here, since we write the current chip
             # configuration into inputs/{design}.pkg.json earlier in _runstep.
-            utils.copytree(f"../../../{job}/{in_step}/{in_index}/outputs", 'inputs/', dirs_exist_ok=True,
+            utils.copytree(f"../../../{in_job}/{in_step}/{in_index}/outputs", 'inputs/', dirs_exist_ok=True,
                 ignore=[f'{design}.pkg.json'], link=True)
 
         ##################


### PR DESCRIPTION
This PR fixes a subtle bug with the way the 'jobinput' parameter is handled. For any task that has a 'jobinput' set, the `job` variable gets overwritten with the name of the input job, but this `job` variable is also used to determine where records get stored when 'track' is set to True (see [core.py line 3413](https://github.com/siliconcompiler/siliconcompiler/blob/e724bcfb290a846710a6f44368b72a97e9b0c0d9/siliconcompiler/core.py#L3413)). 

Changing the variable name fixes this problem and should make thing safer from bugs in the future, since the new name is a bit more explicit.