### PR TITLE
Fix _make_record() for schema changes

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3543,7 +3543,7 @@ class Chip:
         ##################
         # 23. Make a record if tracking is enabled
         if self.get('track'):
-            self._make_record(job, step, index, wall_start, wall_end, version)
+            self._make_record(step, index, wall_start, wall_end, version)
 
         ##################
         # 24. Save a successful manifest
@@ -4204,7 +4204,7 @@ class Chip:
         return 'local'
 
     #######################################
-    def _make_record(self, job, step, index, start, end, toolversion):
+    def _make_record(self, step, index, start, end, toolversion):
         '''
         Records provenance details for a runstep.
         '''
@@ -4213,28 +4213,25 @@ class Chip:
         end_date = datetime.datetime.fromtimestamp(end).strftime('%Y-%m-%d %H:%M:%S')
 
         userid = getpass.getuser()
-        self.set('record', job, step, index, 'userid', userid)
-
-        scversion = self.get('version', 'sc')
-        self.set('record', job, step, index, 'version', 'sc', scversion)
+        self.set('record', step, index, 'userid', userid)
 
         if toolversion:
-            self.set('record', job, step, index, 'version', 'tool', toolversion)
+            self.set('record', step, index, 'toolversion', toolversion)
 
-        self.set('record', job, step, index, 'starttime', start_date)
-        self.set('record', job, step, index, 'endtime', end_date)
+        self.set('record', step, index, 'starttime', start_date)
+        self.set('record', step, index, 'endtime', end_date)
 
         machine = platform.node()
-        self.set('record', job, step, index, 'machine', machine)
+        self.set('record', step, index, 'machine', machine)
 
-        self.set('record', job, step, index, 'region', self._get_cloud_region())
+        self.set('record', step, index, 'region', self._get_cloud_region())
 
         try:
             gateways = netifaces.gateways()
             ipaddr, interface = gateways['default'][netifaces.AF_INET]
             macaddr = netifaces.ifaddresses(interface)[netifaces.AF_LINK][0]['addr']
-            self.set('record', job, step, index, 'ipaddr', ipaddr)
-            self.set('record', job, step, index, 'macaddr', macaddr)
+            self.set('record', step, index, 'ipaddr', ipaddr)
+            self.set('record', step, index, 'macaddr', macaddr)
         except KeyError:
             self.logger.warning('Could not find default network interface info')
 
@@ -4243,11 +4240,11 @@ class Chip:
             lower_sys_name = 'macos'
         else:
             lower_sys_name = system.lower()
-        self.set('record', job, step, index, 'platform', lower_sys_name)
+        self.set('record', step, index, 'platform', lower_sys_name)
 
         if system == 'Linux':
             distro_name = distro.id()
-            self.set('record', job, step, index, 'distro', distro_name)
+            self.set('record', step, index, 'distro', distro_name)
 
         if system == 'Darwin':
             osversion, _, _ = platform.mac_ver()
@@ -4255,7 +4252,7 @@ class Chip:
             osversion = distro.version()
         else:
             osversion = platform.release()
-        self.set('record', job, step, index, 'version', 'os', osversion)
+        self.set('record', step, index, 'osversion', osversion)
 
         if system == 'Linux':
             kernelversion = platform.release()
@@ -4266,10 +4263,10 @@ class Chip:
         else:
             kernelversion = None
         if kernelversion:
-            self.set('record', job, step, index, 'version', 'kernel', kernelversion)
+            self.set('record', step, index, 'kernelversion', kernelversion)
 
         arch = platform.machine()
-        self.set('record', job, step, index, 'arch', arch)
+        self.set('record', step, index, 'arch', arch)
 
     #######################################
     def _safecompare(self, value, op, goal):


### PR DESCRIPTION
This PR updates the 'record' keypaths being used by _make_record().

It's interesting to me that this didn't cause any failures, 'track' is on in examples/gcd/gcd.py and it produces ERROR logs without being fatal:

`pytest tests/examples/test_gcd::test_py -s`

```
| INFO    | job0    | import       | 0   | Copying /home/noah/code/siliconcompiler/examples/gcd/gcd.sdc to 'inputs' directory
| INFO    | job0    | import       | 0   | Checking executable. Tool 'surelog' found with version '1.25'
| INFO    | job0    | import       | 0   | Running in /tmp/pytest-of-noah/pytest-22/test_py0/build/gcd/job0/import/0
| INFO    | job0    | import       | 0   | surelog -parse /tmp/pytest-of-noah/pytest-22/test_py0/build/gcd/job0/import/0/outputs/gcd_0a998a746037a840df8d7f2133c57f4846e3405f.v -top gcd +libext+.sv
| ERROR   | job0    | import       | 0   | Get keypath [record,job0,import,0,userid] does not exist.
| ERROR   | job0    | import       | 0   | Get keypath [version,sc] does not exist.
| ERROR   | job0    | import       | 0   | Get keypath [record,job0,import,0,version,sc] does not exist.
| ERROR   | job0    | import       | 0   | Get keypath [record,job0,import,0,version,tool] does not exist.
| ERROR   | job0    | import       | 0   | Get keypath [record,job0,import,0,starttime] does not exist.
| ERROR   | job0    | import       | 0   | Get keypath [record,job0,import,0,endtime] does not exist.
| ERROR   | job0    | import       | 0   | Get keypath [record,job0,import,0,machine] does not exist.
| ERROR   | job0    | import       | 0   | Get keypath [record,job0,import,0,region] does not exist.
```

I'll make a note to look into where we set/check the error flag and make sure it's done consistently and thoughtfully. 