### PR TITLE
Tweaks to replay script generation

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4124,9 +4124,20 @@ class Chip:
             for option in runtime_options(self):
                 cmdlist.extend(shlex.split(option, posix=is_posix))
 
+        envvars = {}
+        for key in self.getkeys('env'):
+            envvars[key] = self.get('env', key)
+        if (step in self.getkeys('eda', tool, 'environment') and
+            index in self.getkeys('eda', tool, 'environment', step)):
+            for key in self.getkeys('eda', tool, 'environment', step, index):
+                envvars[key] = self.get('eda', tool, 'environment', step, index, key)
+
         #create replay file
         with open('replay.sh', 'w') as f:
-            print('#!/bin/bash\n', ' '.join(cmdlist), file=f)
+            print('#!/bin/bash', file=f)
+            for key, val in envvars.items():
+                print(f'export {key}={val}', file=f)
+            print(' '.join(shlex.quote(arg) for arg in cmdlist), file=f)
         os.chmod("replay.sh", 0o755)
 
         return cmdlist

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4131,10 +4131,10 @@ class Chip:
             license_file = self.get('eda', tool, 'licenseserver', item)
             if license_file:
                 envvars[item] = ':'.join(license_file)
-        if (step in self.getkeys('eda', tool, 'environment') and
-            index in self.getkeys('eda', tool, 'environment', step)):
-            for key in self.getkeys('eda', tool, 'environment', step, index):
-                envvars[key] = self.get('eda', tool, 'environment', step, index, key)
+        if (step in self.getkeys('eda', tool, 'env') and
+            index in self.getkeys('eda', tool, 'env', step)):
+            for key in self.getkeys('eda', tool, 'env', step, index):
+                envvars[key] = self.get('eda', tool, 'env', step, index, key)
 
         #create replay file
         is_posix = 'win' not in sys.platform

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4097,7 +4097,7 @@ class Chip:
     def _makecmd(self, tool, step, index, extra_options=None):
         '''
         Constructs a subprocess run command based on eda tool setup.
-        Creates a replay.sh command in current directory.
+        Creates a replay script in current directory.
         '''
 
         fullexe = self._getexe(tool)
@@ -4127,18 +4127,28 @@ class Chip:
         envvars = {}
         for key in self.getkeys('env'):
             envvars[key] = self.get('env', key)
+        for item in self.getkeys('eda', tool, 'licenseserver'):
+            license_file = self.get('eda', tool, 'licenseserver', item)
+            if license_file:
+                envvars[item] = ':'.join(license_file)
         if (step in self.getkeys('eda', tool, 'environment') and
             index in self.getkeys('eda', tool, 'environment', step)):
             for key in self.getkeys('eda', tool, 'environment', step, index):
                 envvars[key] = self.get('eda', tool, 'environment', step, index, key)
 
         #create replay file
-        with open('replay.sh', 'w') as f:
-            print('#!/bin/bash', file=f)
+        is_posix = 'win' not in sys.platform
+        script_name = 'replay.sh' if is_posix else 'replay.bat'
+        with open(script_name, 'w') as f:
+            if is_posix:
+                print('#!/bin/bash', file=f)
+
+            envvar_cmd = 'export' if is_posix else 'set'
             for key, val in envvars.items():
-                print(f'export {key}={val}', file=f)
+                print(f'{envvar_cmd} {key}={val}', file=f)
+
             print(' '.join(shlex.quote(arg) for arg in cmdlist), file=f)
-        os.chmod("replay.sh", 0o755)
+        os.chmod(script_name, 0o755)
 
         return cmdlist
 

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1391,7 +1391,7 @@ def schema_eda(cfg, tool='default', step='default', index='default'):
 
     name = 'default'
     scparam(cfg, ['eda', tool, 'env', step, index, name],
-            sctype='[str]',
+            sctype='str',
             scope='job',
             shorthelp="Tool environment variables",
             switch="-eda_env 'tool step index name <str>'",

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -817,7 +817,7 @@
                 "default": {
                     "default": {
                         "default": {
-                            "defvalue": [],
+                            "defvalue": null,
                             "example": [
                                 "cli: -eda_env 'openroad cts 0 MYVAR 42'",
                                 "api: chip.set('eda','openroad','env','cts','0','MYVAR','42')"
@@ -827,10 +827,10 @@
                             "require": null,
                             "scope": "job",
                             "shorthelp": "Tool environment variables",
-                            "signature": [],
+                            "signature": null,
                             "switch": "-eda_env 'tool step index name <str>'",
-                            "type": "[str]",
-                            "value": []
+                            "type": "str",
+                            "value": null
                         }
                     }
                 }

--- a/tests/tools/test_surelog.py
+++ b/tests/tools/test_surelog.py
@@ -68,7 +68,7 @@ def test_replay(scroot):
     chip.set('arg', 'step', step)
     chip.set('flow', 'surelog')
     chip.set('quiet', True)
-    chip.set('eda', 'surelog', 'environment', step, '0', 'SLOG_ENV', 'SUCCESS')
+    chip.set('eda', 'surelog', 'env', step, '0', 'SLOG_ENV', 'SUCCESS')
 
     chip.run()
 


### PR DESCRIPTION
This PR fixes tweaks 3 things surrounding replay script generation:
- Fix issue where grouped parameters would become unquoted (i.e. `-param "a b c"` would become `-param a b c` in script, now it stays the same).
- Add code to set environment variables in script
- Add Windows support: .bat instead of .sh, no `#!/bin/bash` header, set env variables appropriately for each platform

I haven't yet tested the Windows support, but I did add a replay test based on Surelog (so that it catches all platforms), and I can kick off a wheel build to try it out.