### PR TITLE
Adding units to schema parameters as appropriate

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1008,7 +1008,7 @@ class Chip:
                             else:
                                 self.logger.error(f'{field} must be set to boolean.')
                                 self.error = 1
-                        elif field in ('hashalgo', 'scope', 'require','type',
+                        elif field in ('hashalgo', 'scope', 'require', 'type', 'unit',
                                        'shorthelp', 'switch', 'help'):
                             # awlays string scalars
                             cfg[param][field] = val

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1790,8 +1790,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
                     f"cli: -metric_{item} 'place 0 goal 0.01'",
                     f"api: chip.set('metric','place','0','{item}','real', 0.01)"],
                 schelp=f"""
-                Metric tracking the {val} on a per step and index basis.
-                Metric unit is nanoseconds.""")
+                Metric tracking the {val} on a per step and index basis.""")
 
     metrics = {'macros': 'macros',
                'cells': 'cell instances',
@@ -1829,7 +1828,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
                 f"api: chip.set('metric','place','0','{item}','real', 50.0)"],
             schelp=f"""
             Metric tracking the total {item} of the design on a per step
-            and index basis. The unit is meters.""")
+            and index basis.""")
 
     item = 'overflow'
     scparam(cfg, ['metric', step, index, item, group],
@@ -1861,7 +1860,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
                 f"api: chip.set('metric','dfm','0','{item}','real', 10e9)"],
             schelp=f"""
             Metric tracking total peak program memory footprint on a per
-            step and index basis, specified in bytes.""")
+            step and index basis.""")
 
     item = 'exetime'
     scparam(cfg, ['metric', step, index, item, group],
@@ -1878,8 +1877,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
             Metric tracking time spent by the eda executable 'exe' on a
             per step and index basis. It does not include the siliconcompiler
             runtime overhead or time waitig for I/O operations and
-            inter-processor communication to complete. The metric unit
-            is seconds.""")
+            inter-processor communication to complete.""")
 
     item = 'tasktime'
     scparam(cfg, ['metric', step, index, item, group],
@@ -1894,8 +1892,23 @@ def schema_metric(cfg, step='default', index='default',group='default'):
                 f"api: chip.set('metric','dfm','0','{item}','real, 10.0)"],
             schelp=f"""
             Metric trakcing the total amount of time spent on a task from
-            beginning to end, including data transfers and pre/post processing.
-            The metric unit is seconds.""")
+            beginning to end, including data transfers and pre/post
+            processing.""")
+
+    item = 'totaltime'
+    scparam(cfg, ['metric', step, index, item, group],
+            sctype='float',
+            unit='s',
+            scope='job',
+            require='asic',
+            shorthelp=f"Metric: {item}",
+            switch=f"-metric_{item} 'step index group <float>'",
+            example=[
+                f"cli: -metric_{item} 'dfm 0 goal 10.0'",
+                f"api: chip.set('metric','dfm','0','{item}','real, 10.0)"],
+            schelp=f"""
+            Metric tracking the total amount of time spent from the beginning
+            of the run up to and including the current step and index.""")
 
     return cfg
 

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -22,6 +22,7 @@ def scparam(cfg,
             lock='false',
             hashalgo='sha256',
             signature=None,
+            unit=None,
             shorthelp=None,
             switch=None,
             example=None,
@@ -43,8 +44,9 @@ def scparam(cfg,
                 defvalue=defvalue,
                 copy=copy,
                 lock=lock,
-                signature=signature,
                 hashalgo=hashalgo,
+                signature=signature,
+                unit=unit,
                 shorthelp=shorthelp,
                 switch=switch,
                 example=example,
@@ -77,6 +79,10 @@ def scparam(cfg,
         cfg['defvalue'] = defvalue
         cfg['value'] = pycopy.copy(defvalue)
         cfg['signature'] = signature
+
+        # units are optional
+        if unit is not None:
+            cfg['unit'] = unit
 
         # file only values
         if re.search(r'file',sctype):
@@ -347,27 +353,28 @@ def schema_pdk(cfg, stackup='default'):
 
     scparam(cfg, ['pdk', 'wafersize'],
             sctype='float',
+            unit='mm',
             require="asic",
             shorthelp="PDK process node",
             switch="-pdk_wafersize <float>",
             example=["cli: -pdk_wafersize 300",
                     "api:  chip.set('pdk', 'wafersize', 300)"],
             schelp="""
-            Wafer diameter used in manufacturing process specified in mm. The
-            standard diameter for leading edge manufacturing is 300mm. For older
-            process technologies and specialty fabs, smaller diameters such as
-            200, 100, 125, 100 are common. The value is used to calculate dies per
-            wafer and full factory chip costs.""")
+            Wafer diameter used in manufacturing process. The standard diameter
+            for leading edge manufacturing is 300mm. For older process technologies
+            and specialty fabs, smaller diameters such as 200, 100, 125, 100 are common.
+            The value is used to calculate dies per wafer and full factory chip costs.""")
 
     scparam(cfg, ['pdk', 'wafercost'],
             sctype='float',
+            unit='USD',
             shorthelp="PDK wafer cost",
             switch="-pdk_wafercost <float>",
             example=["cli: -pdk_wafercost 10000",
                      "api:  chip.set('pdk', 'wafercost', 10000)"],
             schelp="""
-            Raw cost per wafer purchased specified in USD, not accounting for
-            yield loss. The values is used to calculate chip full factory costs.""")
+            Raw cost per wafer, not accounting for yield loss. The values is
+            used to calculate chip full factory costs.""")
 
     scparam(cfg, ['pdk', 'd0'],
             sctype='float',
@@ -385,12 +392,13 @@ def schema_pdk(cfg, stackup='default'):
 
     scparam(cfg, ['pdk', 'hscribe'],
             sctype='float',
+            unit='mm',
             shorthelp="PDK horizontal scribe line width",
             switch="-pdk_hscribe <float>",
             example=["cli: -pdk_hscribe 0.1",
                      "api:  chip.set('pdk', 'hscribe', 0.1)"],
             schelp="""
-             Width of the horizontal scribe line (in mm) used during die separation.
+            Width of the horizontal scribe line used during die separation.
             The process is generally completed using a mechanical saw, but can be
             done through combinations of mechanical saws, lasers, wafer thinning,
             and chemical etching in more advanced technologies. The value is used
@@ -398,12 +406,13 @@ def schema_pdk(cfg, stackup='default'):
 
     scparam(cfg, ['pdk', 'vscribe'],
             sctype='float',
+            unit='mm',
             shorthelp="PDK vertical scribe line width",
             switch="-pdk_vscribe <float>",
             example=["cli: -pdk_vscribe 0.1",
                      "api:  chip.set('pdk', 'vscribe', 0.1)"],
             schelp="""
-             Width of the vertical scribe line (in mm) used during die separation.
+             Width of the vertical scribe line used during die separation.
             The process is generally completed using a mechanical saw, but can be
             done through combinations of mechanical saws, lasers, wafer thinning,
             and chemical etching in more advanced technologies. The value is used
@@ -411,14 +420,15 @@ def schema_pdk(cfg, stackup='default'):
 
     scparam(cfg, ['pdk', 'edgemargin'],
             sctype='float',
+            unit='mm',
             shorthelp="PDK wafer edge keep-out margin",
             switch="-pdk_edgemargin <float>",
             example=["cli: -pdk_edgemargin 1",
                      "api:  chip.set('pdk', 'edgemargin', 1)"],
             schelp="""
-            Keep-out distance/margin from the wafer edge inwards specified in mm.
-            The wafer edge is prone to chipping and need special treatment that
-            preclude placement of designs in this area. The edge value is used to
+            Keep-out distance/margin from the wafer edge inwards. The wafer edge
+            is prone to chipping and need special treatment that preclude
+            placement of designs in this area. The edge value is used to
             calculate effective dies per wafer and full factory cost.""")
 
     scparam(cfg, ['pdk', 'density'],
@@ -441,6 +451,7 @@ def schema_pdk(cfg, stackup='default'):
 
     scparam(cfg, ['pdk', 'sramsize'],
             sctype='float',
+            unit='um^2',
             shorthelp="PDK SRAM bitcell size",
             switch="-pdk_sramsize <float>",
             example=["cli: -pdk_sramsize 0.032",
@@ -596,6 +607,7 @@ def schema_pdk(cfg, stackup='default'):
 
     scparam(cfg, ['pdk', 'grid', stackup, layer, 'xpitch'],
             sctype='float',
+            unit='um',
             shorthelp="PDK routing grid vertical wire pitch",
             switch="-pdk_grid_xpitch 'stackup layer <float>'",
             example= [
@@ -603,10 +615,11 @@ def schema_pdk(cfg, stackup='default'):
                 "api: chip.set('pdk','grid','M10','m1','xpitch','0.5')"],
             schelp="""
             Defines the routing pitch for vertical wires on a per stackup and
-            per metal basis, specified in um.""")
+            per metal basis.""")
 
     scparam(cfg, ['pdk', 'grid', stackup, layer, 'ypitch'],
             sctype='float',
+            unit='um',
             shorthelp="PDK routing grid horizontal wire pitch",
             switch="-pdk_grid_ypitch 'stackup layer <float>'",
             example= [
@@ -614,10 +627,11 @@ def schema_pdk(cfg, stackup='default'):
                 "api: chip.set('pdk','grid','M10','m1','ypitch','0.5')"],
             schelp="""
             Defines the routing pitch for horizontal wires on a per stackup and
-            per metal basis, specified in um.""")
+            per metal basis.""")
 
     scparam(cfg, ['pdk', 'grid', stackup, layer, 'xoffset'],
             sctype='float',
+            unit='um',
             shorthelp="PDK routing grid vertical wire offset",
             switch="-pdk_grid_xoffset 'stackup layer <float>'",
             example= [
@@ -625,10 +639,11 @@ def schema_pdk(cfg, stackup='default'):
                 "api: chip.set('pdk','grid','M10','m2','xoffset','0.5')"],
             schelp="""
             Defines the grid offset of a vertical metal layer specified on a per
-            stackup and per metal basis, specified in um.""")
+            stackup and per metal basis.""")
 
     scparam(cfg, ['pdk', 'grid', stackup, layer, 'yoffset'],
             sctype='float',
+            unit='um',
             shorthelp="PDK routing grid horizontal wire offset",
             switch="-pdk_grid_yoffset 'stackup layer <float>'",
             example= [
@@ -636,20 +651,7 @@ def schema_pdk(cfg, stackup='default'):
                 "api: chip.set('pdk','grid','M10','m2','yoffset','0.5')"],
             schelp="""
             Defines the grid offset of a horizontal metal layer specified on a per
-            stackup and per metal basis, specified in um.""")
-
-    scparam(cfg, ['pdk', 'grid', stackup, layer, 'adj'],
-            sctype='float',
-            shorthelp="PDK routing grid resource adjustment",
-            switch="-pdk_grid_adj 'stackup layer <float>'",
-            example= [
-                "cli: -pdk_grid_adj 'M10 m2 0.5'",
-                "api: chip.set('pdk','grid','M10','m2','adj','0.5')"],
-            schelp="""
-            Defines the routing resources adjustments for the design on a per layer
-            basis. The value is expressed as a fraction from 0 to 1. A value of
-            0.5 reduces the routing resources by 50%. If not defined, 100%
-            routing resource utilization is permitted.""")
+            stackup and per metal basis.""")
 
     scparam(cfg, ['pdk', 'grid', stackup, layer, 'adj'],
             sctype='float',
@@ -667,6 +669,7 @@ def schema_pdk(cfg, stackup='default'):
     corner='default'
     scparam(cfg, ['pdk', 'grid', stackup, layer, 'cap', corner],
             sctype='float',
+            unit='ff/um',
             shorthelp="PDK routing grid unit capacitance",
             switch="-pdk_grid_cap 'stackup layer corner <float>''",
             example= [
@@ -674,13 +677,14 @@ def schema_pdk(cfg, stackup='default'):
                 "api: chip.set('pdk','grid','M10','m2','cap','fast','0.2')"],
             schelp="""
             Unit capacitance of a wire defined by the grid width and spacing values
-            in the 'grid' structure. The value is specified as ff/um on a per
+            in the 'grid' structure specified on a per
             stackup, metal, and corner basis. As a rough rule of thumb, this value
             tends to stay around 0.2ff/um. This number should only be used for
             reality confirmation. Accurate analysis should use the PEX models.""")
 
     scparam(cfg, ['pdk', 'grid', stackup, layer, 'res', corner],
             sctype='float',
+            unit='ohm/um',
             shorthelp="PDK routing grid unit resistance",
             switch="-pdk_grid_res 'stackup layer corner <float>''",
             example= [
@@ -688,13 +692,14 @@ def schema_pdk(cfg, stackup='default'):
                 "api: chip.set('pdk','grid','M10','m2','res','fast','0.2')"],
             schelp="""
             Resistance of a wire defined by the grid width and spacing values
-            in the 'grid' structure.  The value is specified as ohms/um on a per
+            in the 'grid' structure specified as ohms/um on a per
             stackup, metal, and corner basis. The parameter is only meant to be
             used as a sanity check and for coarse design planning. Accurate
             analysis should use the TCAD PEX models.""")
 
     scparam(cfg, ['pdk', 'grid', stackup, layer, 'tcr', corner],
             sctype='float',
+            unit='%/degree(T)',
             shorthelp="PDK routing grid temperature coefficient",
             switch="-pdk_grid_tcr 'stackup layer corner <float>'",
             example= [
@@ -702,10 +707,10 @@ def schema_pdk(cfg, stackup='default'):
                 "api: chip.set('pdk','grid','M10','m2','tcr','fast','0.2')"],
             schelp="""
             Temperature coefficient of resistance of the wire defined by the grid
-            width and spacing values in the 'grid' structure. The value is specified
-            in %/ deg C on a per stackup, layer, and corner basis. The number is
-            only meant to be used as a sanity check and for coarse design
-            planning. Accurate analysis should use the PEX models.""")
+            width and spacing values in the 'grid' structure on a per stackup,
+            layer, and corner basis. The number is only meant to be used as a
+            sanity check and for coarse design planning. Accurate analysis
+            should use the PEX models.""")
 
     ###############
     # EDA vars
@@ -723,7 +728,6 @@ def schema_pdk(cfg, stackup='default'):
             List of named files specified on a per tool and per stackup basis.
             The parameter should only be used for specifying files that are
             not directly  supported by the SiliconCompiler PDK schema.""")
-
 
     scparam(cfg, ['pdk', 'directory', tool, key, stackup],
             sctype='[dir]',
@@ -1178,6 +1182,7 @@ def schema_flowgraph(cfg, flow='default', step='default', index='default'):
     #flowgraph timeout value
     scparam(cfg,['flowgraph', flow, step, index, 'timeout'],
             sctype='float',
+            unit='s',
             scope='job',
             shorthelp="Flowgraph task timeout value",
             switch="-flowgraph_timeout 'flow step 0 <float>'",
@@ -1623,6 +1628,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
 
     scparam(cfg, ['metric', step, index, 'coverage', group],
             sctype='float',
+            unit='%',
             scope='job',
             require='all',
             shorthelp=f"Metric: coverage",
@@ -1638,6 +1644,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
 
     scparam(cfg, ['metric', step, index, 'security', group],
             sctype='float',
+            unit='%',
             scope='job',
             require='all',
             shorthelp="Metric: security",
@@ -1678,6 +1685,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
     for item, val in metrics.items():
         scparam(cfg, ['metric', step, index, item, group],
                 sctype='float',
+                unit='um^2',
                 scope='job',
                 require='asic',
                 shorthelp=f"Metric: {item}",
@@ -1686,11 +1694,11 @@ def schema_metric(cfg, step='default', index='default',group='default'):
                     f"cli: -metric_{item} 'place 0 goal 100.00'",
                     f"api: chip.set('metric','place','0','{item}','real',100.00)"],
                 schelp=f"""
-                Metric tracking the total {val} occupied by the design. The
-                metric is specified in um^2.""")
+                Metric tracking the total {val} occupied by the design.""")
 
     scparam(cfg, ['metric', step, index, 'utilization', group],
             sctype='float',
+            unit='%',
             scope='job',
             require='asic',
             shorthelp=f"Metric: area utilization",
@@ -1712,6 +1720,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
     for item, val in metrics.items():
         scparam(cfg, ['metric', step, index, item, group],
                 sctype='float',
+                unit='mw',
                 scope='job',
                 require='all',
                 shorthelp=f"Metric: {item}",
@@ -1730,6 +1739,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
 
     scparam(cfg, ['metric', step, index, 'irdrop', group],
             sctype='float',
+            unit='mv',
             scope='job',
             require='asic',
             shorthelp=f"Metric: peak IR drop",
@@ -1771,6 +1781,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
     for item, val in metrics.items():
         scparam(cfg, ['metric', step, index, item, group],
                 sctype='float',
+                unit='ns',
                 scope='job',
                 require='all',
                 shorthelp=f"Metric: {item}",
@@ -1808,6 +1819,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
     item = 'wirelength'
     scparam(cfg, ['metric', step, index, item, group],
             sctype='float',
+            unit='um',
             scope='job',
             require='asic',
             shorthelp=f"Metric: {item}",
@@ -1839,6 +1851,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
     item = 'memory'
     scparam(cfg, ['metric', step, index, item, group],
             sctype='float',
+            unit='B',
             scope='job',
             require='asic',
             shorthelp=f"Metric: {item}",
@@ -1853,6 +1866,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
     item = 'exetime'
     scparam(cfg, ['metric', step, index, item, group],
             sctype='float',
+            unit='s',
             scope='job',
             require='asic',
             shorthelp=f"Metric: {item}",
@@ -1870,6 +1884,7 @@ def schema_metric(cfg, step='default', index='default',group='default'):
     item = 'tasktime'
     scparam(cfg, ['metric', step, index, item, group],
             sctype='float',
+            unit='s',
             scope='job',
             require='asic',
             shorthelp=f"Metric: {item}",
@@ -3024,21 +3039,23 @@ def schema_design(cfg):
     #TODO: use ns, seconds, or specify in units?
     scparam(cfg,['clock', name, 'period'],
             sctype='float',
+            unit='ns',
             shorthelp="Clock period",
             switch="-clock_period 'clkname <float>",
             example=["cli: -clock_period 'clk 10'",
                     "api: chip.set('clock','clk','period','10')"],
             schelp="""
-            Specifies the period for a clock source in nanoseconds.""")
+            Specifies the period for a clock source.""")
 
     scparam(cfg,['clock', name, 'jitter'],
             sctype='float',
+            unit='ns',
             shorthelp="Clock jitter",
             switch="-clock_jitter 'clkname <float>",
             example=["cli: -clock_jitter 'clk 0.01'",
                     "api: chip.set('clock','clk','jitter','0.01')"],
             schelp="""
-            Specifies the jitter for a clock source in nanoseconds.""")
+            Specifies the jitter for a clock source.""")
 
     scparam(cfg,['supply', name, 'pin'],
             sctype='str',
@@ -3054,22 +3071,24 @@ def schema_design(cfg):
     # move to datasheet
     scparam(cfg,['supply', name, 'level'],
             sctype='float',
+            unit='V',
             shorthelp="Supply level",
             switch="-supply_level 'supplyname <float>'",
             example=["cli: -supply_level 'vdd 1.0'",
                     "api: chip.set('supply','vdd','level','1.0')"],
             schelp="""
-            Voltage level for the name supply, specified in Volts.
+            Voltage level for the name supply.
             """)
 
     scparam(cfg,['supply', name, 'noise'],
             sctype='float',
+            unit='V',
             shorthelp="Supply noise",
             switch="-supply_noise 'supplyname <float>'",
-            example=["cli: -supply_noise 'vdd 1.0'",
-                    "api: chip.set('supply','vdd','noise','1.0')"],
+            example=["cli: -supply_noise 'vdd 0.005",
+                    "api: chip.set('supply','vdd','noise','0.005')"],
             schelp="""
-            Voltage noise for the name supply, specified in Volts.
+            Voltage noise for the name supply.
             """)
 
     return cfg
@@ -3230,6 +3249,7 @@ def schema_asic(cfg):
 
     scparam(cfg, ['asic', 'maxlength'],
             sctype='float',
+            unit='um',
             scope='job',
             shorthelp="ASIC maximum wire length",
             switch="-asic_maxlength <float>",
@@ -3242,23 +3262,23 @@ def schema_asic(cfg):
 
     scparam(cfg, ['asic', 'maxcap'],
             sctype='float',
+            unit='F',
             scope='job',
             shorthelp="ASIC maximum net capacitance",
             switch="-asic_maxcap <float>",
             example= ["cli: -asic_maxcap '0.25e-12'",
                       "api: chip.set('asic', 'maxcap', '0.25e-12')"],
-            schelp="""Maximum allowed capacitance per net. The number is
-            specified in Farads.""")
+            schelp="""Maximum allowed capacitance per net.""")
 
     scparam(cfg, ['asic', 'maxslew'],
             sctype='float',
+            unit='s',
             scope='job',
             shorthelp="ASIC maximum slew",
             switch="-asic_maxslew <float>",
             example= ["cli: -asic_maxslew '0.25e-9'",
                     "api: chip.set('asic', 'maxslew', '0.25e-9')"],
-            schelp="""Maximum allowed transition time per net. The number
-            is specified in seconds.""")
+            schelp="""Maximum allowed transition time per net.""")
 
     sigtype='default'
     scparam(cfg, ['asic', 'rclayer', sigtype],
@@ -3316,6 +3336,7 @@ def schema_asic(cfg):
 
     scparam(cfg, ['asic', 'coremargin'],
             sctype='float',
+            unit='um',
             scope='job',
             shorthelp="ASIC block core margin",
             switch="-asic_coremargin <float>",
@@ -3324,7 +3345,7 @@ def schema_asic(cfg):
             schelp="""
             Halo/margin between the die boundary and core placement for
             automated floorplanning when no diearea or floorplan is
-            supplied. The value is specified in microns.""")
+            supplied.""")
 
     scparam(cfg, ['asic', 'aspectratio'],
             sctype='float',
@@ -3342,6 +3363,7 @@ def schema_asic(cfg):
 
     scparam(cfg, ['asic', 'diearea'],
             sctype='[(float,float)]',
+            unit='um',
             scope='job',
             shorthelp="ASIC die area outline",
             switch="-asic_diearea <[(float,float)]>",
@@ -3355,6 +3377,7 @@ def schema_asic(cfg):
 
     scparam(cfg, ['asic', 'corearea'],
             sctype='[(float,float)]',
+            unit='um',
             scope='job',
             shorthelp="ASIC core area outline",
             switch="-asic_corearea <[(float,float)]>",
@@ -3390,13 +3413,13 @@ def schema_mcmm(cfg, scenario='default'):
 
     scparam(cfg,['mcmm', scenario, 'voltage'],
             sctype='float',
+            unit='V',
             scope='job',
             shorthelp="Scenario voltage level",
             switch="-mcmm_voltage 'scenario <float>'",
             example=["cli: -mcmm_voltage 'worst 0.9'",
                      "api: chip.set('mcmm', 'worst','voltage', '0.9')"],
-            schelp="""Operating voltage applied to the scenario,
-            specified in Volts.""")
+            schelp="""Operating voltage applied to the scenario.""")
 
     scparam(cfg,['mcmm', scenario, 'temperature'],
             sctype='float',
@@ -3405,8 +3428,7 @@ def schema_mcmm(cfg, scenario='default'):
             switch="-mcmm_temperature 'scenario <float>'",
             example=["cli: -mcmm_temperature 'worst 125'",
                      "api: chip.set('mcmm', 'worst', 'temperature','125')"],
-            schelp="""Chip temperature applied to the scenario specified in
-            degrees Celsius.""")
+            schelp="""Chip temperature applied to the scenario specified in degrees C.""")
 
     scparam(cfg,['mcmm', scenario, 'libcorner'],
             sctype='str',

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -64,6 +64,7 @@
             "signature": [],
             "switch": "-asic_corearea <[(float,float)]>",
             "type": "[(float,float)]",
+            "unit": "um",
             "value": []
         },
         "coremargin": {
@@ -72,7 +73,7 @@
                 "cli: -asic_coremargin 1",
                 "api: chip.set('asic', 'coremargin', '1')"
             ],
-            "help": "Halo/margin between the die boundary and core placement for\nautomated floorplanning when no diearea or floorplan is\nsupplied. The value is specified in microns.",
+            "help": "Halo/margin between the die boundary and core placement for\nautomated floorplanning when no diearea or floorplan is\nsupplied.",
             "lock": "false",
             "require": null,
             "scope": "job",
@@ -80,6 +81,7 @@
             "signature": null,
             "switch": "-asic_coremargin <float>",
             "type": "float",
+            "unit": "um",
             "value": null
         },
         "delaymodel": {
@@ -128,6 +130,7 @@
             "signature": [],
             "switch": "-asic_diearea <[(float,float)]>",
             "type": "[(float,float)]",
+            "unit": "um",
             "value": []
         },
         "exclude": {
@@ -204,7 +207,7 @@
                 "cli: -asic_maxcap '0.25e-12'",
                 "api: chip.set('asic', 'maxcap', '0.25e-12')"
             ],
-            "help": "Maximum allowed capacitance per net. The number is\nspecified in Farads.",
+            "help": "Maximum allowed capacitance per net.",
             "lock": "false",
             "require": null,
             "scope": "job",
@@ -212,6 +215,7 @@
             "signature": null,
             "switch": "-asic_maxcap <float>",
             "type": "float",
+            "unit": "F",
             "value": null
         },
         "maxfanout": {
@@ -260,6 +264,7 @@
             "signature": null,
             "switch": "-asic_maxlength <float>",
             "type": "float",
+            "unit": "um",
             "value": null
         },
         "maxslew": {
@@ -268,7 +273,7 @@
                 "cli: -asic_maxslew '0.25e-9'",
                 "api: chip.set('asic', 'maxslew', '0.25e-9')"
             ],
-            "help": "Maximum allowed transition time per net. The number\nis specified in seconds.",
+            "help": "Maximum allowed transition time per net.",
             "lock": "false",
             "require": null,
             "scope": "job",
@@ -276,6 +281,7 @@
             "signature": null,
             "switch": "-asic_maxslew <float>",
             "type": "float",
+            "unit": "s",
             "value": null
         },
         "minlayer": {
@@ -624,7 +630,7 @@
                     "cli: -clock_jitter 'clk 0.01'",
                     "api: chip.set('clock','clk','jitter','0.01')"
                 ],
-                "help": "Specifies the jitter for a clock source in nanoseconds.",
+                "help": "Specifies the jitter for a clock source.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -632,6 +638,7 @@
                 "signature": null,
                 "switch": "-clock_jitter 'clkname <float>",
                 "type": "float",
+                "unit": "ns",
                 "value": null
             },
             "period": {
@@ -640,7 +647,7 @@
                     "cli: -clock_period 'clk 10'",
                     "api: chip.set('clock','clk','period','10')"
                 ],
-                "help": "Specifies the period for a clock source in nanoseconds.",
+                "help": "Specifies the period for a clock source.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -648,6 +655,7 @@
                 "signature": null,
                 "switch": "-clock_period 'clkname <float>",
                 "type": "float",
+                "unit": "ns",
                 "value": null
             },
             "pin": {
@@ -1361,6 +1369,7 @@
                         "signature": null,
                         "switch": "-flowgraph_timeout 'flow step 0 <float>'",
                         "type": "float",
+                        "unit": "s",
                         "value": null
                     },
                     "tool": {
@@ -3415,7 +3424,7 @@
                     "cli: -mcmm_temperature 'worst 125'",
                     "api: chip.set('mcmm', 'worst', 'temperature','125')"
                 ],
-                "help": "Chip temperature applied to the scenario specified in\ndegrees Celsius.",
+                "help": "Chip temperature applied to the scenario specified in degrees C.",
                 "lock": "false",
                 "require": null,
                 "scope": "job",
@@ -3431,7 +3440,7 @@
                     "cli: -mcmm_voltage 'worst 0.9'",
                     "api: chip.set('mcmm', 'worst','voltage', '0.9')"
                 ],
-                "help": "Operating voltage applied to the scenario,\nspecified in Volts.",
+                "help": "Operating voltage applied to the scenario.",
                 "lock": "false",
                 "require": null,
                 "scope": "job",
@@ -3439,6 +3448,7 @@
                 "signature": null,
                 "switch": "-mcmm_voltage 'scenario <float>'",
                 "type": "float",
+                "unit": "V",
                 "value": null
             }
         }
@@ -3461,6 +3471,7 @@
                         "signature": null,
                         "switch": "-metric_averagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": null
                     }
                 },
@@ -3507,7 +3518,7 @@
                             "cli: -metric_cellarea 'place 0 goal 100.00'",
                             "api: chip.set('metric','place','0','cellarea','real',100.00)"
                         ],
-                        "help": "Metric tracking the total cell area (ignoring fillers) occupied by the design. The\nmetric is specified in um^2.",
+                        "help": "Metric tracking the total cell area (ignoring fillers) occupied by the design.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3515,6 +3526,7 @@
                         "signature": null,
                         "switch": "-metric_cellarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": null
                     }
                 },
@@ -3551,6 +3563,7 @@
                         "signature": null,
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": null
                     }
                 },
@@ -3569,6 +3582,7 @@
                         "signature": null,
                         "switch": "-metric_dozepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": null
                     }
                 },
@@ -3641,6 +3655,7 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
+                        "unit": "s",
                         "value": null
                     }
                 },
@@ -3677,6 +3692,7 @@
                         "signature": null,
                         "switch": "-metric_holdslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": null
                     }
                 },
@@ -3695,6 +3711,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": null
                     }
                 },
@@ -3713,6 +3730,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": null
                     }
                 },
@@ -3731,6 +3749,7 @@
                         "signature": null,
                         "switch": "-metric_idlepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": null
                     }
                 },
@@ -3749,6 +3768,7 @@
                         "signature": null,
                         "switch": "-metric_irdrop 'step index group <float>'",
                         "type": "float",
+                        "unit": "mv",
                         "value": null
                     }
                 },
@@ -3767,6 +3787,7 @@
                         "signature": null,
                         "switch": "-metric_leakagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": null
                     }
                 },
@@ -3821,6 +3842,7 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
+                        "unit": "B",
                         "value": null
                     }
                 },
@@ -3875,6 +3897,7 @@
                         "signature": null,
                         "switch": "-metric_peakpower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": null
                     }
                 },
@@ -3929,6 +3952,7 @@
                         "signature": null,
                         "switch": "-metric_security 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": null
                     }
                 },
@@ -3965,6 +3989,7 @@
                         "signature": null,
                         "switch": "-metric_setupslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": null
                     }
                 },
@@ -3983,6 +4008,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": null
                     }
                 },
@@ -4001,6 +4027,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": null
                     }
                 },
@@ -4019,6 +4046,7 @@
                         "signature": null,
                         "switch": "-metric_sleeppower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": null
                     }
                 },
@@ -4037,6 +4065,7 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
+                        "unit": "s",
                         "value": null
                     }
                 },
@@ -4047,7 +4076,7 @@
                             "cli: -metric_totalarea 'place 0 goal 100.00'",
                             "api: chip.set('metric','place','0','totalarea','real',100.00)"
                         ],
-                        "help": "Metric tracking the total physical die area occupied by the design. The\nmetric is specified in um^2.",
+                        "help": "Metric tracking the total physical die area occupied by the design.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -4055,6 +4084,7 @@
                         "signature": null,
                         "switch": "-metric_totalarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": null
                     }
                 },
@@ -4109,6 +4139,7 @@
                         "signature": null,
                         "switch": "-metric_utilization step index group <float>",
                         "type": "float",
+                        "unit": "%",
                         "value": null
                     }
                 },
@@ -4163,6 +4194,7 @@
                         "signature": null,
                         "switch": "-metric_wirelength 'step index group <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": null
                     }
                 }
@@ -5186,7 +5218,7 @@
                 "cli: -pdk_edgemargin 1",
                 "api:  chip.set('pdk', 'edgemargin', 1)"
             ],
-            "help": "Keep-out distance/margin from the wafer edge inwards specified in mm.\nThe wafer edge is prone to chipping and need special treatment that\npreclude placement of designs in this area. The edge value is used to\ncalculate effective dies per wafer and full factory cost.",
+            "help": "Keep-out distance/margin from the wafer edge inwards. The wafer edge\nis prone to chipping and need special treatment that preclude\nplacement of designs in this area. The edge value is used to\ncalculate effective dies per wafer and full factory cost.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -5194,6 +5226,7 @@
             "signature": null,
             "switch": "-pdk_edgemargin <float>",
             "type": "float",
+            "unit": "mm",
             "value": null
         },
         "erc": {
@@ -5321,7 +5354,7 @@
                                 "cli: -pdk_grid_cap 'M10 m2 fast 0.2'",
                                 "api: chip.set('pdk','grid','M10','m2','cap','fast','0.2')"
                             ],
-                            "help": "Unit capacitance of a wire defined by the grid width and spacing values\nin the 'grid' structure. The value is specified as ff/um on a per\nstackup, metal, and corner basis. As a rough rule of thumb, this value\ntends to stay around 0.2ff/um. This number should only be used for\nreality confirmation. Accurate analysis should use the PEX models.",
+                            "help": "Unit capacitance of a wire defined by the grid width and spacing values\nin the 'grid' structure specified on a per\nstackup, metal, and corner basis. As a rough rule of thumb, this value\ntends to stay around 0.2ff/um. This number should only be used for\nreality confirmation. Accurate analysis should use the PEX models.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -5329,6 +5362,7 @@
                             "signature": null,
                             "switch": "-pdk_grid_cap 'stackup layer corner <float>''",
                             "type": "float",
+                            "unit": "ff/um",
                             "value": null
                         }
                     },
@@ -5371,7 +5405,7 @@
                                 "cli: -pdk_grid_res 'M10 m2 fast 0.2'",
                                 "api: chip.set('pdk','grid','M10','m2','res','fast','0.2')"
                             ],
-                            "help": "Resistance of a wire defined by the grid width and spacing values\nin the 'grid' structure.  The value is specified as ohms/um on a per\nstackup, metal, and corner basis. The parameter is only meant to be\nused as a sanity check and for coarse design planning. Accurate\nanalysis should use the TCAD PEX models.",
+                            "help": "Resistance of a wire defined by the grid width and spacing values\nin the 'grid' structure specified as ohms/um on a per\nstackup, metal, and corner basis. The parameter is only meant to be\nused as a sanity check and for coarse design planning. Accurate\nanalysis should use the TCAD PEX models.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -5379,6 +5413,7 @@
                             "signature": null,
                             "switch": "-pdk_grid_res 'stackup layer corner <float>''",
                             "type": "float",
+                            "unit": "ohm/um",
                             "value": null
                         }
                     },
@@ -5389,7 +5424,7 @@
                                 "cli: -pdk_grid_tcr 'M10 m2 fast 0.2'",
                                 "api: chip.set('pdk','grid','M10','m2','tcr','fast','0.2')"
                             ],
-                            "help": "Temperature coefficient of resistance of the wire defined by the grid\nwidth and spacing values in the 'grid' structure. The value is specified\nin %/ deg C on a per stackup, layer, and corner basis. The number is\nonly meant to be used as a sanity check and for coarse design\nplanning. Accurate analysis should use the PEX models.",
+                            "help": "Temperature coefficient of resistance of the wire defined by the grid\nwidth and spacing values in the 'grid' structure on a per stackup,\nlayer, and corner basis. The number is only meant to be used as a\nsanity check and for coarse design planning. Accurate analysis\nshould use the PEX models.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
@@ -5397,6 +5432,7 @@
                             "signature": null,
                             "switch": "-pdk_grid_tcr 'stackup layer corner <float>'",
                             "type": "float",
+                            "unit": "%/degree(T)",
                             "value": null
                         }
                     },
@@ -5406,7 +5442,7 @@
                             "cli: -pdk_grid_xoffset 'M10 m2 0.5'",
                             "api: chip.set('pdk','grid','M10','m2','xoffset','0.5')"
                         ],
-                        "help": "Defines the grid offset of a vertical metal layer specified on a per\nstackup and per metal basis, specified in um.",
+                        "help": "Defines the grid offset of a vertical metal layer specified on a per\nstackup and per metal basis.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5414,6 +5450,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": null
                     },
                     "xpitch": {
@@ -5422,7 +5459,7 @@
                             "cli: -pdk_grid_xpitch 'M10 m1 0.5'",
                             "api: chip.set('pdk','grid','M10','m1','xpitch','0.5')"
                         ],
-                        "help": "Defines the routing pitch for vertical wires on a per stackup and\nper metal basis, specified in um.",
+                        "help": "Defines the routing pitch for vertical wires on a per stackup and\nper metal basis.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5430,6 +5467,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xpitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": null
                     },
                     "yoffset": {
@@ -5438,7 +5476,7 @@
                             "cli: -pdk_grid_yoffset 'M10 m2 0.5'",
                             "api: chip.set('pdk','grid','M10','m2','yoffset','0.5')"
                         ],
-                        "help": "Defines the grid offset of a horizontal metal layer specified on a per\nstackup and per metal basis, specified in um.",
+                        "help": "Defines the grid offset of a horizontal metal layer specified on a per\nstackup and per metal basis.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5446,6 +5484,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_yoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": null
                     },
                     "ypitch": {
@@ -5454,7 +5493,7 @@
                             "cli: -pdk_grid_ypitch 'M10 m1 0.5'",
                             "api: chip.set('pdk','grid','M10','m1','ypitch','0.5')"
                         ],
-                        "help": "Defines the routing pitch for horizontal wires on a per stackup and\nper metal basis, specified in um.",
+                        "help": "Defines the routing pitch for horizontal wires on a per stackup and\nper metal basis.",
                         "lock": "false",
                         "require": null,
                         "scope": "global",
@@ -5462,6 +5501,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_ypitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": null
                     }
                 }
@@ -5473,7 +5513,7 @@
                 "cli: -pdk_hscribe 0.1",
                 "api:  chip.set('pdk', 'hscribe', 0.1)"
             ],
-            "help": " Width of the horizontal scribe line (in mm) used during die separation.\nThe process is generally completed using a mechanical saw, but can be\ndone through combinations of mechanical saws, lasers, wafer thinning,\nand chemical etching in more advanced technologies. The value is used\nto calculate effective dies per wafer and full factory cost.",
+            "help": "Width of the horizontal scribe line used during die separation.\nThe process is generally completed using a mechanical saw, but can be\ndone through combinations of mechanical saws, lasers, wafer thinning,\nand chemical etching in more advanced technologies. The value is used\nto calculate effective dies per wafer and full factory cost.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -5481,6 +5521,7 @@
             "signature": null,
             "switch": "-pdk_hscribe <float>",
             "type": "float",
+            "unit": "mm",
             "value": null
         },
         "layermap": {
@@ -5641,6 +5682,7 @@
             "signature": null,
             "switch": "-pdk_sramsize <float>",
             "type": "float",
+            "unit": "um^2",
             "value": null
         },
         "stackup": {
@@ -5703,7 +5745,7 @@
                 "cli: -pdk_vscribe 0.1",
                 "api:  chip.set('pdk', 'vscribe', 0.1)"
             ],
-            "help": " Width of the vertical scribe line (in mm) used during die separation.\nThe process is generally completed using a mechanical saw, but can be\ndone through combinations of mechanical saws, lasers, wafer thinning,\nand chemical etching in more advanced technologies. The value is used\nto calculate effective dies per wafer and full factory cost.",
+            "help": " Width of the vertical scribe line used during die separation.\nThe process is generally completed using a mechanical saw, but can be\ndone through combinations of mechanical saws, lasers, wafer thinning,\nand chemical etching in more advanced technologies. The value is used\nto calculate effective dies per wafer and full factory cost.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -5711,6 +5753,7 @@
             "signature": null,
             "switch": "-pdk_vscribe <float>",
             "type": "float",
+            "unit": "mm",
             "value": null
         },
         "wafercost": {
@@ -5719,7 +5762,7 @@
                 "cli: -pdk_wafercost 10000",
                 "api:  chip.set('pdk', 'wafercost', 10000)"
             ],
-            "help": "Raw cost per wafer purchased specified in USD, not accounting for\nyield loss. The values is used to calculate chip full factory costs.",
+            "help": "Raw cost per wafer, not accounting for yield loss. The values is\nused to calculate chip full factory costs.",
             "lock": "false",
             "require": null,
             "scope": "global",
@@ -5727,6 +5770,7 @@
             "signature": null,
             "switch": "-pdk_wafercost <float>",
             "type": "float",
+            "unit": "USD",
             "value": null
         },
         "wafersize": {
@@ -5735,7 +5779,7 @@
                 "cli: -pdk_wafersize 300",
                 "api:  chip.set('pdk', 'wafersize', 300)"
             ],
-            "help": "Wafer diameter used in manufacturing process specified in mm. The\nstandard diameter for leading edge manufacturing is 300mm. For older\nprocess technologies and specialty fabs, smaller diameters such as\n200, 100, 125, 100 are common. The value is used to calculate dies per\nwafer and full factory chip costs.",
+            "help": "Wafer diameter used in manufacturing process. The standard diameter\nfor leading edge manufacturing is 300mm. For older process technologies\nand specialty fabs, smaller diameters such as 200, 100, 125, 100 are common.\nThe value is used to calculate dies per wafer and full factory chip costs.",
             "lock": "false",
             "require": "asic",
             "scope": "global",
@@ -5743,6 +5787,7 @@
             "signature": null,
             "switch": "-pdk_wafersize <float>",
             "type": "float",
+            "unit": "mm",
             "value": null
         }
     },
@@ -6419,7 +6464,7 @@
                     "cli: -supply_level 'vdd 1.0'",
                     "api: chip.set('supply','vdd','level','1.0')"
                 ],
-                "help": "Voltage level for the name supply, specified in Volts.",
+                "help": "Voltage level for the name supply.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -6427,15 +6472,16 @@
                 "signature": null,
                 "switch": "-supply_level 'supplyname <float>'",
                 "type": "float",
+                "unit": "V",
                 "value": null
             },
             "noise": {
                 "defvalue": null,
                 "example": [
-                    "cli: -supply_noise 'vdd 1.0'",
-                    "api: chip.set('supply','vdd','noise','1.0')"
+                    "cli: -supply_noise 'vdd 0.005",
+                    "api: chip.set('supply','vdd','noise','0.005')"
                 ],
-                "help": "Voltage noise for the name supply, specified in Volts.",
+                "help": "Voltage noise for the name supply.",
                 "lock": "false",
                 "require": null,
                 "scope": "global",
@@ -6443,6 +6489,7 @@
                 "signature": null,
                 "switch": "-supply_noise 'supplyname <float>'",
                 "type": "float",
+                "unit": "V",
                 "value": null
             },
             "pin": {

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -3647,7 +3647,7 @@
                             "cli: -metric_exetime 'dfm 0 goal 10.0'",
                             "api: chip.set('metric','dfm','0','exetime','real, 10.0)"
                         ],
-                        "help": "Metric tracking time spent by the eda executable 'exe' on a\nper step and index basis. It does not include the siliconcompiler\nruntime overhead or time waitig for I/O operations and\ninter-processor communication to complete. The metric unit\nis seconds.",
+                        "help": "Metric tracking time spent by the eda executable 'exe' on a\nper step and index basis. It does not include the siliconcompiler\nruntime overhead or time waitig for I/O operations and\ninter-processor communication to complete.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3684,7 +3684,7 @@
                             "cli: -metric_holdslack 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','holdslack','real', 0.01)"
                         ],
-                        "help": "Metric tracking the worst hold slack (positive or negative) on a per step and index basis.\nMetric unit is nanoseconds.",
+                        "help": "Metric tracking the worst hold slack (positive or negative) on a per step and index basis.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3703,7 +3703,7 @@
                             "cli: -metric_holdtns 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','holdtns','real', 0.01)"
                         ],
-                        "help": "Metric tracking the total negative hold slack (TNS) on a per step and index basis.\nMetric unit is nanoseconds.",
+                        "help": "Metric tracking the total negative hold slack (TNS) on a per step and index basis.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3722,7 +3722,7 @@
                             "cli: -metric_holdwns 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','holdwns','real', 0.01)"
                         ],
-                        "help": "Metric tracking the worst negative hold slack (positive values truncated to zero) on a per step and index basis.\nMetric unit is nanoseconds.",
+                        "help": "Metric tracking the worst negative hold slack (positive values truncated to zero) on a per step and index basis.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -3834,7 +3834,7 @@
                             "cli: -metric_memory 'dfm 0 goal 10e9'",
                             "api: chip.set('metric','dfm','0','memory','real', 10e9)"
                         ],
-                        "help": "Metric tracking total peak program memory footprint on a per\nstep and index basis, specified in bytes.",
+                        "help": "Metric tracking total peak program memory footprint on a per\nstep and index basis.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -3981,7 +3981,7 @@
                             "cli: -metric_setupslack 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','setupslack','real', 0.01)"
                         ],
-                        "help": "Metric tracking the worst setup slack (positive or negative) on a per step and index basis.\nMetric unit is nanoseconds.",
+                        "help": "Metric tracking the worst setup slack (positive or negative) on a per step and index basis.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -4000,7 +4000,7 @@
                             "cli: -metric_setuptns 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','setuptns','real', 0.01)"
                         ],
-                        "help": "Metric tracking the total negative setup slack (TNS) on a per step and index basis.\nMetric unit is nanoseconds.",
+                        "help": "Metric tracking the total negative setup slack (TNS) on a per step and index basis.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -4019,7 +4019,7 @@
                             "cli: -metric_setupwns 'place 0 goal 0.01'",
                             "api: chip.set('metric','place','0','setupwns','real', 0.01)"
                         ],
-                        "help": "Metric tracking the worst negative setup slack (positive values truncated to zero) on a per step and index basis.\nMetric unit is nanoseconds.",
+                        "help": "Metric tracking the worst negative setup slack (positive values truncated to zero) on a per step and index basis.",
                         "lock": "false",
                         "require": "all",
                         "scope": "job",
@@ -4057,7 +4057,7 @@
                             "cli: -metric_tasktime 'dfm 0 goal 10.0'",
                             "api: chip.set('metric','dfm','0','tasktime','real, 10.0)"
                         ],
-                        "help": "Metric trakcing the total amount of time spent on a task from\nbeginning to end, including data transfers and pre/post processing.\nThe metric unit is seconds.",
+                        "help": "Metric trakcing the total amount of time spent on a task from\nbeginning to end, including data transfers and pre/post\nprocessing.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",
@@ -4085,6 +4085,25 @@
                         "switch": "-metric_totalarea 'step index group <float>'",
                         "type": "float",
                         "unit": "um^2",
+                        "value": null
+                    }
+                },
+                "totaltime": {
+                    "default": {
+                        "defvalue": null,
+                        "example": [
+                            "cli: -metric_totaltime 'dfm 0 goal 10.0'",
+                            "api: chip.set('metric','dfm','0','totaltime','real, 10.0)"
+                        ],
+                        "help": "Metric tracking the total amount of time spent from the beginning\nof the run up to and including the current step and index.",
+                        "lock": "false",
+                        "require": "asic",
+                        "scope": "job",
+                        "shorthelp": "Metric: totaltime",
+                        "signature": null,
+                        "switch": "-metric_totaltime 'step index group <float>'",
+                        "type": "float",
+                        "unit": "s",
                         "value": null
                     }
                 },
@@ -4186,7 +4205,7 @@
                             "cli: -metric_wirelength 'place 0 goal 100.0'",
                             "api: chip.set('metric','place','0','wirelength','real', 50.0)"
                         ],
-                        "help": "Metric tracking the total wirelength of the design on a per step\nand index basis. The unit is meters.",
+                        "help": "Metric tracking the total wirelength of the design on a per step\nand index basis.",
                         "lock": "false",
                         "require": "asic",
                         "scope": "job",

--- a/tests/core/data/gcd.pkg.json
+++ b/tests/core/data/gcd.pkg.json
@@ -20,6 +20,7 @@
             "signature": [],
             "switch": "-asic_corearea <[(float,float)]>",
             "type": "[(float,float)]",
+            "unit": "um",
             "value": [
                 "(10.07,11.2)",
                 "(90.25,91)"
@@ -34,6 +35,7 @@
             "signature": null,
             "switch": "-asic_coremargin <float>",
             "type": "float",
+            "unit": "um",
             "value": "1.9"
         },
         "delaymodel": {
@@ -67,6 +69,7 @@
             "signature": [],
             "switch": "-asic_diearea <[(float,float)]>",
             "type": "[(float,float)]",
+            "unit": "um",
             "value": [
                 "(0,0)",
                 "(100.13,100.8)"
@@ -105,6 +108,7 @@
             "signature": null,
             "switch": "-asic_maxcap <float>",
             "type": "float",
+            "unit": "F",
             "value": "2e-13"
         },
         "maxfanout": {
@@ -138,6 +142,7 @@
             "signature": null,
             "switch": "-asic_maxlength <float>",
             "type": "float",
+            "unit": "um",
             "value": "1000"
         },
         "maxslew": {
@@ -149,6 +154,7 @@
             "signature": null,
             "switch": "-asic_maxslew <float>",
             "type": "float",
+            "unit": "s",
             "value": "2e-10"
         },
         "minlayer": {
@@ -1045,6 +1051,4210 @@
                     }
                 }
             },
+            "regex": {
+                "cts": {
+                    "0": {
+                        "errors": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "ERROR"
+                            ]
+                        },
+                        "warnings": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "WARNING"
+                            ]
+                        }
+                    }
+                },
+                "dfm": {
+                    "0": {
+                        "errors": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "ERROR"
+                            ]
+                        },
+                        "warnings": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "WARNING"
+                            ]
+                        }
+                    }
+                },
+                "floorplan": {
+                    "0": {
+                        "errors": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "ERROR"
+                            ]
+                        },
+                        "warnings": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "WARNING"
+                            ]
+                        }
+                    }
+                },
+                "physyn": {
+                    "0": {
+                        "errors": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "ERROR"
+                            ]
+                        },
+                        "warnings": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "WARNING"
+                            ]
+                        }
+                    }
+                },
+                "place": {
+                    "0": {
+                        "errors": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "ERROR"
+                            ]
+                        },
+                        "warnings": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "WARNING"
+                            ]
+                        }
+                    }
+                },
+                "route": {
+                    "0": {
+                        "errors": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "ERROR"
+                            ]
+                        },
+                        "warnings": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "WARNING"
+                            ]
+                        }
+                    }
+                }
+            },
+            "report": {
+                "cts": {
+                    "0": {
+                        "averagepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "buffers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "cellarea": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "cells": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "coverage": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "dozepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "drvs": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "exetime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "holdpaths": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "holdslack": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "holdtns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "holdwns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "idlepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "irdrop": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "leakagepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "macros": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "nets": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "overflow": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "peakpower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "pins": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "registers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "security": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "setuppaths": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "setupslack": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "setuptns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "setupwns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "sleeppower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "tasktime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "totalarea": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "totaltime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "transistors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "unconstrained": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "utilization": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "vias": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "warnings": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        },
+                        "wirelength": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "cts.log"
+                            ]
+                        }
+                    }
+                },
+                "dfm": {
+                    "0": {
+                        "averagepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "buffers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "cellarea": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "cells": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "coverage": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "dozepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "drvs": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "exetime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "holdpaths": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "holdslack": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "holdtns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "holdwns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "idlepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "irdrop": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "leakagepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "macros": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "nets": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "overflow": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "peakpower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "pins": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "registers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "security": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "setuppaths": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "setupslack": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "setuptns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "setupwns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "sleeppower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "tasktime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "totalarea": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "totaltime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "transistors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "unconstrained": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "utilization": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "vias": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "warnings": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        },
+                        "wirelength": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "dfm.log"
+                            ]
+                        }
+                    }
+                },
+                "floorplan": {
+                    "0": {
+                        "averagepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "buffers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "cellarea": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "cells": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "coverage": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "dozepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "drvs": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "exetime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "holdpaths": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "holdslack": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "holdtns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "holdwns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "idlepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "irdrop": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "leakagepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "macros": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "nets": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "overflow": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "peakpower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "pins": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "registers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "security": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "setuppaths": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "setupslack": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "setuptns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "setupwns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "sleeppower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "tasktime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "totalarea": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "totaltime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "transistors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "unconstrained": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "utilization": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "vias": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "warnings": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        },
+                        "wirelength": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "floorplan.log"
+                            ]
+                        }
+                    }
+                },
+                "physyn": {
+                    "0": {
+                        "averagepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "buffers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "cellarea": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "cells": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "coverage": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "dozepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "drvs": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "exetime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "holdpaths": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "holdslack": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "holdtns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "holdwns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "idlepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "irdrop": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "leakagepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "macros": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "nets": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "overflow": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "peakpower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "pins": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "registers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "security": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "setuppaths": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "setupslack": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "setuptns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "setupwns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "sleeppower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "tasktime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "totalarea": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "totaltime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "transistors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "unconstrained": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "utilization": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "vias": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "warnings": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        },
+                        "wirelength": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "physyn.log"
+                            ]
+                        }
+                    }
+                },
+                "place": {
+                    "0": {
+                        "averagepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "buffers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "cellarea": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "cells": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "coverage": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "dozepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "drvs": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "exetime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "holdpaths": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "holdslack": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "holdtns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "holdwns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "idlepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "irdrop": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "leakagepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "macros": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "nets": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "overflow": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "peakpower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "pins": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "registers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "security": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "setuppaths": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "setupslack": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "setuptns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "setupwns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "sleeppower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "tasktime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "totalarea": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "totaltime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "transistors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "unconstrained": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "utilization": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "vias": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "warnings": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        },
+                        "wirelength": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "place.log"
+                            ]
+                        }
+                    }
+                },
+                "route": {
+                    "0": {
+                        "averagepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "buffers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "cellarea": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "cells": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "coverage": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "dozepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "drvs": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "exetime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "holdpaths": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "holdslack": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "holdtns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "holdwns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "idlepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "irdrop": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "leakagepower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "macros": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "nets": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "overflow": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "peakpower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "pins": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "registers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "security": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "setuppaths": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "setupslack": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "setuptns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "setupwns": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "sleeppower": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "tasktime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "totalarea": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "totaltime": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "transistors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "unconstrained": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "utilization": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "vias": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "warnings": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        },
+                        "wirelength": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "route.log"
+                            ]
+                        }
+                    }
+                }
+            },
             "require": {
                 "cts": {
                     "0": {
@@ -1330,7 +5540,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "8"
+                        "value": "20"
                     }
                 },
                 "dfm": {
@@ -1343,7 +5553,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "8"
+                        "value": "20"
                     }
                 },
                 "floorplan": {
@@ -1356,7 +5566,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "8"
+                        "value": "20"
                     }
                 },
                 "physyn": {
@@ -1369,7 +5579,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "8"
+                        "value": "20"
                     }
                 },
                 "place": {
@@ -1382,7 +5592,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "8"
+                        "value": "20"
                     }
                 },
                 "route": {
@@ -1395,7 +5605,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "8"
+                        "value": "20"
                     }
                 }
             },
@@ -1927,6 +6137,80 @@
                     }
                 }
             },
+            "regex": {
+                "import": {
+                    "0": {
+                        "errors": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "ERROR"
+                            ]
+                        },
+                        "warnings": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "WARNING"
+                            ]
+                        }
+                    }
+                }
+            },
+            "report": {
+                "import": {
+                    "0": {
+                        "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "import.log"
+                            ]
+                        },
+                        "warnings": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "import.log"
+                            ]
+                        }
+                    }
+                }
+            },
             "require": {
                 "import": {
                     "0": {
@@ -1955,7 +6239,7 @@
                         "signature": null,
                         "switch": "-eda_threads 'tool step index <int>'",
                         "type": "int",
-                        "value": "8"
+                        "value": "20"
                     }
                 }
             },
@@ -2108,6 +6392,296 @@
                         "value": [
                             "tools/yosys"
                         ]
+                    }
+                }
+            },
+            "regex": {
+                "syn": {
+                    "0": {
+                        "errors": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "Error"
+                            ]
+                        },
+                        "warnings": {
+                            "defvalue": [],
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool regex filter",
+                            "signature": [],
+                            "switch": "-eda_regex 'tool step index suffix <str>'",
+                            "type": "[str]",
+                            "value": [
+                                "Warning"
+                            ]
+                        }
+                    }
+                }
+            },
+            "report": {
+                "syn": {
+                    "0": {
+                        "brams": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        },
+                        "buffers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        },
+                        "cellarea": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        },
+                        "cells": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        },
+                        "coverage": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        },
+                        "drvs": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        },
+                        "dsps": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        },
+                        "errors": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        },
+                        "luts": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        },
+                        "nets": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        },
+                        "pins": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        },
+                        "registers": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        },
+                        "security": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        },
+                        "warnings": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool report files",
+                            "signature": [],
+                            "switch": "-eda_report 'tool step index metric <str>'",
+                            "type": "[file]",
+                            "value": [
+                                "syn.log"
+                            ]
+                        }
                     }
                 }
             },
@@ -2606,6 +7180,17 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "totaltime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": null,
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "transistors": {
                             "defvalue": null,
                             "lock": "false",
@@ -3077,6 +7662,17 @@
                             "value": "0"
                         },
                         "totalarea": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": null,
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "totaltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -3568,6 +8164,17 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "totaltime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": null,
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "transistors": {
                             "defvalue": null,
                             "lock": "false",
@@ -4049,6 +8656,17 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "totaltime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": null,
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "transistors": {
                             "defvalue": null,
                             "lock": "false",
@@ -4507,6 +9125,17 @@
                             "value": "0"
                         },
                         "totalarea": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": null,
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "totaltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -4998,6 +9627,17 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "totaltime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": null,
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "transistors": {
                             "defvalue": null,
                             "lock": "false",
@@ -5469,6 +10109,17 @@
                             "value": "0"
                         },
                         "totalarea": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": null,
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "totaltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -5960,6 +10611,17 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "totaltime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": null,
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "transistors": {
                             "defvalue": null,
                             "lock": "false",
@@ -6431,6 +11093,17 @@
                             "value": "0"
                         },
                         "totalarea": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": null,
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "totaltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -6924,6 +11597,17 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "totaltime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": null,
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "transistors": {
                             "defvalue": null,
                             "lock": "false",
@@ -7382,6 +12066,17 @@
                             "value": "0"
                         },
                         "totalarea": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": null,
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "totaltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -7874,6 +12569,17 @@
                             "type": "float",
                             "value": "0"
                         },
+                        "totaltime": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": null,
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
                         "transistors": {
                             "defvalue": null,
                             "lock": "false",
@@ -8345,6 +13051,17 @@
                             "value": "0"
                         },
                         "totalarea": {
+                            "defvalue": null,
+                            "lock": "false",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Flowgraph metric weights",
+                            "signature": null,
+                            "switch": "-flowgraph_weight 'flow step metric <float>'",
+                            "type": "float",
+                            "value": "0"
+                        },
+                        "totaltime": {
                             "defvalue": null,
                             "lock": "false",
                             "require": null,
@@ -9107,6 +13824,7 @@
                         "signature": null,
                         "switch": "-metric_averagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -9146,6 +13864,7 @@
                         "signature": null,
                         "switch": "-metric_cellarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "494.0"
                     }
                 },
@@ -9172,6 +13891,7 @@
                         "signature": null,
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -9185,6 +13905,7 @@
                         "signature": null,
                         "switch": "-metric_dozepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -9259,7 +13980,8 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "2.06"
+                        "unit": "s",
+                        "value": "1.83"
                     }
                 },
                 "holdpaths": {
@@ -9285,6 +14007,7 @@
                         "signature": null,
                         "switch": "-metric_holdslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.11"
                     }
                 },
@@ -9298,6 +14021,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -9309,6 +14033,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -9322,6 +14047,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -9333,6 +14059,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -9346,6 +14073,7 @@
                         "signature": null,
                         "switch": "-metric_idlepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -9359,6 +14087,7 @@
                         "signature": null,
                         "switch": "-metric_irdrop 'step index group <float>'",
                         "type": "float",
+                        "unit": "mv",
                         "value": "0.0"
                     }
                 },
@@ -9372,6 +14101,7 @@
                         "signature": null,
                         "switch": "-metric_leakagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "1.17e-05"
                     }
                 },
@@ -9411,7 +14141,8 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "100618240.0"
+                        "unit": "B",
+                        "value": "100048896.0"
                     }
                 },
                 "nets": {
@@ -9450,6 +14181,7 @@
                         "signature": null,
                         "switch": "-metric_peakpower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.000277"
                     }
                 },
@@ -9489,6 +14221,7 @@
                         "signature": null,
                         "switch": "-metric_security 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -9515,6 +14248,7 @@
                         "signature": null,
                         "switch": "-metric_setupslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "1.0"
                     }
                 },
@@ -9528,6 +14262,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -9539,6 +14274,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -9552,6 +14288,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -9563,6 +14300,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -9576,6 +14314,7 @@
                         "signature": null,
                         "switch": "-metric_sleeppower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -9589,7 +14328,8 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "2.32"
+                        "unit": "s",
+                        "value": "2.12"
                     }
                 },
                 "totalarea": {
@@ -9602,7 +14342,22 @@
                         "signature": null,
                         "switch": "-metric_totalarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "6175.0"
+                    }
+                },
+                "totaltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "asic",
+                        "scope": "job",
+                        "shorthelp": "Metric: totaltime",
+                        "signature": null,
+                        "switch": "-metric_totaltime 'step index group <float>'",
+                        "type": "float",
+                        "unit": "s",
+                        "value": "0.0"
                     }
                 },
                 "transistors": {
@@ -9641,6 +14396,7 @@
                         "signature": null,
                         "switch": "-metric_utilization step index group <float>",
                         "type": "float",
+                        "unit": "%",
                         "value": "8.0"
                     }
                 },
@@ -9680,6 +14436,7 @@
                         "signature": null,
                         "switch": "-metric_wirelength 'step index group <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.0"
                     }
                 }
@@ -9697,6 +14454,7 @@
                         "signature": null,
                         "switch": "-metric_averagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -9736,6 +14494,7 @@
                         "signature": null,
                         "switch": "-metric_cellarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "494.0"
                     }
                 },
@@ -9762,6 +14521,7 @@
                         "signature": null,
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -9775,6 +14535,7 @@
                         "signature": null,
                         "switch": "-metric_dozepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -9849,7 +14610,8 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.41"
+                        "unit": "s",
+                        "value": "0.31"
                     }
                 },
                 "holdpaths": {
@@ -9875,6 +14637,7 @@
                         "signature": null,
                         "switch": "-metric_holdslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.11"
                     }
                 },
@@ -9888,6 +14651,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -9899,6 +14663,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -9912,6 +14677,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -9923,6 +14689,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -9936,6 +14703,7 @@
                         "signature": null,
                         "switch": "-metric_idlepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -9949,6 +14717,7 @@
                         "signature": null,
                         "switch": "-metric_irdrop 'step index group <float>'",
                         "type": "float",
+                        "unit": "mv",
                         "value": "0.0"
                     }
                 },
@@ -9962,6 +14731,7 @@
                         "signature": null,
                         "switch": "-metric_leakagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "1.17e-05"
                     }
                 },
@@ -10001,7 +14771,8 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "89817088.0"
+                        "unit": "B",
+                        "value": "79347712.0"
                     }
                 },
                 "nets": {
@@ -10040,6 +14811,7 @@
                         "signature": null,
                         "switch": "-metric_peakpower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.000289"
                     }
                 },
@@ -10079,6 +14851,7 @@
                         "signature": null,
                         "switch": "-metric_security 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -10105,6 +14878,7 @@
                         "signature": null,
                         "switch": "-metric_setupslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.98"
                     }
                 },
@@ -10118,6 +14892,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -10129,6 +14904,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -10142,6 +14918,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -10153,6 +14930,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -10166,6 +14944,7 @@
                         "signature": null,
                         "switch": "-metric_sleeppower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -10179,7 +14958,8 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.66"
+                        "unit": "s",
+                        "value": "0.57"
                     }
                 },
                 "totalarea": {
@@ -10192,7 +14972,22 @@
                         "signature": null,
                         "switch": "-metric_totalarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "6175.0"
+                    }
+                },
+                "totaltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "asic",
+                        "scope": "job",
+                        "shorthelp": "Metric: totaltime",
+                        "signature": null,
+                        "switch": "-metric_totaltime 'step index group <float>'",
+                        "type": "float",
+                        "unit": "s",
+                        "value": "0.0"
                     }
                 },
                 "transistors": {
@@ -10231,6 +15026,7 @@
                         "signature": null,
                         "switch": "-metric_utilization step index group <float>",
                         "type": "float",
+                        "unit": "%",
                         "value": "8.0"
                     }
                 },
@@ -10270,6 +15066,7 @@
                         "signature": null,
                         "switch": "-metric_wirelength 'step index group <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.0"
                     }
                 }
@@ -10287,6 +15084,7 @@
                         "signature": null,
                         "switch": "-metric_averagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0"
                     }
                 },
@@ -10326,6 +15124,7 @@
                         "signature": null,
                         "switch": "-metric_cellarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "0"
                     }
                 },
@@ -10352,6 +15151,7 @@
                         "signature": null,
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0"
                     }
                 },
@@ -10365,6 +15165,7 @@
                         "signature": null,
                         "switch": "-metric_dozepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0"
                     }
                 },
@@ -10439,7 +15240,8 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.97"
+                        "unit": "s",
+                        "value": "0.85"
                     }
                 },
                 "holdpaths": {
@@ -10465,6 +15267,7 @@
                         "signature": null,
                         "switch": "-metric_holdslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     }
                 },
@@ -10478,6 +15281,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -10489,6 +15293,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     }
                 },
@@ -10502,6 +15307,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -10513,6 +15319,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     }
                 },
@@ -10526,6 +15333,7 @@
                         "signature": null,
                         "switch": "-metric_idlepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0"
                     }
                 },
@@ -10539,6 +15347,7 @@
                         "signature": null,
                         "switch": "-metric_irdrop 'step index group <float>'",
                         "type": "float",
+                        "unit": "mv",
                         "value": "0"
                     }
                 },
@@ -10552,6 +15361,7 @@
                         "signature": null,
                         "switch": "-metric_leakagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0"
                     }
                 },
@@ -10591,7 +15401,8 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "365531136"
+                        "unit": "B",
+                        "value": "367104000"
                     }
                 },
                 "nets": {
@@ -10630,6 +15441,7 @@
                         "signature": null,
                         "switch": "-metric_peakpower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0"
                     }
                 },
@@ -10669,6 +15481,7 @@
                         "signature": null,
                         "switch": "-metric_security 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0"
                     }
                 },
@@ -10695,6 +15508,7 @@
                         "signature": null,
                         "switch": "-metric_setupslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     }
                 },
@@ -10708,6 +15522,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -10719,6 +15534,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     }
                 },
@@ -10732,6 +15548,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -10743,6 +15560,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     }
                 },
@@ -10756,6 +15574,7 @@
                         "signature": null,
                         "switch": "-metric_sleeppower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0"
                     }
                 },
@@ -10769,7 +15588,8 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "1.29"
+                        "unit": "s",
+                        "value": "1.15"
                     }
                 },
                 "totalarea": {
@@ -10782,6 +15602,21 @@
                         "signature": null,
                         "switch": "-metric_totalarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
+                        "value": "0"
+                    }
+                },
+                "totaltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "asic",
+                        "scope": "job",
+                        "shorthelp": "Metric: totaltime",
+                        "signature": null,
+                        "switch": "-metric_totaltime 'step index group <float>'",
+                        "type": "float",
+                        "unit": "s",
                         "value": "0"
                     }
                 },
@@ -10821,6 +15656,7 @@
                         "signature": null,
                         "switch": "-metric_utilization step index group <float>",
                         "type": "float",
+                        "unit": "%",
                         "value": "0"
                     }
                 },
@@ -10860,6 +15696,7 @@
                         "signature": null,
                         "switch": "-metric_wirelength 'step index group <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0"
                     }
                 }
@@ -10877,6 +15714,7 @@
                         "signature": null,
                         "switch": "-metric_averagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -10916,6 +15754,7 @@
                         "signature": null,
                         "switch": "-metric_cellarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "415.0"
                     }
                 },
@@ -10942,6 +15781,7 @@
                         "signature": null,
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -10955,6 +15795,7 @@
                         "signature": null,
                         "switch": "-metric_dozepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -11029,7 +15870,8 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.41"
+                        "unit": "s",
+                        "value": "0.31"
                     }
                 },
                 "holdpaths": {
@@ -11055,6 +15897,7 @@
                         "signature": null,
                         "switch": "-metric_holdslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.11"
                     }
                 },
@@ -11068,6 +15911,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -11079,6 +15923,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -11092,6 +15937,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -11103,6 +15949,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -11116,6 +15963,7 @@
                         "signature": null,
                         "switch": "-metric_idlepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -11129,6 +15977,7 @@
                         "signature": null,
                         "switch": "-metric_irdrop 'step index group <float>'",
                         "type": "float",
+                        "unit": "mv",
                         "value": "0.0"
                     }
                 },
@@ -11142,6 +15991,7 @@
                         "signature": null,
                         "switch": "-metric_leakagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "8.69e-06"
                     }
                 },
@@ -11181,7 +16031,8 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "86728704.0"
+                        "unit": "B",
+                        "value": "79089664.0"
                     }
                 },
                 "nets": {
@@ -11220,6 +16071,7 @@
                         "signature": null,
                         "switch": "-metric_peakpower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.000188"
                     }
                 },
@@ -11259,6 +16111,7 @@
                         "signature": null,
                         "switch": "-metric_security 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -11285,6 +16138,7 @@
                         "signature": null,
                         "switch": "-metric_setupslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.79"
                     }
                 },
@@ -11298,6 +16152,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -11309,6 +16164,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -11322,6 +16178,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -11333,6 +16190,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -11346,6 +16204,7 @@
                         "signature": null,
                         "switch": "-metric_sleeppower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -11359,7 +16218,8 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.66"
+                        "unit": "s",
+                        "value": "0.6"
                     }
                 },
                 "totalarea": {
@@ -11372,7 +16232,22 @@
                         "signature": null,
                         "switch": "-metric_totalarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "6916.67"
+                    }
+                },
+                "totaltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "asic",
+                        "scope": "job",
+                        "shorthelp": "Metric: totaltime",
+                        "signature": null,
+                        "switch": "-metric_totaltime 'step index group <float>'",
+                        "type": "float",
+                        "unit": "s",
+                        "value": "0.0"
                     }
                 },
                 "transistors": {
@@ -11411,6 +16286,7 @@
                         "signature": null,
                         "switch": "-metric_utilization step index group <float>",
                         "type": "float",
+                        "unit": "%",
                         "value": "6.0"
                     }
                 },
@@ -11450,6 +16326,7 @@
                         "signature": null,
                         "switch": "-metric_wirelength 'step index group <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.0"
                     }
                 }
@@ -11467,6 +16344,7 @@
                         "signature": null,
                         "switch": "-metric_averagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -11506,6 +16384,7 @@
                         "signature": null,
                         "switch": "-metric_cellarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "0.0"
                     }
                 },
@@ -11532,6 +16411,7 @@
                         "signature": null,
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -11545,6 +16425,7 @@
                         "signature": null,
                         "switch": "-metric_dozepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -11619,7 +16500,8 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.41"
+                        "unit": "s",
+                        "value": "0.31"
                     }
                 },
                 "holdpaths": {
@@ -11645,6 +16527,7 @@
                         "signature": null,
                         "switch": "-metric_holdslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -11658,6 +16541,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -11669,6 +16553,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -11682,6 +16567,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -11693,6 +16579,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -11706,6 +16593,7 @@
                         "signature": null,
                         "switch": "-metric_idlepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -11719,6 +16607,7 @@
                         "signature": null,
                         "switch": "-metric_irdrop 'step index group <float>'",
                         "type": "float",
+                        "unit": "mv",
                         "value": "0.0"
                     }
                 },
@@ -11732,6 +16621,7 @@
                         "signature": null,
                         "switch": "-metric_leakagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -11771,7 +16661,8 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "37380096.0"
+                        "unit": "B",
+                        "value": "35889152.0"
                     }
                 },
                 "nets": {
@@ -11810,6 +16701,7 @@
                         "signature": null,
                         "switch": "-metric_peakpower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -11849,6 +16741,7 @@
                         "signature": null,
                         "switch": "-metric_security 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -11875,6 +16768,7 @@
                         "signature": null,
                         "switch": "-metric_setupslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -11888,6 +16782,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -11899,6 +16794,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -11912,6 +16808,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -11923,6 +16820,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -11936,6 +16834,7 @@
                         "signature": null,
                         "switch": "-metric_sleeppower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -11949,7 +16848,8 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.5"
+                        "unit": "s",
+                        "value": "0.41"
                     }
                 },
                 "totalarea": {
@@ -11962,6 +16862,21 @@
                         "signature": null,
                         "switch": "-metric_totalarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
+                        "value": "0.0"
+                    }
+                },
+                "totaltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "asic",
+                        "scope": "job",
+                        "shorthelp": "Metric: totaltime",
+                        "signature": null,
+                        "switch": "-metric_totaltime 'step index group <float>'",
+                        "type": "float",
+                        "unit": "s",
                         "value": "0.0"
                     }
                 },
@@ -12001,6 +16916,7 @@
                         "signature": null,
                         "switch": "-metric_utilization step index group <float>",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -12040,6 +16956,7 @@
                         "signature": null,
                         "switch": "-metric_wirelength 'step index group <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.0"
                     }
                 }
@@ -12074,6 +16991,7 @@
                         "signature": null,
                         "switch": "-metric_averagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -12113,6 +17031,7 @@
                         "signature": null,
                         "switch": "-metric_cellarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "415.0"
                     }
                 },
@@ -12139,6 +17058,7 @@
                         "signature": null,
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -12152,6 +17072,7 @@
                         "signature": null,
                         "switch": "-metric_dozepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -12226,6 +17147,7 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
+                        "unit": "s",
                         "value": "0.31"
                     }
                 },
@@ -12252,6 +17174,7 @@
                         "signature": null,
                         "switch": "-metric_holdslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.11"
                     }
                 },
@@ -12265,6 +17188,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -12276,6 +17200,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -12289,6 +17214,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -12300,6 +17226,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -12313,6 +17240,7 @@
                         "signature": null,
                         "switch": "-metric_idlepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -12326,6 +17254,7 @@
                         "signature": null,
                         "switch": "-metric_irdrop 'step index group <float>'",
                         "type": "float",
+                        "unit": "mv",
                         "value": "0.0"
                     }
                 },
@@ -12339,6 +17268,7 @@
                         "signature": null,
                         "switch": "-metric_leakagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "8.69e-06"
                     }
                 },
@@ -12378,7 +17308,8 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "76849152.0"
+                        "unit": "B",
+                        "value": "80646144.0"
                     }
                 },
                 "nets": {
@@ -12417,6 +17348,7 @@
                         "signature": null,
                         "switch": "-metric_peakpower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.000188"
                     }
                 },
@@ -12456,6 +17388,7 @@
                         "signature": null,
                         "switch": "-metric_security 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -12482,6 +17415,7 @@
                         "signature": null,
                         "switch": "-metric_setupslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.79"
                     }
                 },
@@ -12495,6 +17429,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -12506,6 +17441,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -12519,6 +17455,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -12530,6 +17467,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -12543,6 +17481,7 @@
                         "signature": null,
                         "switch": "-metric_sleeppower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -12556,7 +17495,8 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.54"
+                        "unit": "s",
+                        "value": "0.56"
                     }
                 },
                 "totalarea": {
@@ -12569,7 +17509,22 @@
                         "signature": null,
                         "switch": "-metric_totalarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "6916.67"
+                    }
+                },
+                "totaltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "asic",
+                        "scope": "job",
+                        "shorthelp": "Metric: totaltime",
+                        "signature": null,
+                        "switch": "-metric_totaltime 'step index group <float>'",
+                        "type": "float",
+                        "unit": "s",
+                        "value": "0.0"
                     }
                 },
                 "transistors": {
@@ -12608,6 +17563,7 @@
                         "signature": null,
                         "switch": "-metric_utilization step index group <float>",
                         "type": "float",
+                        "unit": "%",
                         "value": "6.0"
                     }
                 },
@@ -12647,6 +17603,7 @@
                         "signature": null,
                         "switch": "-metric_wirelength 'step index group <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.0"
                     }
                 }
@@ -12664,6 +17621,7 @@
                         "signature": null,
                         "switch": "-metric_averagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -12703,6 +17661,7 @@
                         "signature": null,
                         "switch": "-metric_cellarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "485.0"
                     }
                 },
@@ -12729,6 +17688,7 @@
                         "signature": null,
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -12742,6 +17702,7 @@
                         "signature": null,
                         "switch": "-metric_dozepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -12816,7 +17777,8 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.62"
+                        "unit": "s",
+                        "value": "0.52"
                     }
                 },
                 "holdpaths": {
@@ -12842,6 +17804,7 @@
                         "signature": null,
                         "switch": "-metric_holdslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.11"
                     }
                 },
@@ -12855,6 +17818,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -12866,6 +17830,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -12879,6 +17844,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -12890,6 +17856,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -12903,6 +17870,7 @@
                         "signature": null,
                         "switch": "-metric_idlepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -12916,6 +17884,7 @@
                         "signature": null,
                         "switch": "-metric_irdrop 'step index group <float>'",
                         "type": "float",
+                        "unit": "mv",
                         "value": "0.0"
                     }
                 },
@@ -12929,6 +17898,7 @@
                         "signature": null,
                         "switch": "-metric_leakagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "1.12e-05"
                     }
                 },
@@ -12968,7 +17938,8 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "107102208.0"
+                        "unit": "B",
+                        "value": "186880000.0"
                     }
                 },
                 "nets": {
@@ -13007,6 +17978,7 @@
                         "signature": null,
                         "switch": "-metric_peakpower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.000205"
                     }
                 },
@@ -13046,6 +18018,7 @@
                         "signature": null,
                         "switch": "-metric_security 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -13072,6 +18045,7 @@
                         "signature": null,
                         "switch": "-metric_setupslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "1.01"
                     }
                 },
@@ -13085,6 +18059,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -13096,6 +18071,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -13109,6 +18085,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -13120,6 +18097,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -13133,6 +18111,7 @@
                         "signature": null,
                         "switch": "-metric_sleeppower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -13146,7 +18125,8 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.86"
+                        "unit": "s",
+                        "value": "0.75"
                     }
                 },
                 "totalarea": {
@@ -13159,7 +18139,22 @@
                         "signature": null,
                         "switch": "-metric_totalarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "6062.5"
+                    }
+                },
+                "totaltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "asic",
+                        "scope": "job",
+                        "shorthelp": "Metric: totaltime",
+                        "signature": null,
+                        "switch": "-metric_totaltime 'step index group <float>'",
+                        "type": "float",
+                        "unit": "s",
+                        "value": "0.0"
                     }
                 },
                 "transistors": {
@@ -13198,6 +18193,7 @@
                         "signature": null,
                         "switch": "-metric_utilization step index group <float>",
                         "type": "float",
+                        "unit": "%",
                         "value": "8.0"
                     }
                 },
@@ -13237,6 +18233,7 @@
                         "signature": null,
                         "switch": "-metric_wirelength 'step index group <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.0"
                     }
                 }
@@ -13254,6 +18251,7 @@
                         "signature": null,
                         "switch": "-metric_averagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -13293,6 +18291,7 @@
                         "signature": null,
                         "switch": "-metric_cellarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "494.0"
                     }
                 },
@@ -13319,6 +18318,7 @@
                         "signature": null,
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -13332,6 +18332,7 @@
                         "signature": null,
                         "switch": "-metric_dozepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -13406,7 +18407,8 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
-                        "value": "3.42"
+                        "unit": "s",
+                        "value": "1.91"
                     }
                 },
                 "holdpaths": {
@@ -13432,6 +18434,7 @@
                         "signature": null,
                         "switch": "-metric_holdslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.11"
                     }
                 },
@@ -13445,6 +18448,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -13456,6 +18460,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -13469,6 +18474,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -13480,6 +18486,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -13493,6 +18500,7 @@
                         "signature": null,
                         "switch": "-metric_idlepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -13506,6 +18514,7 @@
                         "signature": null,
                         "switch": "-metric_irdrop 'step index group <float>'",
                         "type": "float",
+                        "unit": "mv",
                         "value": "0.0"
                     }
                 },
@@ -13519,6 +18528,7 @@
                         "signature": null,
                         "switch": "-metric_leakagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "1.17e-05"
                     }
                 },
@@ -13558,7 +18568,8 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "745259008.0"
+                        "unit": "B",
+                        "value": "814366720.0"
                     }
                 },
                 "nets": {
@@ -13597,6 +18608,7 @@
                         "signature": null,
                         "switch": "-metric_peakpower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.000289"
                     }
                 },
@@ -13636,6 +18648,7 @@
                         "signature": null,
                         "switch": "-metric_security 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -13662,6 +18675,7 @@
                         "signature": null,
                         "switch": "-metric_setupslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.98"
                     }
                 },
@@ -13675,6 +18689,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -13686,6 +18701,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -13699,6 +18715,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -13710,6 +18727,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -13723,6 +18741,7 @@
                         "signature": null,
                         "switch": "-metric_sleeppower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -13736,7 +18755,8 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "3.67"
+                        "unit": "s",
+                        "value": "2.26"
                     }
                 },
                 "totalarea": {
@@ -13749,7 +18769,22 @@
                         "signature": null,
                         "switch": "-metric_totalarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "6175.0"
+                    }
+                },
+                "totaltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "asic",
+                        "scope": "job",
+                        "shorthelp": "Metric: totaltime",
+                        "signature": null,
+                        "switch": "-metric_totaltime 'step index group <float>'",
+                        "type": "float",
+                        "unit": "s",
+                        "value": "0.0"
                     }
                 },
                 "transistors": {
@@ -13788,6 +18823,7 @@
                         "signature": null,
                         "switch": "-metric_utilization step index group <float>",
                         "type": "float",
+                        "unit": "%",
                         "value": "8.0"
                     }
                 },
@@ -13827,6 +18863,7 @@
                         "signature": null,
                         "switch": "-metric_wirelength 'step index group <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "6300.0"
                     }
                 }
@@ -13844,6 +18881,7 @@
                         "signature": null,
                         "switch": "-metric_averagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -13883,6 +18921,7 @@
                         "signature": null,
                         "switch": "-metric_cellarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
                         "value": "414.96"
                     }
                 },
@@ -13909,6 +18948,7 @@
                         "signature": null,
                         "switch": "-metric_coverage 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -13922,6 +18962,7 @@
                         "signature": null,
                         "switch": "-metric_dozepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -13996,6 +19037,7 @@
                         "signature": null,
                         "switch": "-metric_exetime 'step index group <float>'",
                         "type": "float",
+                        "unit": "s",
                         "value": "0.71"
                     }
                 },
@@ -14022,6 +19064,7 @@
                         "signature": null,
                         "switch": "-metric_holdslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -14035,6 +19078,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -14046,6 +19090,7 @@
                         "signature": null,
                         "switch": "-metric_holdtns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -14059,6 +19104,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -14070,6 +19116,7 @@
                         "signature": null,
                         "switch": "-metric_holdwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -14083,6 +19130,7 @@
                         "signature": null,
                         "switch": "-metric_idlepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -14096,6 +19144,7 @@
                         "signature": null,
                         "switch": "-metric_irdrop 'step index group <float>'",
                         "type": "float",
+                        "unit": "mv",
                         "value": "0.0"
                     }
                 },
@@ -14109,6 +19158,7 @@
                         "signature": null,
                         "switch": "-metric_leakagepower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -14148,7 +19198,8 @@
                         "signature": null,
                         "switch": "-metric_memory 'step index group <float>'",
                         "type": "float",
-                        "value": "30490624.0"
+                        "unit": "B",
+                        "value": "30666752.0"
                     }
                 },
                 "nets": {
@@ -14187,6 +19238,7 @@
                         "signature": null,
                         "switch": "-metric_peakpower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -14226,6 +19278,7 @@
                         "signature": null,
                         "switch": "-metric_security 'step index group <float>'",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -14252,6 +19305,7 @@
                         "signature": null,
                         "switch": "-metric_setupslack 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -14265,6 +19319,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -14276,6 +19331,7 @@
                         "signature": null,
                         "switch": "-metric_setuptns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -14289,6 +19345,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0"
                     },
                     "real": {
@@ -14300,6 +19357,7 @@
                         "signature": null,
                         "switch": "-metric_setupwns 'step index group <float>'",
                         "type": "float",
+                        "unit": "ns",
                         "value": "0.0"
                     }
                 },
@@ -14313,6 +19371,7 @@
                         "signature": null,
                         "switch": "-metric_sleeppower 'step index group <float>'",
                         "type": "float",
+                        "unit": "mw",
                         "value": "0.0"
                     }
                 },
@@ -14326,7 +19385,8 @@
                         "signature": null,
                         "switch": "-metric_tasktime 'step index group <float>'",
                         "type": "float",
-                        "value": "0.92"
+                        "unit": "s",
+                        "value": "0.97"
                     }
                 },
                 "totalarea": {
@@ -14339,6 +19399,21 @@
                         "signature": null,
                         "switch": "-metric_totalarea 'step index group <float>'",
                         "type": "float",
+                        "unit": "um^2",
+                        "value": "0.0"
+                    }
+                },
+                "totaltime": {
+                    "real": {
+                        "defvalue": null,
+                        "lock": "false",
+                        "require": "asic",
+                        "scope": "job",
+                        "shorthelp": "Metric: totaltime",
+                        "signature": null,
+                        "switch": "-metric_totaltime 'step index group <float>'",
+                        "type": "float",
+                        "unit": "s",
                         "value": "0.0"
                     }
                 },
@@ -14378,6 +19453,7 @@
                         "signature": null,
                         "switch": "-metric_utilization step index group <float>",
                         "type": "float",
+                        "unit": "%",
                         "value": "0.0"
                     }
                 },
@@ -14417,6 +19493,7 @@
                         "signature": null,
                         "switch": "-metric_wirelength 'step index group <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.0"
                     }
                 }
@@ -14442,6 +19519,17 @@
         "shorthelp": "Headless execution",
         "signature": null,
         "switch": "-nodisplay <bool>",
+        "type": "bool",
+        "value": "false"
+    },
+    "novercheck": {
+        "defvalue": "false",
+        "lock": "false",
+        "require": "all",
+        "scope": "job",
+        "shorthelp": "Disable version checking",
+        "signature": null,
+        "switch": "-novercheck <bool>",
         "type": "bool",
         "value": "false"
     },
@@ -14573,6 +19661,7 @@
             "signature": null,
             "switch": "-pdk_edgemargin <float>",
             "type": "float",
+            "unit": "mm",
             "value": "2"
         },
         "foundry": {
@@ -14631,6 +19720,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.095"
                     },
                     "xpitch": {
@@ -14642,6 +19732,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xpitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.19"
                     },
                     "yoffset": {
@@ -14653,6 +19744,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_yoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.07"
                     },
                     "ypitch": {
@@ -14664,6 +19756,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_ypitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.14"
                     }
                 },
@@ -14710,6 +19803,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.095"
                     },
                     "xpitch": {
@@ -14721,6 +19815,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xpitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "1.6"
                     },
                     "yoffset": {
@@ -14732,6 +19827,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_yoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.07"
                     },
                     "ypitch": {
@@ -14743,6 +19839,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_ypitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "1.6"
                     }
                 },
@@ -14789,6 +19886,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.095"
                     },
                     "xpitch": {
@@ -14800,6 +19898,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xpitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.19"
                     },
                     "yoffset": {
@@ -14811,6 +19910,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_yoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.07"
                     },
                     "ypitch": {
@@ -14822,6 +19922,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_ypitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.14"
                     }
                 },
@@ -14868,6 +19969,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.095"
                     },
                     "xpitch": {
@@ -14879,6 +19981,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xpitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.19"
                     },
                     "yoffset": {
@@ -14890,6 +19993,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_yoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.07"
                     },
                     "ypitch": {
@@ -14901,6 +20005,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_ypitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.14"
                     }
                 },
@@ -14947,6 +20052,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.095"
                     },
                     "xpitch": {
@@ -14958,6 +20064,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xpitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.28"
                     },
                     "yoffset": {
@@ -14969,6 +20076,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_yoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.07"
                     },
                     "ypitch": {
@@ -14980,6 +20088,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_ypitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.28"
                     }
                 },
@@ -15026,6 +20135,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.095"
                     },
                     "xpitch": {
@@ -15037,6 +20147,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xpitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.28"
                     },
                     "yoffset": {
@@ -15048,6 +20159,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_yoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.07"
                     },
                     "ypitch": {
@@ -15059,6 +20171,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_ypitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.28"
                     }
                 },
@@ -15105,6 +20218,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.095"
                     },
                     "xpitch": {
@@ -15116,6 +20230,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xpitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.28"
                     },
                     "yoffset": {
@@ -15127,6 +20242,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_yoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.07"
                     },
                     "ypitch": {
@@ -15138,6 +20254,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_ypitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.28"
                     }
                 },
@@ -15184,6 +20301,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.095"
                     },
                     "xpitch": {
@@ -15195,6 +20313,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xpitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.8"
                     },
                     "yoffset": {
@@ -15206,6 +20325,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_yoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.07"
                     },
                     "ypitch": {
@@ -15217,6 +20337,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_ypitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.8"
                     }
                 },
@@ -15263,6 +20384,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.095"
                     },
                     "xpitch": {
@@ -15274,6 +20396,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xpitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.8"
                     },
                     "yoffset": {
@@ -15285,6 +20408,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_yoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.07"
                     },
                     "ypitch": {
@@ -15296,6 +20420,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_ypitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.8"
                     }
                 },
@@ -15342,6 +20467,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.095"
                     },
                     "xpitch": {
@@ -15353,6 +20479,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_xpitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "1.6"
                     },
                     "yoffset": {
@@ -15364,6 +20491,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_yoffset 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "0.07"
                     },
                     "ypitch": {
@@ -15375,6 +20503,7 @@
                         "signature": null,
                         "switch": "-pdk_grid_ypitch 'stackup layer <float>'",
                         "type": "float",
+                        "unit": "um",
                         "value": "1.6"
                     }
                 }
@@ -15389,6 +20518,7 @@
             "signature": null,
             "switch": "-pdk_hscribe <float>",
             "type": "float",
+            "unit": "mm",
             "value": "0.1"
         },
         "layermap": {
@@ -15545,6 +20675,7 @@
             "signature": null,
             "switch": "-pdk_vscribe <float>",
             "type": "float",
+            "unit": "mm",
             "value": "0.1"
         },
         "wafersize": {
@@ -15556,6 +20687,7 @@
             "signature": null,
             "switch": "-pdk_wafersize <float>",
             "type": "float",
+            "unit": "mm",
             "value": "300"
         }
     },
@@ -15602,7 +20734,7 @@
         "switch": "-scpath <dir>",
         "type": "[dir]",
         "value": [
-            "/home/noah/code/siliconcompiler/examples/gcd"
+            "/home/aolofsson/work/zeroasic/siliconcompiler/examples/gcd"
         ]
     },
     "show": {
@@ -15791,17 +20923,6 @@
             "type": "str",
             "value": "mv"
         }
-    },
-    "vercheck": {
-        "defvalue": "true",
-        "lock": "false",
-        "require": "all",
-        "scope": "job",
-        "shorthelp": "Enable version checking",
-        "signature": null,
-        "switch": "-vercheck <bool>",
-        "type": "bool",
-        "value": "true"
     },
     "version": {
         "print": {


### PR DESCRIPTION
- Optional field in each parameter.
- Previously this informationw as embedded in the help of each parameter.
- Embedding the unit inside the parameter avoids the risk of unit contention.
- Future proofs settings by decoupling the units of each parameter from all others.