### PR TITLE
Implement flexible version checking and make 'vercheck' default to True

### DIFF
--- a/docs/user_guide/tools.rst
+++ b/docs/user_guide/tools.rst
@@ -35,17 +35,24 @@ SiliconCompiler execution depends on implementing adapter code "drivers" for eac
      - run()
      - yes
 
+   * - **normalize_version**
+     - Returns executable version
+     - tool version
+     - normalized version
+     - run()
+     - no
+
    * - **pre_process**
      - Pre-executable logic
      - chip
-     - chip
+     - n/a
      - run()
      - no
 
    * - **post_process**
      - Post-executable logic
      - chip
-     - chip
+     - exit code
      - run()
      - yes
 
@@ -91,12 +98,23 @@ parse_version(stdout)
 -----------------------
 The run() function includes built in executable version checking, which can be enabled or disabled with the 'vercheck' parameter. The executable option to use for printing out the version number is specified with the 'vswitch' parameter within the setup() function. Commonly used options include '-v', '\-\-version', '-version'. The executable output varies widely, so we need a parsing function that processes the output and returns a single uniform version string. The example shows how this function is implemented for the Yosys tool. ::
 
+
   def parse_version(stdout):
       # Yosys 0.9+3672 (git sha1 014c7e26, gcc 7.5.0-3ubuntu1~18.04 -fPIC -Os)
-      version = stdout.split()[1]
-      return version.split('+')[0]
+      return stdout.split()[1]
 
 The run() function compares the returned parsed version against the 'version' parameter specified in the setup() function to ensure that a qualified executable version is being used.
+
+normalize_version(version)
+--------------------------
+SC's version checking logic is based on Python's `PEP-440 standard <https://peps.python.org/pep-0440/>`_. In order to perform version checking for tools that do not natively provide PEP-440 compatible version numbers, this function must be implemented to convert the tool-specific versions to a PEP-440 compatible equivalent.
+
+Note that a raw version number may parse as a valid PEP-440 version but not be semantically correct. normalize_version() must be implemented in these cases to ensure version comparisons make sense. For example, we have to do this for Yosys. ::
+
+  def normalize_version(version):
+      # Replace '+', which represents a "local version label", with '-', which is
+      # an "implicit post release number".
+      return version.replace('+', '-')
 
 pre_process(chip)
 -----------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ cryptography >= 3.4.7
 graphviz >= 0.18.1
 netifaces >= 0.11.0
 distro >= 1.6.0
+packaging >= 21.3
 
 # Build dependencies
 #:build

--- a/setup/install-ice40.sh
+++ b/setup/install-ice40.sh
@@ -15,7 +15,7 @@ cd -
 
 git clone https://github.com/YosysHQ/nextpnr nextpnr
 cd nextpnr
-git checkout c73d4cf6
+git checkout nextpnr-0.2
 cmake -DARCH=ice40 -DCMAKE_INSTALL_PREFIX=/usr/local .
 make -j$(nproc)
 sudo make install

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -58,7 +58,8 @@ def scparam(cfg,
         # note (bools are never lists)
         if re.match(r'bool',sctype):
             require = 'all'
-            defvalue = 'false'
+            if defvalue is None:
+                defvalue = 'false'
         if re.match(r'\[',sctype) and signature is None:
             signature = []
         if re.match(r'\[',sctype) and defvalue is None:
@@ -2395,6 +2396,7 @@ def schema_options(cfg):
 
     scparam(cfg, ['vercheck'],
             sctype='bool',
+            defvalue='true',
             scope='job',
             shorthelp="Enable version checking",
             switch="-vercheck <bool>",

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1280,14 +1280,17 @@ def schema_eda(cfg, tool='default', step='default', index='default'):
             scope='job',
             shorthelp="Tool version number",
             switch="-eda_version 'tool <str>'",
-            example=["cli: -eda_version 'openroad 2.0'",
-                     "api:  chip.set('eda','openroad','version','2.0')"],
+            example=["cli: -eda_version 'openroad >=v2.0'",
+                     "api:  chip.set('eda','openroad','version','>=v2.0')"],
             schelp="""
-            List of acceptable versions of the tool executable to be used.
-            During task execution, the the tool is called with the 'vswitch'
-            to check the runtime executable version. When the 'vercheck'
-            is set to True, of the 'version' fails to match the system
-            executable, then the job is halted pre-execution.""")
+            List of acceptable versions of the tool executable to be used. Each
+            entry in this list must be a version specifier as described by Python
+            `PEP-440 <https://peps.python.org/pep-0440/#version-specifiers>`_.
+            During task execution, the tool is called with the 'vswitch' to
+            check the runtime executable version. When 'vercheck' is set to
+            True, if the version of the system executable is not allowed by any
+            of the specifiers in 'version', then the job is halted
+            pre-execution.""")
 
     scparam(cfg, ['eda', tool, 'format'],
             sctype='str',

--- a/siliconcompiler/tools/bambu/bambu.py
+++ b/siliconcompiler/tools/bambu/bambu.py
@@ -33,7 +33,7 @@ def setup(chip):
     refdir = 'tools/'+tool
     chip.set('eda', tool, 'exe', 'bambu', clobber=False)
     chip.set('eda', tool, 'vswitch', '--version', clobber=False)
-    chip.set('eda', tool, 'version', '0.9.6', clobber=False)
+    chip.set('eda', tool, 'version', '>=0.9.6', clobber=False)
     chip.set('eda', tool, 'refdir', step, index, refdir, clobber=False)
     chip.set('eda', tool, 'threads', step, index, os.cpu_count(), clobber=False)
     chip.set('eda', tool, 'option', step, index, [])

--- a/siliconcompiler/tools/bluespec/bluespec.py
+++ b/siliconcompiler/tools/bluespec/bluespec.py
@@ -49,7 +49,7 @@ def setup(chip):
     # This is technically the 'verbose' flag, but used alone it happens to give
     # us the version # and exit cleanly, so we'll use it here.
     chip.set('eda', tool, 'vswitch', '-v', clobber=False)
-    chip.set('eda', tool, 'version', '2021.07', clobber=False)
+    chip.set('eda', tool, 'version', '>=2021.07', clobber=False)
     chip.set('eda', tool, 'copy', False, clobber=False)
     chip.set('eda', tool, 'refdir', step, index,  refdir, clobber=False)
     chip.set('eda', tool, 'threads', step, index,  os.cpu_count(), clobber=False)
@@ -62,7 +62,9 @@ def setup(chip):
     chip.add('eda', tool, 'require', step, index, 'source')
 
 def parse_version(stdout):
+    # Examples:
     # Bluespec Compiler, version 2021.12.1-27-g9a7d5e05 (build 9a7d5e05)
+    # Bluespec Compiler, version 2021.07 (build 4cac6eba)
 
     long_version = stdout.split()[3]
     return long_version.split('-')[0]

--- a/siliconcompiler/tools/chisel/chisel.py
+++ b/siliconcompiler/tools/chisel/chisel.py
@@ -45,7 +45,7 @@ def setup(chip):
     refdir = 'tools/'+tool
     chip.set('eda', tool, 'exe', 'sbt', clobber=False)
     chip.set('eda', tool, 'vswitch', '--version', clobber=False)
-    chip.set('eda', tool, 'version', '1.5.5', clobber=False)
+    chip.set('eda', tool, 'version', '>=1.5.5', clobber=False)
     chip.set('eda', tool, 'copy', True, clobber=False)
     chip.set('eda', tool, 'refdir', step, index,  refdir, clobber=False)
     chip.set('eda', tool, 'threads', step, index,  os.cpu_count(), clobber=False)

--- a/siliconcompiler/tools/ghdl/ghdl.py
+++ b/siliconcompiler/tools/ghdl/ghdl.py
@@ -45,7 +45,7 @@ def setup(chip):
     chip.set('eda', tool, 'copy', 'false', clobber=clobber)
     chip.set('eda', tool, 'exe', 'ghdl', clobber=clobber)
     chip.set('eda', tool, 'vswitch', '--version', clobber=clobber)
-    chip.set('eda', tool, 'version', '2.0.0-dev', clobber=clobber)
+    chip.set('eda', tool, 'version', '>=2.0.0-dev', clobber=clobber)
     chip.set('eda', tool, 'threads', step, index, '4', clobber=clobber)
     chip.set('eda', tool, 'option', step, index, '', clobber=clobber)
 
@@ -92,6 +92,9 @@ def runtime_options(chip):
 
 def parse_version(stdout):
     # first line: GHDL 2.0.0-dev (1.0.0.r827.ge49cb7b9) [Dunoon edition]
+
+    # '*-dev' is interpreted by packaging.version as a "developmental release",
+    # which has the correct semantics. e.g. Version('2.0.0') > Version('2.0.0-dev')
     return stdout.split()[1]
 
 ################################

--- a/siliconcompiler/tools/icarus/icarus.py
+++ b/siliconcompiler/tools/icarus/icarus.py
@@ -47,7 +47,7 @@ def setup(chip):
     # Standard Setup
     chip.set('eda', tool, 'exe', 'iverilog', clobber=False)
     chip.set('eda', tool, 'vswitch', '-V', clobber=False)
-    chip.set('eda', tool, 'version', '10.3', clobber=False)
+    chip.set('eda', tool, 'version', '>=10.3', clobber=False)
     chip.set('eda', tool, 'threads', step, index, os.cpu_count(), clobber=False)
 
     if step == 'compile':

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -90,7 +90,8 @@ def setup(chip, mode="batch"):
 
     chip.set('eda', tool, 'exe', klayout_exe, clobber=True)
     chip.set('eda', tool, 'vswitch', ['-zz', '-v'], clobber=clobber)
-    chip.set('eda', tool, 'version', '0.27.8', clobber=clobber)
+    # Versions < 0.27.6 may be bundled with an incompatible version of Python.
+    chip.set('eda', tool, 'version', '>=0.27.6', clobber=clobber)
     chip.set('eda', tool, 'format', 'json', clobber=clobber)
     chip.set('eda', tool, 'copy', 'true', clobber=clobber)
     chip.set('eda', tool, 'refdir', step, index, refdir, clobber=clobber)

--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -53,7 +53,7 @@ def setup(chip):
 
     chip.set('eda', tool, 'exe', tool)
     chip.set('eda', tool, 'vswitch', '--version')
-    chip.set('eda', tool, 'version', '8.3.274')
+    chip.set('eda', tool, 'version', '>=8.3.196')
     chip.set('eda', tool, 'format', 'tcl')
     chip.set('eda', tool, 'copy', 'true') # copy in .magicrc file
     chip.set('eda', tool, 'threads', step, index,  4)

--- a/siliconcompiler/tools/netgen/netgen.py
+++ b/siliconcompiler/tools/netgen/netgen.py
@@ -49,7 +49,7 @@ def setup(chip):
 
     chip.set('eda', tool, 'exe', tool)
     chip.set('eda', tool, 'vswitch', '-batch')
-    chip.set('eda', tool, 'version', '1.5.210')
+    chip.set('eda', tool, 'version', '>=1.5.192')
     chip.set('eda', tool, 'format', 'tcl')
     chip.set('eda', tool, 'copy', 'true')
     chip.set('eda', tool, 'threads', step, index, 4)

--- a/siliconcompiler/tools/nextpnr/nextpnr.py
+++ b/siliconcompiler/tools/nextpnr/nextpnr.py
@@ -40,7 +40,7 @@ def setup(chip):
     clobber = False
     chip.set('eda', tool, 'exe', 'nextpnr-ice40', clobber=clobber)
     chip.set('eda', tool, 'vswitch', '--version', clobber=clobber)
-    chip.set('eda', tool, 'version', 'c73d4cf6', clobber=clobber)
+    chip.set('eda', tool, 'version', '>=0.2', clobber=clobber)
     chip.set('eda', tool, 'option', step, index, "", clobber=clobber)
 
     topmodule = chip.get('design')
@@ -80,8 +80,14 @@ def runtime_options(chip):
 ################################
 
 def parse_version(stdout):
+    # Examples:
     # nextpnr-ice40 -- Next Generation Place and Route (Version c73d4cf6)
-    return stdout.split()[-1].rstrip(')')
+    # nextpnr-ice40 -- Next Generation Place and Route (Version nextpnr-0.2)
+    version = stdout.split()[-1].rstrip(')')
+    if version.startswith('nextpnr-'):
+        return version.split('-')[1]
+    else:
+        return version
 
 ################################
 # Setup Tool (pre executable)

--- a/siliconcompiler/tools/openfpga/openfpga.py
+++ b/siliconcompiler/tools/openfpga/openfpga.py
@@ -48,7 +48,6 @@ def setup(chip):
     index = chip.get('arg','index')
 
 
-    chip.set('eda', tool, 'version', '0.0')
     chip.set('eda', tool, 'copy', 'true')
     chip.set('eda', tool, 'refdir', step, index,  refdir)
 

--- a/siliconcompiler/tools/openfpgaloader/openfpgaloader.py
+++ b/siliconcompiler/tools/openfpgaloader/openfpgaloader.py
@@ -50,7 +50,7 @@ def setup(chip):
     # tool setup
     chip.set('eda', tool, 'exe', tool, clobber=False)
     chip.set('eda', tool, 'vswitch', '--Version', clobber=False)
-    chip.set('eda', tool, 'version', 'v0.5.0', clobber=False)
+    chip.set('eda', tool, 'version', '0.5.0', clobber=False)
 
     options = []
     options.append("inputs" + chip.get('design') + ".bit")

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -62,7 +62,7 @@ def setup(chip, mode='batch'):
 
     chip.set('eda', tool, 'exe', tool, clobber=clobber)
     chip.set('eda', tool, 'vswitch', '-version', clobber=clobber)
-    chip.set('eda', tool, 'version', 'v2.0', clobber=clobber)
+    chip.set('eda', tool, 'version', '>=v2.0-3078', clobber=clobber)
     chip.set('eda', tool, 'format', 'tcl', clobber=clobber)
     chip.set('eda', tool, 'copy', 'true', clobber=clobber)
     chip.set('eda', tool, 'option',  step, index, option, clobber=clobber)
@@ -147,8 +147,18 @@ def parse_version(stdout):
     # strip off the "1" prefix if it's there
     version = stdout.split()[-1]
 
-    # strip off extra details in new version styles
-    return version.split('-')[0]
+    pieces = version.split('-')
+    if len(pieces) > 1:
+        # strip off the hash in the new version style
+        return '-'.join(pieces[:-1])
+    else:
+        return pieces[0]
+
+def normalize_version(version):
+    if '.' in version:
+        return version.lstrip('v')
+    else:
+        return '0'
 
 def pre_process(chip):
     step = chip.get('arg', 'step')

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -52,7 +52,7 @@ def setup(chip):
     # Standard Setup
     chip.set('eda', tool, 'exe', exe, clobber=False)
     chip.set('eda', tool, 'vswitch', '--version', clobber=False)
-    chip.set('eda', tool, 'version', '>=1.14', clobber=False)
+    chip.set('eda', tool, 'version', '>=1.13', clobber=False)
     chip.set('eda', tool, 'threads', step, index,  os.cpu_count(), clobber=False)
 
     # -parse is slow but ensures the SV code is valid
@@ -86,9 +86,6 @@ def parse_version(stdout):
 
     # grab version # by splitting on whitespace
     return stdout.split()[1]
-
-def normalize_version(version):
-    return tuple(int(v) for v in version.split('.'))
 
 ################################
 #  Custom runtime options

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -52,7 +52,7 @@ def setup(chip):
     # Standard Setup
     chip.set('eda', tool, 'exe', exe, clobber=False)
     chip.set('eda', tool, 'vswitch', '--version', clobber=False)
-    chip.set('eda', tool, 'version', '1.14', clobber=False)
+    chip.set('eda', tool, 'version', '>=1.14', clobber=False)
     chip.set('eda', tool, 'threads', step, index,  os.cpu_count(), clobber=False)
 
     # -parse is slow but ensures the SV code is valid
@@ -86,6 +86,9 @@ def parse_version(stdout):
 
     # grab version # by splitting on whitespace
     return stdout.split()[1]
+
+def normalize_version(version):
+    return tuple(int(v) for v in version.split('.'))
 
 ################################
 #  Custom runtime options

--- a/siliconcompiler/tools/sv2v/sv2v.py
+++ b/siliconcompiler/tools/sv2v/sv2v.py
@@ -50,7 +50,7 @@ def setup(chip):
 
     chip.set('eda', tool, 'exe', tool)
     chip.set('eda', tool, 'vswitch', '--numeric-version')
-    chip.set('eda', tool, 'version', '0.0.9')
+    chip.set('eda', tool, 'version', '>=0.0.9')
     chip.set('eda', tool, 'threads', step, index,  4)
 
     # Since we run sv2v after the import/preprocess step, there should be no
@@ -72,7 +72,7 @@ def setup(chip):
 
 def parse_version(stdout):
     # 0.0.7-130-g1aa30ea
-    return stdout.split('-')[0]
+    return '-'.join(stdout.split('-')[:-1])
 
 ################################
 # Post_process (post executable)

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -55,7 +55,7 @@ def setup(chip):
     # Standard Setup
     chip.set('eda', tool, 'exe', 'verilator', clobber=False)
     chip.set('eda', tool, 'vswitch', '--version', clobber=False)
-    chip.set('eda', tool, 'version', '4.028', clobber=False)
+    chip.set('eda', tool, 'version', '>=4.028', clobber=False)
     chip.set('eda', tool, 'threads', step, index,  os.cpu_count(), clobber=False)
 
     # Options driven on a per step basis (use 'set' on first call!)

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -50,7 +50,7 @@ def setup(chip):
     # Standard Setup
     chip.set('eda', tool, 'exe', 'yosys', clobber=False)
     chip.set('eda', tool, 'vswitch', '--version', clobber=False)
-    chip.set('eda', tool, 'version', '0.13', clobber=False)
+    chip.set('eda', tool, 'version', '>=0.13', clobber=False)
     chip.set('eda', tool, 'format', 'tcl', clobber=False)
     chip.set('eda', tool, 'copy', 'true', clobber=False)
     chip.set('eda', tool, 'option', step, index, '-c', clobber=False)
@@ -116,8 +116,12 @@ def pre_process(chip):
 
 def parse_version(stdout):
     # Yosys 0.9+3672 (git sha1 014c7e26, gcc 7.5.0-3ubuntu1~18.04 -fPIC -Os)
-    version = stdout.split()[1]
-    return version.split('+')[0]
+    return stdout.split()[1]
+
+def normalize_version(version):
+    # Replace '+', which represents a "local version label", with '-', which is
+    # an "implicit post release number".
+    return version.replace('+', '-')
 
 ################################
 # Post_process (post executable)

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1196,10 +1196,10 @@
             "version": {
                 "defvalue": [],
                 "example": [
-                    "cli: -eda_version 'openroad 2.0'",
-                    "api:  chip.set('eda','openroad','version','2.0')"
+                    "cli: -eda_version 'openroad >=v2.0'",
+                    "api:  chip.set('eda','openroad','version','>=v2.0')"
                 ],
-                "help": "List of acceptable versions of the tool executable to be used.\nDuring task execution, the the tool is called with the 'vswitch'\nto check the runtime executable version. When the 'vercheck'\nis set to True, of the 'version' fails to match the system\nexecutable, then the job is halted pre-execution.",
+                "help": "List of acceptable versions of the tool executable to be used. Each\nentry in this list must be a version specifier as described by Python\n`PEP-440 <https://peps.python.org/pep-0440/#version-specifiers>`_.\nDuring task execution, the tool is called with the 'vswitch' to\ncheck the runtime executable version. When 'vercheck' is set to\nTrue, if the version of the system executable is not allowed by any\nof the specifiers in 'version', then the job is halted\npre-execution.",
                 "lock": "false",
                 "require": null,
                 "scope": "job",
@@ -6621,7 +6621,7 @@
         }
     },
     "vercheck": {
-        "defvalue": "false",
+        "defvalue": "true",
         "example": [
             "cli: -vercheck",
             "api: chip.set('vercheck', 'true')"
@@ -6634,7 +6634,7 @@
         "signature": null,
         "switch": "-vercheck <bool>",
         "type": "bool",
-        "value": "false"
+        "value": "true"
     },
     "version": {
         "print": {


### PR DESCRIPTION
This PR implements a proposal for flexible version checking that allows for comparisons. I've implemented this as a baseline for discussion before I go ahead and modify more tool drivers (although I implemented it in a way that somewhat maintains backwards compatibility).

Here is the approach:
- `parse_version()` stays the same
- Tools may define a new function, `normalize_version()`. This is intended to take in a version string produced by `parse_version()`, and return a comparable value such that if `ver_a` is newer than `ver_b`, `normalize_version(ver_a) > normalize_version(ver_b)`
  - As a methodology thing, I think it makes the most sense for tools to return tuples of int. The way tuple comparison is implemented lets us do semantic versioning-style comparisons easily. For example, `(2, 0) > (1, 5)` is true, and `(1, 100) > (1, 95)` is true. 
  - If a tool doesn't have a `normalize_version()`, the result of `parse_version()` is used but the specifiers are restricted to exact match or != (backwards compatibility)
- In the 'eda', 'version' field, drivers provide a list of version specifiers that are either a bare version, or one of `==, !=, >=, >` followed by 0 or more whitespace characters, followed by a version.
  - A bare version translates to an exact match (backwards compatibility)
  - Everything in the list is a logical AND (i.e. version needs to match all specifiers for check to be ok)

The main thing that I want to discuss is whether to make each entry in the list a logical "and" or "or". I can see value in both patterns:
- and is good for excluding a single bad version: `>=1.0.0 && != 1.05` 
- or is good for specifying a list of known good versions: `==0.6 || ==0.7`

I implemented this as "and" since it matches the Python [PEP-440](https://peps.python.org/pep-0440/) standard for lists of version specifiers, but I've been thinking about ways we could potentially do both.