### PR TITLE
Update scheduler.py to account for recent schema changes.

### DIFF
--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -58,7 +58,7 @@ def _deferstep(chip, step, index, status):
         sf.write('#!/bin/bash\n')
         sf.write(f'sc -cfg {shlex.quote(cfg_file)} -builddir {shlex.quote(chip.get("option", "builddir"))} '\
                     f'-arg_step {shlex.quote(step)} -arg_index {shlex.quote(index)} '\
-                    f"-jobscheduler '' -design {shlex.quote(chip.get('design')}")
+                    f"-jobscheduler '' -design {shlex.quote(chip.get('design'))}")
     schedule_cmd.append(script_path)
 
     # Run the 'srun' command, and track its output.


### PR DESCRIPTION
A few parameters in scheduler.py need updating to work with the new schema. We can also remove the active/error tracking bits now that each task's status is tracked in the schema.