### PR TITLE
Replace direct cfg merge w/ partial read_manifest

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1448,7 +1448,7 @@ class Chip:
 
 
     ###########################################################################
-    def merge_manifest(self, cfg, job=None, clobber=True, clear=True, check=False):
+    def merge_manifest(self, cfg, job=None, clobber=True, clear=True, check=False, partial=False):
         """
         Merges an external manifest with the current compilation manifest.
 
@@ -1461,6 +1461,8 @@ class Chip:
             clear (bool): If True, disables append operations for list type
             clobber (bool): If True, overwrites existing parameter value
             check (bool): If True, checks the validity of each key
+            partial (bool): If True, perform a partial merge, only merging
+                keypaths that may have been updated during run().
 
         Examples:
             >>> chip.merge_manifest('my.pkg.json')
@@ -1476,6 +1478,8 @@ class Chip:
             dst = self.cfg
 
         for keylist in self.getkeys(cfg=cfg):
+            if partial and keylist[0] not in ('metric', 'flowstatus', 'record'):
+                continue
             #only read in valid keypaths without 'default'
             key_valid = True
             if check:
@@ -1793,7 +1797,7 @@ class Chip:
         return True
 
     ###########################################################################
-    def read_manifest(self, filename, job=None, clear=True, clobber=True):
+    def read_manifest(self, filename, job=None, clear=True, clobber=True, partial=False):
         """
         Reads a manifest from disk and merges it with the current compilation manifest.
 
@@ -1805,6 +1809,8 @@ class Chip:
             job (str): Specifies non-default job to merge into.
             clear (bool): If True, disables append operations for list type.
             clobber (bool): If True, overwrites existing parameter value.
+            partial (bool): If True, perform a partial read, only merging
+                keypaths that may have been updated during run().
 
         Examples:
             >>> chip.read_manifest('mychip.json')
@@ -1826,7 +1832,7 @@ class Chip:
         f.close()
 
         #Merging arguments with the Chip configuration
-        self.merge_manifest(localcfg, job=job, clear=clear, clobber=clobber)
+        self.merge_manifest(localcfg, job=job, clear=clear, clobber=clobber, partial=partial)
 
     ###########################################################################
     def write_manifest(self, filename, prune=True, abspath=False, job=None):
@@ -3350,10 +3356,7 @@ class Chip:
                 self.set('flowstatus', in_step, in_index, 'status', in_task_status)
                 if in_task_status != TaskStatus.ERROR:
                     cfgfile = f"../../../{in_job}/{in_step}/{in_index}/outputs/{design}.pkg.json"
-                    with open(cfgfile, 'r') as f:
-                        localcfg = json.load(f)
-                    # quick copy of task history
-                    self.cfg['metric'][in_step][in_index] = copy.deepcopy(localcfg['metric'][in_step][in_index])
+                    self.read_manifest(cfgfile, clobber=False, partial=True)
 
         ##################
         # 5. Write manifest prior to step running into inputs
@@ -3908,40 +3911,32 @@ class Chip:
         # Note: any information generated in steps that do not merge into the
         # last step will not be picked up in this chip object.
 
-        #1. Use the last manifest
         laststep = steplist[-1]
         last_step_failed = True
-        lastdir = self._getworkdir(step=laststep, index=index)
+        for index in indexlist[laststep]:
+            lastdir = self._getworkdir(step=laststep, index=index)
 
-        # This no-op listdir operation is important for ensuring we have a
-        # consistent view of the filesystem when dealing with NFS. Without
-        # this, this thread is often unable to find the final manifest of
-        # runs performed on job schedulers, even if they completed
-        # successfully. Inspired by: https://stackoverflow.com/a/70029046.
+            # This no-op listdir operation is important for ensuring we have a
+            # consistent view of the filesystem when dealing with NFS. Without
+            # this, this thread is often unable to find the final manifest of
+            # runs performed on job schedulers, even if they completed
+            # successfully. Inspired by: https://stackoverflow.com/a/70029046.
 
-        os.listdir(os.path.dirname(lastdir))
+            os.listdir(os.path.dirname(lastdir))
 
-        lastcfg = f"{lastdir}/outputs/{self.get('design')}.pkg.json"
-        if os.path.isfile(lastcfg):
-            last_step_failed = False
-            local_dir = self.get('dir')
-            self.read_manifest(lastcfg, clobber=True, clear=True)
-            self.set('dir', local_dir)
+            lastcfg = f"{lastdir}/outputs/{self.get('design')}.pkg.json"
+            if os.path.isfile(lastcfg):
+                if last_step_failed:
+                    # If this is our first result manifest, do a full read.
+                    local_dir = self.get('dir')
+                    self.read_manifest(lastcfg, clobber=True, clear=True)
+                    self.set('dir', local_dir)
+                else:
+                    # For manifests from other indices, just pull in possible
+                    # additional info.
+                    self.read_manifest(lastcfg, clobber=False, partial=True)
 
-        #2. Read in flowstatus and metrics from all directories
-        for step in self.getkeys('flowgraph', flow):
-            for index in self.getkeys('flowgraph', flow, step):
-                if step in steplist and index in indexlist[step]:
-                    taskdir = self._getworkdir(step=step, index=index)
-                    os.listdir(os.path.dirname(taskdir))
-                    cfg = f"{taskdir}/outputs/{self.get('design')}.pkg.json"
-                    if not os.path.isfile(cfg):
-                        break
-                    with open(cfg, 'r') as f:
-                        localcfg = json.load(f)
-                    self.cfg['metric'][step][index] = copy.deepcopy(localcfg['metric'][step][index])
-                    self.cfg['flowstatus'][step][index] = copy.deepcopy(localcfg['flowstatus'][step][index])
-
+                last_step_failed = False
 
         if last_step_failed:
             # Hack to find first failed step by checking for presence of output


### PR DESCRIPTION
This PR tweaks the `read_manifest()` replacement from PR #954 by moving back to `read_manifest()`, with a 'partial' option that causes it to only merge the keys we care about.

It turns out the previous approach has a few functionality issues:
- It doesn't read data from steps/indices prior to a tasks immediate inputs, so the manifests don't store metrics cumulatively. 
- Since the json manifest has "default" keypaths pruned, doing a full copy in of an entry from this dictionary breaks the ability to go back and create more groups underneath dynamic keys. 

This new approach of doing a "partial" read_manifest() gets most of the performance benefit without the correctness pitfalls. The following data is collected by running `python examples/benchmarks/scalability.py parallel`. It constructs a wide flowgraph with 10, 100, and 250 parallel nodes, and measures the runtime from import completion (so setup not counted), to final merge (but not run() cleanup), and divides this by the number of parallel tasks.

**Time per task**

|# nodes| read_manifest() | optimize_runtask | read_manifest(partial=True) |
|-----------|----|----|---|
| 10  | 0.14s  | 0.07s | 0.07s|
| 100 | 7.05s | 0.66s | 0.85s|
| 250 | 32.32s | 4.56s | 5.71s|

