### PR TITLE
Post-schema refactor fixes

### DIFF
--- a/docs/_ext/dynamicgen.py
+++ b/docs/_ext/dynamicgen.py
@@ -19,7 +19,7 @@ import subprocess
 
 from common import *
 
-import siliconcompiler
+from siliconcompiler import utils
 
 #############
 # Helpers
@@ -98,37 +98,6 @@ def build_config_recursive(schema, keypath_prefix=[], sec_key_prefix=[]):
         # schema without leaves.
         return child_sections
 
-def trim(docstring):
-    '''Helper function for cleaning up indentation of docstring.
-
-    This is important for properly parsing complex RST in our docs.
-
-    Source:
-    https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation'''
-    if not docstring:
-        return ''
-    # Convert tabs to spaces (following the normal Python rules)
-    # and split into a list of lines:
-    lines = docstring.expandtabs().splitlines()
-    # Determine minimum indentation (first line doesn't count):
-    indent = sys.maxsize
-    for line in lines[1:]:
-        stripped = line.lstrip()
-        if stripped:
-            indent = min(indent, len(line) - len(stripped))
-    # Remove indentation (first line is special):
-    trimmed = [lines[0].strip()]
-    if indent < sys.maxsize:
-        for line in lines[1:]:
-            trimmed.append(line[indent:].rstrip())
-    # Strip off trailing and leading blank lines:
-    while trimmed and not trimmed[-1]:
-        trimmed.pop()
-    while trimmed and not trimmed[0]:
-        trimmed.pop(0)
-    # Return a single string:
-    return '\n'.join(trimmed)
-
 #############
 # Base class
 #############
@@ -159,7 +128,7 @@ class DynamicGen(SphinxDirective):
         # raw docstrings have funky indentation (basically, each line is already
         # indented as much as the function), so we call trim() helper function
         # to clean it up
-        docstr = trim(make_docs.__doc__)
+        docstr = utils.trim(make_docs.__doc__)
 
         if docstr:
             self.parse_rst(docstr, s)

--- a/docs/_ext/schemagen.py
+++ b/docs/_ext/schemagen.py
@@ -67,8 +67,9 @@ class SchemaGen(SphinxDirective):
 
     def parse_rst(self, content):
         rst = ViewList()
-        # use fake filename 'inline' and fake line number '1' for error reporting
-        rst.append(content, 'inline', 1)
+        # use fake filename 'inline' for error # reporting
+        for i, line in enumerate(content.split('\n')):
+            rst.append(line, 'inline', i)
         body = nodes.paragraph()
         nested_parse_with_titles(self.state, rst, body)
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -978,9 +978,7 @@ class Chip:
                 if cfg[param]['lock'] == "true":
                     self.logger.debug("Ignoring {mode}{} to [{keypath}]. Lock bit is set.")
                 elif (mode == 'set'):
-                    #print(keypath, "**", param, field, val, isinstance(val, list))
-                    #TODO: line below is broken, should check for field
-                    if (selval in empty) | clobber:
+                    if (field != 'value') or (selval in empty) or clobber:
                         if field in ('copy', 'lock'):
                             # boolean fields
                             if val is True:

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1534,7 +1534,7 @@ def schema_arg(cfg):
             Dynamic parameter passed in by the sc runtime as an argument to
             a runtime task. The parameter enables configuration code
             (usually TCL) to use control flow that depend on the current
-            'step'. The parameter is used the run() fucntion and
+            'step'. The parameter is used the run() function and
             is not intended for external use.""")
 
     scparam(cfg, ['arg', 'index'],
@@ -1547,7 +1547,7 @@ def schema_arg(cfg):
             Dynamic parameter passed in by the sc runtime as an argument to
             a runtime task. The parameter enables configuration code
             (usually TCL) to use control flow that depend on the current
-            'index'. The parameter is used the run() fucntion and
+            'index'. The parameter is used the run() function and
             is not intended for external use.""")
 
     return cfg
@@ -1891,7 +1891,7 @@ def schema_record(cfg, step='default', index='default'):
                'toolversion': ['tool version',
                                '1.0',
                                """The tool version captured correspnds to the 'tool'
-                               parameter within the 'eda' dictoinary'."""],
+                               parameter within the 'eda' dictionary."""],
                'osversion': ['O/S version',
                              '20.04.1-Ubuntu',
                              """Since there is not standard version system for operating
@@ -2466,7 +2466,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_name '{keys}yac'",
                 f"api: chip.set({api},'name','yac')"],
-            schelp="""{shelp} name.""")
+            schelp=f"""{shelp} name.""")
 
     scparam(cfg,[*path, 'version'],
             sctype='str',
@@ -2475,7 +2475,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_version '{keys}1.0'",
                 f"api: chip.set({api},'version','1.0')"],
-            schelp="""{shelp} version. Can be a branch, tag, commit hash,
+            schelp=f"""{shelp} version. Can be a branch, tag, commit hash,
             or a semver compatible version.""")
 
     scparam(cfg,[*path, 'description'],
@@ -2485,7 +2485,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_description '{keys}Yet another cpu'",
                 f"api: chip.set({api},'description','Yet another cpu')"],
-            schelp="""{shelp} short one line description for package
+            schelp=f"""{shelp} short one line description for package
             managers and summary reports.""")
 
     scparam(cfg,[*path, 'keyword'],
@@ -2495,7 +2495,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_keyword '{keys}cpu'",
                 f"api: chip.set({api},'keyword','cpu')"],
-            schelp="""{shelp} keyword(s) used to characterize package.""")
+            schelp=f"""{shelp} keyword(s) used to characterize package.""")
 
     scparam(cfg,[*path, 'homepage'],
             sctype='str',
@@ -2504,7 +2504,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_homepage '{keys}index.html'",
                 f"api: chip.set({api},'homepage','index.html')"],
-            schelp="""{shelp} homepage.""")
+            schelp=f"""{shelp} homepage.""")
 
     scparam(cfg,[*path, 'doc', 'homepage'],
             sctype='str',
@@ -2513,7 +2513,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_doc_homepage '{keys}index.html'",
                 f"api: chip.set({api},'doc', 'homepage','index.html')"],
-            schelp="""
+            schelp=f"""
             {shelp} documentation homepage. Filepath to design docs homepage.
             Complex designs can can include a long non standard list of
             documents dependent.  A single html entry point can be used to
@@ -2536,7 +2536,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_doc_{item} '{keys}{item}.pdf'",
                 f"api: chip.set({api},'doc',{item},'{item}.pdf')"],
-            schelp=""" {shelp} list of {item} documents.""")
+            schelp=f""" {shelp} list of {item} documents.""")
 
     scparam(cfg,[*path, 'repo'],
             sctype='[str]',
@@ -2545,7 +2545,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_repo '{keys}git@github.com:aolofsson/oh.git'",
                 f"api: chip.set({api},'repo','git@github.com:aolofsson/oh.git')"],
-            schelp="""{shelp} IP address to source code repository.""")
+            schelp=f"""{shelp} IP address to source code repository.""")
 
 
     scparam(cfg,[*path, 'dependency', name],
@@ -2555,7 +2555,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_dependency '{keys}hell0 1.0'",
                 f"api: chip.set({api},'dependency','hello', '1.0')"],
-            schelp="""{shelp} dependencies specified as a key value pair.
+            schelp=f"""{shelp} dependencies specified as a key value pair.
             Versions shall follow the semver standard.""")
 
     scparam(cfg,[*path, 'target'],
@@ -2565,7 +2565,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_target '{keys}asicflow_freepdk45'",
                 f"api: chip.set({api},'target','asicflow_freepdk45')"],
-            schelp="""{shelp} list of qualified compilation targets.""")
+            schelp=f"""{shelp} list of qualified compilation targets.""")
 
     scparam(cfg,[*path, 'license'],
             sctype='[str]',
@@ -2574,7 +2574,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_license '{keys}Apache-2.0'",
                 f"api: chip.set({api},'license','Apache-2.0')"],
-            schelp="""{shelp} list of SPDX license identifiers.""")
+            schelp=f"""{shelp} list of SPDX license identifiers.""")
 
     scparam(cfg,[*path, 'licensefile'],
             sctype='[file]',
@@ -2583,7 +2583,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_licensefile '{keys}./LICENSE'",
                 f"api: chip.set({api},'licensefile','./LICENSE')"],
-            schelp="""{shelp} list of license files for {group} to be
+            schelp=f"""{shelp} list of license files for {group} to be
             applied in cases when a SPDX identifier is not available.
             (eg. proprietary licenses).list of SPDX license identifiers.""")
 
@@ -2594,7 +2594,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_location '{keys}mars'",
                 f"api: chip.set({api},'location','mars')"],
-            schelp="""{shelp} country of origin specified as standardized
+            schelp=f"""{shelp} country of origin specified as standardized
             international country codes. The field can be left blank
             if the location is unknown or global.""")
 
@@ -2605,7 +2605,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_organization '{keys}humanity'",
                 f"api: chip.set({api},'organization','humanity')"],
-            schelp="""{shelp} sponsoring organization. The field can be left
+            schelp=f"""{shelp} sponsoring organization. The field can be left
             blank if not applicable.""")
 
     scparam(cfg,[*path, 'publickey'],
@@ -2615,7 +2615,7 @@ def schema_package(cfg, group):
             example=[
                 f"cli: -{switch}_publickey '{keys}6EB695706EB69570'",
                 f"api: chip.set({api},'publickey','6EB695706EB69570')"],
-            schelp="""{shelp} public project key.""")
+            schelp=f"""{shelp} public project key.""")
 
     record = ['name',
               'email',
@@ -2633,7 +2633,7 @@ def schema_package(cfg, group):
                 example=[
                     f"cli: -{switch}_author_{item} '{keys}wiley wiley@acme.com'",
                     f"api: chip.set({api},'author','wiley','{item}','wiley@acme.com')"],
-                schelp="""{shelp} author {item} provided with full name as key and
+                schelp=f"""{shelp} author {item} provided with full name as key and
                 {item} as value.""")
 
     return cfg
@@ -2668,7 +2668,7 @@ def schema_checklist(cfg, group='checklist'):
             example=[
                 f"cli: -{emit_group}_description '{emit_switch}ISO D000 A-DESCRIPTION'",
                 f"api: chip.set({emit_api},'ISO','D000','description','A-DESCRIPTION')"],
-            schelp="""
+            schelp=f"""
             A short one line description of the {group} checklist item.""")
 
     scparam(cfg,[*path, standard, item, 'requirement'],
@@ -2678,7 +2678,7 @@ def schema_checklist(cfg, group='checklist'):
             example=[
                 f"cli: -{emit_group}_requirement '{emit_switch}ISO D000 DOCSTRING'",
                 f"api: chip.set({emit_api},'ISO','D000','requirement','DOCSTRING')"],
-            schelp="""
+            schelp=f"""
             A complete requirement description of the {group} checklist item
             entered as a multi-line string.""")
 
@@ -2689,7 +2689,7 @@ def schema_checklist(cfg, group='checklist'):
             example=[
                 f"cli: -{emit_group}_rational '{emit_switch}ISO D000 reliability'",
                 f"api: chip.set({emit_api},'ISO','D000','rationale','reliability')"],
-            schelp="""
+            schelp=f"""
             Rationale for the the {group} checklist item. Rationale should be a
             unique alphanumeric code used by the standard or a short one line
             or single word description.""")
@@ -2701,7 +2701,7 @@ def schema_checklist(cfg, group='checklist'):
             example=[
                 f"cli: -{emit_group}_criteria '{emit_switch}ISO D000 errors==0'",
                 f"api: chip.set({emit_api},'ISO','D000','criteria','errors==0')"],
-            schelp="""
+            schelp=f"""
             Simple list of signoff criteria for {group} checklist item which
             must all be met for signoff. Each signoff criteria consists of
             a metric, a relational operator, and a value in the form.
@@ -2714,7 +2714,7 @@ def schema_checklist(cfg, group='checklist'):
             example=[
                 f"cli: -{emit_group}_step '{emit_switch}ISO D000 place'",
                 f"api: chip.set({emit_api},'ISO','D000','step','place')"],
-            schelp="""
+            schelp=f"""
             Flowgraph step used to verify the {group} checklist item.
             The parameter should be left empty for manual and for tool
             flows that bypass the SC infrastructure.""")
@@ -2727,7 +2727,7 @@ def schema_checklist(cfg, group='checklist'):
             example=[
                 f"cli: -{emit_group}_index '{emit_switch}ISO D000 1'",
                 f"api: chip.set({emit_api},'ISO','D000','index','1')"],
-            schelp="""
+            schelp=f"""
             Flowgraph index used to verify the {group} checklist item.
             The parameter should be left empty for manual checks and
             for tool flows that bypass the SC infrastructure.""")
@@ -2739,7 +2739,7 @@ def schema_checklist(cfg, group='checklist'):
             example=[
                 f"cli: -{emit_group}_report '{emit_switch}ISO D000 bold my.rpt'",
                 f"api: chip.set({emit_api},'ISO','D000','report','hold', 'my.rpt')"],
-            schelp="""
+            schelp=f"""
             Filepath to report(s) of specified type documenting the successful
             validation of the {group} checklist item. Specified on a per
             metric basis.""")
@@ -2751,7 +2751,7 @@ def schema_checklist(cfg, group='checklist'):
             example=[
                 f"cli: -{emit_group}_waiver '{emit_switch}ISO D000 bold my.txt'",
                 f"api: chip.set({emit_api},'ISO','D000','waiver','hold', 'my.txt')"],
-            schelp="""
+            schelp=f"""
             Filepath to report(s) documenting waivers for the {group} checklist
             item specified on a per metric basis.""")
 
@@ -2762,7 +2762,7 @@ def schema_checklist(cfg, group='checklist'):
             example=[
                 f"cli: -{emit_group}_ok '{emit_switch}ISO D000 true'",
                 f"api: chip.set({emit_api},'ISO','D000','ok', True)"],
-            schelp="""
+            schelp=f"""
             Boolean check mark for the {group} checklist item. A value of
             True indicates a human has inspected the all item dictionary
             parameters check out.""")

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1,5 +1,7 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 
+from siliconcompiler import utils
+
 import re
 import os
 import sys
@@ -49,9 +51,8 @@ def scparam(cfg,
                 schelp=schelp)
     else:
 
-        # removing leading newline and space
-        schelp = re.sub(r'\n\s*', " ", schelp)
-        schelp = schelp.strip()
+        # removing leading spaces as if schelp were a docstring
+        schelp = utils.trim(schelp)
 
         # setting valus based on types
         # note (bools are never lists)
@@ -1880,6 +1881,7 @@ def schema_record(cfg, step='default', index='default'):
                'region' : ['cloud region',
                            'US Gov Boston',
                            """Recommended naming methodology:
+
                            * local: node is the local machine
                            * onprem: node in on-premises IT infrastructure
                            * public: generic public cloud
@@ -1903,6 +1905,7 @@ def schema_record(cfg, step='default', index='default'):
     }
 
     for item,val in records.items():
+        helpext = utils.trim(val[2])
         scparam(cfg, ['record', step, index, item],
                 sctype='str',
                 scope='job',
@@ -1911,10 +1914,7 @@ def schema_record(cfg, step='default', index='default'):
                 example=[
                     f"cli: -record_{item} 'dfm 0 <{val[1]}>'",
                     f"api: chip.set('record','dfm','0','{item}', <{val[1]}>)"],
-                schelp=f"""
-                Record tracking the {val[0]} per step and index basis.
-                {val[2]}
-                """)
+                schelp=f'Record tracking the {val[0]} per step and index basis. {helpext}')
 
     return cfg
 

--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 
 def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
     '''Simple implementation of shutil.copytree to give us a dirs_exist_ok
@@ -23,3 +24,34 @@ def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
             os.link(srcfile, dstfile)
         else:
             shutil.copy2(srcfile, dstfile)
+
+def trim(docstring):
+    '''Helper function for cleaning up indentation of docstring.
+
+    This is important for properly parsing complex RST in our docs.
+
+    Source:
+    https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation'''
+    if not docstring:
+        return ''
+    # Convert tabs to spaces (following the normal Python rules)
+    # and split into a list of lines:
+    lines = docstring.expandtabs().splitlines()
+    # Determine minimum indentation (first line doesn't count):
+    indent = sys.maxsize
+    for line in lines[1:]:
+        stripped = line.lstrip()
+        if stripped:
+            indent = min(indent, len(line) - len(stripped))
+    # Remove indentation (first line is special):
+    trimmed = [lines[0].strip()]
+    if indent < sys.maxsize:
+        for line in lines[1:]:
+            trimmed.append(line[indent:].rstrip())
+    # Strip off trailing and leading blank lines:
+    while trimmed and not trimmed[-1]:
+        trimmed.pop()
+    while trimmed and not trimmed[0]:
+        trimmed.pop(0)
+    # Return a single string:
+    return '\n'.join(trimmed)

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -6,7 +6,7 @@
                 "cli: -arg_index 0",
                 "api: chip.set('arg','index','0')"
             ],
-            "help": "Dynamic parameter passed in by the sc runtime as an argument to a runtime task. The parameter enables configuration code (usually TCL) to use control flow that depend on the current 'index'. The parameter is used the run() fucntion and is not intended for external use.",
+            "help": "Dynamic parameter passed in by the sc runtime as an argument to\na runtime task. The parameter enables configuration code\n(usually TCL) to use control flow that depend on the current\n'index'. The parameter is used the run() function and\nis not intended for external use.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -22,7 +22,7 @@
                 "cli: -arg_step 'route'",
                 "api: chip.set('arg', 'step', 'route')"
             ],
-            "help": "Dynamic parameter passed in by the sc runtime as an argument to a runtime task. The parameter enables configuration code (usually TCL) to use control flow that depend on the current 'step'. The parameter is used the run() fucntion and is not intended for external use.",
+            "help": "Dynamic parameter passed in by the sc runtime as an argument to\na runtime task. The parameter enables configuration code\n(usually TCL) to use control flow that depend on the current\n'step'. The parameter is used the run() function and\nis not intended for external use.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -40,7 +40,7 @@
                 "cli: -asic_aspectratio 2.0",
                 "api: chip.set('asic', 'aspectratio', '2.0')"
             ],
-            "help": "Height to width ratio of the block for automated floor-planning. Values below 0.1 and above 10 should be avoided as they will likely fail to converge during placement and routing. The ideal aspect ratio for most designs is 1. This value is only used when no diearea or floorplan is supplied.",
+            "help": "Height to width ratio of the block for automated floor-planning.\nValues below 0.1 and above 10 should be avoided as they will likely fail\nto converge during placement and routing. The ideal aspect ratio for\nmost designs is 1. This value is only used when no diearea or floorplan\nis supplied.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -56,7 +56,7 @@
                 "cli: -asic_corearea '(0,0)'",
                 "api: chip.set('asic', 'corearea', (0,0))"
             ],
-            "help": "List of (x,y) points that define the outline of the core area for the physical design. Simple rectangle areas can be defined with two points, one for the lower left corner and one for the upper right corner. All values are specified in microns.",
+            "help": "List of (x,y) points that define the outline of the core area for the\nphysical design. Simple rectangle areas can be defined with two points,\none for the lower left corner and one for the upper right corner. All\nvalues are specified in microns.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -72,7 +72,7 @@
                 "cli: -asic_coremargin 1",
                 "api: chip.set('asic', 'coremargin', '1')"
             ],
-            "help": "Halo/margin between the die boundary and core placement for automated floorplanning when no diearea or floorplan is supplied. The value is specified in microns.",
+            "help": "Halo/margin between the die boundary and core placement for\nautomated floorplanning when no diearea or floorplan is\nsupplied. The value is specified in microns.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -88,7 +88,7 @@
                 "cli: -asic_delaymodel ccs",
                 "api: chip.set('asic', 'delaymodel', 'ccs')"
             ],
-            "help": "Delay model to use for the target libs. Supported values are nldm and ccs.",
+            "help": "Delay model to use for the target libs. Supported values\nare nldm and ccs.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -104,7 +104,7 @@
                 "cli: -asic_density 30",
                 "api: chip.set('asic', 'density', '30')"
             ],
-            "help": "Target density based on the total design cell area reported after synthesis. This number is used when no diearea or floorplan is supplied. Any number between 1 and 100 is legal, but values above 50 may fail due to area/congestion issues during apr.",
+            "help": "Target density based on the total design cell area reported\nafter synthesis. This number is used when no diearea or floorplan is\nsupplied. Any number between 1 and 100 is legal, but values above 50\nmay fail due to area/congestion issues during apr.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -120,7 +120,7 @@
                 "cli: -asic_diearea '(0,0)'",
                 "api: chip.set('asic', 'diearea', (0,0))"
             ],
-            "help": "List of (x,y) points that define the outline of the die area for the physical design. Simple rectangle areas can be defined with two points, one for the lower left corner and one for the upper right corner. All values are specified in microns.",
+            "help": "List of (x,y) points that define the outline of the die area for the\nphysical design. Simple rectangle areas can be defined with two points,\none for the lower left corner and one for the upper right corner. All\nvalues are specified in microns.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -138,7 +138,7 @@
                         "cli: -asic_exclude drc 0 sram_macro",
                         "api: chip.set('asic','exclude','drc','0','sram_macro')"
                     ],
-                    "help": "List of physical cells to exclude during execution. The process of exclusion is controlled by the flow step and tool setup. The list is commonly used by DRC tools and GDS export tools to direct the tool to exclude GDS information during GDS merge/export.",
+                    "help": "List of physical cells to exclude during execution. The process\nof exclusion is controlled by the flow step and tool setup. The list\nis commonly used by DRC tools and GDS export tools to direct the tool\nto exclude GDS information during GDS merge/export.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -156,7 +156,7 @@
                 "cli: -asic_hpinlayer m4",
                 "api: chip.set('asic', 'hpinlayer', 'm4')"
             ],
-            "help": "Metal layer to use for automated horizontal pin placement during APR.  The metal layers can be specified as technology agnostic SC layers starting with m1 or as hard PDK specific layer names.",
+            "help": "Metal layer to use for automated horizontal pin placement\nduring APR.  The metal layers can be specified as technology\nagnostic SC layers starting with m1 or as hard PDK specific\nlayer names.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -172,7 +172,7 @@
                 "cli: -asic_logiclib nangate45",
                 "api: chip.set('asic', 'logiclib','nangate45')"
             ],
-            "help": "List of all selected logic libraries libraries to use for optimization for a given library architecture (9T, 11T, etc).",
+            "help": "List of all selected logic libraries libraries\nto use for optimization for a given library architecture\n(9T, 11T, etc).",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -188,7 +188,7 @@
                 "cli: -asic_macrolib sram64x1024",
                 "api: chip.set('asic', 'macrolib','sram64x1024')"
             ],
-            "help": "List of macro libraries to be linked in during synthesis and place and route. Macro libraries are used for resolving instances but are not used as targets for logic synthesis.",
+            "help": "List of macro libraries to be linked in during synthesis and place\nand route. Macro libraries are used for resolving instances but are\nnot used as targets for logic synthesis.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -204,7 +204,7 @@
                 "cli: -asic_maxcap '0.25e-12'",
                 "api: chip.set('asic', 'maxcap', '0.25e-12')"
             ],
-            "help": "Maximum allowed capacitance per net. The number is specified in Farads.",
+            "help": "Maximum allowed capacitance per net. The number is\nspecified in Farads.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -220,7 +220,7 @@
                 "cli: -asic_maxfanout 64",
                 "api: chip.set('asic', 'maxfanout', '64')"
             ],
-            "help": "Maximum driver fanout allowed during automated place and route. The parameter directs the APR tool to break up any net with fanout larger than maxfanout into sub nets and buffer.",
+            "help": " Maximum driver fanout allowed during automated place and route.\nThe parameter directs the APR tool to break up any net with fanout\nlarger than maxfanout into sub nets and buffer.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -236,7 +236,7 @@
                 "cli: -asic_maxlayer m2",
                 "api: chip.set('asic', 'maxlayer', 'm2')"
             ],
-            "help": "Maximum SC metal layer name to be used for automated place and route . Alternatively the layer can be a string that matches a layer hard coded in the pdk_aprtech file. Designers wishing to use the same setup across multiple process nodes should use the integer approach. For processes with ambiguous starting routing layers, exact strings should be used.",
+            "help": "Maximum SC metal layer name to be used for automated place and route .\nAlternatively the layer can be a string that matches a layer hard coded\nin the pdk_aprtech file. Designers wishing to use the same setup across\nmultiple process nodes should use the integer approach. For processes\nwith ambiguous starting routing layers, exact strings should be used.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -252,7 +252,7 @@
                 "cli: -asic_maxlength 1000",
                 "api: chip.set('asic', 'maxlength', '1000')"
             ],
-            "help": "Maximum total wire length allowed in design during APR. Any net that is longer than maxlength is broken up into segments by the tool.",
+            "help": "Maximum total wire length allowed in design during APR. Any\nnet that is longer than maxlength is broken up into segments by\nthe tool.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -268,7 +268,7 @@
                 "cli: -asic_maxslew '0.25e-9'",
                 "api: chip.set('asic', 'maxslew', '0.25e-9')"
             ],
-            "help": "Maximum allowed transition time per net. The number is specified in seconds.",
+            "help": "Maximum allowed transition time per net. The number\nis specified in seconds.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -284,7 +284,7 @@
                 "cli: -asic_minlayer m2",
                 "api: chip.set('asic', 'minlayer', 'm2')"
             ],
-            "help": "Minimum SC metal layer name to be used for automated place and route . Alternatively the layer can be a string that matches a layer hard coded in the pdk_aprtech file. Designers wishing to use the same setup across multiple process nodes should use the integer approach. For processes with ambiguous starting routing layers, exact strings should be used.",
+            "help": "Minimum SC metal layer name to be used for automated place and route .\nAlternatively the layer can be a string that matches a layer hard coded\nin the pdk_aprtech file. Designers wishing to use the same setup across\nmultiple process nodes should use the integer approach. For processes\nwith ambiguous starting routing layers, exact strings should be used.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -301,7 +301,7 @@
                     "cli: -asic_ndr_width 'clk (0.2,0.2)",
                     "api: chip.set('asic','ndr','clk', (0.2,0.2))"
                 ],
-                "help": "Definitions of non-default routing rule specified on a per net basis. Constraints are entered as a (width,space) tuples specified in microns.",
+                "help": "Definitions of non-default routing rule specified on a per\nnet basis. Constraints are entered as a (width,space) tuples\nspecified in microns.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -320,7 +320,7 @@
                         "cli: -asic_optlib 'place 0 asap7_lvt'",
                         "api: chip.set('asic','optlib','place','0','asap7_lvt')"
                     ],
-                    "help": "List of logical libraries used during synthesis and place and route specified on a per step and per index basis.",
+                    "help": "List of logical libraries used during synthesis and place and route\nspecified on a per step and per index basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -339,7 +339,7 @@
                     "cli: -asic_rclayer 'clk m3",
                     "api: chip.set('asic', 'rclayer', 'clk', 'm3')"
                 ],
-                "help": "Technology agnostic metal layer to be used for parasitic extraction estimation during APR for the wire type specified Current the supported wire types are: clk, data. The metal layers can be specified as technology agnostic SC layers starting with m1 or as hard PDK specific layer names.",
+                "help": "Technology agnostic metal layer to be used for parasitic\nextraction estimation during APR for the wire type specified\nCurrent the supported wire types are: clk, data. The metal\nlayers can be specified as technology agnostic SC layers\nstarting with m1 or as hard PDK specific layer names.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -356,7 +356,7 @@
                 "cli: -asic_stackup 2MA4MB2MC",
                 "api: chip.set('asic','stackup','2MA4MB2MC')"
             ],
-            "help": "Target stackup to use in the design. The stackup is required parameter for PDKs with multiple metal stackups.",
+            "help": "Target stackup to use in the design. The stackup is required\nparameter for PDKs with multiple metal stackups.",
             "lock": "false",
             "require": "asic",
             "scope": "global",
@@ -372,7 +372,7 @@
                 "cli: -asic_vpinlayer m3",
                 "api: chip.set('asic', 'vpinlayer', 'm3')"
             ],
-            "help": "Metal layer to use for automated vertical pin placement during APR.  The metal layers can be specified as technology agnostic SC layers starting with m1 or as hard PDK specific layer names.",
+            "help": "Metal layer to use for automated vertical pin placement\nduring APR.  The metal layers can be specified as technology\nagnostic SC layers starting with m1 or as hard PDK specific\nlayer names.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -389,7 +389,7 @@
             "cli: -bkpt place",
             "api: chip.set('bkpt','place')"
         ],
-        "help": "List of step stop (break) points. If the step is a TCL based tool, then the breakpoints stops the flow inside the EDA tool. If the step is a command line tool, then the flow drops into a Python interpreter.",
+        "help": "List of step stop (break) points. If the step is a TCL\nbased tool, then the breakpoints stops the flow inside the\nEDA tool. If the step is a command line tool, then the flow\ndrops into a Python interpreter.",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -410,7 +410,7 @@
         ],
         "filehash": [],
         "hashalgo": "sha256",
-        "help": "List of filepaths to JSON formatted schema configuration manifests. The files are read in automatically when using the 'sc' command line application. In Python programs, JSON manifests can be merged into the current working manifest using the read_manifest() method.",
+        "help": "List of filepaths to JSON formatted schema configuration\nmanifests. The files are read in automatically when using the\n'sc' command line application. In Python programs, JSON manifests\ncan be merged into the current working manifest using the\nread_manifest() method.",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -429,7 +429,7 @@
                         "cli: -checklist_criteria 'ISO D000 errors==0'",
                         "api: chip.set('checklist','ISO','D000','criteria','errors==0')"
                     ],
-                    "help": "Simple list of signoff criteria for {group} checklist item which must all be met for signoff. Each signoff criteria consists of a metric, a relational operator, and a value in the form. 'metric op value'.",
+                    "help": "Simple list of signoff criteria for checklist checklist item which\nmust all be met for signoff. Each signoff criteria consists of\na metric, a relational operator, and a value in the form.\n'metric op value'.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -445,7 +445,7 @@
                         "cli: -checklist_description 'ISO D000 A-DESCRIPTION'",
                         "api: chip.set('checklist','ISO','D000','description','A-DESCRIPTION')"
                     ],
-                    "help": "A short one line description of the {group} checklist item.",
+                    "help": "A short one line description of the checklist checklist item.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -461,7 +461,7 @@
                         "cli: -checklist_index 'ISO D000 1'",
                         "api: chip.set('checklist','ISO','D000','index','1')"
                     ],
-                    "help": "Flowgraph index used to verify the {group} checklist item. The parameter should be left empty for manual checks and for tool flows that bypass the SC infrastructure.",
+                    "help": "Flowgraph index used to verify the checklist checklist item.\nThe parameter should be left empty for manual checks and\nfor tool flows that bypass the SC infrastructure.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -477,7 +477,7 @@
                         "cli: -checklist_ok 'ISO D000 true'",
                         "api: chip.set('checklist','ISO','D000','ok', True)"
                     ],
-                    "help": "Boolean check mark for the {group} checklist item. A value of True indicates a human has inspected the all item dictionary parameters check out.",
+                    "help": "Boolean check mark for the checklist checklist item. A value of\nTrue indicates a human has inspected the all item dictionary\nparameters check out.",
                     "lock": "false",
                     "require": "all",
                     "scope": "global",
@@ -493,7 +493,7 @@
                         "cli: -checklist_rational 'ISO D000 reliability'",
                         "api: chip.set('checklist','ISO','D000','rationale','reliability')"
                     ],
-                    "help": "Rationale for the the {group} checklist item. Rationale should be a unique alphanumeric code used by the standard or a short one line or single word description.",
+                    "help": "Rationale for the the checklist checklist item. Rationale should be a\nunique alphanumeric code used by the standard or a short one line\nor single word description.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -515,7 +515,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "Filepath to report(s) of specified type documenting the successful validation of the {group} checklist item. Specified on a per metric basis.",
+                        "help": "Filepath to report(s) of specified type documenting the successful\nvalidation of the checklist checklist item. Specified on a per\nmetric basis.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -532,7 +532,7 @@
                         "cli: -checklist_requirement 'ISO D000 DOCSTRING'",
                         "api: chip.set('checklist','ISO','D000','requirement','DOCSTRING')"
                     ],
-                    "help": "A complete requirement description of the {group} checklist item entered as a multi-line string.",
+                    "help": "A complete requirement description of the checklist checklist item\nentered as a multi-line string.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -548,7 +548,7 @@
                         "cli: -checklist_step 'ISO D000 place'",
                         "api: chip.set('checklist','ISO','D000','step','place')"
                     ],
-                    "help": "Flowgraph step used to verify the {group} checklist item. The parameter should be left empty for manual and for tool flows that bypass the SC infrastructure.",
+                    "help": "Flowgraph step used to verify the checklist checklist item.\nThe parameter should be left empty for manual and for tool\nflows that bypass the SC infrastructure.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -570,7 +570,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "Filepath to report(s) documenting waivers for the {group} checklist item specified on a per metric basis.",
+                        "help": "Filepath to report(s) documenting waivers for the checklist checklist\nitem specified on a per metric basis.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -590,7 +590,7 @@
             "cli: -clean",
             "api: chip.set('clean', True)"
         ],
-        "help": "Clean up all intermediate and non essential files at the end of a task, leaving only the log file and 'report' and 'output' parameters associated with the task tool.",
+        "help": "Clean up all intermediate and non essential files at the end\nof a task, leaving only the log file and 'report' and\n'output' parameters associated with the task tool.",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -663,7 +663,7 @@
         ],
         "filehash": [],
         "hashalgo": "sha256",
-        "help": "Read the specified file, and act as if all text inside it was specified as command line parameters. Supported by most verilog simulators including Icarus and Verilator. The format of the file is not strongly standardized. Support for comments and environment variables within the file varies and depends on the tool used. SC simply passes on the filepath toe the tool executable.",
+        "help": "Read the specified file, and act as if all text inside it was specified\nas command line parameters. Supported by most verilog simulators\nincluding Icarus and Verilator. The format of the file is not strongly\nstandardized. Support for comments and environment variables within\nthe file varies and depends on the tool used. SC simply passes on\nthe filepath toe the tool executable.",
         "lock": "false",
         "require": null,
         "scope": "global",
@@ -684,7 +684,7 @@
         ],
         "filehash": [],
         "hashalgo": "sha256",
-        "help": "List of global constraints for the design to use during compilation. Types of constraints include timing (SDC) and pin mappings files (PCF) for FPGAs. More than one file can be supplied. Timing constraints are global and sourced in all MCMM scenarios.",
+        "help": "List of global constraints for the design to use during compilation.\nTypes of constraints include timing (SDC) and pin mappings files (PCF)\nfor FPGAs. More than one file can be supplied. Timing constraints are\nglobal and sourced in all MCMM scenarios.",
         "lock": "false",
         "require": null,
         "scope": "global",
@@ -700,7 +700,7 @@
             "cli: -copyall",
             "api: chip.set('copyall', 'true')"
         ],
-        "help": "Specifies that all used files should be copied into the build directory, overriding the per schema entry copy settings.",
+        "help": "Specifies that all used files should be copied into the\nbuild directory, overriding the per schema entry copy\nsettings.",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -721,7 +721,7 @@
         ],
         "filehash": [],
         "hashalgo": "sha256",
-        "help": "Filepath to credentials used for remote processing. If the credentials parameter is empty, the remote processing client program tries to access the \".sc/credentials\" file in the user's home directory. The file supports the following fields: userid=<user id> secret_key=<secret key used for authentication> server=<ipaddr or url>",
+        "help": "Filepath to credentials used for remote processing. If the\ncredentials parameter is empty, the remote processing client program\ntries to access the \".sc/credentials\" file in the user's home\ndirectory. The file supports the following fields:\n\nuserid=<user id>\nsecret_key=<secret key used for authentication>\nserver=<ipaddr or url>",
         "lock": "false",
         "require": null,
         "scope": "global",
@@ -753,7 +753,7 @@
             "cli: -design hello_world",
             "api: chip.set('design', 'hello_world')"
         ],
-        "help": "Name of the top level module to compile. Required for all designs with more than one module.",
+        "help": "Name of the top level module to compile.\nRequired for all designs with more than one module.",
         "lock": "false",
         "require": "all",
         "scope": "global",
@@ -769,7 +769,7 @@
             "cli: -dir ./build_the_future",
             "api: chip.set('dir','./build_the_future')"
         ],
-        "help": "The default build directory is in the local './build' where SC was executed. The 'dir' parameters can be used to set an alternate compilation directory path.",
+        "help": "The default build directory is in the local './build' where SC was\nexecuted. The 'dir' parameters can be used to set an alternate\ncompilation directory path.",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -787,7 +787,7 @@
                     "cli: -eda_continue 'verilator true'",
                     "api: chip.set('eda','verilator','continue', true)"
                 ],
-                "help": "Directs tool to continue operating even if errors are encountered.",
+                "help": "Directs tool to continue operating even if errors are\nencountered.",
                 "lock": "false",
                 "require": "all",
                 "scope": "global",
@@ -803,7 +803,7 @@
                     "cli: -eda_copy 'openroad true'",
                     "api: chip.set('eda','openroad','copy',true)"
                 ],
-                "help": "Specifies that the reference script directory should be copied and run from the local run directory.",
+                "help": "Specifies that the reference script directory should be copied and run\nfrom the local run directory.",
                 "lock": "false",
                 "require": "all",
                 "scope": "global",
@@ -822,7 +822,7 @@
                                 "cli: -eda_env 'openroad cts 0 MYVAR 42'",
                                 "api: chip.set('eda','openroad','env','cts','0','MYVAR','42')"
                             ],
-                            "help": "Environment variables to set for individual tasks. Keys and values should be set in accordance with the tool's documentation. Most tools do not require extra environment variables to function.",
+                            "help": "Environment variables to set for individual tasks. Keys and values\nshould be set in accordance with the tool's documentation. Most\ntools do not require extra environment variables to function.",
                             "lock": "false",
                             "require": null,
                             "scope": "job",
@@ -857,7 +857,7 @@
                     "cli: -eda_format 'yosys tcl'",
                     "api: chip.set('eda','yosys','format','tcl')"
                 ],
-                "help": "File format for tool manifest handoff. Supported formats are tcl, yaml, and json.",
+                "help": "File format for tool manifest handoff. Supported formats are tcl,\nyaml, and json.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -880,7 +880,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "List of data files to be copied from previous flowgraph steps 'output' directory. The list of steps to copy files from is defined by the list defined by the dictionary key ['flowgraph', step, index, 'input']. All files must be available for flow to continue. If a file is missing, the program exists on an error.",
+                        "help": "List of data files to be copied from previous flowgraph steps 'output'\ndirectory. The list of steps to copy files from is defined by the\nlist defined by the dictionary key ['flowgraph', step, index, 'input'].\nAll files must be available for flow to continue. If a file\nis missing, the program exists on an error.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -899,7 +899,7 @@
                         "cli: -eda_licenseserver 'atool ACME_LICENSE 1700@server'",
                         "api: chip.set('eda','atool','licenseserver','ACME_LICENSE','1700@server')"
                     ],
-                    "help": "Defines a set of tool specific environment variables used by the executables that depend on license key servers to control access. For multiple servers, separate each server by a 'colon'. The named license variable are read at runtime (run()) and the environment variables are set.",
+                    "help": "Defines a set of tool specific environment variables used by the executables\nthat depend on license key servers to control access. For multiple servers,\nseparate each server by a 'colon'. The named license variable are read at\nruntime (run()) and the environment variables are set.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -918,7 +918,7 @@
                             "cli: -eda_option 'openroad cts 0 -no_init'",
                             "api: chip.set('eda','openroad','option','cts','0','-no_init')"
                         ],
-                        "help": "List of command line options for the tool executable, specified on a per tool and per step basis. Options must not include spaces. For multiple argument options, each option is a separate list element.",
+                        "help": "List of command line options for the tool executable, specified on\na per tool and per step basis. Options must not include spaces.\nFor multiple argument options, each option is a separate list element.",
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -943,7 +943,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "List of data files to be copied from previous flowgraph steps 'output' directory. The list of steps to copy files from is defined by the list defined by the dictionary key ['flowgraph', step, index, 'output']. All files must be available for flow to continue. If a file is missing, the program exists on an error.",
+                        "help": "List of data files to be copied from previous flowgraph steps 'output'\ndirectory. The list of steps to copy files from is defined by the\nlist defined by the dictionary key ['flowgraph', step, index, 'output'].\nAll files must be available for flow to continue. If a file\nis missing, the program exists on an error.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -961,7 +961,7 @@
                     "cli: -eda_path 'openroad /usr/local/bin'",
                     "api:  chip.set('eda','openroad','path','/usr/local/bin')"
                 ],
-                "help": "File system path to tool executable. The path is pre pended to the 'exe' parameter for batch runs and output as an environment variable for interactive setup. The path parameter can be left blank if the 'exe' is already in the environment search path. Tool executable name.",
+                "help": "File system path to tool executable. The path is pre pended to the 'exe'\nparameter for batch runs and output as an environment variable for\ninteractive setup. The path parameter can be left blank if the 'exe'\nis already in the environment search path.\nTool executable name.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -984,7 +984,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "Path to a user supplied script to be executed after all built in tasks (except for data export) have completed.",
+                        "help": "Path to a user supplied script to be executed after all built in\ntasks (except for data export) have completed.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -1009,7 +1009,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "Path to a user supplied script to execute after reading in the design but before the main execution stage of the step. Exact entry point depends on the step and main script being executed. An example of a prescript entry point would be immediately before global placement.",
+                        "help": "Path to a user supplied script to execute after reading in the design\nbut before the main execution stage of the step. Exact entry point\ndepends on the step and main script being executed. An example\nof a prescript entry point would be immediately before global\nplacement.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -1029,7 +1029,7 @@
                             "cli: -eda_refdir 'yosys syn 0 ./myref'",
                             "api:  chip.set('eda','yosys','refdir','syn','0','./myref')"
                         ],
-                        "help": "Path to directories containing reference flow scripts, specified on a per step and index basis.",
+                        "help": "Path to directories containing reference flow scripts, specified\non a per step and index basis.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -1050,7 +1050,7 @@
                                 "cli: -eda_regex 'openroad place 0 error -v ERROR",
                                 "api: chip.set('eda','openroad','regex','place','0','error','-v ERROR')"
                             ],
-                            "help": "A list of piped together grep commands. Each entry represents a set of command line arguments for grep including the regex pattern to match. Starting with the first list entry, each grep output is piped into the following grep command in the list. Supported grep options include, -t, -i, -E, -x, -e. Patterns starting with \"-\" should be directly preceeded by the \"-e\" option. The following example illustrates the concept. UNIX grep: >> grep WARNING place.log | grep -v \"bbox\" > place.warnings siliconcompiler: chip.set('eda','openroad','regex','place',0','warnings',[\"WARNING\",\"-v bbox\"]) Defines a set of tool specific environment variables used by the executables that depend on license key servers to control access. For multiple servers, separate each server by a 'colon'. The named license variable are read at runtime (run()) and the environment variables are set.",
+                            "help": " A list of piped together grep commands. Each entry represents a set\nof command line arguments for grep including the regex pattern to\nmatch. Starting with the first list entry, each grep output is piped\ninto the following grep command in the list. Supported grep options\ninclude, -t, -i, -E, -x, -e. Patterns starting with \"-\" should be\ndirectly preceeded by the \"-e\" option. The following example\nillustrates the concept.\n\nUNIX grep:\n>> grep WARNING place.log | grep -v \"bbox\" > place.warnings\n\nsiliconcompiler:\nchip.set('eda','openroad','regex','place',0','warnings',[\"WARNING\",\"-v bbox\"])\n\nDefines a set of tool specific environment variables used by the executables\nthat depend on license key servers to control access. For multiple servers,\nseparate each server by a 'colon'. The named license variable are read at\nruntime (run()) and the environment variables are set.",
                             "lock": "false",
                             "require": null,
                             "scope": "job",
@@ -1077,7 +1077,7 @@
                             ],
                             "filehash": [],
                             "hashalgo": "sha256",
-                            "help": "List of report files associated with a specific 'metric'. The file path specified is relative to the run directory of the current task.",
+                            "help": "List of report files associated with a specific 'metric'. The file path\nspecified is relative to the run directory of the current task.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -1098,7 +1098,7 @@
                             "cli: -eda_require 'openroad cts 0 design'",
                             "api: chip.set('eda','openroad','require','cts','0','design')"
                         ],
-                        "help": "List of keypaths to required tool parameters. The list is used by check() to verify that all parameters have been set up before step execution begins.",
+                        "help": "List of keypaths to required tool parameters. The list is used\nby check() to verify that all parameters have been set up before\nstep execution begins.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -1123,7 +1123,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "Path to the entry script called by the executable specified on a per tool and per step basis.",
+                        "help": "Path to the entry script called by the executable specified\non a per tool and per step basis.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -1143,7 +1143,7 @@
                             "cli: -eda_threads 'magic drc 0 64'",
                             "api: chip.set('eda','magic','threads','drc','0','64')"
                         ],
-                        "help": "Thread parallelism to use for execution specified on a per tool and per step basis. If not specified, SC queries the operating system and sets the threads based on the maximum thread count supported by the hardware.",
+                        "help": "Thread parallelism to use for execution specified on a per tool and per\nstep basis. If not specified, SC queries the operating system and sets\nthe threads based on the maximum thread count supported by the\nhardware.",
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -1164,7 +1164,7 @@
                                 "cli: -eda_variable 'openroad cts 0 myvar 42'",
                                 "api: chip.set('eda','openroad','variable','cts','0','myvar','42')"
                             ],
-                            "help": "Tool script variables specified as key value pairs. Variable names and value types must match the name and type of tool and reference script consuming the variable.",
+                            "help": "Tool script variables specified as key value pairs. Variable\nnames and value types must match the name and type of tool and reference\nscript consuming the variable.",
                             "lock": "false",
                             "require": null,
                             "scope": "job",
@@ -1183,7 +1183,7 @@
                     "cli: -eda_vendor 'yosys yosys'",
                     "api: chip.set('eda','yosys','vendor','yosys')"
                 ],
-                "help": "Name of the tool vendor. Parameter can be used to set vendor specific technology variables in the PDK and libraries. For open source projects, the project name should be used in place of vendor.",
+                "help": "Name of the tool vendor. Parameter can be used to set vendor\nspecific technology variables in the PDK and libraries. For\nopen source projects, the project name should be used in\nplace of vendor.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -1199,7 +1199,7 @@
                     "cli: -eda_version 'openroad 2.0'",
                     "api:  chip.set('eda','openroad','version','2.0')"
                 ],
-                "help": "List of acceptable versions of the tool executable to be used. During task execution, the the tool is called with the 'vswitch' to check the runtime executable version. When the 'vercheck' is set to True, of the 'version' fails to match the system executable, then the job is halted pre-execution.",
+                "help": "List of acceptable versions of the tool executable to be used.\nDuring task execution, the the tool is called with the 'vswitch'\nto check the runtime executable version. When the 'vercheck'\nis set to True, of the 'version' fails to match the system\nexecutable, then the job is halted pre-execution.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -1215,7 +1215,7 @@
                     "cli: -eda_vswitch 'openroad -version'",
                     "api:  chip.set('eda','openroad','vswitch','-version')"
                 ],
-                "help": "Command line switch to use with executable used to print out the version number. Common switches include -v, -version, --version. Some tools may require extra flags to run in batch mode.",
+                "help": "Command line switch to use with executable used to print out\nthe version number. Common switches include -v, -version,\n--version. Some tools may require extra flags to run in batch mode.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -1231,7 +1231,7 @@
                     "cli: -eda_warningoff 'verilator COMBDLY'",
                     "api: chip.set('eda','verilator','warningoff','COMBDLY')"
                 ],
-                "help": "A list of EDA warnings for which printing should be suppressed. Generally this is done on a per design basis after review has determined that warning can be safely ignored The code for turning off warnings can be found in the specific tool reference manual.",
+                "help": "A list of EDA warnings for which printing should be suppressed.\nGenerally this is done on a per design basis after review has\ndetermined that warning can be safely ignored The code for turning\noff warnings can be found in the specific tool reference manual.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -1250,7 +1250,7 @@
                 "cli: -env 'PDK_HOME /disk/mypdk'",
                 "api: chip.set('env', 'PDK_HOME', '/disk/mypdk')"
             ],
-            "help": "Certain tools and reference flows require global environment variables to be set. These variables can be managed externally or specified through the env variable.",
+            "help": "Certain tools and reference flows require global environment\nvariables to be set. These variables can be managed externally or\nspecified through the env variable.",
             "lock": "false",
             "require": null,
             "scope": "job",
@@ -1267,7 +1267,7 @@
             "cli: -flow asicfow",
             "api: chip.set('flow','asicflow')"
         ],
-        "help": "Sets the flow for the current run. The flow name must match up with an 'flow' in the flowgraph",
+        "help": "Sets the flow for the current run. The flow name\nmust match up with an 'flow' in the flowgraph",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -1284,7 +1284,7 @@
                 "cli: -flowarg 'n 100",
                 "api: chip.set('flowarg','n', 100)"
             ],
-            "help": "Parameter passed in as key/value pair to the flow target referenced in the load_flow() API call. See the target flow for specific guidelines regarding configuration parameters.",
+            "help": "Parameter passed in as key/value pair to the flow target\nreferenced in the load_flow() API call. See the target flow\nfor specific guidelines regarding configuration parameters.",
             "lock": "false",
             "require": null,
             "scope": "job",
@@ -1305,7 +1305,7 @@
                             "cli: -flowgraph_args 'asicflow cts 0 0'",
                             "api:  chip.add('flowgraph','asicflow','cts','0','args','0')"
                         ],
-                        "help": "User specified flowgraph string arguments specified on a per step and per index basis.",
+                        "help": "User specified flowgraph string arguments specified on a per\nstep and per index basis.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -1321,7 +1321,7 @@
                             "cli: -flowgraph_input 'asicflow cts 0 (place,0)'",
                             "api:  chip.set('flowgraph','asicflow','cts','0','input',('place','0'))"
                         ],
-                        "help": "A list of inputs for the current step and index, specified as a (step,index) tuple.",
+                        "help": "A list of inputs for the current step and index, specified as a\n(step,index) tuple.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -1337,7 +1337,7 @@
                             "cli: -flowgraph_timeout 'asicflow cts 0 3600'",
                             "api:  chip.set('flowgraph','asicflow','cts','0','timeout', 3600)"
                         ],
-                        "help": "Timeout value in seconds specified on a per step and per index basis. The flowgraph timeout value is compared against the wall time tracked by the SC runtime to determine if an operation should continue. Timeout values help in situations where 1.) an operation is stuck and may never finish. 2.) the operation progress has saturated and continued execution has a negative return on investment.",
+                        "help": "Timeout value in seconds specified on a per step and per index\nbasis. The flowgraph timeout value is compared against the\nwall time tracked by the SC runtime to determine if an\noperation should continue. Timeout values help in situations\nwhere 1.) an operation is stuck and may never finish. 2.) the\noperation progress has saturated and continued execution has\na negative return on investment.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -1353,7 +1353,7 @@
                             "cli: -flowgraph_tool 'asicflow place openroad'",
                             "api: chip.set('flowgraph','asicflow','place','0','tool','openroad')"
                         ],
-                        "help": "Name of the tool name used for task execution. Builtin tool names associated bound to core API functions include: minimum, maximum, join, verify, mux.",
+                        "help": "Name of the tool name used for task execution. Builtin tool names\nassociated bound to core API functions include: minimum, maximum, join,\nverify, mux.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -1369,7 +1369,7 @@
                             "cli: -flowgraph_valid 'asicflow cts 0 true'",
                             "api:  chip.set('flowgraph','asicflow','cts','0','valid',True)"
                         ],
-                        "help": "Flowgraph valid bit specified on a per step and per index basis. The parameter can be used to control flow execution. If the bit is cleared (0), then the step/index combination is invalid and should not be run.",
+                        "help": "Flowgraph valid bit specified on a per step and per index basis.\nThe parameter can be used to control flow execution. If the bit\nis cleared (0), then the step/index combination is invalid and\nshould not be run.",
                         "lock": "false",
                         "require": "all",
                         "scope": "global",
@@ -1386,7 +1386,7 @@
                                 "cli: -flowgraph_weight 'asicflow cts 0 area_cells 1.0'",
                                 "api:  chip.set('flowgraph','asicflow','cts','0','weight','area_cells',1.0)"
                             ],
-                            "help": "Weights specified on a per step and per metric basis used to give effective \"goodnes\" score for a step by calculating the sum all step real metrics results by the corresponding per step weights.",
+                            "help": "Weights specified on a per step and per metric basis used to give\neffective \"goodnes\" score for a step by calculating the sum all step\nreal metrics results by the corresponding per step weights.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -1426,7 +1426,7 @@
                         "cli: -flowstatus_select 'cts 0 (place,42)'",
                         "api:  chip.set('flowstatus','cts','0','select',('place','42'))"
                     ],
-                    "help": "List of selected inputs for the current step/index specified as (in_step,in_index) tuple.",
+                    "help": "List of selected inputs for the current step/index specified as\n(in_step,in_index) tuple.",
                     "lock": "false",
                     "require": null,
                     "scope": "job",
@@ -1451,7 +1451,7 @@
             ],
             "filehash": [],
             "hashalgo": "sha256",
-            "help": "Architecture definition file for FPGA place and route tool. For the VPR tool, the file is a required XML based description, allowing targeting a large number of virtual and commercial architectures. For most commercial tools, the fpga part name provides enough information to enable compilation and the 'arch' parameter is optional.",
+            "help": "Architecture definition file for FPGA place and route\ntool. For the VPR tool, the file is a required XML based description,\nallowing targeting a large number of virtual and commercial\narchitectures. For most commercial tools, the fpga part name provides\nenough information to enable compilation and the 'arch' parameter is\noptional.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -1467,7 +1467,7 @@
                 "cli: -fpga_board parallella",
                 "api:  chip.set('fpga', 'board', 'parallella')"
             ],
-            "help": "Complete board name used as a device target by the FPGA compilation tool. The board name must be an exact string match to the partname hard coded within the FPGA eda tool. The parameter is optional and can be used in place of a partname and pin constraints for some tools.",
+            "help": "Complete board name used as a device target by the FPGA compilation\ntool. The board name must be an exact string match to the partname\nhard coded within the FPGA eda tool. The parameter is optional and can\nbe used in place of a partname and pin constraints for some tools.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -1483,7 +1483,7 @@
                 "cli: -fpga_flash",
                 "api:  chip.set('fpga', 'flash', True)"
             ],
-            "help": "Specifies that the bitstream should be flashed in the board/device. The default is to load the bitstream into volatile memory (SRAM).",
+            "help": "Specifies that the bitstream should be flashed in the board/device.\nThe default is to load the bitstream into volatile memory (SRAM).",
             "lock": "false",
             "require": "all",
             "scope": "global",
@@ -1499,7 +1499,7 @@
                 "cli: -fpga_partname fpga64k",
                 "api:  chip.set('fpga', 'partname', 'fpga64k')"
             ],
-            "help": "Complete part name used as a device target by the FPGA compilation tool. The part name must be an exact string match to the partname hard coded within the FPGA eda tool.",
+            "help": "Complete part name used as a device target by the FPGA compilation\ntool. The part name must be an exact string match to the partname\nhard coded within the FPGA eda tool.",
             "lock": "false",
             "require": "fpga",
             "scope": "global",
@@ -1531,7 +1531,7 @@
                 "cli: -fpga_vendor acme",
                 "api:  chip.set('fpga', 'vendor', 'acme')"
             ],
-            "help": "Name of the FPGA vendor. The parameter is used to check part name and to select the eda tool flow in case 'edaflow' is unspecified.",
+            "help": "Name of the FPGA vendor. The parameter is used to check part\nname and to select the eda tool flow in case 'edaflow' is\nunspecified.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -1548,7 +1548,7 @@
             "cli: -frontend systemverilog",
             "api: chip.set('frontend', 'systemverilog')"
         ],
-        "help": "Specifies the frontend that flows should use for importing and processing source files. Default option is 'verilog', also supports 'systemverilog' and 'chisel'. When using the Python API, this parameter must be configured before calling load_target().",
+        "help": "Specifies the frontend that flows should use for importing and\nprocessing source files. Default option is 'verilog', also supports\n'systemverilog' and 'chisel'. When using the Python API, this parameter\nmust be configured before calling load_target().",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -1564,7 +1564,7 @@
             "cli: -hash",
             "api: chip.set('hash', True)"
         ],
-        "help": "Enables hashing of all inputs and outputs during compilation. The hash values are stored in the hashvalue field of the individual parameters.",
+        "help": "Enables hashing of all inputs and outputs during\ncompilation. The hash values are stored in the hashvalue\nfield of the individual parameters.",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -1580,7 +1580,7 @@
             "cli: '+incdir+./mylib'",
             "api: chip.set('idir','./mylib')"
         ],
-        "help": "Search paths to look for files included in the design using the ```include`` statement.",
+        "help": "Search paths to look for files included in the design using\nthe ```include`` statement.",
         "lock": "false",
         "require": null,
         "scope": "global",
@@ -1599,7 +1599,7 @@
             "cli: -indexlist 0",
             "api: chip.set('indexlist','0')"
         ],
-        "help": "List of indices to execute. The default is to execute all indices for each step of a run.",
+        "help": "List of indices to execute. The default is to execute all\nindices for each step of a run.",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -1615,7 +1615,7 @@
             "cli: -jobincr",
             "api: chip.set('jobincr', True)"
         ],
-        "help": "Forces an auto-update of the jobname parameter if a directory matching the jobname is found in the build directory. If the jobname does not include a trailing digit, then a the number '1' is added to the jobname before updating the jobname parameter.",
+        "help": "Forces an auto-update of the jobname parameter if a directory\nmatching the jobname is found in the build directory. If the\njobname does not include a trailing digit, then a the number\n'1' is added to the jobname before updating the jobname\nparameter.",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -1634,7 +1634,7 @@
                         "cli: -jobinput 'job1 cts 0 job0'",
                         "api:  chip.set('jobinput', 'job1', 'cts, '0', 'job0')"
                     ],
-                    "help": "Specifies jobname inputs for the current run() on a per step and per index basis. During execution, the default behavior is to copy inputs from the current job.",
+                    "help": "Specifies jobname inputs for the current run() on a per step\nand per index basis. During execution, the default behavior is to\ncopy inputs from the current job.",
                     "lock": "false",
                     "require": null,
                     "scope": "job",
@@ -1653,7 +1653,7 @@
             "cli: -jobname may1",
             "api: chip.set('jobname','may1')"
         ],
-        "help": "Jobname during invocation of run(). The jobname combined with a defined director structure (<dir>/<design>/<jobname>/<step>/<index>) enables multiple levels of transparent job, step, and index introspection.",
+        "help": "Jobname during invocation of run(). The jobname combined with a\ndefined director structure (<dir>/<design>/<jobname>/<step>/<index>)\nenables multiple levels of transparent job, step, and index\nintrospection.",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -1669,7 +1669,7 @@
             "cli: -jobscheduler slurm",
             "api: chip.set('jobscheduler','slurm')"
         ],
-        "help": "Sets the type of job scheduler to be used for each individual flowgraph steps. If the parameter is undefined, the steps are executed on the same machine that the SC was launched on. If 'slurm' is used, the host running the 'sc' command must be running a 'slurmctld' daemon managing a Slurm cluster. Additionally, the build directory ('-dir') must be located in shared storage which can be accessed by all hosts in the cluster.",
+        "help": "Sets the type of job scheduler to be used for each individual\nflowgraph steps. If the parameter is undefined, the steps are executed\non the same machine that the SC was launched on. If 'slurm' is used,\nthe host running the 'sc' command must be running a 'slurmctld' daemon\nmanaging a Slurm cluster. Additionally, the build directory ('-dir')\nmust be located in shared storage which can be accessed by all hosts\nin the cluster.",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -1685,7 +1685,7 @@
             "cli: +libext+sv",
             "api: chip.set('libext','sv')"
         ],
-        "help": "List of file extensions that should be used for finding modules. For example, if -y is specified as ./lib\", and '.v' is specified as libext then the files ./lib/\\*.v \", will be searched for module matches.",
+        "help": "List of file extensions that should be used for finding modules.\nFor example, if -y is specified as ./lib\", and '.v' is specified as\nlibext then the files ./lib/\\*.v \", will be searched for\nmodule matches.",
         "lock": "false",
         "require": null,
         "scope": "global",
@@ -1710,7 +1710,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "Filepaths to AOCV models. Timing files are specified per lib, corner, and filetype basis. Acceptable file formats include 'lib', 'lib.gz', and 'ldb'.",
+                        "help": "Filepaths to AOCV models. Timing files are specified\nper lib, corner, and filetype basis. Acceptable file formats\ninclude 'lib', 'lib.gz', and 'ldb'.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -1728,7 +1728,7 @@
                     "cli: -library_arch 'mylib 12t'",
                     "api: chip.set('library','mylib','arch,'12t')"
                 ],
-                "help": "Specifier string that identifies the row height or performance class of a standard cell library for APR. The arch must match up with the name used in the pdk_aprtech dictionary. Mixing of library archs in a flat place and route block is not allowed. Examples of library archs include 6 track libraries, 9 track libraries, 10 track libraries, etc. The parameter is optional for 'component' libtypes.",
+                "help": "Specifier string that identifies the row height or performance\nclass of a standard cell library for APR. The arch must match up with\nthe name used in the pdk_aprtech dictionary. Mixing of library archs\nin a flat place and route block is not allowed. Examples of library\narchs include 6 track libraries, 9 track libraries, 10 track\nlibraries, etc. The parameter is optional for 'component'\nlibtypes.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -1751,7 +1751,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "Filepaths to CCS models. Timing files are specified per lib, corner, and filetype basis. Acceptable file formats include 'lib', 'lib.gz', and 'ldb'.",
+                        "help": "Filepaths to CCS models. Timing files are specified\nper lib, corner, and filetype basis. Acceptable file formats\ninclude 'lib', 'lib.gz', and 'ldb'.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -1770,7 +1770,7 @@
                         "cli: -library_cells_antenna 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',antenna,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1786,7 +1786,7 @@
                         "cli: -library_cells_buf 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',buf,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1802,7 +1802,7 @@
                         "cli: -library_cells_clkbuf 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',clkbuf,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1818,7 +1818,7 @@
                         "cli: -library_cells_clkgate 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',clkgate,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1834,7 +1834,7 @@
                         "cli: -library_cells_clkinv 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',clkinv,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1850,7 +1850,7 @@
                         "cli: -library_cells_clklogic 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',clklogic,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1866,7 +1866,7 @@
                         "cli: -library_cells_driver 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',driver,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1882,7 +1882,7 @@
                         "cli: -library_cells_endcap 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',endcap,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1898,7 +1898,7 @@
                         "cli: -library_cells_filler 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',filler,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1914,7 +1914,7 @@
                         "cli: -library_cells_hold 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',hold,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1930,7 +1930,7 @@
                         "cli: -library_cells_ignore 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',ignore,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1946,7 +1946,7 @@
                         "cli: -library_cells_load 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',load,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1962,7 +1962,7 @@
                         "cli: -library_cells_tap 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',tap,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1978,7 +1978,7 @@
                         "cli: -library_cells_tie 'mylib *eco*'",
                         "api: chip.set('library','mylib','cells',tie,'*eco*')"
                     ],
-                    "help": "List of cells grouped by a property that can be accessed directly by the designer and tools. The example below shows how all cells containing the string 'eco' could be marked as dont use for the tool.",
+                    "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -1998,7 +1998,7 @@
                                 "cli: -library_checklist_criteria 'lib ISO D000 errors==0'",
                                 "api: chip.set('library','default','checklist','ISO','D000','criteria','errors==0')"
                             ],
-                            "help": "Simple list of signoff criteria for {group} checklist item which must all be met for signoff. Each signoff criteria consists of a metric, a relational operator, and a value in the form. 'metric op value'.",
+                            "help": "Simple list of signoff criteria for library checklist item which\nmust all be met for signoff. Each signoff criteria consists of\na metric, a relational operator, and a value in the form.\n'metric op value'.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2014,7 +2014,7 @@
                                 "cli: -library_checklist_description 'lib ISO D000 A-DESCRIPTION'",
                                 "api: chip.set('library','default','checklist','ISO','D000','description','A-DESCRIPTION')"
                             ],
-                            "help": "A short one line description of the {group} checklist item.",
+                            "help": "A short one line description of the library checklist item.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2030,7 +2030,7 @@
                                 "cli: -library_checklist_index 'lib ISO D000 1'",
                                 "api: chip.set('library','default','checklist','ISO','D000','index','1')"
                             ],
-                            "help": "Flowgraph index used to verify the {group} checklist item. The parameter should be left empty for manual checks and for tool flows that bypass the SC infrastructure.",
+                            "help": "Flowgraph index used to verify the library checklist item.\nThe parameter should be left empty for manual checks and\nfor tool flows that bypass the SC infrastructure.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2046,7 +2046,7 @@
                                 "cli: -library_checklist_ok 'lib ISO D000 true'",
                                 "api: chip.set('library','default','checklist','ISO','D000','ok', True)"
                             ],
-                            "help": "Boolean check mark for the {group} checklist item. A value of True indicates a human has inspected the all item dictionary parameters check out.",
+                            "help": "Boolean check mark for the library checklist item. A value of\nTrue indicates a human has inspected the all item dictionary\nparameters check out.",
                             "lock": "false",
                             "require": "all",
                             "scope": "global",
@@ -2062,7 +2062,7 @@
                                 "cli: -library_checklist_rational 'lib ISO D000 reliability'",
                                 "api: chip.set('library','default','checklist','ISO','D000','rationale','reliability')"
                             ],
-                            "help": "Rationale for the the {group} checklist item. Rationale should be a unique alphanumeric code used by the standard or a short one line or single word description.",
+                            "help": "Rationale for the the library checklist item. Rationale should be a\nunique alphanumeric code used by the standard or a short one line\nor single word description.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2084,7 +2084,7 @@
                                 ],
                                 "filehash": [],
                                 "hashalgo": "sha256",
-                                "help": "Filepath to report(s) of specified type documenting the successful validation of the {group} checklist item. Specified on a per metric basis.",
+                                "help": "Filepath to report(s) of specified type documenting the successful\nvalidation of the library checklist item. Specified on a per\nmetric basis.",
                                 "lock": "false",
                                 "require": null,
                                 "scope": "global",
@@ -2101,7 +2101,7 @@
                                 "cli: -library_checklist_requirement 'lib ISO D000 DOCSTRING'",
                                 "api: chip.set('library','default','checklist','ISO','D000','requirement','DOCSTRING')"
                             ],
-                            "help": "A complete requirement description of the {group} checklist item entered as a multi-line string.",
+                            "help": "A complete requirement description of the library checklist item\nentered as a multi-line string.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2117,7 +2117,7 @@
                                 "cli: -library_checklist_step 'lib ISO D000 place'",
                                 "api: chip.set('library','default','checklist','ISO','D000','step','place')"
                             ],
-                            "help": "Flowgraph step used to verify the {group} checklist item. The parameter should be left empty for manual and for tool flows that bypass the SC infrastructure.",
+                            "help": "Flowgraph step used to verify the library checklist item.\nThe parameter should be left empty for manual and for tool\nflows that bypass the SC infrastructure.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2139,7 +2139,7 @@
                                 ],
                                 "filehash": [],
                                 "hashalgo": "sha256",
-                                "help": "Filepath to report(s) documenting waivers for the {group} checklist item specified on a per metric basis.",
+                                "help": "Filepath to report(s) documenting waivers for the library checklist\nitem specified on a per metric basis.",
                                 "lock": "false",
                                 "require": null,
                                 "scope": "global",
@@ -2165,7 +2165,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "List of library DEF layout files specified on a per stackup basis.",
+                    "help": "List of library DEF layout files specified on a\nper stackup basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -2188,7 +2188,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "List of library source files specified on a per design basis. File type is inferred from the file suffix. The parameter is required or 'soft' library types and optional for 'hard' and 'stdcell' library types. (\\*.v, \\*.vh) = Verilog (\\*.vhd)      = VHDL (\\*.sv)       = SystemVerilog (\\*.c)        = C (\\*.cpp, .cc) = C++ (\\*.py)       = Python",
+                    "help": "List of library source files specified on a per design basis. File type\nis inferred from the file suffix. The parameter is required or\n'soft' library types and optional for 'hard' and 'stdcell'\nlibrary types.\n(\\*.v, \\*.vh) = Verilog\n(\\*.vhd)      = VHDL\n(\\*.sv)       = SystemVerilog\n(\\*.c)        = C\n(\\*.cpp, .cc) = C++\n(\\*.py)       = Python",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -2225,7 +2225,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "A list of all library testbench sources. The files are read in order from first to last entered. File type is inferred from the file suffix: (\\*.v, \\*.vh) = Verilog (\\*.vhd)      = VHDL (\\*.sv)       = SystemVerilog (\\*.c)        = C (\\*.cpp, .cc) = C++ (\\*.py)       = Python",
+                    "help": "A list of all library testbench sources. The files are read in order\nfrom first to last entered. File type is inferred from the file suffix:\n(\\*.v, \\*.vh) = Verilog\n(\\*.vhd)      = VHDL\n(\\*.sv)       = SystemVerilog\n(\\*.c)        = C\n(\\*.cpp, .cc) = C++\n(\\*.py)       = Python",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -2262,7 +2262,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "Library waveform(s) used as a golden test vectors to ensure that compilation transformations do not modify the functional behavior of the source code. The waveform file must be compatible with the testbench and compilation flow tools. The wavefor is supplied on a per design basis.",
+                    "help": "Library waveform(s) used as a golden test vectors to ensure that\ncompilation transformations do not modify the functional behavior of\nthe source code. The waveform file must be compatible with the\ntestbench and compilation flow tools. The wavefor is supplied\non a per design basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -2279,7 +2279,7 @@
                     "cli: -library_design 'mylib mytop'",
                     "api: chip.set('library','mylib','design','mytop')"
                 ],
-                "help": "List of complete design functions within the library that can be instantiated directly by the caller.",
+                "help": "List of complete design functions within the library that can\nbe instantiated directly by the caller.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -2298,7 +2298,7 @@
                                 "cli: -library_dir 'lib atool db 10M ~/libdb'",
                                 "api: chip.set('library','lib','dir','atool','db',10M,'~/libdb')"
                             ],
-                            "help": "List of named dirs specified on a per tool and per stackup basis. The parameter should only be used for specifying dirs that are not directly supported by the Library schema.",
+                            "help": "List of named dirs specified on a per tool and per stackup basis.\nThe parameter should only be used for specifying dirs that are\nnot directly supported by the Library schema.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2325,7 +2325,7 @@
                             ],
                             "filehash": [],
                             "hashalgo": "sha256",
-                            "help": "List of named files specified on a per tool and per stackup basis. The parameter should only be used for specifying files that are not directly supported by the Library schema.",
+                            "help": "List of named files specified on a per tool and per stackup basis.\nThe parameter should only be used for specifying files that are\nnot directly supported by the Library schema.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2350,7 +2350,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "List of library GDS layout files specified on a per stackup basis.",
+                    "help": "List of library GDS layout files specified on a\nper stackup basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -2373,7 +2373,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "List of library GERBER layout files specified on a per stackup basis.",
+                    "help": "List of library GERBER layout files specified on a\nper stackup basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -2396,7 +2396,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "List of library LEF layout files specified on a per stackup basis.",
+                    "help": "List of library LEF layout files specified on a\nper stackup basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -2592,7 +2592,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "Filepaths to NLDM models. Timing files are specified per lib, corner, and filetype basis. Acceptable file formats include 'lib', 'lib.gz', and 'ldb'.",
+                        "help": "Filepaths to NLDM models. Timing files are specified\nper lib, corner, and filetype basis. Acceptable file formats\ninclude 'lib', 'lib.gz', and 'ldb'.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -2613,7 +2613,7 @@
                                 "cli: -library_package_author_email 'lib wiley wiley@acme.com'",
                                 "api: chip.set('library', 'lib', 'package','author','wiley','email','wiley@acme.com')"
                             ],
-                            "help": "{shelp} author {item} provided with full name as key and {item} as value.",
+                            "help": "Library package author email provided with full name as key and\nemail as value.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2629,7 +2629,7 @@
                                 "cli: -library_package_author_location 'lib wiley wiley@acme.com'",
                                 "api: chip.set('library', 'lib', 'package','author','wiley','location','wiley@acme.com')"
                             ],
-                            "help": "{shelp} author {item} provided with full name as key and {item} as value.",
+                            "help": "Library package author location provided with full name as key and\nlocation as value.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2645,7 +2645,7 @@
                                 "cli: -library_package_author_name 'lib wiley wiley@acme.com'",
                                 "api: chip.set('library', 'lib', 'package','author','wiley','name','wiley@acme.com')"
                             ],
-                            "help": "{shelp} author {item} provided with full name as key and {item} as value.",
+                            "help": "Library package author name provided with full name as key and\nname as value.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2661,7 +2661,7 @@
                                 "cli: -library_package_author_organization 'lib wiley wiley@acme.com'",
                                 "api: chip.set('library', 'lib', 'package','author','wiley','organization','wiley@acme.com')"
                             ],
-                            "help": "{shelp} author {item} provided with full name as key and {item} as value.",
+                            "help": "Library package author organization provided with full name as key and\norganization as value.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2677,7 +2677,7 @@
                                 "cli: -library_package_author_publickey 'lib wiley wiley@acme.com'",
                                 "api: chip.set('library', 'lib', 'package','author','wiley','publickey','wiley@acme.com')"
                             ],
-                            "help": "{shelp} author {item} provided with full name as key and {item} as value.",
+                            "help": "Library package author publickey provided with full name as key and\npublickey as value.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2693,7 +2693,7 @@
                                 "cli: -library_package_author_username 'lib wiley wiley@acme.com'",
                                 "api: chip.set('library', 'lib', 'package','author','wiley','username','wiley@acme.com')"
                             ],
-                            "help": "{shelp} author {item} provided with full name as key and {item} as value.",
+                            "help": "Library package author username provided with full name as key and\nusername as value.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -2712,7 +2712,7 @@
                             "cli: -library_package_dependency 'lib hell0 1.0'",
                             "api: chip.set('library', 'lib', 'package','dependency','hello', '1.0')"
                         ],
-                        "help": "{shelp} dependencies specified as a key value pair. Versions shall follow the semver standard.",
+                        "help": "Library package dependencies specified as a key value pair.\nVersions shall follow the semver standard.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -2729,7 +2729,7 @@
                         "cli: -library_package_description 'lib Yet another cpu'",
                         "api: chip.set('library', 'lib', 'package','description','Yet another cpu')"
                     ],
-                    "help": "{shelp} short one line description for package managers and summary reports.",
+                    "help": "Library package short one line description for package\nmanagers and summary reports.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -2751,7 +2751,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "{shelp} list of {item} documents.",
+                        "help": "Library package list of datasheet documents.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -2767,7 +2767,7 @@
                             "cli: -library_package_doc_homepage 'lib index.html'",
                             "api: chip.set('library', 'lib', 'package','doc', 'homepage','index.html')"
                         ],
-                        "help": "{shelp} documentation homepage. Filepath to design docs homepage. Complex designs can can include a long non standard list of documents dependent.  A single html entry point can be used to present an organized documentation dashboard to the designer.",
+                        "help": "Library package documentation homepage. Filepath to design docs homepage.\nComplex designs can can include a long non standard list of\ndocuments dependent.  A single html entry point can be used to\npresent an organized documentation dashboard to the designer.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -2788,7 +2788,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "{shelp} list of {item} documents.",
+                        "help": "Library package list of quickstart documents.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -2809,7 +2809,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "{shelp} list of {item} documents.",
+                        "help": "Library package list of reference documents.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -2830,7 +2830,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "{shelp} list of {item} documents.",
+                        "help": "Library package list of releasenotes documents.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -2851,7 +2851,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "{shelp} list of {item} documents.",
+                        "help": "Library package list of signoff documents.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -2872,7 +2872,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "{shelp} list of {item} documents.",
+                        "help": "Library package list of testplan documents.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -2893,7 +2893,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "{shelp} list of {item} documents.",
+                        "help": "Library package list of tutorial documents.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -2914,7 +2914,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "{shelp} list of {item} documents.",
+                        "help": "Library package list of userguide documents.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -2931,7 +2931,7 @@
                         "cli: -library_package_homepage 'lib index.html'",
                         "api: chip.set('library', 'lib', 'package','homepage','index.html')"
                     ],
-                    "help": "{shelp} homepage.",
+                    "help": "Library package homepage.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -2947,7 +2947,7 @@
                         "cli: -library_package_keyword 'lib cpu'",
                         "api: chip.set('library', 'lib', 'package','keyword','cpu')"
                     ],
-                    "help": "{shelp} keyword(s) used to characterize package.",
+                    "help": "Library package keyword(s) used to characterize package.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -2963,7 +2963,7 @@
                         "cli: -library_package_license 'lib Apache-2.0'",
                         "api: chip.set('library', 'lib', 'package','license','Apache-2.0')"
                     ],
-                    "help": "{shelp} list of SPDX license identifiers.",
+                    "help": "Library package list of SPDX license identifiers.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -2984,7 +2984,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "{shelp} list of license files for {group} to be applied in cases when a SPDX identifier is not available. (eg. proprietary licenses).list of SPDX license identifiers.",
+                    "help": "Library package list of license files for library to be\napplied in cases when a SPDX identifier is not available.\n(eg. proprietary licenses).list of SPDX license identifiers.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -3000,7 +3000,7 @@
                         "cli: -library_package_location 'lib mars'",
                         "api: chip.set('library', 'lib', 'package','location','mars')"
                     ],
-                    "help": "{shelp} country of origin specified as standardized international country codes. The field can be left blank if the location is unknown or global.",
+                    "help": "Library package country of origin specified as standardized\ninternational country codes. The field can be left blank\nif the location is unknown or global.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -3016,7 +3016,7 @@
                         "cli: -library_package_name 'lib yac'",
                         "api: chip.set('library', 'lib', 'package','name','yac')"
                     ],
-                    "help": "{shelp} name.",
+                    "help": "Library package name.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -3032,7 +3032,7 @@
                         "cli: -library_package_organization 'lib humanity'",
                         "api: chip.set('library', 'lib', 'package','organization','humanity')"
                     ],
-                    "help": "{shelp} sponsoring organization. The field can be left blank if not applicable.",
+                    "help": "Library package sponsoring organization. The field can be left\nblank if not applicable.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -3048,7 +3048,7 @@
                         "cli: -library_package_publickey 'lib 6EB695706EB69570'",
                         "api: chip.set('library', 'lib', 'package','publickey','6EB695706EB69570')"
                     ],
-                    "help": "{shelp} public project key.",
+                    "help": "Library package public project key.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -3064,7 +3064,7 @@
                         "cli: -library_package_repo 'lib git@github.com:aolofsson/oh.git'",
                         "api: chip.set('library', 'lib', 'package','repo','git@github.com:aolofsson/oh.git')"
                     ],
-                    "help": "{shelp} IP address to source code repository.",
+                    "help": "Library package IP address to source code repository.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -3080,7 +3080,7 @@
                         "cli: -library_package_target 'lib asicflow_freepdk45'",
                         "api: chip.set('library', 'lib', 'package','target','asicflow_freepdk45')"
                     ],
-                    "help": "{shelp} list of qualified compilation targets.",
+                    "help": "Library package list of qualified compilation targets.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -3096,7 +3096,7 @@
                         "cli: -library_package_version 'lib 1.0'",
                         "api: chip.set('library', 'lib', 'package','version','1.0')"
                     ],
-                    "help": "{shelp} version. Can be a branch, tag, commit hash, or a semver compatible version.",
+                    "help": "Library package version. Can be a branch, tag, commit hash,\nor a semver compatible version.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -3113,7 +3113,7 @@
                     "cli: -library_pdk 'mylib freepdk45",
                     "api:  chip.set('library', 'mylib', 'pdk', 'freepdk45')"
                 ],
-                "help": "List of PDK modules supported by the library. The parameter is required for technology hardened ASIC libraries.",
+                "help": "List of PDK modules supported by the library. The\nparameter is required for technology hardened ASIC libraries.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -3129,7 +3129,7 @@
                     "cli: -library_pgmetal 'mylib m1'",
                     "api: chip.set('library','mylib','pgmetal','m1')"
                 ],
-                "help": "Top metal layer used for power and ground routing within the library. The parameter can be used to guide cell power grid hookup by APR tools.",
+                "help": "Top metal layer used for power and ground routing within the\nlibrary. The parameter can be used to guide cell power grid\nhookup by APR tools.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -3152,7 +3152,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "Filepaths to SCM models. Timing files are specified per lib, corner, and filetype basis. Acceptable file formats include 'lib', 'lib.gz', and 'ldb'.",
+                        "help": "Filepaths to SCM models. Timing files are specified\nper lib, corner, and filetype basis. Acceptable file formats\ninclude 'lib', 'lib.gz', and 'ldb'.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -3172,7 +3172,7 @@
                             "cli: -library_site_size 'mylib core (1.0,1.0)'",
                             "api: chip.set('library','mylib','site','core','size',(1.0,1.0))"
                         ],
-                        "help": "Size of the library size described as a (width, height) tuple in microns.",
+                        "help": "Size of the library size described as a (width, height) tuple in\nmicrons.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -3188,7 +3188,7 @@
                             "cli: -library_site_symmetry 'mylib core X Y'",
                             "api: chip.set('library','mylib','site','core','symmetry','X Y')"
                         ],
-                        "help": "Site flip-symmetry based on LEF standard definition. 'X' implies symmetric about the x axis, 'Y' implies symmetry about the y axis, and 'X Y' implies symmetry about the x and y axis.",
+                        "help": " Site flip-symmetry based on LEF standard definition. 'X' implies\nsymmetric about the x axis, 'Y' implies symmetry about the y axis, and\n'X Y' implies symmetry about the x and y axis.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -3206,7 +3206,7 @@
                     "cli: -library_tag 'mylib virtual'",
                     "api: chip.set('library','mylib','tag','virtual')"
                 ],
-                "help": "Marks a library with a set of tags that can be used by the designer and EDA tools for optimization purposes. The tags are meant to cover features not currently supported by built in EDA optimization flows, but which can be queried through EDA tool TCL commands and lists. The example below demonstrates tagging the whole library as virtual.",
+                "help": "Marks a library with a set of tags that can be used by the designer\nand EDA tools for optimization purposes. The tags are meant to cover\nfeatures not currently supported by built in EDA optimization flows,\nbut which can be queried through EDA tool TCL commands and lists.\nThe example below demonstrates tagging the whole library as\nvirtual.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -3228,7 +3228,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "Filepaths specifying mappings from tool-specific generic cells to library cells.",
+                    "help": "Filepaths specifying mappings from tool-specific generic cells to\nlibrary cells.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -3245,7 +3245,7 @@
                     "cli: -library_type 'mylib logiclib'",
                     "api: chip.set('library','mylib','type','logiclib')"
                 ],
-                "help": "Type of the library being configured. A 'logiclib' type is reserved for fixed height cell libraries. A 'soft' type indicates a library that is provided as target agnostic source code, and a 'hard' type indicates a non-logiclib target specificlibrary.",
+                "help": "Type of the library being configured. A 'logiclib' type is reserved\nfor fixed height cell libraries. A 'soft' type indicates a library\nthat is provided as target agnostic source code, and a 'hard'\ntype indicates a non-logiclib target specificlibrary.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -3263,7 +3263,7 @@
             "cli: -loglevel INFO",
             "api: chip.set('loglevel', 'INFO')"
         ],
-        "help": "Provides explicit control over the level of debug logging printed. Valid entries include INFO, DEBUG, WARNING, ERROR.",
+        "help": "Provides explicit control over the level of debug logging printed.\nValid entries include INFO, DEBUG, WARNING, ERROR.",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -3281,7 +3281,7 @@
                     "cli: -mcmm_check 'worst check setup'",
                     "api: chip.add('mcmm','worst','check','setup')"
                 ],
-                "help": "List of checks for to perform for the scenario. The checks must align with the capabilities of the EDA tools and flow being used. Checks generally include objectives like meeting setup and hold goals and minimize power. Standard check names include setup, hold, power, noise, reliability.",
+                "help": "List of checks for to perform for the scenario. The checks must\nalign with the capabilities of the EDA tools and flow being used.\nChecks generally include objectives like meeting setup and hold goals\nand minimize power. Standard check names include setup, hold, power,\nnoise, reliability.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -3302,7 +3302,7 @@
                 ],
                 "filehash": [],
                 "hashalgo": "sha256",
-                "help": "List of timing constraint files to use for the scenario. The values are combined with any constraints specified by the design 'constraint' parameter. If no constraints are found, a default constraint file is used based on the clock definitions.",
+                "help": "List of timing constraint files to use for the scenario. The\nvalues are combined with any constraints specified by the design\n'constraint' parameter. If no constraints are found, a default\nconstraint file is used based on the clock definitions.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -3318,7 +3318,7 @@
                     "cli: -mcmm_libcorner 'worst ttt'",
                     "api: chip.set('mcmm', 'worst', 'libcorner', 'ttt')"
                 ],
-                "help": "Library corner applied to the scenario to scale library timing models based on the libcorner value for models that support it. The parameter is ignored for libraries that have one hard coded model per libcorner.",
+                "help": "Library corner applied to the scenario to scale\nlibrary timing models based on the libcorner value for models\nthat support it. The parameter is ignored for libraries that\nhave one hard coded model per libcorner.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -3334,7 +3334,7 @@
                     "cli: -mcmm_mode 'worst test'",
                     "api: chip.set('mcmm',  'worst','mode', 'test')"
                 ],
-                "help": "Operating mode for the scenario. Operating mode strings can be values such as test, functional, standby.",
+                "help": "Operating mode for the scenario. Operating mode strings\ncan be values such as test, functional, standby.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -3350,7 +3350,7 @@
                     "cli: -mcmm_opcond 'worst typical_1.0'",
                     "api: chip.set('mcmm', 'worst', 'opcond',  'typical_1.0')"
                 ],
-                "help": "Operating condition applied to the scenario. The value can be used to access specific conditions within the library timing models from the 'logiclib' timing models.",
+                "help": "Operating condition applied to the scenario. The value\ncan be used to access specific conditions within the library\ntiming models from the 'logiclib' timing models.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -3366,7 +3366,7 @@
                     "cli: -mcmm_pexcorner 'worst max'",
                     "api: chip.set('mcmm', 'worst', 'pexcorner', 'max')"
                 ],
-                "help": "Parasitic corner applied to the scenario. The 'pexcorner' string must match a corner found in the pdk pexmodel setup.",
+                "help": "Parasitic corner applied to the scenario. The\n'pexcorner' string must match a corner found in the pdk\npexmodel setup.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -3382,7 +3382,7 @@
                     "cli: -mcmm_temperature 'worst 125'",
                     "api: chip.set('mcmm', 'worst', 'temperature','125')"
                 ],
-                "help": "Chip temperature applied to the scenario specified in degrees Celsius.",
+                "help": "Chip temperature applied to the scenario specified in\ndegrees Celsius.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -3398,7 +3398,7 @@
                     "cli: -mcmm_voltage 'worst 0.9'",
                     "api: chip.set('mcmm', 'worst','voltage', '0.9')"
                 ],
-                "help": "Operating voltage applied to the scenario, specified in Volts.",
+                "help": "Operating voltage applied to the scenario,\nspecified in Volts.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -3420,7 +3420,7 @@
                             "cli: -metric_averagepower 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','averagepower','real',0.01)"
                         ],
-                        "help": "Metric tracking the average workload power of the design specified on a per step and index basis. Power metric depend heavily on the method being used for extraction: dynamic vs static, workload specification (vcd vs saif), power models, process/voltage/temperature. The power averagepower metric tries to capture the data that would usually be reflected inside a datasheet given the approprate footnote conditions.",
+                        "help": "Metric tracking the average workload power of the design specified on a per step\nand index basis. Power metric depend heavily on the method\nbeing used for extraction: dynamic vs static, workload\nspecification (vcd vs saif), power models, process/voltage/temperature.\nThe power averagepower metric tries to capture the data that would\nusually be reflected inside a datasheet given the approprate\nfootnote conditions.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3438,7 +3438,7 @@
                             "cli: -metric_brams 'place 0 goal 100'",
                             "api: chip.set('metric','place','0','brams','real',100)"
                         ],
-                        "help": "Metric tracking the total FPGA BRAM tiles used by the design as reported by the implementation tool. There is no standardized definition for this metric across vendors, so metric comparisons can generally only be done between runs on identical tools and device families.",
+                        "help": "Metric tracking the total FPGA BRAM tiles used by the design as reported\nby the implementation tool. There is no standardized definition\nfor this metric across vendors, so metric comparisons can\ngenerally only be done between runs on identical tools and\ndevice families.",
                         "lock": "false",
                         "require": "fpga",
                         "scope": "job",
@@ -3456,7 +3456,7 @@
                             "cli: -metric_buffers 'place 0 goal 100'",
                             "api: chip.set('metric','place','0','buffers','real', 50)"
                         ],
-                        "help": "Metric tracking the total number of buffer and inverter instances in the design on a per step and index basis.",
+                        "help": "Metric tracking the total number of buffer and inverter instances in the design\non a per step and index basis.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3474,7 +3474,7 @@
                             "cli: -metric_cellarea 'place 0 goal 100.00'",
                             "api: chip.set('metric','place','0','cellarea','real',100.00)"
                         ],
-                        "help": "Metric tracking the total cell area (ignoring fillers) occupied by the design. The metric is specified in um^2.",
+                        "help": "Metric tracking the total cell area (ignoring fillers) occupied by the design. The\nmetric is specified in um^2.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3492,7 +3492,7 @@
                             "cli: -metric_cells 'place 0 goal 100'",
                             "api: chip.set('metric','place','0','cells','real', 50)"
                         ],
-                        "help": "Metric tracking the total number of cell instances in the design on a per step and index basis.",
+                        "help": "Metric tracking the total number of cell instances in the design\non a per step and index basis.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3510,7 +3510,7 @@
                             "cli: -metric_coverage 'place 0 goal 99.9'",
                             "api: chip.set('metric','place','0','coverage','goal',99.9)"
                         ],
-                        "help": "Metric tracking the test coverage in the design expressed as a percentage with 100 meaning full coverage. The meaning of the metric depends on the task being executed. It can refer to code coverage, feature coverage, stuck at fault coverage.",
+                        "help": "Metric tracking the test coverage in the design expressed as a percentage\nwith 100 meaning full coverage. The meaning of the metric depends on the\ntask being executed. It can refer to code coverage, feature coverage,\nstuck at fault coverage.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3528,7 +3528,7 @@
                             "cli: -metric_dozepower 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','dozepower','real',0.01)"
                         ],
-                        "help": "Metric tracking the power consumed while in low frequency operating mode of the design specified on a per step and index basis. Power metric depend heavily on the method being used for extraction: dynamic vs static, workload specification (vcd vs saif), power models, process/voltage/temperature. The power dozepower metric tries to capture the data that would usually be reflected inside a datasheet given the approprate footnote conditions.",
+                        "help": "Metric tracking the power consumed while in low frequency operating mode of the design specified on a per step\nand index basis. Power metric depend heavily on the method\nbeing used for extraction: dynamic vs static, workload\nspecification (vcd vs saif), power models, process/voltage/temperature.\nThe power dozepower metric tries to capture the data that would\nusually be reflected inside a datasheet given the approprate\nfootnote conditions.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3546,7 +3546,7 @@
                             "cli: -metric_drvs 'dfm 0 goal 0'",
                             "api: chip.set('metric','dfm','0','drvs','real',0)"
                         ],
-                        "help": "Metric tracking the total number of design rule violations on a per step and index basis.",
+                        "help": "Metric tracking the total number of design rule violations on a\nper step and index basis.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3564,7 +3564,7 @@
                             "cli: -metric_dsps 'place 0 goal 100'",
                             "api: chip.set('metric','place','0','dsps','real',100)"
                         ],
-                        "help": "Metric tracking the total FPGA DSP slices used by the design as reported by the implementation tool. There is no standardized definition for this metric across vendors, so metric comparisons can generally only be done between runs on identical tools and device families.",
+                        "help": "Metric tracking the total FPGA DSP slices used by the design as reported\nby the implementation tool. There is no standardized definition\nfor this metric across vendors, so metric comparisons can\ngenerally only be done between runs on identical tools and\ndevice families.",
                         "lock": "false",
                         "require": "fpga",
                         "scope": "job",
@@ -3582,7 +3582,7 @@
                             "cli: -metric_errors 'dfm 0 goal 0'",
                             "api: chip.set('metric','dfm','0','errors','real',0)"
                         ],
-                        "help": "Metric tracking the total number of errors on a per step and index basis.",
+                        "help": "Metric tracking the total number of errors on a\nper step and index basis.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3600,7 +3600,7 @@
                             "cli: -metric_exetime 'dfm 0 goal 10.0'",
                             "api: chip.set('metric','dfm','0','exetime','real, 10.0)"
                         ],
-                        "help": "Metric tracking time spent by the eda executable 'exe' on a per step and index basis. It does not include the siliconcompiler runtime overhead or time waitig for I/O operations and inter-processor communication to complete. The metric unit is seconds.",
+                        "help": "Metric tracking time spent by the eda executable 'exe' on a\nper step and index basis. It does not include the siliconcompiler\nruntime overhead or time waitig for I/O operations and\ninter-processor communication to complete. The metric unit\nis seconds.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3618,7 +3618,7 @@
                             "cli: -metric_holdpaths 'place 0 goal 10'",
                             "api: chip.set('metric','place','0','holdpaths','real',10)"
                         ],
-                        "help": "Metric tracking the total number of timing paths violating hold constraints.",
+                        "help": "Metric tracking the total number of timing paths violating hold\nconstraints.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3636,7 +3636,7 @@
                             "cli: -metric_holdslack 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','holdslack','real', 0.01)"
                         ],
-                        "help": "Metric tracking the worst hold slack (positive or negative) on a per step and index basis. Metric unit is nanoseconds.",
+                        "help": "Metric tracking the worst hold slack (positive or negative) on a per step and index basis.\nMetric unit is nanoseconds.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3654,7 +3654,7 @@
                             "cli: -metric_holdtns 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','holdtns','real', 0.01)"
                         ],
-                        "help": "Metric tracking the total negative hold slack (TNS) on a per step and index basis. Metric unit is nanoseconds.",
+                        "help": "Metric tracking the total negative hold slack (TNS) on a per step and index basis.\nMetric unit is nanoseconds.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3672,7 +3672,7 @@
                             "cli: -metric_holdwns 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','holdwns','real', 0.01)"
                         ],
-                        "help": "Metric tracking the worst negative hold slack (positive values truncated to zero) on a per step and index basis. Metric unit is nanoseconds.",
+                        "help": "Metric tracking the worst negative hold slack (positive values truncated to zero) on a per step and index basis.\nMetric unit is nanoseconds.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3690,7 +3690,7 @@
                             "cli: -metric_idlepower 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','idlepower','real',0.01)"
                         ],
-                        "help": "Metric tracking the power while not performing useful work of the design specified on a per step and index basis. Power metric depend heavily on the method being used for extraction: dynamic vs static, workload specification (vcd vs saif), power models, process/voltage/temperature. The power idlepower metric tries to capture the data that would usually be reflected inside a datasheet given the approprate footnote conditions.",
+                        "help": "Metric tracking the power while not performing useful work of the design specified on a per step\nand index basis. Power metric depend heavily on the method\nbeing used for extraction: dynamic vs static, workload\nspecification (vcd vs saif), power models, process/voltage/temperature.\nThe power idlepower metric tries to capture the data that would\nusually be reflected inside a datasheet given the approprate\nfootnote conditions.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3708,7 +3708,7 @@
                             "cli: -metric_irdrop 'place 0 real 0.05'",
                             "api: chip.set('metric','place','0','irdrop','real',0.05)"
                         ],
-                        "help": "Metric tracking the peak IR drop in the design based on extracted power and ground rail parasitics, library power models, and switching activity. The switching activity calculated on a per node basis is taken from one of three possible sources, in order of priority: VCD file, SAIF file, 'activityfactor' parameter.",
+                        "help": "Metric tracking the peak IR drop in the design based on extracted\npower and ground rail parasitics, library power models, and\nswitching activity. The switching activity calculated on a per\nnode basis is taken from one of three possible sources, in order\nof priority: VCD file, SAIF file, 'activityfactor' parameter.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3726,7 +3726,7 @@
                             "cli: -metric_leakagepower 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','leakagepower','real',0.01)"
                         ],
-                        "help": "Metric tracking the leakage power with rails active but without any dynamic switching activity of the design specified on a per step and index basis. Power metric depend heavily on the method being used for extraction: dynamic vs static, workload specification (vcd vs saif), power models, process/voltage/temperature. The power leakagepower metric tries to capture the data that would usually be reflected inside a datasheet given the approprate footnote conditions.",
+                        "help": "Metric tracking the leakage power with rails active but without any dynamic switching activity of the design specified on a per step\nand index basis. Power metric depend heavily on the method\nbeing used for extraction: dynamic vs static, workload\nspecification (vcd vs saif), power models, process/voltage/temperature.\nThe power leakagepower metric tries to capture the data that would\nusually be reflected inside a datasheet given the approprate\nfootnote conditions.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3744,7 +3744,7 @@
                             "cli: -metric_luts 'place 0 goal 100'",
                             "api: chip.set('metric','place','0','luts','real',100)"
                         ],
-                        "help": "Metric tracking the total FPGA LUTs used by the design as reported by the implementation tool. There is no standardized definition for this metric across vendors, so metric comparisons can generally only be done between runs on identical tools and device families.",
+                        "help": "Metric tracking the total FPGA LUTs used by the design as reported\nby the implementation tool. There is no standardized definition\nfor this metric across vendors, so metric comparisons can\ngenerally only be done between runs on identical tools and\ndevice families.",
                         "lock": "false",
                         "require": "fpga",
                         "scope": "job",
@@ -3762,7 +3762,7 @@
                             "cli: -metric_macros 'place 0 goal 100'",
                             "api: chip.set('metric','place','0','macros','real', 50)"
                         ],
-                        "help": "Metric tracking the total number of macros in the design on a per step and index basis.",
+                        "help": "Metric tracking the total number of macros in the design\non a per step and index basis.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3780,7 +3780,7 @@
                             "cli: -metric_memory 'dfm 0 goal 10e9'",
                             "api: chip.set('metric','dfm','0','memory','real, 10e9)"
                         ],
-                        "help": "Metric tracking total peak program memory footprint on a per step and index basis, specified in bytes.",
+                        "help": "Metric tracking total peak program memory footprint on a per\nstep and index basis, specified in bytes.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3798,7 +3798,7 @@
                             "cli: -metric_nets 'place 0 goal 100'",
                             "api: chip.set('metric','place','0','nets','real', 50)"
                         ],
-                        "help": "Metric tracking the total number of nets in the design on a per step and index basis.",
+                        "help": "Metric tracking the total number of nets in the design\non a per step and index basis.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3816,7 +3816,7 @@
                             "cli: -metric_overflow 'place 0 goal 0'",
                             "api: chip.set('metric','place','0','overflow','real', 50)"
                         ],
-                        "help": "Metric tracking the total number of overflow tracks for the routing on per step and index basis. Any non-zero number suggests an over congested design. To analyze where the congestion is occurring inspect the router log files for detailed per metal overflow reporting and open up the design to find routing hotspots.",
+                        "help": "Metric tracking the total number of overflow tracks for the routing\non per step and index basis. Any non-zero number suggests an over\ncongested design. To analyze where the congestion is occurring\ninspect the router log files for detailed per metal overflow\nreporting and open up the design to find routing hotspots.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3834,7 +3834,7 @@
                             "cli: -metric_peakpower 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','peakpower','real',0.01)"
                         ],
-                        "help": "Metric tracking the worst case total peak power of the design specified on a per step and index basis. Power metric depend heavily on the method being used for extraction: dynamic vs static, workload specification (vcd vs saif), power models, process/voltage/temperature. The power peakpower metric tries to capture the data that would usually be reflected inside a datasheet given the approprate footnote conditions.",
+                        "help": "Metric tracking the worst case total peak power of the design specified on a per step\nand index basis. Power metric depend heavily on the method\nbeing used for extraction: dynamic vs static, workload\nspecification (vcd vs saif), power models, process/voltage/temperature.\nThe power peakpower metric tries to capture the data that would\nusually be reflected inside a datasheet given the approprate\nfootnote conditions.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3852,7 +3852,7 @@
                             "cli: -metric_pins 'place 0 goal 100'",
                             "api: chip.set('metric','place','0','pins','real', 50)"
                         ],
-                        "help": "Metric tracking the total number of pins in the design on a per step and index basis.",
+                        "help": "Metric tracking the total number of pins in the design\non a per step and index basis.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3870,7 +3870,7 @@
                             "cli: -metric_registers 'place 0 goal 100'",
                             "api: chip.set('metric','place','0','registers','real', 50)"
                         ],
-                        "help": "Metric tracking the total number of register instances in the design on a per step and index basis.",
+                        "help": "Metric tracking the total number of register instances in the design\non a per step and index basis.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3888,7 +3888,7 @@
                             "cli: -metric_security 'place 0 goal 100'",
                             "api: chip.set('metric','place','0','security','goal',100)"
                         ],
-                        "help": "Metric tracking the level of security (1/vulnerability) of the design. A completely secure design would have a score of 100. There is no absolute scale for the security metrics (like with power, area, etc) so the metric will be task and tool dependent.",
+                        "help": "Metric tracking the level of security (1/vulnerability) of the design.\nA completely secure design would have a score of 100. There is no\nabsolute scale for the security metrics (like with power, area, etc)\nso the metric will be task and tool dependent.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3906,7 +3906,7 @@
                             "cli: -metric_setuppaths 'place 0 goal 10'",
                             "api: chip.set('metric','place','0','setuppaths','real',10)"
                         ],
-                        "help": "Metric tracking the total number of timing paths violating setup constraints.",
+                        "help": "Metric tracking the total number of timing paths violating setup\nconstraints.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3924,7 +3924,7 @@
                             "cli: -metric_setupslack 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','setupslack','real', 0.01)"
                         ],
-                        "help": "Metric tracking the worst setup slack (positive or negative) on a per step and index basis. Metric unit is nanoseconds.",
+                        "help": "Metric tracking the worst setup slack (positive or negative) on a per step and index basis.\nMetric unit is nanoseconds.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3942,7 +3942,7 @@
                             "cli: -metric_setuptns 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','setuptns','real', 0.01)"
                         ],
-                        "help": "Metric tracking the total negative setup slack (TNS) on a per step and index basis. Metric unit is nanoseconds.",
+                        "help": "Metric tracking the total negative setup slack (TNS) on a per step and index basis.\nMetric unit is nanoseconds.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3960,7 +3960,7 @@
                             "cli: -metric_setupwns 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','setupwns','real', 0.01)"
                         ],
-                        "help": "Metric tracking the worst negative setup slack (positive values truncated to zero) on a per step and index basis. Metric unit is nanoseconds.",
+                        "help": "Metric tracking the worst negative setup slack (positive values truncated to zero) on a per step and index basis.\nMetric unit is nanoseconds.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3978,7 +3978,7 @@
                             "cli: -metric_sleeppower 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','sleeppower','real',0.01)"
                         ],
-                        "help": "Metric tracking the power consumed with some or all power rails gated off of the design specified on a per step and index basis. Power metric depend heavily on the method being used for extraction: dynamic vs static, workload specification (vcd vs saif), power models, process/voltage/temperature. The power sleeppower metric tries to capture the data that would usually be reflected inside a datasheet given the approprate footnote conditions.",
+                        "help": "Metric tracking the power consumed with some or all power rails gated off of the design specified on a per step\nand index basis. Power metric depend heavily on the method\nbeing used for extraction: dynamic vs static, workload\nspecification (vcd vs saif), power models, process/voltage/temperature.\nThe power sleeppower metric tries to capture the data that would\nusually be reflected inside a datasheet given the approprate\nfootnote conditions.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3996,7 +3996,7 @@
                             "cli: -metric_tasktime 'dfm 0 goal 10.0'",
                             "api: chip.set('metric','dfm','0','tasktime','real, 10.0)"
                         ],
-                        "help": "Metric trakcing the total amount of time spent on a task from beginning to end, including data transfers and pre/post processing. The metric unit is seconds.",
+                        "help": "Metric trakcing the total amount of time spent on a task from\nbeginning to end, including data transfers and pre/post processing.\nThe metric unit is seconds.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -4014,7 +4014,7 @@
                             "cli: -metric_totalarea 'place 0 goal 100.00'",
                             "api: chip.set('metric','place','0','totalarea','real',100.00)"
                         ],
-                        "help": "Metric tracking the total physical die area occupied by the design. The metric is specified in um^2.",
+                        "help": "Metric tracking the total physical die area occupied by the design. The\nmetric is specified in um^2.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -4032,7 +4032,7 @@
                             "cli: -metric_transistors 'place 0 goal 100'",
                             "api: chip.set('metric','place','0','transistors','real', 50)"
                         ],
-                        "help": "Metric tracking the total number of transistors in the design on a per step and index basis.",
+                        "help": "Metric tracking the total number of transistors in the design\non a per step and index basis.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -4050,7 +4050,7 @@
                             "cli: -metric_unconstrained 'dfm 0 goal 0'",
                             "api: chip.set('metric','dfm','0','unconstrained','real',0)"
                         ],
-                        "help": "Metric tracking the total number of unconstrained timing paths on a per step and index basis.",
+                        "help": "Metric tracking the total number of unconstrained timing paths on a\nper step and index basis.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -4068,7 +4068,7 @@
                             "cli: -metric_utilization 'place 0 goal 50.00'",
                             "api: chip.set('metric','place','0','utilization','real',50.00)"
                         ],
-                        "help": "Metric tracking the area utilization of the design calculated as 100 * (cellarea/totalarea).",
+                        "help": "Metric tracking the area utilization of the design calculated as\n100 * (cellarea/totalarea).",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -4086,7 +4086,7 @@
                             "cli: -metric_vias 'place 0 goal 100'",
                             "api: chip.set('metric','place','0','vias','real', 50)"
                         ],
-                        "help": "Metric tracking the total number of vias in the design on a per step and index basis.",
+                        "help": "Metric tracking the total number of vias in the design\non a per step and index basis.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -4104,7 +4104,7 @@
                             "cli: -metric_warnings 'dfm 0 goal 0'",
                             "api: chip.set('metric','dfm','0','warnings','real',0)"
                         ],
-                        "help": "Metric tracking the total number of warnings on a per step and index basis.",
+                        "help": "Metric tracking the total number of warnings on a\nper step and index basis.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -4122,7 +4122,7 @@
                             "cli: -metric_wirelength 'place 0 goal 100.0'",
                             "api: chip.set('metric','place','0','wirelength','real', 50.0)"
                         ],
-                        "help": "Metric tracking the total wirelength of the design on a per step and index basis. The unit is meters.",
+                        "help": "Metric tracking the total wirelength of the design on a per step\nand index basis. The unit is meters.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -4142,7 +4142,7 @@
             "cli: -metricoff 'wirelength'",
             "api: chip.set('metricoff','wirelength')"
         ],
-        "help": "List of metrics to supress when printing out the run summary.",
+        "help": "List of metrics to supress when printing out the run\nsummary.",
         "lock": "false",
         "require": null,
         "scope": "global",
@@ -4158,7 +4158,7 @@
             "cli: -mode asic",
             "api: chip.set('mode','asic')"
         ],
-        "help": "Sets the operating mode of the compiler. Valid modes are: asic: RTL to GDS ASIC compilation fpga: RTL to bitstream FPGA compilation sim: simulation to verify design and compilation",
+        "help": "Sets the operating mode of the compiler. Valid modes are:\nasic: RTL to GDS ASIC compilation\nfpga: RTL to bitstream FPGA compilation\nsim: simulation to verify design and compilation",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -4174,7 +4174,7 @@
             "cli: -msgcontact 'wile.e.coyote@acme.com'",
             "api: chip.set('msgcontact','wile.e.coyote@acme.com')"
         ],
-        "help": "A list of phone numbers or email addresses to message on a event event within the msg_event param. Actual support for email and phone messages is platform dependent.",
+        "help": "A list of phone numbers or email addresses to message\non a event event within the msg_event param. Actual\nsupport for email and phone messages is platform\ndependent.",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -4190,7 +4190,7 @@
             "cli: -msgevent export",
             "api: chip.set('msgevent','export')"
         ],
-        "help": "A list of steps after which to notify a recipient. For example if values of syn, place, cts are entered separate messages would be sent after the completion of the syn, place, and cts steps.",
+        "help": "A list of steps after which to notify a recipient. For\nexample if values of syn, place, cts are entered separate\nmessages would be sent after the completion of the syn,\nplace, and cts steps.",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -4206,7 +4206,7 @@
             "cli: -nodisplay",
             "api: chip.set('nodisplay', True)"
         ],
-        "help": "The '-nodisplay' flag prevents SiliconCompiler from opening GUI windows such as the final metrics report.",
+        "help": "The '-nodisplay' flag prevents SiliconCompiler from\nopening GUI windows such as the final metrics report.",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -4222,7 +4222,7 @@
             "cli: -oformat gds",
             "api: chip.set('oformat', 'gds')"
         ],
-        "help": "File format to use for writing the final siliconcompiler output to disk. For cases, when only one output format exists, the 'oformat' parameter can be omitted. Examples of ASIC layout output formats include GDS and OASIS.",
+        "help": "File format to use for writing the final siliconcompiler output to\ndisk. For cases, when only one output format exists, the 'oformat'\nparameter can be omitted. Examples of ASIC layout output formats\ninclude GDS and OASIS.",
         "lock": "false",
         "require": null,
         "scope": "global",
@@ -4238,7 +4238,7 @@
             "cli: -O3",
             "api: chip.set('optmode','3')"
         ],
-        "help": "The compiler has modes to prioritize run time and ppa. Modes include. (0) = Exploration mode for debugging setup (1) = Higher effort and better PPA than O0 (2) = Higher effort and better PPA than O1 (3) = Signoff quality. Better PPA and higher run times than O2 (4-98) = Reserved (compiler/target dependent) (99) = Experimental highest possible effort, may be unstable",
+        "help": "The compiler has modes to prioritize run time and ppa. Modes\ninclude.\n\n(0) = Exploration mode for debugging setup\n(1) = Higher effort and better PPA than O0\n(2) = Higher effort and better PPA than O1\n(3) = Signoff quality. Better PPA and higher run times than O2\n(4-98) = Reserved (compiler/target dependent)\n(99) = Experimental highest possible effort, may be unstable",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -4257,7 +4257,7 @@
                         "cli: -package_author_email 'wiley wiley@acme.com'",
                         "api: chip.set(package,'author','wiley','email','wiley@acme.com')"
                     ],
-                    "help": "{shelp} author {item} provided with full name as key and {item} as value.",
+                    "help": "Package author email provided with full name as key and\nemail as value.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -4273,7 +4273,7 @@
                         "cli: -package_author_location 'wiley wiley@acme.com'",
                         "api: chip.set(package,'author','wiley','location','wiley@acme.com')"
                     ],
-                    "help": "{shelp} author {item} provided with full name as key and {item} as value.",
+                    "help": "Package author location provided with full name as key and\nlocation as value.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -4289,7 +4289,7 @@
                         "cli: -package_author_name 'wiley wiley@acme.com'",
                         "api: chip.set(package,'author','wiley','name','wiley@acme.com')"
                     ],
-                    "help": "{shelp} author {item} provided with full name as key and {item} as value.",
+                    "help": "Package author name provided with full name as key and\nname as value.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -4305,7 +4305,7 @@
                         "cli: -package_author_organization 'wiley wiley@acme.com'",
                         "api: chip.set(package,'author','wiley','organization','wiley@acme.com')"
                     ],
-                    "help": "{shelp} author {item} provided with full name as key and {item} as value.",
+                    "help": "Package author organization provided with full name as key and\norganization as value.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -4321,7 +4321,7 @@
                         "cli: -package_author_publickey 'wiley wiley@acme.com'",
                         "api: chip.set(package,'author','wiley','publickey','wiley@acme.com')"
                     ],
-                    "help": "{shelp} author {item} provided with full name as key and {item} as value.",
+                    "help": "Package author publickey provided with full name as key and\npublickey as value.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -4337,7 +4337,7 @@
                         "cli: -package_author_username 'wiley wiley@acme.com'",
                         "api: chip.set(package,'author','wiley','username','wiley@acme.com')"
                     ],
-                    "help": "{shelp} author {item} provided with full name as key and {item} as value.",
+                    "help": "Package author username provided with full name as key and\nusername as value.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -4356,7 +4356,7 @@
                     "cli: -package_dependency 'hell0 1.0'",
                     "api: chip.set(package,'dependency','hello', '1.0')"
                 ],
-                "help": "{shelp} dependencies specified as a key value pair. Versions shall follow the semver standard.",
+                "help": "Package dependencies specified as a key value pair.\nVersions shall follow the semver standard.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -4373,7 +4373,7 @@
                 "cli: -package_description 'Yet another cpu'",
                 "api: chip.set(package,'description','Yet another cpu')"
             ],
-            "help": "{shelp} short one line description for package managers and summary reports.",
+            "help": "Package short one line description for package\nmanagers and summary reports.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4395,7 +4395,7 @@
                 ],
                 "filehash": [],
                 "hashalgo": "sha256",
-                "help": "{shelp} list of {item} documents.",
+                "help": "Package list of datasheet documents.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -4411,7 +4411,7 @@
                     "cli: -package_doc_homepage 'index.html'",
                     "api: chip.set(package,'doc', 'homepage','index.html')"
                 ],
-                "help": "{shelp} documentation homepage. Filepath to design docs homepage. Complex designs can can include a long non standard list of documents dependent.  A single html entry point can be used to present an organized documentation dashboard to the designer.",
+                "help": "Package documentation homepage. Filepath to design docs homepage.\nComplex designs can can include a long non standard list of\ndocuments dependent.  A single html entry point can be used to\npresent an organized documentation dashboard to the designer.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -4432,7 +4432,7 @@
                 ],
                 "filehash": [],
                 "hashalgo": "sha256",
-                "help": "{shelp} list of {item} documents.",
+                "help": "Package list of quickstart documents.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -4453,7 +4453,7 @@
                 ],
                 "filehash": [],
                 "hashalgo": "sha256",
-                "help": "{shelp} list of {item} documents.",
+                "help": "Package list of reference documents.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -4474,7 +4474,7 @@
                 ],
                 "filehash": [],
                 "hashalgo": "sha256",
-                "help": "{shelp} list of {item} documents.",
+                "help": "Package list of releasenotes documents.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -4495,7 +4495,7 @@
                 ],
                 "filehash": [],
                 "hashalgo": "sha256",
-                "help": "{shelp} list of {item} documents.",
+                "help": "Package list of signoff documents.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -4516,7 +4516,7 @@
                 ],
                 "filehash": [],
                 "hashalgo": "sha256",
-                "help": "{shelp} list of {item} documents.",
+                "help": "Package list of testplan documents.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -4537,7 +4537,7 @@
                 ],
                 "filehash": [],
                 "hashalgo": "sha256",
-                "help": "{shelp} list of {item} documents.",
+                "help": "Package list of tutorial documents.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -4558,7 +4558,7 @@
                 ],
                 "filehash": [],
                 "hashalgo": "sha256",
-                "help": "{shelp} list of {item} documents.",
+                "help": "Package list of userguide documents.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -4575,7 +4575,7 @@
                 "cli: -package_homepage 'index.html'",
                 "api: chip.set(package,'homepage','index.html')"
             ],
-            "help": "{shelp} homepage.",
+            "help": "Package homepage.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4591,7 +4591,7 @@
                 "cli: -package_keyword 'cpu'",
                 "api: chip.set(package,'keyword','cpu')"
             ],
-            "help": "{shelp} keyword(s) used to characterize package.",
+            "help": "Package keyword(s) used to characterize package.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4607,7 +4607,7 @@
                 "cli: -package_license 'Apache-2.0'",
                 "api: chip.set(package,'license','Apache-2.0')"
             ],
-            "help": "{shelp} list of SPDX license identifiers.",
+            "help": "Package list of SPDX license identifiers.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4628,7 +4628,7 @@
             ],
             "filehash": [],
             "hashalgo": "sha256",
-            "help": "{shelp} list of license files for {group} to be applied in cases when a SPDX identifier is not available. (eg. proprietary licenses).list of SPDX license identifiers.",
+            "help": "Package list of license files for package to be\napplied in cases when a SPDX identifier is not available.\n(eg. proprietary licenses).list of SPDX license identifiers.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4644,7 +4644,7 @@
                 "cli: -package_location 'mars'",
                 "api: chip.set(package,'location','mars')"
             ],
-            "help": "{shelp} country of origin specified as standardized international country codes. The field can be left blank if the location is unknown or global.",
+            "help": "Package country of origin specified as standardized\ninternational country codes. The field can be left blank\nif the location is unknown or global.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4660,7 +4660,7 @@
                 "cli: -package_name 'yac'",
                 "api: chip.set(package,'name','yac')"
             ],
-            "help": "{shelp} name.",
+            "help": "Package name.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4676,7 +4676,7 @@
                 "cli: -package_organization 'humanity'",
                 "api: chip.set(package,'organization','humanity')"
             ],
-            "help": "{shelp} sponsoring organization. The field can be left blank if not applicable.",
+            "help": "Package sponsoring organization. The field can be left\nblank if not applicable.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4692,7 +4692,7 @@
                 "cli: -package_publickey '6EB695706EB69570'",
                 "api: chip.set(package,'publickey','6EB695706EB69570')"
             ],
-            "help": "{shelp} public project key.",
+            "help": "Package public project key.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4708,7 +4708,7 @@
                 "cli: -package_repo 'git@github.com:aolofsson/oh.git'",
                 "api: chip.set(package,'repo','git@github.com:aolofsson/oh.git')"
             ],
-            "help": "{shelp} IP address to source code repository.",
+            "help": "Package IP address to source code repository.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4724,7 +4724,7 @@
                 "cli: -package_target 'asicflow_freepdk45'",
                 "api: chip.set(package,'target','asicflow_freepdk45')"
             ],
-            "help": "{shelp} list of qualified compilation targets.",
+            "help": "Package list of qualified compilation targets.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4740,7 +4740,7 @@
                 "cli: -package_version '1.0'",
                 "api: chip.set(package,'version','1.0')"
             ],
-            "help": "{shelp} version. Can be a branch, tag, commit hash, or a semver compatible version.",
+            "help": "Package version. Can be a branch, tag, commit hash,\nor a semver compatible version.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4758,7 +4758,7 @@
                 "cli: -param 'N 64'",
                 "api: chip.set('param','N', '64')"
             ],
-            "help": "Sets a top level module parameter. The value is limited to basic data literals. The parameter override is passed into tools such as Verilator and Yosys. The parameters support Verilog integer literals (64'h4, 2'b0, 4) and strings. Name of the top level module to compile.",
+            "help": "Sets a top level module parameter. The value\nis limited to basic data literals. The parameter override is\npassed into tools such as Verilator and Yosys. The parameters\nsupport Verilog integer literals (64'h4, 2'b0, 4) and strings.\nName of the top level module to compile.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4785,7 +4785,7 @@
                             ],
                             "filehash": [],
                             "hashalgo": "sha256",
-                            "help": "Technology file containing setup information needed to enable DRC clean APR for the specified stackup, libarch, and format. The 'libarch' specifies the library architecture (e.g. library height). For example a PDK with support for 9 and 12 track libraries might have 'libarchs' called 9t and 12t. The standard filetype for specifying place and route design rules for a process node is through a 'lef' format technology file. The 'filetype' used in the aprtech is used by the tool specific APR TCL scripts to set up the technology parameters. Some tools may require additional files beyond the tech.lef file. Examples of extra file types include antenna, tracks, tapcell, viarules, em.",
+                            "help": "Technology file containing setup information needed to enable DRC clean APR\nfor the specified stackup, libarch, and format. The 'libarch' specifies the\nlibrary architecture (e.g. library height). For example a PDK with support\nfor 9 and 12 track libraries might have 'libarchs' called 9t and 12t.\nThe standard filetype for specifying place and route design rules for a\nprocess node is through a 'lef' format technology file. The\n'filetype' used in the aprtech is used by the tool specific APR TCL scripts\nto set up the technology parameters. Some tools may require additional\nfiles beyond the tech.lef file. Examples of extra file types include\nantenna, tracks, tapcell, viarules, em.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -4805,7 +4805,7 @@
                 "cli: -pdk_d0 0.1",
                 "api:  chip.set('pdk', 'd0', 0.1)"
             ],
-            "help": "Process defect density (d0) expressed as random defects per cm^2. The value is used to calculate yield losses as a function of area, which in turn affects the chip full factory costs. Two yield models are supported: Poisson (default), and Murphy. The Poisson based yield is calculated as dy = exp(-area * d0/100). The Murphy based yield is calculated as dy = ((1-exp(-area * d0/100))/(area * d0/100))^2.",
+            "help": "Process defect density (d0) expressed as random defects per cm^2. The\nvalue is used to calculate yield losses as a function of area, which in\nturn affects the chip full factory costs. Two yield models are\nsupported: Poisson (default), and Murphy. The Poisson based yield is\ncalculated as dy = exp(-area * d0/100). The Murphy based yield is\ncalculated as dy = ((1-exp(-area * d0/100))/(area * d0/100))^2.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4821,7 +4821,7 @@
                 "cli: -pdk_density 100e6",
                 "api:  chip.set('pdk', 'density', 10e6)"
             ],
-            "help": "Approximate logic density expressed as # transistors / mm^2 calculated as: 0.6 * (Nand2 Transistor Count) / (Nand2 Cell Area) + 0.4 * (Register Transistor Count) / (Register Cell Area) The value is specified for a fixed standard cell library within a node and will differ depending on the library vendor, library track height and library type. The value can be used to to normalize the effective density reported for the design across different process nodes. The value can be derived from a variety of sources, including the PDK DRM, library LEFs, conference presentations, and public analysis.",
+            "help": "Approximate logic density expressed as # transistors / mm^2\ncalculated as:\n0.6 * (Nand2 Transistor Count) / (Nand2 Cell Area) +\n0.4 * (Register Transistor Count) / (Register Cell Area)\nThe value is specified for a fixed standard cell library within a node\nand will differ depending on the library vendor, library track height\nand library type. The value can be used to to normalize the effective\ndensity reported for the design across different process nodes. The\nvalue can be derived from a variety of sources, including the PDK DRM,\nlibrary LEFs, conference presentations, and public analysis.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -4845,7 +4845,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "List of filepaths to PDK device models for different simulation purposes and for different tools. Examples of device model types include spice, aging, electromigration, radiation. An example of a 'spice' tool is xyce. Device models are specified on a per metal stack basis. Process nodes with a single device model across all stacks will have a unique parameter record per metal stack pointing to the same device model file.  Device types and tools are dynamic entries that depend on the tool setup and device technology. Pseud-standardized device types include spice, em (electromigration), and aging.",
+                        "help": "List of filepaths to PDK device models for different simulation\npurposes and for different tools. Examples of device model types\ninclude spice, aging, electromigration, radiation. An example of a\n'spice' tool is xyce. Device models are specified on a per metal stack\nbasis. Process nodes with a single device model across all stacks will\nhave a unique parameter record per metal stack pointing to the same\ndevice model file.  Device types and tools are dynamic entries\nthat depend on the tool setup and device technology. Pseud-standardized\ndevice types include spice, em (electromigration), and aging.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -4867,7 +4867,7 @@
                             "cli: -pdk_directory 'xyce rfmodel M10 rftechdir'",
                             "api: chip.set('pdk','directory','xyce','rfmodel','M10','rftechdir')"
                         ],
-                        "help": "List of named directories specified on a per tool and per stackup basis. The parameter should only be used for specifying files that are not directly  supported by the SiliconCompiler PDK schema.",
+                        "help": "List of named directories specified on a per tool and per stackup basis.\nThe parameter should only be used for specifying files that are\nnot directly  supported by the SiliconCompiler PDK schema.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -4893,7 +4893,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "Display configuration files describing colors and pattern schemes for all layers in the PDK. The display configuration file is entered on a stackup and tool basis.",
+                    "help": "Display configuration files describing colors and pattern schemes for\nall layers in the PDK. The display configuration file is entered on a\nstackup and tool basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -4938,7 +4938,7 @@
                 ],
                 "filehash": [],
                 "hashalgo": "sha256",
-                "help": "Filepath to PDK docs homepage. Modern PDKs can include tens or hundreds of individual documents. A single html entry point can be used to present an organized documentation dashboard to the designer.",
+                "help": "Filepath to PDK docs homepage. Modern PDKs can include tens or\nhundreds of individual documents. A single html entry point can\nbe used to present an organized documentation dashboard to the\ndesigner.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -5133,7 +5133,7 @@
                 "cli: -pdk_edgemargin 1",
                 "api:  chip.set('pdk', 'edgemargin', 1)"
             ],
-            "help": "Keep-out distance/margin from the wafer edge inwards specified in mm. The wafer edge is prone to chipping and need special treatment that preclude placement of designs in this area. The edge value is used to calculate effective dies per wafer and full factory cost.",
+            "help": "Keep-out distance/margin from the wafer edge inwards specified in mm.\nThe wafer edge is prone to chipping and need special treatment that\npreclude placement of designs in this area. The edge value is used to\ncalculate effective dies per wafer and full factory cost.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -5209,7 +5209,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "List of named files specified on a per tool and per stackup basis. The parameter should only be used for specifying files that are not directly  supported by the SiliconCompiler PDK schema.",
+                        "help": "List of named files specified on a per tool and per stackup basis.\nThe parameter should only be used for specifying files that are\nnot directly  supported by the SiliconCompiler PDK schema.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5228,7 +5228,7 @@
                 "cli: -pdk_foundry virtual",
                 "api:  chip.set('pdk', 'foundry', 'virtual')"
             ],
-            "help": "Name of foundry corporation. Examples include intel, gf, tsmc, samsung, skywater, virtual. The 'virtual' keyword is reserved for simulated non-manufacturable processes.",
+            "help": "Name of foundry corporation. Examples include intel, gf, tsmc,\nsamsung, skywater, virtual. The 'virtual' keyword is reserved for\nsimulated non-manufacturable processes.",
             "lock": "false",
             "require": "asic",
             "scope": "global",
@@ -5247,7 +5247,7 @@
                             "cli: -pdk_grid_adj 'M10 m2 0.5'",
                             "api: chip.set('pdk','grid','M10','m2','adj','0.5')"
                         ],
-                        "help": "Defines the routing resources adjustments for the design on a per layer basis. The value is expressed as a fraction from 0 to 1. A value of 0.5 reduces the routing resources by 50%. If not defined, 100% routing resource utilization is permitted.",
+                        "help": "Defines the routing resources adjustments for the design on a per layer\nbasis. The value is expressed as a fraction from 0 to 1. A value of\n0.5 reduces the routing resources by 50%. If not defined, 100%\nrouting resource utilization is permitted.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5264,7 +5264,7 @@
                                 "cli: -pdk_grid_cap 'M10 m2 fast 0.2'",
                                 "api: chip.set('pdk','grid','M10','m2','cap','fast','0.2')"
                             ],
-                            "help": "Unit capacitance of a wire defined by the grid width and spacing values in the 'grid' structure. The value is specified as ff/um on a per stackup, metal, and corner basis. As a rough rule of thumb, this value tends to stay around 0.2ff/um. This number should only be used for reality confirmation. Accurate analysis should use the PEX models.",
+                            "help": "Unit capacitance of a wire defined by the grid width and spacing values\nin the 'grid' structure. The value is specified as ff/um on a per\nstackup, metal, and corner basis. As a rough rule of thumb, this value\ntends to stay around 0.2ff/um. This number should only be used for\nreality confirmation. Accurate analysis should use the PEX models.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -5281,7 +5281,7 @@
                             "cli: -pdk_grid_dir 'M10 m1 horizontal'",
                             "api: chip.set('pdk','grid','M10','m1','dir','horizontal')"
                         ],
-                        "help": "Preferred routing direction specified on a per stackup and per metal basis. Valid routing directions are horizontal and vertical.",
+                        "help": "Preferred routing direction specified on a per stackup\nand per metal basis. Valid routing directions are horizontal\nand vertical.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5297,7 +5297,7 @@
                             "cli: -pdk_grid_name 'M10 metal1 m1'",
                             "api: chip.set('pdk','grid','M10','metal1','name','m1')"
                         ],
-                        "help": "Maps PDK metal names to the SC standardized layer stack starting with m1 as the lowest routing layer and ending with m<n> as the highest routing layer. The map is specified on a per metal stack basis.",
+                        "help": "Maps PDK metal names to the SC standardized layer stack\nstarting with m1 as the lowest routing layer and ending\nwith m<n> as the highest routing layer. The map is\nspecified on a per metal stack basis.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5314,7 +5314,7 @@
                                 "cli: -pdk_grid_res 'M10 m2 fast 0.2'",
                                 "api: chip.set('pdk','grid','M10','m2','res','fast','0.2')"
                             ],
-                            "help": "Resistance of a wire defined by the grid width and spacing values in the 'grid' structure.  The value is specified as ohms/um on a per stackup, metal, and corner basis. The parameter is only meant to be used as a sanity check and for coarse design planning. Accurate analysis should use the TCAD PEX models.",
+                            "help": "Resistance of a wire defined by the grid width and spacing values\nin the 'grid' structure.  The value is specified as ohms/um on a per\nstackup, metal, and corner basis. The parameter is only meant to be\nused as a sanity check and for coarse design planning. Accurate\nanalysis should use the TCAD PEX models.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -5332,7 +5332,7 @@
                                 "cli: -pdk_grid_tcr 'M10 m2 fast 0.2'",
                                 "api: chip.set('pdk','grid','M10','m2','tcr','fast','0.2')"
                             ],
-                            "help": "Temperature coefficient of resistance of the wire defined by the grid width and spacing values in the 'grid' structure. The value is specified in %/ deg C on a per stackup, layer, and corner basis. The number is only meant to be used as a sanity check and for coarse design planning. Accurate analysis should use the PEX models.",
+                            "help": "Temperature coefficient of resistance of the wire defined by the grid\nwidth and spacing values in the 'grid' structure. The value is specified\nin %/ deg C on a per stackup, layer, and corner basis. The number is\nonly meant to be used as a sanity check and for coarse design\nplanning. Accurate analysis should use the PEX models.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -5349,7 +5349,7 @@
                             "cli: -pdk_grid_xoffset 'M10 m2 0.5'",
                             "api: chip.set('pdk','grid','M10','m2','xoffset','0.5')"
                         ],
-                        "help": "Defines the grid offset of a vertical metal layer specified on a per stackup and per metal basis, specified in um.",
+                        "help": "Defines the grid offset of a vertical metal layer specified on a per\nstackup and per metal basis, specified in um.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5365,7 +5365,7 @@
                             "cli: -pdk_grid_xpitch 'M10 m1 0.5'",
                             "api: chip.set('pdk','grid','M10','m1','xpitch','0.5')"
                         ],
-                        "help": "Defines the routing pitch for vertical wires on a per stackup and per metal basis, specified in um.",
+                        "help": "Defines the routing pitch for vertical wires on a per stackup and\nper metal basis, specified in um.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5381,7 +5381,7 @@
                             "cli: -pdk_grid_yoffset 'M10 m2 0.5'",
                             "api: chip.set('pdk','grid','M10','m2','yoffset','0.5')"
                         ],
-                        "help": "Defines the grid offset of a horizontal metal layer specified on a per stackup and per metal basis, specified in um.",
+                        "help": "Defines the grid offset of a horizontal metal layer specified on a per\nstackup and per metal basis, specified in um.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5397,7 +5397,7 @@
                             "cli: -pdk_grid_ypitch 'M10 m1 0.5'",
                             "api: chip.set('pdk','grid','M10','m1','ypitch','0.5')"
                         ],
-                        "help": "Defines the routing pitch for horizontal wires on a per stackup and per metal basis, specified in um.",
+                        "help": "Defines the routing pitch for horizontal wires on a per stackup and\nper metal basis, specified in um.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5416,7 +5416,7 @@
                 "cli: -pdk_hscribe 0.1",
                 "api:  chip.set('pdk', 'hscribe', 0.1)"
             ],
-            "help": "Width of the horizontal scribe line (in mm) used during die separation. The process is generally completed using a mechanical saw, but can be done through combinations of mechanical saws, lasers, wafer thinning, and chemical etching in more advanced technologies. The value is used to calculate effective dies per wafer and full factory cost.",
+            "help": " Width of the horizontal scribe line (in mm) used during die separation.\nThe process is generally completed using a mechanical saw, but can be\ndone through combinations of mechanical saws, lasers, wafer thinning,\nand chemical etching in more advanced technologies. The value is used\nto calculate effective dies per wafer and full factory cost.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -5441,7 +5441,7 @@
                             ],
                             "filehash": [],
                             "hashalgo": "sha256",
-                            "help": "Files describing input/output mapping for streaming layout data from one format to another. A foundry PDK will include an official layer list for all user entered and generated layers supported in the GDS accepted by the foundry for processing, but there is no standardized layer definition format that can be read and written by all EDA tools. To ensure mask layer matching, key/value type mapping files are needed to convert EDA databases to/from GDS and to convert between different types of EDA databases. Layer maps are specified on a per metal stackup basis. The 'src' and 'dst' can be names of SC supported tools or file formats (like 'gds').",
+                            "help": "Files describing input/output mapping for streaming layout data from\none format to another. A foundry PDK will include an official layer\nlist for all user entered and generated layers supported in the GDS\naccepted by the foundry for processing, but there is no standardized\nlayer definition format that can be read and written by all EDA tools.\nTo ensure mask layer matching, key/value type mapping files are needed\nto convert EDA databases to/from GDS and to convert between different\ntypes of EDA databases. Layer maps are specified on a per metal\nstackup basis. The 'src' and 'dst' can be names of SC supported tools\nor file formats (like 'gds').",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -5513,7 +5513,7 @@
                 "cli: -pdk_node 130",
                 "api:  chip.set('pdk', 'node', 130)"
             ],
-            "help": "Approximate relative minimum dimension of the process target specified in nanometers. The parameter is required for flows and tools that leverage the value to drive technology dependent synthesis and APR optimization. Node examples include 180, 130, 90, 65, 45, 32, 22 14, 10, 7, 5, 3.",
+            "help": "Approximate relative minimum dimension of the process target specified\nin nanometers. The parameter is required for flows and tools that\nleverage the value to drive technology dependent synthesis and APR\noptimization. Node examples include 180, 130, 90, 65, 45, 32, 22 14,\n10, 7, 5, 3.",
             "lock": "false",
             "require": "asic",
             "scope": "global",
@@ -5537,7 +5537,7 @@
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
-                        "help": "List of filepaths to PDK wire TCAD models used during automated synthesis, APR, and signoff verification. Pexmodels are specified on a per metal stack basis. Corner values depend on the process being used, but typically include nomenclature such as min, max, nominal. For exact names, refer to the DRM. Pexmodels are generally not standardized and specified on a per tool basis. An example of pexmodel type is 'fastcap'.",
+                        "help": "List of filepaths to PDK wire TCAD models used during automated\nsynthesis, APR, and signoff verification. Pexmodels are specified on\na per metal stack basis. Corner values depend on the process being\nused, but typically include nomenclature such as min, max, nominal.\nFor exact names, refer to the DRM. Pexmodels are generally not\nstandardized and specified on a per tool basis. An example of pexmodel\ntype is 'fastcap'.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5556,7 +5556,7 @@
                 "cli: -pdk_process asap7",
                 "api:  chip.set('pdk', 'process', 'asap7')"
             ],
-            "help": "Public name of the foundry process. The string is case insensitive and must match the public process name exactly. Examples of virtual processes include freepdk45 and asap7.",
+            "help": "Public name of the foundry process. The string is case insensitive and\nmust match the public process name exactly. Examples of virtual\nprocesses include freepdk45 and asap7.",
             "lock": "false",
             "require": "asic",
             "scope": "global",
@@ -5572,7 +5572,7 @@
                 "cli: -pdk_sramsize 0.032",
                 "api:  chip.set('pdk', 'sramsize', '0.026')"
             ],
-            "help": "Area of an SRAM bitcell expressed in um^2. The value can be derived from a variety of sources, including the PDK DRM, library LEFs, conference presentations, and public analysis. The number is a good first order indicator of SRAM density for large memory arrays where the bitcell dominates the array I/O logic.",
+            "help": "Area of an SRAM bitcell expressed in um^2. The value can be derived\nfrom a variety of sources, including the PDK DRM, library LEFs,\nconference presentations, and public analysis. The number is a good\nfirst order indicator of SRAM density for large memory arrays where\nthe bitcell dominates the array I/O logic.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -5588,7 +5588,7 @@
                 "cli: -pdk_stackup 2MA4MB2MC",
                 "api: chip.add('pdk','stackup','2MA4MB2MC')"
             ],
-            "help": "List of all metal stackups offered in the process node. Older process nodes may only offer a single metal stackup, while advanced nodes offer a large but finite list of metal stacks with varying combinations of metal line pitches and thicknesses. Stackup naming is unique to a foundry, but is generally a long string or code. For example, a 10 metal stackup with two 1x wide, four 2x wide, and 4x wide metals, might be identified as 2MA4MB2MC, where MA, MB, and MC denote wiring layers with different properties (thickness, width, space). Each stackup will come with its own set of routing technology files and parasitic models specified in the pdk_pexmodel and pdk_aprtech parameters.",
+            "help": "List of all metal stackups offered in the process node. Older process\nnodes may only offer a single metal stackup, while advanced nodes\noffer a large but finite list of metal stacks with varying combinations\nof metal line pitches and thicknesses. Stackup naming is unique to a\nfoundry, but is generally a long string or code. For example, a 10\nmetal stackup with two 1x wide, four 2x wide, and 4x wide metals,\nmight be identified as 2MA4MB2MC, where MA, MB, and MC denote wiring\nlayers with different properties (thickness, width, space). Each\nstackup will come with its own set of routing technology files and\nparasitic models specified in the pdk_pexmodel and pdk_aprtech\nparameters.",
             "lock": "false",
             "require": "asic",
             "scope": "global",
@@ -5607,7 +5607,7 @@
                             "cli: -pdk_variable 'xyce modeltype M10 bsim4'",
                             "api: chip.set('pdk','variable','xyce','modeltype','M10','bsim4')"
                         ],
-                        "help": "List of key/value strings specified on a per tool and per stackup basis. The parameter should only be used for specifying variables that are not directly  supported by the SiliconCompiler PDK schema.",
+                        "help": " List of key/value strings specified on a per tool and per stackup basis.\nThe parameter should only be used for specifying variables that are\nnot directly  supported by the SiliconCompiler PDK schema.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5626,7 +5626,7 @@
                 "cli: -pdk_version 1.0",
                 "api:  chip.set('pdk', 'version', '1.0')"
             ],
-            "help": "Alphanumeric string specifying the version of the PDK. Verification of correct PDK and IP versions is a hard ASIC tapeout require in all commercial foundries. The version number can be used for design manifest tracking and tapeout checklists.",
+            "help": "Alphanumeric string specifying the version of the PDK. Verification of\ncorrect PDK and IP versions is a hard ASIC tapeout require in all\ncommercial foundries. The version number can be used for design manifest\ntracking and tapeout checklists.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -5642,7 +5642,7 @@
                 "cli: -pdk_vscribe 0.1",
                 "api:  chip.set('pdk', 'vscribe', 0.1)"
             ],
-            "help": "Width of the vertical scribe line (in mm) used during die separation. The process is generally completed using a mechanical saw, but can be done through combinations of mechanical saws, lasers, wafer thinning, and chemical etching in more advanced technologies. The value is used to calculate effective dies per wafer and full factory cost.",
+            "help": " Width of the vertical scribe line (in mm) used during die separation.\nThe process is generally completed using a mechanical saw, but can be\ndone through combinations of mechanical saws, lasers, wafer thinning,\nand chemical etching in more advanced technologies. The value is used\nto calculate effective dies per wafer and full factory cost.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -5658,7 +5658,7 @@
                 "cli: -pdk_wafercost 10000",
                 "api:  chip.set('pdk', 'wafercost', 10000)"
             ],
-            "help": "Raw cost per wafer purchased specified in USD, not accounting for yield loss. The values is used to calculate chip full factory costs.",
+            "help": "Raw cost per wafer purchased specified in USD, not accounting for\nyield loss. The values is used to calculate chip full factory costs.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -5674,7 +5674,7 @@
                 "cli: -pdk_wafersize 300",
                 "api:  chip.set('pdk', 'wafersize', 300)"
             ],
-            "help": "Wafer diameter used in manufacturing process specified in mm. The standard diameter for leading edge manufacturing is 300mm. For older process technologies and specialty fabs, smaller diameters such as 200, 100, 125, 100 are common. The value is used to calculate dies per wafer and full factory chip costs.",
+            "help": "Wafer diameter used in manufacturing process specified in mm. The\nstandard diameter for leading edge manufacturing is 300mm. For older\nprocess technologies and specialty fabs, smaller diameters such as\n200, 100, 125, 100 are common. The value is used to calculate dies per\nwafer and full factory chip costs.",
             "lock": "false",
             "require": "asic",
             "scope": "global",
@@ -5691,7 +5691,7 @@
             "cli: -quiet",
             "api: chip.set('quiet', True)"
         ],
-        "help": "The -quiet option forces all steps to print to a log file. This can be useful with Modern EDA tools which print significant content to the screen.",
+        "help": "The -quiet option forces all steps to print to a log file.\nThis can be useful with Modern EDA tools which print\nsignificant content to the screen.",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -5715,7 +5715,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "Reads files(s) formatted in DEF specified on a per step and index basis.",
+                    "help": "Reads files(s) formatted in DEF specified on a per step\nand index basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -5740,7 +5740,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "Reads files(s) formatted in GDS specified on a per step and index basis.",
+                    "help": "Reads files(s) formatted in GDS specified on a per step\nand index basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -5765,7 +5765,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "Reads files(s) formatted in GERBER specified on a per step and index basis.",
+                    "help": "Reads files(s) formatted in GERBER specified on a per step\nand index basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -5790,7 +5790,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "Reads files(s) formatted in NETLIST specified on a per step and index basis.",
+                    "help": "Reads files(s) formatted in NETLIST specified on a per step\nand index basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -5815,7 +5815,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "Reads files(s) formatted in PCF specified on a per step and index basis.",
+                    "help": "Reads files(s) formatted in PCF specified on a per step\nand index basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -5840,7 +5840,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "Reads files(s) formatted in SAIF specified on a per step and index basis.",
+                    "help": "Reads files(s) formatted in SAIF specified on a per step\nand index basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -5865,7 +5865,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "Reads files(s) formatted in SDC specified on a per step and index basis.",
+                    "help": "Reads files(s) formatted in SDC specified on a per step\nand index basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -5890,7 +5890,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "Reads files(s) formatted in SDF specified on a per step and index basis.",
+                    "help": "Reads files(s) formatted in SDF specified on a per step\nand index basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -5915,7 +5915,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "Reads files(s) formatted in SPEF specified on a per step and index basis.",
+                    "help": "Reads files(s) formatted in SPEF specified on a per step\nand index basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -5940,7 +5940,7 @@
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
-                    "help": "Reads files(s) formatted in VCD specified on a per step and index basis.",
+                    "help": "Reads files(s) formatted in VCD specified on a per step\nand index basis.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -6026,7 +6026,7 @@
                         "cli: -record_kernelversion 'dfm 0 <5.11.0-34-generic>'",
                         "api: chip.set('record','dfm','0','kernelversion', <5.11.0-34-generic>)"
                     ],
-                    "help": "Record tracking the O/S kernel version per step and index basis. Used for platforms that support a distinction between os kernels and os distributions.",
+                    "help": "Record tracking the O/S kernel version per step and index basis. Used for platforms that support a distinction\nbetween os kernels and os distributions.",
                     "lock": "false",
                     "require": null,
                     "scope": "job",
@@ -6074,7 +6074,7 @@
                         "cli: -record_osversion 'dfm 0 <20.04.1-Ubuntu>'",
                         "api: chip.set('record','dfm','0','osversion', <20.04.1-Ubuntu>)"
                     ],
-                    "help": "Record tracking the O/S version per step and index basis. Since there is not standard version system for operating systems, extracting information from is platform dependent. For Linux based operating systems, the 'osversion' is the version of the distro.",
+                    "help": "Record tracking the O/S version per step and index basis. Since there is not standard version system for operating\nsystems, extracting information from is platform dependent.\nFor Linux based operating systems, the 'osversion' is the\nversion of the distro.",
                     "lock": "false",
                     "require": null,
                     "scope": "job",
@@ -6122,7 +6122,7 @@
                         "cli: -record_region 'dfm 0 <US Gov Boston>'",
                         "api: chip.set('record','dfm','0','region', <US Gov Boston>)"
                     ],
-                    "help": "Record tracking the cloud region per step and index basis. Recommended naming methodology: * local: node is the local machine * onprem: node in on-premises IT infrastructure * public: generic public cloud * govcloud: generic US government cloud * <region>: cloud and entity specific region string name",
+                    "help": "Record tracking the cloud region per step and index basis. Recommended naming methodology:\n\n* local: node is the local machine\n* onprem: node in on-premises IT infrastructure\n* public: generic public cloud\n* govcloud: generic US government cloud\n* <region>: cloud and entity specific region string name",
                     "lock": "false",
                     "require": null,
                     "scope": "job",
@@ -6154,7 +6154,7 @@
                         "cli: -record_toolversion 'dfm 0 <1.0>'",
                         "api: chip.set('record','dfm','0','toolversion', <1.0>)"
                     ],
-                    "help": "Record tracking the tool version per step and index basis. The tool version captured correspnds to the 'tool' parameter within the 'eda' dictoinary'.",
+                    "help": "Record tracking the tool version per step and index basis. The tool version captured correspnds to the 'tool'\nparameter within the 'eda' dictionary.",
                     "lock": "false",
                     "require": null,
                     "scope": "job",
@@ -6189,7 +6189,7 @@
             "cli: -relax",
             "api: chip.set('relax', 'true')"
         ],
-        "help": "Specifies that tools should be lenient and suppress some warnings that may or may not indicate design issues.",
+        "help": "Specifies that tools should be lenient and suppress some\nwarnings that may or may not indicate design issues.",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -6205,7 +6205,7 @@
             "cli: -remote",
             "api: chip.set('remote', True)"
         ],
-        "help": "Sends job for remote processing if set to true. The remote option requires a credentials file to be placed in the home directory. Fore more information, see the credentials parameter.",
+        "help": "Sends job for remote processing if set to true. The remote\noption requires a credentials file to be placed in the home\ndirectory. Fore more information, see the credentials\nparameter.",
         "lock": "false",
         "require": "all",
         "scope": "global",
@@ -6237,7 +6237,7 @@
             "cli: -show",
             "api: chip.set('show', 'true')"
         ],
-        "help": "Specifies that the final hardware layout should be shown after the compilation has been completed. The final layout and tool used to display the layout is flow dependent.",
+        "help": "Specifies that the final hardware layout should be\nshown after the compilation has been completed. The\nfinal layout and tool used to display the layout is\nflow dependent.",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -6254,7 +6254,7 @@
                 "cli: -showtool 'gds klayout'",
                 "api: chip.set('showtool', 'gds', 'klayout')"
             ],
-            "help": "Selects the tool to use by the show function for displaying the specified filetype.",
+            "help": "Selects the tool to use by the show function for displaying\nthe specified filetype.",
             "lock": "false",
             "require": null,
             "scope": "job",
@@ -6271,7 +6271,7 @@
             "cli: -skipall",
             "api: chip.set('skipall', 'true')"
         ],
-        "help": "Skips the execution of all tools in run(), enabling a quick check of tool and setup without having to run through each step of a flow to completion.",
+        "help": "Skips the execution of all tools in run(), enabling a quick\ncheck of tool and setup without having to run through each\nstep of a flow to completion.",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -6287,7 +6287,7 @@
             "cli: -skipcheck",
             "api: chip.set('skipcheck', True)"
         ],
-        "help": "Bypasses the strict runtime manifest check. Can be used for accelerating initial bringup of tool/flow/pdk/libs targets. The flag should not be used for production compilation.",
+        "help": "Bypasses the strict runtime manifest check. Can be used for\naccelerating initial bringup of tool/flow/pdk/libs targets.\nThe flag should not be used for production compilation.",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -6303,7 +6303,7 @@
             "cli: -skipstep lvs",
             "api: chip.set('skipstep', 'lvs')"
         ],
-        "help": "List of steps to skip during execution.The default is to execute all steps  defined in the flow graph.",
+        "help": "List of steps to skip during execution.The default is to\nexecute all steps  defined in the flow graph.",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -6324,7 +6324,7 @@
         ],
         "filehash": [],
         "hashalgo": "sha256",
-        "help": "A list of source files to read in for elaboration. The files are read in order from first to last entered. File type is inferred from the file suffix. (\\*.v, \\*.vh) = Verilog (\\*.vhd)       = VHDL (\\*.sv)        = SystemVerilog (\\*.c)         = C (\\*.cpp, .cc)  = C++ (\\*.py)        = Python",
+        "help": "A list of source files to read in for elaboration. The files are read\nin order from first to last entered. File type is inferred from the\nfile suffix.\n(\\*.v, \\*.vh) = Verilog\n(\\*.vhd)       = VHDL\n(\\*.sv)        = SystemVerilog\n(\\*.c)         = C\n(\\*.cpp, .cc)  = C++\n(\\*.py)        = Python",
         "lock": "false",
         "require": null,
         "scope": "global",
@@ -6340,7 +6340,7 @@
             "cli: -steplist 'import'",
             "api: chip.set('steplist','import')"
         ],
-        "help": "List of steps to execute. The default is to execute all steps defined in the flow graph.",
+        "help": "List of steps to execute. The default is to execute all steps\ndefined in the flow graph.",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -6390,7 +6390,7 @@
                     "cli: -supply_pin 'vdd vdd_0'",
                     "api: chip.set('supply','vdd','pin','vdd_0')"
                 ],
-                "help": "Defines a supply name alias to assign to a power source. A power supply source can be a list of block pins or a regulator output pin.",
+                "help": "Defines a supply name alias to assign to a power source.\nA power supply source can be a list of block pins or a regulator\noutput pin.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -6408,7 +6408,7 @@
             "cli: -target freepdk45_demo",
             "api: chip.set('target','freepdk45_demo')"
         ],
-        "help": "Sets a target module to be used for compilation. The target module must set up all paramaters needed. The target module may load multiple flows and libraries.",
+        "help": "Sets a target module to be used for compilation. The target\nmodule must set up all paramaters needed. The target module\nmay load multiple flows and libraries.",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -6425,7 +6425,7 @@
                 "cli: -techarg 'mimcap true",
                 "api: chip.set('techarg','mimcap', 'true')"
             ],
-            "help": "Parameter passed in as key/value pair to the technology target referenced in the load_pdk() API call. See the target technology for specific guidelines regarding configuration parameters.",
+            "help": "Parameter passed in as key/value pair to the technology target\nreferenced in the load_pdk() API call. See the target technology\nfor specific guidelines regarding configuration parameters.",
             "lock": "false",
             "require": null,
             "scope": "job",
@@ -6447,7 +6447,7 @@
         ],
         "filehash": [],
         "hashalgo": "sha256",
-        "help": "A list of testbench sources. The files are read in order from first to last entered. File type is inferred from the file suffix: (\\*.v, \\*.vh) = Verilog (\\*.vhd)      = VHDL (\\*.sv)       = SystemVerilog (\\*.c)        = C (\\*.cpp, .cc) = C++ (\\*.py)       = Python",
+        "help": "A list of testbench sources. The files are read in order from first to\nlast entered. File type is inferred from the file suffix:\n(\\*.v, \\*.vh) = Verilog\n(\\*.vhd)      = VHDL\n(\\*.sv)       = SystemVerilog\n(\\*.c)        = C\n(\\*.cpp, .cc) = C++\n(\\*.py)       = Python",
         "lock": "false",
         "require": null,
         "scope": "global",
@@ -6495,7 +6495,7 @@
             "cli: -track",
             "api: chip.set('track', 'true')"
         ],
-        "help": "Turns on tracking of all 'record' parameters during each task. Tracking will result in potentially sensitive data being recorded in the manifest so only turn on this feature if you have control of the final manifest.",
+        "help": "Turns on tracking of all 'record' parameters during each\ntask. Tracking will result in potentially sensitive data\nbeing recorded in the manifest so only turn on this feature\nif you have control of the final manifest.",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -6625,7 +6625,7 @@
             "cli: -vercheck",
             "api: chip.set('vercheck', 'true')"
         ],
-        "help": "Enforces strict version checking on all invoked tools if True. The list of supported version numbers is defined in the 'version' parameter in the 'eda' dictionary for each tool.",
+        "help": "Enforces strict version checking on all invoked tools if True.\nThe list of supported version numbers is defined in the\n'version' parameter in the 'eda' dictionary for each tool.",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -6642,7 +6642,7 @@
                 "cli: -version",
                 "api: chip.get('version', 'print')"
             ],
-            "help": "Command line switch to print the schema and software version numbers in an 'sc' command line app.",
+            "help": "Command line switch to print the schema and software\nversion numbers in an 'sc' command line app.",
             "lock": "false",
             "require": "all",
             "scope": "global",
@@ -6669,7 +6669,7 @@
             "value": "0.8.0"
         },
         "software": {
-            "defvalue": null,
+            "defvalue": "0.8.0",
             "example": [
                 "cli: -version_software",
                 "api: chip.get('version', 'software')"
@@ -6682,7 +6682,7 @@
             "signature": null,
             "switch": "-version_software <str>",
             "type": "str",
-            "value": null
+            "value": "0.8.0"
         }
     },
     "vlib": {
@@ -6696,7 +6696,7 @@
         ],
         "filehash": [],
         "hashalgo": "sha256",
-        "help": "List of library files to be read in. Modules found in the libraries are not interpreted as root modules.",
+        "help": "List of library files to be read in. Modules found in the\nlibraries are not interpreted as root modules.",
         "lock": "false",
         "require": null,
         "scope": "global",
@@ -6717,7 +6717,7 @@
         ],
         "filehash": [],
         "hashalgo": "sha256",
-        "help": "Waveform(s) used as a golden test vectors to ensure that compilation transformations do not modify the functional behavior of the source code. The waveform file must be compatible with the testbench and compilation flow tools.",
+        "help": "Waveform(s) used as a golden test vectors to ensure that compilation\ntransformations do not modify the functional behavior of the source\ncode. The waveform file must be compatible with the testbench and\ncompilation flow tools.",
         "lock": "false",
         "require": null,
         "scope": "global",
@@ -6733,7 +6733,7 @@
             "cli: -y './mylib'",
             "api: chip.set('ydir','./mylib')"
         ],
-        "help": "Search paths to look for verilog modules found in the the source list. The import engine will look for modules inside files with the specified +libext+ param suffix.",
+        "help": "Search paths to look for verilog modules found in the the\nsource list. The import engine will look for modules inside\nfiles with the specified +libext+ param suffix.",
         "lock": "false",
         "require": null,
         "scope": "global",

--- a/tests/core/test_scparam.py
+++ b/tests/core/test_scparam.py
@@ -111,7 +111,7 @@ def test_scparam():
         'example': [
             "cli: -metric_cells 'place 0 goal 100'",
             "api: chip.set('metric','place','0','cells','goal,'100')"],
-        'help': """Metric tracking the total number of instances on a per step basis. Total cells includes registers. In the case of FPGAs, it represents the number of LUTs."""
+        'help': """Metric tracking the total number of instances on a per step basis.\nTotal cells includes registers. In the case of FPGAs, it\nrepresents the number of LUTs."""
     }
 
     assert cfg == cfg_golden


### PR DESCRIPTION
This PR:
- Implements the TODO in _search() mentioned in code review
- Fixes up RST parsing of schema help strings

For the latter, I decided move to processing schelp using the Python standard "trim()" function for preprocessing docstrings that we were already using for the flows/pdks/libs/etc. documentation. The previous regex approach was stripping away newlines, which made it impossible to do fancier RST formatting, such as lists.

The new approach strips off a calculated amount of leading spaces to preserve additional indentation (for inserting things like codeblocks), and preserves newlines. A consequence of this change is that there will be newlines in the help string, but I think this is a worthwhile tradeoff, since it makes the actual docs look much nicer:

## Before
![Screenshot from 2022-03-15 11-33-55](https://user-images.githubusercontent.com/4412459/158422147-ef2ba7f1-e853-498e-a247-139ca5b63a39.png)

## After
![Screenshot from 2022-03-15 11-39-02](https://user-images.githubusercontent.com/4412459/158422160-c933e455-c894-4c39-8f01-183da99ce38f.png)

