### PR TITLE
Adding oformat parameter to schema.

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3193,8 +3193,8 @@ class Chip:
         T19. Run post_process()
         T20. Check log file
         T21. Hash all task files
-        T22. Make a task record
-        T23. Stop Wall timer
+        T22. Stop Wall timer
+        T23. Make a task record
         T24. Save manifest to disk
         T25. Clean up
         T26. chdir
@@ -3502,15 +3502,15 @@ class Chip:
                         self.hash_files(*args)
 
         ##################
-        # 22. Make a record if tracking is enabled
-        if self.get('track'):
-            self._make_record(job, step, index, start, end, version)
-
-        ##################
-        # 23. Capture wall runtime
+        # 22. Capture wall runtime
         wall_end = time.time()
         walltime = round((wall_end - wall_start),2)
         self.set('metric',step, index, 'walltime', 'real', walltime)
+
+        ##################
+        # 23. Make a record if tracking is enabled
+        if self.get('track'):
+            self._make_record(job, step, index, wall_start, wall_end, version)
 
         ##################
         # 24. Save a successful manifest

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3173,30 +3173,32 @@ class Chip:
 
         Execution flow:
         T1. Wait in loop until all previous steps/indexes have completed
-        T2. Defer job to compute node if using job scheduler
-        T3. Start task timer
+        T2. Start wall timer
+        T3. Defer job to compute node if using job scheduler
         T4. Set up working directory + chdir
         T5. Merge manifests from all input dependancies
         T6. Write manifest to input directory for convenience
-        T7. Resetting all metrics to 0 (consider removing)
+        T7. Reset all metrics to 0 (consider removing)
         T8. Select inputs
         T9. Copy data from previous step outputs into inputs
         T10. Copy reference script directory
         T11. Check manifest
         T12. Run pre_process() function
-        T13. Set license file
+        T13. Set environment variables
         T14. Check EXE version
         T15. Save manifest as TCL/YAML
-        T16. Run EXE
-        T17. Run post_process()
-        T18. Check log file
-        T19. Hash all task files
-        T20. Measure run time
-        T21. Make a task record
-        T22. Save manifest to disk
-        T23. Clean up
-        T24. chdir
-        T25. clear error/active bits and return control to run()
+        T16. Start CPU timer
+        T17. Run EXE
+        T18. stop CPU timer
+        T19. Run post_process()
+        T20. Check log file
+        T21. Hash all task files
+        T22. Make a task record
+        T23. Stop Wall timer
+        T24. Save manifest to disk
+        T25. Clean up
+        T26. chdir
+        T27. clear error/active bits and return control to run()
 
         Note that since _runtask occurs in its own process with a separate
         address space, any changes made to the `self` object will not
@@ -3226,21 +3228,23 @@ class Chip:
             time.sleep(0.1)
 
         ##################
-        # 2. Defer job to compute node
+        # 2. Start wall timer
+        wall_start = time.time()
+
+        ##################
+        # 3. Defer job to compute node
         # If the job is configured to run on a cluster, collect the schema
         # and send it to a compute node for deferred execution.
         # (Run the initial 'import' stage[s] locally)
+
+        wall_start = time.time()
+
         if self.get('jobscheduler') and \
            self.get('flowgraph', flow, step, index, 'input'):
             # Note: The _deferstep method blocks until the compute node
             # finishes processing this step, and it sets the active/error bits.
             _deferstep(self, step, index, active, error)
             return
-
-        ##################
-        # 3. Start Task Timer
-        self.logger.debug(f"Starting process")
-        start = time.time()
 
         ##################
         # 4. Directory setup
@@ -3276,7 +3280,7 @@ class Chip:
                     self.read_manifest(cfgfile, clobber=False)
 
         ##################
-        # 6. Write configuration prior to step running into inputs
+        # 6. Write manifest prior to step running into inputs
 
         self.set('arg', 'step', None, clobber=True)
         self.set('arg', 'index', None, clobber=True)
@@ -3284,7 +3288,7 @@ class Chip:
         #self.write_manifest(f'inputs/{design}.pkg.json')
 
         ##################
-        # 7. Resetting metrics to zero
+        # 7. Reset metrics to zero
         # TODO: There should be no need for this, but need to fix
         # without it we need to be more careful with flows to make sure
         # things like the builtin functions don't look at None values
@@ -3324,7 +3328,7 @@ class Chip:
         self.set('flowstatus', step, index, 'select', sel_inputs)
 
         ##################
-        # 9. Copy outputs from previous steps
+        # 9. Copy (link) output data from previous steps
 
         if step == 'import':
             self._collect(step, index, active)
@@ -3353,7 +3357,7 @@ class Chip:
                 utils.copytree(refdir, ".", dirs_exist_ok=True)
 
         ##################
-        # 11. Check that all requirements met
+        # 11. Check manifest
         self.set('arg', 'step', step, clobber=True)
         self.set('arg', 'index', index, clobber=True)
 
@@ -3413,13 +3417,18 @@ class Chip:
                     self._haltstep(step, index, active)
 
         ##################
-        # 15. Interface with tools (Don't move this!)
+        # 15. Write manifest (tool interface) (Don't move this!)
         suffix = self.get('eda', tool, 'format')
         if suffix:
             self.write_manifest(f"sc_manifest.{suffix}", abspath=True)
 
         ##################
-        # 16. Run executable (or copy inputs to outputs for builtin functions)
+        # 16. Start CPU Timer
+        self.logger.debug(f"Starting executable")
+        cpu_start = time.time()
+
+        ##################
+        # 17. Run executable (or copy inputs to outputs for builtin functions)
 
         if tool in self.builtin:
             utils.copytree(f"inputs", 'outputs', dirs_exist_ok=True, link=True)
@@ -3458,7 +3467,14 @@ class Chip:
                     self._haltstep(step, index, active)
 
         ##################
-        # 17. Post process (could fail)
+        # 18. Capture cpu runtime
+
+        cpu_end = time.time()
+        cputime = round((cpu_end - cpu_start),2)
+        self.set('metric',step, index, 'cputime', 'real', cputime)
+
+        ##################
+        # 19. Post process (could fail)
         post_error = 0
         if (tool not in self.builtin) and (not self.get('skip', 'all')) :
             func = self.find_function(tool, 'post_process', 'tools')
@@ -3469,12 +3485,12 @@ class Chip:
                     self._haltstep(step, index, active)
 
         ##################
-        # 18. Check log file (must be after post-process)
+        # 20. Check log file (must be after post-process)
         if (tool not in self.builtin) and (not self.get('skip', 'all')) :
             self.check_logfile(step=step, index=index, display=not quiet)
 
         ##################
-        # 19. Hash files
+        # 21. Hash files
         if self.get('hash') and (tool not in self.builtin):
             # hash all outputs
             self.hash_files('eda', tool, 'output', step, index)
@@ -3486,20 +3502,18 @@ class Chip:
                         self.hash_files(*args)
 
         ##################
-        # 20. Capture total runtime
-
-        end = time.time()
-        elapsed_time = round((end - start),2)
-        self.set('metric',step, index, 'runtime', 'real', elapsed_time)
-
-        ##################
-        # 21. Make a record if tracking is enabled
+        # 22. Make a record if tracking is enabled
         if self.get('track'):
             self._make_record(job, step, index, start, end, version)
 
         ##################
-        # 22. Save a successful manifest
+        # 23. Capture wall runtime
+        wall_end = time.time()
+        walltime = round((wall_end - wall_start),2)
+        self.set('metric',step, index, 'walltime', 'real', walltime)
 
+        ##################
+        # 24. Save a successful manifest
         self.set('flowstatus', step, str(index), 'error', 0)
         self.set('arg', 'step', None, clobber=True)
         self.set('arg', 'index', None, clobber=True)
@@ -3507,16 +3521,16 @@ class Chip:
         self.write_manifest("outputs/" + self.get('design') +'.pkg.json')
 
         ##################
-        # 23. Clean up non-essential files
+        # 25. Clean up non-essential files
         if self.get('clean'):
             self.logger.error('Self clean not implemented')
 
         ##################
-        # 24. return to original directory
+        # 26. return to original directory
         os.chdir(cwd)
 
         ##################
-        # 25. clearing active and error bits
+        # 27. clearing active and error bits
         # !!Do not move this code!!
         error[step + str(index)] = 0
         active[step + str(index)] = 0

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3489,7 +3489,7 @@ class Chip:
 
         cpu_end = time.time()
         cputime = round((cpu_end - cpu_start),2)
-        self.set('metric',step, index, 'cputime', 'real', cputime)
+        self.set('metric',step, index, 'exetime', 'real', cputime)
 
         ##################
         # 19. Post process (could fail)
@@ -3523,7 +3523,7 @@ class Chip:
         # 22. Capture wall runtime
         wall_end = time.time()
         walltime = round((wall_end - wall_start),2)
-        self.set('metric',step, index, 'walltime', 'real', walltime)
+        self.set('metric',step, index, 'tasktime', 'real', walltime)
 
         ##################
         # 23. Make a record if tracking is enabled

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1620,7 +1620,7 @@ class Chip:
         for step in steplist:
             for index in self.getkeys('flowgraph', flow, step):
                 tool = self.get('flowgraph', flow, step, index, 'tool')
-                if (tool not in self.builtin) and (self.valid('eda', tool)):
+                if (tool not in self.builtin) and (tool in self.getkeys('eda')):
                     # checking that requirements are set
                     if self.valid('eda', tool, 'require', step, index):
                         all_required = self.get('eda', tool, 'require', step, index)

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -4836,6 +4836,24 @@ def schema_design(cfg):
         """
     }
 
+    cfg['oformat'] = {
+        'switch': "-oformat <str>",
+        'type': 'str',
+        'lock': 'false',
+        'require': None,
+        'signature': None,
+        'defvalue': [],
+        'shorthelp': 'Output format',
+        'example': ["cli: -oformat gds",
+                    "api: chip.set('oformat', 'gds')"],
+        'help': """
+        File format to use for writing the final siliconcompiler output to
+        disk. For cases, when only one output format exists, the 'oformat'
+        parameter can be omitted. Examples of ASIC layout output formats
+        include GDS and OASIS.
+        """
+    }
+
     cfg['constraint'] = {
         'switch': "-constraint <file>",
         'type': '[file]',

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -3237,41 +3237,41 @@ def schema_metric(cfg, step='default', index='default',group='default', ):
         """
     }
 
-    cfg['metric'][step][index]['cputime'] = {}
-    cfg['metric'][step][index]['cputime'][group] = {
-        'switch': "-metric_cputime 'step index group <float>",
+    cfg['metric'][step][index]['exetime'] = {}
+    cfg['metric'][step][index]['exetime'][group] = {
+        'switch': "-metric_exetime 'step index group <float>",
         'type': 'float',
         'lock': 'false',
         'require': 'all',
         'signature': None,
         'defvalue': None,
-        'shorthelp': 'Metric CPU time',
+        'shorthelp': 'Metric executable time',
         'example': [
-            "cli: -metric_cputime 'dfm 0 goal 35.3'",
-            "api: chip.set('metric','dfm','0','cputime','real','35.3')"],
+            "cli: -metric_exetime 'dfm 0 goal 35.3'",
+            "api: chip.set('metric','dfm','0','exetime','real','35.3')"],
         'help': """
-        CPU time tracks the amount of time spent executing a task on a compute
-        node. It does not include the time used by the siliconcompiler runtime
-        or waitig for I/O operations and inter-processor communication to
-        complete.
+        Executable time tracks the amount of time spent by the eda
+        executable 'exe'. It does not include the siliconcompiler
+        runtime overhead or time waitig for I/O operations and
+        inter-processor communication to complete.
         """
     }
 
-    cfg['metric'][step][index]['walltime'] = {}
-    cfg['metric'][step][index]['walltime'][group] = {
-        'switch': "-metric_walltime 'step index group <float>",
+    cfg['metric'][step][index]['tasktime'] = {}
+    cfg['metric'][step][index]['tasktime'][group] = {
+        'switch': "-metric_tasktime 'step index group <float>",
         'type': 'float',
         'lock': 'false',
         'require': 'all',
         'signature': None,
         'defvalue': None,
-        'shorthelp': 'Metric wall time',
+        'shorthelp': 'Metric task time',
         'example': [
-            "cli: -metric_walltime 'dfm 0 goal 35.3'",
-            "api: chip.set('metric','dfm','0','walltime','real','35.3')"],
+            "cli: -metric_tasktime 'dfm 0 goal 35.3'",
+            "api: chip.set('metric','dfm','0','tasktime','real','35.3')"],
         'help': """
-        Wall time tracks the total amount of tie spent executing a task from
-        beginning to end, including data transfer time.
+        Task time tracks the total amount of time spent on a task from
+        beginning to end, including data transfers and pre/post processing.
         """
     }
 

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -3219,24 +3219,6 @@ def schema_metric(cfg, step='default', index='default',group='default', ):
         """
     }
 
-    cfg['metric'][step][index]['runtime'] = {}
-    cfg['metric'][step][index]['runtime'][group] = {
-        'switch': "-metric_runtime 'step index group <float>",
-        'type': 'float',
-        'lock': 'false',
-        'require': 'all',
-        'signature': None,
-        'defvalue': None,
-        'shorthelp': 'Metric total runtime',
-        'example': [
-            "cli: -metric_runtime 'dfm 0 goal 35.3'",
-            "api: chip.set('metric','dfm','0','runtime','real','35.3')"],
-        'help': """
-        Metric tracking the total runtime on a per step basis. Time recorded
-        as wall clock time specified in seconds.
-        """
-    }
-
     cfg['metric'][step][index]['memory'] = {}
     cfg['metric'][step][index]['memory'][group] = {
         'switch': "-metric_memory 'step index group <float>'",
@@ -3252,6 +3234,44 @@ def schema_metric(cfg, step='default', index='default',group='default', ):
         'help': """
         Metric tracking the total memory on a per step basis, specified
         in bytes.
+        """
+    }
+
+    cfg['metric'][step][index]['cputime'] = {}
+    cfg['metric'][step][index]['cputime'][group] = {
+        'switch': "-metric_cputime 'step index group <float>",
+        'type': 'float',
+        'lock': 'false',
+        'require': 'all',
+        'signature': None,
+        'defvalue': None,
+        'shorthelp': 'Metric CPU time',
+        'example': [
+            "cli: -metric_cputime 'dfm 0 goal 35.3'",
+            "api: chip.set('metric','dfm','0','cputime','real','35.3')"],
+        'help': """
+        CPU time tracks the amount of time spent executing a task on a compute
+        node. It does not include the time used by the siliconcompiler runtime
+        or waitig for I/O operations and inter-processor communication to
+        complete.
+        """
+    }
+
+    cfg['metric'][step][index]['walltime'] = {}
+    cfg['metric'][step][index]['walltime'][group] = {
+        'switch': "-metric_walltime 'step index group <float>",
+        'type': 'float',
+        'lock': 'false',
+        'require': 'all',
+        'signature': None,
+        'defvalue': None,
+        'shorthelp': 'Metric wall time',
+        'example': [
+            "cli: -metric_walltime 'dfm 0 goal 35.3'",
+            "api: chip.set('metric','dfm','0','walltime','real','35.3')"],
+        'help': """
+        Wall time tracks the total amount of tie spent executing a task from
+        beginning to end, including data transfer time.
         """
     }
 

--- a/tests/core/data/gcd.pkg.json
+++ b/tests/core/data/gcd.pkg.json
@@ -1,18 +1,4 @@
 {
-    "arg": {
-        "index": {
-            "defvalue": "0",
-            "lock": "false",
-            "require": null,
-            "shorthelp": "Current index",
-            "signature": [
-                null
-            ],
-            "switch": "-arg_index <str>",
-            "type": "str",
-            "value": null
-        }
-    },
     "asic": {
         "aspectratio": {
             "defvalue": null,
@@ -271,7 +257,7 @@
     "design": {
         "defvalue": null,
         "lock": "false",
-        "require": null,
+        "require": "all",
         "shorthelp": "Design top module name",
         "signature": [
             null
@@ -1318,6 +1304,25 @@
                                 "cts.log"
                             ]
                         },
+                        "cputime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
                         "drvs": {
                             "author": [],
                             "copy": "false",
@@ -1737,6 +1742,25 @@
                             ]
                         },
                         "vias": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "walltime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -1873,6 +1897,25 @@
                                 "dfm.log"
                             ]
                         },
+                        "cputime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
                         "drvs": {
                             "author": [],
                             "copy": "false",
@@ -2292,6 +2335,25 @@
                             ]
                         },
                         "vias": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "walltime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -2428,6 +2490,25 @@
                                 "floorplan.log"
                             ]
                         },
+                        "cputime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
                         "drvs": {
                             "author": [],
                             "copy": "false",
@@ -2847,6 +2928,25 @@
                             ]
                         },
                         "vias": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "walltime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -2983,6 +3083,25 @@
                                 "physyn.log"
                             ]
                         },
+                        "cputime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
                         "drvs": {
                             "author": [],
                             "copy": "false",
@@ -3402,6 +3521,25 @@
                             ]
                         },
                         "vias": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "walltime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -3538,6 +3676,25 @@
                                 "place.log"
                             ]
                         },
+                        "cputime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
                         "drvs": {
                             "author": [],
                             "copy": "false",
@@ -3957,6 +4114,25 @@
                             ]
                         },
                         "vias": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "walltime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -4093,6 +4269,25 @@
                                 "route.log"
                             ]
                         },
+                        "cputime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
                         "drvs": {
                             "author": [],
                             "copy": "false",
@@ -4512,6 +4707,25 @@
                             ]
                         },
                         "vias": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "walltime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -6180,6 +6394,18 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "cputime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -6360,18 +6586,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "runtime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "security": {
                             "defvalue": null,
                             "lock": "false",
@@ -6493,6 +6707,18 @@
                             "value": "0"
                         },
                         "vias": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -6630,6 +6856,18 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "cputime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -6810,18 +7048,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "runtime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "security": {
                             "defvalue": null,
                             "lock": "false",
@@ -6943,6 +7169,18 @@
                             "value": "0"
                         },
                         "vias": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -7080,6 +7318,18 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "cputime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -7260,18 +7510,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "runtime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "security": {
                             "defvalue": null,
                             "lock": "false",
@@ -7393,6 +7631,18 @@
                             "value": "0"
                         },
                         "vias": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -7530,6 +7780,18 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "cputime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -7710,18 +7972,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "runtime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "security": {
                             "defvalue": null,
                             "lock": "false",
@@ -7843,6 +8093,18 @@
                             "value": "0"
                         },
                         "vias": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -7968,6 +8230,18 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "cputime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -8148,18 +8422,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "runtime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "security": {
                             "defvalue": null,
                             "lock": "false",
@@ -8281,6 +8543,18 @@
                             "value": "0"
                         },
                         "vias": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -8418,6 +8692,18 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "cputime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -8598,18 +8884,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "runtime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "security": {
                             "defvalue": null,
                             "lock": "false",
@@ -8731,6 +9005,18 @@
                             "value": "0"
                         },
                         "vias": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -8868,6 +9154,18 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "cputime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -9048,18 +9346,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "runtime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "security": {
                             "defvalue": null,
                             "lock": "false",
@@ -9181,6 +9467,18 @@
                             "value": "0"
                         },
                         "vias": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -9318,6 +9616,18 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "cputime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -9498,18 +9808,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "runtime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "security": {
                             "defvalue": null,
                             "lock": "false",
@@ -9631,6 +9929,18 @@
                             "value": "0"
                         },
                         "vias": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -9768,6 +10078,18 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "cputime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -9948,18 +10270,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "runtime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "security": {
                             "defvalue": null,
                             "lock": "false",
@@ -10081,6 +10391,18 @@
                             "value": "0"
                         },
                         "vias": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -10858,6 +11180,20 @@
                         "value": "0.0"
                     }
                 },
+                "cputime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric CPU time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_cputime 'step index group <float>",
+                        "type": "float",
+                        "value": "2.31"
+                    }
+                },
                 "drvs": {
                     "goal": {
                         "defvalue": null,
@@ -11116,20 +11452,6 @@
                         "value": "0"
                     }
                 },
-                "runtime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric total runtime",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_runtime 'step index group <float>",
-                        "type": "float",
-                        "value": "2.62"
-                    }
-                },
                 "security": {
                     "real": {
                         "defvalue": null,
@@ -11308,6 +11630,20 @@
                         "value": "0"
                     }
                 },
+                "walltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric wall time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_walltime 'step index group <float>",
+                        "type": "float",
+                        "value": "2.52"
+                    }
+                },
                 "warnings": {
                     "real": {
                         "defvalue": null,
@@ -11408,6 +11744,20 @@
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
                         "value": "0.0"
+                    }
+                },
+                "cputime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric CPU time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_cputime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.81"
                     }
                 },
                 "drvs": {
@@ -11668,20 +12018,6 @@
                         "value": "0"
                     }
                 },
-                "runtime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric total runtime",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_runtime 'step index group <float>",
-                        "type": "float",
-                        "value": "1.16"
-                    }
-                },
                 "security": {
                     "real": {
                         "defvalue": null,
@@ -11860,6 +12196,20 @@
                         "value": "0"
                     }
                 },
+                "walltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric wall time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_walltime 'step index group <float>",
+                        "type": "float",
+                        "value": "1.05"
+                    }
+                },
                 "warnings": {
                     "real": {
                         "defvalue": null,
@@ -11950,6 +12300,18 @@
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
                         "value": "0"
+                    }
+                },
+                "cputime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric CPU time",
+                        "signature": null,
+                        "switch": "-metric_cputime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.71"
                     }
                 },
                 "drvs": {
@@ -12180,18 +12542,6 @@
                         "value": "0"
                     }
                 },
-                "runtime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric total runtime",
-                        "signature": null,
-                        "switch": "-metric_runtime 'step index group <float>",
-                        "type": "float",
-                        "value": "1.06"
-                    }
-                },
                 "security": {
                     "real": {
                         "defvalue": null,
@@ -12348,6 +12698,18 @@
                         "value": "0"
                     }
                 },
+                "walltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric wall time",
+                        "signature": null,
+                        "switch": "-metric_walltime 'step index group <float>",
+                        "type": "float",
+                        "value": "1.04"
+                    }
+                },
                 "warnings": {
                     "real": {
                         "defvalue": null,
@@ -12444,6 +12806,20 @@
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
                         "value": "0.0"
+                    }
+                },
+                "cputime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric CPU time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_cputime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.81"
                     }
                 },
                 "drvs": {
@@ -12704,20 +13080,6 @@
                         "value": "0"
                     }
                 },
-                "runtime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric total runtime",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_runtime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.98"
-                    }
-                },
                 "security": {
                     "real": {
                         "defvalue": null,
@@ -12894,6 +13256,20 @@
                         "switch": "-metric_vias step index group <int>",
                         "type": "int",
                         "value": "0"
+                    }
+                },
+                "walltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric wall time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_walltime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.97"
                     }
                 },
                 "warnings": {
@@ -12998,6 +13374,20 @@
                         "value": "0.0"
                     }
                 },
+                "cputime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric CPU time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_cputime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.31"
+                    }
+                },
                 "drvs": {
                     "goal": {
                         "defvalue": null,
@@ -13256,20 +13646,6 @@
                         "value": "0"
                     }
                 },
-                "runtime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric total runtime",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_runtime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.39"
-                    }
-                },
                 "security": {
                     "real": {
                         "defvalue": null,
@@ -13448,6 +13824,20 @@
                         "value": "0"
                     }
                 },
+                "walltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric wall time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_walltime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.38"
+                    }
+                },
                 "warnings": {
                     "real": {
                         "defvalue": null,
@@ -13548,6 +13938,20 @@
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
                         "value": "0.0"
+                    }
+                },
+                "cputime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric CPU time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_cputime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.81"
                     }
                 },
                 "drvs": {
@@ -13808,20 +14212,6 @@
                         "value": "0"
                     }
                 },
-                "runtime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric total runtime",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_runtime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.99"
-                    }
-                },
                 "security": {
                     "real": {
                         "defvalue": null,
@@ -14000,6 +14390,20 @@
                         "value": "0"
                     }
                 },
+                "walltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric wall time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_walltime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.99"
+                    }
+                },
                 "warnings": {
                     "real": {
                         "defvalue": null,
@@ -14100,6 +14504,20 @@
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
                         "value": "0.0"
+                    }
+                },
+                "cputime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric CPU time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_cputime 'step index group <float>",
+                        "type": "float",
+                        "value": "1.01"
                     }
                 },
                 "drvs": {
@@ -14360,20 +14778,6 @@
                         "value": "0"
                     }
                 },
-                "runtime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric total runtime",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_runtime 'step index group <float>",
-                        "type": "float",
-                        "value": "1.21"
-                    }
-                },
                 "security": {
                     "real": {
                         "defvalue": null,
@@ -14552,6 +14956,20 @@
                         "value": "0"
                     }
                 },
+                "walltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric wall time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_walltime 'step index group <float>",
+                        "type": "float",
+                        "value": "1.25"
+                    }
+                },
                 "warnings": {
                     "real": {
                         "defvalue": null,
@@ -14652,6 +15070,20 @@
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
                         "value": "0.0"
+                    }
+                },
+                "cputime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric CPU time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_cputime 'step index group <float>",
+                        "type": "float",
+                        "value": "2.51"
                     }
                 },
                 "drvs": {
@@ -14912,20 +15344,6 @@
                         "value": "0"
                     }
                 },
-                "runtime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric total runtime",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_runtime 'step index group <float>",
-                        "type": "float",
-                        "value": "2.65"
-                    }
-                },
                 "security": {
                     "real": {
                         "defvalue": null,
@@ -15104,6 +15522,20 @@
                         "value": "2194"
                     }
                 },
+                "walltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric wall time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_walltime 'step index group <float>",
+                        "type": "float",
+                        "value": "2.79"
+                    }
+                },
                 "warnings": {
                     "real": {
                         "defvalue": null,
@@ -15204,6 +15636,20 @@
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
                         "value": "0.0"
+                    }
+                },
+                "cputime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric CPU time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_cputime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.61"
                     }
                 },
                 "drvs": {
@@ -15464,20 +15910,6 @@
                         "value": "0"
                     }
                 },
-                "runtime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric total runtime",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_runtime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.86"
-                    }
-                },
                 "security": {
                     "real": {
                         "defvalue": null,
@@ -15656,6 +16088,20 @@
                         "value": "0"
                     }
                 },
+                "walltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric wall time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_walltime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.77"
+                    }
+                },
                 "warnings": {
                     "real": {
                         "defvalue": null,
@@ -15698,6 +16144,18 @@
         "switch": "-mode <str>",
         "type": "str",
         "value": "asic"
+    },
+    "nodisplay": {
+        "defvalue": "false",
+        "lock": "false",
+        "require": "all",
+        "shorthelp": "Headless execution",
+        "signature": [
+            null
+        ],
+        "switch": "-nodisplay <bool>",
+        "type": "bool",
+        "value": "false"
     },
     "optmode": {
         "defvalue": "O0",
@@ -17091,7 +17549,7 @@
             "signature": null,
             "switch": "-version_sc <str>",
             "type": "str",
-            "value": "0.6.0"
+            "value": "0.7.0"
         },
         "schema": {
             "defvalue": "0.7.0",

--- a/tests/core/data/gcd.pkg.json
+++ b/tests/core/data/gcd.pkg.json
@@ -1304,25 +1304,6 @@
                                 "cts.log"
                             ]
                         },
-                        "cputime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": [
-                                "sha256"
-                            ],
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Tool report files ",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
                         "drvs": {
                             "author": [],
                             "copy": "false",
@@ -1343,6 +1324,25 @@
                             ]
                         },
                         "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "exetime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -1665,6 +1665,25 @@
                                 "cts.log"
                             ]
                         },
+                        "tasktime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
                         "totalarea": {
                             "author": [],
                             "copy": "false",
@@ -1742,25 +1761,6 @@
                             ]
                         },
                         "vias": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": [
-                                "sha256"
-                            ],
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Tool report files ",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "walltime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -1897,25 +1897,6 @@
                                 "dfm.log"
                             ]
                         },
-                        "cputime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": [
-                                "sha256"
-                            ],
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Tool report files ",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
                         "drvs": {
                             "author": [],
                             "copy": "false",
@@ -1936,6 +1917,25 @@
                             ]
                         },
                         "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "exetime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -2258,6 +2258,25 @@
                                 "dfm.log"
                             ]
                         },
+                        "tasktime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
                         "totalarea": {
                             "author": [],
                             "copy": "false",
@@ -2335,25 +2354,6 @@
                             ]
                         },
                         "vias": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": [
-                                "sha256"
-                            ],
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Tool report files ",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "walltime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -2490,25 +2490,6 @@
                                 "floorplan.log"
                             ]
                         },
-                        "cputime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": [
-                                "sha256"
-                            ],
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Tool report files ",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
                         "drvs": {
                             "author": [],
                             "copy": "false",
@@ -2529,6 +2510,25 @@
                             ]
                         },
                         "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "exetime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -2851,6 +2851,25 @@
                                 "floorplan.log"
                             ]
                         },
+                        "tasktime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
                         "totalarea": {
                             "author": [],
                             "copy": "false",
@@ -2928,25 +2947,6 @@
                             ]
                         },
                         "vias": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": [
-                                "sha256"
-                            ],
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Tool report files ",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "walltime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -3083,25 +3083,6 @@
                                 "physyn.log"
                             ]
                         },
-                        "cputime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": [
-                                "sha256"
-                            ],
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Tool report files ",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
                         "drvs": {
                             "author": [],
                             "copy": "false",
@@ -3122,6 +3103,25 @@
                             ]
                         },
                         "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "exetime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -3444,6 +3444,25 @@
                                 "physyn.log"
                             ]
                         },
+                        "tasktime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
                         "totalarea": {
                             "author": [],
                             "copy": "false",
@@ -3521,25 +3540,6 @@
                             ]
                         },
                         "vias": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": [
-                                "sha256"
-                            ],
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Tool report files ",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "walltime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -3676,25 +3676,6 @@
                                 "place.log"
                             ]
                         },
-                        "cputime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": [
-                                "sha256"
-                            ],
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Tool report files ",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
                         "drvs": {
                             "author": [],
                             "copy": "false",
@@ -3715,6 +3696,25 @@
                             ]
                         },
                         "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "exetime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -4037,6 +4037,25 @@
                                 "place.log"
                             ]
                         },
+                        "tasktime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
                         "totalarea": {
                             "author": [],
                             "copy": "false",
@@ -4114,25 +4133,6 @@
                             ]
                         },
                         "vias": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": [
-                                "sha256"
-                            ],
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Tool report files ",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "walltime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -4269,25 +4269,6 @@
                                 "route.log"
                             ]
                         },
-                        "cputime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": [
-                                "sha256"
-                            ],
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Tool report files ",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
                         "drvs": {
                             "author": [],
                             "copy": "false",
@@ -4308,6 +4289,25 @@
                             ]
                         },
                         "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "exetime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -4630,6 +4630,25 @@
                                 "route.log"
                             ]
                         },
+                        "tasktime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": [
+                                "sha256"
+                            ],
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Tool report files ",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
                         "totalarea": {
                             "author": [],
                             "copy": "false",
@@ -4707,25 +4726,6 @@
                             ]
                         },
                         "vias": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": [
-                                "sha256"
-                            ],
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Tool report files ",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "walltime": {
                             "author": [],
                             "copy": "false",
                             "date": [],
@@ -6394,18 +6394,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "cputime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -6431,6 +6419,18 @@
                             "value": "0"
                         },
                         "errors": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "exetime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -6658,6 +6658,18 @@
                             "type": "float",
                             "value": "1.0"
                         },
+                        "tasktime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "totalarea": {
                             "defvalue": null,
                             "lock": "false",
@@ -6707,18 +6719,6 @@
                             "value": "0"
                         },
                         "vias": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
-                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -6856,18 +6856,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "cputime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -6893,6 +6881,18 @@
                             "value": "0"
                         },
                         "errors": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "exetime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -7120,6 +7120,18 @@
                             "type": "float",
                             "value": "1.0"
                         },
+                        "tasktime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "totalarea": {
                             "defvalue": null,
                             "lock": "false",
@@ -7169,18 +7181,6 @@
                             "value": "0"
                         },
                         "vias": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
-                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -7318,18 +7318,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "cputime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -7355,6 +7343,18 @@
                             "value": "0"
                         },
                         "errors": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "exetime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -7582,6 +7582,18 @@
                             "type": "float",
                             "value": "1.0"
                         },
+                        "tasktime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "totalarea": {
                             "defvalue": null,
                             "lock": "false",
@@ -7631,18 +7643,6 @@
                             "value": "0"
                         },
                         "vias": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
-                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -7780,18 +7780,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "cputime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -7817,6 +7805,18 @@
                             "value": "0"
                         },
                         "errors": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "exetime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -8044,6 +8044,18 @@
                             "type": "float",
                             "value": "1.0"
                         },
+                        "tasktime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "totalarea": {
                             "defvalue": null,
                             "lock": "false",
@@ -8093,18 +8105,6 @@
                             "value": "0"
                         },
                         "vias": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
-                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -8230,18 +8230,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "cputime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -8267,6 +8255,18 @@
                             "value": "0"
                         },
                         "errors": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "exetime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -8494,6 +8494,18 @@
                             "type": "float",
                             "value": "1.0"
                         },
+                        "tasktime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "totalarea": {
                             "defvalue": null,
                             "lock": "false",
@@ -8543,18 +8555,6 @@
                             "value": "0"
                         },
                         "vias": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
-                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -8692,18 +8692,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "cputime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -8729,6 +8717,18 @@
                             "value": "0"
                         },
                         "errors": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "exetime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -8956,6 +8956,18 @@
                             "type": "float",
                             "value": "1.0"
                         },
+                        "tasktime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "totalarea": {
                             "defvalue": null,
                             "lock": "false",
@@ -9005,18 +9017,6 @@
                             "value": "0"
                         },
                         "vias": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
-                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -9154,18 +9154,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "cputime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -9191,6 +9179,18 @@
                             "value": "0"
                         },
                         "errors": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "exetime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -9418,6 +9418,18 @@
                             "type": "float",
                             "value": "1.0"
                         },
+                        "tasktime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "totalarea": {
                             "defvalue": null,
                             "lock": "false",
@@ -9467,18 +9479,6 @@
                             "value": "0"
                         },
                         "vias": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
-                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -9616,18 +9616,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "cputime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -9653,6 +9641,18 @@
                             "value": "0"
                         },
                         "errors": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "exetime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -9880,6 +9880,18 @@
                             "type": "float",
                             "value": "1.0"
                         },
+                        "tasktime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "totalarea": {
                             "defvalue": null,
                             "lock": "false",
@@ -9929,18 +9941,6 @@
                             "value": "0"
                         },
                         "vias": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
-                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -10078,18 +10078,6 @@
                             "type": "float",
                             "value": "0"
                         },
-                        "cputime": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
                         "drvs": {
                             "defvalue": null,
                             "lock": "false",
@@ -10115,6 +10103,18 @@
                             "value": "0"
                         },
                         "errors": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "exetime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -10342,6 +10342,18 @@
                             "type": "float",
                             "value": "1.0"
                         },
+                        "tasktime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": [
+                                null
+                            ],
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "totalarea": {
                             "defvalue": null,
                             "lock": "false",
@@ -10391,18 +10403,6 @@
                             "value": "0"
                         },
                         "vias": {
-                            "defvalue": null,
-                            "lock": "false",
-                            "require": null,
-                            "shorthelp": "Flowgraph metric weights",
-                            "signature": [
-                                null
-                            ],
-                            "switch": "-flowgraph_weight 'flow step metric <float>'",
-                            "type": "float",
-                            "value": "0"
-                        },
-                        "walltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -11180,20 +11180,6 @@
                         "value": "0.0"
                     }
                 },
-                "cputime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric CPU time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_cputime 'step index group <float>",
-                        "type": "float",
-                        "value": "2.31"
-                    }
-                },
                 "drvs": {
                     "goal": {
                         "defvalue": null,
@@ -11258,6 +11244,20 @@
                         "switch": "-metric_errors 'step index group <int>'",
                         "type": "int",
                         "value": "0"
+                    }
+                },
+                "exetime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric executable time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_exetime 'step index group <float>",
+                        "type": "float",
+                        "value": "2.21"
                     }
                 },
                 "holdpaths": {
@@ -11560,6 +11560,20 @@
                         "value": "1.17e-05"
                     }
                 },
+                "tasktime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric task time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_tasktime 'step index group <float>",
+                        "type": "float",
+                        "value": "2.42"
+                    }
+                },
                 "totalarea": {
                     "real": {
                         "defvalue": null,
@@ -11628,20 +11642,6 @@
                         "switch": "-metric_vias step index group <int>",
                         "type": "int",
                         "value": "0"
-                    }
-                },
-                "walltime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric wall time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_walltime 'step index group <float>",
-                        "type": "float",
-                        "value": "2.52"
                     }
                 },
                 "warnings": {
@@ -11746,20 +11746,6 @@
                         "value": "0.0"
                     }
                 },
-                "cputime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric CPU time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_cputime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.81"
-                    }
-                },
                 "drvs": {
                     "goal": {
                         "defvalue": null,
@@ -11824,6 +11810,20 @@
                         "switch": "-metric_errors 'step index group <int>'",
                         "type": "int",
                         "value": "0"
+                    }
+                },
+                "exetime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric executable time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_exetime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.91"
                     }
                 },
                 "holdpaths": {
@@ -12126,6 +12126,20 @@
                         "value": "1.17e-05"
                     }
                 },
+                "tasktime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric task time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_tasktime 'step index group <float>",
+                        "type": "float",
+                        "value": "1.15"
+                    }
+                },
                 "totalarea": {
                     "real": {
                         "defvalue": null,
@@ -12194,20 +12208,6 @@
                         "switch": "-metric_vias step index group <int>",
                         "type": "int",
                         "value": "0"
-                    }
-                },
-                "walltime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric wall time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_walltime 'step index group <float>",
-                        "type": "float",
-                        "value": "1.05"
                     }
                 },
                 "warnings": {
@@ -12302,18 +12302,6 @@
                         "value": "0"
                     }
                 },
-                "cputime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric CPU time",
-                        "signature": null,
-                        "switch": "-metric_cputime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.71"
-                    }
-                },
                 "drvs": {
                     "goal": {
                         "defvalue": null,
@@ -12372,6 +12360,18 @@
                         "switch": "-metric_errors 'step index group <int>'",
                         "type": "int",
                         "value": "0"
+                    }
+                },
+                "exetime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric executable time",
+                        "signature": null,
+                        "switch": "-metric_exetime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.71"
                     }
                 },
                 "holdpaths": {
@@ -12638,6 +12638,18 @@
                         "value": "0"
                     }
                 },
+                "tasktime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric task time",
+                        "signature": null,
+                        "switch": "-metric_tasktime 'step index group <float>",
+                        "type": "float",
+                        "value": "1.05"
+                    }
+                },
                 "totalarea": {
                     "real": {
                         "defvalue": null,
@@ -12696,18 +12708,6 @@
                         "switch": "-metric_vias step index group <int>",
                         "type": "int",
                         "value": "0"
-                    }
-                },
-                "walltime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric wall time",
-                        "signature": null,
-                        "switch": "-metric_walltime 'step index group <float>",
-                        "type": "float",
-                        "value": "1.04"
                     }
                 },
                 "warnings": {
@@ -12808,20 +12808,6 @@
                         "value": "0.0"
                     }
                 },
-                "cputime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric CPU time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_cputime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.81"
-                    }
-                },
                 "drvs": {
                     "goal": {
                         "defvalue": null,
@@ -12886,6 +12872,20 @@
                         "switch": "-metric_errors 'step index group <int>'",
                         "type": "int",
                         "value": "0"
+                    }
+                },
+                "exetime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric executable time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_exetime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.81"
                     }
                 },
                 "holdpaths": {
@@ -13188,6 +13188,20 @@
                         "value": "8.62e-06"
                     }
                 },
+                "tasktime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric task time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_tasktime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.98"
+                    }
+                },
                 "totalarea": {
                     "real": {
                         "defvalue": null,
@@ -13256,20 +13270,6 @@
                         "switch": "-metric_vias step index group <int>",
                         "type": "int",
                         "value": "0"
-                    }
-                },
-                "walltime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric wall time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_walltime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.97"
                     }
                 },
                 "warnings": {
@@ -13374,20 +13374,6 @@
                         "value": "0.0"
                     }
                 },
-                "cputime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric CPU time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_cputime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.31"
-                    }
-                },
                 "drvs": {
                     "goal": {
                         "defvalue": null,
@@ -13452,6 +13438,20 @@
                         "switch": "-metric_errors 'step index group <int>'",
                         "type": "int",
                         "value": "0"
+                    }
+                },
+                "exetime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric executable time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_exetime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.31"
                     }
                 },
                 "holdpaths": {
@@ -13754,6 +13754,20 @@
                         "value": "0.0"
                     }
                 },
+                "tasktime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric task time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_tasktime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.38"
+                    }
+                },
                 "totalarea": {
                     "real": {
                         "defvalue": null,
@@ -13822,20 +13836,6 @@
                         "switch": "-metric_vias step index group <int>",
                         "type": "int",
                         "value": "0"
-                    }
-                },
-                "walltime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric wall time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_walltime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.38"
                     }
                 },
                 "warnings": {
@@ -13940,20 +13940,6 @@
                         "value": "0.0"
                     }
                 },
-                "cputime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric CPU time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_cputime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.81"
-                    }
-                },
                 "drvs": {
                     "goal": {
                         "defvalue": null,
@@ -14018,6 +14004,20 @@
                         "switch": "-metric_errors 'step index group <int>'",
                         "type": "int",
                         "value": "0"
+                    }
+                },
+                "exetime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric executable time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_exetime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.81"
                     }
                 },
                 "holdpaths": {
@@ -14320,6 +14320,20 @@
                         "value": "8.62e-06"
                     }
                 },
+                "tasktime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric task time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_tasktime 'step index group <float>",
+                        "type": "float",
+                        "value": "1.03"
+                    }
+                },
                 "totalarea": {
                     "real": {
                         "defvalue": null,
@@ -14388,20 +14402,6 @@
                         "switch": "-metric_vias step index group <int>",
                         "type": "int",
                         "value": "0"
-                    }
-                },
-                "walltime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric wall time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_walltime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.99"
                     }
                 },
                 "warnings": {
@@ -14506,20 +14506,6 @@
                         "value": "0.0"
                     }
                 },
-                "cputime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric CPU time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_cputime 'step index group <float>",
-                        "type": "float",
-                        "value": "1.01"
-                    }
-                },
                 "drvs": {
                     "goal": {
                         "defvalue": null,
@@ -14584,6 +14570,20 @@
                         "switch": "-metric_errors 'step index group <int>'",
                         "type": "int",
                         "value": "0"
+                    }
+                },
+                "exetime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric executable time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_exetime 'step index group <float>",
+                        "type": "float",
+                        "value": "1.01"
                     }
                 },
                 "holdpaths": {
@@ -14886,6 +14886,20 @@
                         "value": "1.13e-05"
                     }
                 },
+                "tasktime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric task time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_tasktime 'step index group <float>",
+                        "type": "float",
+                        "value": "1.2"
+                    }
+                },
                 "totalarea": {
                     "real": {
                         "defvalue": null,
@@ -14954,20 +14968,6 @@
                         "switch": "-metric_vias step index group <int>",
                         "type": "int",
                         "value": "0"
-                    }
-                },
-                "walltime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric wall time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_walltime 'step index group <float>",
-                        "type": "float",
-                        "value": "1.25"
                     }
                 },
                 "warnings": {
@@ -15072,20 +15072,6 @@
                         "value": "0.0"
                     }
                 },
-                "cputime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric CPU time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_cputime 'step index group <float>",
-                        "type": "float",
-                        "value": "2.51"
-                    }
-                },
                 "drvs": {
                     "goal": {
                         "defvalue": null,
@@ -15150,6 +15136,20 @@
                         "switch": "-metric_errors 'step index group <int>'",
                         "type": "int",
                         "value": "0"
+                    }
+                },
+                "exetime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric executable time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_exetime 'step index group <float>",
+                        "type": "float",
+                        "value": "2.41"
                     }
                 },
                 "holdpaths": {
@@ -15452,6 +15452,20 @@
                         "value": "1.17e-05"
                     }
                 },
+                "tasktime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric task time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_tasktime 'step index group <float>",
+                        "type": "float",
+                        "value": "2.68"
+                    }
+                },
                 "totalarea": {
                     "real": {
                         "defvalue": null,
@@ -15520,20 +15534,6 @@
                         "switch": "-metric_vias step index group <int>",
                         "type": "int",
                         "value": "2194"
-                    }
-                },
-                "walltime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric wall time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_walltime 'step index group <float>",
-                        "type": "float",
-                        "value": "2.79"
                     }
                 },
                 "warnings": {
@@ -15638,20 +15638,6 @@
                         "value": "0.0"
                     }
                 },
-                "cputime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric CPU time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_cputime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.61"
-                    }
-                },
                 "drvs": {
                     "goal": {
                         "defvalue": null,
@@ -15716,6 +15702,20 @@
                         "switch": "-metric_errors 'step index group <int>'",
                         "type": "int",
                         "value": "0"
+                    }
+                },
+                "exetime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric executable time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_exetime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.61"
                     }
                 },
                 "holdpaths": {
@@ -16018,6 +16018,20 @@
                         "value": "0.0"
                     }
                 },
+                "tasktime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "all",
+                        "shorthelp": "Metric task time",
+                        "signature": [
+                            null
+                        ],
+                        "switch": "-metric_tasktime 'step index group <float>",
+                        "type": "float",
+                        "value": "0.77"
+                    }
+                },
                 "totalarea": {
                     "real": {
                         "defvalue": null,
@@ -16086,20 +16100,6 @@
                         "switch": "-metric_vias step index group <int>",
                         "type": "int",
                         "value": "0"
-                    }
-                },
-                "walltime": {
-                    "real": {
-                        "defvalue": null,
-                        "lock": "false",
-                        "require": "all",
-                        "shorthelp": "Metric wall time",
-                        "signature": [
-                            null
-                        ],
-                        "switch": "-metric_walltime 'step index group <float>",
-                        "type": "float",
-                        "value": "0.77"
                     }
                 },
                 "warnings": {

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -87,7 +87,7 @@ def test_check_missing_file_param():
     chip.set('eda', 'yosys', 'output', 'syn', '0',[])
 
     # not real file, will cause error
-    libname = 'NangateOpenCellLibrary'
+    libname = 'nangate45'
     corner = 'typical'
     chip.add('library', libname, 'nldm', corner, 'lib', '/fake/timing/file.lib')
 
@@ -96,3 +96,4 @@ def test_check_missing_file_param():
 #########################
 if __name__ == "__main__":
     test_check_manifest()
+    test_check_missing_file_param()

--- a/tests/core/test_nop.py
+++ b/tests/core/test_nop.py
@@ -1,0 +1,25 @@
+# Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
+import siliconcompiler
+import pytest
+
+
+##################################
+def test_nop():
+    '''API test for nop methods
+    '''
+
+    chip = siliconcompiler.Chip()
+    chip.load_target('freepdk45_demo')
+    chip.set('design', 'gcd')
+    chip.set('flow', 'test')
+    chip.node('test', 'import', 'surelog')
+    chip.node('test', 'nop1', 'nop')
+    chip.node('test', 'nop2', 'nop')
+    chip.edge('test', 'import', 'nop1')
+    chip.edge('test', 'nop1', 'nop2')
+    chip.check_manifest()
+    chip.write_flowgraph("nop.png")
+
+#########################
+if __name__ == "__main__":
+    test_nop()


### PR DESCRIPTION
- Necessary to enable selection between different output formats
- gds vs oasis is one example
- gerber vs ipc2581 is another