### PR TITLE
Allow yosys to skip libraries if they are expected but not present in the schema

### DIFF
--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -19,13 +19,17 @@ set stat_libs ""
 foreach item $sc_scenarios {
     set libcorner [dict get $sc_cfg mcmm $item libcorner]
     foreach lib $sc_targetlibs {
-	set lib_file [dict get $sc_cfg library $lib $sc_delaymodel $libcorner lib]
-	yosys read_liberty -lib $lib_file
+        if [dict exists dict get $sc_cfg library $lib $sc_delaymodel $libcorner lib] {
+            set lib_file [dict get $sc_cfg library $lib $sc_delaymodel $libcorner lib]
+            yosys read_liberty -lib $lib_file
+        }
     }
     foreach lib $sc_macrolibs {
-	set lib_file [dict get $sc_cfg library $lib $sc_delaymodel $libcorner lib]
-	yosys read_liberty -lib $lib_file
-	append stat_libs "-liberty $lib_file "
+        if [dict exists dict get $sc_cfg library $lib $sc_delaymodel $libcorner lib] {
+            set lib_file [dict get $sc_cfg library $lib $sc_delaymodel $libcorner lib]
+            yosys read_liberty -lib $lib_file
+            append stat_libs "-liberty $lib_file "
+        }
     }
 }
 

--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -19,10 +19,8 @@ set stat_libs ""
 foreach item $sc_scenarios {
     set libcorner [dict get $sc_cfg mcmm $item libcorner]
     foreach lib $sc_targetlibs {
-        if [dict exists dict get $sc_cfg library $lib $sc_delaymodel $libcorner lib] {
-            set lib_file [dict get $sc_cfg library $lib $sc_delaymodel $libcorner lib]
-            yosys read_liberty -lib $lib_file
-        }
+        set lib_file [dict get $sc_cfg library $lib $sc_delaymodel $libcorner lib]
+        yosys read_liberty -lib $lib_file
     }
     foreach lib $sc_macrolibs {
         if [dict exists dict get $sc_cfg library $lib $sc_delaymodel $libcorner lib] {


### PR DESCRIPTION
This change fixes the `syn` branch of `asictopflow`, by making .lib files optional for components. Some macros, such as the core GDS/DEF outputs from an `asicflow` job, may not have associated liberty files.