### PR TITLE
Decode non-ASCII stdout output in AppGen

### DIFF
--- a/docs/_ext/dynamicgen.py
+++ b/docs/_ext/dynamicgen.py
@@ -427,7 +427,7 @@ class AppGen(DynamicGen):
         cmd_name = modname.replace('_', '-')
         cmd = [cmd_name, '--help']
 
-        output = subprocess.check_output(cmd).decode('ascii')
+        output = subprocess.check_output(cmd).decode('utf-8')
 
         section = build_section(cmd_name, cmd_name)
         section += literalblock(output)


### PR DESCRIPTION
This change should fix the failing docs build in `pacman` branch. The AppGen extension expected app help output to be all ASCII, but 'sup' uses unicode characters for representing the directory structure.