### PR TITLE
Remove requirement for totaltime metric

### DIFF
--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1884,7 +1884,6 @@ def schema_metric(cfg, step='default', index='default',group='default'):
             sctype='float',
             unit='s',
             scope='job',
-            require='asic',
             shorthelp=f"Metric: {item}",
             switch=f"-metric_{item} 'step index group <float>'",
             example=[

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -4097,7 +4097,7 @@
                         ],
                         "help": "Metric tracking the total amount of time spent from the beginning\nof the run up to and including the current step and index.",
                         "lock": "false",
-                        "require": "asic",
+                        "require": null,
                         "scope": "job",
                         "shorthelp": "Metric: totaltime",
                         "signature": null,


### PR DESCRIPTION
Looks like tests broke after the fix-daily-tests got merged, since there was a new metric 'totaltime' added, and we need to get rid of `require` for metrics now. This commit should fix things up!