### PR TITLE
Fix 'path' parameter behavior

### DIFF
--- a/examples/gcd/run.sh
+++ b/examples/gcd/run.sh
@@ -19,4 +19,5 @@ sc gcd.v \
    -quiet \
    -relax \
    -design gcd \
+   -track \
    -scpath $SCRIPT_DIR

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3717,6 +3717,7 @@ class Chip:
         veropt = self.get('eda', tool, 'vswitch')
         exe = self._getexe(tool)
         version = None
+        toolpath = exe # For record
         if exe is not None:
             exe_path, exe_base = os.path.split(exe)
             if veropt:
@@ -3866,7 +3867,7 @@ class Chip:
         ##################
         # 22. Make a record if tracking is enabled
         if self.get('track'):
-            self._make_record(step, index, wall_start, wall_end, version)
+            self._make_record(step, index, wall_start, wall_end, version, toolpath)
 
         ##################
         # 23. Save a successful manifest
@@ -4611,7 +4612,7 @@ class Chip:
         return 'local'
 
     #######################################
-    def _make_record(self, step, index, start, end, toolversion):
+    def _make_record(self, step, index, start, end, toolversion, toolpath):
         '''
         Records provenance details for a runstep.
         '''
@@ -4674,6 +4675,8 @@ class Chip:
 
         arch = platform.machine()
         self.set('record', step, index, 'arch', arch)
+
+        self.set('record', step, index, 'toolpath', toolpath)
 
     #######################################
     def _safecompare(self, value, op, goal):

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3735,8 +3735,9 @@ class Chip:
                     self._haltstep(step, index)
             else:
                 self.logger.info(f"Tool '{exe_base}' found in directory '{exe_path}'")
-        else:
-            self.logger.error(f'Executable {exe} not found')
+        elif tool not in self.builtin:
+            exe_base = self.get('eda', tool, 'exe')
+            self.logger.error(f'Executable {exe_base} not found')
             self._haltstep(step, index)
 
         ##################

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1262,11 +1262,10 @@ def schema_eda(cfg, tool='default', step='default', index='default'):
             example=["cli: -eda_path 'openroad /usr/local/bin'",
                      "api:  chip.set('eda','openroad','path','/usr/local/bin')"],
             schelp="""
-            File system path to tool executable. The path is pre pended to the 'exe'
-            parameter for batch runs and output as an environment variable for
-            interactive setup. The path parameter can be left blank if the 'exe'
-            is already in the environment search path.
-            Tool executable name.""")
+            File system path to tool executable. The path is prepended to the
+            system PATH environment variable for batch and interactive runs. The
+            path parameter can be left blank if the 'exe' is already in the
+            environment search path.""")
 
     scparam(cfg, ['eda', tool, 'vswitch'],
             sctype='[str]',

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2003,6 +2003,10 @@ def schema_record(cfg, step='default', index='default'):
                                '1.0',
                                """The tool version captured correspnds to the 'tool'
                                parameter within the 'eda' dictionary."""],
+                'toolpath': ['tool path',
+                             '/usr/bin/openroad',
+                             """Full path to tool executable used to run this
+                             task."""],
                'osversion': ['O/S version',
                              '20.04.1-Ubuntu',
                              """Since there is not standard version system for operating

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1001,7 +1001,7 @@
                     "cli: -eda_path 'openroad /usr/local/bin'",
                     "api:  chip.set('eda','openroad','path','/usr/local/bin')"
                 ],
-                "help": "File system path to tool executable. The path is pre pended to the 'exe'\nparameter for batch runs and output as an environment variable for\ninteractive setup. The path parameter can be left blank if the 'exe'\nis already in the environment search path.\nTool executable name.",
+                "help": "File system path to tool executable. The path is prepended to the\nsystem PATH environment variable for batch and interactive runs. The\npath parameter can be left blank if the 'exe' is already in the\nenvironment search path.",
                 "lock": "false",
                 "require": null,
                 "scope": "job",
@@ -6388,6 +6388,22 @@
                     "shorthelp": "Record: start time",
                     "signature": null,
                     "switch": "-record_starttime 'step index <str>'",
+                    "type": "str",
+                    "value": null
+                },
+                "toolpath": {
+                    "defvalue": null,
+                    "example": [
+                        "cli: -record_toolpath 'dfm 0 </usr/bin/openroad>'",
+                        "api: chip.set('record','dfm','0','toolpath', </usr/bin/openroad>)"
+                    ],
+                    "help": "Record tracking the tool path per step and index basis. Full path to tool executable used to run this\ntask.",
+                    "lock": "false",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Record: tool path",
+                    "signature": null,
+                    "switch": "-record_toolpath 'step index <str>'",
                     "type": "str",
                     "value": null
                 },

--- a/tests/tools/test_surelog.py
+++ b/tests/tools/test_surelog.py
@@ -54,6 +54,7 @@ def test_surelog_preproc_regression(datadir):
 
 @pytest.mark.eda
 @pytest.mark.quick
+@pytest.mark.skipif(sys.platform=='win32', reason='Replay script not supported on Windows')
 def test_replay(scroot):
     src = os.path.join(scroot, 'examples', 'gcd', 'gcd.v')
     design = "gcd"
@@ -73,12 +74,8 @@ def test_replay(scroot):
     chip.run()
 
     workdir = chip._getworkdir(step=step)
-    if sys.platform == 'win32':
-        script = 'replay.cmd'
-        echo = 'if %errorlevel% neq 0 exit /b %errorlevel%\necho %SLOG_ENV%'
-    else:
-        script = './replay.sh'
-        echo = 'echo $SLOG_ENV'
+    script = './replay.sh'
+    echo = 'echo $SLOG_ENV'
 
     with open(os.path.join(workdir, script), 'a') as f:
         f.write(echo + '\n')


### PR DESCRIPTION
This PR updates the ['eda', tool, 'path'] behavior to prepend the provided path to the system path and perform a search, rather than always hardcoding the provided path to the executable name.

In addition to this change, I made two tweaks to facilitate review of which executable is running:
- Logging the directory used to run the exe alongside the version
- Adding an entry to 'record' that stores the full path to the exe

Before:
```
| INFO    | job0  | syn        | 0  | Checking executable. Tool 'yosys' found with version '0.13+15'
| INFO    | job0  | syn        | 0  | Running in /home/noah/code/siliconcompiler/build/gcd/job0/syn/0
| INFO    | job0  | syn        | 0  | yosys -c /home/noah/code/siliconcompiler/siliconcompiler/tools/yosys/sc_syn.tcl
| INFO    | job0  | syn        | 0  | Finished task in 0.91s
```

After:
```
| INFO    | job0  | syn        | 0  | Tool 'yosys' found with version '0.13+15' in directory '/home/noah/eda/OpenROAD-flow-scripts/tools/install/yosys/bin'
| INFO    | job0  | syn        | 0  | Running in /home/noah/code/siliconcompiler/build/gcd/job0/syn/0
| INFO    | job0  | syn        | 0  | yosys -c /home/noah/code/siliconcompiler/siliconcompiler/tools/yosys/sc_syn.tcl
| INFO    | job0  | syn        | 0  | Finished task in 0.9s
```

One question I have: do we want the full path used hard coded in replay.sh? Current behavior is:
```
#!/bin/bash
/home/noah/eda/OpenROAD-flow-scripts/tools/install/yosys/bin/yosys -c /home/noah/code/siliconcompiler/siliconcompiler/tools/yosys/sc_syn.tcl
```

But I could see also changing this to
```
#!/bin/bash
PATH=/home/noah/eda/OpenROAD-flow-scripts/tools/install/yosys/bin/:$PATH
yosys -c /home/noah/code/siliconcompiler/siliconcompiler/tools/yosys/sc_syn.tcl
```

The first is more explicit/useful for exact replay, the second seems a bit more useful for experimenting with different versions (although one could always tweak the script by hand).
