### PR TITLE
Small fixes to setup scripts

### DIFF
--- a/setup/install-klayout.sh
+++ b/setup/install-klayout.sh
@@ -3,18 +3,19 @@
 mkdir -p deps
 cd deps
 
+pkg_version="0.27.8-1"
 version=$(lsb_release -sr)
 
 if [ "$version" = "18.04" ]; then
-    url=https://www.klayout.org/downloads/Ubuntu-18/klayout_0.27.8-1_amd64.deb
+    url=https://www.klayout.org/downloads/Ubuntu-18/klayout_${pkg_version}_amd64.deb
 elif [ "$version" = "20.04" ]; then
-    url=https://www.klayout.org/downloads/Ubuntu-20/klayout_0.27.8-1_amd64.deb
+    url=https://www.klayout.org/downloads/Ubuntu-20/klayout_${pkg_version}_amd64.deb
 else
     echo "Script doesn't support Ubuntu version $version."
 fi
 
 wget $url
-sudo dpkg -i klayout_0.26.12-1_amd64.deb
+sudo dpkg -i klayout_${pkg_version}_amd64.deb
 
 echo "Please add \"export QT_QPA_PLATFORM=offscreen\" to your .bashrc"
 

--- a/setup/install-klayout.sh
+++ b/setup/install-klayout.sh
@@ -14,7 +14,13 @@ else
     echo "Script doesn't support Ubuntu version $version."
 fi
 
+# Fetch package
 wget $url
+# Install dependencies
+sudo apt-get install -y libqt5core5a libqt5designer5 libqt5gui5 libqt5multimedia5 \
+       libqt5multimediawidgets5 libqt5network5 libqt5opengl5 libqt5printsupport5 \
+       libqt5sql5 libqt5svg5 libqt5widgets5 libqt5xml5 libqt5xmlpatterns5 libruby2.7
+# Install package
 sudo dpkg -i klayout_${pkg_version}_amd64.deb
 
 echo "Please add \"export QT_QPA_PLATFORM=offscreen\" to your .bashrc"

--- a/setup/install-openroad-rhel7.sh
+++ b/setup/install-openroad-rhel7.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-scr_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
 
 sudo yum groupinstall -y 'Development Tools'
 sudo yum install -y pkgconfig bzip2 openssl-devel pth libatomic bison flex readline-devel gawk libffi-devel git graphviz zlib-devel wget
@@ -109,7 +109,7 @@ sudo ldconfig
 cd -
 
 # Install OpenROAD tools.
-cd ${scr_path}/..
+cd ${src_path}/..
 git submodule update --init --recursive third_party/tools/openroad
 cd third_party/tools/openroad
 ./build_openroad.sh -o

--- a/setup/install-openroad-rhel7.sh
+++ b/setup/install-openroad-rhel7.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+scr_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
+
 sudo yum groupinstall -y 'Development Tools'
 sudo yum install -y pkgconfig bzip2 openssl-devel pth libatomic bison flex readline-devel gawk libffi-devel git graphviz zlib-devel wget
 sudo yum install -y qt5-qt3d-devel
@@ -106,11 +108,8 @@ sudo ln -s /usr/bin/tclsh8.6 /usr/bin/tclsh
 sudo ldconfig
 cd -
 
-
-cd ..
-
 # Install OpenROAD tools.
-cd ..
+cd ${scr_path}/..
 git submodule update --init --recursive third_party/tools/openroad
 cd third_party/tools/openroad
 ./build_openroad.sh -o

--- a/setup/install-openroad.sh
+++ b/setup/install-openroad.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-scr_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
 
 sudo apt-get install -y pkg-config build-essential libatomic-ops-dev python3 bison flex libreadline-dev gawk libffi-dev git graphviz tcl xdot libboost-system-dev libboost-python-dev libboost-filesystem-dev libboost-serialization-dev libboost-thread-dev zlib1g-dev cmake swig libeigen3-dev
 sudo apt-get install -y libboost-test-dev libspdlog-dev libqt5opengl5-dev
@@ -25,7 +25,7 @@ cd -
 sudo ln -s /usr/bin/python3 /usr/bin/python
 sudo ln -s /usr/local/lib/libtcl8.6.so /usr/local/lib/libtcl.so
 
-cd ${scr_path}/..
+cd ${src_path}/..
 
 git submodule update --init --recursive third_party/tools/openroad
 cd third_party/tools/openroad

--- a/setup/install-openroad.sh
+++ b/setup/install-openroad.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+scr_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
+
 sudo apt-get install -y pkg-config build-essential libatomic-ops-dev python3 bison flex libreadline-dev gawk libffi-dev git graphviz tcl xdot libboost-system-dev libboost-python-dev libboost-filesystem-dev libboost-serialization-dev libboost-thread-dev zlib1g-dev cmake swig libeigen3-dev
 sudo apt-get install -y libboost-test-dev libspdlog-dev libqt5opengl5-dev
 
@@ -23,7 +25,7 @@ cd -
 sudo ln -s /usr/bin/python3 /usr/bin/python
 sudo ln -s /usr/local/lib/libtcl8.6.so /usr/local/lib/libtcl.so
 
-cd ..
+cd ${scr_path}/..
 
 git submodule update --init --recursive third_party/tools/openroad
 cd third_party/tools/openroad


### PR DESCRIPTION
I encountered a few issues using the setup scripts in my fresh Ubuntu 20.04 VM, so I would like to share my fixes. I see that using conda is the most convenient solution, but these scripts can still be useful to someone who prefers a traditional approach.