### PR TITLE
Move EDA report setup to tool setup() functions

### DIFF
--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -125,8 +125,15 @@ def setup(chip, mode="batch"):
             chip.error = 1
             chip.logger.error(f'Stackup and targetlib paremeters required for Klayout.')
 
+    logfile = f"{step}.log"
 
+    # Log file parsing
+    chip.set('eda', tool, 'regex', step, index, 'warnings', "WARNING", clobber=False)
+    chip.set('eda', tool, 'regex', step, index, 'errors', "ERROR", clobber=False)
 
+    # Reports
+    for metric in ('errors', 'warnings'):
+        chip.set('eda', tool, 'report', step, index, metric, logfile)
 
 ################################
 #  Environment setup
@@ -168,20 +175,6 @@ def parse_version(stdout):
 def post_process(chip):
     ''' Tool specific function to run after step execution
     '''
-
-    tool = 'klayout'
-    step = chip.get('arg', 'step')
-    index = chip.get('arg','index')
-    logfile = f"{step}.log"
-
-    # Log file parsing
-    chip.set('eda', tool, 'regex', step, index, 'warnings', "WARNING", clobber=False)
-    chip.set('eda', tool, 'regex', step, index, 'errors', "ERROR", clobber=False)
-
-    # Reports
-    for metric in ('errors', 'warnings'):
-        chip.set('eda', tool, 'report', step, index, metric, logfile)
-
     return 0
 
 ##################################################

--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -76,6 +76,10 @@ def setup(chip):
     if step == 'extspice':
         chip.add('eda', tool, 'output', step, index, f'{design}.spice')
 
+    if step == 'drc':
+        report_path = f'reports/{design}.drc'
+        chip.set('eda', tool, 'report', step, index, 'errors', report_path)
+
 ################################
 # Version Check
 ################################
@@ -92,7 +96,6 @@ def post_process(chip):
 
     Reads error count from output and fills in appropriate entry in metrics
     '''
-    tool = 'magic'
     step = chip.get('arg', 'step')
     index = chip.get('arg', 'index')
     design = chip.get('design')
@@ -105,7 +108,6 @@ def post_process(chip):
 
                 if errors:
                     chip.set('metric', step, index, 'errors', 'real', errors.group(1))
-            chip.set('eda', tool, 'report', step, index, 'errors', report_path)
 
     #TODO: return error code
     return 0

--- a/siliconcompiler/tools/netgen/netgen.py
+++ b/siliconcompiler/tools/netgen/netgen.py
@@ -69,6 +69,10 @@ def setup(chip):
     else:
         chip.add('eda', tool, 'input', step, index, f'{design}.vg')
 
+    report_path = f'reports/{design}.lvs.out'
+    chip.set('eda', tool, 'report', step, index, 'errors', report_path)
+    chip.set('eda', tool, 'report', step, index, 'warnings', report_path)
+
 ################################
 # Version Check
 ################################
@@ -86,7 +90,6 @@ def post_process(chip):
 
     Reads error count from output and fills in appropriate entry in metrics
     '''
-    tool = 'netgen'
     step = chip.get('arg', 'step')
     index = chip.get('arg', 'index')
     design = chip.get('design')
@@ -103,10 +106,6 @@ def post_process(chip):
         errors = lvs_failures[0] - pin_failures
         chip.set('metric', step, index, 'errors', 'real', errors)
         chip.set('metric', step, index, 'warnings', 'real', pin_failures)
-
-    report_path = f'reports/{design}.lvs.out'
-    chip.set('eda', tool, 'report', step, index, 'errors', report_path)
-    chip.set('eda', tool, 'report', step, index, 'warnings', report_path)
 
     #TODO: return error code
     return 0

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -149,7 +149,7 @@ def setup(chip, mode='batch'):
 
     # reports
     logfile = f"{step}.log"
-    for metric in chip.getkeys('metric', step, index):
+    for metric in chip.getkeys('metric', 'default', 'default'):
         if metric not in ('runtime', 'memory',
                           'luts', 'dsps', 'brams'):
             chip.set('eda', tool, 'report', step, index, metric, logfile)

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -143,6 +143,17 @@ def setup(chip, mode='batch'):
         chip.add('eda', tool, 'require', step, index, ','.join(['supply', supply, 'level']))
         chip.add('eda', tool, 'require', step, index, ','.join(['supply', supply, 'pin']))
 
+    # basic warning and error grep check on logfile
+    chip.set('eda', tool, 'regex', step, index, 'warnings', "WARNING", clobber=False)
+    chip.set('eda', tool, 'regex', step, index, 'errors', "ERROR", clobber=False)
+
+    # reports
+    logfile = f"{step}.log"
+    for metric in chip.getkeys('metric', step, index):
+        if metric not in ('runtime', 'memory',
+                          'luts', 'dsps', 'brams'):
+            chip.set('eda', tool, 'report', step, index, metric, logfile)
+
 ################################
 # Version Check
 ################################
@@ -197,21 +208,10 @@ def post_process(chip):
     '''
 
     #Check log file for errors and statistics
-    tool = 'openroad'
     step = chip.get('arg', 'step')
     index = chip.get('arg', 'index')
     design = chip.get('design')
     logfile = f"{step}.log"
-
-    # basic warning and error grep check on logfile
-    chip.set('eda', tool, 'regex', step, index, 'warnings', "WARNING", clobber=False)
-    chip.set('eda', tool, 'regex', step, index, 'errors', "ERROR", clobber=False)
-
-    # reports
-    for metric in chip.getkeys('metric', step, index):
-        if metric not in ('runtime', 'memory',
-                          'luts', 'dsps', 'brams'):
-            chip.set('eda', tool, 'report', step, index, metric, logfile)
 
     # parsing log file
     errors = 0

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -77,6 +77,13 @@ def setup(chip):
         surelog_path = os.path.join(os.path.dirname(__file__), 'bin')
         chip.set('eda', tool, 'path', surelog_path, clobber=False)
 
+    # Log file parsing
+    chip.set('eda', tool, 'regex', step, index, 'warnings', "WARNING")
+    chip.set('eda', tool, 'regex', step, index, 'errors', "ERROR")
+
+    # Output reprts for deep dive
+    for metric in ('errors', 'warnings'):
+        chip.set('eda', tool, 'report', step, index, metric, f"{step}.log")
 
 
 def parse_version(stdout):
@@ -140,14 +147,6 @@ def post_process(chip):
 
     if step != 'import':
         return 0
-
-    # Log file parsing
-    chip.set('eda', tool, 'regex', step, index, 'warnings', "WARNING")
-    chip.set('eda', tool, 'regex', step, index, 'errors', "ERROR")
-
-    # Output reprts for deep dive
-    for metric in ('errors', 'warnings'):
-        chip.set('eda', tool, 'report', step, index, metric, f"{step}.log")
 
     # Look in slpp_all/file_elab.lst for list of Verilog files included in
     # design, read these and concatenate them into one pickled output file.

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -99,6 +99,16 @@ def setup(chip):
     else:
         chip.add('eda', tool, 'require', step, index, ",".join(['fpga','partname']))
 
+    # Setting up regex patterns
+    chip.set('eda', tool, 'regex', step, index, 'warnings', "Warning", clobber=False)
+    chip.set('eda', tool, 'regex', step, index, 'errors', "Error", clobber=False)
+
+    # Reports
+    for metric in ('errors', 'warnings', 'drvs', 'coverage', 'security',
+                   'luts', 'dsps', 'brams',
+                   'cellarea',
+                   'cells', 'registers', 'buffers', 'nets', 'pins'):
+        chip.set('eda', tool, 'report', step, index, metric, f"{step}.log")
 
 #############################################
 # Runtime pre processing
@@ -130,20 +140,8 @@ def post_process(chip):
     ''' Tool specific function to run after step execution
     '''
 
-    tool = 'yosys'
     step = chip.get('arg','step')
     index = chip.get('arg','index')
-
-    # Setting up regex patterns
-    chip.set('eda', tool, 'regex', step, index, 'warnings', "Warning", clobber=False)
-    chip.set('eda', tool, 'regex', step, index, 'errors', "Error", clobber=False)
-
-    # Reports
-    for metric in ('errors', 'warnings', 'drvs', 'coverage', 'security',
-                   'luts', 'dsps', 'brams',
-                   'cellarea',
-                   'cells', 'registers', 'buffers', 'nets', 'pins'):
-        chip.set('eda', tool, 'report', step, index, metric, f"{step}.log")
 
     # Extracting
     if step == 'syn':

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -18,6 +18,14 @@ def test_py(setup_example_test):
     # Verify that report file was generated.
     assert os.path.isfile('build/gcd/job0/report.html')
 
+    manifest = 'build/gcd/job0/export/0/outputs/gcd.pkg.json'
+    assert os.path.isfile(manifest)
+
+    chip = siliconcompiler.Chip()
+    chip.read_manifest(manifest)
+
+    assert chip.get('eda', 'yosys', 'report', 'syn', '0', 'cellarea') == ['syn.log']
+
 @pytest.mark.eda
 @pytest.mark.quick
 def test_cli(setup_example_test):


### PR DESCRIPTION
RE: https://github.com/siliconcompiler/siliconcompiler/pull/954#discussion_r837860771, this PR moves all the EDA report setup from post_process() to each tool driver's setup() function. This is more consistent with the input/output schema, and it is necessary now that we don't persist any mid-run changes to schema other than metrics/record/flowstatus.