### PR TITLE
Two small fixes

### DIFF
--- a/docs/_ext/installgen.py
+++ b/docs/_ext/installgen.py
@@ -16,8 +16,11 @@ class InstallScripts(SphinxDirective):
         scripts = {}
 
         for script in os.listdir(setup_dir):
+            if not script.startswith('install-'):
+                continue
+
             # Ignore directories such as 'setup/docker/'.
-            if os.path.isfile(script):
+            if os.path.isfile(os.path.join(setup_dir, script)):
                 components = script.split('.')[0].split('-')
                 tool = components[1]
 

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -67,6 +67,9 @@ def chip(scroot):
     chip.set('quiet', True)
     chip.load_target('freepdk45_demo')
 
+    # Important: set up our own flow instead of using asicflow.
+    chip.set('flow', 'test')
+
     # no-op import since we're not preprocessing source files
     chip.set('flowgraph', chip.get('flow'), 'import', '0', 'tool', 'join')
 
@@ -80,7 +83,6 @@ def chip(scroot):
 
 @pytest.mark.eda
 @pytest.mark.quick
-@pytest.mark.skip(reason="TODO: why is this failing???")
 def test_failed_branch_min(chip):
     '''Test that a minimum will allow failed inputs, as long as at least
     one passes.'''


### PR DESCRIPTION
- Fix installgen: `os.listdir()` doesn't give full path, so the `os.path.isfile` check always fails. Turns out the list of setup scripts has been missing from the docs for a while!
- Fix skipped test_tool_option: Problem was that with the new target scheme the test was hacking invalid changes into asicflow, so we needed to set up a test flow in its own "lane".