### PR TITLE
Some minor cleanup

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1919,7 +1919,6 @@ class Chip:
             else:
                 self.logger.error('File format not recognized %s', filepath)
                 self.error = 1
-            #flush writes
 
     ###########################################################################
     def check_checklist(self, standard, item=None):
@@ -2739,10 +2738,9 @@ class Chip:
                     stepindex = step + index
                     for i in  self.getkeys('flowstatus'):
                         for j in  self.getkeys('flowstatus',i):
-                            if 'select' in self.getkeys('flowstatus',i,j):
-                                for in_step, in_index in self.get('flowstatus',i,j,'select'):
-                                    if (in_step + in_index) == stepindex:
-                                        indices_to_show[step] = index
+                            for in_step, in_index in self.get('flowstatus',i,j,'select'):
+                                if (in_step + in_index) == stepindex:
+                                    indices_to_show[step] = index
 
         # header for data frame
         for step in steplist:
@@ -3428,9 +3426,7 @@ class Chip:
             self.logger.error(f'No inputs selected after running {tool}')
             self._haltstep(step, index)
 
-        #TODO: This should not be needed
-        if step != 'import':
-            self.set('flowstatus', step, index, 'select', sel_inputs)
+        self.set('flowstatus', step, index, 'select', sel_inputs)
 
         ##################
         # 8. Copy (link) output data from previous steps

--- a/siliconcompiler/server.py
+++ b/siliconcompiler/server.py
@@ -223,7 +223,7 @@ class Server:
 
         # Remove 'remote' JSON config value to run locally on compute node.
         chip.set('remote', False, clobber=True)
-        chip.set('remote', 'credentials', '', clobber=True)
+        chip.set('credentials', '', clobber=True)
         # Rename source files in the config dict; the 'import' step already
         # ran and collected the sources into a single Verilog file.
         chip.set('source', '%s/import/%s/outputs/%s.v'%(build_dir, '0', chip.get('design')), clobber=True)
@@ -424,7 +424,7 @@ class Server:
             chip.set('dir', f'{nfs_mount}/{job_hash}', clobber=True)
             chip.set('jobscheduler', 'slurm')
             chip.set('remote', False)
-            chip.set('remote', 'credentials', '', clobber=True)
+            chip.set('credentials', '', clobber=True)
             chip.status['decrypt_key'] = base64.urlsafe_b64encode(pk)
             chip.run()
         else:


### PR DESCRIPTION
Was going through the optimize runtask PR to make sure I didn't miss anything that needed to be handled in the scheduler PR. I didn't find anything like that, but I am curious if we can undo the 'flowstatus' change with a TODO on it? Doesn't seem necessary to me, and tests pass without it (not sure if they weren't before).

Also bundled in some other small non-controversial cleanup commits.