### PR TITLE
Surelog fix and ZeroSoC docs update

### DIFF
--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -117,8 +117,7 @@ def runtime_options(chip):
 
     cmdlist.append('-top ' + chip.get('design'))
     # make sure we can find .sv files in ydirs
-    cmdlist.append('+libext+.sv')
-    cmdlist.append('+libext+.v')
+    cmdlist.append('+libext+.sv+.v')
 
     # Set up user-provided parameters to ensure we elaborate the correct modules
     for param in chip.getkeys('param'):


### PR DESCRIPTION
This PR adds some fixes that came up when I was getting ZeroSoC DRC/LVS clean again.

1) Adding `+libext+v`  as a Surelog option breaks the ZeroSoC build since it overrides the previous `+libext` flag. Proper syntax is to specify both extensions after one flag like so: `+libext+sv+v`.
2) Updated tutorial to account for floorplan changes needed to fix DRC/LVS violations.