### PR TITLE
Add no-op lisdir to fix network filesystem issue

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3664,6 +3664,14 @@ class Chip:
         last_step_failed = True
         for index in indexlist[laststep]:
             lastdir = self._getworkdir(step=laststep, index=index)
+
+            # This no-op listdir operation is important for ensuring we have a
+            # consistent view of the filesystem when dealing with NFS. Without
+            # this, this thread is often unable to find the final manifest of
+            # runs performed on job schedulers, even if they completed
+            # successfully. Inspired by: https://stackoverflow.com/a/70029046.
+            os.listdir(os.path.dirname(lastdir))
+
             lastcfg = f"{lastdir}/outputs/{self.get('design')}.pkg.json"
             if os.path.isfile(lastcfg):
                 last_step_failed = False


### PR DESCRIPTION
I ran into a weird bug with a Slurm-based run using NFS to host the shared build directory. The main `run()` thread consistently failed to find the final results file, even though manual inspection after the completed run showed that it exists.

I did some digging around, and it seems likely that it's related to some sort of NFS cache coherency issue. This person had a very similar scenario: https://stackoverflow.com/questions/21292365/python-os-path-exists-failing-for-nfs-mounted-directory-file-that-exists. 

One of the answers suggested that using an `os.system('ls')` call fixes the issue by forcing a cache flush, and I found that the Python `listdir()` method seems to have the same effect (which I actually noticed by accident while using it to debug).

I figure we can merge this since this is a common Slurm use case and I think this line is otherwise harmless (despite it being an incredible hack). Another option seems to be to configure the filesystem not to cache file attributes, but this may have a performance impact. This is something we could look into, and it would require no changes to SC, just carefully documented methodology.

@WRansohoff, have you noticed any issues like this? I think you might have mentioned something related the other day, but I can't remember. Would also love to get your feedback on the problem/solution in general!

(Note: this PR is based off PR #877, if that one is merged first I might have to rebase this one)