### PR TITLE
Update openroad version

### DIFF
--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -64,7 +64,7 @@ def setup(chip, mode='batch'):
 
     chip.set('eda', tool, 'exe', tool, clobber=clobber)
     chip.set('eda', tool, 'vswitch', '-version', clobber=clobber)
-    chip.set('eda', tool, 'version', '>=v2.0-3078', clobber=clobber)
+    chip.set('eda', tool, 'version', '>=v2.0-3394', clobber=clobber)
     chip.set('eda', tool, 'format', 'tcl', clobber=clobber)
     chip.set('eda', tool, 'copy', 'true', clobber=clobber)
     chip.set('eda', tool, 'option',  step, index, option, clobber=clobber)


### PR DESCRIPTION
It looks like we can update our version of OpenROAD to include some recent power grid generation improvements without changing our tcl scripts.

I tested the newer version on Ubuntu 20.04 and RHEL7.9 with our heartbeat and ZeroSoC examples, and everything completed successfully.

I've also installed the newer version on our CI runner so that the tests pass, but we can revert that if problems crop up.