### PR TITLE
Fix failing daily & wheel tests

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4612,7 +4612,7 @@ class Chip:
                 print(f'{envvar_cmd} {key}={val}', file=f)
 
             replay_cmdlist = [os.path.basename(cmdlist[0])] + cmdlist[1:]
-            print(shlex.join(replay_cmdlist), file=f)
+            print(' '.join(f'"{arg}"' if ' ' in arg else arg for arg in replay_cmdlist), file=f)
         os.chmod(script_name, 0o755)
 
         return cmdlist

--- a/tests/designs/test_picorv32.py
+++ b/tests/designs/test_picorv32.py
@@ -2,14 +2,10 @@ import os
 import siliconcompiler
 import pytest
 
-# Command line version
-# sc ../../third_party/designs/picorv32/picorv32.v -design picorv32 -mode sim -target "surelog" -arg_step "import" -quiet
-
 @pytest.mark.eda
 def test_picorv32(picorv32_dir):
     source = os.path.join(picorv32_dir, 'picorv32.v')
     design = "picorv32"
-    step = "import"
 
     chip = siliconcompiler.Chip(loglevel="INFO")
     chip.load_target('freepdk45_demo')
@@ -17,12 +13,9 @@ def test_picorv32(picorv32_dir):
     chip.add('source', source)
     chip.set('design', design)
     chip.set('steplist', ['import'])
-    chip.set('mode', 'sim')
-    chip.set('arg', 'step', step)
-    chip.set('flow', 'surelog')
     chip.run()
 
-    assert chip.find_result('v', step=step) is not None
+    assert chip.find_result('v', step='import') is not None
 
 if __name__ == "__main__":
     from tests.fixtures import scroot


### PR DESCRIPTION
This PR fixes some of our nightly tests I broke yesterday.

- In PR #1003 I switched a line in the `replay.sh` generation logic to use `shlex.join()`, since I incorrectly thought that the reason I didn't use `shlex.join()` originally is that it doesn't work for Windows. Turns out the fundamental problem was that it's actually only in Python >=3.8. I reverted to the old version of this line to be safe.
- I missed updating a test (picorv32) in PR #1001 that used the old single-step flow interface.