### PR TITLE
Fix recent daily test failures

### DIFF
--- a/examples/gcd/run_asap7.sh
+++ b/examples/gcd/run_asap7.sh
@@ -10,6 +10,7 @@ sc gcd.v \
    -asic_diearea "(100.13,100.8)" \
    -asic_corearea "(10.07,11.2)" \
    -asic_corearea "(90.25,91)" \
+   -pdk_wafersize "300.0" \
    -loglevel "INFO" \
    -quiet \
    -relax \

--- a/examples/gcd/run_asap7.sh
+++ b/examples/gcd/run_asap7.sh
@@ -10,7 +10,6 @@ sc gcd.v \
    -asic_diearea "(100.13,100.8)" \
    -asic_corearea "(10.07,11.2)" \
    -asic_corearea "(90.25,91)" \
-   -pdk_wafersize "300.0" \
    -loglevel "INFO" \
    -quiet \
    -relax \

--- a/tests/flows/test_failure.py
+++ b/tests/flows/test_failure.py
@@ -32,7 +32,7 @@ def test_failure_notquiet(chip):
     '''
 
     # Expect that command exits early
-    with pytest.raises(SystemExit):
+    with pytest.raises(siliconcompiler.SiliconCompilerError):
         chip.run()
 
     # Check we made it past initial setup
@@ -52,7 +52,7 @@ def test_failure_quiet(chip):
     chip.set('quiet', 'true')
 
     # Expect that command exits early
-    with pytest.raises(SystemExit):
+    with pytest.raises(siliconcompiler.SiliconCompilerError):
         chip.run()
 
     # Check we made it past initial setup

--- a/tests/flows/test_gcd_server_auth.py
+++ b/tests/flows/test_gcd_server_auth.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+import siliconcompiler
 import subprocess
 
 import pytest
@@ -97,10 +98,10 @@ def test_gcd_server_not_authenticated(gcd_chip, scroot):
     gcd_chip.set('remote', 'user', 'test_user')
     gcd_chip.set('remote', 'password', 'wrong_password')
 
-    # Run remote build. It may fail, so catch SystemExit exceptions.
+    # Run remote build. It should fail, so catch the expected exception.
     try:
         gcd_chip.run()
-    except SystemExit:
+    except siliconcompiler.SiliconCompilerError:
         pass
 
     # Kill the server process.

--- a/tests/flows/test_timeout.py
+++ b/tests/flows/test_timeout.py
@@ -1,4 +1,5 @@
 import pytest
+import siliconcompiler
 
 @pytest.mark.eda
 def test_timeout(gcd_chip):
@@ -7,5 +8,5 @@ def test_timeout(gcd_chip):
 
     # Expect that command exits early
     # TODO: automated check that run timed out vs failed for a different reason
-    with pytest.raises(SystemExit):
+    with pytest.raises(siliconcompiler.SiliconCompilerError):
         gcd_chip.run()


### PR DESCRIPTION
This change should fix the recent daily test failures.

Most of them were caused by my recent change to move from `sys.exit` to Python exceptions - sorry that I only checked the quick tests for that PR.

I believe that the ASAP7 GCD test was failing because of a missing 'wafersize' parameter, which is newly required for the 'asic' mode.

[I started an extra test run on this branch](https://github.com/siliconcompiler/siliconcompiler/actions/runs/2060655730) to verify that this will fix the daily test suite.