### PR TITLE
Implement checklists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,4 +10,5 @@ include CMakeLists.txt
 graft siliconcompiler/leflib
 graft siliconcompiler/templates
 graft siliconcompiler/tools
+graft siliconcompiler/checklists
 graft third_party/tools/openroad/tools/OpenROAD/src/odb/src/lef

--- a/examples/gcd/gcd_skywater.py
+++ b/examples/gcd/gcd_skywater.py
@@ -59,20 +59,20 @@ def main():
 
     chip.add('checklist', 'oh_tapeout', 'errors_warnings', 'waiver', 'warnings', waiver_path)
 
-    chip.set('checklist', 'oh_tapeout', 'drc_clean', 'tasks', ('signoff', 'drc', '0'))
-    chip.set('checklist', 'oh_tapeout', 'lvs_clean', 'tasks', ('signoff', 'lvs', '0'))
-    chip.set('checklist', 'oh_tapeout', 'setup_time', 'tasks', ('rtl2gds', 'dfm', '0'))
+    chip.set('checklist', 'oh_tapeout', 'drc_clean', 'task', ('signoff', 'drc', '0'))
+    chip.set('checklist', 'oh_tapeout', 'lvs_clean', 'task', ('signoff', 'lvs', '0'))
+    chip.set('checklist', 'oh_tapeout', 'setup_time', 'task', ('rtl2gds', 'dfm', '0'))
 
     for step in chip.getkeys('flowgraph', 'asicflow'):
         for index in chip.getkeys('flowgraph', 'asicflow', step):
             tool = chip.get('flowgraph', 'asicflow', step, index, 'tool')
             if tool not in chip.builtin:
-                chip.add('checklist', 'oh_tapeout', 'errors_warnings', 'tasks', ('rtl2gds', step, index))
+                chip.add('checklist', 'oh_tapeout', 'errors_warnings', 'task', ('rtl2gds', step, index))
     for step in chip.getkeys('flowgraph', 'signoffflow'):
         for index in chip.getkeys('flowgraph', 'signoffflow', step):
             tool = chip.get('flowgraph', 'signoffflow', step, index, 'tool')
             if tool not in chip.builtin:
-                chip.add('checklist', 'oh_tapeout', 'errors_warnings', 'tasks', ('signoff', step, index))
+                chip.add('checklist', 'oh_tapeout', 'errors_warnings', 'task', ('signoff', step, index))
 
     status = chip.check_checklist('oh_tapeout')
     if not status:

--- a/examples/gcd/gcd_skywater.py
+++ b/examples/gcd/gcd_skywater.py
@@ -1,5 +1,8 @@
 import siliconcompiler
 
+import os
+import sys
+
 from sky130_floorplan import make_floorplan
 
 def main():
@@ -13,7 +16,7 @@ def main():
     chip.set('relax', True)
     chip.set('quiet', True)
     chip.set('clock', 'core_clock', 'pin', 'clk')
-    chip.set('clock', 'core_clock', 'period', 2)
+    chip.set('clock', 'core_clock', 'period', 5)
 
     chip.load_target("skywater130_demo")
 
@@ -29,6 +32,7 @@ def main():
     def_path = make_floorplan(chip)
     chip.set('read', 'def', 'floorplan', '0', def_path)
 
+    chip.set('jobname', 'rtl2gds')
     chip.run()
     chip.summary()
 
@@ -46,6 +50,43 @@ def main():
 
     chip.run()
     chip.summary()
+
+    # 3) Checklist
+    # Manual reports
+    spec_path = os.path.join(os.path.dirname(__file__), 'spec.txt')
+    chip.add('checklist', 'oh_tapeout', 'spec', 'report', spec_path)
+    waiver_path = os.path.join(os.path.dirname(__file__), 'route_waiver.txt')
+
+    chip.add('checklist', 'oh_tapeout', 'errors_warnings', 'waiver', 'warnings', waiver_path)
+
+    chip.set('checklist', 'oh_tapeout', 'drc_clean', 'tasks', ('signoff', 'drc', '0'))
+    chip.set('checklist', 'oh_tapeout', 'lvs_clean', 'tasks', ('signoff', 'lvs', '0'))
+    chip.set('checklist', 'oh_tapeout', 'setup_time', 'tasks', ('rtl2gds', 'dfm', '0'))
+
+    for step in chip.getkeys('flowgraph', 'asicflow'):
+        for index in chip.getkeys('flowgraph', 'asicflow', step):
+            tool = chip.get('flowgraph', 'asicflow', step, index, 'tool')
+            if tool not in chip.builtin:
+                chip.add('checklist', 'oh_tapeout', 'errors_warnings', 'tasks', ('rtl2gds', step, index))
+    for step in chip.getkeys('flowgraph', 'signoffflow'):
+        for index in chip.getkeys('flowgraph', 'signoffflow', step):
+            tool = chip.get('flowgraph', 'signoffflow', step, index, 'tool')
+            if tool not in chip.builtin:
+                chip.add('checklist', 'oh_tapeout', 'errors_warnings', 'tasks', ('signoff', step, index))
+
+    status = chip.check_checklist('oh_tapeout')
+    if not status:
+        sys.exit(1)
+
+    # Mark 'ok'
+    for item in chip.getkeys('checklist', 'oh_tapeout'):
+        chip.set('checklist', 'oh_tapeout', item, 'ok', True)
+
+    status = chip.check_checklist('oh_tapeout', check_ok=True)
+    if not status:
+        sys.exit(1)
+
+    chip.write_manifest('gcd.checked.pkg.json')
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -96,11 +96,13 @@ if not on_rtd:
 else:
     skbuild_args = {}
 
-tool_package_data = []
-for f in glob.glob('siliconcompiler/tools/**/*', recursive=True):
-    if os.path.isfile(f):
-        # strip off directory and add to list
-        tool_package_data.append(f[len('siliconcompiler/tools/'):])
+def get_package_data(item):
+    package_data = []
+    for f in glob.glob(f'siliconcompiler/{item}/**/*', recursive=True):
+        if os.path.isfile(f):
+            # strip off directory and add to list
+            package_data.append(f[len(f'siliconcompiler/{item}/'):])
+    return package_data
 
 install_reqs, extras_req = parse_reqs()
 
@@ -130,7 +132,8 @@ setup(
     #include_package_data=True,
     package_data={
         'siliconcompiler': ['templates/*.j2', 'templates/report/*'],
-        'siliconcompiler.tools': tool_package_data
+        'siliconcompiler.tools': get_package_data('tools'),
+        'siliconcompiler.checklists': get_package_data('checklists'),
     },
 
     python_requires=">=3.6",

--- a/siliconcompiler/checklists/oh_tapeout/oh_tapeout.py
+++ b/siliconcompiler/checklists/oh_tapeout/oh_tapeout.py
@@ -1,0 +1,35 @@
+import siliconcompiler
+
+def make_docs():
+    '''Subset of OH! library tapeout checklist.
+
+    https://github.com/aolofsson/oh/blob/master/docs/tapeout_checklist.md
+    '''
+    chip = siliconcompiler.Chip()
+    setup(chip)
+    return chip
+
+def setup(chip):
+    standard = 'oh_tapeout'
+
+    # Automated
+    chip.set('checklist', standard, 'drc_clean', 'description',
+             'Is block DRC clean?')
+    chip.set('checklist', standard, 'drc_clean', 'criteria', 'drvs==0')
+
+    chip.set('checklist', standard, 'lvs_clean', 'description',
+             'Is block LVS clean?')
+    chip.set('checklist', standard, 'lvs_clean', 'criteria', 'drvs==0')
+
+    chip.set('checklist', standard, 'setup_time', 'description',
+             'Setup time met?')
+    chip.set('checklist', standard, 'setup_time', 'criteria', 'setupslack>=0')
+
+    chip.set('checklist', standard, 'errors_warnings', 'description',
+             'Are all EDA warnings/errors acceptable?')
+    chip.set('checklist', standard, 'errors_warnings', 'criteria',
+              ['errors==0', 'warnings==0'])
+
+    # Manual
+    chip.set('checklist', standard, 'spec', 'description',
+        'Is there a written specification?')

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -798,7 +798,7 @@ class Chip:
         return self._search(cfg, keypathstr, *keypath, field=field, mode='get')
 
     ###########################################################################
-    def getkeys(self, *keypath, cfg=None):
+    def getkeys(self, *keypath, cfg=None, job=None):
         """
         Returns a list of schema dictionary keys.
 
@@ -808,8 +808,10 @@ class Chip:
         Chip object error flag.
 
         Args:
-            keypath(list str): Variable length ordered schema key list
-            cfg(dict): Alternate dictionary to access in place of self.cfg
+            keypath (list str): Variable length ordered schema key list
+            cfg (dict): Alternate dictionary to access in place of self.cfg
+            job (str): Jobname to use for dictionary access in place of the
+                current active jobname.
 
         Returns:
             List of keys found for the keypath provided.
@@ -822,7 +824,10 @@ class Chip:
         """
 
         if cfg is None:
-            cfg = self.cfg
+            if job is None:
+                cfg = self.cfg
+            else:
+                cfg = self.cfg['history'][job]
 
         if len(list(keypath)) > 0:
             keypathstr = ','.join(keypath)
@@ -1113,13 +1118,13 @@ class Chip:
                                 return_list.append(int(item))
                             elif sctype == 'float':
                                 return_list.append(float(item))
-                            elif sctype == '(str,str)':
+                            elif sctype.startswith('(str,'):
                                 if isinstance(item,tuple):
                                     return_list.append(item)
                                 else:
                                     tuplestr = re.sub(r'[\(\)\'\s]','',item)
                                     return_list.append(tuple(tuplestr.split(',')))
-                            elif sctype == '(float,float)':
+                            elif sctype.startswith('(float,'):
                                 if isinstance(item,tuple):
                                     return_list.append(item)
                                 else:
@@ -1282,7 +1287,7 @@ class Chip:
         return result
 
     ###########################################################################
-    def find_files(self, *keypath, cfg=None, missing_ok=False):
+    def find_files(self, *keypath, cfg=None, missing_ok=False, job=None):
         """
         Returns absolute paths to files or directories based on the keypath
         provided.
@@ -1299,6 +1304,10 @@ class Chip:
             keypath (list str): Variable length schema key list.
             cfg (dict): Alternate dictionary to access in place of the default
                 chip object schema dictionary.
+            missing_ok (bool): If True, silently return None when files aren't
+                found. If False, print an error and set the error flag.
+            job (str): Jobname to use for dictionary access in place of the
+                current active jobname.
 
         Returns:
             If keys points to a scalar entry, returns an absolute path to that
@@ -1315,11 +1324,11 @@ class Chip:
         if cfg is None:
             cfg = self.cfg
 
-        copyall = self.get('copyall', cfg=cfg)
-        paramtype = self.get(*keypath, field='type', cfg=cfg)
+        copyall = self.get('copyall', cfg=cfg, job=job)
+        paramtype = self.get(*keypath, field='type', cfg=cfg, job=job)
 
         if 'file' in paramtype:
-            copy = self.get(*keypath, field='copy', cfg=cfg)
+            copy = self.get(*keypath, field='copy', cfg=cfg, job=job)
         else:
             copy = False
 
@@ -1330,7 +1339,7 @@ class Chip:
 
         is_list = bool(re.match(r'\[', paramtype))
 
-        paths = self.get(*keypath, cfg=cfg)
+        paths = self.get(*keypath, cfg=cfg, job=job)
         # Convert to list if we have scalar
         if not is_list:
             paths = [paths]
@@ -1346,7 +1355,7 @@ class Chip:
                 io = ""
             else:
                 io = keypath[2] + 's'
-            iodir = os.path.join(self._getworkdir(step=step, index=index), io)
+            iodir = os.path.join(self._getworkdir(jobname=job, step=step, index=index), io)
             for path in paths:
                 abspath = os.path.join(iodir, path)
                 if os.path.isfile(abspath):
@@ -1356,7 +1365,7 @@ class Chip:
         for path in paths:
             if (copyall or copy) and ('file' in paramtype):
                 name = self._get_imported_filename(path)
-                abspath = os.path.join(self._getworkdir(step='import'), 'outputs', name)
+                abspath = os.path.join(self._getworkdir(jobname=job, step='import'), 'outputs', name)
                 if os.path.isfile(abspath):
                     # if copy is True and file is found in import outputs,
                     # continue. Otherwise, fall through to _find_sc_file (the
@@ -1981,22 +1990,29 @@ class Chip:
                 self.error = 1
 
     ###########################################################################
-    def check_checklist(self, standard, item=None):
+    def check_checklist(self, standard, items=None, check_ok=False):
         '''
-        Check an item in checklist.
+        Check items in a checklist.
 
-        Checks the status of an item in the checklist for the standard
-        provided. If the item is unspecified, all items are checked.
+        Checks the status of items in a checklist for the standard provided. If
+        a specific list of items is unspecified, all items are checked.
 
-        The function relies on the checklist 'criteria' parameter and
-        'step' parameter to check for the existence of report filess
-        and a passing metric based criteria. Checklist items with
-        empty 'report' values or unmet criteria result in error messages
-        and raising the error flag.
+        All items have an associated 'tasks' parameter, which indicates which
+        tasks can be used to automatically validate the item. For an item to be
+        checked, all tasks must satisfy the item's criteria, unless waivers are
+        provided. In addition, that task must have generated EDA report files
+        for each metric in the criteria.
+
+        For items without an associated task, the only requirement is that at
+        least one report has been added to that item.
+
+        When 'check_ok' is True, every item must also have its 'ok' parameter
+        set to True, indicating that a human has reviewed the item.
 
         Args:
-            standard(str): Standard to check.
-            item(str): Item to check from standard.
+            standard (str): Standard to check.
+            items (list of str): Items to check from standard.
+            check_ok (bool): Whether to check item 'ok' parameter.
 
         Returns:
             Status of item check.
@@ -2006,61 +2022,80 @@ class Chip:
             Returns status.
         '''
 
-        if item is None:
+        self.logger.info(f'Checking checklist {standard}')
+
+        if items is None:
             items = self.getkeys('checklist', standard)
-        else:
-            items = [item]
 
         flow = self.get('flow')
-        global_check = True
 
         for item in items:
-            step = self.get('checklist', standard, item, 'step')
-            index = self.get('checklist', standard, item, 'index')
             all_criteria = self.get('checklist', standard, item, 'criteria')
-            report_ok = False
-            criteria_ok = True
-            # manual
-            if step not in self.getkeys('flowgraph',flow):
-                #criteria not used, so always ok
-                criteria_ok = True
-                if len(self.getkeys('checklist',standard, item, 'report')) <2:
-                    self.logger.error(f"No report found for {item}")
-                    report_ok = False
-            else:
-                tool = self.get('flowgraph', flow, step, index, 'tool')
-                # copy report paths over to checklsit
-                for reptype in self.getkeys('eda', tool, 'report', step, index):
-                    report_ok = True
-                    report = self.get('eda', tool, 'report', step, index, reptype)
-                    self.set('checklist', standard, item, 'report', reptype, report)
-                # quantifiable checklist criteria
-                for criteria in all_criteria:
-                    m = re.match(r'(\w+)([\>\=\<]+)(\w+)', criteria)
-                    if not m:
-                        self.logger.error(f"Illegal checklist criteria: {criteria}")
-                        return False
-                    elif m.group(1) not in self.getkeys('metric', step, index):
-                        self.logger.error(f"Critera must use legal metrics only: {criteria}")
-                        return False
+            for criteria in all_criteria:
+                m = re.match(r'(\w+)([\>\=\<]+)(\w+)', criteria)
+                if not m:
+                    self.logger.error(f"Illegal checklist criteria: {criteria}")
+                    self.error = 1
+                    return False
+                elif m.group(1) not in self.getkeys('metric', 'default', 'default'):
+                    self.logger.error(f"Critera must use legal metrics only: {criteria}")
+                    self.error = 1
+                    return False
+
+                metric = m.group(1)
+                op = m.group(2)
+                goal = str(m.group(3))
+
+                tasks = self.get('checklist', standard, item, 'tasks')
+                for job, step, index in tasks:
+                    # Automated checks
+                    flow = self.get('flow', job=job)
+                    tool = self.get('flowgraph', flow, step, index, 'tool', job=job)
+
+                    value = str(self.get('metric', step, index, metric, 'real', job=job))
+                    criteria_ok = self._safecompare(value, op, goal)
+                    if metric in self.getkeys('checklist', standard, item, 'waiver'):
+                        waivers = self.get('checklist', standard, item, 'waiver', metric)
                     else:
-                        param = m.group(1)
-                        op = m.group(2)
-                        goal = str(m.group(3))
-                        value = str(self.get('metric', step, index, param, 'real'))
-                        criteria_ok = self._safecompare(value, op, goal)
+                        waivers = []
 
-            #item check
-            if not report_ok:
-                self.logger.error(f"Report missing for checklist: {standard} {item}")
-                global_check = False
-                self.error = 1
-            elif not criteria_ok:
-                self.logger.error(f"Criteria check failed for checklist: {standard} {item}")
-                global_check = False
-                self.error = 1
+                    criteria_str = f'{metric}{op}{goal}'
+                    if not criteria_ok and waivers:
+                        self.logger.warning(f'{item} criteria {criteria_str} unmet by task {step}{index}, but found waivers.')
+                    elif not criteria_ok:
+                        self.logger.error(f'{item} criteria {criteria_str} unmet by task {step}{index}.')
+                        self.error = 1
+                        return False
 
-        return global_check
+                    if (step in self.getkeys('eda', tool, 'report', job=job) and
+                        index in self.getkeys('eda', tool, 'report', step, job=job) and
+                        metric in self.getkeys('eda', tool, 'report', step, index, job=job)):
+                        eda_reports = self.find_files('eda', tool, 'report', step, index, metric, job=job)
+                    else:
+                        eda_reports = None
+
+                    if not eda_reports:
+                        self.logger.error(f'No EDA reports generated for metric {metric} in task {step}{index}')
+                        self.error = 1
+                        return False
+
+                    for report in eda_reports:
+                        if report not in self.get('checklist', standard, item, 'report'):
+                            self.add('checklist', standard, item, 'report', report)
+
+            if len(self.get('checklist', standard, item, 'report')) == 0:
+                self.logger.error(f'No report documenting item {item}')
+                self.error = 1
+                return False
+
+            if check_ok and not self.get('checklist', standard, item, 'ok'):
+                self.logger.error(f"Item {item} 'ok' field not checked")
+                self.error = 1
+                return False
+
+        self.logger.info('Check succeeded!')
+
+        return True
 
     ###########################################################################
     def read_file(self, filename, step='import', index='0'):
@@ -4093,8 +4128,7 @@ class Chip:
             # ignore history in case of cumulative history
             if key[0] != 'history':
                 scope = self.get(*key, field='scope')
-                value = self.get(*key)
-                if value and (scope == 'job'):
+                if not self._keypath_empty(key) and (scope == 'job'):
                     self._copyparam(self.cfg,
                                     self.cfg['history'][jobname],
                                     key)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2046,7 +2046,7 @@ class Chip:
 
                 metric = m.group(1)
                 op = m.group(2)
-                goal = str(m.group(3))
+                goal = float(m.group(3))
 
                 tasks = self.get('checklist', standard, item, 'tasks')
                 for job, step, index in tasks:
@@ -2054,7 +2054,7 @@ class Chip:
                     flow = self.get('flow', job=job)
                     tool = self.get('flowgraph', flow, step, index, 'tool', job=job)
 
-                    value = str(self.get('metric', step, index, metric, 'real', job=job))
+                    value = self.get('metric', step, index, metric, 'real', job=job)
                     criteria_ok = self._safecompare(value, op, goal)
                     if metric in self.getkeys('checklist', standard, item, 'waiver'):
                         waivers = self.get('checklist', standard, item, 'waiver', metric)
@@ -2086,6 +2086,7 @@ class Chip:
                             self.add('checklist', standard, item, 'report', report)
 
             if len(self.get('checklist', standard, item, 'report')) == 0:
+                # TODO: validate that report exists?
                 self.logger.error(f'No report documenting item {item}')
                 self.error = 1
                 return False

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1380,7 +1380,7 @@ class Chip:
         return result
 
     ###########################################################################
-    def find_result(self, filetype, step, jobname='job0', index='0'):
+    def find_result(self, filetype, step, jobname=None, index='0'):
         """
         Returns the absolute path of a compilation result.
 
@@ -1403,6 +1403,8 @@ class Chip:
             >>> manifest_filepath = chip.find_result('.vg', 'syn')
            Returns the absolute path to the manifest.
         """
+        if jobname is None:
+            jobname = self.get('jobname')
 
         workdir = self._getworkdir(jobname, step, index)
         design = self.get('design')

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1999,7 +1999,7 @@ class Chip:
         Checks the status of items in a checklist for the standard provided. If
         a specific list of items is unspecified, all items are checked.
 
-        All items have an associated 'tasks' parameter, which indicates which
+        All items have an associated 'task' parameter, which indicates which
         tasks can be used to automatically validate the item. For an item to be
         checked, all tasks must satisfy the item's criteria, unless waivers are
         provided. In addition, that task must have generated EDA report files
@@ -2048,7 +2048,7 @@ class Chip:
                 op = m.group(2)
                 goal = float(m.group(3))
 
-                tasks = self.get('checklist', standard, item, 'tasks')
+                tasks = self.get('checklist', standard, item, 'task')
                 for job, step, index in tasks:
                     # Automated checks
                     flow = self.get('flow', job=job)

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2795,32 +2795,19 @@ def schema_checklist(cfg, group='checklist'):
             a metric, a relational operator, and a value in the form.
             'metric op value'.""")
 
-    scparam(cfg,[*path, standard, item, 'step'],
-            sctype='str',
-            shorthelp=f"{emit_help} item step",
-            switch=f"-{emit_group}_step '{emit_switch}standard item <str>'",
+    scparam(cfg,[*path, standard, item, 'tasks'],
+            sctype='[(str,str,str)]',
+            shorthelp=f"{emit_help} item task",
+            switch=f"-{emit_group}_task '{emit_switch}standard item <(str, str, str)>'",
             example=[
-                f"cli: -{emit_group}_step '{emit_switch}ISO D000 place'",
-                f"api: chip.set({emit_api},'ISO','D000','step','place')"],
+                f"cli: -{emit_group}_task '{emit_switch}ISO D000 (job0, place, 0)'",
+                f"api: chip.set({emit_api},'ISO','D000','task',('job0', 'place', '0')"],
             schelp=f"""
-            Flowgraph step used to verify the {group} checklist item.
+            Flowgraph job and task used to verify the {group} checklist item.
             The parameter should be left empty for manual and for tool
             flows that bypass the SC infrastructure.""")
 
-    scparam(cfg,[*path, standard, item, 'index'],
-            sctype='str',
-            defvalue='0',
-            shorthelp=f"{emit_help} item index",
-            switch=f"-{emit_group}_index '{emit_switch}standard item <str>'",
-            example=[
-                f"cli: -{emit_group}_index '{emit_switch}ISO D000 1'",
-                f"api: chip.set({emit_api},'ISO','D000','index','1')"],
-            schelp=f"""
-            Flowgraph index used to verify the {group} checklist item.
-            The parameter should be left empty for manual checks and
-            for tool flows that bypass the SC infrastructure.""")
-
-    scparam(cfg,[*path, standard, item, 'report', metric],
+    scparam(cfg,[*path, standard, item, 'report'],
             sctype='[file]',
             shorthelp=f"{emit_help} item metric report",
             switch=f"-{emit_group}_report '{emit_switch}standard item metric <file>'",
@@ -2829,8 +2816,7 @@ def schema_checklist(cfg, group='checklist'):
                 f"api: chip.set({emit_api},'ISO','D000','report','hold', 'my.rpt')"],
             schelp=f"""
             Filepath to report(s) of specified type documenting the successful
-            validation of the {group} checklist item. Specified on a per
-            metric basis.""")
+            validation of the {group} checklist item.""")
 
     scparam(cfg,[*path, standard, item, 'waiver', metric],
             sctype='[file]',

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2795,13 +2795,13 @@ def schema_checklist(cfg, group='checklist'):
             a metric, a relational operator, and a value in the form.
             'metric op value'.""")
 
-    scparam(cfg,[*path, standard, item, 'tasks'],
+    scparam(cfg,[*path, standard, item, 'task'],
             sctype='[(str,str,str)]',
             shorthelp=f"{emit_help} item task",
-            switch=f"-{emit_group}_tasks '{emit_switch}standard item <(str, str, str)>'",
+            switch=f"-{emit_group}_task '{emit_switch}standard item <(str, str, str)>'",
             example=[
-                f"cli: -{emit_group}_tasks '{emit_switch}ISO D000 (job0,place,0)'",
-                f"api: chip.set({emit_api},'ISO','D000','tasks',('job0','place','0'))"],
+                f"cli: -{emit_group}_task '{emit_switch}ISO D000 (job0,place,0)'",
+                f"api: chip.set({emit_api},'ISO','D000','task',('job0','place','0'))"],
             schelp=f"""
             Flowgraph job and task used to verify the {group} checklist item.
             The parameter should be left empty for manual and for tool

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2798,10 +2798,10 @@ def schema_checklist(cfg, group='checklist'):
     scparam(cfg,[*path, standard, item, 'tasks'],
             sctype='[(str,str,str)]',
             shorthelp=f"{emit_help} item task",
-            switch=f"-{emit_group}_task '{emit_switch}standard item <(str, str, str)>'",
+            switch=f"-{emit_group}_tasks '{emit_switch}standard item <(str, str, str)>'",
             example=[
-                f"cli: -{emit_group}_task '{emit_switch}ISO D000 (job0, place, 0)'",
-                f"api: chip.set({emit_api},'ISO','D000','task',('job0', 'place', '0')"],
+                f"cli: -{emit_group}_tasks '{emit_switch}ISO D000 (job0,place,0)'",
+                f"api: chip.set({emit_api},'ISO','D000','tasks',('job0','place','0'))"],
             schelp=f"""
             Flowgraph job and task used to verify the {group} checklist item.
             The parameter should be left empty for manual and for tool
@@ -2809,11 +2809,11 @@ def schema_checklist(cfg, group='checklist'):
 
     scparam(cfg,[*path, standard, item, 'report'],
             sctype='[file]',
-            shorthelp=f"{emit_help} item metric report",
-            switch=f"-{emit_group}_report '{emit_switch}standard item metric <file>'",
+            shorthelp=f"{emit_help} item report",
+            switch=f"-{emit_group}_report '{emit_switch}standard item <file>'",
             example=[
-                f"cli: -{emit_group}_report '{emit_switch}ISO D000 bold my.rpt'",
-                f"api: chip.set({emit_api},'ISO','D000','report','hold', 'my.rpt')"],
+                f"cli: -{emit_group}_report '{emit_switch}ISO D000 my.rpt'",
+                f"api: chip.set({emit_api},'ISO','D000','report','my.rpt')"],
             schelp=f"""
             Filepath to report(s) of specified type documenting the successful
             validation of the {group} checklist item.""")

--- a/siliconcompiler/targets/skywater130_demo.py
+++ b/siliconcompiler/targets/skywater130_demo.py
@@ -34,6 +34,7 @@ def setup(chip):
     chip.load_flow('asictopflow')
     chip.load_flow('signoffflow')
     chip.load_lib('sky130')
+    chip.load_checklist('oh_tapeout')
 
     #3. Set default targets
     chip.set('flow', 'asicflow')

--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -76,9 +76,14 @@ def setup(chip):
     if step == 'extspice':
         chip.add('eda', tool, 'output', step, index, f'{design}.spice')
 
+    # TODO: actually parse errors/warnings in post_process()
+    logfile = f"{step}.log"
+    chip.set('eda', tool, 'report', step, index, 'errors', logfile)
+    chip.set('eda', tool, 'report', step, index, 'warnings', logfile)
+
     if step == 'drc':
         report_path = f'reports/{design}.drc'
-        chip.set('eda', tool, 'report', step, index, 'errors', report_path)
+        chip.set('eda', tool, 'report', step, index, 'drvs', report_path)
 
 ################################
 # Version Check
@@ -107,7 +112,7 @@ def post_process(chip):
                 errors = re.search(r'^\[INFO\]: COUNT: (\d+)', line)
 
                 if errors:
-                    chip.set('metric', step, index, 'errors', 'real', errors.group(1))
+                    chip.set('metric', step, index, 'drvs', 'real', errors.group(1))
 
     #TODO: return error code
     return 0

--- a/siliconcompiler/tools/netgen/netgen.py
+++ b/siliconcompiler/tools/netgen/netgen.py
@@ -69,8 +69,11 @@ def setup(chip):
     else:
         chip.add('eda', tool, 'input', step, index, f'{design}.vg')
 
+    # TODO: actually parse tool errors in post_process()
+    logfile = f'{step}.log'
     report_path = f'reports/{design}.lvs.out'
-    chip.set('eda', tool, 'report', step, index, 'errors', report_path)
+    chip.set('eda', tool, 'report', step, index, 'errors', logfile)
+    chip.set('eda', tool, 'report', step, index, 'drvs', report_path)
     chip.set('eda', tool, 'report', step, index, 'warnings', report_path)
 
 ################################
@@ -104,7 +107,7 @@ def post_process(chip):
         # details.
         pin_failures = lvs_failures[3]
         errors = lvs_failures[0] - pin_failures
-        chip.set('metric', step, index, 'errors', 'real', errors)
+        chip.set('metric', step, index, 'drvs', 'real', errors)
         chip.set('metric', step, index, 'warnings', 'real', pin_failures)
 
     #TODO: return error code

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -546,11 +546,11 @@
                     "type": "str",
                     "value": null
                 },
-                "tasks": {
+                "task": {
                     "defvalue": [],
                     "example": [
-                        "cli: -checklist_tasks 'ISO D000 (job0,place,0)'",
-                        "api: chip.set('checklist','ISO','D000','tasks',('job0','place','0'))"
+                        "cli: -checklist_task 'ISO D000 (job0,place,0)'",
+                        "api: chip.set('checklist','ISO','D000','task',('job0','place','0'))"
                     ],
                     "help": "Flowgraph job and task used to verify the checklist checklist item.\nThe parameter should be left empty for manual and for tool\nflows that bypass the SC infrastructure.",
                     "lock": "false",
@@ -558,7 +558,7 @@
                     "scope": "global",
                     "shorthelp": "Checklist item task",
                     "signature": [],
-                    "switch": "-checklist_tasks 'standard item <(str, str, str)>'",
+                    "switch": "-checklist_task 'standard item <(str, str, str)>'",
                     "type": "[(str,str,str)]",
                     "value": []
                 },
@@ -2117,11 +2117,11 @@
                             "type": "str",
                             "value": null
                         },
-                        "tasks": {
+                        "task": {
                             "defvalue": [],
                             "example": [
-                                "cli: -library_checklist_tasks 'lib ISO D000 (job0,place,0)'",
-                                "api: chip.set('library','default','checklist','ISO','D000','tasks',('job0','place','0'))"
+                                "cli: -library_checklist_task 'lib ISO D000 (job0,place,0)'",
+                                "api: chip.set('library','default','checklist','ISO','D000','task',('job0','place','0'))"
                             ],
                             "help": "Flowgraph job and task used to verify the library checklist item.\nThe parameter should be left empty for manual and for tool\nflows that bypass the SC infrastructure.",
                             "lock": "false",
@@ -2129,7 +2129,7 @@
                             "scope": "global",
                             "shorthelp": "Library checklist item task",
                             "signature": [],
-                            "switch": "-library_checklist_tasks 'lib standard item <(str, str, str)>'",
+                            "switch": "-library_checklist_task 'lib standard item <(str, str, str)>'",
                             "type": "[(str,str,str)]",
                             "value": []
                         },

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -477,22 +477,6 @@
                     "type": "str",
                     "value": null
                 },
-                "index": {
-                    "defvalue": "0",
-                    "example": [
-                        "cli: -checklist_index 'ISO D000 1'",
-                        "api: chip.set('checklist','ISO','D000','index','1')"
-                    ],
-                    "help": "Flowgraph index used to verify the checklist checklist item.\nThe parameter should be left empty for manual checks and\nfor tool flows that bypass the SC infrastructure.",
-                    "lock": "false",
-                    "require": null,
-                    "scope": "global",
-                    "shorthelp": "Checklist item index",
-                    "signature": null,
-                    "switch": "-checklist_index 'standard item <str>'",
-                    "type": "str",
-                    "value": "0"
-                },
                 "ok": {
                     "defvalue": "false",
                     "example": [
@@ -526,27 +510,25 @@
                     "value": []
                 },
                 "report": {
-                    "default": {
-                        "author": [],
-                        "copy": "false",
-                        "date": [],
-                        "defvalue": [],
-                        "example": [
-                            "cli: -checklist_report 'ISO D000 bold my.rpt'",
-                            "api: chip.set('checklist','ISO','D000','report','hold', 'my.rpt')"
-                        ],
-                        "filehash": [],
-                        "hashalgo": "sha256",
-                        "help": "Filepath to report(s) of specified type documenting the successful\nvalidation of the checklist checklist item. Specified on a per\nmetric basis.",
-                        "lock": "false",
-                        "require": null,
-                        "scope": "global",
-                        "shorthelp": "Checklist item metric report",
-                        "signature": [],
-                        "switch": "-checklist_report 'standard item metric <file>'",
-                        "type": "[file]",
-                        "value": []
-                    }
+                    "author": [],
+                    "copy": "false",
+                    "date": [],
+                    "defvalue": [],
+                    "example": [
+                        "cli: -checklist_report 'ISO D000 bold my.rpt'",
+                        "api: chip.set('checklist','ISO','D000','report','hold', 'my.rpt')"
+                    ],
+                    "filehash": [],
+                    "hashalgo": "sha256",
+                    "help": "Filepath to report(s) of specified type documenting the successful\nvalidation of the checklist checklist item.",
+                    "lock": "false",
+                    "require": null,
+                    "scope": "global",
+                    "shorthelp": "Checklist item metric report",
+                    "signature": [],
+                    "switch": "-checklist_report 'standard item metric <file>'",
+                    "type": "[file]",
+                    "value": []
                 },
                 "requirement": {
                     "defvalue": null,
@@ -564,21 +546,21 @@
                     "type": "str",
                     "value": null
                 },
-                "step": {
-                    "defvalue": null,
+                "tasks": {
+                    "defvalue": [],
                     "example": [
-                        "cli: -checklist_step 'ISO D000 place'",
-                        "api: chip.set('checklist','ISO','D000','step','place')"
+                        "cli: -checklist_task 'ISO D000 (job0, place, 0)'",
+                        "api: chip.set('checklist','ISO','D000','task',('job0', 'place', '0')"
                     ],
-                    "help": "Flowgraph step used to verify the checklist checklist item.\nThe parameter should be left empty for manual and for tool\nflows that bypass the SC infrastructure.",
+                    "help": "Flowgraph job and task used to verify the checklist checklist item.\nThe parameter should be left empty for manual and for tool\nflows that bypass the SC infrastructure.",
                     "lock": "false",
                     "require": null,
                     "scope": "global",
-                    "shorthelp": "Checklist item step",
-                    "signature": null,
-                    "switch": "-checklist_step 'standard item <str>'",
-                    "type": "str",
-                    "value": null
+                    "shorthelp": "Checklist item task",
+                    "signature": [],
+                    "switch": "-checklist_task 'standard item <(str, str, str)>'",
+                    "type": "[(str,str,str)]",
+                    "value": []
                 },
                 "waiver": {
                     "default": {
@@ -2066,22 +2048,6 @@
                             "type": "str",
                             "value": null
                         },
-                        "index": {
-                            "defvalue": "0",
-                            "example": [
-                                "cli: -library_checklist_index 'lib ISO D000 1'",
-                                "api: chip.set('library','default','checklist','ISO','D000','index','1')"
-                            ],
-                            "help": "Flowgraph index used to verify the library checklist item.\nThe parameter should be left empty for manual checks and\nfor tool flows that bypass the SC infrastructure.",
-                            "lock": "false",
-                            "require": null,
-                            "scope": "global",
-                            "shorthelp": "Library checklist item index",
-                            "signature": null,
-                            "switch": "-library_checklist_index 'lib standard item <str>'",
-                            "type": "str",
-                            "value": "0"
-                        },
                         "ok": {
                             "defvalue": "false",
                             "example": [
@@ -2115,27 +2081,25 @@
                             "value": []
                         },
                         "report": {
-                            "default": {
-                                "author": [],
-                                "copy": "false",
-                                "date": [],
-                                "defvalue": [],
-                                "example": [
-                                    "cli: -library_checklist_report 'lib ISO D000 bold my.rpt'",
-                                    "api: chip.set('library','default','checklist','ISO','D000','report','hold', 'my.rpt')"
-                                ],
-                                "filehash": [],
-                                "hashalgo": "sha256",
-                                "help": "Filepath to report(s) of specified type documenting the successful\nvalidation of the library checklist item. Specified on a per\nmetric basis.",
-                                "lock": "false",
-                                "require": null,
-                                "scope": "global",
-                                "shorthelp": "Library checklist item metric report",
-                                "signature": [],
-                                "switch": "-library_checklist_report 'lib standard item metric <file>'",
-                                "type": "[file]",
-                                "value": []
-                            }
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "example": [
+                                "cli: -library_checklist_report 'lib ISO D000 bold my.rpt'",
+                                "api: chip.set('library','default','checklist','ISO','D000','report','hold', 'my.rpt')"
+                            ],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "help": "Filepath to report(s) of specified type documenting the successful\nvalidation of the library checklist item.",
+                            "lock": "false",
+                            "require": null,
+                            "scope": "global",
+                            "shorthelp": "Library checklist item metric report",
+                            "signature": [],
+                            "switch": "-library_checklist_report 'lib standard item metric <file>'",
+                            "type": "[file]",
+                            "value": []
                         },
                         "requirement": {
                             "defvalue": null,
@@ -2153,21 +2117,21 @@
                             "type": "str",
                             "value": null
                         },
-                        "step": {
-                            "defvalue": null,
+                        "tasks": {
+                            "defvalue": [],
                             "example": [
-                                "cli: -library_checklist_step 'lib ISO D000 place'",
-                                "api: chip.set('library','default','checklist','ISO','D000','step','place')"
+                                "cli: -library_checklist_task 'lib ISO D000 (job0, place, 0)'",
+                                "api: chip.set('library','default','checklist','ISO','D000','task',('job0', 'place', '0')"
                             ],
-                            "help": "Flowgraph step used to verify the library checklist item.\nThe parameter should be left empty for manual and for tool\nflows that bypass the SC infrastructure.",
+                            "help": "Flowgraph job and task used to verify the library checklist item.\nThe parameter should be left empty for manual and for tool\nflows that bypass the SC infrastructure.",
                             "lock": "false",
                             "require": null,
                             "scope": "global",
-                            "shorthelp": "Library checklist item step",
-                            "signature": null,
-                            "switch": "-library_checklist_step 'lib standard item <str>'",
-                            "type": "str",
-                            "value": null
+                            "shorthelp": "Library checklist item task",
+                            "signature": [],
+                            "switch": "-library_checklist_task 'lib standard item <(str, str, str)>'",
+                            "type": "[(str,str,str)]",
+                            "value": []
                         },
                         "waiver": {
                             "default": {

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -515,8 +515,8 @@
                     "date": [],
                     "defvalue": [],
                     "example": [
-                        "cli: -checklist_report 'ISO D000 bold my.rpt'",
-                        "api: chip.set('checklist','ISO','D000','report','hold', 'my.rpt')"
+                        "cli: -checklist_report 'ISO D000 my.rpt'",
+                        "api: chip.set('checklist','ISO','D000','report','my.rpt')"
                     ],
                     "filehash": [],
                     "hashalgo": "sha256",
@@ -524,9 +524,9 @@
                     "lock": "false",
                     "require": null,
                     "scope": "global",
-                    "shorthelp": "Checklist item metric report",
+                    "shorthelp": "Checklist item report",
                     "signature": [],
-                    "switch": "-checklist_report 'standard item metric <file>'",
+                    "switch": "-checklist_report 'standard item <file>'",
                     "type": "[file]",
                     "value": []
                 },
@@ -549,8 +549,8 @@
                 "tasks": {
                     "defvalue": [],
                     "example": [
-                        "cli: -checklist_task 'ISO D000 (job0, place, 0)'",
-                        "api: chip.set('checklist','ISO','D000','task',('job0', 'place', '0')"
+                        "cli: -checklist_tasks 'ISO D000 (job0,place,0)'",
+                        "api: chip.set('checklist','ISO','D000','tasks',('job0','place','0'))"
                     ],
                     "help": "Flowgraph job and task used to verify the checklist checklist item.\nThe parameter should be left empty for manual and for tool\nflows that bypass the SC infrastructure.",
                     "lock": "false",
@@ -558,7 +558,7 @@
                     "scope": "global",
                     "shorthelp": "Checklist item task",
                     "signature": [],
-                    "switch": "-checklist_task 'standard item <(str, str, str)>'",
+                    "switch": "-checklist_tasks 'standard item <(str, str, str)>'",
                     "type": "[(str,str,str)]",
                     "value": []
                 },
@@ -2086,8 +2086,8 @@
                             "date": [],
                             "defvalue": [],
                             "example": [
-                                "cli: -library_checklist_report 'lib ISO D000 bold my.rpt'",
-                                "api: chip.set('library','default','checklist','ISO','D000','report','hold', 'my.rpt')"
+                                "cli: -library_checklist_report 'lib ISO D000 my.rpt'",
+                                "api: chip.set('library','default','checklist','ISO','D000','report','my.rpt')"
                             ],
                             "filehash": [],
                             "hashalgo": "sha256",
@@ -2095,9 +2095,9 @@
                             "lock": "false",
                             "require": null,
                             "scope": "global",
-                            "shorthelp": "Library checklist item metric report",
+                            "shorthelp": "Library checklist item report",
                             "signature": [],
-                            "switch": "-library_checklist_report 'lib standard item metric <file>'",
+                            "switch": "-library_checklist_report 'lib standard item <file>'",
                             "type": "[file]",
                             "value": []
                         },
@@ -2120,8 +2120,8 @@
                         "tasks": {
                             "defvalue": [],
                             "example": [
-                                "cli: -library_checklist_task 'lib ISO D000 (job0, place, 0)'",
-                                "api: chip.set('library','default','checklist','ISO','D000','task',('job0', 'place', '0')"
+                                "cli: -library_checklist_tasks 'lib ISO D000 (job0,place,0)'",
+                                "api: chip.set('library','default','checklist','ISO','D000','tasks',('job0','place','0'))"
                             ],
                             "help": "Flowgraph job and task used to verify the library checklist item.\nThe parameter should be left empty for manual and for tool\nflows that bypass the SC infrastructure.",
                             "lock": "false",
@@ -2129,7 +2129,7 @@
                             "scope": "global",
                             "shorthelp": "Library checklist item task",
                             "signature": [],
-                            "switch": "-library_checklist_task 'lib standard item <(str, str, str)>'",
+                            "switch": "-library_checklist_tasks 'lib standard item <(str, str, str)>'",
                             "type": "[(str,str,str)]",
                             "value": []
                         },

--- a/tests/core/test_checklist.py
+++ b/tests/core/test_checklist.py
@@ -1,23 +1,39 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 import siliconcompiler
 
+import os
+
 def test_checklist():
     '''API test for help method
     '''
 
     chip = siliconcompiler.Chip(loglevel="INFO")
+    chip.set('design', 'test')
     chip.load_target('freepdk45_demo')
 
-    #automated fail
+    # Test won't work if file doesn't exist
+    os.makedirs('build/test/job0/syn/0')
+    with open('build/test/job0/syn/0/yosys.log', 'w') as f:
+        f.write('test')
+
     chip.set('metric','syn','0', 'errors', 'real', 1)
-    chip.set('eda','yosys','report', 'syn', '0', 'qor', 'qor.rpt')
+    chip.set('eda', 'yosys', 'report', 'syn', '0', 'errors', 'yosys.log')
+    chip.record_history()
+
+    #automated fail
     chip.set('checklist','iso', 'd0', 'criteria', 'errors==0')
-    chip.set('checklist','iso', 'd0', 'step', 'syn')
-    assert not chip.check_checklist('iso', 'd0')
+    chip.set('checklist','iso', 'd0', 'tasks', ('job0', 'syn', '0'))
+    assert not chip.check_checklist('iso', ['d0'])
 
     #automated pass
-    chip.set('checklist','iso', 'd1', 'step', 'syn')
-    assert chip.check_checklist('iso', 'd1')
+    chip.set('checklist', 'iso', 'd1', 'criteria', 'errors<2')
+    chip.set('checklist','iso', 'd1', 'tasks', ('job0', 'syn', '0'))
+    assert chip.check_checklist('iso', ['d1'])
+
+    assert not chip.check_checklist('iso', ['d1'], check_ok=True)
+
+    chip.set('checklist', 'iso', 'd1', 'ok', True)
+    assert chip.check_checklist('iso', ['d1'], check_ok=True)
 
 #########################
 if __name__ == "__main__":

--- a/tests/core/test_checklist.py
+++ b/tests/core/test_checklist.py
@@ -22,12 +22,12 @@ def test_checklist():
 
     #automated fail
     chip.set('checklist','iso', 'd0', 'criteria', 'errors==0')
-    chip.set('checklist','iso', 'd0', 'tasks', ('job0', 'syn', '0'))
+    chip.set('checklist','iso', 'd0', 'task', ('job0', 'syn', '0'))
     assert not chip.check_checklist('iso', ['d0'])
 
     #automated pass
     chip.set('checklist', 'iso', 'd1', 'criteria', 'errors<2')
-    chip.set('checklist','iso', 'd1', 'tasks', ('job0', 'syn', '0'))
+    chip.set('checklist','iso', 'd1', 'task', ('job0', 'syn', '0'))
     assert chip.check_checklist('iso', ['d1'])
 
     assert not chip.check_checklist('iso', ['d1'], check_ok=True)

--- a/tests/core/test_setget.py
+++ b/tests/core/test_setget.py
@@ -35,7 +35,7 @@ def test_setget():
         if tuplematch:
             keypath = tuplematch.group(1).split(',')
             tuplestr = tuplematch.group(2)
-            if '(str,str)' in sctype:
+            if sctype.strip('[]').startswith('(str,'):
                 tuplestr = re.sub(r'[\(\)\'\s]','',tuplestr)
                 value = tuple(tuplestr.split(','))
             else:

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -42,7 +42,7 @@ def test_py_sky130(setup_example_test):
     import gcd_skywater
     gcd_skywater.main()
 
-    assert os.path.isfile('build/gcd/job0/export/0/outputs/gcd.gds')
+    assert os.path.isfile('build/gcd/rtl2gds/export/0/outputs/gcd.gds')
 
     manifest = 'build/gcd/signoff/signoff/0/outputs/gcd.pkg.json'
     assert os.path.isfile(manifest)
@@ -51,8 +51,8 @@ def test_py_sky130(setup_example_test):
     chip.read_manifest(manifest)
 
     # Verify that the build was LVS and DRC clean.
-    assert chip.get('metric', 'lvs', '0', 'errors', 'real') == 0
-    assert chip.get('metric', 'drc', '0', 'errors', 'real') == 0
+    assert chip.get('metric', 'lvs', '0', 'drvs', 'real') == 0
+    assert chip.get('metric', 'drc', '0', 'drvs', 'real') == 0
 
 @pytest.mark.eda
 def test_cli_asap7(setup_example_test):


### PR DESCRIPTION
This PR implements checklist functionality. Main changes:

- Add `load_checklist()` function to dynamically load checklist modules
- Re-implement `check_checklist()` based on the algorithm we discussed offline
   - Items that can be automatically checked must meet criteria for all associated tasks (unless waivers exist), and EDA reports must exist for all criteria
   - Items that are not automatically checked must have at least one report (manually added)
   - If `check_ok` is True, items must also have 'ok' parameter checked
- Re-architect the 'checklist' schema slightly to enable automatic checks of multiple tasks
  - I also got rid of the 'metric' subkey under 'report' to simplify things a bit, since we seemed okay with it being a catch-all bucket. However, I can add that back if you don't think that's a good change.
- Add example to `gcd_skywater.py` with simple subset of the OH tapeout checklist

Since the `check_checklist()` function has to go back into the schema history to handle multiple jobs, this change also entailed adding an optional `job` kwarg to some of our core functions, following the pattern of `set`/`get`/`add`.