### PR TITLE
Fix wheels tests

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4627,9 +4627,10 @@ class Chip:
         fullexe = self._getexe(tool)
 
         options = []
+        is_posix = (sys.platform != 'win32')
 
         for option in self.get('eda', tool, 'option', step, index):
-            options.extend(shlex.split(option))
+            options.extend(shlex.split(option, posix=is_posix))
 
         # Add scripts files
         if self.valid('eda', tool, 'script', step, index):
@@ -4645,7 +4646,7 @@ class Chip:
         runtime_options = self.find_function(tool, 'runtime_options', 'tools')
         if runtime_options:
             for option in runtime_options(self):
-                cmdlist.extend(shlex.split(option))
+                cmdlist.extend(shlex.split(option, posix=is_posix))
 
         envvars = {}
         for key in self.getkeys('env'):


### PR DESCRIPTION
Add back is_posix to shlex.split() calls in _makecmd

I got a little too aggressive when clearing out the multi-platform
replay script code. We need to properly handle different platforms for
actually creating the command itself!

Verified back to green: https://github.com/siliconcompiler/siliconcompiler/actions/runs/2265960443