### PR TITLE
Make '==' default version spec operation

### DIFF
--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1295,7 +1295,9 @@ def schema_eda(cfg, tool='default', step='default', index='default'):
             check the runtime executable version. When 'vercheck' is set to
             True, if the version of the system executable is not allowed by any
             of the specifiers in 'version', then the job is halted
-            pre-execution.""")
+            pre-execution. For backwards compatibility, entries that do not
+            conform to the standard will be interpreted as a version with an
+            '==' specifier.""")
 
     scparam(cfg, ['eda', tool, 'format'],
             sctype='str',

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1199,7 +1199,7 @@
                     "cli: -eda_version 'openroad >=v2.0'",
                     "api:  chip.set('eda','openroad','version','>=v2.0')"
                 ],
-                "help": "List of acceptable versions of the tool executable to be used. Each\nentry in this list must be a version specifier as described by Python\n`PEP-440 <https://peps.python.org/pep-0440/#version-specifiers>`_.\nDuring task execution, the tool is called with the 'vswitch' to\ncheck the runtime executable version. When 'vercheck' is set to\nTrue, if the version of the system executable is not allowed by any\nof the specifiers in 'version', then the job is halted\npre-execution.",
+                "help": "List of acceptable versions of the tool executable to be used. Each\nentry in this list must be a version specifier as described by Python\n`PEP-440 <https://peps.python.org/pep-0440/#version-specifiers>`_.\nDuring task execution, the tool is called with the 'vswitch' to\ncheck the runtime executable version. When 'vercheck' is set to\nTrue, if the version of the system executable is not allowed by any\nof the specifiers in 'version', then the job is halted\npre-execution. For backwards compatibility, entries that do not\nconform to the standard will be interpreted as a version with an\n'==' specifier.",
                 "lock": "false",
                 "require": null,
                 "scope": "job",


### PR DESCRIPTION
For backwards compatibility, this PR makes it so any version specifier that's missing an operator defaults to a '==' specifier. 