### PR TITLE
Create distinct asictopflow and signoffflow

### DIFF
--- a/docs/_ext/dynamicgen.py
+++ b/docs/_ext/dynamicgen.py
@@ -338,9 +338,10 @@ class LibGen(DynamicGen):
     def extra_content(self, chip, modname):
         # assume same pdk for all libraries configured by this module
         libname = chip.getkeys('library')[0]
-        pdk = chip.get('library', libname, 'pdk')
+        pdks = chip.get('library', libname, 'pdk')
 
-        if pdk:
+        if len(pdks) > 0:
+            pdk = pdks[0]
             p = docutils.nodes.inline('')
             self.parse_rst(f'Associated PDK: :ref:`{pdk}<{pdk}-ref>`', p)
             return [p]

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3911,6 +3911,8 @@ class Chip:
             self.set('arg', 'index', index)
             setup_tool = self.find_function(tool, 'setup', 'tools')
             setup_tool(self, mode='show')
+            self.set('arg', 'step', None)
+            self.set('arg', 'index', None)
 
             exe = self._getexe(tool)
             if shutil.which(exe) is None:

--- a/siliconcompiler/flows/asicflow.py
+++ b/siliconcompiler/flows/asicflow.py
@@ -38,9 +38,6 @@ def make_docs():
     * place_np : Number of parallel place jobs to launch
     * cts_np : Number of parallel clock tree synthesis jobs to launch
     * route_np : Number of parallel routing jobs to launch
-
-    In order to enable running DRC and LVS verification, set the 'flowarg',
-    'verify' arg to "true" (currently supported for Skywater130 only).
     '''
 
     chip = siliconcompiler.Chip()
@@ -113,11 +110,6 @@ def setup(chip, flowname='asicflow'):
             flowpipe.append(step)
         prevstep = step
 
-    # Run verification steps only if `flowarg, verify` is True
-    verify = ('verify' in chip.getkeys('flowarg') and
-              len(chip.get('flowarg', 'verify')) > 0 and
-              chip.get('flowarg', 'verify')[0] == 'true')
-
     # Set mandatory mode
     chip.set('mode', 'asic')
 
@@ -153,22 +145,6 @@ def setup(chip, flowname='asicflow'):
             for metric in ('cellarea', 'peakpower', 'standbypower'):
                 chip.set('flowgraph', flowname, step, str(index), 'weight', metric, 1.0)
         prevstep = step
-
-    # If running verify steps, manually set up parallel LVS/DRC
-    if verify:
-        chip.node(flowname, 'extspice', 'magic')
-        chip.node(flowname, 'lvsjoin', 'join')
-        chip.node(flowname, 'drc', 'magic')
-        chip.node(flowname, 'lvs', 'netgen')
-        chip.node(flowname, 'signoff', 'join')
-
-        chip.edge(flowname, 'export', 'extspice')
-        chip.edge(flowname, 'extspice', 'lvsjoin')
-        chip.edge(flowname, 'dfm', 'lvsjoin')
-        chip.edge(flowname, 'lvsjoin', 'lvs')
-        chip.edge(flowname, 'export', 'drc')
-        chip.edge(flowname, 'lvs', 'signoff')
-        chip.edge(flowname, 'drc', 'signoff')
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/flows/asictopflow.py
+++ b/siliconcompiler/flows/asictopflow.py
@@ -1,0 +1,34 @@
+import siliconcompiler
+
+def make_docs():
+    '''A flow for stitching together hardened blocks without doing any automated
+    place-and-route.
+
+    This flow generates a GDS and a netlist for passing to a
+    verification/signoff flow.
+    '''
+    chip = siliconcompiler.Chip()
+    setup(chip)
+    return chip
+
+def setup(chip):
+    flow = 'asictopflow'
+    chip.node(flow, 'import', 'surelog')
+    chip.node(flow, 'syn', 'yosys')
+    chip.node(flow, 'export', 'klayout')
+    chip.node(flow, 'merge', 'join')
+
+    chip.edge(flow, 'import', 'export')
+    chip.edge(flow, 'import', 'syn')
+
+    chip.edge(flow, 'export', 'merge')
+    chip.edge(flow, 'syn', 'merge')
+
+    chip.set('mode', 'asic')
+
+    chip.set('showtool', 'def', 'klayout')
+    chip.set('showtool', 'gds', 'klayout')
+
+    # Set default goal
+    for step in chip.getkeys('flowgraph', flow):
+        chip.set('metric', step, '0', 'errors', 'goal', 0)

--- a/siliconcompiler/flows/asictopflow.py
+++ b/siliconcompiler/flows/asictopflow.py
@@ -8,6 +8,7 @@ def make_docs():
     verification/signoff flow.
     '''
     chip = siliconcompiler.Chip()
+    chip.set('flow', 'asictopflow')
     setup(chip)
     return chip
 

--- a/siliconcompiler/flows/signoffflow.py
+++ b/siliconcompiler/flows/signoffflow.py
@@ -1,0 +1,41 @@
+import siliconcompiler
+
+def make_docs():
+    '''A flow for running LVS/DRC signoff on a GDS layout.
+
+    Inputs must be passed to this flow as follows::
+
+        chip.set('read', 'gds', 'extspice', '0', '<path-to-layout>.gds')
+        chip.set('read', 'netlist', 'lvs', '0', '<path-to-netlist>.vg')
+        chip.set('read', 'gds', 'drc', '0', '<path-to-layout>.gds')
+    '''
+    chip = siliconcompiler.Chip()
+    setup(chip)
+    return chip
+
+def setup(chip):
+    flow = 'signoffflow'
+
+    # nop import since we don't need to pull in any sources
+    chip.node(flow, 'import', 'nop')
+
+    chip.node(flow, 'extspice', 'magic')
+    chip.node(flow, 'drc', 'magic')
+    chip.node(flow, 'lvs', 'netgen')
+    chip.node(flow, 'signoff', 'join')
+
+    chip.edge(flow, 'import', 'drc')
+    chip.edge(flow, 'import', 'extspice')
+    chip.edge(flow, 'extspice', 'lvs')
+    chip.edge(flow, 'lvs', 'signoff')
+    chip.edge(flow, 'drc', 'signoff')
+
+    chip.set('mode', 'asic')
+
+    chip.set('showtool', 'def', 'klayout')
+    chip.set('showtool', 'gds', 'klayout')
+
+    # Set default goal
+    for step in chip.getkeys('flowgraph', flow):
+        chip.set('metric', step, '0', 'errors', 'goal', 0)
+

--- a/siliconcompiler/flows/signoffflow.py
+++ b/siliconcompiler/flows/signoffflow.py
@@ -10,6 +10,7 @@ def make_docs():
         chip.set('read', 'gds', 'drc', '0', '<path-to-layout>.gds')
     '''
     chip = siliconcompiler.Chip()
+    chip.set('flow', 'signoffflow')
     setup(chip)
     return chip
 

--- a/siliconcompiler/targets/freepdk45_demo.py
+++ b/siliconcompiler/targets/freepdk45_demo.py
@@ -30,6 +30,7 @@ def setup(chip):
     #2. Load PDK, flow, libs combo
     chip.load_pdk('freepdk45')
     chip.load_flow('asicflow')
+    chip.load_flow('asictopflow')
     chip.load_lib('nangate45')
 
     #3. Set default flow

--- a/siliconcompiler/targets/skywater130_demo.py
+++ b/siliconcompiler/targets/skywater130_demo.py
@@ -31,6 +31,7 @@ def setup(chip):
     #2. Load PDK, flow, libs
     chip.load_pdk('skywater130')
     chip.load_flow('asicflow')
+    chip.load_flow('signoffflow')
     chip.load_lib('sky130')
 
     #3. Set default targets

--- a/siliconcompiler/targets/skywater130_demo.py
+++ b/siliconcompiler/targets/skywater130_demo.py
@@ -31,6 +31,7 @@ def setup(chip):
     #2. Load PDK, flow, libs
     chip.load_pdk('skywater130')
     chip.load_flow('asicflow')
+    chip.load_flow('asictopflow')
     chip.load_flow('signoffflow')
     chip.load_lib('sky130')
 

--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -69,7 +69,10 @@ def setup(chip):
     chip.set('eda', tool, 'option', step, index,  options, clobber=False)
 
     design = chip.get('design')
-    chip.add('eda', tool, 'input', step, index, f'{design}.gds')
+    if chip.valid('read', 'gds', step, index):
+        chip.add('eda', tool, 'require', step, index, ','.join(['read', 'gds', step, index]))
+    else:
+        chip.add('eda', tool, 'input', step, index, f'{design}.gds')
     if step == 'extspice':
         chip.add('eda', tool, 'output', step, index, f'{design}.spice')
     elif step == 'drc':

--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -47,12 +47,9 @@ def setup(chip):
     index = chip.get('arg','index')
 
     # magic used for drc and lvs
-    if step == 'drc':
-        script = 'sc_drc.tcl'
-    elif step == 'extspice':
-        script = 'sc_extspice.tcl'
-    else:
+    if step not in ('drc', 'extspice'):
         raise ValueError(f"Magic tool doesn't support step {step}.")
+    script = 'sc_magic.tcl'
 
     chip.set('eda', tool, 'exe', tool)
     chip.set('eda', tool, 'vswitch', '--version')

--- a/siliconcompiler/tools/magic/sc_drc.tcl
+++ b/siliconcompiler/tools/magic/sc_drc.tcl
@@ -20,6 +20,9 @@ set sc_macrolibs [dict get $sc_cfg asic macrolib]
 set sc_exclude [dict get $sc_cfg asic exclude]
 set sc_stackup [dict get $sc_cfg asic stackup]
 
+set sc_step    [dict get $sc_cfg arg step]
+set sc_index   [dict get $sc_cfg arg index]
+
 # Ignore specific libraries by reading their LEFs (causes magic to abstract them)
 foreach lib $sc_macrolibs {
     puts $lib
@@ -30,7 +33,13 @@ foreach lib $sc_macrolibs {
 
 gds noduplicates true
 
-gds read inputs/$sc_design.gds
+if {[dict exists $sc_cfg "read" gds $sc_step $sc_index]} {
+    set gds_path [dict get $sc_cfg "read" gds $sc_step $sc_index]
+} else {
+    set gds_path "inputs/$sc_design.gds"
+}
+
+gds read $gds_path
 puts $sc_design.gds
 set fout [open outputs/$sc_design.drc w]
 set oscale [cif scale out]

--- a/siliconcompiler/tools/magic/sc_extspice.tcl
+++ b/siliconcompiler/tools/magic/sc_extspice.tcl
@@ -9,6 +9,9 @@ set sc_liblef  [dict get $sc_cfg library $sc_mainlib lef $sc_stackup]
 set sc_macrolibs [dict get $sc_cfg asic macrolib]
 set sc_exclude [dict get $sc_cfg asic exclude]
 
+set sc_step    [dict get $sc_cfg arg step]
+set sc_index   [dict get $sc_cfg arg index]
+
 lef read $sc_techlef
 lef read $sc_liblef
 
@@ -20,8 +23,14 @@ foreach lib $sc_macrolibs {
     }
 }
 
+if {[dict exists $sc_cfg "read" gds $sc_step $sc_index]} {
+    set gds_path [dict get $sc_cfg "read" gds $sc_step $sc_index]
+} else {
+    set gds_path "inputs/$sc_design.gds"
+}
+
 gds noduplicates true
-gds read inputs/$sc_design.gds
+gds read $gds_path
 
 # Extract layout to Spice netlist
 load $sc_design -dereference

--- a/siliconcompiler/tools/magic/sc_magic.tcl
+++ b/siliconcompiler/tools/magic/sc_magic.tcl
@@ -1,0 +1,10 @@
+source ./sc_manifest.tcl
+
+set sc_step    [dict get $sc_cfg arg step]
+
+if {[catch {source "sc_$sc_step.tcl"} err]} {
+    puts $err
+    exit 1
+}
+
+exit 0

--- a/siliconcompiler/tools/netgen/netgen.py
+++ b/siliconcompiler/tools/netgen/netgen.py
@@ -64,7 +64,10 @@ def setup(chip):
 
     design = chip.get('design')
     chip.add('eda', tool, 'input', step, index, f'{design}.spice')
-    chip.add('eda', tool, 'input', step, index, f'{design}.vg')
+    if chip.valid('read', 'netlist', step, index):
+        chip.add('eda', tool, 'require', step, index, ','.join(['read', 'netlist', step, index]))
+    else:
+        chip.add('eda', tool, 'input', step, index, f'{design}.vg')
     chip.add('eda', tool, 'output', step, index, f'{design}.lvs.out')
 
 ################################

--- a/siliconcompiler/tools/netgen/sc_lvs.tcl
+++ b/siliconcompiler/tools/netgen/sc_lvs.tcl
@@ -6,8 +6,16 @@ set sc_exclude [dict get $sc_cfg asic exclude]
 set sc_stackup [dict get $sc_cfg asic stackup]
 set sc_runset [dict get $sc_cfg pdk lvs netgen $sc_stackup runset]
 
+set sc_step    [dict get $sc_cfg arg step]
+set sc_index   [dict get $sc_cfg arg index]
+
 set layout_file "inputs/$sc_design.spice"
-set schematic_file "inputs/$sc_design.vg"
+if {[dict exists $sc_cfg "read" netlist $sc_step $sc_index]} {
+    set schematic_file [dict get $sc_cfg "read" netlist $sc_step $sc_index]
+} else {
+    set schematic_file "inputs/$sc_design.vg"
+}
+
 
 # readnet returns a number that can be used to associate additional files with
 # each netlist read in here

--- a/tests/flows/test_gcd_skywater.py
+++ b/tests/flows/test_gcd_skywater.py
@@ -173,7 +173,6 @@ def test_gcd_checks(scroot):
     chip.set('quiet', True)
     chip.set('clock', 'core_clock', 'pin', 'clk')
     chip.set('clock', 'core_clock', 'period', 2)
-    # chip.set('flowarg', 'verify', 'true')
 
     chip.load_target("skywater130_demo")
 


### PR DESCRIPTION
This PR creates two new flows:

- signoffflow: this is the optional verification component of asicflow, split into its own. It has been added to the Skywater target.
- asictopflow: this is the "physflow" that is currently hardcoded into the ZeroSoC build script. It takes in a DEF and just does a GDS stream out with any configured libraries, and also generates a netlist for passing into future LVS steps.

This sets us up nicely to begin thinking about how we want to stitch flows together. Right now, I've settled on using the 'read' schema coupled with '`chip.find_result(...)` to implement the hand-off from one to another (see changes to test_gcd_skywater.py as an example), but I think there are certainly ways this could be improved.