### PR TITLE
Insert valid steplist check

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1376,7 +1376,6 @@ class Chip:
         if os.path.isfile(filename):
             return filename
         else:
-            self.error = 1
             return None
 
     ###########################################################################
@@ -1615,16 +1614,12 @@ class Chip:
             Returns True of the Chip object dictionary checks out.
 
         '''
-        # TODO: validate steplist: ensure that everything in steplist either has
-        # dependencies that:
-        # (a) have been run OR (b) are in the steplist
-
         flow = self.get('flow')
         steplist = self.get('steplist')
         if not steplist:
             steplist = self.list_steps()
 
-        #1. Checking that flowgraph is legal
+        #1. Checking that flowgraph and stelist are legal
         if flow not in self.getkeys('flowgraph'):
             self.error = 1
             self.logger.error(f"flowgraph {flow} not defined.")
@@ -1633,6 +1628,26 @@ class Chip:
         if 'import' not in legal_steps:
             self.error = 1
             self.logger.error("Flowgraph doesn't contain import step.")
+
+        indexlist = {}
+        for step in steplist:
+            if self.get('indexlist'):
+                indexlist[step] = self.get('indexlist')
+            else:
+                indexlist[step] = self.getkeys('flowgraph', flow, step)
+
+        for step in steplist:
+            for index in indexlist[step]:
+                for in_step, in_index in self.get('flowgraph', flow, step, index, 'input'):
+                    if in_step in steplist and in_index in indexlist[step]:
+                        # we're gonna run this step, OK
+                        continue
+                    if self.get('flowstatus', in_step, in_index, 'status') == TaskStatus.SUCCESS:
+                        # this task has already completed successfully, OK
+                        continue
+                    self.logger.error(f'{step}{index} relies on {in_step}{in_index}, '
+                        'but this task has not been run and is not in the current steplist.')
+                    self.error = 1
 
         #2. Check libary names
         for item in self.get('asic', 'logiclib'):

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1621,7 +1621,7 @@ class Chip:
         if not steplist:
             steplist = self.list_steps()
 
-        #1. Checking that flowgraph and stelist are legal
+        #1. Checking that flowgraph and steplist are legal
         if flow not in self.getkeys('flowgraph'):
             self.error = 1
             self.logger.error(f"flowgraph {flow} not defined.")

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1656,7 +1656,7 @@ class Chip:
                                 'but this task has not been run.')
                             self.error = 1
                         continue
-                    if in_step in steplist and in_index in indexlist[step]:
+                    if in_step in steplist and in_index in indexlist[in_step]:
                         # we're gonna run this step, OK
                         continue
                     if self.get('flowstatus', in_step, in_index, 'status') == TaskStatus.SUCCESS:
@@ -3848,7 +3848,7 @@ class Chip:
                 # Hack to find first failed step by checking for presence of
                 # output manifests.
                 # TODO: fetch_results() should return info about step failures.
-                failed_step = laststep
+                failed_step = steplist[-1]
                 for step in steplist[:-1]:
                     step_has_cfg = False
                     for index in indexlist[step]:

--- a/tests/flows/test_steplist.py
+++ b/tests/flows/test_steplist.py
@@ -1,0 +1,35 @@
+import siliconcompiler
+
+import pytest
+
+@pytest.mark.eda
+def test_steplist(gcd_chip):
+    # Initial run
+    gcd_chip.set('steplist', ['import', 'syn'])
+    gcd_chip.run()
+
+    # Make sure we didn't finish
+    assert gcd_chip.find_result('gds', step='export') is None
+    # Make sure we ran syn
+    assert gcd_chip.find_result('vg', step='syn')
+    assert gcd_chip.get('flowstatus', 'import', '0', 'status') == siliconcompiler.TaskStatus.SUCCESS
+    assert gcd_chip.get('flowstatus', 'syn', '0', 'status') == siliconcompiler.TaskStatus.SUCCESS
+
+    # Re-run
+    gcd_chip.set('steplist', ['syn'])
+    gcd_chip.run()
+    assert gcd_chip.find_result('gds', step='export') is None
+    assert gcd_chip.find_result('vg', step='syn')
+
+    gcd_chip.set('steplist', ['floorplan'])
+    gcd_chip.run()
+    assert gcd_chip.find_result('def', step='floorplan')
+
+@pytest.mark.eda
+def test_invalid(gcd_chip):
+    # Invalid steplist, need to run import first
+    gcd_chip.set('steplist', 'syn')
+
+    with pytest.raises(siliconcompiler.SiliconCompilerError):
+        # Should be caught by check_manifest()
+        gcd_chip.run()

--- a/tests/flows/test_steplist.py
+++ b/tests/flows/test_steplist.py
@@ -33,3 +33,11 @@ def test_invalid(gcd_chip):
     with pytest.raises(siliconcompiler.SiliconCompilerError):
         # Should be caught by check_manifest()
         gcd_chip.run()
+
+@pytest.mark.eda
+def test_invalid_jobinput(gcd_chip):
+    gcd_chip.set('jobname', 'job1')
+    gcd_chip.set('jobinput', 'job1', 'syn', '0', 'job0')
+    gcd_chip.set('steplist', 'syn')
+    with pytest.raises(siliconcompiler.SiliconCompilerError):
+        gcd_chip.run()


### PR DESCRIPTION
This PR implements a `check_manifest()` check for ensuring that a steplist is valid. This will print a clean error early on if you try to run a flowgraph with a steplist that doesn't work, e.g.

```python
...
chip.set('steplist', ['syn'])
chip.run()
```

Gives you:
```
| INFO    | job0  | --         | -  | Checking manifest before running.
| ERROR   | job0  | --         | -  | syn0 relies on import0, but this task has not been run and is not in the current steplist.
| ERROR   | job0  | --         | -  | Check failed. See previous errors.
```
