### PR TITLE
Raise exceptions instead of calling 'sys.exit', to facilitate using siliconcompiler as a Python library

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -170,7 +170,7 @@ def request_remote_run(chip):
             elif resp.status_code >= 400:
                 chip.logger.error(resp.json()['message'])
                 chip.logger.error('Error starting remote job run; quitting.')
-                sys.exit(1)
+                raise RuntimeError('Remote server returned unrecoverable error code.')
             else:
                 chip.logger.info(resp.text)
                 return

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -508,7 +508,7 @@ class Chip:
             func(self)
         else:
             self.logger.error(f'Module {name} not found.')
-            raise RuntimeError(f'Module {name} not found.')
+            raise SiliconCompilerError(f'Module {name} not found.')
 
     ##########################################################################
     def load_pdk(self, name):
@@ -533,7 +533,7 @@ class Chip:
             func(self)
         else:
             self.logger.error(f'Module {name} not found.')
-            raise RuntimeError(f'Module {name} not found.')
+            raise SiliconCompilerError(f'Module {name} not found.')
 
     ##########################################################################
     def load_flow(self, name):
@@ -558,7 +558,7 @@ class Chip:
             func(self)
         else:
             self.logger.error(f'Module {name} not found.')
-            raise RuntimeError(f'Module {name} not found.')
+            raise SiliconCompilerError(f'Module {name} not found.')
 
     ##########################################################################
     def load_lib(self, name):
@@ -583,7 +583,7 @@ class Chip:
             func(self)
         else:
             self.logger.error(f'Module {name} not found.')
-            raise RuntimeError(f'Module {name} not found.')
+            raise SiliconCompilerError(f'Module {name} not found.')
 
 
     ###########################################################################
@@ -3742,12 +3742,12 @@ class Chip:
                 cfg_file = os.path.join(cfg_dir, 'credentials')
             if (not os.path.isdir(cfg_dir)) or (not os.path.isfile(cfg_file)):
                 self.logger.error('Could not find remote server configuration - please run "sc-configure" and enter your server address and credentials.')
-                raise RuntimeError('Valid remote credentials could not be found.')
+                raise SiliconCompilerError('Valid remote credentials could not be found.')
             with open(cfg_file, 'r') as cfgf:
                 self.status['remote_cfg'] = json.loads(cfgf.read())
             if (not 'address' in self.status['remote_cfg']):
                 self.logger.error('Improperly formatted remote server configuration - please run "sc-configure" and enter your server address and credentials.')
-                raise RuntimeError('Valid remote credentials could not be found.')
+                raise SiliconCompilerError('Valid remote credentials could not be found.')
 
             # Pre-process: Run an 'import' stage locally, and upload the
             # in-progress build directory to the remote server.
@@ -3785,7 +3785,7 @@ class Chip:
                             func = self.find_function(tool, 'setup', 'tools')
                             if func is None:
                                 self.logger.error(f'setup() not found for tool {tool}')
-                                raise RuntimeError(f'setup() not found for tool {tool}')
+                                raise SiliconCompilerError(f'setup() not found for tool {tool}')
                             func(self)
                             # Need to clear index, otherwise we will skip
                             # setting up other indices. Clear step for good
@@ -3818,7 +3818,7 @@ class Chip:
             # Check if there were errors before proceeding with run
             if self.error:
                 self.logger.error(f"Check failed. See previous errors.")
-                raise RuntimeError(f"Manifest checks failed.")
+                raise SiliconCompilerError(f"Manifest checks failed.")
 
             # Create all processes
             processes = []
@@ -3853,7 +3853,7 @@ class Chip:
                 halt = halt + index_error
             if halt:
                 self.logger.error('Run() failed, exiting! See previous errors.')
-                raise RuntimeError('Run() failed, see previous errors.')
+                raise SiliconCompilerError('Run() failed, see previous errors.')
 
         # Clear scratchpad args since these are checked on run() entry
         self.set('arg', 'step', None, clobber=True)
@@ -3901,7 +3901,7 @@ class Chip:
             stepdir = self._getworkdir(step=failed_step)[:-1]
             self.logger.error(f'Run() failed on step {failed_step}, exiting! '
                 f'See logs in {stepdir} for error details.')
-            raise RuntimeError(f'Run() failed on step {failed_step}! '
+            raise SiliconCompilerError(f'Run() failed on step {failed_step}! '
                 f'See logs in {stepdir} for error details.')
 
         # Store run in history
@@ -4421,3 +4421,9 @@ class Chip:
 class YamlIndentDumper(yaml.Dumper):
     def increase_indent(self, flow=False, indentless=False):
         return super(YamlIndentDumper, self).increase_indent(flow, False)
+
+class SiliconCompilerError(Exception):
+    ''' Minimal Exception wrapper used to raise sc runtime errors.
+    '''
+    def __init__(self, message):
+        super(Exception, self).__init__(message)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -333,11 +333,11 @@ class Chip:
             if 'mode' in cmdargs.keys():
                 self.set('mode', cmdargs['mode'], clobber=True)
             if 'techarg' in cmdargs.keys():
-                print("NOT IMPLEMENTED")
-                raise NotImplementedError('NOT IMPLEMENTED')
+                print("NOT IMPLEMENTED: 'techarg' parameter")
+                raise NotImplementedError("NOT IMPLEMENTED: 'techarg' parameter")
             if 'flowarg' in cmdargs.keys():
-                print("NOT IMPLEMENTED")
-                raise NotImplementedError('NOT IMPLEMENTED')
+                print("NOT IMPLEMENTED: 'flowarg' parameter")
+                raise NotImplementedError("NOT IMPLEMENTED: 'flowarg' parameter")
             if 'arg_step' in cmdargs.keys():
                 self.set('arg', 'step', cmdargs['arg_step'], clobber=True)
             if 'fpga_partname' in cmdargs.keys():
@@ -507,8 +507,8 @@ class Chip:
         if func is not None:
             func(self)
         else:
-            self.logger.error(f'Module {name} not found.')
-            raise SiliconCompilerError(f'Module {name} not found.')
+            self.logger.error(f'Target module {name} not found in $SCPATH or siliconcompiler/targets/.')
+            raise SiliconCompilerError(f'Target module {name} not found $SCPATH or siliconcompiler/targets/.')
 
     ##########################################################################
     def load_pdk(self, name):
@@ -532,8 +532,8 @@ class Chip:
             self._loaded_modules['pdks'].append(name)
             func(self)
         else:
-            self.logger.error(f'Module {name} not found.')
-            raise SiliconCompilerError(f'Module {name} not found.')
+            self.logger.error(f'PDK module {name} not found in $SCPATH or siliconcompiler/pdks/.')
+            raise SiliconCompilerError(f'PDK module {name} not found in $SCPATH or siliconcompiler/pdks/.')
 
     ##########################################################################
     def load_flow(self, name):
@@ -557,8 +557,8 @@ class Chip:
             self._loaded_modules['flows'].append(name)
             func(self)
         else:
-            self.logger.error(f'Module {name} not found.')
-            raise SiliconCompilerError(f'Module {name} not found.')
+            self.logger.error(f'Flow module {name} not found in $SCPATH or siliconcompiler/flows/.')
+            raise SiliconCompilerError(f'Flow module {name} not found in $SCPATH or siliconcompiler/flows/.')
 
     ##########################################################################
     def load_lib(self, name):
@@ -582,8 +582,8 @@ class Chip:
             self._loaded_modules['libs'].append(name)
             func(self)
         else:
-            self.logger.error(f'Module {name} not found.')
-            raise SiliconCompilerError(f'Module {name} not found.')
+            self.logger.error(f'Library module {name} not found in $SCPATH or siliconcompiler/libs/.')
+            raise SiliconCompilerError(f'Library module {name} not found in $SCPATH or siliconcompiler/libs/.')
 
 
     ###########################################################################

--- a/siliconcompiler/flows/fpgaflow.py
+++ b/siliconcompiler/flows/fpgaflow.py
@@ -64,7 +64,7 @@ def setup(chip, flowname='fpgaflow'):
         partname = chip.get('fpga', 'partname')
     else:
         chip.logger.error("FPGA partname not specified")
-        sys.exit()
+        raise RuntimeError("FPGA partname not specified")
 
     # Set FPGA mode if not set
     chip.set('mode', 'fpga')

--- a/siliconcompiler/flows/fpgaflow.py
+++ b/siliconcompiler/flows/fpgaflow.py
@@ -64,7 +64,7 @@ def setup(chip, flowname='fpgaflow'):
         partname = chip.get('fpga', 'partname')
     else:
         chip.logger.error("FPGA partname not specified")
-        raise RuntimeError("FPGA partname not specified")
+        raise siliconcompiler.SiliconCompilerError("FPGA partname not specified")
 
     # Set FPGA mode if not set
     chip.set('mode', 'fpga')

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -68,7 +68,7 @@ def setup(chip):
         chip.add('eda', tool, 'option', step, index,  '--cc')
     else:
         chip.logger.error(f'Step {step} not supported for verilator')
-        raise RuntimeError(f'Step {step} not supported for verilator')
+        raise siliconcompiler.SiliconCompilerError(f'Step {step} not supported for verilator')
 
     if step == 'import':
         design = chip.get('design')
@@ -152,7 +152,7 @@ def post_process(chip):
         if (modules > 1) & (chip.cfg['design']['value'] == ""):
             chip.logger.error('Multiple modules found during import, \
             but sc_design was not set')
-            raise RuntimeError('Multiple modules found during import, \
+            raise siliconcompiler.SiliconCompilerError('Multiple modules found during import, \
             but sc_design was not set')
         else:
             chip.logger.info('Setting design (topmodule) to %s', topmodule)

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -67,8 +67,8 @@ def setup(chip):
     elif (step == 'compile'):
         chip.add('eda', tool, 'option', step, index,  '--cc')
     else:
-        chip.logger.error('Step %s not supported for verilator', step)
-        sys.exit()
+        chip.logger.error(f'Step {step} not supported for verilator')
+        raise RuntimeError(f'Step {step} not supported for verilator')
 
     if step == 'import':
         design = chip.get('design')
@@ -152,7 +152,8 @@ def post_process(chip):
         if (modules > 1) & (chip.cfg['design']['value'] == ""):
             chip.logger.error('Multiple modules found during import, \
             but sc_design was not set')
-            sys.exit()
+            raise RuntimeError('Multiple modules found during import, \
+            but sc_design was not set')
         else:
             chip.logger.info('Setting design (topmodule) to %s', topmodule)
             chip.cfg['design']['value'].append(topmodule)

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -33,11 +33,10 @@ def test_target_fpga_valid():
 def test_target_pdk_error():
     '''Ensure that we error out in ASIC mode if given an invalid PDK name.'''
     chip = siliconcompiler.Chip()
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
+    with pytest.raises(RuntimeError) as pytest_wrapped_e:
         chip.load_flow('asicflow')
         chip.load_pdk('fakepdk')
-    assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == 1
+    assert pytest_wrapped_e.type == RuntimeError
 
 @pytest.mark.parametrize('pdk', ['asap7', 'freepdk45', 'skywater130'])
 def test_pdk(pdk):

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -33,10 +33,10 @@ def test_target_fpga_valid():
 def test_target_pdk_error():
     '''Ensure that we error out in ASIC mode if given an invalid PDK name.'''
     chip = siliconcompiler.Chip()
-    with pytest.raises(RuntimeError) as pytest_wrapped_e:
+    with pytest.raises(siliconcompiler.SiliconCompilerError) as pytest_wrapped_e:
         chip.load_flow('asicflow')
         chip.load_pdk('fakepdk')
-    assert pytest_wrapped_e.type == RuntimeError
+    assert pytest_wrapped_e.type == siliconcompiler.SiliconCompilerError
 
 @pytest.mark.parametrize('pdk', ['asap7', 'freepdk45', 'skywater130'])
 def test_pdk(pdk):

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -118,7 +118,7 @@ def test_all_failed_min(chip):
     chip.set('flowgraph', chip.get('flow'), 'placemin', '0', 'input', [('place','0'), ('place','1')])
 
     # Expect that command exits early
-    with pytest.raises(SystemExit):
+    with pytest.raises(RuntimeError):
         chip.run()
 
     # check that compilation failed
@@ -139,7 +139,7 @@ def test_branch_failed_join(chip):
     chip.set('flowgraph', chip.get('flow'), 'placemin', '0', 'input', [('place','0'), ('place','1')])
 
     # Expect that command exits early
-    with pytest.raises(SystemExit):
+    with pytest.raises(RuntimeError):
         chip.run()
 
     # check that compilation failed

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -118,7 +118,7 @@ def test_all_failed_min(chip):
     chip.set('flowgraph', chip.get('flow'), 'placemin', '0', 'input', [('place','0'), ('place','1')])
 
     # Expect that command exits early
-    with pytest.raises(RuntimeError):
+    with pytest.raises(siliconcompiler.SiliconCompilerError):
         chip.run()
 
     # check that compilation failed
@@ -139,7 +139,7 @@ def test_branch_failed_join(chip):
     chip.set('flowgraph', chip.get('flow'), 'placemin', '0', 'input', [('place','0'), ('place','1')])
 
     # Expect that command exits early
-    with pytest.raises(RuntimeError):
+    with pytest.raises(siliconcompiler.SiliconCompilerError):
         chip.run()
 
     # check that compilation failed


### PR DESCRIPTION
This change replaces most of our `sys.exit` calls with Python exceptions, because we want to make it easy to catch build errors within custom Python flows.

I left one `sys.exit` call in the `_haltstep` method, because the `_runtask` calls which it interrupts are typically run within a `multiprocessing.Process`. Raising exceptions in `_haltstep` would also make the command-line errors more verbose and less helpful, by printing an identical stack trace for every failed task in the flow.