### PR TITLE
Change CLI behavior to store optmode with 'O' prefix

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -378,6 +378,11 @@ class Chip:
             if not isinstance(vals, list):
                 vals = [vals]
 
+            # Hack to handle the fact that we want optmode stored with an 'O'
+            # prefix.
+            if switch == 'option_optmode':
+                vals = ['O'+vals[0]]
+
             # Cycle throug all items in list types
             for item in vals:
                 args = [None] * (len(switchmap[switch])+1)

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2170,17 +2170,17 @@ def schema_option(cfg):
             shorthelp="Optimization mode",
             switch="-O<str>",
             example=["cli: -O3",
-                    "api: chip.set('option','optmode','3')"],
+                    "api: chip.set('option','optmode','O3')"],
             schelp="""
             The compiler has modes to prioritize run time and ppa. Modes
             include.
 
-            (0) = Exploration mode for debugging setup
-            (1) = Higher effort and better PPA than O0
-            (2) = Higher effort and better PPA than O1
-            (3) = Signoff quality. Better PPA and higher run times than O2
-            (4-98) = Reserved (compiler/target dependent)
-            (99) = Experimental highest possible effort, may be unstable
+            (O0) = Exploration mode for debugging setup
+            (O1) = Higher effort and better PPA than O0
+            (O2) = Higher effort and better PPA than O1
+            (O3) = Signoff quality. Better PPA and higher run times than O2
+            (O4-O98) = Reserved (compiler/target dependent)
+            (O99) = Experimental highest possible effort, may be unstable
             """)
 
     #TODO: with modular flows does this go away?

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -3689,9 +3689,9 @@
             "defvalue": "O0",
             "example": [
                 "cli: -O3",
-                "api: chip.set('option','optmode','3')"
+                "api: chip.set('option','optmode','O3')"
             ],
-            "help": "The compiler has modes to prioritize run time and ppa. Modes\ninclude.\n\n(0) = Exploration mode for debugging setup\n(1) = Higher effort and better PPA than O0\n(2) = Higher effort and better PPA than O1\n(3) = Signoff quality. Better PPA and higher run times than O2\n(4-98) = Reserved (compiler/target dependent)\n(99) = Experimental highest possible effort, may be unstable",
+            "help": "The compiler has modes to prioritize run time and ppa. Modes\ninclude.\n\n(O0) = Exploration mode for debugging setup\n(O1) = Higher effort and better PPA than O0\n(O2) = Higher effort and better PPA than O1\n(O3) = Signoff quality. Better PPA and higher run times than O2\n(O4-O98) = Reserved (compiler/target dependent)\n(O99) = Experimental highest possible effort, may be unstable",
             "lock": "false",
             "notes": null,
             "require": "all",

--- a/tests/core/test_create_cmdline.py
+++ b/tests/core/test_create_cmdline.py
@@ -1,11 +1,15 @@
 import siliconcompiler
 
+def do_cli_test(args, monkeypatch):
+    chip = siliconcompiler.Chip('test')
+    monkeypatch.setattr('sys.argv', args)
+    chip.create_cmdline('sc')
+    return chip
+
 def test_cli_multi_source(monkeypatch):
     ''' Regression test for bug where CLI parser wasn't handling multiple
     source files properly.
     '''
-    chip = siliconcompiler.Chip('test')
-
     # I think it doesn't matter if these files actually exist, since we're just
     # checking that the CLI app parses them correctly
     args = ['sc',
@@ -13,8 +17,7 @@ def test_cli_multi_source(monkeypatch):
             '-input', 'verilog examples/ibex/ibex_branch_predict.v',
             '-target', 'freepdk45_demo']
 
-    monkeypatch.setattr('sys.argv', args)
-    chip.create_cmdline('sc')
+    chip = do_cli_test(args, monkeypatch)
 
     assert chip.get('input','verilog') == ['examples/ibex/ibex_alu.v',
                                            'examples/ibex/ibex_branch_predict.v']
@@ -24,16 +27,19 @@ def test_cli_include_flag(monkeypatch):
     ''' Regression test for bug where CLI parser wasn't handling multiple
     source files properly.
     '''
-    chip = siliconcompiler.Chip('test')
-
-    # It doesn't matter that these files/dirs don't exist, since we're just
-    # checking that the CLI app parses them correctly
     args = ['sc',
             '-input', 'verilog source.v',
             '-I', 'include/inc1', '+incdir+include/inc2']
 
-    monkeypatch.setattr('sys.argv', args)
-    chip.create_cmdline('sc')
+    chip = do_cli_test(args, monkeypatch)
 
     assert chip.get('input', 'verilog') == ['source.v']
     assert chip.get('option', 'idir') == ['include/inc1', 'include/inc2']
+
+def test_optmode(monkeypatch):
+    '''Test optmode special handling.'''
+    args = ['sc', '-O3']
+
+    chip = do_cli_test(args, monkeypatch)
+
+    assert chip.get('option', 'optmode') == 'O3'


### PR DESCRIPTION
~I think this default value is not legal, based on the docs there should be no 'O' prefix.~

Update: per our discussion this morning, seems like the intended behavior is for the optmode to be stored with an 'O' prefix. I added a special case to the `create_cmdline()` function to handle this, updated the docs to reflect the intended behavior, and added a test case.