### PR TITLE
Remove single-step flow logic from run()

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3268,36 +3268,6 @@ class Chip:
             prevstep = step
 
     ###########################################################################
-    def single_step(self, step, tool, flow=None):
-        '''
-        Sets up a flow that runs a single tool step.
-
-        This function creates a flowgraph that runs a single tool step. If the
-        specified step name is not "import", this function adds a no-op "import"
-        step to satisfy the import requirement. This function also sets weights
-        for a few basic metrics to ensure that the summary() function displays
-        errors, warnings, and runtime.
-
-        Args:
-            step (str): Name of step
-            tool (str): Name of tool
-            flow (str): Name of flow to instantiate. If `None`, defaults to tool
-                name
-        '''
-        if flow is None:
-            flow = tool
-
-        self.node(flow, step, tool)
-
-        if step != 'import':
-            self.node(flow, 'import', 'nop')
-            self.edge('import', step)
-
-        self.set('flowgraph', flow, step, '0', 'weight', 'errors', 0)
-        self.set('flowgraph', flow, step, '0', 'weight', 'warnings', 0)
-        self.set('flowgraph', flow, step, '0', 'weight', 'runtime', 0)
-
-    ###########################################################################
     def join(self, *tasks):
         '''
         Merges outputs from a list of input tasks.

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2148,7 +2148,7 @@ def schema_options(cfg):
                      "api: chip.set('flow','asicflow')"],
             schelp="""
             Sets the flow for the current run. The flow name
-            must match up with an 'flow' in the flowgraph""")
+            must match up with a 'flow' in the flowgraph""")
 
     scparam(cfg, ['optmode'],
             sctype='str',

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1307,7 +1307,7 @@
             "cli: -flow asicfow",
             "api: chip.set('flow','asicflow')"
         ],
-        "help": "Sets the flow for the current run. The flow name\nmust match up with an 'flow' in the flowgraph",
+        "help": "Sets the flow for the current run. The flow name\nmust match up with a 'flow' in the flowgraph",
         "lock": "false",
         "require": null,
         "scope": "job",

--- a/tests/tools/test_ghdl.py
+++ b/tests/tools/test_ghdl.py
@@ -14,7 +14,8 @@ def test_ghdl(datadir):
     chip.set('source', design_src)
     chip.set('design', design)
     chip.set('mode', 'sim')
-    chip.set('arg','step','import')
+
+    chip.single_step('import', 'ghdl')
     chip.set('flow', 'ghdl')
 
     chip.run()

--- a/tests/tools/test_ghdl.py
+++ b/tests/tools/test_ghdl.py
@@ -15,7 +15,7 @@ def test_ghdl(datadir):
     chip.set('design', design)
     chip.set('mode', 'sim')
 
-    chip.single_step('import', 'ghdl')
+    chip.node('ghdl', 'import', 'ghdl')
     chip.set('flow', 'ghdl')
 
     chip.run()

--- a/tests/tools/test_icarus.py
+++ b/tests/tools/test_icarus.py
@@ -17,8 +17,13 @@ def test_icarus(oh_dir):
     chip.set('design', design)
     chip.set('source', topfile)
     chip.set('mode', 'sim')
-    chip.set('arg','step','compile')
-    chip.set('flow', 'icarus')
+
+    flow = 'sim'
+    chip.node(flow, 'import', 'nop')
+    chip.node(flow, 'compile', 'icarus')
+    chip.edge(flow, 'import', 'compile')
+    chip.set('flow', flow)
+
     chip.run()
 
     # check that compilation succeeded

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -21,8 +21,11 @@ def test_klayout(datadir):
     chip.set('library', 'heartbeat', 'lef', '10M', library_lef)
     chip.set('library', 'heartbeat', 'gds', '10M', library_gds)
 
-    chip.set('arg', 'step', 'export')
-    chip.set('flow', 'klayout')
+    flow = 'export'
+    chip.node(flow, 'import', 'nop')
+    chip.node(flow, 'export', 'klayout')
+    chip.edge(flow, 'import', 'export')
+    chip.set('flow', flow)
 
     chip.set('eda', 'klayout', 'variable', 'export', '0', 'timestamps', 'false')
 

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -24,8 +24,11 @@ def test_openroad(scroot):
     chip.load_target("freepdk45_demo")
 
     # set up tool for floorplan
-    chip.set('flow', 'openroad')
-    chip.set('arg', 'step', 'floorplan')
+    flow = 'floorplan'
+    chip.node(flow, 'import', 'nop')
+    chip.node(flow, 'floorplan', 'openroad')
+    chip.edge(flow, 'import', 'floorplan')
+    chip.set('flow', flow)
 
     chip.run()
 

--- a/tests/tools/test_surelog.py
+++ b/tests/tools/test_surelog.py
@@ -19,7 +19,7 @@ def test_surelog(scroot):
     chip.add('source', gcd_src)
     chip.set('design', design)
     chip.set('mode', 'sim')
-    chip.set('arg', 'step', step)
+    chip.node('surelog', step, 'surelog')
     chip.set('flow', 'surelog')
 
     chip.run()
@@ -39,8 +39,8 @@ def test_surelog_preproc_regression(datadir):
     chip.add('source', src)
     chip.add('define', 'MEM_ROOT=test')
     chip.set('design', design)
-    chip.set('mode', 'asicflow')
-    chip.set('arg', 'step', step)
+    chip.set('mode', 'sim')
+    chip.node('surelog', step, 'surelog')
     chip.set('flow', 'surelog')
 
     chip.run()
@@ -65,7 +65,7 @@ def test_replay(scroot):
     chip.add('source', src)
     chip.set('design', design)
     chip.set('mode', 'sim')
-    chip.set('arg', 'step', step)
+    chip.node('surelog', step, 'surelog')
     chip.set('flow', 'surelog')
     chip.set('quiet', True)
     chip.set('eda', 'surelog', 'env', step, '0', 'SLOG_ENV', 'SUCCESS')

--- a/tests/tools/test_verilator.py
+++ b/tests/tools/test_verilator.py
@@ -20,7 +20,7 @@ def test_verilator(oh_dir):
     chip.set('relax', True)
     chip.set('quiet', True)
     chip.set('mode', 'sim')
-    chip.set('arg','step',step)
+    chip.node('verilator', step, 'verilator')
     chip.set('flow','verilator')
     chip.run()
 

--- a/tests/tools/test_yosys.py
+++ b/tests/tools/test_yosys.py
@@ -10,10 +10,14 @@ def test_yosys_lec(datadir):
     chip = siliconcompiler.Chip()
     chip.load_target('freepdk45_demo')
 
-    chip.set('arg', 'step', 'lec')
     chip.set('design', 'foo')
     chip.set('mode', 'asic')
-    chip.set('flow', 'yosys')
+
+    flow = 'lec'
+    chip.node(flow, 'import', 'nop')
+    chip.node(flow, 'lec', 'yosys')
+    chip.edge(flow, 'import', 'lec')
+    chip.set('flow', flow)
 
     chip.add('source', os.path.join(lec_dir, 'foo.v'))
     chip.add('read', 'netlist', 'lec', '0', os.path.join(lec_dir, 'foo.vg'))
@@ -32,10 +36,15 @@ def test_yosys_lec_broken(datadir):
     chip = siliconcompiler.Chip()
     chip.load_target('freepdk45_demo')
 
-    chip.set('arg', 'step', 'lec')
     chip.set('design', 'foo')
     chip.set('mode', 'asic')
-    chip.set('flow', 'yosys')
+
+    flow = 'lec'
+    chip.node(flow, 'import', 'nop')
+    chip.node(flow, 'lec', 'yosys')
+    chip.edge(flow, 'import', 'lec')
+    chip.set('flow', flow)
+
     chip.set('eda', 'yosys', 'continue', True)
 
     chip.add('source', os.path.join(lec_dir, 'foo_broken.v'))


### PR DESCRIPTION
This PR removes the single-step flow logic from the top of `run()`, one of our cleanup backlog items. I replaced it with a helper function to take care of some of the boilerplate required when creating a single-step graph (import no-op, default metric weights).

A consequence of this change, however, is that we will no longer be able to concisely run a single tool step through the CLI. Before, we supported:

`sc foo.vhdl -flow icarus -arg_step compile`

Now, we'd have to do something very verbose like:

```bash
sc foo.v \
  -flow icarus \
  -flowgraph_tool "icarus compile 0 icarus" \ 
  -flowgraph_tool "icarus import 0 nop"  \
  -flowgraph_input "icarus compile 0 (import, 0)" \
  -flowgraph_weight "icarus compile 0 errors 0 " \
 etc...
```

I wanted to get thoughts on this before finalizing this change. I could see it as a dealbreaker, since I think quickly running a tool directly is a good use of the SC CLI.
