### PR TITLE
Fix Surelog install script

### DIFF
--- a/setup/docker/Dockerfile
+++ b/setup/docker/Dockerfile
@@ -3,9 +3,6 @@ FROM ubuntu:20.04
 RUN apt-get update && apt-get upgrade -y && apt-get -y install python3 cmake wget
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install git python3-pip lsb-core libqt5designer5 libqt5multimedia5 libqt5multimediawidgets5 libqt5xmlpatterns5 libqt5printsupport5 libqt5sql5 libruby2.7
 
-# Fix to allow utfcpp to be cloned after recent GitHub security updates around SSH cloning.
-RUN git config --global url."https://".insteadOf git://
-
 RUN git clone https://github.com/siliconcompiler/siliconcompiler.git
 
 COPY container_init.py /siliconcompiler/container_init.py

--- a/setup/docker/Dockerfile
+++ b/setup/docker/Dockerfile
@@ -3,6 +3,9 @@ FROM ubuntu:20.04
 RUN apt-get update && apt-get upgrade -y && apt-get -y install python3 cmake wget
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install git python3-pip lsb-core libqt5designer5 libqt5multimedia5 libqt5multimediawidgets5 libqt5xmlpatterns5 libqt5printsupport5 libqt5sql5 libruby2.7
 
+# Fix to allow utfcpp to be cloned after recent GitHub security updates around SSH cloning.
+RUN git config --global url."https://".insteadOf git://
+
 RUN git clone https://github.com/siliconcompiler/siliconcompiler.git
 
 COPY container_init.py /siliconcompiler/container_init.py

--- a/setup/install-surelog.sh
+++ b/setup/install-surelog.sh
@@ -3,6 +3,14 @@ sudo apt-get install -y default-jre
 
 git submodule update --init --recursive third_party/tools/surelog
 cd third_party/tools/surelog
+
+# Workaround: Surelog's antlr4 dependency clones a git:// repo during its build process.
+# GitHub recently deprecated some ways of cloning via git://, so we need to use https:// instead.
+# We don't want to overwrite the user's global git config, so use $HOME to set global search path.
+# In git v2.35+, we'll be able to use $GIT_CONFIG_GLOBAL, but not many systems will support that.
+git config --file $(pwd)/.gitconfig url."https://".insteadOf git://
+export HOME=$(pwd)
+
 make
 make install
 cd -

--- a/setup/install-surelog.sh
+++ b/setup/install-surelog.sh
@@ -7,7 +7,7 @@ cd third_party/tools/surelog
 # Workaround: Surelog's antlr4 dependency clones a git:// repo during its build process.
 # GitHub recently deprecated some ways of cloning via git://, so we need to use https:// instead.
 # We don't want to overwrite the user's global git config, so use $HOME to set global search path.
-# In git v2.35+, we'll be able to use $GIT_CONFIG_GLOBAL, but not many systems will support that.
+# In git v2.32+, we'll be able to use $GIT_CONFIG_GLOBAL, but not many systems will support that.
 git config --file $(pwd)/.gitconfig url."https://".insteadOf git://
 export HOME=$(pwd)
 


### PR DESCRIPTION
It looks like GitHub recently changed its security policy to block some methods of cloning git:// addresses. One of Surelog's dependencies includes a 'git clone' call that points to such a repository, so our surelog install script has started to fail.

It looks like the solution is to force Git to use https:// instead of git://. It's a little tricky to force that setting without modifying the system's Git configuration, but I think the easiest approach is to override the default `~/.gitconfig` search path in `install-surelog.sh`.