### PR TITLE
Make summary properly select winners for parallel paths

### DIFF
--- a/tests/core/test_summary.py
+++ b/tests/core/test_summary.py
@@ -27,15 +27,56 @@ def test_steplist(datadir, capfd):
     assert 'import0' not in stdout
     assert 'syn0' in stdout
 
+def test_parallel_path(capfd):
+    with capfd.disabled():
+        chip = siliconcompiler.Chip()
+        chip.set('design', 'test')
+
+        flow = 'test'
+        chip.set('flow', flow)
+        chip.node(flow, 'import', 'nop')
+        chip.node(flow, 'placemin', 'minimum')
+
+        chip.set('flowstatus', 'import', '0', 'status', siliconcompiler.TaskStatus.SUCCESS)
+        chip.set('flowstatus', 'placemin', '0', 'status', siliconcompiler.TaskStatus.SUCCESS)
+        chip.set('flowstatus', 'placemin', '0', 'select', ('cts', '1'))
+
+        for i in ('0', '1', '2'):
+            chip.node(flow, 'place', 'openroad', index=i)
+            chip.node(flow, 'cts', 'openroad', index=i)
+
+            chip.set('flowstatus', 'place', i, 'status', siliconcompiler.TaskStatus.SUCCESS)
+            chip.set('flowstatus', 'cts', i, 'status', siliconcompiler.TaskStatus.SUCCESS)
+
+            chip.edge(flow, 'place', 'cts', tail_index=i, head_index=i)
+            chip.edge(flow, 'cts', 'placemin', tail_index=i)
+            chip.edge(flow, 'import', 'place', head_index=i)
+
+            chip.set('flowstatus', 'place', i, 'select', ('import', '0'))
+            chip.set('flowstatus', 'cts', i, 'select', ('place', i))
+
+    chip.summary()
+    stdout, _ = capfd.readouterr()
+    print(stdout)
+    assert 'place1' in stdout
+    assert 'cts1' in stdout
+    assert 'place0' not in stdout
+    assert 'cts0' not in stdout
+    assert 'place2' not in stdout
+    assert 'cts2' not in stdout
+
 @pytest.mark.eda
 def test_steplist_repeat(gcd_chip, capfd):
     '''Regression test for #458.'''
     with capfd.disabled():
         gcd_chip.set('steplist', ['import', 'syn', 'floorplan'])
+        gcd_chip.run()
         gcd_chip.set('steplist', ['syn'])
+        gcd_chip.run()
 
     gcd_chip.summary()
     stdout, _ = capfd.readouterr()
+    print(stdout)
 
     assert 'import0' not in stdout
     assert 'syn0' in stdout

--- a/tests/flows/test_flowstatus.py
+++ b/tests/flows/test_flowstatus.py
@@ -60,6 +60,8 @@ def test_flowstatus(scroot, steplist):
 
     chip.run()
 
+    chip.summary()
+
     assert chip.get('flowstatus', 'place', '0', 'status') == siliconcompiler.TaskStatus.ERROR
     assert chip.get('flowstatus', 'place', '1', 'status') == siliconcompiler.TaskStatus.SUCCESS
 


### PR DESCRIPTION
This PR fixes an old bug I noticed in the summary() function. 

Suppose you have a flowgraph like the following:

![test_graph](https://user-images.githubusercontent.com/4412459/165782749-1cd5e791-88dc-4957-a25c-826b8ebc2815.png)

Let's say cts1 is selected by ctsmin. Before, summary() would display cts1, but erroneously default to displaying place2 (or whatever the last index of the previous steps are):

```
                  place2      cts1  
 errors             0          0    
 warnings           0          0   
... 
```

This PR implements a fix that searches backwards from the last tasks in the steplist to find the whole chain of selected tasks, so it will properly display place1 and cts1 in this example:


```
                  place1      cts1  
 errors             0          0    
 warnings           0          0  
...  
```
