### PR TITLE
Prevent text from overflowing tables in PDF docs

### DIFF
--- a/docs/_ext/dynamicgen.py
+++ b/docs/_ext/dynamicgen.py
@@ -61,7 +61,11 @@ def build_schema_value_table(schema, keypath_prefix=[], skip_zero_weight=False):
             table.append([p, val_node])
 
     if len(table) > 1:
-        return build_table(table)
+        # This colspec creates two columns of equal width that fill the entire
+        # page, and adds line breaks if table cell contents are longer than one
+        # line. "\X" is defined by Sphinx, otherwise this is standard LaTeX.
+        colspec = r'{|\X{1}{2}|\X{1}{2}|}'
+        return build_table(table, colspec=colspec)
     else:
         return None
 

--- a/docs/_ext/requirements.py
+++ b/docs/_ext/requirements.py
@@ -84,7 +84,7 @@ class RequirementsLicenses(SphinxDirective):
                 entries.append([p, para(license)])
 
         body = build_table(entries)
-        return [body]
+        return body
 
 def setup(app):
     app.add_directive('requirements', Requirements)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,9 +104,16 @@ html_css_files = [
 
 # -- Options for Latex output ------------------------------------------------
 
-# Don't add blank pages after some chapters
+# Allow linebreaks on underscores (fixes long cell names running past end of
+# table cells)
+latex_preamble = r"""\newcommand{\origunderscore}{}
+\let\origunderscore\_
+\renewcommand{\_}{\allowbreak\origunderscore}
+"""
+
 latex_elements = {
-  'extraclassoptions': 'openany,oneside'
+  'extraclassoptions': 'openany,oneside', # Don't add blank pages after some chapters
+  'preamble': latex_preamble
 }
 
 # -- Options for autodoc -----------------------------------------------------


### PR DESCRIPTION
This PR makes a couple changes to fix up some issues we had with long autogenerated table contents overflowing table cells.

## Example 1
### Before 
![Screenshot from 2022-04-29 17-30-58](https://user-images.githubusercontent.com/4412459/166071859-df64cbf2-74d2-4a0b-856b-5ee06051b9ae.png)
### After
![Screenshot from 2022-04-29 16-17-33](https://user-images.githubusercontent.com/4412459/166071845-57ef1d9d-549c-4b85-b20c-25ed23f4d41b.png)

## Example 2
### Before
![Screenshot from 2022-04-29 17-31-36](https://user-images.githubusercontent.com/4412459/166071860-182c4fd3-808d-4d1e-81fc-39ab8b8b4840.png)

### After
![Screenshot from 2022-04-29 16-17-05](https://user-images.githubusercontent.com/4412459/166071839-fc25d0e1-3334-421b-9afd-f2c261ab1f92.png)
