### PR TITLE
Add pip wheel to offline install bundle

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -128,6 +128,7 @@ jobs:
     - name: Package SC
       run: |
         mkdir scdeps
+        $python -m pip download pip -d scdeps
         $python -m pip download ./dist/siliconcompiler*${{matrix.python}}*linux*.whl -d scdeps
         tar -czvf scdeps-${{matrix.python}}.tar.gz scdeps
       env:

--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -110,6 +110,7 @@ To install from a bundle, create a Python virtual environment following the inst
 .. code-block:: bash
 
    tar -xzvf scdeps-<pyversion>.tar.gz
+   pip install --upgrade pip --no-index --find-links scdeps
    pip install siliconcompiler --no-index --find-links scdeps
 
 Cloud Access


### PR DESCRIPTION
Some versions of Python use an unsuitably old version of Pip, so we need
to provide a wheel to bootstrap the version on a disconnected machine.