### PR TITLE
Update path to test_show.py in Wheels CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -83,7 +83,7 @@ jobs:
         CIBW_TEST_COMMAND: >
           pytest --import-mode=append {package}/tests/ -m "not eda" &&
           pytest --import-mode=append {package}/tests/tools/test_surelog.py &&
-          pytest --import-mode=append {package}/tests/core/test_show.py
+          pytest --import-mode=append {package}/tests/flows/test_show.py
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
This is what made the Wheels CI turn red. Tests are passing, it just failed because it was trying to run a test that doesn't exist (test got moved)!