### PR TITLE
Support new versions of KLayout, Magic, and Netgen

### DIFF
--- a/examples/gcd/gcd.v
+++ b/examples/gcd/gcd.v
@@ -9,6 +9,8 @@
 //module GcdUnit
 module gcd
 (
+  input wire vdd,
+  input wire vss,
   input  wire clk,
   input  wire [  31:0] req_msg,
   output wire req_rdy,

--- a/setup/install-klayout.sh
+++ b/setup/install-klayout.sh
@@ -6,9 +6,9 @@ cd deps
 version=$(lsb_release -sr)
 
 if [ "$version" = "18.04" ]; then
-    url=https://www.klayout.org/downloads/Ubuntu-18/klayout_0.26.12-1_amd64.deb
+    url=https://www.klayout.org/downloads/Ubuntu-18/klayout_0.27.8-1_amd64.deb
 elif [ "$version" = "20.04" ]; then
-    url=https://www.klayout.org/downloads/Ubuntu-20/klayout_0.26.12-1_amd64.deb
+    url=https://www.klayout.org/downloads/Ubuntu-20/klayout_0.27.8-1_amd64.deb
 else
     echo "Script doesn't support Ubuntu version $version."
 fi

--- a/setup/install-magic.sh
+++ b/setup/install-magic.sh
@@ -7,7 +7,7 @@ cd deps
 
 git clone https://github.com/RTimothyEdwards/magic.git
 cd magic
-git checkout 8.3.196
+git checkout 8.3.274
 
 ./configure
 make

--- a/setup/install-netgen.sh
+++ b/setup/install-netgen.sh
@@ -8,8 +8,7 @@ cd deps
 git clone https://github.com/RTimothyEdwards/netgen.git
 cd netgen
 
-# TODO: our tests don't pass with newer versions
-git checkout 1.5.192
+git checkout 1.5.210
 
 ./configure
 make

--- a/siliconcompiler/floorplan.py
+++ b/siliconcompiler/floorplan.py
@@ -1086,7 +1086,7 @@ class Floorplan:
                 'vias': []
             }
 
-    def place_ring(self, net, x, y, width, height, hwidth, vwidth, hlayer, vlayer):
+    def place_ring(self, net, x, y, width, height, hwidth, vwidth, hlayer, vlayer, pins=False):
         '''Place wire ring.
 
         Args:
@@ -1099,6 +1099,7 @@ class Floorplan:
             vwidth (float): Width of vertical wires used in ring.
             hlayer (str): Metal layer to place horizontal wires on.
             vlayer (str): Metal layer to place vertical wires on.
+            pins (bool): Whether to overlay pin definitions on rings.
         '''
 
         # bottom
@@ -1109,6 +1110,12 @@ class Floorplan:
         self.place_wires([net], x, y, 0, 0, vwidth, height, vlayer, 'stripe')
         # right
         self.place_wires([net], x + width - vwidth, y, 0, 0, vwidth, height, vlayer, 'stripe')
+
+        if pins:
+            self.place_pins([net], x, y, 0, 0, width, hwidth, hlayer, use='power')
+            self.place_pins([net], x, y + height - hwidth, 0, 0, width, hwidth, hlayer, use='power')
+            self.place_pins([net], x, y, 0, 0, vwidth, height, vlayer, use='power')
+            self.place_pins([net], x + width - vwidth, y, 0, 0, vwidth, height, vlayer, use='power')
 
     def _determine_num_via_cols(self, viarule, width, lower_dir):
         '''Determine number of via columns we can insert in a given intersection.
@@ -1355,6 +1362,166 @@ class Floorplan:
         pitch = self.layers[layer]['ypitch']
         # snapping to grid cleans up floating point imprecision
         return self.snap_to_grid(round((y - offset) / pitch) * pitch + offset)
+
+    def place_pdn(self, vdd, vss, hwidth, hspacing, hlayer, vwidth, vspacing,
+                  vlayer, stdcell_pin_vdd, stdcell_pin_vss, stdcell_pin_width):
+        '''Generates PDN for a block-level design.
+
+        This function generates a power delivery grid for a block-level design
+        based on the supplied parameters. Note that it doesn't take into account
+        macros, so be aware that generating a PDN for a design with hardened
+        macros may result in shorts.
+
+        This function supports a PDN with a single power domain, and constructs
+        a ring around the grid with vss on the outside and vdd on the inside.
+
+        Args:
+            vdd (str): Name of power net in design.
+            vss (str): Name of ground net in design.
+            hwidth (float): Width of horizontal power wires in microns.
+            hspacing (float): Spacing between horizontal power grid wires in
+                microns.
+            hlayer (str): Layer to use for horizontal power wires.
+            vwidth (float): Width of vertical power wires in microns.
+            vspacing (float): Spacing between vertical power grid wires in
+                microns.
+            vlayer (str): Layer to use for horizontal power wires.
+            stdcell_pin_vdd (str): Name of power pin for standard cells.
+            stdcell_pin_vss (str): Name of ground pin for standard cells.
+            stdcell_pin_width (float): Width of pin used for routing power to
+                standard cells in microns.
+        '''
+        # TODO: read power pin names from LEF
+        if vdd not in self.nets:
+            self.add_net(vdd, [stdcell_pin_vdd], 'power')
+        if vss not in self.nets:
+            self.add_net(vss, [stdcell_pin_vss], 'ground')
+
+        core_left, core_bottom = self.corearea[0]
+        core_right, core_top = self.corearea[1]
+
+        core_w = core_right - core_left
+        core_h = core_top - core_bottom
+
+        vss_ring_left = core_left - 4 * vwidth
+        vss_ring_bottom = core_bottom - 4 * hwidth
+        vss_ring_width = core_w + 9 * vwidth
+        vss_ring_height = core_h + 9 * hwidth
+
+        vdd_ring_left = vss_ring_left + 2 * vwidth
+        vdd_ring_bottom = vss_ring_bottom + 2 * hwidth
+        vdd_ring_width = vss_ring_width - 4 * vwidth
+        vdd_ring_height = vss_ring_height - 4 * hwidth
+
+        self.place_ring(vdd, vdd_ring_left, vdd_ring_bottom, vdd_ring_width,
+                        vdd_ring_height, hwidth, vwidth, hlayer, vlayer, pins=True)
+        self.place_ring(vss, vss_ring_left, vss_ring_bottom, vss_ring_width,
+                        vss_ring_height, hwidth, vwidth, hlayer, vlayer, pins=True)
+
+        # Horizontal stripes
+        spacing = 2 * (hspacing + hwidth)
+        n_hori = int(core_h // (hspacing + hwidth))
+
+        bottom = core_bottom + hspacing
+        self.place_wires([vdd] * (n_hori // 2), vdd_ring_left, bottom, 0, spacing,
+                    vdd_ring_width, hwidth, hlayer, shape='stripe')
+
+        bottom = core_bottom + hspacing + (hspacing + hwidth)
+        self.place_wires([vss] * (n_hori // 2), vss_ring_left, bottom, 0, spacing,
+                    vss_ring_width, hwidth, hlayer, shape='stripe')
+
+        # Vertical stripes
+        spacing = 2 * (vspacing + vwidth)
+        n_vert = int(core_w // (vspacing + vwidth))
+
+        left = core_left + vspacing
+        self.place_wires([vdd] * (n_vert // 2), left, vdd_ring_bottom, spacing, 0,
+                    vwidth, vdd_ring_height, vlayer, shape='stripe')
+
+        left = core_left + vspacing + (vspacing + vwidth)
+        self.place_wires([vss] * (n_vert // 2), left, vss_ring_bottom, spacing, 0,
+                    vwidth, vss_ring_height, vlayer, shape='stripe')
+
+        # Power stripes
+        rows = len(self.rows)
+        npwr = 1 + math.floor(rows / 2)
+        ngnd = math.ceil(rows / 2)
+
+        # TODO: infer stripe_w from LEF
+        stripe_w = stdcell_pin_width
+        mainlib = self.chip.get('asic', 'logiclib')[0]
+        stripe_layer = self.chip.get('library', mainlib, 'pgmetal')
+        spacing = 2 * self.stdcell_height
+
+        bottom = core_bottom - stripe_w/2
+        self.place_wires([vdd] * npwr, core_left, bottom, 0, spacing,
+                         core_w, stripe_w, stripe_layer, 'followpin')
+
+        bottom = core_bottom - stripe_w/2 + self.stdcell_height
+        self.place_wires([vss] * ngnd, core_left, bottom, 0, spacing,
+                         core_w, stripe_w, stripe_layer, 'followpin')
+
+        self.insert_vias(layers=[(stripe_layer, vlayer), (vlayer, hlayer)])
+
+    def generate_block_floorplan(self, diearea, corearea, inputs, outputs, pdn=None):
+        '''Generate a basic floorplan for a block-level design.
+
+        This function generates a basic floorplan based on the supplied
+        parameters.  Input pins are evenly spaced on the west side of the die,
+        and output pins are evenly spaced on the east side of the die. The
+        floorplan can optionally include a PDN.
+
+        Args:
+            diearea (list of (float, float)): List of points that form the die
+                area. Currently only allowed to provide two points, specifying
+                the two bounding corners of a rectangular die. Dimensions are
+                specified in microns.
+            corearea (list of (float, float)): List of points that form the
+                core area of the physical design. If `None`, corearea is set to
+                be equivalent to the die area. Currently only allowed to provide
+                two points, specifying the two bounding corners of a rectangular
+                area.  Dimensions are specified in microns.
+            inputs (list of (str, int)): List of input pins, specified as tuples
+                of pin name, bus width. For individual pins, provide 1 for the
+                bus width.
+            outputs (list of (str, int)): List of output pins, specified as
+                tuples of pin name, bus width. For individual pins, provide 1
+                for the bus width.
+            pdn (dict): Parameters for PDN generation. See ``place_pdn``
+                documentation for argument list. This dictionary gets passed
+                directly into this function as kwargs.
+        '''
+        self.create_diearea(diearea, corearea)
+
+        input_pins = []
+        for name, width in inputs:
+            if width > 1:
+                input_pins.extend([f'{name}[{i}]' for i in range(width)])
+            else:
+                input_pins.append(name)
+
+        output_pins = []
+        for name, width in outputs:
+            if width > 1:
+                output_pins.extend([f'{name}[{i}]' for i in range(width)])
+            else:
+                output_pins.append(name)
+
+        layer = self.chip.get('asic', 'hpinlayer')
+        width = self.layers[layer]['width']
+        depth = 3 * width
+
+        die_width, die_height = diearea[1]
+        in_spacing = (die_height - len(input_pins) * width) / (len(input_pins) + 1)
+        self.place_pins(input_pins, 0, in_spacing, 0, in_spacing + width, depth, width, layer, snap=True)
+
+        out_spacing = (die_height - len(output_pins) * width) / (len(output_pins) + 1)
+        self.place_pins(output_pins, die_width-depth, out_spacing, 0, out_spacing + width, depth, width, layer, snap=True)
+
+        if pdn:
+            self.place_pdn(**pdn)
+
+        return pdn
 
     def _validate_orientation(self, orientation):
         if orientation.lower() not in ('n', 's', 'w', 'e', 'fn', 'fs', 'fw', 'fe'):

--- a/siliconcompiler/libs/nangate45.py
+++ b/siliconcompiler/libs/nangate45.py
@@ -100,6 +100,8 @@ def setup(chip):
     chip.add('library', libname, 'techmap', 'yosys',
              libdir + '/techmap/yosys/cells_latch.v')
 
+    chip.set('library', libname, 'pgmetal', 'm1')
+
 #########################
 if __name__ == "__main__":
 

--- a/siliconcompiler/libs/sky130.py
+++ b/siliconcompiler/libs/sky130.py
@@ -125,3 +125,5 @@ def setup(chip):
     # Techmap
     chip.add('library', libname, 'techmap', 'yosys',
              libdir + '/techmap/yosys/cells_latch.v')
+
+    chip.set('library', libname, 'pgmetal', 'm1')

--- a/siliconcompiler/pdks/freepdk45.py
+++ b/siliconcompiler/pdks/freepdk45.py
@@ -86,8 +86,11 @@ def setup(chip):
                  pdkdir+'/apr/freepdk45.tech.lef')
 
     # Klayout setup file
-    chip.set('pdk','layermap','klayout',stackup, 'def', 'gds',
+    chip.set('pdk','layermap', 'klayout', stackup, 'def', 'gds',
              pdkdir+'/setup/klayout/freepdk45.lyt')
+
+    chip.set('pdk', 'display', 'klayout', stackup,
+            pdkdir + '/setup/klayout/freepdk45.lyp')
 
     # Routing Grid Definitions
     for layer, sc_name in [('metal1', 'm1')]:

--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -95,8 +95,9 @@ def setup(chip):
     # LVS Runsets
     chip.set('pdk','lvs','netgen', stackup, 'runset', pdkdir+'/setup/netgen/lvs_setup.tcl')
 
-    # Layer map
-    chip.set('pdk','layermap','klayout',stackup, 'def', 'gds', pdkdir+'/setup/klayout/skywater130.lyt')
+    # Layer map and display file
+    chip.set('pdk', 'layermap', 'klayout', stackup, 'def', 'gds', pdkdir+'/setup/klayout/skywater130.lyt')
+    chip.set('pdk', 'display', 'klayout', stackup, pdkdir+'/setup/klayout/sky130A.lyp')
 
     # Routing Grid Definitions
 

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -90,7 +90,7 @@ def setup(chip, mode="batch"):
 
     chip.set('eda', tool, 'exe', klayout_exe, clobber=True)
     chip.set('eda', tool, 'vswitch', ['-zz', '-v'], clobber=clobber)
-    chip.set('eda', tool, 'version', '0.26.11', clobber=clobber)
+    chip.set('eda', tool, 'version', '0.27.8', clobber=clobber)
     chip.set('eda', tool, 'format', 'json', clobber=clobber)
     chip.set('eda', tool, 'copy', 'true', clobber=clobber)
     chip.set('eda', tool, 'refdir', step, index, refdir, clobber=clobber)

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -15,18 +15,14 @@ sc_stackup = sc_cfg['pdk']['stackup']['value'][0]
 sc_mainlib = sc_cfg['asic']['logiclib']['value'][0]
 sc_libtype = sc_cfg['library'][sc_mainlib]['arch']['value']
 
-# The layermap may be provided as part of a KLayout tech file (.lyt),
-# or in the standalone format (.lyp).
-tech_filename = sc_cfg['pdk']['layermap']['klayout'][sc_stackup]['def']['gds']['value'][0]
-tech_file = None
-lyp_path = None
-if tech_filename:
-    if tech_filename[-4:] == '.lyt':
-        # 'lyp_path' will be read out of the .lyt file later.
-        tech_file = tech_filename
-    elif tech_filename[-4:] == '.lyp':
-        # Tech file will not be imported, only layermap properties.
-        lyp_path = tech_filename
+try:
+    tech_file = sc_cfg['pdk']['layermap']['klayout'][sc_stackup]['def']['gds']['value'][0]
+except KeyError:
+    tech_file = None
+try:
+    lyp_path = sc_cfg['pdk']['display']['klayout'][sc_stackup]['value'][0]
+except KeyError:
+    lyp_path = None
 
 macro_lefs = []
 if 'macrolib' in sc_cfg['asic']:
@@ -82,12 +78,6 @@ app.set_config('text-visible', 'false')
 # Display the file!
 cell_view = pya.MainWindow.instance().load_layout(filename, layoutOptions, 0)
 layout_view = cell_view.view()
-
-if tech_file and os.path.isfile(tech_file):
-    # We assume the layer properties file is specified as a relative path in our
-    # technology file, and resolve it relative to the tech file's directory.
-    tech_file_dir = os.path.dirname(tech_file)
-    lyp_path = tech_file_dir + '/' + tech.layer_properties_file
 
 if lyp_path:
     # Set layer properties -- setting second argument to True ensures things like

--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -56,7 +56,7 @@ def setup(chip):
 
     chip.set('eda', tool, 'exe', tool)
     chip.set('eda', tool, 'vswitch', '--version')
-    chip.set('eda', tool, 'version', '8.3.196')
+    chip.set('eda', tool, 'version', '8.3.274')
     chip.set('eda', tool, 'format', 'tcl')
     chip.set('eda', tool, 'copy', 'true') # copy in .magicrc file
     chip.set('eda', tool, 'threads', step, index,  4)

--- a/siliconcompiler/tools/netgen/netgen.py
+++ b/siliconcompiler/tools/netgen/netgen.py
@@ -49,7 +49,7 @@ def setup(chip):
 
     chip.set('eda', tool, 'exe', tool)
     chip.set('eda', tool, 'vswitch', '-batch')
-    chip.set('eda', tool, 'version', '1.5.192')
+    chip.set('eda', tool, 'version', '1.5.210')
     chip.set('eda', tool, 'format', 'tcl')
     chip.set('eda', tool, 'copy', 'true')
     chip.set('eda', tool, 'threads', step, index, 4)

--- a/tests/floorplan/test_generate_block.py
+++ b/tests/floorplan/test_generate_block.py
@@ -1,0 +1,44 @@
+import siliconcompiler
+from siliconcompiler.floorplan import Floorplan
+
+import os
+
+def test_generate_block_freepdk45():
+    chip = siliconcompiler.Chip()
+
+    chip.set('design', 'gcd')
+    chip.load_target('freepdk45_demo')
+    fp = Floorplan(chip)
+
+    diearea = [(0,0), (100.13,100.8)]
+    corearea = [(10.07,11.2), (90.25,91)]
+    inputs = [
+        ('clk', 1),
+        ('req_val', 1),
+        ('reset', 1),
+        ('resp_rdy', 1),
+        ('req_msg', 32)
+    ]
+    outputs = [
+        ('req_rdy', 1),
+        ('resp_val', 1),
+        ('resp_msg', 16)
+    ]
+    pdn_params = {
+        'vdd': 'vdd',
+        'vss': 'vss',
+        'hwidth': 2,
+        'hspacing': 10,
+        'hlayer': 'm9',
+        'vwidth': 2,
+        'vspacing': 10,
+        'vlayer': 'm10',
+        'stdcell_pin_vdd': 'VDD',
+        'stdcell_pin_vss': 'VSS',
+        'stdcell_pin_width': 0.17
+    }
+
+    fp.generate_block_floorplan(diearea, corearea, inputs, outputs, pdn_params)
+    fp.write_def('gcd.def')
+
+    assert os.path.isfile('gcd.def')

--- a/third_party/pdks/skywater/skywater130/pdk/v0_0_2/setup/klayout/skywater130.lyt
+++ b/third_party/pdks/skywater/skywater130/pdk/v0_0_2/setup/klayout/skywater130.lyt
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <technology>
  <name>sky130A</name>
- <description>sky130A-metals</description>
+ <description>SkyWater 130nm technology</description>
+ <group/>
  <dbu>0.001</dbu>
+ <base-path>./platforms/sky130hd/</base-path>
+ <original-base-path>.klayout/tech/sky130</original-base-path>
  <layer-properties_file>sky130A.lyp</layer-properties_file>
  <add-other-layers>true</add-other-layers>
  <reader-options>
@@ -25,30 +28,49 @@
    <net-property-name>#1</net-property-name>
    <produce-inst-names>true</produce-inst-names>
    <inst-property-name>#1</inst-property-name>
-   <produce-cell-outlines>false</produce-cell-outlines>
-   <cell-outline-layer>OUTLINE</cell-outline-layer>
+   <produce-pin-names>false</produce-pin-names>
+   <pin-property-name>#1</pin-property-name>
+   <produce-cell-outlines>true</produce-cell-outlines>
+   <cell-outline-layer>prBoundary.boundary</cell-outline-layer>
    <produce-placement-blockages>true</produce-placement-blockages>
    <placement-blockage-layer>PLACEMENT_BLK</placement-blockage-layer>
    <produce-regions>true</produce-regions>
    <region-layer>REGIONS</region-layer>
    <produce-via-geometry>true</produce-via-geometry>
-   <via-geometry-suffix>.drawing</via-geometry-suffix>
-   <via-geometry-datatype>0</via-geometry-datatype>
+   <special-via_geometry-suffix-string>.drawing</special-via_geometry-suffix-string>
+   <special-via_geometry-datatype-string>44</special-via_geometry-datatype-string>
    <produce-pins>true</produce-pins>
-   <pins-suffix>.pin</pins-suffix>
-   <pins-datatype>2</pins-datatype>
+   <special-pins-suffix-string>.pin</special-pins-suffix-string>
+   <special-pins-datatype-string>16</special-pins-datatype-string>
+   <produce-lef-pins>true</produce-lef-pins>
+   <special-lef_pins-suffix-string>.pin</special-lef_pins-suffix-string>
+   <special-lef_pins-datatype-string>16</special-lef_pins-datatype-string>
+   <produce-fills>false</produce-fills>
+   <special-fills-suffix-string>.FILL</special-fills-suffix-string>
+   <special-fills-datatype-string>5</special-fills-datatype-string>
    <produce-obstructions>false</produce-obstructions>
    <obstructions-suffix>.blockage</obstructions-suffix>
-   <obstructions-datatype>3</obstructions-datatype>
-   <produce-blockages>false</produce-blockages>
+   <obstructions-datatype>10</obstructions-datatype>
+   <produce-blockages>true</produce-blockages>
    <blockages-suffix>.blockage</blockages-suffix>
-   <blockages-datatype>4</blockages-datatype>
+   <blockages-datatype>10</blockages-datatype>
    <produce-labels>true</produce-labels>
    <labels-suffix>.label</labels-suffix>
-   <labels-datatype>1</labels-datatype>
+   <labels-datatype>5</labels-datatype>
+   <produce-lef-labels>true</produce-lef-labels>
+   <lef-labels-suffix>.label</lef-labels-suffix>
+   <lef-labels-datatype>5</lef-labels-datatype>
    <produce-routing>true</produce-routing>
-   <routing-suffix>.drawing</routing-suffix>
-   <routing-datatype>0</routing-datatype>
+   <special-routing-suffix-string>.drawing</special-routing-suffix-string>
+   <special-routing-datatype-string>20</special-routing-datatype-string>
+   <produce-special-routing>true</produce-special-routing>
+   <routing-suffix-string>.drawing</routing-suffix-string>
+   <routing-datatype-string>20</routing-datatype-string>
+   <via-cellname-prefix>VIA_</via-cellname-prefix>
+   <read-lef-with-def>true</read-lef-with-def>
+   <macro-resolution-mode>default</macro-resolution-mode>
+   <separate-groups>false</separate-groups>
+   <map-file/>
    <lef-files>./sky130_fd_sc_hd_merged_tech.lef</lef-files>
   </lefdef>
   <dxf>
@@ -72,6 +94,16 @@
    <create-other-layers>true</create-other-layers>
    <keep-layer-names>false</keep-layer-names>
   </cif>
+  <mag>
+   <lambda>1</lambda>
+   <dbu>0.001</dbu>
+   <layer-map>layer_map()</layer-map>
+   <create-other-layers>true</create-other-layers>
+   <keep-layer-names>false</keep-layer-names>
+   <merge>true</merge>
+   <lib-paths>
+   </lib-paths>
+  </mag>
  </reader-options>
  <writer-options>
   <gds2>
@@ -80,6 +112,7 @@
    <write-file-properties>false</write-file-properties>
    <no-zero-length-paths>false</no-zero-length-paths>
    <multi-xy-records>false</multi-xy-records>
+   <resolve-skew-arrays>false</resolve-skew-arrays>
    <max-vertex-count>8000</max-vertex-count>
    <max-cellname-length>32000</max-cellname-length>
    <libname>LIB</libname>
@@ -99,19 +132,27 @@
    <dummy-calls>false</dummy-calls>
    <blank-separator>false</blank-separator>
   </cif>
+  <mag>
+   <lambda>0</lambda>
+   <tech/>
+   <write-timestamp>true</write-timestamp>
+  </mag>
  </writer-options>
  <connectivity>
-  <connection>66/20,66/44,li</connection>
-  <connection>li,67/44,met1</connection>
-  <connection>met1,68/44,met2</connection>
-  <connection>met2,69/44,met3</connection>
-  <connection>met3,70/44,met4</connection>
-  <connection>met4,71/44,met5</connection>
-  <symbols>li='67/20+67/5'</symbols>
-  <symbols>met1='68/20+68/5'</symbols>
-  <symbols>met2='69/20+69/5'</symbols>
-  <symbols>met3='70/20+70/5'</symbols>
-  <symbols>met4='71/20+71/5'</symbols>
-  <symbols>met5='72/20+72/5'</symbols>
+  <connection>li1,mcon,met1</connection>
+  <connection>met1,via,met2</connection>
+  <connection>met2,via2,met3</connection>
+  <connection>met3,via3,met4</connection>
+  <connection>met4,via4,met5</connection>
+  <symbols>li1='67/20+67/16'</symbols>
+  <symbols>met1='68/20+68/16'</symbols>
+  <symbols>met2='69/20+69/16'</symbols>
+  <symbols>met3='70/20+70/16'</symbols>
+  <symbols>met4='71/20+71/16'</symbols>
+  <symbols>met5='72/20-72/15+72/16'</symbols>
+  <symbols>via='68/44'</symbols>
+  <symbols>via2='69/44'</symbols>
+  <symbols>via3='70/44'</symbols>
+  <symbols>via4='71/44'</symbols>
  </connectivity>
 </technology>


### PR DESCRIPTION
This PR is working towards ensuring we support the newest versions of our export and signoff tools, inspired by our supported version of KLayout being bumped off the downloads page and some recent issues.

I initially thought there were some coupling issues between the three, but luckily that doesn't seem to be the case. Necessary things for updating:

KLayout:

The main thing here is we need to update the *.lyt file, since I noticed layers weren't being mapped properly for Sky130 in 0.27.x. This is a duplicate of this ORFS issue: https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/299. 

Magic/Netgen:

Older versions of Netgen seemed to disregard the std. cell power pins, so we were able to do a logical connection-only LVS for our basic test. This no longer seems to be the case, and I had trouble getting newer versions of Netgen to replicate this behavior (see #865, #480). I think it might be fair to say that power needs to be routed to get a clean LVS result. I wrote up a quick floorplan + PDN to use for our Skywater130 signoff test, and decided it was generic enough that we might as well make it a floorplan.py "super-function" so that people can do quick experiments with a PDN. We can discuss this however, and I can make it a one-off if preferred.

Marking as draft, todo:
- [x] Double check that KLayout 0.27.x maps FreePDK45 still
- [x] lyt own place in schema
- [ ] Update tools on test runner, once we're otherwise good to merge (this might cause some disruption)
- [x] Update setup scripts