### PR TITLE
Fix bug causing [arg, index] to not be respected

### DIFF
--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2508,7 +2508,7 @@ def schema_arg(cfg):
         'lock': 'false',
         'require': None,
         'signature': None,
-        'defvalue': '0',
+        'defvalue': None,
         'shorthelp': 'Current index',
         'example': ["cli: -arg_index 0",
                     "api: chip.set('arg','index','0')"],


### PR DESCRIPTION
Since we clobber [arg, index] when running the tool setup loop, using it
later to determine whether or not to only run a single index for a step
doesn't work. Precomputing a per-step indexlist avoids this problem and
also makes the code cleaner.

This also fixes an additional uncaught bug where the indexlist parameter
wouldn't be respected by run().