### PR TITLE
Some small cleanup things in core.py

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -433,10 +433,10 @@ class Chip:
         Args:
             modulename (str): Name of module to import.
             funcname (str): Name of the function to find within the module.
-            moduletype (str): Type of module (flows, pdks,libs,targets).
+            moduletype (str): Type of module (flows, pdks, libs, targets).
 
         Examples:
-            >>> setup_pdk = chip.find_function('freepdk45', 'setup', 'pdk')
+            >>> setup_pdk = chip.find_function('freepdk45', 'setup', 'pdks')
             >>> setup_pdk()
             Imports the freepdk45 module and runs the setup_pdk function
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1781,8 +1781,6 @@ class Chip:
         if update:
             self.merge_manifest(localcfg, job=job, clear=clear, clobber=clobber)
 
-        return localcfg
-
     ###########################################################################
     def write_manifest(self, filename, prune=True, abspath=False, job=None):
         '''

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1716,7 +1716,12 @@ class Chip:
                         # If we're not running the input step, the required
                         # inputs need to already be copied into the build
                         # directory.
-                        workdir = self._getworkdir(step=in_step, index=in_index)
+                        jobname = self.get('jobname')
+                        if self.valid('jobinput', jobname, step, index):
+                            in_job = self.get('jobinput', jobname, step, index)
+                        else:
+                            in_job = jobname
+                        workdir = self._getworkdir(jobname=in_job, step=in_step, index=in_index)
                         in_step_out_dir = os.path.join(workdir, 'outputs')
                         inputs = set(os.listdir(in_step_out_dir))
                     else:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -344,7 +344,7 @@ class Chip:
         # 4. read in all cfg files
         if 'cfg' in cmdargs.keys():
             for item in cmdargs['cfg']:
-                self.read_manifest(item, update=True, clobber=True, clear=True)
+                self.read_manifest(item, clobber=True, clear=True)
 
         # insert all parameters in dictionary
         self.logger.info('Setting commandline arguments')
@@ -1742,7 +1742,7 @@ class Chip:
         return True
 
     ###########################################################################
-    def read_manifest(self, filename, job=None, update=True, clear=True, clobber=True):
+    def read_manifest(self, filename, job=None, clear=True, clobber=True):
         """
         Reads a manifest from disk and merges it with the current compilation manifest.
 
@@ -1751,12 +1751,9 @@ class Chip:
 
         Args:
             filename (filepath): Path to a manifest file to be loaded.
-            update (bool): If True, manifest is merged into chip object.
+            job (str): Specifies non-default job to merge into.
             clear (bool): If True, disables append operations for list type.
             clobber (bool): If True, overwrites existing parameter value.
-
-        Returns:
-            A manifest dictionary.
 
         Examples:
             >>> chip.read_manifest('mychip.json')
@@ -1778,8 +1775,7 @@ class Chip:
         f.close()
 
         #Merging arguments with the Chip configuration
-        if update:
-            self.merge_manifest(localcfg, job=job, clear=clear, clobber=clobber)
+        self.merge_manifest(localcfg, job=job, clear=clear, clobber=clobber)
 
     ###########################################################################
     def write_manifest(self, filename, prune=True, abspath=False, job=None):


### PR DESCRIPTION
A few changes I had in my local branch:

- Docstring fix
- Fix bug in `_check_flowgraph_io()` that would occasionally cause checks to fail when using 'jobinput'
- Remove return value from `read_manifest()`. This is a very small change but might be the most controversial - however, I don't think we rely on the return value of this function anywhere (it's not even documented), and it can be annoying when using the interactive Python shell. The problem is that the REPL prints out the return value of any function when it's not assigned to something, so if you do `chip.read_manifest(...)` it will print out a massive dictionary that obscures previous command history.