### PR TITLE
Bump required scikit-build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ psutil >= 5.8.0
 
 # Build dependencies
 #:build
-scikit-build >= 0.12
+scikit-build >= 0.14.1
 cython
 cmake
 


### PR DESCRIPTION
We need to bump the required version of scikit-build to fix failing Windows CI build: seems to be a configuration change in Github Actions requires us to use Visual Studio 2019, which scikit-build had trouble using until this newer version: https://github.com/scikit-build/scikit-build/pull/526