### PR TITLE
Implement schema changes from todo list in schema_rearchitect

### DIFF
--- a/docs/user_guide/examples/flowgraph_doe.py
+++ b/docs/user_guide/examples/flowgraph_doe.py
@@ -9,7 +9,7 @@ for index in range(len(syn_strategies)):
     chip.node(flow, 'syn', 'yosys', index=str(index))
     chip.edge(flow, 'import', 'syn', head_index=str(index))
     chip.edge(flow, 'syn', 'synmin', tail_index=str(index))
-    chip.set('eda', 'yosys', 'variable', 'syn', str(index), 'strategy', syn_strategies[index])
+    chip.set('eda', 'yosys', 'var', 'syn', str(index), 'strategy', syn_strategies[index])
     for metric in ('cellarea', 'peakpower', 'standbypower'):
         chip.set('flowgraph', flow, 'syn', str(index), 'weight', metric, 1.0)
 chip.node(flow, 'synmin', 'minimum')

--- a/docs/user_guide/faq.rst
+++ b/docs/user_guide/faq.rst
@@ -58,7 +58,7 @@ How do I...
 ... change the build directory?
     .. code-block:: python
 
-       chip.set('dir', <dirpath>)
+       chip.set('option', 'builddir', <dirpath>)
 
 ... use the setup json file from a previous run?
     .. code-block:: python

--- a/examples/heartbeat_padring/build.py
+++ b/examples/heartbeat_padring/build.py
@@ -51,8 +51,8 @@ def build_core():
     # Configure the Chip object for a full build.
     core_chip.set('read', 'def', 'floorplan', '0', 'floorplan/heartbeat.def', clobber=True)
     core_chip.set('source', 'heartbeat.v')
-    core_chip.set('eda', 'openroad', 'variable', 'place', '0', 'place_density', ['0.15'])
-    core_chip.set('eda', 'openroad', 'variable', 'route', '0', 'grt_allow_congestion', ['true'])
+    core_chip.set('eda', 'openroad', 'var', 'place', '0', 'place_density', ['0.15'])
+    core_chip.set('eda', 'openroad', 'var', 'route', '0', 'grt_allow_congestion', ['true'])
     core_chip.clock(name='clk', pin='clk', period=20)
 
     # Run the actual ASIC build flow with the resulting floorplan.

--- a/examples/heartbeat_padring/build.py
+++ b/examples/heartbeat_padring/build.py
@@ -62,7 +62,7 @@ def build_core():
 
     # Copy stream files for padring integration.
     design = core_chip.get('design')
-    jobdir = (core_chip.get('dir') +
+    jobdir = (core_chip.get('option', 'builddir') +
             "/" + design + "/" +
             core_chip.get('jobname'))
     shutil.copy(f'{jobdir}/export/0/outputs/{design}.gds', f'{design}.gds')

--- a/examples/heartbeat_padring/floorplan_build.py
+++ b/examples/heartbeat_padring/floorplan_build.py
@@ -535,7 +535,7 @@ def build_core():
 
     # Copy stream files for padring integration.
     design = core_chip.get('design')
-    jobdir = (core_chip.get('dir') +
+    jobdir = (core_chip.get('option', 'builddir') +
             "/" + design + "/" +
             core_chip.get('jobname'))
     shutil.copy(f'{jobdir}/export/0/outputs/{design}.gds', f'{design}.gds')

--- a/examples/heartbeat_padring/floorplan_build.py
+++ b/examples/heartbeat_padring/floorplan_build.py
@@ -524,8 +524,8 @@ def build_core():
     # Configure the Chip object for a full build.
     core_chip.set('read', 'def', 'floorplan', '0', 'heartbeat.def', clobber=True)
     core_chip.set('source', 'heartbeat.v')
-    core_chip.set('eda', 'openroad', 'variable', 'place', '0', 'place_density', ['0.15'])
-    core_chip.set('eda', 'openroad', 'variable', 'route', '0', 'grt_allow_congestion', ['true'])
+    core_chip.set('eda', 'openroad', 'var', 'place', '0', 'place_density', ['0.15'])
+    core_chip.set('eda', 'openroad', 'var', 'route', '0', 'grt_allow_congestion', ['true'])
     core_chip.clock(name='clk', pin='clk', period=20)
 
     # Run the ASIC build flow with the resulting floorplan.

--- a/examples/oh_experiments/feedback_loop.py
+++ b/examples/oh_experiments/feedback_loop.py
@@ -45,7 +45,7 @@ def main():
         chip.set('option', 'jobname', newid)
 
         # Specifying that imports are copied from job0
-        chip.set('option', 'jobinput', newid, step, index, 'job0')
+        chip.set('option', 'jobinput', step, index, 'job0')
 
         # Make a run
         chip.run()

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -93,7 +93,7 @@ def remote_run(chip):
     request_remote_run(chip)
 
     # Remove the local 'import.tar.gz' archive.
-    local_archive = stepdir = os.path.join(chip.get('dir'),
+    local_archive = stepdir = os.path.join(chip.get('option', 'builddir'),
                                            chip.get('design'),
                                            chip.get('jobname'),
                                            'import.tar.gz')
@@ -132,7 +132,7 @@ def request_remote_run(chip):
             'job_hash': chip.status['jobhash'],
         }
     }
-    local_build_dir = stepdir = os.path.join(chip.get('dir'),
+    local_build_dir = stepdir = os.path.join(chip.get('option', 'builddir'),
                                              chip.get('design'),
                                              job_nameid)
     rcfg = chip.status['remote_cfg']
@@ -290,7 +290,7 @@ def fetch_results(chip):
     top_design = chip.get('design')
     job_hash = chip.status['jobhash']
     job_nameid = f"{chip.get('jobname')}"
-    local_dir = chip.get('dir')
+    local_dir = chip.get('option', 'builddir')
 
     # Authenticated jobs get a zip file full of other zip files.
     # So we need to extract and delete those.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1574,7 +1574,7 @@ class Chip:
 
     ###########################################################################
     def _check_files(self):
-        allowed_paths = [os.path.join(self.cwd, self.get('option', 'dir'))]
+        allowed_paths = [os.path.join(self.cwd, self.get('option', 'builddir'))]
         allowed_paths.extend(os.environ['SC_VALID_PATHS'].split(os.pathsep))
 
         for keypath in self.getkeys():
@@ -2489,7 +2489,7 @@ class Chip:
 
         design = self.get('design')
         jobname = self.get('option', 'jobname')
-        buildpath = self.get('option', 'dir')
+        buildpath = self.get('option', 'builddir')
 
         if step:
             steplist = [step]
@@ -3029,7 +3029,7 @@ class Chip:
 
         # Create a report for the Chip object which can be viewed in a web browser.
         # Place report files in the build's root directory.
-        web_dir = os.path.join(self.get('option', 'dir'),
+        web_dir = os.path.join(self.get('option', 'builddir'),
                                self.get('design'),
                                self.get('option', 'jobname'))
         if os.path.isdir(web_dir):
@@ -4121,9 +4121,9 @@ class Chip:
             # Read back configuration from final manifest.
             cfg = os.path.join(self._getworkdir(),f"{self.get('design')}.pkg.json")
             if os.path.isfile(cfg):
-                local_dir = self.get('option','dir')
+                local_dir = self.get('option','builddir')
                 self.read_manifest(cfg, clobber=True, clear=True)
-                self.set('option', 'dir', local_dir)
+                self.set('option', 'builddir', local_dir)
             else:
                 # Hack to find first failed step by checking for presence of
                 # output manifests.
@@ -4180,7 +4180,7 @@ class Chip:
 
             # Implement auto-update of jobincrement
             try:
-                alljobs = os.listdir(self.get('option','dir') + "/" + self.get('design'))
+                alljobs = os.listdir(self.get('option','builddir') + "/" + self.get('design'))
                 if self.get('option','jobincr'):
                     jobid = 0
                     for item in alljobs:
@@ -4450,7 +4450,7 @@ class Chip:
 
         # Opening file from temp directory
         cwd = os.getcwd()
-        showdir = self.get('option','dir') + "/_show"
+        showdir = self.get('option','builddir') + "/_show"
         os.makedirs(showdir, exist_ok=True)
         os.chdir(showdir)
 
@@ -4794,7 +4794,7 @@ class Chip:
             jobname = self.get('option','jobname')
 
         dirlist =[self.cwd,
-                  self.get('option','dir'),
+                  self.get('option','builddir'),
                   self.get('design'),
                   jobname]
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1736,10 +1736,9 @@ class Chip:
         for step in steplist:
             for index in indexlist[step]:
                 in_job = None
-                if (jobname in self.getkeys('option', 'jobinput') and
-                    step in self.getkeys('option', 'jobinput', jobname) and
-                    index in self.getkeys('option', 'jobinput', jobname, step)):
-                    in_job = self.get('option', 'jobinput', jobname, step, index)
+                if (step in self.getkeys('option', 'jobinput') and
+                    index in self.getkeys('option', 'jobinput', step)):
+                    in_job = self.get('option', 'jobinput', step, index)
 
                 for in_step, in_index in self.get('flowgraph', flow, step, index, 'input'):
                     if in_job is not None:
@@ -1878,8 +1877,8 @@ class Chip:
                         # inputs need to already be copied into the build
                         # directory.
                         jobname = self.get('option', 'jobname')
-                        if self.valid('option', 'jobinput', jobname, step, index):
-                            in_job = self.get('option', 'jobinput', jobname, step, index)
+                        if self.valid('option', 'jobinput', step, index):
+                            in_job = self.get('option', 'jobinput', step, index)
                         else:
                             in_job = jobname
                         workdir = self._getworkdir(jobname=in_job, step=in_step, index=in_index)
@@ -3590,10 +3589,9 @@ class Chip:
         # support for sharing data across jobs
         job = self.get('option', 'jobname')
         in_job = job
-        if job in self.getkeys('option', 'jobinput'):
-            if step in self.getkeys('option', 'jobinput',job):
-                if index in self.getkeys('option', 'jobinput',job,step):
-                    in_job = self.get('option', 'jobinput', job, step, index)
+        if step in self.getkeys('option', 'jobinput'):
+            if index in self.getkeys('option', 'jobinput', step):
+                in_job = self.get('option', 'jobinput', step, index)
 
         workdir = self._getworkdir(step=step,index=index)
         cwd = os.getcwd()
@@ -4212,10 +4210,9 @@ class Chip:
 
                     inputs = [step+index for step, index in self.get('flowgraph', flow, step, index, 'input')]
 
-                    if (jobname in self.getkeys('option','jobinput') and
-                        step in self.getkeys('option','jobinput', jobname) and
-                        index in self.getkeys('option','jobinput', jobname, step) and
-                        self.get('option','jobinput', jobname, step, index) != jobname):
+                    if (step in self.getkeys('option','jobinput') and
+                        index in self.getkeys('option','jobinput', step) and
+                        self.get('option','jobinput', step, index) != jobname):
                         # If we specify a different job as input to this task,
                         # we assume we are good to run it.
                         tasks_to_run[step+index] = []

--- a/siliconcompiler/pdks/asap7.py
+++ b/siliconcompiler/pdks/asap7.py
@@ -133,11 +133,11 @@ def setup(chip):
         chip.set('pdk','grid', stackup, layer, 'adj',     0.4)
 
     # Defaults for OpenROAD tool variables
-    chip.set('pdk', 'variable', 'openroad', stackup, 'place_density', ['0.77'])
-    chip.set('pdk', 'variable', 'openroad', stackup, 'pad_global_place', ['2'])
-    chip.set('pdk', 'variable', 'openroad', stackup, 'pad_detail_place', ['1'])
-    chip.set('pdk', 'variable', 'openroad', stackup, 'macro_place_halo', ['22.4', '15.12'])
-    chip.set('pdk', 'variable', 'openroad', stackup, 'macro_place_channel', ['18.8', '19.95'])
+    chip.set('pdk', 'var', 'openroad', stackup, 'place_density', ['0.77'])
+    chip.set('pdk', 'var', 'openroad', stackup, 'pad_global_place', ['2'])
+    chip.set('pdk', 'var', 'openroad', stackup, 'pad_detail_place', ['1'])
+    chip.set('pdk', 'var', 'openroad', stackup, 'macro_place_halo', ['22.4', '15.12'])
+    chip.set('pdk', 'var', 'openroad', stackup, 'macro_place_channel', ['18.8', '19.95'])
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/pdks/freepdk45.py
+++ b/siliconcompiler/pdks/freepdk45.py
@@ -152,9 +152,9 @@ def setup(chip):
         if layer in ('metal10'):
             chip.set('pdk', process, 'grid', stackup, layer, 'dir', 'vertical')
         else:
-            chip.set('pdk', process, 'grid', stackup, layer, 'dir', 'horizontal')
+            chip.set('pdk','grid', stackup, layer, 'dir', 'horizontal')
 
-    # Defaults for OpenROAD tool vars
+    # Defaults for OpenROAD tool variables
     chip.set('pdk', process, 'var', 'openroad', stackup, 'place_density', ['0.3'])
     chip.set('pdk', process, 'var', 'openroad', stackup, 'pad_global_place', ['2'])
     chip.set('pdk', process, 'var', 'openroad', stackup, 'pad_detail_place', ['1'])

--- a/siliconcompiler/pdks/freepdk45.py
+++ b/siliconcompiler/pdks/freepdk45.py
@@ -152,7 +152,7 @@ def setup(chip):
         if layer in ('metal10'):
             chip.set('pdk', process, 'grid', stackup, layer, 'dir', 'vertical')
         else:
-            chip.set('pdk','grid', stackup, layer, 'dir', 'horizontal')
+            chip.set('pdk', process, 'grid', stackup, layer, 'dir', 'horizontal')
 
     # Defaults for OpenROAD tool variables
     chip.set('pdk', process, 'var', 'openroad', stackup, 'place_density', ['0.3'])

--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -140,11 +140,11 @@ def setup(chip):
     chip.set('pdk', process, 'grid', stackup, 'met5', 'adj', 0.5)
 
     # Defaults for OpenROAD tool variables
-    chip.set('pdk', process, 'variable', 'openroad', stackup, 'place_density', ['0.6'])
-    chip.set('pdk', process, 'variable', 'openroad', stackup, 'pad_global_place', ['4'])
-    chip.set('pdk', process, 'variable', 'openroad', stackup, 'pad_detail_place', ['2'])
-    chip.set('pdk', process, 'variable', 'openroad', stackup, 'macro_place_halo', ['1', '1'])
-    chip.set('pdk', process, 'variable', 'openroad', stackup, 'macro_place_channel', ['80', '80'])
+    chip.set('pdk', process, 'var', 'openroad', stackup, 'place_density', ['0.6'])
+    chip.set('pdk', process, 'var', 'openroad', stackup, 'pad_global_place', ['4'])
+    chip.set('pdk', process, 'var', 'openroad', stackup, 'pad_detail_place', ['2'])
+    chip.set('pdk', process, 'var', 'openroad', stackup, 'macro_place_halo', ['1', '1'])
+    chip.set('pdk', process, 'var', 'openroad', stackup, 'macro_place_channel', ['80', '80'])
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -48,7 +48,7 @@ def _deferstep(chip, step, index, status):
 
     # Job data is not encrypted, so it can be run in shared storage.
     # Write out the current schema for the compute node to pick up.
-    job_dir = "/".join([chip.get('dir'),
+    job_dir = "/".join([chip.get('option', 'builddir'),
                         chip.get('design'),
                         chip.get('jobname')])
     cfg_dir = f'{job_dir}/configs'
@@ -91,7 +91,7 @@ def _deferstep(chip, step, index, status):
 
         # If a maximum disk space was defined, ensure that it is respected.
         if 'max_fs_bytes' in chip.status:
-            du_cmd = subprocess.run(['du', '-sb', chip.get('dir')],
+            du_cmd = subprocess.run(['du', '-sb', chip.get('option', 'builddir')],
                                     stdout=subprocess.PIPE)
             cur_fs_bytes = int(du_cmd.stdout.decode().split()[0])
             if cur_fs_bytes > int(chip.status['max_fs_bytes']):

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -767,12 +767,12 @@ def schema_pdk(cfg, stackup='default'):
             sctype='[str]',
             scope='global',
             shorthelp="PDK: special variable",
-            switch="-pdk_variable 'pdkname tool stackup key <str>'",
+            switch="-pdk_var 'pdkname tool stackup key <str>'",
             example=[
-                "cli: -pdk_variable 'asap7 xyce modeltype M10 bsim4'""",
+                "cli: -pdk_var 'asap7 xyce modeltype M10 bsim4'""",
                 "api: chip.set('pdk','asap7','var','xyce','modeltype','M10','bsim4')"],
             schelp="""
-             List of key/value strings specified on a per tool and per stackup basis.
+            List of key/value strings specified on a per tool and per stackup basis.
             The parameter should only be used for specifying variables that are
             not directly  supported by the SiliconCompiler PDK schema.""")
 
@@ -3331,7 +3331,7 @@ def schema_asic(cfg):
             schelp="""
             List of key/value strings specified on a per basis. The parameter
             should only be used for specifying variables that are
-            not directly  supported by the SiliconCompiler PDK schema.""")
+            not directly supported by the SiliconCompiler PDK schema.""")
 
 
     # TODO: Expand on the exact definitions of these types of cells.

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2281,14 +2281,14 @@ def schema_option(cfg):
             introspection.""")
 
     #TODO: remove?
-    scparam(cfg, ['option','jobinput','default','default','default'],
+    scparam(cfg, ['option','jobinput','default','default'],
             sctype='str',
             scope='job',
             shorthelp="Input job name",
-            switch="-jobinput 'job step index <str>'",
+            switch="-jobinput 'step index <str>'",
             example=[
-                "cli: -jobinput 'job1 cts 0 job0'",
-                "api:  chip.set('option','jobinput','job1','cts,'0','job0')"],
+                "cli: -jobinput 'cts 0 job0'",
+                "api:  chip.set('option','jobinput','cts,'0','job0')"],
             schelp="""
             Specifies jobname inputs for the current run() on a per step
             and per index basis. During execution, the default behavior is to

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2251,18 +2251,18 @@ def schema_option(cfg):
             Provides explicit control over the level of debug logging printed.
             Valid entries include INFO, DEBUG, WARNING, ERROR.""")
 
-    scparam(cfg, ['option', 'dir'],
+    scparam(cfg, ['option', 'builddir'],
             sctype='dir',
             scope='job',
             defvalue='build',
             shorthelp="Build directory",
-            switch="-dir <dir>",
+            switch="-builddir <dir>",
             example=[
-                "cli: -dir ./build_the_future",
-                "api: chip.set('option', 'dir','./build_the_future')"],
+                "cli: -builddir ./build_the_future",
+                "api: chip.set('option', 'builddir','./build_the_future')"],
             schelp="""
             The default build directory is in the local './build' where SC was
-            executed. The 'dir' parameters can be used to set an alternate
+            executed. The 'builddir' parameter can be used to set an alternate
             compilation directory path.""")
 
     scparam(cfg, ['option', 'jobname'],

--- a/siliconcompiler/server.py
+++ b/siliconcompiler/server.py
@@ -216,7 +216,7 @@ class Server:
 
         # Create the working directory for the given 'job hash' if necessary.
         subprocess.run(['mkdir', '-p', jobs_dir])
-        chip.set('dir', build_dir, clobber=True)
+        chip.set('option', 'builddir', build_dir, clobber=True)
         # Link to the 'import' directory if necessary.
         subprocess.run(['mkdir', '-p', '%s/%s'%(jobs_dir, job_nameid)])
         #subprocess.run(['ln', '-s', '%s/import0'%build_dir, '%s/%s/import0'%(jobs_dir, job_nameid)])
@@ -421,14 +421,14 @@ class Server:
         run_cmd = ''
         if self.cfg['cluster']['value'][-1] == 'slurm':
             # Run the job with slurm clustering.
-            chip.set('dir', f'{nfs_mount}/{job_hash}', clobber=True)
+            chip.set('option', 'builddir', f'{nfs_mount}/{job_hash}', clobber=True)
             chip.set('jobscheduler', 'slurm')
             chip.set('remote', False)
             chip.set('credentials', '', clobber=True)
             chip.status['decrypt_key'] = base64.urlsafe_b64encode(pk)
             chip.run()
         else:
-            chip.set('dir', build_dir, clobber=True)
+            chip.set('option', 'builddir', build_dir, clobber=True)
             # Run the build command locally.
             from_dir = '%s/%s'%(nfs_mount, job_hash)
             to_dir   = '/tmp/%s_%s'%(job_hash, job_nameid)
@@ -486,7 +486,7 @@ class Server:
         job_hash = chip.status['jobhash']
         top_module = chip.get('design')
         sc_sources = chip.get('source')
-        build_dir = chip.get('dir')
+        build_dir = chip.get('option', 'builddir')
         jobid = chip.get('jobname')
 
         # Mark the job hash as being busy.

--- a/siliconcompiler/tools/template/template.py
+++ b/siliconcompiler/tools/template/template.py
@@ -56,7 +56,7 @@ def setup(chip):
     chip.set('eda', tool, 'refdir',  step, index, refdir, clobber=False)
     chip.set('eda', tool, 'script',  step, index, refdir + script, clobber=False)
     for key in variables:
-        chip.set('eda', tool, 'variable', step, index, key, variables[key], clobber=False)
+        chip.set('eda', tool, 'var', step, index, key, variables[key], clobber=False)
 
     # Required for checker
     chip.add('eda', tool, 'output', step, index, outputs)

--- a/tests/flows/test_flowstatus.py
+++ b/tests/flows/test_flowstatus.py
@@ -42,9 +42,9 @@ def test_flowstatus(scroot, steplist):
     chip.edge(flow, 'import', 'place', head_index='1')
 
     # Illegal value, so this branch will fail!
-    chip.set('tool', 'openroad', 'variable', 'place', '0', 'place_density', 'asdf')
+    chip.set('tool', 'openroad', 'var', 'place', '0', 'place_density', 'asdf')
     # Legal value, so this branch should succeed
-    chip.set('tool', 'openroad', 'variable', 'place', '1', 'place_density', '0.5')
+    chip.set('tool', 'openroad', 'var', 'place', '1', 'place_density', '0.5')
 
     # Perform minimum
     chip.node(flow, 'placemin', 'minimum')
@@ -99,9 +99,9 @@ def test_long_branch(scroot):
     chip.edge(flow, 'import', 'place', head_index='1')
 
     # Illegal value, so this branch will fail!
-    chip.set('tool', 'openroad', 'variable', 'place', '0', 'place_density', 'asdf')
+    chip.set('tool', 'openroad', 'var', 'place', '0', 'place_density', 'asdf')
     # Legal value, so this branch should succeed
-    chip.set('tool', 'openroad', 'variable', 'place', '1', 'place_density', '0.5')
+    chip.set('tool', 'openroad', 'var', 'place', '1', 'place_density', '0.5')
 
     chip.node(flow, 'cts', 'openroad', index='0')
     chip.node(flow, 'cts', 'openroad', index='1')
@@ -141,9 +141,9 @@ def test_remote(scroot):
 
     chip.set('arg', 'flow', 'place_np', '2')
     # Illegal value, so this branch will fail!
-    chip.set('tool', 'openroad', 'variable', 'place', '0', 'place_density', 'asdf')
+    chip.set('tool', 'openroad', 'var', 'place', '0', 'place_density', 'asdf')
     # Legal value, so this branch should succeed
-    chip.set('tool', 'openroad', 'variable', 'place', '1', 'place_density', '0.5')
+    chip.set('tool', 'openroad', 'var', 'place', '1', 'place_density', '0.5')
 
     chip.load_target('freepdk45_demo')
     flow = chip.get('option', 'flow')

--- a/tests/flows/test_resume.py
+++ b/tests/flows/test_resume.py
@@ -6,7 +6,7 @@ import os
 @pytest.mark.eda
 def test_resume(gcd_chip):
     # Set a value that will cause place to break
-    gcd_chip.set('tool', 'openroad', 'variable', 'place', '0', 'place_density', 'asdf')
+    gcd_chip.set('tool', 'openroad', 'var', 'place', '0', 'place_density', 'asdf')
 
     with pytest.raises(siliconcompiler.SiliconCompilerError):
         gcd_chip.run()
@@ -20,7 +20,7 @@ def test_resume(gcd_chip):
     assert gcd_chip.find_result('gds', step='export') is None
 
     # Fix place step and re-run
-    gcd_chip.set('tool', 'openroad', 'variable', 'place', '0', 'place_density', '0.15')
+    gcd_chip.set('tool', 'openroad', 'var', 'place', '0', 'place_density', '0.15')
     gcd_chip.set('resume', True)
     gcd_chip.run()
 

--- a/tests/flows/test_steplist.py
+++ b/tests/flows/test_steplist.py
@@ -37,7 +37,7 @@ def test_invalid(gcd_chip):
 @pytest.mark.eda
 def test_invalid_jobinput(gcd_chip):
     gcd_chip.set('jobname', 'job1')
-    gcd_chip.set('jobinput', 'job1', 'syn', '0', 'job0')
+    gcd_chip.set('jobinput', 'syn', '0', 'job0')
     gcd_chip.set('steplist', 'syn')
     with pytest.raises(siliconcompiler.SiliconCompilerError):
         gcd_chip.run()

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -24,8 +24,8 @@ def test_tool_option(scroot):
     chip.set('arg', 'flow', 'place_np', ['2'])
     chip.load_target('freepdk45_demo')
 
-    chip.set('tool', 'openroad', 'variable', 'place', '0',  'place_density', '0.15')
-    chip.set('tool', 'openroad', 'variable', 'place', '1',  'place_density', '0.3')
+    chip.set('tool', 'openroad', 'var', 'place', '0',  'place_density', '0.15')
+    chip.set('tool', 'openroad', 'var', 'place', '1',  'place_density', '0.3')
 
     # No need to run beyond place, we just want to check that setting place_density
     # doesn't break anything.
@@ -88,9 +88,9 @@ def test_failed_branch_min(chip):
     flow = chip.get('option', 'flow')
 
     # Illegal value, so this branch will fail!
-    chip.set('tool', 'openroad', 'variable', 'place', '0', 'place_density', 'asdf')
+    chip.set('tool', 'openroad', 'var', 'place', '0', 'place_density', 'asdf')
     # Legal value, so this branch should succeed
-    chip.set('tool', 'openroad', 'variable', 'place', '1', 'place_density', '0.5')
+    chip.set('tool', 'openroad', 'var', 'place', '1', 'place_density', '0.5')
 
     # Perform minimum
     chip.set('flowgraph', flow, 'placemin', '0', 'tool', 'minimum')
@@ -118,8 +118,8 @@ def test_all_failed_min(chip):
     flow = chip.get('option', 'flow')
 
     # Illegal values, so both branches should fail
-    chip.set('tool', 'openroad', 'variable', 'place', '0', 'place_density', 'asdf')
-    chip.set('tool', 'openroad', 'variable', 'place', '1', 'place_density', 'asdf')
+    chip.set('tool', 'openroad', 'var', 'place', '0', 'place_density', 'asdf')
+    chip.set('tool', 'openroad', 'var', 'place', '1', 'place_density', 'asdf')
 
     # Perform minimum
     chip.set('flowgraph', flow, 'placemin', '0', 'tool', 'minimum')
@@ -140,9 +140,9 @@ def test_branch_failed_join(chip):
     flow = chip.get('option','flow')
 
     # Illegal values, so branch should fail
-    chip.set('tool', 'openroad', 'variable', 'place', '0', 'place_density', 'asdf')
+    chip.set('tool', 'openroad', 'var', 'place', '0', 'place_density', 'asdf')
     # Legal value, so branch should succeed
-    chip.set('tool', 'openroad', 'variable', 'place', '1', 'place_density', '0.5')
+    chip.set('tool', 'openroad', 'var', 'place', '1', 'place_density', '0.5')
 
     # Perform join
     chip.set('flowgraph', flow, 'placemin', '0', 'tool', 'join')

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -29,7 +29,7 @@ def test_klayout(datadir):
     chip.edge(flow, 'import', 'export')
     chip.set('option', 'flow', flow)
 
-    chip.set('tool', 'klayout', 'variable', 'export', '0', 'timestamps', 'false')
+    chip.set('tool', 'klayout', 'var', 'export', '0', 'timestamps', 'false')
 
     chip.run()
 


### PR DESCRIPTION
This PR adds some of the small schema tweaks from our backlog into the schema_rearchitect branch. I figure now is a good time to knock these out of the way since we're refactoring the entire thing anyway. Let me know if you don't want to do any of these changes anymore and I can remove it from the PR:

- Rename `'variable'` to `'var'` (in `['pdk', ...]`, `['tool', ...]`, and `['asic', ...]`)
- Rename `['option', 'dir']` to `['option', 'build']`
  - (my 2 cents on this one is I think a rename is good, but not 100% sure about 'build'. Maybe 'builddir' or 'outdir'?)
- Remove `<job>` from `['jobinput', ...]` 