### PR TITLE
Optimizing runtask  

### DIFF
--- a/examples/aes/aes.sdc
+++ b/examples/aes/aes.sdc
@@ -2,7 +2,7 @@ current_design aes_cipher_top
 
 set clk_name  clk
 set clk_port_name clk
-set clk_period 5.9 
+set clk_period 10
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]
@@ -11,6 +11,5 @@ create_clock -name $clk_name -period $clk_period $clk_port
 
 set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
 
-set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs 
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
 set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
-

--- a/examples/benchmark/benchmark.py
+++ b/examples/benchmark/benchmark.py
@@ -57,7 +57,7 @@ def main():
             walltime = round((wall_end - wall_start),2)
             results[design][n] = walltime
             with open(f"results.txt", 'w') as f:
-                print(results, file=f)
+                f.write(results)
 
 if __name__ == '__main__':
     main()

--- a/examples/benchmark/benchmark.py
+++ b/examples/benchmark/benchmark.py
@@ -12,9 +12,7 @@ def main():
 
     examples = [{'heartbeat' : 1000},
                 {'picorv32' : 1000},
-                {'aes' : 1500},]
-
-    examples = [{'heartbeat' : 1000}]
+                {'aes' : 1500}]
 
     results = {}
 
@@ -25,13 +23,13 @@ def main():
         rootdir = os.path.join(parent, design)
         results[design] = {}
         for n in ['1','2','4','8','16']:
-        for n in ['4']
             wall_start = time.time()
             chip = siliconcompiler.Chip(design)
             chip.set('jobname', f"job{n}")
             chip.load_target('skywater130_demo')
             chip.set('relax', True)
             chip.set('quiet', True)
+            chip.set('remote',False)
 
             # load dsign
             chip.add('source', os.path.join(rootdir, f"{design}.v"))
@@ -43,7 +41,6 @@ def main():
             chip.set('flowarg', 'syn_np', n)
             chip.set('flowarg', 'place_np', n)
             chip.set('flowarg', 'cts_np', n)
-            chip.set('flowarg', 'route_np', n)
             chip.load_flow('asicflow')
             chip.set('flow', 'asicflow')
 
@@ -59,9 +56,8 @@ def main():
             wall_end = time.time()
             walltime = round((wall_end - wall_start),2)
             results[design][n] = walltime
-            chip.write_manifest("tmp.tcl")
-
-    print(results)
+            with open(f"results.txt", 'w') as f:
+                print(results, file=f)
 
 if __name__ == '__main__':
     main()

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3898,6 +3898,7 @@ class Chip:
         # successfully. Inspired by: https://stackoverflow.com/a/70029046.
 
         os.listdir(os.path.dirname(lastdir))
+
         lastcfg = f"{lastdir}/outputs/{self.get('design')}.pkg.json"
         if os.path.isfile(lastcfg):
             last_step_failed = False
@@ -3912,6 +3913,8 @@ class Chip:
                     taskdir = self._getworkdir(step=step, index=index)
                     os.listdir(os.path.dirname(taskdir))
                     cfg = f"{taskdir}/outputs/{self.get('design')}.pkg.json"
+                    if not os.path.isfile(cfg):
+                        break
                     with open(cfg, 'r') as f:
                         localcfg = json.load(f)
                     self.cfg['metric'][step][index] = copy.deepcopy(localcfg['metric'][step][index])
@@ -3940,6 +3943,7 @@ class Chip:
                 f'See logs in {stepdir} for error details.')
             raise SiliconCompilerError(f'Run() failed on step {failed_step}! '
                 f'See logs in {stepdir} for error details.')
+
 
         # Store run in history
         self.record_history()

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3432,7 +3432,9 @@ class Chip:
             self.logger.error(f'No inputs selected after running {tool}')
             self._haltstep(step, index, active)
 
-        self.set('flowstatus', step, index, 'select', sel_inputs)
+        #TODO: This should not be needed
+        if step != 'import':
+            self.set('flowstatus', step, index, 'select', sel_inputs)
 
         ##################
         # 9. Copy (link) output data from previous steps

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3655,7 +3655,7 @@ class Chip:
         self.set('arg', 'step', None, clobber=True)
         self.set('arg', 'index', None, clobber=True)
 
-        self.write_manifest(f"outputs/{design}.pkg.json")
+        self.write_manifest(os.path.join("outputs", f"{design}.pkg.json"))
 
         ##################
         # 25. Clean up non-essential files

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3370,9 +3370,6 @@ class Chip:
                         localcfg = json.load(f)
                     # quick copy of task history
                     self.cfg['metric'][in_step][in_index] = copy.deepcopy(localcfg['metric'][in_step][in_index])
-                    if self.get('track'):
-                        self.cfg['record'][in_step][in_index] = copy.deepcopy(localcfg['record'][in_step][in_index])
-                    #self.read_manifest(cfgfile)
 
         ##################
         # 6. Write manifest prior to step running into inputs

--- a/siliconcompiler/pdks/asap7.py
+++ b/siliconcompiler/pdks/asap7.py
@@ -56,6 +56,7 @@ def setup(chip):
     node = 7
     rev = 'r1p7'
     stackup = '10M'
+    wafersize = 300
     libtype = '7p5t'
     pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
 
@@ -66,6 +67,7 @@ def setup(chip):
     chip.set('pdk','foundry', foundry)
     chip.set('pdk','process', process)
     chip.set('pdk','node', node)
+    chip.set('pdk','wafersize', wafersize)
     chip.set('pdk','version', rev)
     chip.set('pdk','stackup', stackup)
 

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1833,10 +1833,24 @@ def schema_metric(cfg, step='default', index='default',group='default'):
             switch=f"-metric_{item} 'step index group <float>'",
             example=[
                 f"cli: -metric_{item} 'dfm 0 goal 10e9'",
-                f"api: chip.set('metric','dfm','0','{item}','real, 10e9)"],
+                f"api: chip.set('metric','dfm','0','{item}','real', 10e9)"],
             schelp=f"""
             Metric tracking total peak program memory footprint on a per
             step and index basis, specified in bytes.""")
+
+    item = 'cpucores'
+    scparam(cfg, ['metric', step, index, item, group],
+            sctype='int',
+            scope='job',
+            require='asic',
+            shorthelp=f"Metric: {item}",
+            switch=f"-metric_{item} 'step index group <float>'",
+            example=[
+                f"cli: -metric_{item} 'dfm 0 goal 1024'",
+                f"api: chip.set('metric','dfm','0','{item}','real', 1024)"],
+            schelp=f"""
+            Metric tracking the number of machine CPU cores on a per
+            step and index basis.""")
 
     item = 'exetime'
     scparam(cfg, ['metric', step, index, item, group],

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1838,20 +1838,6 @@ def schema_metric(cfg, step='default', index='default',group='default'):
             Metric tracking total peak program memory footprint on a per
             step and index basis, specified in bytes.""")
 
-    item = 'cpucores'
-    scparam(cfg, ['metric', step, index, item, group],
-            sctype='int',
-            scope='job',
-            require='asic',
-            shorthelp=f"Metric: {item}",
-            switch=f"-metric_{item} 'step index group <float>'",
-            example=[
-                f"cli: -metric_{item} 'dfm 0 goal 1024'",
-                f"api: chip.set('metric','dfm','0','{item}','real', 1024)"],
-            schelp=f"""
-            Metric tracking the number of machine CPU cores on a per
-            step and index basis.""")
-
     item = 'exetime'
     scparam(cfg, ['metric', step, index, item, group],
             sctype='float',

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -71,8 +71,12 @@ def setup(chip, mode='batch'):
     chip.set('eda', tool, 'refdir',  step, index, refdir, clobber=clobber)
     chip.set('eda', tool, 'script',  step, index, refdir + script, clobber=clobber)
 
-    np = len(chip.getkeys('flowgraph', flow, step))
-    threads = int(math.ceil(os.cpu_count()/np))
+    # normalizing thread count based on parallelism and local
+    threads = os.cpu_count()
+    if not chip.get('remote') and step in chip.getkeys('flowgraph', flow):
+        np = len(chip.getkeys('flowgraph', flow, step))
+        threads = int(math.ceil(os.cpu_count()/np))
+
     chip.set('eda', tool, 'threads', step, index, threads, clobber=clobber)
 
     # Input/Output requirements

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -1,6 +1,7 @@
 import os
 import re
 import shutil
+import math
 import siliconcompiler
 from siliconcompiler.floorplan import _infer_diearea
 
@@ -46,6 +47,7 @@ def setup(chip, mode='batch'):
     refdir = 'tools/'+tool
     step = chip.get('arg', 'step')
     index = chip.get('arg', 'index')
+    flow = chip.get('flow')
 
     if mode == 'show':
         clobber = True
@@ -68,7 +70,10 @@ def setup(chip, mode='batch'):
     chip.set('eda', tool, 'option',  step, index, option, clobber=clobber)
     chip.set('eda', tool, 'refdir',  step, index, refdir, clobber=clobber)
     chip.set('eda', tool, 'script',  step, index, refdir + script, clobber=clobber)
-    chip.set('eda', tool, 'threads', step, index, os.cpu_count(), clobber=clobber)
+
+    np = len(chip.getkeys('flowgraph', flow, step))
+    threads = int(math.ceil(os.cpu_count()/np))
+    chip.set('eda', tool, 'threads', step, index, threads, clobber=clobber)
 
     # Input/Output requirements
     if step == 'floorplan':

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -3779,7 +3779,7 @@
                         "defvalue": null,
                         "example": [
                             "cli: -metric_memory 'dfm 0 goal 10e9'",
-                            "api: chip.set('metric','dfm','0','memory','real, 10e9)"
+                            "api: chip.set('metric','dfm','0','memory','real', 10e9)"
                         ],
                         "help": "Metric tracking total peak program memory footprint on a per\nstep and index basis, specified in bytes.",
                         "lock": "false",


### PR DESCRIPTION
- The runtask was not behaving nicely for large N. The min function was taking a tone of time due to the read_manifest step. During the runtask we don't need the heave checking that is available in the API, we can just access the dictionary directly. 
- Normalizing runtask sleep to not waste resources when tons of threads are running (hundreds).
- Removing read_manifest for critical merge steps in favor of dict copy.
- Normalizing openroad thread count based on task level parallelism

NOTE: Some of this work will get replaced by Noah's new run scheduler, but we should still merge the optimization method as a place holder. No need for read_manifest when we can just copy the dict.