### PR TITLE
Clear record schema in _runtask()

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3382,12 +3382,17 @@ class Chip:
         #self.write_manifest(f'inputs/{design}.pkg.json')
 
         ##################
-        # 6. Reset metrics to zero
+        # 6. Reset metrics/records
+        # Make metrics zero
         # TODO: There should be no need for this, but need to fix
         # without it we need to be more careful with flows to make sure
         # things like the builtin functions don't look at None values
         for metric in self.getkeys('metric', 'default', 'default'):
             self.set('metric', step, index, metric, 'real', 0)
+
+        # Make records None
+        for record in self.getkeys('record', 'default', 'default'):
+            self.set('record', step, index, record, None)
 
         ##################
         # 7. Select inputs


### PR DESCRIPTION
RE: #969, this adds code to the top of _runtask() to clear out potentially stale record entries. Now we reset the records, metrics, and flowstatus, so I think we should be okay to close that issue.