### PR TITLE
Fix bug in flowstatus reset

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3754,7 +3754,7 @@ class Chip:
             for index in self.getkeys('flowgraph', flow, step):
                 stepdir = self._getworkdir(step=step, index=index)
                 cfg = f"{stepdir}/outputs/{self.get('design')}.pkg.json"
-                if not os.path.isdir(stepdir):
+                if not os.path.isdir(stepdir) or (step in steplist and index in indexlist[step]):
                     self.set('flowstatus', step, index, 'status', None)
                 elif os.path.isfile(cfg):
                     self.set('flowstatus', step, index, 'status', TaskStatus.SUCCESS)


### PR DESCRIPTION
Small bug I ran into: even if the directory exists, we still want to set a task to pending if it is in our step/index list.