### PR TITLE
Update klayout version in install-klayout.sh

### DIFF
--- a/setup/install-klayout.sh
+++ b/setup/install-klayout.sh
@@ -6,15 +6,15 @@ cd deps
 version=$(lsb_release -sr)
 
 if [ "$version" = "18.04" ]; then
-    url=https://www.klayout.org/downloads/Ubuntu-18/klayout_0.26.11-1_amd64.deb
+    url=https://www.klayout.org/downloads/Ubuntu-18/klayout_0.26.12-1_amd64.deb
 elif [ "$version" = "20.04" ]; then
-    url=https://www.klayout.org/downloads/Ubuntu-20/klayout_0.26.11-1_amd64.deb
+    url=https://www.klayout.org/downloads/Ubuntu-20/klayout_0.26.12-1_amd64.deb
 else
     echo "Script doesn't support Ubuntu version $version."
 fi
 
 wget $url
-sudo dpkg -i klayout_0.26.11-1_amd64.deb
+sudo dpkg -i klayout_0.26.12-1_amd64.deb
 
 echo "Please add \"export QT_QPA_PLATFORM=offscreen\" to your .bashrc"
 


### PR DESCRIPTION
The old URLs are dead. The new ones point to the current 0.26.XX version.