### PR TITLE
Adding named runset feature to schema

### DIFF
--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -88,10 +88,10 @@ def setup(chip):
                  pdkdir+'/apr/tapcell.tcl')
 
     # DRC Runsets
-    chip.set('pdk','drc','runset', 'magic', stackup, pdkdir+'/setup/magic/sky130A.tech')
+    chip.set('pdk','drc','runset', 'magic', stackup, 'basic', pdkdir+'/setup/magic/sky130A.tech')
 
     # LVS Runsets
-    chip.set('pdk','lvs','runset','netgen', stackup, pdkdir+'/setup/netgen/lvs_setup.tcl')
+    chip.set('pdk','lvs','runset','netgen', stackup, 'basic', pdkdir+'/setup/netgen/lvs_setup.tcl')
 
     # Layer map and display file
     chip.set('pdk', 'layermap', 'klayout', 'def', 'gds', stackup, pdkdir+'/setup/klayout/skywater130.lyt')

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -544,23 +544,24 @@ def schema_pdk(cfg, stackup='default'):
             antenna, tracks, tapcell, viarules, em.""")
 
     checks = ['lvs', 'drc', 'erc']
+    name = 'default'
     for item in checks:
-        scparam(cfg, ['pdk', item, 'runset', tool, stackup],
+        scparam(cfg, ['pdk', item, 'runset', tool, stackup, name],
                 sctype='[file]',
                 shorthelp=f"PDK {item.upper()} runset files",
-                switch=f"-pdk_{item}_runset 'tool stackup <file>'",
+                switch=f"-pdk_{item}_runset 'tool stackup name <file>'",
                 example=[
-                    f"cli: -pdk_{item}_runset 'magic M10 $PDK/{item}.rs'",
-                    f"api: chip.set('pdk','{item}','runset','magic','M10','$PDK/{item}.rs')"],
+                    f"cli: -pdk_{item}_runset 'magic M10 basic $PDK/{item}.rs'",
+                    f"api: chip.set('pdk','{item}','runset','magic','M10','basic','$PDK/{item}.rs')"],
                 schelp=f"""Runset files for {item.upper()} verification.""")
 
-        scparam(cfg, ['pdk', item, 'waiver', tool, stackup],
+        scparam(cfg, ['pdk', item, 'waiver', tool, stackup, name],
                 sctype='[file]',
                 shorthelp=f"PDK {item.upper()} waiver files",
-                switch=f"-pdk_{item}_waiver 'tool stackup <file>'",
+                switch=f"-pdk_{item}_waiver 'tool stackup name <file>'",
                 example=[
-                    f"cli: -pdk_{item}_waiver 'magic M10 $PDK/{item}.txt'",
-                    f"api: chip.set('pdk','{item}','waiver','magic','M10','$PDK/{item}.txt')"],
+                    f"cli: -pdk_{item}_waiver 'magic M10 basic $PDK/{item}.txt'",
+                    f"api: chip.set('pdk','{item}','waiver','magic','M10','basic','$PDK/{item}.txt')"],
                 schelp=f"""Waiver files for {item.upper()} verification.""")
 
     ################

--- a/siliconcompiler/tools/magic/sc.magicrc
+++ b/siliconcompiler/tools/magic/sc.magicrc
@@ -3,7 +3,7 @@ puts stdout "Sourcing .magicrc for Silicon Compiler..."
 source ./sc_manifest.tcl
 
 set sc_stackup [dict get $sc_cfg asic stackup]
-set sc_runset [dict get $sc_cfg pdk drc runset magic $sc_stackup]
+set sc_runset [dict get $sc_cfg pdk drc runset magic $sc_stackup basic]
 set sc_process [dict get $sc_cfg pdk process]
 
 # Put grid on 0.005 pitch.  This is important, as some commands don't

--- a/siliconcompiler/tools/netgen/sc_lvs.tcl
+++ b/siliconcompiler/tools/netgen/sc_lvs.tcl
@@ -6,7 +6,7 @@ set sc_index   [dict get $sc_cfg arg index]
 set sc_design  [dict get $sc_cfg design]
 set sc_macrolibs [dict get $sc_cfg asic macrolib]
 set sc_stackup [dict get $sc_cfg asic stackup]
-set sc_runset [dict get $sc_cfg pdk lvs runset netgen $sc_stackup]
+set sc_runset [dict get $sc_cfg pdk lvs runset netgen $sc_stackup basic]
 
 if {[dict exists $sc_cfg asic exclude $sc_step $sc_index]} {
     set sc_exclude  [dict get $sc_cfg asic exclude $sc_step $sc_index]

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -5080,50 +5080,54 @@
             "runset": {
                 "default": {
                     "default": {
-                        "author": [],
-                        "copy": "false",
-                        "date": [],
-                        "defvalue": [],
-                        "example": [
-                            "cli: -pdk_drc_runset 'magic M10 $PDK/drc.rs'",
-                            "api: chip.set('pdk','drc','runset','magic','M10','$PDK/drc.rs')"
-                        ],
-                        "filehash": [],
-                        "hashalgo": "sha256",
-                        "help": "Runset files for DRC verification.",
-                        "lock": "false",
-                        "require": null,
-                        "scope": "global",
-                        "shorthelp": "PDK DRC runset files",
-                        "signature": [],
-                        "switch": "-pdk_drc_runset 'tool stackup <file>'",
-                        "type": "[file]",
-                        "value": []
+                        "default": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "example": [
+                                "cli: -pdk_drc_runset 'magic M10 basic $PDK/drc.rs'",
+                                "api: chip.set('pdk','drc','runset','magic','M10','basic','$PDK/drc.rs')"
+                            ],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "help": "Runset files for DRC verification.",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "global",
+                            "shorthelp": "PDK DRC runset files",
+                            "signature": [],
+                            "switch": "-pdk_drc_runset 'tool stackup name <file>'",
+                            "type": "[file]",
+                            "value": []
+                        }
                     }
                 }
             },
             "waiver": {
                 "default": {
                     "default": {
-                        "author": [],
-                        "copy": "false",
-                        "date": [],
-                        "defvalue": [],
-                        "example": [
-                            "cli: -pdk_drc_waiver 'magic M10 $PDK/drc.txt'",
-                            "api: chip.set('pdk','drc','waiver','magic','M10','$PDK/drc.txt')"
-                        ],
-                        "filehash": [],
-                        "hashalgo": "sha256",
-                        "help": "Waiver files for DRC verification.",
-                        "lock": "false",
-                        "require": null,
-                        "scope": "global",
-                        "shorthelp": "PDK DRC waiver files",
-                        "signature": [],
-                        "switch": "-pdk_drc_waiver 'tool stackup <file>'",
-                        "type": "[file]",
-                        "value": []
+                        "default": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "example": [
+                                "cli: -pdk_drc_waiver 'magic M10 basic $PDK/drc.txt'",
+                                "api: chip.set('pdk','drc','waiver','magic','M10','basic','$PDK/drc.txt')"
+                            ],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "help": "Waiver files for DRC verification.",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "global",
+                            "shorthelp": "PDK DRC waiver files",
+                            "signature": [],
+                            "switch": "-pdk_drc_waiver 'tool stackup name <file>'",
+                            "type": "[file]",
+                            "value": []
+                        }
                     }
                 }
             }
@@ -5148,50 +5152,54 @@
             "runset": {
                 "default": {
                     "default": {
-                        "author": [],
-                        "copy": "false",
-                        "date": [],
-                        "defvalue": [],
-                        "example": [
-                            "cli: -pdk_erc_runset 'magic M10 $PDK/erc.rs'",
-                            "api: chip.set('pdk','erc','runset','magic','M10','$PDK/erc.rs')"
-                        ],
-                        "filehash": [],
-                        "hashalgo": "sha256",
-                        "help": "Runset files for ERC verification.",
-                        "lock": "false",
-                        "require": null,
-                        "scope": "global",
-                        "shorthelp": "PDK ERC runset files",
-                        "signature": [],
-                        "switch": "-pdk_erc_runset 'tool stackup <file>'",
-                        "type": "[file]",
-                        "value": []
+                        "default": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "example": [
+                                "cli: -pdk_erc_runset 'magic M10 basic $PDK/erc.rs'",
+                                "api: chip.set('pdk','erc','runset','magic','M10','basic','$PDK/erc.rs')"
+                            ],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "help": "Runset files for ERC verification.",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "global",
+                            "shorthelp": "PDK ERC runset files",
+                            "signature": [],
+                            "switch": "-pdk_erc_runset 'tool stackup name <file>'",
+                            "type": "[file]",
+                            "value": []
+                        }
                     }
                 }
             },
             "waiver": {
                 "default": {
                     "default": {
-                        "author": [],
-                        "copy": "false",
-                        "date": [],
-                        "defvalue": [],
-                        "example": [
-                            "cli: -pdk_erc_waiver 'magic M10 $PDK/erc.txt'",
-                            "api: chip.set('pdk','erc','waiver','magic','M10','$PDK/erc.txt')"
-                        ],
-                        "filehash": [],
-                        "hashalgo": "sha256",
-                        "help": "Waiver files for ERC verification.",
-                        "lock": "false",
-                        "require": null,
-                        "scope": "global",
-                        "shorthelp": "PDK ERC waiver files",
-                        "signature": [],
-                        "switch": "-pdk_erc_waiver 'tool stackup <file>'",
-                        "type": "[file]",
-                        "value": []
+                        "default": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "example": [
+                                "cli: -pdk_erc_waiver 'magic M10 basic $PDK/erc.txt'",
+                                "api: chip.set('pdk','erc','waiver','magic','M10','basic','$PDK/erc.txt')"
+                            ],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "help": "Waiver files for ERC verification.",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "global",
+                            "shorthelp": "PDK ERC waiver files",
+                            "signature": [],
+                            "switch": "-pdk_erc_waiver 'tool stackup name <file>'",
+                            "type": "[file]",
+                            "value": []
+                        }
                     }
                 }
             }
@@ -5460,50 +5468,54 @@
             "runset": {
                 "default": {
                     "default": {
-                        "author": [],
-                        "copy": "false",
-                        "date": [],
-                        "defvalue": [],
-                        "example": [
-                            "cli: -pdk_lvs_runset 'magic M10 $PDK/lvs.rs'",
-                            "api: chip.set('pdk','lvs','runset','magic','M10','$PDK/lvs.rs')"
-                        ],
-                        "filehash": [],
-                        "hashalgo": "sha256",
-                        "help": "Runset files for LVS verification.",
-                        "lock": "false",
-                        "require": null,
-                        "scope": "global",
-                        "shorthelp": "PDK LVS runset files",
-                        "signature": [],
-                        "switch": "-pdk_lvs_runset 'tool stackup <file>'",
-                        "type": "[file]",
-                        "value": []
+                        "default": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "example": [
+                                "cli: -pdk_lvs_runset 'magic M10 basic $PDK/lvs.rs'",
+                                "api: chip.set('pdk','lvs','runset','magic','M10','basic','$PDK/lvs.rs')"
+                            ],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "help": "Runset files for LVS verification.",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "global",
+                            "shorthelp": "PDK LVS runset files",
+                            "signature": [],
+                            "switch": "-pdk_lvs_runset 'tool stackup name <file>'",
+                            "type": "[file]",
+                            "value": []
+                        }
                     }
                 }
             },
             "waiver": {
                 "default": {
                     "default": {
-                        "author": [],
-                        "copy": "false",
-                        "date": [],
-                        "defvalue": [],
-                        "example": [
-                            "cli: -pdk_lvs_waiver 'magic M10 $PDK/lvs.txt'",
-                            "api: chip.set('pdk','lvs','waiver','magic','M10','$PDK/lvs.txt')"
-                        ],
-                        "filehash": [],
-                        "hashalgo": "sha256",
-                        "help": "Waiver files for LVS verification.",
-                        "lock": "false",
-                        "require": null,
-                        "scope": "global",
-                        "shorthelp": "PDK LVS waiver files",
-                        "signature": [],
-                        "switch": "-pdk_lvs_waiver 'tool stackup <file>'",
-                        "type": "[file]",
-                        "value": []
+                        "default": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "example": [
+                                "cli: -pdk_lvs_waiver 'magic M10 basic $PDK/lvs.txt'",
+                                "api: chip.set('pdk','lvs','waiver','magic','M10','basic','$PDK/lvs.txt')"
+                            ],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "help": "Waiver files for LVS verification.",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "global",
+                            "shorthelp": "PDK LVS waiver files",
+                            "signature": [],
+                            "switch": "-pdk_lvs_waiver 'tool stackup name <file>'",
+                            "type": "[file]",
+                            "value": []
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- We cannot assume that there is only one major runset file for modern nodes.
- While we had a list of files, there that really wasn't enough.
- We need to be able to refer to named runsets
- Note that the names used are tightly coupled with the tool and the flow, thus the pass through non-standardized runset names.
- The drc/lvs/erc are general enough classes to be standardized.