### PR TITLE
Implement 'resume' option

### DIFF
--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2499,6 +2499,19 @@ def schema_options(cfg):
             Specifies that tools should be lenient and suppress some
             warnings that may or may not indicate design issues.""")
 
+    scparam(cfg, ['resume'],
+            sctype='bool',
+            scope='job',
+            shorthelp="Resume build",
+            switch="-resume <bool>",
+            example=["cli: -resume",
+                    "api: chip.set('resume', True)"],
+            schelp="""
+            If results exist for current job, then don't re-run any steps that
+            had at least one index run successfully. Useful for debugging a
+            flow that failed partway through.
+            """)
+
     scparam(cfg, ['track'],
             sctype='bool',
             scope='job',

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -6490,6 +6490,22 @@
         "type": "bool",
         "value": "false"
     },
+    "resume": {
+        "defvalue": "false",
+        "example": [
+            "cli: -resume",
+            "api: chip.set('resume', True)"
+        ],
+        "help": "If results exist for current job, then don't re-run any steps that\nhad at least one index run successfully. Useful for debugging a\nflow that failed partway through.",
+        "lock": "false",
+        "require": "all",
+        "scope": "job",
+        "shorthelp": "Resume build",
+        "signature": null,
+        "switch": "-resume <bool>",
+        "type": "bool",
+        "value": "false"
+    },
     "scpath": {
         "defvalue": [],
         "example": [

--- a/tests/flows/test_resume.py
+++ b/tests/flows/test_resume.py
@@ -1,0 +1,34 @@
+import siliconcompiler
+
+import pytest
+import os
+
+@pytest.mark.eda
+def test_resume(gcd_chip):
+    # Set a value that will cause place to break
+    gcd_chip.set('eda', 'openroad', 'variable', 'place', '0', 'place_density', 'asdf')
+
+    with pytest.raises(siliconcompiler.SiliconCompilerError):
+        gcd_chip.run()
+    
+    # Ensure flow failed at placement, and store last modified time of floorplan
+    fp_result = gcd_chip.find_result('def', step='floorplan')
+    assert fp_result is not None
+    old_fp_mtime = os.path.getmtime(fp_result)
+
+    assert gcd_chip.find_result('def', step='place') is None
+    assert gcd_chip.find_result('gds', step='export') is None
+
+    # Fix place step and re-run
+    gcd_chip.set('eda', 'openroad', 'variable', 'place', '0', 'place_density', '0.15')
+    gcd_chip.set('resume', True)
+    gcd_chip.run()
+
+    # Ensure floorplan did not get re-run
+    fp_result = gcd_chip.find_result('def', step='floorplan')
+    assert fp_result is not None
+    assert os.path.getmtime(fp_result) == old_fp_mtime
+
+    # Ensure flow finished successfully
+    assert gcd_chip.find_result('def', step='place') is not None
+    assert gcd_chip.find_result('gds', step='export') is not None


### PR DESCRIPTION
This PR implements a 'resume' option that allows you to re-run a job starting with the last failing step. One key decision was to make a step be considered failing (and be re-run) only if all its indices fail. This simplifies handling some edge cases, and if a user needs a different behavior, they can always manually re-run things using the steplist. 

