### PR TITLE
Fix summary/report generation issues

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2677,7 +2677,10 @@ class Chip:
         # display whole flowgraph if no steplist specified
         flow = self.get('flow')
         if not steplist:
-            steplist = self.list_steps()
+            if self.get('steplist'):
+                steplist = self.get('steplist')
+            else:
+                steplist = self.list_steps()
 
         #only report tool based steps functions
         for step in steplist:

--- a/siliconcompiler/templates/report/sc_report.j2
+++ b/siliconcompiler/templates/report/sc_report.j2
@@ -53,7 +53,8 @@
         {% for mk in metric_keys %}
           {% for step in tasks %}
             {% for index in tasks[step] %}
-              {% if step in manifest['eda'][manifest['flowgraph'][manifest['flow']['value']][step][index]['tool']['value']]['report'] and mk in manifest['eda'][manifest['flowgraph'][manifest['flow']['value']][step][index]['tool']['value']]['report'][step][index] %}
+              {% set report = manifest['eda'][manifest['flowgraph'][manifest['flow']['value']][step][index]['tool']['value']]['report'] %}
+              {% if (step in report) and (index in report[step]) and (mk in report[step][index]) %}
                 var sim_log_btn = document.getElementById("{{ step }}{{ index }}_{{ mk }}_metlink");
                 sim_log_btn.addEventListener('click', () => {
                   // TODO: clean up... >_>
@@ -115,7 +116,9 @@
                 <th>{{ mk }}</th>
                 {% for step in tasks %}
                   {% for index in tasks[step] %}
-                    {% if step in manifest['eda'][manifest['flowgraph'][manifest['flow']['value']][step][index]['tool']['value']]['report'] and mk in manifest['eda'][manifest['flowgraph'][manifest['flow']['value']][step][index]['tool']['value']]['report'][step][index] %}
+                    {% if manifest['flowstatus'][step][index]['status']['value'] == 'error' %}
+                      <td>(failed)</td>
+                    {% elif step in manifest['eda'][manifest['flowgraph'][manifest['flow']['value']][step][index]['tool']['value']]['report'] and mk in manifest['eda'][manifest['flowgraph'][manifest['flow']['value']][step][index]['tool']['value']]['report'][step][index] %}
                       <td><a href="#" class="link-success" id="{{ step }}{{ index }}_{{ mk }}_metlink">{{ manifest["metric"][step][index][mk]["real"]["value"] }}</a></td>
                     {% else %}
                       <td>{{ manifest["metric"][step][index][mk]["real"]["value"] }}</td>
@@ -149,7 +152,9 @@
                 </tr>
                 <tr>
                   {% for mk in metric_keys %}
-                    {% if step in manifest['eda'][manifest['flowgraph'][manifest['flow']['value']][step][index]['tool']['value']]['report'] and mk in manifest['eda'][manifest['flowgraph'][manifest['flow']['value']][step][index]['tool']['value']]['report'][step][index] %}
+                    {% if manifest['flowstatus'][step][index]['status']['value'] == 'error' %}
+                      <td>(failed)</td>
+                    {% elif step in manifest['eda'][manifest['flowgraph'][manifest['flow']['value']][step][index]['tool']['value']]['report'] and mk in manifest['eda'][manifest['flowgraph'][manifest['flow']['value']][step][index]['tool']['value']]['report'][step][index] %}
                       <td><a href="#" class="link-success" id="{{ step }}{{ index }}_{{ mk }}_ddmetlink">{{ manifest["metric"][step][index][mk]["real"]["value"] }}</a></td>
                     {% else %}
                       <td>{{ manifest["metric"][step][index][mk]["real"]["value"] }}</td>

--- a/tests/core/data/gcd.pkg.json
+++ b/tests/core/data/gcd.pkg.json
@@ -12,10 +12,7 @@
             "value": "1"
         },
         "corearea": {
-            "defvalue": [
-                "(10.07,11.2)",
-                "(90.25,91)"
-            ],
+            "defvalue": [],
             "lock": "false",
             "require": null,
             "scope": "job",
@@ -62,10 +59,7 @@
             "value": "10"
         },
         "diearea": {
-            "defvalue": [
-                "(0,0)",
-                "(100.13,100.8)"
-            ],
+            "defvalue": [],
             "lock": "false",
             "require": null,
             "scope": "job",
@@ -230,9 +224,7 @@
         "author": [],
         "copy": "true",
         "date": [],
-        "defvalue": [
-            "gcd.sdc"
-        ],
+        "defvalue": [],
         "filehash": [],
         "hashalgo": "sha256",
         "lock": "false",
@@ -331,9 +323,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.def"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -373,9 +363,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.gds"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -485,13 +473,7 @@
             "require": {
                 "export": {
                     "0": {
-                        "defvalue": [
-                            "asic,logiclib",
-                            "asic,stackup",
-                            "pdk,layermap,klayout,def,gds,10M",
-                            "library,nangate45,gds,10M",
-                            "library,nangate45,lef,10M"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -560,7 +542,7 @@
                 "switch": "-eda_version 'tool <str>'",
                 "type": "[str]",
                 "value": [
-                    "0.27.8"
+                    ">=0.27.6"
                 ]
             },
             "vswitch": {
@@ -629,9 +611,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.def"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -651,9 +631,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.def"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -673,9 +651,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.vg"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -695,9 +671,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.def"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -717,9 +691,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.def"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -739,9 +711,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.def"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -855,11 +825,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.sdc",
-                            "gcd.vg",
-                            "gcd.def"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -881,11 +847,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.sdc",
-                            "gcd.vg",
-                            "gcd.def"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -907,11 +869,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.sdc",
-                            "gcd.vg",
-                            "gcd.def"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -933,11 +891,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.sdc",
-                            "gcd.vg",
-                            "gcd.def"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -959,11 +913,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.sdc",
-                            "gcd.vg",
-                            "gcd.def"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -985,11 +935,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.sdc",
-                            "gcd.vg",
-                            "gcd.def"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -1099,4118 +1045,10 @@
                     }
                 }
             },
-            "regex": {
-                "cts": {
-                    "0": {
-                        "errors": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "ERROR"
-                            ]
-                        },
-                        "warnings": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "WARNING"
-                            ]
-                        }
-                    }
-                },
-                "dfm": {
-                    "0": {
-                        "errors": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "ERROR"
-                            ]
-                        },
-                        "warnings": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "WARNING"
-                            ]
-                        }
-                    }
-                },
-                "floorplan": {
-                    "0": {
-                        "errors": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "ERROR"
-                            ]
-                        },
-                        "warnings": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "WARNING"
-                            ]
-                        }
-                    }
-                },
-                "physyn": {
-                    "0": {
-                        "errors": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "ERROR"
-                            ]
-                        },
-                        "warnings": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "WARNING"
-                            ]
-                        }
-                    }
-                },
-                "place": {
-                    "0": {
-                        "errors": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "ERROR"
-                            ]
-                        },
-                        "warnings": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "WARNING"
-                            ]
-                        }
-                    }
-                },
-                "route": {
-                    "0": {
-                        "errors": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "ERROR"
-                            ]
-                        },
-                        "warnings": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "WARNING"
-                            ]
-                        }
-                    }
-                }
-            },
-            "report": {
-                "cts": {
-                    "0": {
-                        "averagepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "buffers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "cellarea": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "cells": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "coverage": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "dozepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "drvs": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "errors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "exetime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "holdpaths": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "holdslack": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "holdtns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "holdwns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "idlepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "irdrop": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "leakagepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "macros": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "nets": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "overflow": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "peakpower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "pins": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "registers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "security": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "setuppaths": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "setupslack": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "setuptns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "setupwns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "sleeppower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "tasktime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "totalarea": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "transistors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "unconstrained": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "utilization": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "vias": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "warnings": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        },
-                        "wirelength": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "cts.log"
-                            ]
-                        }
-                    }
-                },
-                "dfm": {
-                    "0": {
-                        "averagepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "buffers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "cellarea": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "cells": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "coverage": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "dozepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "drvs": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "errors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "exetime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "holdpaths": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "holdslack": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "holdtns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "holdwns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "idlepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "irdrop": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "leakagepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "macros": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "nets": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "overflow": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "peakpower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "pins": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "registers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "security": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "setuppaths": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "setupslack": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "setuptns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "setupwns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "sleeppower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "tasktime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "totalarea": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "transistors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "unconstrained": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "utilization": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "vias": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "warnings": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        },
-                        "wirelength": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "dfm.log"
-                            ]
-                        }
-                    }
-                },
-                "floorplan": {
-                    "0": {
-                        "averagepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "buffers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "cellarea": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "cells": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "coverage": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "dozepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "drvs": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "errors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "exetime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "holdpaths": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "holdslack": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "holdtns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "holdwns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "idlepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "irdrop": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "leakagepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "macros": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "nets": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "overflow": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "peakpower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "pins": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "registers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "security": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "setuppaths": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "setupslack": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "setuptns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "setupwns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "sleeppower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "tasktime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "totalarea": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "transistors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "unconstrained": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "utilization": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "vias": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "warnings": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        },
-                        "wirelength": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "floorplan.log"
-                            ]
-                        }
-                    }
-                },
-                "physyn": {
-                    "0": {
-                        "averagepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "buffers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "cellarea": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "cells": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "coverage": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "dozepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "drvs": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "errors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "exetime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "holdpaths": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "holdslack": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "holdtns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "holdwns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "idlepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "irdrop": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "leakagepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "macros": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "nets": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "overflow": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "peakpower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "pins": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "registers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "security": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "setuppaths": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "setupslack": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "setuptns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "setupwns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "sleeppower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "tasktime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "totalarea": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "transistors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "unconstrained": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "utilization": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "vias": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "warnings": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        },
-                        "wirelength": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "physyn.log"
-                            ]
-                        }
-                    }
-                },
-                "place": {
-                    "0": {
-                        "averagepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "buffers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "cellarea": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "cells": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "coverage": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "dozepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "drvs": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "errors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "exetime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "holdpaths": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "holdslack": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "holdtns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "holdwns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "idlepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "irdrop": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "leakagepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "macros": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "nets": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "overflow": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "peakpower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "pins": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "registers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "security": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "setuppaths": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "setupslack": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "setuptns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "setupwns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "sleeppower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "tasktime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "totalarea": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "transistors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "unconstrained": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "utilization": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "vias": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "warnings": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        },
-                        "wirelength": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "place.log"
-                            ]
-                        }
-                    }
-                },
-                "route": {
-                    "0": {
-                        "averagepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "buffers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "cellarea": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "cells": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "coverage": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "dozepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "drvs": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "errors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "exetime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "holdpaths": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "holdslack": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "holdtns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "holdwns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "idlepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "irdrop": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "leakagepower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "macros": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "nets": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "overflow": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "peakpower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "pins": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "registers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "security": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "setuppaths": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "setupslack": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "setuptns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "setupwns": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "sleeppower": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "tasktime": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "totalarea": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "transistors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "unconstrained": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "utilization": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "vias": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "warnings": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        },
-                        "wirelength": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "route.log"
-                            ]
-                        }
-                    }
-                }
-            },
             "require": {
                 "cts": {
                     "0": {
-                        "defvalue": [
-                            "asic,logiclib",
-                            "asic,stackup",
-                            "library,nangate45,arch",
-                            "pdk,aprtech,openroad,10M,10t,lef",
-                            "library,nangate45,nldm,typical,lib",
-                            "library,nangate45,lef,10M",
-                            "eda,openroad,variable,cts,0,place_density",
-                            "eda,openroad,variable,cts,0,pad_global_place",
-                            "eda,openroad,variable,cts,0,pad_detail_place",
-                            "eda,openroad,variable,cts,0,macro_place_halo",
-                            "eda,openroad,variable,cts,0,macro_place_channel"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -5235,19 +1073,7 @@
                 },
                 "dfm": {
                     "0": {
-                        "defvalue": [
-                            "asic,logiclib",
-                            "asic,stackup",
-                            "library,nangate45,arch",
-                            "pdk,aprtech,openroad,10M,10t,lef",
-                            "library,nangate45,nldm,typical,lib",
-                            "library,nangate45,lef,10M",
-                            "eda,openroad,variable,dfm,0,place_density",
-                            "eda,openroad,variable,dfm,0,pad_global_place",
-                            "eda,openroad,variable,dfm,0,pad_detail_place",
-                            "eda,openroad,variable,dfm,0,macro_place_halo",
-                            "eda,openroad,variable,dfm,0,macro_place_channel"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -5272,19 +1098,7 @@
                 },
                 "floorplan": {
                     "0": {
-                        "defvalue": [
-                            "asic,logiclib",
-                            "asic,stackup",
-                            "library,nangate45,arch",
-                            "pdk,aprtech,openroad,10M,10t,lef",
-                            "library,nangate45,nldm,typical,lib",
-                            "library,nangate45,lef,10M",
-                            "eda,openroad,variable,floorplan,0,place_density",
-                            "eda,openroad,variable,floorplan,0,pad_global_place",
-                            "eda,openroad,variable,floorplan,0,pad_detail_place",
-                            "eda,openroad,variable,floorplan,0,macro_place_halo",
-                            "eda,openroad,variable,floorplan,0,macro_place_channel"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -5309,19 +1123,7 @@
                 },
                 "physyn": {
                     "0": {
-                        "defvalue": [
-                            "asic,logiclib",
-                            "asic,stackup",
-                            "library,nangate45,arch",
-                            "pdk,aprtech,openroad,10M,10t,lef",
-                            "library,nangate45,nldm,typical,lib",
-                            "library,nangate45,lef,10M",
-                            "eda,openroad,variable,physyn,0,place_density",
-                            "eda,openroad,variable,physyn,0,pad_global_place",
-                            "eda,openroad,variable,physyn,0,pad_detail_place",
-                            "eda,openroad,variable,physyn,0,macro_place_halo",
-                            "eda,openroad,variable,physyn,0,macro_place_channel"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -5346,19 +1148,7 @@
                 },
                 "place": {
                     "0": {
-                        "defvalue": [
-                            "asic,logiclib",
-                            "asic,stackup",
-                            "library,nangate45,arch",
-                            "pdk,aprtech,openroad,10M,10t,lef",
-                            "library,nangate45,nldm,typical,lib",
-                            "library,nangate45,lef,10M",
-                            "eda,openroad,variable,place,0,place_density",
-                            "eda,openroad,variable,place,0,pad_global_place",
-                            "eda,openroad,variable,place,0,pad_detail_place",
-                            "eda,openroad,variable,place,0,macro_place_halo",
-                            "eda,openroad,variable,place,0,macro_place_channel"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -5383,19 +1173,7 @@
                 },
                 "route": {
                     "0": {
-                        "defvalue": [
-                            "asic,logiclib",
-                            "asic,stackup",
-                            "library,nangate45,arch",
-                            "pdk,aprtech,openroad,10M,10t,lef",
-                            "library,nangate45,nldm,typical,lib",
-                            "library,nangate45,lef,10M",
-                            "eda,openroad,variable,route,0,place_density",
-                            "eda,openroad,variable,route,0,pad_global_place",
-                            "eda,openroad,variable,route,0,pad_detail_place",
-                            "eda,openroad,variable,route,0,macro_place_halo",
-                            "eda,openroad,variable,route,0,macro_place_channel"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -5552,7 +1330,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "20"
+                        "value": "8"
                     }
                 },
                 "dfm": {
@@ -5565,7 +1343,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "20"
+                        "value": "8"
                     }
                 },
                 "floorplan": {
@@ -5578,7 +1356,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "20"
+                        "value": "8"
                     }
                 },
                 "physyn": {
@@ -5591,7 +1369,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "20"
+                        "value": "8"
                     }
                 },
                 "place": {
@@ -5604,7 +1382,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "20"
+                        "value": "8"
                     }
                 },
                 "route": {
@@ -5617,7 +1395,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "20"
+                        "value": "8"
                     }
                 }
             },
@@ -6059,7 +1837,7 @@
                 "switch": "-eda_version 'tool <str>'",
                 "type": "[str]",
                 "value": [
-                    "v2.0"
+                    ">=v2.0-3078"
                 ]
             },
             "vswitch": {
@@ -6113,9 +1891,7 @@
             "option": {
                 "import": {
                     "0": {
-                        "defvalue": [
-                            "-parse"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -6135,9 +1911,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "gcd.v"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -6153,86 +1927,10 @@
                     }
                 }
             },
-            "regex": {
-                "import": {
-                    "0": {
-                        "errors": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "ERROR"
-                            ]
-                        },
-                        "warnings": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "WARNING"
-                            ]
-                        }
-                    }
-                }
-            },
-            "report": {
-                "import": {
-                    "0": {
-                        "errors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "import.log"
-                            ]
-                        },
-                        "warnings": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "import.log"
-                            ]
-                        }
-                    }
-                }
-            },
             "require": {
                 "import": {
                     "0": {
-                        "defvalue": [
-                            "source"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -6257,7 +1955,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "20"
+                        "value": "8"
                     }
                 }
             },
@@ -6271,7 +1969,7 @@
                 "switch": "-eda_version 'tool <str>'",
                 "type": "[str]",
                 "value": [
-                    "1.14"
+                    ">=1.13"
                 ]
             },
             "vswitch": {
@@ -6413,305 +2111,10 @@
                     }
                 }
             },
-            "regex": {
-                "syn": {
-                    "0": {
-                        "errors": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "Error"
-                            ]
-                        },
-                        "warnings": {
-                            "defvalue": [],
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool regex filter",
-                            "signature": [],
-                            "switch": "-eda_regex 'tool step index suffix <str>'",
-                            "type": "[str]",
-                            "value": [
-                                "Warning"
-                            ]
-                        }
-                    }
-                }
-            },
-            "report": {
-                "syn": {
-                    "0": {
-                        "brams": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        },
-                        "buffers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        },
-                        "cellarea": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        },
-                        "cells": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        },
-                        "coverage": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        },
-                        "drvs": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        },
-                        "dsps": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        },
-                        "errors": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        },
-                        "luts": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        },
-                        "nets": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        },
-                        "pins": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        },
-                        "registers": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        },
-                        "security": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        },
-                        "warnings": {
-                            "author": [],
-                            "copy": "false",
-                            "date": [],
-                            "defvalue": [],
-                            "filehash": [],
-                            "hashalgo": "sha256",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Tool report files",
-                            "signature": [],
-                            "switch": "-eda_report 'tool step index metric <str>'",
-                            "type": "[file]",
-                            "value": [
-                                "syn.log"
-                            ]
-                        }
-                    }
-                }
-            },
             "require": {
                 "syn": {
                     "0": {
-                        "defvalue": [
-                            "pdk,process",
-                            "design",
-                            "asic,logiclib",
-                            "library,nangate45,nldm,typical,lib"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -6760,7 +2163,7 @@
                 "switch": "-eda_version 'tool <str>'",
                 "type": "[str]",
                 "value": [
-                    "0.13"
+                    ">=0.13"
                 ]
             },
             "vswitch": {
@@ -6794,9 +2197,7 @@
             "cts": {
                 "0": {
                     "input": {
-                        "defvalue": [
-                            "('place', '0')"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -7277,9 +2678,7 @@
             "dfm": {
                 "0": {
                     "input": {
-                        "defvalue": [
-                            "('route', '0')"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -7760,9 +3159,7 @@
             "export": {
                 "0": {
                     "input": {
-                        "defvalue": [
-                            "('dfm', '0')"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -8243,9 +3640,7 @@
             "floorplan": {
                 "0": {
                     "input": {
-                        "defvalue": [
-                            "('syn', '0')"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -9194,9 +4589,7 @@
             "physyn": {
                 "0": {
                     "input": {
-                        "defvalue": [
-                            "('floorplan', '0')"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -9677,9 +5070,7 @@
             "place": {
                 "0": {
                     "input": {
-                        "defvalue": [
-                            "('physyn', '0')"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -10160,9 +5551,7 @@
             "route": {
                 "0": {
                     "input": {
-                        "defvalue": [
-                            "('cts', '0')"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -10643,9 +6032,7 @@
             "syn": {
                 "0": {
                     "input": {
-                        "defvalue": [
-                            "('import', '0')"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -11128,9 +6515,7 @@
             "export": {
                 "0": {
                     "input": {
-                        "defvalue": [
-                            "('import', '0')"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -12079,10 +7464,7 @@
             "merge": {
                 "0": {
                     "input": {
-                        "defvalue": [
-                            "('export', '0')",
-                            "('syn', '0')"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -12564,9 +7946,7 @@
             "syn": {
                 "0": {
                     "input": {
-                        "defvalue": [
-                            "('import', '0')"
-                        ],
+                        "defvalue": [],
                         "lock": "false",
                         "require": null,
                         "scope": "job",
@@ -13049,17 +8429,6 @@
     "flowstatus": {
         "cts": {
             "0": {
-                "error": {
-                    "defvalue": null,
-                    "lock": "false",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Flowgraph task error status",
-                    "signature": null,
-                    "switch": "-flowstatus_error 'step index <int>'",
-                    "type": "int",
-                    "value": "1"
-                },
                 "select": {
                     "defvalue": [],
                     "lock": "false",
@@ -13072,22 +8441,22 @@
                     "value": [
                         "('place', '0')"
                     ]
+                },
+                "status": {
+                    "defvalue": null,
+                    "lock": "false",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Flowgraph task status",
+                    "signature": null,
+                    "switch": "-flowstatus_status 'step index <str>'",
+                    "type": "str",
+                    "value": "success"
                 }
             }
         },
         "dfm": {
             "0": {
-                "error": {
-                    "defvalue": null,
-                    "lock": "false",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Flowgraph task error status",
-                    "signature": null,
-                    "switch": "-flowstatus_error 'step index <int>'",
-                    "type": "int",
-                    "value": "0"
-                },
                 "select": {
                     "defvalue": [],
                     "lock": "false",
@@ -13100,22 +8469,22 @@
                     "value": [
                         "('route', '0')"
                     ]
+                },
+                "status": {
+                    "defvalue": null,
+                    "lock": "false",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Flowgraph task status",
+                    "signature": null,
+                    "switch": "-flowstatus_status 'step index <str>'",
+                    "type": "str",
+                    "value": "success"
                 }
             }
         },
         "export": {
             "0": {
-                "error": {
-                    "defvalue": null,
-                    "lock": "false",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Flowgraph task error status",
-                    "signature": null,
-                    "switch": "-flowstatus_error 'step index <int>'",
-                    "type": "int",
-                    "value": "0"
-                },
                 "select": {
                     "defvalue": [],
                     "lock": "false",
@@ -13128,22 +8497,22 @@
                     "value": [
                         "('dfm', '0')"
                     ]
+                },
+                "status": {
+                    "defvalue": null,
+                    "lock": "false",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Flowgraph task status",
+                    "signature": null,
+                    "switch": "-flowstatus_status 'step index <str>'",
+                    "type": "str",
+                    "value": "success"
                 }
             }
         },
         "floorplan": {
             "0": {
-                "error": {
-                    "defvalue": null,
-                    "lock": "false",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Flowgraph task error status",
-                    "signature": null,
-                    "switch": "-flowstatus_error 'step index <int>'",
-                    "type": "int",
-                    "value": "1"
-                },
                 "select": {
                     "defvalue": [],
                     "lock": "false",
@@ -13156,37 +8525,37 @@
                     "value": [
                         "('syn', '0')"
                     ]
+                },
+                "status": {
+                    "defvalue": null,
+                    "lock": "false",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Flowgraph task status",
+                    "signature": null,
+                    "switch": "-flowstatus_status 'step index <str>'",
+                    "type": "str",
+                    "value": "success"
                 }
             }
         },
         "import": {
             "0": {
-                "error": {
+                "status": {
                     "defvalue": null,
                     "lock": "false",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Flowgraph task error status",
+                    "shorthelp": "Flowgraph task status",
                     "signature": null,
-                    "switch": "-flowstatus_error 'step index <int>'",
-                    "type": "int",
-                    "value": "1"
+                    "switch": "-flowstatus_status 'step index <str>'",
+                    "type": "str",
+                    "value": "success"
                 }
             }
         },
         "physyn": {
             "0": {
-                "error": {
-                    "defvalue": null,
-                    "lock": "false",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Flowgraph task error status",
-                    "signature": null,
-                    "switch": "-flowstatus_error 'step index <int>'",
-                    "type": "int",
-                    "value": "1"
-                },
                 "select": {
                     "defvalue": [],
                     "lock": "false",
@@ -13199,22 +8568,22 @@
                     "value": [
                         "('floorplan', '0')"
                     ]
+                },
+                "status": {
+                    "defvalue": null,
+                    "lock": "false",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Flowgraph task status",
+                    "signature": null,
+                    "switch": "-flowstatus_status 'step index <str>'",
+                    "type": "str",
+                    "value": "success"
                 }
             }
         },
         "place": {
             "0": {
-                "error": {
-                    "defvalue": null,
-                    "lock": "false",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Flowgraph task error status",
-                    "signature": null,
-                    "switch": "-flowstatus_error 'step index <int>'",
-                    "type": "int",
-                    "value": "1"
-                },
                 "select": {
                     "defvalue": [],
                     "lock": "false",
@@ -13227,22 +8596,22 @@
                     "value": [
                         "('physyn', '0')"
                     ]
+                },
+                "status": {
+                    "defvalue": null,
+                    "lock": "false",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Flowgraph task status",
+                    "signature": null,
+                    "switch": "-flowstatus_status 'step index <str>'",
+                    "type": "str",
+                    "value": "success"
                 }
             }
         },
         "route": {
             "0": {
-                "error": {
-                    "defvalue": null,
-                    "lock": "false",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Flowgraph task error status",
-                    "signature": null,
-                    "switch": "-flowstatus_error 'step index <int>'",
-                    "type": "int",
-                    "value": "1"
-                },
                 "select": {
                     "defvalue": [],
                     "lock": "false",
@@ -13255,22 +8624,22 @@
                     "value": [
                         "('cts', '0')"
                     ]
+                },
+                "status": {
+                    "defvalue": null,
+                    "lock": "false",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Flowgraph task status",
+                    "signature": null,
+                    "switch": "-flowstatus_status 'step index <str>'",
+                    "type": "str",
+                    "value": "success"
                 }
             }
         },
         "syn": {
             "0": {
-                "error": {
-                    "defvalue": null,
-                    "lock": "false",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Flowgraph task error status",
-                    "signature": null,
-                    "switch": "-flowstatus_error 'step index <int>'",
-                    "type": "int",
-                    "value": "1"
-                },
                 "select": {
                     "defvalue": [],
                     "lock": "false",
@@ -13283,6 +8652,17 @@
                     "value": [
                         "('import', '0')"
                     ]
+                },
+                "status": {
+                    "defvalue": null,
+                    "lock": "false",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Flowgraph task status",
+                    "signature": null,
+                    "switch": "-flowstatus_status 'step index <str>'",
+                    "type": "str",
+                    "value": "success"
                 }
             }
         }
@@ -13370,9 +8750,7 @@
             },
             "cells": {
                 "buf": {
-                    "defvalue": [
-                        "BUF_X1/A/Z"
-                    ],
+                    "defvalue": [],
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -13385,9 +8763,7 @@
                     ]
                 },
                 "clkbuf": {
-                    "defvalue": [
-                        "BUF_X4"
-                    ],
+                    "defvalue": [],
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -13400,9 +8776,7 @@
                     ]
                 },
                 "driver": {
-                    "defvalue": [
-                        "BUF_X4"
-                    ],
+                    "defvalue": [],
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -13415,9 +8789,7 @@
                     ]
                 },
                 "endcap": {
-                    "defvalue": [
-                        "FILLCELL_X1"
-                    ],
+                    "defvalue": [],
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -13430,14 +8802,7 @@
                     ]
                 },
                 "filler": {
-                    "defvalue": [
-                        "FILLCELL_X1",
-                        "FILLCELL_X2",
-                        "FILLCELL_X4",
-                        "FILLCELL_X8",
-                        "FILLCELL_X16",
-                        "FILLCELL_X32"
-                    ],
+                    "defvalue": [],
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -13455,9 +8820,7 @@
                     ]
                 },
                 "hold": {
-                    "defvalue": [
-                        "BUF_X1"
-                    ],
+                    "defvalue": [],
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -13470,10 +8833,7 @@
                     ]
                 },
                 "ignore": {
-                    "defvalue": [
-                        "AOI211_X1",
-                        "OAI211_X1"
-                    ],
+                    "defvalue": [],
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -13487,9 +8847,7 @@
                     ]
                 },
                 "tap": {
-                    "defvalue": [
-                        "FILLCELL_X1"
-                    ],
+                    "defvalue": [],
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -13502,10 +8860,7 @@
                     ]
                 },
                 "tie": {
-                    "defvalue": [
-                        "LOGIC1_X1/Z",
-                        "LOGIC0_X1/Z"
-                    ],
+                    "defvalue": [],
                     "lock": "false",
                     "require": null,
                     "scope": "global",
@@ -13524,9 +8879,7 @@
                     "author": [],
                     "copy": "false",
                     "date": [],
-                    "defvalue": [
-                        "../third_party/pdks/virtual/freepdk45/libs/nangate45/r1p0/gds/NangateOpenCellLibrary.gds"
-                    ],
+                    "defvalue": [],
                     "filehash": [],
                     "hashalgo": "sha256",
                     "lock": "false",
@@ -13546,9 +8899,7 @@
                     "author": [],
                     "copy": "false",
                     "date": [],
-                    "defvalue": [
-                        "../third_party/pdks/virtual/freepdk45/libs/nangate45/r1p0/lef/NangateOpenCellLibrary.macro.mod.lef"
-                    ],
+                    "defvalue": [],
                     "filehash": [],
                     "hashalgo": "sha256",
                     "lock": "false",
@@ -13569,9 +8920,7 @@
                         "author": [],
                         "copy": "false",
                         "date": [],
-                        "defvalue": [
-                            "../third_party/pdks/virtual/freepdk45/libs/nangate45/r1p0/lib/NangateOpenCellLibrary_typical.lib"
-                        ],
+                        "defvalue": [],
                         "filehash": [],
                         "hashalgo": "sha256",
                         "lock": "false",
@@ -13655,9 +9004,7 @@
                     "author": [],
                     "copy": "false",
                     "date": [],
-                    "defvalue": [
-                        "../third_party/pdks/virtual/freepdk45/libs/nangate45/r1p0/techmap/yosys/cells_latch.v"
-                    ],
+                    "defvalue": [],
                     "filehash": [],
                     "hashalgo": "sha256",
                     "lock": "false",
@@ -13686,7 +9033,7 @@
         }
     },
     "loglevel": {
-        "defvalue": "WARNING",
+        "defvalue": "INFO",
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -13912,7 +9259,7 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "1.91"
+                        "value": "2.06"
                     }
                 },
                 "holdpaths": {
@@ -14064,7 +9411,7 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "0.0"
+                        "value": "100618240.0"
                     }
                 },
                 "nets": {
@@ -14242,7 +9589,7 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "2.22"
+                        "value": "2.32"
                     }
                 },
                 "totalarea": {
@@ -14502,7 +9849,7 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.31"
+                        "value": "0.41"
                     }
                 },
                 "holdpaths": {
@@ -14654,7 +10001,7 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "0.0"
+                        "value": "89817088.0"
                     }
                 },
                 "nets": {
@@ -14832,7 +10179,7 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.65"
+                        "value": "0.66"
                     }
                 },
                 "totalarea": {
@@ -15092,7 +10439,7 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.81"
+                        "value": "0.97"
                     }
                 },
                 "holdpaths": {
@@ -15244,7 +10591,7 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "0"
+                        "value": "365531136"
                     }
                 },
                 "nets": {
@@ -15422,7 +10769,7 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "1.22"
+                        "value": "1.29"
                     }
                 },
                 "totalarea": {
@@ -15682,7 +11029,7 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.31"
+                        "value": "0.41"
                     }
                 },
                 "holdpaths": {
@@ -15834,7 +11181,7 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "0.0"
+                        "value": "86728704.0"
                     }
                 },
                 "nets": {
@@ -16012,7 +11359,7 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.57"
+                        "value": "0.66"
                     }
                 },
                 "totalarea": {
@@ -16272,7 +11619,7 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.3"
+                        "value": "0.41"
                     }
                 },
                 "holdpaths": {
@@ -16424,7 +11771,7 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "0.0"
+                        "value": "37380096.0"
                     }
                 },
                 "nets": {
@@ -16602,7 +11949,7 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.39"
+                        "value": "0.5"
                     }
                 },
                 "totalarea": {
@@ -17031,7 +12378,7 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "0.0"
+                        "value": "76849152.0"
                     }
                 },
                 "nets": {
@@ -17209,7 +12556,7 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.58"
+                        "value": "0.54"
                     }
                 },
                 "totalarea": {
@@ -17469,7 +12816,7 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.51"
+                        "value": "0.62"
                     }
                 },
                 "holdpaths": {
@@ -17621,7 +12968,7 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "0.0"
+                        "value": "107102208.0"
                     }
                 },
                 "nets": {
@@ -17799,7 +13146,7 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.8"
+                        "value": "0.86"
                     }
                 },
                 "totalarea": {
@@ -18059,7 +13406,7 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "1.91"
+                        "value": "3.42"
                     }
                 },
                 "holdpaths": {
@@ -18211,7 +13558,7 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "0.0"
+                        "value": "745259008.0"
                     }
                 },
                 "nets": {
@@ -18389,7 +13736,7 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "2.27"
+                        "value": "3.67"
                     }
                 },
                 "totalarea": {
@@ -18801,7 +14148,7 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "0.0"
+                        "value": "30490624.0"
                     }
                 },
                 "nets": {
@@ -18979,7 +14326,7 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.95"
+                        "value": "0.92"
                     }
                 },
                 "totalarea": {
@@ -20246,9 +15593,7 @@
         "value": "false"
     },
     "scpath": {
-        "defvalue": [
-            "/home/aolofsson/work/zeroasic/siliconcompiler/examples/gcd"
-        ],
+        "defvalue": [],
         "lock": "false",
         "require": null,
         "scope": "job",
@@ -20257,7 +15602,7 @@
         "switch": "-scpath <dir>",
         "type": "[dir]",
         "value": [
-            "/home/aolofsson/work/zeroasic/siliconcompiler/examples/gcd"
+            "/home/noah/code/siliconcompiler/examples/gcd"
         ]
     },
     "show": {
@@ -20321,9 +15666,7 @@
         "author": [],
         "copy": "true",
         "date": [],
-        "defvalue": [
-            "gcd.v"
-        ],
+        "defvalue": [],
         "filehash": [],
         "hashalgo": "sha256",
         "lock": "false",
@@ -20450,7 +15793,7 @@
         }
     },
     "vercheck": {
-        "defvalue": "false",
+        "defvalue": "true",
         "lock": "false",
         "require": "all",
         "scope": "job",
@@ -20458,7 +15801,7 @@
         "signature": null,
         "switch": "-vercheck <bool>",
         "type": "bool",
-        "value": "false"
+        "value": "true"
     },
     "version": {
         "print": {

--- a/tests/core/test_summary.py
+++ b/tests/core/test_summary.py
@@ -11,6 +11,19 @@ def test_summary(datadir):
 
     chip.summary()
 
+def test_steplist(datadir, capfd):
+    with capfd.disabled():
+        chip = siliconcompiler.Chip()
+        manifest = os.path.join(datadir, 'gcd.pkg.json')
+
+        chip.read_manifest(manifest)
+        chip.set('steplist', ['syn'])
+
+    chip.summary()
+    stdout, _ = capfd.readouterr()
+
+    assert 'import0' not in stdout
+    assert 'syn0' in stdout
 
 #########################
 if __name__ == "__main__":

--- a/tests/flows/test_flowstatus.py
+++ b/tests/flows/test_flowstatus.py
@@ -154,3 +154,5 @@ def test_remote(scroot):
 
     assert chip.get('flowstatus', 'place', '0', 'status') == siliconcompiler.TaskStatus.ERROR
     assert chip.get('flowstatus', 'place', '1', 'status') == siliconcompiler.TaskStatus.SUCCESS
+
+    chip.summary()

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -85,6 +85,7 @@ def chip(scroot):
 def test_failed_branch_min(chip):
     '''Test that a minimum will allow failed inputs, as long as at least
     one passes.'''
+    flow = chip.get('flow')
 
     # Illegal value, so this branch will fail!
     chip.set('eda', 'openroad', 'variable', 'place', '0', 'place_density', 'asdf')
@@ -92,8 +93,8 @@ def test_failed_branch_min(chip):
     chip.set('eda', 'openroad', 'variable', 'place', '1', 'place_density', '0.5')
 
     # Perform minimum
-    chip.set('flowgraph', chip.get('flow'), 'placemin', '0', 'tool', 'minimum')
-    chip.set('flowgraph', chip.get('flow'), 'placemin', '0', 'input', [('place','0'), ('place','1')])
+    chip.set('flowgraph', flow, 'placemin', '0', 'tool', 'minimum')
+    chip.set('flowgraph', flow, 'placemin', '0', 'input', [('place','0'), ('place','1')])
 
     chip.run()
 
@@ -102,6 +103,12 @@ def test_failed_branch_min(chip):
 
     # check that compilation succeeded
     assert chip.find_result('def', step='placemin') is not None
+
+    # Ensure that summary/report generation can handle failed branch without
+    # error.
+    chip.set('flowgraph', flow, 'place', '0', 'weight', 'errors', 0)
+    chip.set('flowgraph', flow, 'place', '0', 'weight', 'warnings', 0)
+    chip.summary()
 
 @pytest.mark.eda
 @pytest.mark.quick


### PR DESCRIPTION
This PR fixes:
- "ERR" when running summary() on a chip with steplist. We changed this in #777 but I can't remember why, and I think we should probably go back.
- Missing report key (issue #932). This extra check might not be necessary once we swap report pointers to always be done in setup(), but it won't hurt for now.
- Display "(failed)" under metrics for tasks that error out, since they won't have metric values filled in (was causing KeyError).

I inserted some summary() calls into tests with weird steplists to try and catch these issues in CI.