### PR TITLE
Prevent defvalue lists from getting overwritten

### DIFF
--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -5,7 +5,7 @@ from siliconcompiler import utils
 import re
 import os
 import sys
-import copy
+import copy as pycopy
 import json
 
 #############################################################################
@@ -75,7 +75,7 @@ def scparam(cfg,
         cfg['example'] = example
         cfg['help'] = schelp
         cfg['defvalue'] = defvalue
-        cfg['value'] = defvalue
+        cfg['value'] = pycopy.copy(defvalue)
         cfg['signature'] = signature
 
         # file only values

--- a/tests/core/test_scparam.py
+++ b/tests/core/test_scparam.py
@@ -116,6 +116,13 @@ def test_scparam():
 
     assert cfg == cfg_golden
 
+def test_defvalue():
+    '''Regression test that changing list-type value doesn't change defvalue.'''
+
+    chip = siliconcompiler.Chip()
+    assert chip.cfg['pdk']['stackup']['defvalue'] == []
+    chip.add('pdk', 'stackup', '10m')
+    assert chip.cfg['pdk']['stackup']['defvalue'] == []
 
 #########################
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes a little bug I noticed where defvalues for list items are updated as the value is, since the value is pointing to the same object. 