### PR TITLE
Update OpenROAD to latest 

### DIFF
--- a/siliconcompiler/tools/openroad/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/sc_apr.tcl
@@ -185,10 +185,6 @@ set_dont_use $sc_dontuse
 set_wire_rc -clock  -layer $sc_clkmetal
 set_wire_rc -signal -layer $sc_rcmetal
 
-set_placement_padding -global \
-    -left $openroad_pad_global_place \
-    -right $openroad_pad_global_place
-
 ###############################
 # Source Step Script
 ###############################

--- a/siliconcompiler/tools/openroad/sc_cts.tcl
+++ b/siliconcompiler/tools/openroad/sc_cts.tcl
@@ -24,8 +24,8 @@ if {[llength [all_clocks]] > 0} {
     repair_clock_nets
 
     set_placement_padding -global \
-	-left $openroad_pad_global_place \
-	-right $openroad_pad_global_place
+	-left $openroad_pad_detail_place \
+	-right $openroad_pad_detail_place
 
     detailed_placement
 

--- a/siliconcompiler/tools/openroad/sc_route.tcl
+++ b/siliconcompiler/tools/openroad/sc_route.tcl
@@ -31,9 +31,9 @@ if {[dict exists $sc_cfg eda $sc_tool variable $sc_step $sc_index grt_allow_cong
 }
 
 global_route -guide_file "./route.guide" \
-    -overflow_iterations $openroad_overflow_iter \
-    -verbose 2 \
-    $additional_grt_args
+    -congestion_iterations $openroad_overflow_iter \
+    -verbose \
+    {*}$additional_grt_args
 
 ######################
 # Report Antennas

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -50,7 +50,7 @@ def setup(chip):
     # Standard Setup
     chip.set('eda', tool, 'exe', 'yosys', clobber=False)
     chip.set('eda', tool, 'vswitch', '--version', clobber=False)
-    chip.set('eda', tool, 'version', '0.9', clobber=False)
+    chip.set('eda', tool, 'version', '0.13', clobber=False)
     chip.set('eda', tool, 'format', 'tcl', clobber=False)
     chip.set('eda', tool, 'copy', 'true', clobber=False)
     chip.set('eda', tool, 'option', step, index, '-c', clobber=False)

--- a/tests/flows/test_gcd_infer_diesize.py
+++ b/tests/flows/test_gcd_infer_diesize.py
@@ -28,7 +28,7 @@ def test_gcd_infer_diesize(gcd_chip):
             diearea = match.group(1, 2, 3, 4)
             break
 
-    assert diearea == ('0', '0', '136400', '136400')
+    assert diearea == ('0', '0', '139200', '139200')
 
 if __name__ == '__main__':
     from tests.fixtures import gcd_chip

--- a/tests/flows/test_gcd_skywater.py
+++ b/tests/flows/test_gcd_skywater.py
@@ -21,7 +21,6 @@ def test_gcd_checks(scroot):
     chip.set('quiet', True)
     chip.set('clock', 'core_clock', 'pin', 'clk')
     chip.set('clock', 'core_clock', 'period', 2)
-    chip.add('constraint', os.path.join(gcd_ex_dir, 'gcd_noclock.sdc'))
     chip.set('flowarg', 'verify', 'true')
     chip.set('asic', 'diearea', [(0, 0), (200.56, 201.28)])
     chip.set('asic', 'corearea', [(20.24, 21.76), (180.32, 184.96)])


### PR DESCRIPTION
This PR updates our OpenROAD-flow-scripts submodule to the latest version, and ensures that all the scripts still work.

There was actually only one small breaking API change, but the process revealed a bug in how we were handling placement padding. From the commit notes:

- We should use the $openroad_pad_detail_place value instead of the
  $openroad_pad_global_place in sc_cts.tcl, since we are doing a
  detailed placement here. This is consistent with ORFS.
- This makes the global call to set_placement_padding in sc_apr.tcl
  problematic, because it sets the placement padding value to the global
  value and then runs a placement check. However, the default detailed
  placement padding for Sky130 is smaller than the global placement
  padding, so this check can then fail overlap checks.
- This bug also revealed a bug in the GCD skywater test, where two
  conflicting constraints being provided meant that OpenROAD didn't
  receive clock constraints.

Since this might warrant some discussion, I don't want to update the version of OpenROAD on our test runner until we think we're set to merge this (since making that change will break CI for other PRs in the meantime). Let me know once you're ready to go with this, and I can update the test runner to make sure this PR is green.