### PR TITLE
Record each task's maximum memory usage in metrics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ cryptography >= 3.4.7
 graphviz >= 0.18.1
 netifaces >= 0.11.0
 distro >= 1.6.0
+psutil >= 5.8.0
 
 # Build dependencies
 #:build

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3555,11 +3555,7 @@ class Chip:
                         # Gather subprocess memory usage.
                         try:
                             pproc = psutil.Process(proc.pid)
-                            pchildren = list(pproc.children(recursive=True))
-                            mem_uss = pproc.memory_full_info().uss
-                            for child in pchildren:
-                                mem_uss += child.memory_full_info().uss
-                            max_mem_bytes = max(max_mem_bytes, mem_uss)
+                            max_mem_bytes = max(max_mem_bytes, pproc.memory_full_info().uss)
                         except psutil.Error:
                             # Process may have already terminated or been killed.
                             # Retain existing memory usage statistics in this case.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3548,7 +3548,6 @@ class Chip:
                     # live output in non-blocking way, so we can monitor the
                     # timeout. Based on https://stackoverflow.com/a/18422264.
                     cmd_start_time = time.time()
-                    max_mem_bytes = 0
                     proc = subprocess.Popen(cmdlist,
                                             stdout=log_writer,
                                             stderr=subprocess.STDOUT)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3514,6 +3514,9 @@ class Chip:
         ##################
         # 17. Run executable (or copy inputs to outputs for builtin functions)
 
+        # TODO: Currently no memory usage tracking in breakpoints, builtins, or unexpected errors.
+        max_mem_bytes = 0
+
         if tool in self.builtin:
             utils.copytree(f"inputs", 'outputs', dirs_exist_ok=True, link=True)
         elif not self.get('skipall'):
@@ -3539,9 +3542,6 @@ class Chip:
                         return data
                     import pty # Note: this import throws exception on Windows
                     retcode = pty.spawn(cmdlist, read)
-
-                # TODO: Currently no memory usage tracking in breakpoints.
-                max_mem_bytes = 0
             else:
                 with open(logfile, 'w') as log_writer, open(logfile, 'r') as log_reader:
                     # Use separate reader/writer file objects as hack to display


### PR DESCRIPTION
We want to record peak memory usage as part of the metrics collected for each task.

The built-in [resource](https://docs.python.org/3/library/resource.html) library looked like a promising solution, but there were a couple of issues:

* It is not included in Windows installations of Python.

* It looks like the most detailed statistic that it  can provide is the maximum "Resident Set Size". That includes shared memory such as libraries which may be used by several processes without actually "belonging" to the process whose memory usage we are interested in.

The [`psutil`](https://pypi.org/project/psutil/) module can provide more comprehensive information about processes, and it appears to be fairly widely-used. It can report the "Unique Set Size" for a process and its children, which only includes memory dedicated to that process.

This approach should work on Windows/OSX/Linux/etc, but it appears to return values of zero bytes when run within a Windows/Linux subsystem (v1). I wasn't able to find a simpler, more cross-platform approach within a small timebox, but I would be open to suggestions if there are better built-in options.