### PR TITLE
Skip Microwatt test: it causes CI to time out

### DIFF
--- a/tests/examples/test_microwatt.py
+++ b/tests/examples/test_microwatt.py
@@ -5,6 +5,7 @@ import sys
 # go from end-to-end, and we already have a quick GHDL test.
 
 @pytest.mark.eda
+@pytest.mark.skip(reason='Slow (takes half hour to run)')
 def test_py(setup_example_test, microwatt_dir):
     # Note: value of microwatt_dir is unused, but specifying it is important to
     # ensure that the submodule is cloned.


### PR DESCRIPTION
I noticed our daily CI tests started timing out after #961 got merged (which adds synthesis). It takes ~35 minutes on my machine to run. I'd say we should skip it for now to get these tests back to green, and perhaps switch over to just running the Verilog we get out of GHDL through a linter or something (since we run synthesis mainly to check that it's OK).