### PR TITLE
Account for `environment` parameters being stored as an array

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3385,7 +3385,7 @@ class Chip:
         if (step in self.getkeys('eda', tool, 'environment')) and \
            (index in self.getkeys('eda', tool, 'environment', step)):
             for item in self.getkeys('eda', tool, 'environment', step, index):
-                os.environ[item] = self.get('eda', tool, 'environment', step, index, item)
+                os.environ[item] = ':'.join(self.get('eda', tool, 'environment', step, index, item))
 
         ##################
         # 14. Check exe version

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3385,7 +3385,7 @@ class Chip:
         if (step in self.getkeys('eda', tool, 'environment')) and \
            (index in self.getkeys('eda', tool, 'environment', step)):
             for item in self.getkeys('eda', tool, 'environment', step, index):
-                os.environ[item] = ':'.join(self.get('eda', tool, 'environment', step, index, item))
+                os.environ[item] = self.get('eda', tool, 'environment', step, index, item)
 
         ##################
         # 14. Check exe version

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2333,7 +2333,7 @@ def schema_eda(cfg, tool='default', step='default', index='default'):
     cfg['eda'][tool]['environment'][step][index] = {}
     cfg['eda'][tool]['environment'][step][index]['default'] = {
         'switch': "-eda_environment 'tool step index name <str>'",
-        'type': '[str]',
+        'type': 'str',
         'lock': 'false',
         'require': None,
         'signature' : [],


### PR DESCRIPTION
The `environment` schema parameter is stored as an array, not a string. So it probably makes sense to use `':'.join` with these values, even though there's usually only one value for each environment variable.