### PR TITLE
Prettify logging

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3685,7 +3685,6 @@ class Chip:
             Runs the execution flow defined by the flowgraph dictionary.
         '''
 
-        self._init_logger(in_run=True)
         flow = self.get('flow')
 
         if not flow in self.getkeys('flowgraph'):
@@ -3707,6 +3706,9 @@ class Chip:
                 self.set('flowgraph', flow, 'import', '0', 'tool', 'nop')
 
             self.set('arg', 'step', None)
+
+        # Re-init logger to include run info after setting up flowgraph.
+        self._init_logger(in_run=True)
 
         # Run steps if set, otherwise run whole graph
         if self.get('arg', 'step'):


### PR DESCRIPTION
Some changes to the logger to make it look nicer and be more intuitive. This takes care of a couple cleanup tasks.

- Don't include job/step/index until we're in "run()". This prevents us
  from display the default job name ("job0") when the user is eventually
  going to set something else.
- Loop through all steps/indices in the current flowgraph so we size the
  step and index columns appropriately. This prevents the columns from
  being broken by long step names.

**Before**
```
| INFO    | job0    | ---          | -   | Pre-run log
| INFO    | job0    | ---          | -   | Checking manifest before running.
| INFO    | myjob   | import       | 0   | Waiting for inputs...
| INFO    | myjob   | reallyreallyreallylongstep | 0   | Waiting for inputs...
| INFO    | myjob   | import       | 0   | Collecting input sources
| ERROR   | myjob   | import       | 0   | File examples/gcd/gcd.v was not found
| ERROR   | myjob   | import       | 0   | Halting step 'import' index '0' due to errors.
| INFO    | myjob   | reallyreallyreallylongstep | 0   | Running built in task 'nop'
| ERROR   | myjob   | reallyreallyreallylongstep | 0   | Halting step due to previous error in import0
| ERROR   | myjob   | reallyreallyreallylongstep | 0   | Halting step 'reallyreallyreallylongstep' index '0' due to errors.
| ERROR   | myjob   | ---          | -   | Run() failed, exiting! See previous errors.
```

**After**
```
| INFO    | Pre-run log
| INFO    | myjob  | ------                      | -  | Checking manifest before running.
| INFO    | myjob  | import                      | 0  | Waiting for inputs...
| INFO    | myjob  | reallyreallyreallylongstep  | 0  | Waiting for inputs...
| INFO    | myjob  | import                      | 0  | Collecting input sources
| ERROR   | myjob  | import                      | 0  | File examples/gcd/gcd.v was not found
| ERROR   | myjob  | import                      | 0  | Halting step 'import' index '0' due to errors.
| INFO    | myjob  | reallyreallyreallylongstep  | 0  | Running built in task 'nop'
| ERROR   | myjob  | reallyreallyreallylongstep  | 0  | Halting step due to previous error in import0
| ERROR   | myjob  | reallyreallyreallylongstep  | 0  | Halting step 'reallyreallyreallylongstep' index '0' due to errors.
| ERROR   | Run() failed, exiting! See previous errors.
```