### PR TITLE
Enable linking to schema reference manual throughout docs

### DIFF
--- a/docs/_ext/common.py
+++ b/docs/_ext/common.py
@@ -107,32 +107,41 @@ def flatten(cfg, prefix=()):
     return flat_cfg
 
 def keypath(*args):
-    text = '[' + ', '.join(args) + ']'
-    normalized_keypath = []
+    '''Helper function for displaying Schema keypaths.'''
+    text_parts = []
+    key_parts = []
     cfg = schema_cfg()
     for key in args:
         if list(cfg.keys()) != ['default']:
-            normalized_keypath.append(key)
+            text_parts.append(f"'{key}'")
+            key_parts.append(key)
             try:
                 cfg = cfg[key]
             except KeyError:
                 raise ValueError(f'Invalid keypath {args}')
         else:
             cfg = cfg['default']
+            if key.startswith('<') and key.endswith('>'):
+                # Placeholder
+                text_parts.append(key)
+            else:
+                # Fully-qualified
+                text_parts.append(f"'{key}'")
 
-    refid = '-'.join(normalized_keypath)
+    if 'help' not in cfg:
+        # Not leaf
+        text_parts.append('...')
+
+    text = f"[{', '.join(text_parts)}]"
+    refid = '-'.join(key_parts)
     # TODO: figure out URL automatically/figure out internal ref for PDF
     url = f'https://docs.siliconcompiler.com/en/latest/reference_manual/schema.html#{refid}'
 
-    # This weird node hierarchy (paragraph -> reference -> literal) is necessary
-    # for this to work with both Latex and HTML builders. The reference needs to
-    # be a child of a text node, otherwise the HTML builder fails. However, it
-    # cannot be a child of a literal node, otherwise the URL gets mangled by the
-    # Latex builder for some reason.
-    para_node = nodes.paragraph()
+    # Note: The literal node returned by code() must be a child of the reference
+    # node (not the other way round), otherwise the Latex builder mangles the
+    # URL.
     ref_node = nodes.reference(internal=False, refuri=url)
     text_node = code(text)
-    para_node += ref_node
     ref_node += text_node
 
-    return para_node
+    return ref_node

--- a/docs/_ext/dynamicgen.py
+++ b/docs/_ext/dynamicgen.py
@@ -40,8 +40,6 @@ def build_schema_value_table(schema, keypath_prefix=[], skip_zero_weight=False):
             'value' in val and val['value'] == '0'):
             continue
 
-        keypath = ', '.join(full_keypath)
-
         if 'value' in val and val['value']:
             # Don't display false booleans
             if val['type'] == 'bool' and val['value'] == 'false':
@@ -56,7 +54,7 @@ def build_schema_value_table(schema, keypath_prefix=[], skip_zero_weight=False):
             else:
                 val_node = code(val['value'])
 
-            table.append([code(keypath), val_node])
+            table.append([keypath(*full_keypath), val_node])
 
     if len(table) > 1:
         return build_table(table)
@@ -118,6 +116,8 @@ class DynamicGen(SphinxDirective):
 
     def document_module(self, module, modname, path):
         '''Build section documenting given module and name.'''
+        print(f'Generating docs for module {modname}...')
+
         s = build_section_with_target(modname, f'{modname}-ref', self.state.document)
 
         if not hasattr(module, 'make_docs'):
@@ -282,7 +282,7 @@ class FlowGen(DynamicGen):
         section = build_section('showtool', section_key)
         cfg = chip.getdict('showtool')
         pruned = chip._prune(cfg)
-        table = build_schema_value_table(pruned)
+        table = build_schema_value_table(pruned, keypath_prefix=['showtool'])
         if table is not None:
             section += table
             settings += section

--- a/docs/_ext/dynamicgen.py
+++ b/docs/_ext/dynamicgen.py
@@ -54,7 +54,11 @@ def build_schema_value_table(schema, keypath_prefix=[], skip_zero_weight=False):
             else:
                 val_node = code(val['value'])
 
-            table.append([keypath(*full_keypath), val_node])
+            # HTML builder fails if we don't make a text node the parent of the
+            # reference node returned by keypath()
+            p = nodes.paragraph()
+            p += keypath(*full_keypath)
+            table.append([p, val_node])
 
     if len(table) > 1:
         return build_table(table)

--- a/docs/_ext/schemagen.py
+++ b/docs/_ext/schemagen.py
@@ -75,9 +75,14 @@ class SchemaGen(SphinxDirective):
 
         return body
 
+def keypath_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    # Split and clean up keypath
+    keys = [key.strip() for key in text.split(',')]
+    return [keypath(*keys)], []
 
 def setup(app):
     app.add_directive('schemagen', SchemaGen)
+    app.add_role('keypath', keypath_role)
 
     return {
         'version': '0.1',

--- a/docs/user_guide/records.rst
+++ b/docs/user_guide/records.rst
@@ -1,7 +1,7 @@
 Records
 =======
 
-To support hardware provenance, the SiliconCompiler supports automated tracking of a number of execution and place of origin related parameters. Tracking is off by default in the SiliconCompiler, but can be turned on with the 'track' parameter. ::
+To support hardware provenance, the SiliconCompiler supports automated tracking of a number of execution and place of origin related parameters. Tracking is off by default in the SiliconCompiler, but can be turned on with the :keypath:`track` parameter. ::
 
   chip.set('track', True)
 

--- a/docs/user_guide/tools.rst
+++ b/docs/user_guide/tools.rst
@@ -63,7 +63,7 @@ SiliconCompiler execution depends on implementing adapter code "drivers" for eac
      - sphinx
      - no
 
-For a complete example of a tool setup module, see `OpenROAD <https://github.com/siliconcompiler/siliconcompiler/blob/main/siliconcompiler/tools/openroad/openroad.py>`_. For more in depth information about the various 'eda' parameters, see the :ref:`Schema <SiliconCompiler Schema>` section of the reference manual.
+For a complete example of a tool setup module, see `OpenROAD <https://github.com/siliconcompiler/siliconcompiler/blob/main/siliconcompiler/tools/openroad/openroad.py>`_. For more in depth information about the various :keypath:`eda` parameters, see the :ref:`Schema <SiliconCompiler Schema>` section of the reference manual.
 
 
 setup(chip)
@@ -96,14 +96,14 @@ To leverage the run() function's internal setup checking logic, it is highly rec
 
 parse_version(stdout)
 -----------------------
-The run() function includes built in executable version checking, which can be disabled with the 'novercheck' parameter. The executable option to use for printing out the version number is specified with the 'vswitch' parameter within the setup() function. Commonly used options include '-v', '\-\-version', '-version'. The executable output varies widely, so we need a parsing function that processes the output and returns a single uniform version string. The example shows how this function is implemented for the Yosys tool. ::
+The run() function includes built in executable version checking, which can be disabled with the :keypath:`novercheck` parameter. The executable option to use for printing out the version number is specified with the :keypath:`eda, <tool>, vswitch` parameter within the setup() function. Commonly used options include '-v', '\-\-version', '-version'. The executable output varies widely, so we need a parsing function that processes the output and returns a single uniform version string. The example shows how this function is implemented for the Yosys tool. ::
 
 
   def parse_version(stdout):
       # Yosys 0.9+3672 (git sha1 014c7e26, gcc 7.5.0-3ubuntu1~18.04 -fPIC -Os)
       return stdout.split()[1]
 
-The run() function compares the returned parsed version against the 'version' parameter specified in the setup() function to ensure that a qualified executable version is being used.
+The run() function compares the returned parsed version against the :keypath:`eda, <tool>, version` parameter specified in the setup() function to ensure that a qualified executable version is being used.
 
 normalize_version(version)
 --------------------------

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -763,12 +763,13 @@ class Chip:
         """
         Returns a schema parameter field.
 
-        Returns a schema parameter filed based on the keypath and value provided
-        in the ``*args``. The returned type is consistent with the type field of
-        the parameter. Fetching parameters with empty or undefined value files
-        returns None for scalar types and [] (empty list) for list types.
-        Accessing a non-existent keypath produces a logger error message and
-        raises the Chip object error flag.
+        Returns a schema parameter field based on the keypath provided in the
+        ``*args``. See the :ref:`Schema Reference Manual<SiliconCompiler
+        Schema>` for documentation of all supported keypaths. The returned type
+        is consistent with the type field of the parameter. Fetching parameters
+        with empty or undefined value files returns None for scalar types and []
+        (empty list) for list types.  Accessing a non-existent keypath produces
+        a logger error message and raises the Chip object error flag.
 
         Args:
             keypath(list str): Variable length schema key list.
@@ -878,11 +879,12 @@ class Chip:
         '''
         Sets a schema parameter field.
 
-        Sets a schema parameter field based on the keypath and value provided
-        in the ``*args``. New schema dictionaries are automatically created for
-        keypaths that overlap with 'default' dictionaries. The write action
-        is ignored if the parameter value is non-empty and the clobber
-        option is set to False.
+        Sets a schema parameter field based on the keypath and value provided in
+        the ``*args``. See the :ref:`Schema Reference Manual<SiliconCompiler
+        Schema>` for documentation of all supported keypaths. New schema
+        dictionaries are automatically created for keypaths that overlap with
+        'default' dictionaries. The write action is ignored if the parameter
+        value is non-empty and the clobber option is set to False.
 
         The value provided must agree with the dictionary parameter 'type'.
         Accessing a non-existent keypath or providing a value that disagrees
@@ -924,9 +926,10 @@ class Chip:
         Adds item(s) to a schema parameter list.
 
         Adds item(s) to schema parameter list based on the keypath and value
-        provided in the ``*args``. New schema dictionaries are
-        automatically created for keypaths that overlap with 'default'
-        dictionaries.
+        provided in the ``*args``.  See the :ref:`Schema Reference
+        Manual<SiliconCompiler Schema>` for documentation of all supported
+        keypaths. New schema dictionaries are automatically created for keypaths
+        that overlap with 'default' dictionaries.
 
         The value provided must agree with the dictionary parameter 'type'.
         Accessing a non-existent keypath, providing a value that disagrees

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -764,7 +764,7 @@ class Chip:
         Returns a schema parameter field.
 
         Returns a schema parameter field based on the keypath provided in the
-        ``*args``. See the :ref:`Schema Reference Manual<SiliconCompiler
+        ``*keypath``. See the :ref:`Schema Reference Manual<SiliconCompiler
         Schema>` for documentation of all supported keypaths. The returned type
         is consistent with the type field of the parameter. Fetching parameters
         with empty or undefined value files returns None for scalar types and []


### PR DESCRIPTION
This PR makes a few enhancements to our documentation, all related to linking to the schema reference manual.

### Link to schema reference manual in set()/get()/add() docs

This is the simplest change. Added this due to feedback that if you just look at the API reference for these functions, it's unclear what valid arguments would be.

### Make keypaths in the schema value tables link to schema reference

Now, the entries in the "Keypath" column of the tables in the tools/pdks/flows/targets/libs directory pages are clickable links that take you to the relevant entry in the schema docs.

E.g. Clicking here:
![Screenshot from 2022-04-28 15-47-30](https://user-images.githubusercontent.com/4412459/165834142-4b866087-5eda-4eeb-879d-52fbcbb6c60b.png)

takes you here:
![Screenshot from 2022-04-28 15-47-50](https://user-images.githubusercontent.com/4412459/165834037-e3728e0b-caca-4bb1-8aef-f91094a15414.png)

### Add `:keypath:` inline command

Following on the previous change, I also added a new inline command (or "role" as Sphinx calls them) that lets you easily insert links to the schema reference manual in prose. I haven't gone through and changed everything to use this yet, but I included a few examples in this PR.

For example, if you include the following in a .rst source file: ``:keypath:`quiet` ``, it renders as `['quiet']`, and it automatically links to the [reference](https://docs.siliconcompiler.com/en/latest/reference_manual/schema.html#quiet) for the 'quiet' parameter.

The other cool thing about this is that it ensures consistent formatting of keypaths in the text as well. I've adopted what I think has been a de-facto but not 100% consistent standard of putting them inside square brackets, and added support for a couple different categories:
| Type | RST source | Processed result |
|--------|-------|----------|
| Fully-qualified | ``:keypath:`eda, yosys, exe` ``| `['eda', 'yosys', 'exe']`|
| Placeholder | ``:keypath:`eda, <tool>, exe` ``| `['eda', <tool>, 'exe']`|
| Prefix | ``:keypath:`eda` ``| `['eda', ...]` |

We can tweak the appearance of these if you'd like.