### PR TITLE
Build offline installation bundles in CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -105,3 +105,35 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_DEPLOY }}
+
+  package_offline:
+    # We want to run this on the official PEP Python-wheel building platform to
+    # ensure the downloaded wheels have the broadest compatibility. Using the
+    # '--platform' tag for 'pip download' doesn't work for us, since it requires
+    # setting --only-binary=:all: and some of our deps aren't available as
+    # wheels on some platforms.
+    container: quay.io/pypa/manylinux2014_x86_64
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: [cp36-cp36m, cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310]
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifact
+        path: dist
+
+    - name: Package SC
+      run: |
+        mkdir scdeps
+        $python -m pip download ./dist/siliconcompiler*${{matrix.python}}*linux*.whl -d scdeps
+        tar -czvf scdeps-${{matrix.python}}.tar.gz scdeps
+      env:
+        python: /opt/python/${{matrix.python}}/bin/python
+
+    - name: Upload package
+      uses: actions/upload-artifact@v2
+      with:
+        path: scdeps*.tar.gz

--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -100,6 +100,17 @@ only supported on Linux/MacOS platforms.
    pip install -r requirements.txt
    python -m pip install -e .
 
+Offline Install (Linux only)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We also provide packages that bundle SC with all of its Python dependencies to enable installation on machines without an external internet connection. They can be found under the "Artifacts" section of any passing nightly or release build on our `builds page <https://github.com/siliconcompiler/siliconcompiler/actions/workflows/wheels.yml>`_. The packages are named ``scdeps-<pyversion>.tar.gz``, depending on which Python version they are associated with.
+
+To install from a bundle, create a Python virtual environment following the instructions above, then perform the following commands.
+
+.. code-block:: bash
+
+   tar -xzvf scdeps-<pyversion>.tar.gz
+   pip install siliconcompiler --no-index --find-links scdeps
 
 Cloud Access
 --------------


### PR DESCRIPTION
This PR adds code to package up SC wheels and their dependencies into a single tarball in CI. This can then be installed like so:

```
tar -xzvf scdeps-<pyversion>.tar.gz
pip install siliconcompiler --no-index --find-links scdeps
```

I've also added these instructions to the docs.