### PR TITLE
Simplify scheduler log output

### DIFF
--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -31,19 +31,10 @@ def _deferstep(chip, step, index, active, error):
             slurm_constraint = chip.status['slurm_constraint']
         else:
             slurm_constraint = 'SHARED'
-        # The task directory may not exist before the 'sc' command is run;
-        # create it to ensure that the log file can be written to.
-        os.makedirs(os.path.join(chip.get('dir'),
-                                 chip.get('design'),
-                                 chip.get('jobname'),
-                                 step,
-                                 index),
-                    exist_ok = True)
+        # Set the log file location.
         output_file = os.path.join(chip.get('design'),
                                    chip.get('jobname'),
-                                   step,
-                                   index,
-                                   'sc_remote.log')
+                                   f'sc_remote-{step}-{index}.log')
         schedule_cmd = ['sbatch', '--exclusive',
                        '--constraint', slurm_constraint,
                        '--account', username,


### PR DESCRIPTION
Slurm seems to have a bit of trouble writing log files to non-existant or newly-created directories.

I've been writing the slurm log files to the build's root directory and relocating them in the server's `get_results` call as a workaround; it seems like we should formalize that change since it's been in effect for a couple of releases.