### PR TITLE
Fix flowstatus bug

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3918,6 +3918,16 @@ class Chip:
                 if not index_succeeded:
                     raise SiliconCompilerError('Run() failed, see previous errors.')
 
+            # On success, write out status dict to 'flowstatus'. We do this
+            # since certain scenarios won't be caught by reading in manifests (a
+            # failing step doesn't dump a manifest). For example, if the
+            # steplist's final step has two indices and one fails.
+            for step in steplist:
+                for index in indexlist[step]:
+                    stepstr = step + index
+                    if status[stepstr] != TaskStatus.PENDING:
+                        self.set('flowstatus', step, index, 'status', status[stepstr])
+
         # Clear scratchpad args since these are checked on run() entry
         self.set('arg', 'step', None, clobber=True)
         self.set('arg', 'index', None, clobber=True)
@@ -3950,7 +3960,6 @@ class Chip:
                     # For manifests from other indices, just pull in possible
                     # additional info.
                     self._read_manifest(lastcfg, clobber=False, partial=True)
-
                 last_step_failed = False
 
         if last_step_failed:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -50,7 +50,7 @@ class TaskStatus():
     # Could use Python 'enum' class here, but that doesn't work nicely with
     # schema.
     PENDING = 'pending'
-    SUCCESS = 'complete'
+    SUCCESS = 'success'
     ERROR = 'error'
 
 class Chip:
@@ -3366,8 +3366,6 @@ class Chip:
 
         all_inputs = []
         if not self.get('remote'):
-            #copy over status from
-
             for in_step, in_index in self.get('flowgraph', flow, step, index, 'input'):
                 in_task_status = status[in_step + in_index]
                 self.set('flowstatus', in_step, in_index, 'status', in_task_status)
@@ -3749,7 +3747,7 @@ class Chip:
                 stepdir = self._getworkdir(step=step, index=index)
                 cfg = f"{stepdir}/outputs/{self.get('design')}.pkg.json"
                 if not os.path.isdir(stepdir):
-                    self.set('flowstatus', step, index, 'status', TaskStatus.PENDING)
+                    pass
                 elif os.path.isfile(cfg):
                     self.set('flowstatus', step, index, 'status', TaskStatus.SUCCESS)
                 else:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3747,7 +3747,7 @@ class Chip:
                 stepdir = self._getworkdir(step=step, index=index)
                 cfg = f"{stepdir}/outputs/{self.get('design')}.pkg.json"
                 if not os.path.isdir(stepdir):
-                    pass
+                    self.set('flowstatus', step, index, 'status', None)
                 elif os.path.isfile(cfg):
                     self.set('flowstatus', step, index, 'status', TaskStatus.SUCCESS)
                 else:

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1208,9 +1208,10 @@ def schema_flowstatus(cfg, step='default', index='default'):
                      "api:  chip.set('flowstatus','cts','10','status', 'success')"],
             schelp="""Parameter that tracks the status of a task. Valid values are:
 
-            * "pending": task has not yet completed
             * "success": task ran successfully
-            * "error": task failed with an error""")
+            * "error": task failed with an error
+
+            An empty value indicates the task has not yet been completed.""")
 
     scparam(cfg,['flowstatus', step, index, 'select'],
             sctype='[(str,str)]',

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1426,7 +1426,7 @@
                         "cli: -flowstatus_status 'cts 10 success'",
                         "api:  chip.set('flowstatus','cts','10','status', 'success')"
                     ],
-                    "help": "Parameter that tracks the status of a task. Valid values are:\n\n* \"pending\": task has not yet completed\n* \"success\": task ran successfully\n* \"error\": task failed with an error",
+                    "help": "Parameter that tracks the status of a task. Valid values are:\n\n* \"success\": task ran successfully\n* \"error\": task failed with an error\n\nAn empty value indicates the task has not yet been completed.",
                     "lock": "false",
                     "require": null,
                     "scope": "job",

--- a/tests/flows/test_flowstatus.py
+++ b/tests/flows/test_flowstatus.py
@@ -1,0 +1,149 @@
+import siliconcompiler
+
+import json
+import os
+import subprocess
+import time
+
+import pytest
+
+@pytest.mark.parametrize('steplist', [
+    ['import', 'place'],
+    ['import', 'place', 'placemin'],
+    ['import', 'place', 'placemin', 'cts']
+    ])
+def test_flowstatus(scroot, steplist):
+    netlist = os.path.join(scroot, 'tests', 'data', 'oh_fifo_sync_freepdk45.vg')
+    def_file = os.path.join(scroot, 'tests', 'data', 'oh_fifo_sync.def')
+
+    jobname = 'issue_repro'
+    design = "oh_fifo_sync"
+
+    chip = siliconcompiler.Chip()
+    chip.set('design', design)
+    for index in ('0', '1'):
+        chip.set('read', 'netlist', 'place', index, netlist)
+        chip.set('read', 'def', 'place', index, def_file)
+    chip.set('mode', 'asic')
+    chip.set('quiet', True)
+    chip.set('jobname', jobname)
+
+    chip.load_target('freepdk45_demo')
+
+    flow = 'test'
+    # no-op import since we're not preprocessing source files
+    chip.node(flow, 'import', 'join')
+
+    chip.node(flow, 'place', 'openroad', index='0')
+    chip.node(flow, 'place', 'openroad', index='1')
+
+    chip.edge(flow, 'import', 'place', head_index='0')
+    chip.edge(flow, 'import', 'place', head_index='1')
+
+    # Illegal value, so this branch will fail!
+    chip.set('eda', 'openroad', 'variable', 'place', '0', 'place_density', 'asdf')
+    # Legal value, so this branch should succeed
+    chip.set('eda', 'openroad', 'variable', 'place', '1', 'place_density', '0.5')
+
+    # Perform minimum
+    chip.node(flow, 'placemin', 'minimum')
+    chip.edge(flow, 'place', 'placemin', tail_index='0')
+    chip.edge(flow, 'place', 'placemin', tail_index='1')
+
+    chip.node(flow, 'cts', 'openroad')
+    chip.edge(flow, 'placemin', 'cts')
+
+    chip.set('steplist', steplist)
+    chip.set('flow', flow)
+
+    chip.run()
+
+    assert chip.get('flowstatus', 'place', '0', 'status') == siliconcompiler.TaskStatus.ERROR
+    assert chip.get('flowstatus', 'place', '1', 'status') == siliconcompiler.TaskStatus.SUCCESS
+
+def test_long_branch(scroot):
+    '''Test for this case:
+
+    import0 --> place0 [fail] --> cts0
+            \-> place1 [ ok ] --> cts1
+    '''
+    netlist = os.path.join(scroot, 'tests', 'data', 'oh_fifo_sync_freepdk45.vg')
+    def_file = os.path.join(scroot, 'tests', 'data', 'oh_fifo_sync.def')
+
+    jobname = 'issue_repro'
+    design = "oh_fifo_sync"
+
+    chip = siliconcompiler.Chip()
+    chip.set('design', design)
+    for index in ('0', '1'):
+        chip.set('read', 'netlist', 'place', index, netlist)
+        chip.set('read', 'def', 'place', index, def_file)
+    chip.set('mode', 'asic')
+    chip.set('quiet', True)
+    chip.set('jobname', jobname)
+
+    chip.load_target('freepdk45_demo')
+
+    flow = 'test'
+    # no-op import since we're not preprocessing source files
+    chip.node(flow, 'import', 'join')
+
+    chip.node(flow, 'place', 'openroad', index='0')
+    chip.node(flow, 'place', 'openroad', index='1')
+
+    chip.edge(flow, 'import', 'place', head_index='0')
+    chip.edge(flow, 'import', 'place', head_index='1')
+
+    # Illegal value, so this branch will fail!
+    chip.set('eda', 'openroad', 'variable', 'place', '0', 'place_density', 'asdf')
+    # Legal value, so this branch should succeed
+    chip.set('eda', 'openroad', 'variable', 'place', '1', 'place_density', '0.5')
+
+    chip.node(flow, 'cts', 'openroad', index='0')
+    chip.node(flow, 'cts', 'openroad', index='1')
+    chip.edge(flow, 'place', 'cts', tail_index='0', head_index='0')
+    chip.edge(flow, 'place', 'cts', tail_index='1', head_index='1')
+
+    chip.set('flow', flow)
+
+    chip.run()
+
+    assert chip.get('flowstatus', 'place', '0', 'status') == siliconcompiler.TaskStatus.ERROR
+    assert chip.get('flowstatus', 'place', '1', 'status') == siliconcompiler.TaskStatus.SUCCESS
+
+def test_remote(scroot):
+    # Start running an sc-server instance.
+    os.mkdir('local_server_work')
+    srv_proc = subprocess.Popen(['sc-server',
+                                 '-nfs_mount', './local_server_work',
+                                 '-cluster', 'local'])
+    time.sleep(3)
+
+    chip = siliconcompiler.Chip()
+
+    # Create the temporary credentials file, and set the Chip to use it.
+    tmp_creds = '.test_remote_cfg'
+    with open(tmp_creds, 'w') as tmp_cred_file:
+        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8080}))
+    chip.set('remote', True)
+    chip.set('credentials', os.path.abspath(tmp_creds))
+
+    src = os.path.join(scroot, 'examples', 'gcd', 'gcd.v')
+    chip.set('design', 'gcd')
+    chip.set('source', src)
+
+    chip.set('flowarg', 'place_np', '2')
+    # Illegal value, so this branch will fail!
+    chip.set('eda', 'openroad', 'variable', 'place', '0', 'place_density', 'asdf')
+    # Legal value, so this branch should succeed
+    chip.set('eda', 'openroad', 'variable', 'place', '1', 'place_density', '0.5')
+
+    chip.load_target('freepdk45_demo')
+
+    chip.run()
+
+    # Kill the server process.
+    srv_proc.kill()
+
+    assert chip.get('flowstatus', 'place', '0', 'status') == siliconcompiler.TaskStatus.ERROR
+    assert chip.get('flowstatus', 'place', '1', 'status') == siliconcompiler.TaskStatus.SUCCESS

--- a/tests/flows/test_flowstatus.py
+++ b/tests/flows/test_flowstatus.py
@@ -7,6 +7,8 @@ import time
 
 import pytest
 
+@pytest.mark.eda
+@pytest.mark.quick
 @pytest.mark.parametrize('steplist', [
     ['import', 'place'],
     ['import', 'place', 'placemin'],
@@ -61,6 +63,8 @@ def test_flowstatus(scroot, steplist):
     assert chip.get('flowstatus', 'place', '0', 'status') == siliconcompiler.TaskStatus.ERROR
     assert chip.get('flowstatus', 'place', '1', 'status') == siliconcompiler.TaskStatus.SUCCESS
 
+@pytest.mark.eda
+@pytest.mark.quick
 def test_long_branch(scroot):
     '''Test for this case:
 
@@ -111,6 +115,8 @@ def test_long_branch(scroot):
     assert chip.get('flowstatus', 'place', '0', 'status') == siliconcompiler.TaskStatus.ERROR
     assert chip.get('flowstatus', 'place', '1', 'status') == siliconcompiler.TaskStatus.SUCCESS
 
+@pytest.mark.eda
+@pytest.mark.quick
 def test_remote(scroot):
     # Start running an sc-server instance.
     os.mkdir('local_server_work')


### PR DESCRIPTION
This PR fixes issue #651, the flowstatus issue that has been around for a while.

This PR makes two changes:
- Doesn't store flowstatus "pending" values in the manifest. Storing an explicit value for "pending" meant that our `_read_manifest()` calls wouldn't overwrite these values since they are called with clobber=False.
- Added a code block to write out the `status` dict into the schema on success. This takes care of a few edge cases where we have steps that don't merge into one.

I also added a test based on my reproduction code from the original issue. It runs a handful of graphs with 2 parallel place steps, where one fails and one succeeds. In each test case, it ensures that the flowstatuses for these place steps are recorded correctly.

It tests this graph with 3 steplists:
- `['import', 'place']`
- `['import', 'place', 'placemin']`
- `['import', 'place', 'placemin', 'cts']`

![import-place-placemin-cts](https://user-images.githubusercontent.com/4412459/162114683-7b5d8b2a-576e-4129-b271-d691ba58d711.png)

It tests this other graph:
![longbranch](https://user-images.githubusercontent.com/4412459/162114771-1967fac1-b980-41cc-b666-aaec5ae59c25.png)

And finally it tests the regular asicflow with 2x placement running "remotely" on the dev server.