### PR TITLE
Fix check_manifest() performance bottleneck and add performance tests to CI

### DIFF
--- a/siliconcompiler/tools/echo/echo.py
+++ b/siliconcompiler/tools/echo/echo.py
@@ -16,7 +16,4 @@ def parse_version(stdout):
     return '0'
 
 def post_process(chip):
-    step = chip.get('arg', 'step')
-
-    if step == 'echo_10':
-        raise KeyboardInterrupt
+    return 0

--- a/tests/core/test_summary.py
+++ b/tests/core/test_summary.py
@@ -2,6 +2,8 @@
 import os
 import siliconcompiler
 
+import pytest
+
 def test_summary(datadir):
 
     chip = siliconcompiler.Chip()
@@ -24,6 +26,20 @@ def test_steplist(datadir, capfd):
 
     assert 'import0' not in stdout
     assert 'syn0' in stdout
+
+@pytest.mark.eda
+def test_steplist_repeat(gcd_chip, capfd):
+    '''Regression test for #458.'''
+    with capfd.disabled():
+        gcd_chip.set('steplist', ['import', 'syn', 'floorplan'])
+        gcd_chip.set('steplist', ['syn'])
+
+    gcd_chip.summary()
+    stdout, _ = capfd.readouterr()
+
+    assert 'import0' not in stdout
+    assert 'syn0' in stdout
+    assert 'floorplan0' not in stdout
 
 #########################
 if __name__ == "__main__":

--- a/tests/flows/test_performance.py
+++ b/tests/flows/test_performance.py
@@ -41,6 +41,10 @@ def run_scalability_test(scroot):
 # gave a bit of overhead to account for normal variation run-to-run, but we
 # might need to tune these more to not get false positives.
 
+# These tests don't require EDA tools installed, but marking them as EDA so they
+# only run daily on our runner (which is also faster than GH machines).
+
+@pytest.mark.eda
 def test_long_serial(run_scalability_test):
     steps_to_run = 10
     results = run_scalability_test('serial', (10, 100, 250), steps_to_run)
@@ -52,6 +56,7 @@ def test_long_serial(run_scalability_test):
         # Should take <1 sec per task for each trial
         assert time_per_task < 1
 
+@pytest.mark.eda
 def test_wide_parallel(run_scalability_test):
     results = run_scalability_test('parallel', (10, 100, 250))
     for n, total_time in results.items():

--- a/tests/flows/test_performance.py
+++ b/tests/flows/test_performance.py
@@ -1,0 +1,64 @@
+import os
+import signal
+import subprocess
+import time
+
+import pytest
+
+@pytest.fixture
+def run_scalability_test(scroot):
+    # TODO: I think we're just about at a point where we can pull in code from
+    # scalability.py and call it directly, instead of using this weird
+    # subprocess hack. This was originally done b/c running an entire big
+    # flowgraph was too slow, but with the optimizations we've applied that
+    # shouldn't be the case anymore.
+    test_path = os.path.join(scroot, 'examples', 'benchmark', 'scalability.py')
+
+    def _run(task, trials, steps_to_run=None):
+        results = {}
+        for num_tasks in trials:
+            cmd = ['python', test_path, task, str(num_tasks)]
+            if steps_to_run:
+                cmd.append(str(steps_to_run))
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+            for line in proc.stdout:
+                line = line.decode('ascii')
+                if line.startswith('import0'):
+                    start = time.time()
+                if line.startswith('done'):
+                    end = time.time()
+                    proc.send_signal(signal.SIGINT)
+                    proc.wait()
+                    break
+
+            results[num_tasks] = end - start
+
+        return results
+
+    return _run
+
+# Note: the thresholds here are meant to flag major performance regressions. I
+# gave a bit of overhead to account for normal variation run-to-run, but we
+# might need to tune these more to not get false positives.
+
+def test_long_serial(run_scalability_test):
+    steps_to_run = 10
+    results = run_scalability_test('serial', (10, 100, 250), steps_to_run)
+
+    for n, total_time in results.items():
+        time_per_task = total_time / steps_to_run
+        print(f'{n}, {time_per_task}')
+
+        # Should take <1 sec per task for each trial
+        assert time_per_task < 1
+
+def test_wide_parallel(run_scalability_test):
+    results = run_scalability_test('parallel', (10, 100, 250))
+    for n, total_time in results.items():
+        print(f'{n}, {total_time}')
+        if n <= 10:
+            assert total_time < 1
+        elif n <= 100:
+            assert total_time < 10
+        else:
+            assert total_time < 60


### PR DESCRIPTION
This PR fixes a performance bottleneck in `check_manifest()`. From the commit:

This fixes a performance problem where each task has to incur the
overhead of checking an entire flowgraph for really large graphs. Since
those sorts of things are static, they only need to be checked once in
run(), and the check_manifest() calls inside _runtask() can focus on
dynamic checks.

I also started simplifying the benchmark code I was using and added it to CI. Now that our code is faster I think we can probably get rid of a lot of the complexity in the monitored subprocess approach, but I'm planning on handling that later. For now, I think it'll be nice to have some tests running to flag major performance regressions.

Also, an unrelated test that was meant for a different PR ended up in here (for context on the test_summary.py change).