### PR TITLE
Proposal to refactor task management

### DIFF
--- a/examples/benchmark/scalability.py
+++ b/examples/benchmark/scalability.py
@@ -1,0 +1,74 @@
+'''Benchmark to measure time taken per simple task with large flowgraphs.
+
+Running this file determines the average time taken per task on long serial
+flowgraphs of 10, 100, 250, and 500 simple "echo" tasks.
+
+Since it would take too long to measure the entire run with a flowgraph of such
+a length, we perform a weird trick to measure just the first "STEPS_TO_RUN"
+tasks. Instead of calling "run_long_serial()" directly, this file calls back into
+itself using "subprocess", using a CLI argument to change the codepath. That way,
+it can monitor stdout to start timing when it sees the initial "import" echo (so
+that it doesn't measure start-up time), and finish timing and end the process
+when it sees the "done" echo.
+
+While it would be more straightforward to do this with a steplist, using a
+steplist removes some of the overhead we're trying to measure (e.g. the flooding
+scheduler only launches processes based on what's in the steplist).
+'''
+import siliconcompiler
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+STEPS_TO_RUN = 10
+
+def run_long_serial(N):
+    chip = siliconcompiler.Chip()
+    flow = 'test_long_serial'
+    pipe = [{'import': 'echo'}]
+    pipe += [{f'measured{i}': 'echo'} for i in range(STEPS_TO_RUN - 1)]
+    pipe += [{'done': 'echo'}]
+    pipe += [{f'extra{i}': 'echo'} for i in range(N - (STEPS_TO_RUN + 1))]
+
+    chip.set('design', 'test_long_serial')
+    chip.set('flow', flow)
+    chip.set('mode', 'sim')
+    chip.set('skipcheck', True)
+    chip.pipe(flow, pipe)
+    chip.run()
+
+def main():
+    if len(sys.argv) > 1:
+        # Running this file with an argument executes the "run_long_serial"
+        # benchmark.
+        N = int(sys.argv[1])
+        run_long_serial(N)
+        return
+
+    # Without an argument, we loop over a set of values to try, and re-run this
+    # script with those values provided as arguments.
+    results = {}
+    for N in (10, 100, 250, 500):
+        proc = subprocess.Popen(['python', sys.argv[0], str(N)],
+                                 stdout=subprocess.PIPE)
+        for line in proc.stdout:
+            line = line.decode('ascii')
+            if line.startswith('import0'):
+                start = time.time()
+            if line.startswith('done'):
+                end = time.time()
+                proc.send_signal(signal.SIGINT)
+                proc.wait()
+                break
+
+        time_per_task = (end - start) / STEPS_TO_RUN
+        results[N] = time_per_task
+
+    for N, time_per_task in results.items():
+        print(f'{N}, {time_per_task}')
+
+if __name__ == '__main__':
+    main()

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -46,10 +46,6 @@ def remote_preprocess(chip):
         job_hash = uuid.uuid4().hex
         chip.status['jobhash'] = job_hash
 
-    manager = multiprocessing.Manager()
-    error = manager.dict()
-    active = manager.dict()
-
     # Setup up tools for all local functions
     remote_steplist = chip.getkeys('flowgraph',chip.get('flow'))
     local_step = remote_steplist[0]
@@ -68,7 +64,10 @@ def remote_preprocess(chip):
         chip.set('steplist', local_step)
 
         # Run the actual import step locally.
-        chip._runtask(local_step, index, active, error)
+        # We can pass in an empty 'status' dictionary, since _runtask() will
+        # only look up a step's depedencies in this dictionary, and the first
+        # step should have none.
+        chip._runtask(local_step, index, {})
 
     # Set 'steplist' to only the remote steps, for the future server-side run.
     remote_steplist = remote_steplist[1:]

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3762,11 +3762,8 @@ class Chip:
         else:
             status = {}
 
-            # Launch a thread for eact step in flowgraph
-            # Use a shared even for errors
-            # Use a manager.dict for keeping track of active processes
-            # (one unqiue dict entry per process),
-            # Set up tools and processes
+            # Populate status dict with any flowstatus values that have already
+            # been set.
             for step in self.getkeys('flowgraph', flow):
                 for index in self.getkeys('flowgraph', flow, step):
                     stepstr = step + index
@@ -3776,6 +3773,9 @@ class Chip:
                     else:
                         status[step + index] = TaskStatus.PENDING
 
+            # Setup tools for all tasks to run.
+            for step in steplist:
+                for index in indexlist[step]:
                     # Setting up tool is optional
                     tool = self.get('flowgraph', flow, step, index, 'tool')
                     if tool not in self.builtin:
@@ -3843,6 +3843,8 @@ class Chip:
                         processes[task].start()
                         running_tasks.append(task)
                         del tasks_to_run[task]
+
+                # TODO: check for potential deadlock scenario
 
                 # Check for completed tasks, and clear them from the from the
                 # tasks_to_run dependency lists.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3841,7 +3841,7 @@ class Chip:
                     # if task is bkpt, then don't launch while len(running_tasks) > 0
 
                     # Clear any tasks that have finished from dependency list.
-                    for in_task in deps:
+                    for in_task in deps.copy():
                         if status[in_task] != TaskStatus.PENDING:
                             deps.remove(in_task)
 
@@ -3863,7 +3863,7 @@ class Chip:
                 # Check for completed tasks.
                 # TODO: consider staying in this section of loop until a task
                 # actually completes.
-                for task in list(running_tasks):
+                for task in running_tasks.copy():
                     if not processes[task].is_alive():
                         running_tasks.remove(task)
                         if processes[task].exitcode > 0:
@@ -3959,6 +3959,12 @@ class Chip:
         # Storing manifest in job root directorya
         filepath =  os.path.join(self._getworkdir(),f"{self.get('design')}.pkg.json")
         self.write_manifest(filepath)
+
+        # Hack: clear flowstatus 'status' entries so that we can run a new job
+        # with the same chip object.
+        for step in self.getkeys('flowstatus'):
+            for index in self.getkeys('flowstatus', step):
+                self.set('flowstatus', step, index, 'status', TaskStatus.PENDING)
 
     ##########################################################################
     def record_history(self):

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3711,6 +3711,12 @@ class Chip:
             if os.path.isdir(cur_job_dir):
                 shutil.rmtree(cur_job_dir)
 
+            # Clear flowstatus 'status' entries if we're running from scratch,
+            # so that we can use the same chip object for multiple runs.
+            for step in self.getkeys('flowstatus'):
+                for index in self.getkeys('flowstatus', step):
+                    self.set('flowstatus', step, index, 'status', TaskStatus.PENDING)
+
         # List of indices to run per step. Precomputing this ensures we won't
         # have any problems if [arg, index] gets clobbered, and reduces logic
         # repetition.
@@ -3959,12 +3965,6 @@ class Chip:
         # Storing manifest in job root directorya
         filepath =  os.path.join(self._getworkdir(),f"{self.get('design')}.pkg.json")
         self.write_manifest(filepath)
-
-        # Hack: clear flowstatus 'status' entries so that we can run a new job
-        # with the same chip object.
-        for step in self.getkeys('flowstatus'):
-            for index in self.getkeys('flowstatus', step):
-                self.set('flowstatus', step, index, 'status', TaskStatus.PENDING)
 
     ##########################################################################
     def record_history(self):

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3488,7 +3488,7 @@ class Chip:
 
             self.logger.info(f"Checking executable. Tool '{exe}' found with version '{version}'")
             if vercheck and not self._check_version(version, tool):
-                self._haltstep(step, index, active)
+                self._haltstep(step, index)
 
         ##################
         # 14. Write manifest (tool interface) (Don't move this!)

--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 
 ###########################################################################
-def _deferstep(chip, step, index, active, error):
+def _deferstep(chip, step, index, status):
     '''
     Helper method to run an individual step on a slurm cluster.
     If a base64-encoded 'decrypt_key' is set in the Chip's status
@@ -17,7 +17,7 @@ def _deferstep(chip, step, index, active, error):
     # Ensure that error bits are up-to-date in this schema.
     for in_step, in_index in chip.get('flowgraph', chip.get('flow'), step, index, 'input'):
         #TODO: Why is this needed?
-        chip.set('flowstatus', in_step, in_index, 'error', error[f'{in_step}{in_index}'])
+        chip.set('flowstatus', in_step, in_index, 'status', status[f'{in_step}{in_index}'])
 
     # Determine which HPC job scheduler being used.
     scheduler_type = chip.get('jobscheduler')

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1198,14 +1198,18 @@ def schema_flowgraph(cfg, flow='default', step='default', index='default'):
 ###########################################################################
 def schema_flowstatus(cfg, step='default', index='default'):
 
-    scparam(cfg,['flowstatus', step, index, 'error'],
-            sctype='int',
+    scparam(cfg,['flowstatus', step, index, 'status'],
+            sctype='str',
             scope='job',
-            shorthelp="Flowgraph task error status",
-            switch="-flowstatus_error 'step index <int>'",
-            example=["cli: -flowstatus_error 'cts 10 1'",
-                     "api:  chip.set('flowstatus','cts','10','error',1)"],
-            schelp="""Status parameter that tracks runstep errors.""")
+            shorthelp="Flowgraph task status",
+            switch="-flowstatus_status 'step index <str>'",
+            example=["cli: -flowstatus_status 'cts 10 success'",
+                     "api:  chip.set('flowstatus','cts','10','status', 'success')"],
+            schelp="""Parameter that tracks the status of a task. Valid values are:
+
+            * "pending": task has not yet completed
+            * "success": task ran successfully
+            * "error": task failed with an error""")
 
     scparam(cfg,['flowstatus', step, index, 'select'],
             sctype='[(str,str)]',

--- a/siliconcompiler/tools/echo/echo.py
+++ b/siliconcompiler/tools/echo/echo.py
@@ -1,0 +1,22 @@
+import sys
+
+def setup(chip):
+    tool = 'echo'
+    step = chip.get('arg','step')
+    index = chip.get('arg','index')
+
+    chip.set('eda', tool, 'exe', tool, clobber=False)
+    chip.set('eda', tool, 'option',  step, index, step + index, clobber=False)
+
+def parse_version(stdout):
+    '''
+    Version check based on stdout
+    Depends on tool reported string
+    '''
+    return '0'
+
+def post_process(chip):
+    step = chip.get('arg', 'step')
+
+    if step == 'echo_10':
+        raise KeyboardInterrupt

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1404,22 +1404,6 @@
     "flowstatus": {
         "default": {
             "default": {
-                "error": {
-                    "defvalue": null,
-                    "example": [
-                        "cli: -flowstatus_error 'cts 10 1'",
-                        "api:  chip.set('flowstatus','cts','10','error',1)"
-                    ],
-                    "help": "Status parameter that tracks runstep errors.",
-                    "lock": "false",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Flowgraph task error status",
-                    "signature": null,
-                    "switch": "-flowstatus_error 'step index <int>'",
-                    "type": "int",
-                    "value": null
-                },
                 "select": {
                     "defvalue": [],
                     "example": [
@@ -1435,6 +1419,22 @@
                     "switch": "-flowstatus_select 'step index <(str,str)>'",
                     "type": "[(str,str)]",
                     "value": []
+                },
+                "status": {
+                    "defvalue": null,
+                    "example": [
+                        "cli: -flowstatus_status 'cts 10 success'",
+                        "api:  chip.set('flowstatus','cts','10','status', 'success')"
+                    ],
+                    "help": "Parameter that tracks the status of a task. Valid values are:\n\n* \"pending\": task has not yet completed\n* \"success\": task ran successfully\n* \"error\": task failed with an error",
+                    "lock": "false",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Flowgraph task status",
+                    "signature": null,
+                    "switch": "-flowstatus_status 'step index <str>'",
+                    "type": "str",
+                    "value": null
                 }
             }
         }

--- a/tests/core/test_minmax.py
+++ b/tests/core/test_minmax.py
@@ -82,7 +82,7 @@ def test_all_failed(chip):
     N = len(chip.getkeys('flowgraph', chip.get('flow'), 'syn'))
 
     for index in range(N):
-        chip.set('flowstatus', 'syn', str(index), 'error', 1)
+        chip.set('flowstatus', 'syn', str(index), 'status', siliconcompiler.TaskStatus.ERROR)
 
     steplist = []
     for i in range(N):
@@ -96,7 +96,7 @@ def test_winner_failed(chip):
     N = len(chip.getkeys('flowgraph', chip.get('flow'), 'syn'))
 
     # set error bit on what would otherwise be winner
-    chip.set('flowstatus', 'syn', '9', 'error', 1)
+    chip.set('flowstatus', 'syn', '9', 'status', siliconcompiler.TaskStatus.ERROR)
 
     steplist = []
     for i in range(N):

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -97,8 +97,8 @@ def test_failed_branch_min(chip):
 
     chip.run()
 
-    assert chip.get('flowstatus', 'place', '0', 'status') == siliconcompiler.TaskStatus.ERROR
-    assert chip.get('flowstatus', 'place', '1', 'status') == siliconcompiler.TaskStatus.SUCCESS
+    assert chip.get('history', 'job0', 'flowstatus', 'place', '0', 'status') == siliconcompiler.TaskStatus.ERROR
+    assert chip.get('history', 'job0', 'flowstatus', 'place', '1', 'status') == siliconcompiler.TaskStatus.SUCCESS
 
     # check that compilation succeeded
     assert chip.find_result('def', step='placemin') is not None

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -97,8 +97,8 @@ def test_failed_branch_min(chip):
 
     chip.run()
 
-    assert chip.get('flowstatus', 'place', '0', 'error') == 1
-    assert chip.get('flowstatus', 'place', '1', 'error') == 0
+    assert chip.get('flowstatus', 'place', '0', 'status') == siliconcompiler.TaskStatus.ERROR
+    assert chip.get('flowstatus', 'place', '1', 'status') == siliconcompiler.TaskStatus.SUCCESS
 
     # check that compilation succeeded
     assert chip.find_result('def', step='placemin') is not None


### PR DESCRIPTION
This PR implements an idea I had to refactor our parallelism/task management code. It is meant to take care of a couple things on our to-do list in one sweep, and I think it simplifies our code overall. The main thing it addresses is to make the scheduler graph-based rather than flooding the system with nodes that block until ready.

The proposed algorithm for launching tasks in `run()` is as follows:
- Create a dict `tasks_to_run` that maps each task to a list of its task dependencies
- Create an empty list `tasks_running` that lists each task that is currently active
- While either one of these lists is not empty:
  - Iterate through `tasks_to_run`
    - If any of them have any empty dependency list, launch the task, remove it from `tasks_to_run` and add it to `tasks_running`.
  - Iterate through all tasks in `tasks_running`
    - If any of them have finished, check the exit code to update their status, remove them from `tasks_running`, and remove them from dependency lists in `tasks_to_run`.

I also have an idea on how we can implement breakpoints in a parallel-safe way, and I think this refactor should help fix our latent `'flowstatus', ... 'error'` issues that have been around for a while.

Here are the code simplifications that this refactor enables:
- The main idea is to switch from shared `active`/`error` bit dictionaries to a single enumerated type for tracking task status with 3 states: `STATUS_PENDING`, `STATUS_COMPLETE`, and `STATUS_ERROR`. In addition, we can switch from storing just an error bit in the schema to storing this value under a single `'flowstatus', step, index, 'status'` parameter. This buys us a couple things:
  - Fewer variables to have to pass around
  - We now have the ability to quickly determine via the schema when a step as already been run, which I think will be helpful for future tasks (such as implementing 'resume'-type functionality)
  - Eliminates deadlock potential due to `error`/`active` being changed in the wrong order
- In addition, since we now rely on `run()` to launch each node, we no longer need to use shared dictionaries!
  - Once called, each `_runtask()` can assume it is allowed to go 
  - Each task needs to know the status of all *proceeding* tasks, but we can do that with a "frozen" copy of `status` since those statuses will all be populated before that call.
  - We can determine the outcome of the task by looking at the process exit code. This works with minimal changes since we already use `sys.exit(1)` on error in `_runtask()`
- Getting rid of the synchronization has a few benefits: 
  - Should have positive impacts on performance, since as far as I understand using a multiprocessing `Manager` launches an extra thread behind-the-scenes
  - Makes the code easier to reason about and safer from devious bugs
  - Removes need for things like `_runtask_safe()` wrapper, since processes no longer have a risk of hanging due to unhandled exceptions.



