### PR TITLE
Add read_lef helper for simplifying PDK bringup

### DIFF
--- a/siliconcompiler/leflib/__init__.py
+++ b/siliconcompiler/leflib/__init__.py
@@ -37,7 +37,8 @@ def parse(path):
 
     The dictionary returned by this function is designed to mimic the structure
     of the LEF file as closely as possible, and this function does minimal
-    legality checking. It looks like follows:
+    legality checking. The order all top-level objects appear in the dictionary
+    is guaranteed to match the LEF file. It looks like follows:
 
         .. code-block:: python
 
@@ -116,8 +117,8 @@ def parse(path):
                                     'layer_geometries': [{
                                         'layer': 'M1',
                                         'exceptpgnet': True,
-                                        'spacing': 0.01, 
-                                        'designrulewidth': 0.05, 
+                                        'spacing': 0.01,
+                                        'designrulewidth': 0.05,
                                         'width': 1.5,
                                         'shapes': [
                                             {

--- a/siliconcompiler/leflib/_leflib.pyx
+++ b/siliconcompiler/leflib/_leflib.pyx
@@ -60,6 +60,8 @@ cimport _leflib
 import cython
 import traceback
 
+from collections import OrderedDict
+
 # These are definitions of some custom Cython "fused types". An instance of a
 # fused type can be any one of the types listed in the definition.  For example,
 # an instance of `RectGeometry` (as defined below) could be a pointer to a
@@ -154,7 +156,7 @@ cdef int divider_chars_cb(lefrCallbackType_e cb_type, const char* val, lefiUserD
 cdef int units_cb(lefrCallbackType_e t, lefiUnits* units, lefiUserData data):
     try:
         if 'units' not in _state.data:
-            _state.data['units'] = {}
+            _state.data['units'] = OrderedDict()
 
         if units.hasDatabase():
             _state.data['units']['database'] = units.databaseNumber()
@@ -188,7 +190,7 @@ cdef int manufacturing_grid_cb(lefrCallbackType_e cb_type, double value, lefiUse
 cdef int use_min_spacing_cb(lefrCallbackType_e cb_type, lefiUseMinSpacing* minspacing, lefiUserData data):
     try:
         if 'useminspacing' not in _state.data:
-            _state.data['useminspacing'] = {}
+            _state.data['useminspacing'] = OrderedDict()
 
         # I think this should always be 'OBS', but read from the object just to
         # be flexible.
@@ -224,7 +226,7 @@ cdef int fixed_mask_cb(lefrCallbackType_e cb_type, int val, lefiUserData data):
 cdef int layer_cb(lefrCallbackType_e cb_type, lefiLayer* layer, lefiUserData data):
     try:
         if 'layers' not in _state.data:
-            _state.data['layers'] = {}
+            _state.data['layers'] = OrderedDict()
 
         name = layer.name().decode('ascii')
         _state.data['layers'][name] = {}
@@ -269,7 +271,7 @@ cdef int max_via_stack_cb(lefrCallbackType_e cb_type, lefiMaxStackVia* maxstackv
 cdef int viarule_cb(lefrCallbackType_e cb_type, lefiViaRule* viarule, void* data):
     try:
         if 'viarules' not in _state.data:
-            _state.data['viarules'] = {}
+            _state.data['viarules'] = OrderedDict()
 
         viarule_data = {}
         if viarule.hasDefault():
@@ -328,7 +330,7 @@ cdef int viarule_cb(lefrCallbackType_e cb_type, lefiViaRule* viarule, void* data
 cdef int site_cb(lefrCallbackType_e cb_type, lefiSite* site, lefiUserData data):
     try:
         if 'sites' not in _state.data:
-            _state.data['sites'] = {}
+            _state.data['sites'] = OrderedDict()
 
         site_data = {}
         if site.hasClass():
@@ -375,7 +377,7 @@ cdef int site_cb(lefrCallbackType_e cb_type, lefiSite* site, lefiUserData data):
 cdef int macro_begin_cb(lefrCallbackType_e cb_type, const char* name, lefiUserData data):
     try:
         if 'macros' not in _state.data:
-            _state.data['macros'] = {}
+            _state.data['macros'] = OrderedDict()
 
         _state.cur_macro = name.decode('ascii')
         _state.data['macros'][_state.cur_macro] = {}

--- a/tests/core/test_read_lef.py
+++ b/tests/core/test_read_lef.py
@@ -1,0 +1,34 @@
+import siliconcompiler
+
+import os
+
+def test_read_lef(scroot):
+    chip = siliconcompiler.Chip()
+
+    freepdk45_tlef = os.path.join(scroot,
+                                  'third_party',
+                                  'pdks',
+                                  'virtual',
+                                  'freepdk45',
+                                  'pdk',
+                                  'r1p0',
+                                  'apr',
+                                  'freepdk45.tech.lef')
+    stackup = '10M'
+    chip.read_lef(freepdk45_tlef, stackup)
+
+    assert len(chip.getkeys('pdk', 'grid', stackup)) == 10
+
+    assert chip.get('pdk', 'grid', stackup, 'metal4', 'name') == 'm4'
+    assert chip.get('pdk', 'grid', stackup, 'metal4', 'xpitch') == 0.28
+    assert chip.get('pdk', 'grid', stackup, 'metal4', 'ypitch') == 0.28
+    assert chip.get('pdk', 'grid', stackup, 'metal4', 'xoffset') == 0.095
+    assert chip.get('pdk', 'grid', stackup, 'metal4', 'yoffset') == 0.07
+    assert chip.get('pdk', 'grid', stackup, 'metal4', 'dir') == 'vertical'
+
+    assert chip.get('pdk', 'grid', stackup, 'metal9', 'name') == 'm9'
+    assert chip.get('pdk', 'grid', stackup, 'metal9', 'xpitch') == 1.6
+    assert chip.get('pdk', 'grid', stackup, 'metal9', 'ypitch') == 1.6
+    assert chip.get('pdk', 'grid', stackup, 'metal9', 'xoffset') == 0.095
+    assert chip.get('pdk', 'grid', stackup, 'metal9', 'yoffset') == 0.07
+    assert chip.get('pdk', 'grid', stackup, 'metal9', 'dir') == 'horizontal'


### PR DESCRIPTION
This PR implements a helper function for reading 'pdk', 'grid' data out of a tech LEF. This should be useful for simplifying PDK setup files.

Implementation ended up being pretty straightforward. Main thing that might warrant discussion is interface -- I decided to make it take in a path/stackup explicitly to avoid any sort of schema setup ordering requirements, but we could also consider reading these out of the schema directly. 