### PR TITLE
Refactor create_cmdline()

### DIFF
--- a/siliconcompiler/apps/sc_run.py
+++ b/siliconcompiler/apps/sc_run.py
@@ -5,12 +5,12 @@ import siliconcompiler
 def main():
     progname = "sc-run"
     chip = siliconcompiler.Chip(progname)
-    switchlist = ['cfg',
-                  'loglevel',
-                  'checkonly',
-                  'relax',
-                  'quiet',
-                  'version']
+    switchlist = ['-cfg',
+                  '-loglevel',
+                  '-checkonly',
+                  '-relax',
+                  '-quiet',
+                  '-version']
     description = """
     -----------------------------------------------------------
     Restricted SC app that accepts one or more json based cfg files

--- a/siliconcompiler/apps/sc_show.py
+++ b/siliconcompiler/apps/sc_show.py
@@ -31,7 +31,7 @@ def main():
     chip = siliconcompiler.Chip(UNSET_DESIGN)
 
     chip.create_cmdline(progname,
-                        switchlist=['design', 'input', 'option_loglevel', 'option_cfg'],
+                        switchlist=['-design', '-input', '-loglevel', '-cfg'],
                         description=description)
 
     #Error checking

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -245,9 +245,9 @@ class Chip:
             switchlist (list of str): List of SC parameter switches to expose
                  at the command line. By default all SC schema switches are
                  available. Parameter switches should be entered based on the
-                 parameter 'switch' field in the 'schema'. For parameters with
-                 multiple switches, both will be valid if any one is included in
-                 this list.
+                 parameter 'switch' field in the schema. For parameters with
+                 multiple switches, both will be accepted if any one is included
+                 in this list.
 
         Examples:
             >>> chip.create_cmdline(progname='sc-show',switchlist=['-input','-cfg'])
@@ -266,8 +266,7 @@ class Chip:
         # Get all keys from global dictionary or override at command line
         allkeys = self.getkeys()
 
-        # Iterate over all keys to add parser argument and set up a reverse
-        # switch to keypath hash table
+        # Iterate over all keys to add parser arguments
         for keypath in allkeys:
             #Fetch fields from leaf cell
             helpstr = self.get(*keypath, field='shorthelp')
@@ -278,7 +277,7 @@ class Chip:
 
             switchstrs, metavar = self._get_switches(*keypath)
 
-            #Four switch types (source, scalar, list, bool)
+            # Three switch types (bool, list, scalar)
             if not switchlist or any(switch in switchlist for switch in switchstrs):
                 if typestr == 'bool':
                     parser.add_argument(*switchstrs,

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -261,8 +261,6 @@ class Chip:
                                          formatter_class=argparse.RawDescriptionHelpFormatter,
                                          description=description)
 
-
-
         # Get all keys from global dictionary or override at command line
         allkeys = self.getkeys()
 
@@ -281,10 +279,10 @@ class Chip:
             if not switchlist or any(switch in switchlist for switch in switchstrs):
                 if typestr == 'bool':
                     parser.add_argument(*switchstrs,
+                                        nargs='?',
                                         metavar=metavar,
                                         dest=dest,
-                                        action='store_const',
-                                        const="true",
+                                        const='true',
                                         help=helpstr,
                                         default=argparse.SUPPRESS)
                 #list type arguments

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -180,7 +180,41 @@ class Chip:
         self.logger = None
 
     ###########################################################################
-    def create_cmdline(self, progname, description=None, switchlist=[]):
+    def _get_switches(self, *keypath):
+        '''Helper function for parsing switches and metavars for a keypath.'''
+        #Switch field fully describes switch format
+        switch = self.get(*keypath, field='switch')
+
+        if switch is None:
+            switches = []
+        elif isinstance(switch, list):
+            switches = switch
+        else:
+            switches = [switch]
+        switchstrs = []
+
+        # parse out switch from metavar
+        # TODO: should we validate that metavar matches for each switch?
+        for switch in switches:
+            switchmatch = re.match(r'(-[\w_]+)\s+(.*)', switch)
+            gccmatch = re.match(r'(-[\w_]+)(.*)', switch)
+            plusmatch = re.match(r'(\+[\w_\+]+)(.*)', switch)
+
+            if switchmatch:
+                switchstr = switchmatch.group(1)
+                metavar = switchmatch.group(2)
+            elif gccmatch:
+                switchstr = gccmatch.group(1)
+                metavar = gccmatch.group(2)
+            elif plusmatch:
+                switchstr = plusmatch.group(1)
+                metavar = plusmatch.group(2)
+            switchstrs.append(switchstr)
+
+        return switchstrs, metavar
+
+    ###########################################################################
+    def create_cmdline(self, progname, description=None, switchlist=None):
         """Creates an SC command line interface.
 
         Exposes parameters in the SC schema as command line switches,
@@ -188,14 +222,11 @@ class Chip:
         parameters exposed at the command line. The order of command
         line switch settings parsed from the command line is as follows:
 
-         1. design
-         2. loglevel
-         3. mode
-         4. arg_step
-         5. fpga_partname
-         6. load_target('target')
-         7. read_manifest([cfg])
-         8. all other switches
+         1. loglevel
+         2. fpga_partname
+         3. load_target('target')
+         4. read_manifest([cfg])
+         5. all other switches
 
         The cmdline interface is implemented using the Python argparse package
         and the following use restrictions apply.
@@ -213,11 +244,13 @@ class Chip:
             description (str): Short program description.
             switchlist (list of str): List of SC parameter switches to expose
                  at the command line. By default all SC schema switches are
-                 available.  Parameter switches should be entered without
-                 '-', based on the parameter 'switch' field in the 'schema'.
+                 available. Parameter switches should be entered based on the
+                 parameter 'switch' field in the 'schema'. For parameters with
+                 multiple switches, both will be valid if any one is included in
+                 this list.
 
         Examples:
-            >>> chip.create_cmdline(progname='sc-show',switchlist=['source','cfg'])
+            >>> chip.create_cmdline(progname='sc-show',switchlist=['-input','-cfg'])
             Creates a command line interface for 'sc-show' app.
 
         """
@@ -232,51 +265,24 @@ class Chip:
 
         # Get all keys from global dictionary or override at command line
         allkeys = self.getkeys()
-        switchmap = {}
-        # Iterate over all keys to add parser argument
-        # and setup up a reverse switch to key hash table
+
+        # Iterate over all keys to add parser argument and set up a reverse
+        # switch to keypath hash table
         for keypath in allkeys:
             #Fetch fields from leaf cell
             helpstr = self.get(*keypath, field='shorthelp')
             typestr = self.get(*keypath, field='type')
-            #Switch field fully describes switch format
-            switch = self.get(*keypath, field='switch')
-            if switch is None:
-                switches = []
-            elif isinstance(switch, list):
-                switches = switch
-            else:
-                switches = [switch]
-            switchstrs = []
-            dest = None
-            for switch in switches:
-                switchmatch = re.match(r'(-[\w_]+)\s+(.*)', switch)
-                gccmatch = re.match(r'(-[\w_]+)(.*)', switch)
-                plusmatch = re.match(r'(\+[\w_\+]+)(.*)', switch)
-                # Handling the fact that all options can be entered
-                # without the option prefix
-                if keypath[0]=='option':
-                    dest = f"option_{keypath[1]}"
-                else:
-                    dest = keypath[0]
-                if switchmatch:
-                    switchstr = switchmatch.group(1)
-                    if re.search('_', switchstr):
-                        dest = re.sub('-','',switchstr)
-                elif gccmatch:
-                    switchstr = gccmatch.group(1)
-                elif plusmatch:
-                    switchstr = plusmatch.group(1)
-                switchstrs.append(switchstr)
 
-            # Creating map between switch field posiation and keypath
-            switchmap[dest] = keypath
+            # argparse 'dest' must be a string, so join keypath with commas
+            dest = '_'.join(keypath)
+
+            switchstrs, metavar = self._get_switches(*keypath)
 
             #Four switch types (source, scalar, list, bool)
-            if ((switchlist == []) | (dest in switchlist)):
+            if not switchlist or any(switch in switchlist for switch in switchstrs):
                 if typestr == 'bool':
                     parser.add_argument(*switchstrs,
-                                        metavar='',
+                                        metavar=metavar,
                                         dest=dest,
                                         action='store_const',
                                         const="true",
@@ -286,7 +292,7 @@ class Chip:
                 elif re.match(r'\[', typestr):
                     #all the rest
                     parser.add_argument(*switchstrs,
-                                        metavar='',
+                                        metavar=metavar,
                                         dest=dest,
                                         action='append',
                                         help=helpstr,
@@ -294,7 +300,7 @@ class Chip:
                 else:
                     #all the rest
                     parser.add_argument(*switchstrs,
-                                        metavar='',
+                                        metavar=metavar,
                                         dest=dest,
                                         help=helpstr,
                                         default=argparse.SUPPRESS)
@@ -328,10 +334,7 @@ class Chip:
         parser.add_argument('-version', action='version', version=_metadata.version)
 
         #Grab argument from pre-process sysargs
-        #print(scargs)
         cmdargs = vars(parser.parse_args(scargs))
-        #print(cmdargs)
-        #sys.exit()
 
         # Print banner
         print(_metadata.banner)
@@ -341,26 +344,16 @@ class Chip:
 
         os.environ["COLUMNS"] = '80'
 
-        # 1. set design name (override default)
-        if 'design' in cmdargs.keys():
-            self.name = cmdargs['design']
-
-        # 2. set loglevel if set at command line
+        # 1. set loglevel if set at command line
         if 'option_loglevel' in cmdargs.keys():
             self.logger.setLevel(cmdargs['option_loglevel'])
 
-        # 3. read in target if set
+        # 2. read in target if set
         if 'option_target' in cmdargs.keys():
-            if 'option_mode' in cmdargs.keys():
-                self.set('option', 'mode', cmdargs['option_mode'], clobber=True)
             if 'arg_pdk' in cmdargs.keys():
-                print("NOT IMPLEMENTED: 'techarg' parameter")
-                raise NotImplementedError("NOT IMPLEMENTED: 'techarg' parameter")
+                raise NotImplementedError("NOT IMPLEMENTED: ['arg', 'pdk'] parameter with target")
             if 'arg_flow' in cmdargs.keys():
-                print("NOT IMPLEMENTED: 'flowarg' parameter")
-                raise NotImplementedError("NOT IMPLEMENTED: 'flowarg' parameter")
-            if 'arg_step' in cmdargs.keys():
-                self.set('arg', 'step', cmdargs['arg_step'], clobber=True)
+                raise NotImplementedError("NOT IMPLEMENTED: ['arg', 'flow'] parameter with target")
             if 'fpga_partname' in cmdargs.keys():
                 self.set('fpga', 'partname', cmdargs['fpga_partname'], clobber=True)
             # running target command
@@ -372,42 +365,46 @@ class Chip:
                 self.read_manifest(item, clobber=True, clear=True)
 
         # 5. Cycle through all command args and write to manifest
-        for switch, vals in cmdargs.items():
+        for dest, vals in cmdargs.items():
+            keypath = dest.split('_')
 
             # Turn everything into a list for uniformity
             if not isinstance(vals, list):
                 vals = [vals]
 
-            # Hack to handle the fact that we want optmode stored with an 'O'
-            # prefix.
-            if switch == 'option_optmode':
-                vals = ['O'+vals[0]]
-
-            # Cycle throug all items in list types
+            # Cycle through all items
             for item in vals:
-                args = [None] * (len(switchmap[switch])+1)
-                # First place the sub switches in order
-                for subswitch in switch.split('_'):
-                    for index,value in enumerate(switchmap[switch]):
-                        if subswitch == value:
-                            args[index] = subswitch
-                # Now place space items left to right based on empty slots
-                for j in range(len(args)):
-                    if args[j] is None:
-                        for i in item.split(' '):
-                            args[j] = i
-                            break
-                # Ensureing last item is the data we want
-                args[-1] = item.split(' ')[-1]
+                # Hack to handle the fact that we want optmode stored with an 'O'
+                # prefix.
+                if keypath == ['option', 'optmode']:
+                    item = 'O' + item
+
+                num_free_keys = keypath.count('default')
+
+                if len(item.split(' ')) < num_free_keys + 1:
+                    # Error out if value provided doesn't have enough words to
+                    # fill in 'default' keys.
+                    switches, metavar = self._get_switches(*keypath)
+                    switchstr = '/'.join(switches)
+                    self.logger.error(f'Invalid value {item} for switch {switchstr}. Expected format {metavar}.')
+                    raise SiliconCompilerError('Invalid CLI arguments')
+
+                # We replace 'default' in keypath with first N words in provided
+                # value. Remainder is the actual value we want to store in the
+                # parameter.
+                *free_keys, val = item.split(' ', num_free_keys)
+                args = [free_keys.pop(0) if key == 'default' else key for key in keypath]
+
                 # Storing in manifest
-                self.logger.info(f"Command line argument entered: {args}")
-                if self.valid(*args[:-1], quiet=True):
-                    if re.match(r'\[', self.get(*args[:-1], field='type')):
-                        self.add(*args)
+                self.logger.info(f"Command line argument entered: {args} Value: {val}")
+                typestr = self.get(*keypath, field='type')
+                if typestr.startswith('['):
+                    if self.valid(*args, quiet=True):
+                        self.add(*args, val)
                     else:
-                        self.set(*args, clobber=True)
+                        self.set(*args, val, clobber=True)
                 else:
-                    self.set(*args, clobber=True)
+                    self.set(*args, val, clobber=True)
 
     #########################################################################
     def find_function(self, modulename, funcname, moduletype=None):

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -961,7 +961,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             shorthelp=f"Datasheet: absolute voltage limits",
             switch=f"-datasheet_limits_voltage 'design pin <(float,float)>'",
             example=[
-                f"cli: -datasheet_limits_voltage 'mydevice vdd (-0.4,1.1)>'",
+                f"cli: -datasheet_limits_voltage 'mydevice vdd (-0.4,1.1)'",
                 f"api: chip.set('datasheet','mydevice','limits','voltage','vdd', (-0.4,1.1))"],
             schelp=f"""Device absolute minimum/maximum voltage not to be
             exceeded, specified on a per pin basis.""")
@@ -976,7 +976,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 shorthelp=f"Datasheet: absolute {val}",
                 switch=f"-datasheet_{item} 'design <(float,float)>'",
                 example=[
-                    f"cli: -datasheet_{item} 'mydevice (-40,125)>'",
+                    f"cli: -datasheet_{item} 'mydevice (-40,125)'",
                     f"api: chip.set('datasheet','mydevice','limits','{item}',(-40,125))"],
                 schelp=f"""Device absolute {val} not to be exceeded.""")
 
@@ -1176,7 +1176,7 @@ def schema_flowgraph(cfg, flow='default', step='default', index='default'):
             shorthelp="Flowgraph: tool selection",
             switch="-flowgraph_tool 'flow step <str>'",
             example=[
-                "cli: -flowgraph_tool 'asicflow place openroad'",
+                "cli: -flowgraph_tool 'asicflow place 0 openroad'",
                 "api: chip.set('flowgraph','asicflow','place','0','tool','openroad')"],
             schelp="""Name of the tool name used for task execution. Builtin tool names
             associated bound to core API functions include: minimum, maximum, join,
@@ -1380,7 +1380,7 @@ def schema_tool(cfg, tool='default', step='default', index='default'):
             shorthelp="Tool: regex filter",
             switch="-tool_regex 'tool step index suffix <str>'",
             example=[
-                "cli: -tool_regex 'openroad place 0 error -v ERROR",
+                "cli: -tool_regex 'openroad place 0 error -v ERROR'",
                 "api: chip.set('tool','openroad','regex','place','0','error','-v ERROR')"],
             schelp="""
              A list of piped together grep commands. Each entry represents a set
@@ -1605,7 +1605,7 @@ def schema_arg(cfg):
             shorthelp="ARG: PDK argument",
             switch="-arg_pdk 'key <str>",
             example=[
-                "cli: -arg_pdk 'mimcap true",
+                "cli: -arg_pdk 'mimcap true'",
                 "api: chip.set('arg','pdk','mimcap','true')"],
             schelp="""
             Parameter passed in as key/value pair to the technology target
@@ -1821,7 +1821,7 @@ def schema_metric(cfg, step='default', index='default'):
                 shorthelp=f"Metric: {item}",
                 switch=f"-metric_{item} 'step index <float>'",
                 example=[
-                    f"cli: -metric_{item} 'place 0 goal 0.01'",
+                    f"cli: -metric_{item} 'place 0 0.01'",
                     f"api: chip.set('metric','place','0','{item}', 0.01)"],
                 schelp=f"""
                 Metric tracking the {val} on a per step and index basis.""")
@@ -2612,7 +2612,7 @@ def schema_option(cfg):
             shorthelp="Design search paths",
             switch=['+incdir+<dir>', '-I <dir>'],
             example=[
-                "cli: '+incdir+./mylib'",
+                "cli: +incdir+./mylib",
                 "api: chip.set('option','idir','./mylib')"],
             schelp="""
             Search paths to look for files included in the design using
@@ -2870,7 +2870,7 @@ def schema_package(cfg):
             sctype='[str]',
             scope='global',
             shorthelp=f"Package: sponsoring organization",
-            switch=f"-package_organzation <str>",
+            switch=f"-package_organization <str>",
             example=[
                 f"cli: -package_organization 'humanity'",
                 f"api: chip.set('package','organization','humanity')"],
@@ -2947,7 +2947,7 @@ def schema_checklist(cfg):
             shorthelp="Checklist: item data format",
             switch="-checklist_dataformat 'standard item <float>'",
             example=[
-                "cli: -checklist_dataformat 'README'",
+                "cli: -checklist_dataformat 'ISO D000 dataformat README'",
                 "api: chip.set('checklist','ISO','D000','dataformat','README')"],
             schelp="""
             Free text description of the type of data files acceptable as
@@ -3103,7 +3103,7 @@ def schema_asic(cfg):
             scope='job',
             shorthelp="ASIC: non-default routing rule",
             switch="-asic_ndr 'netname <(float,float)>",
-            example= ["cli: -asic_ndr_width 'clk (0.2,0.2)",
+            example= ["cli: -asic_ndr 'clk (0.2,0.2)'",
                     "api: chip.set('asic','ndr','clk', (0.2,0.2))"],
             schelp="""
             Definitions of non-default routing rule specified on a per
@@ -3191,7 +3191,7 @@ def schema_asic(cfg):
             scope='job',
             shorthelp="ASIC: parasitics layer",
             switch="-asic_rclayer 'sigtype <str>'",
-            example= ["cli: -asic_rclayer 'clk m3",
+            example= ["cli: -asic_rclayer 'clk m3'",
                     "api: chip.set('asic', 'rclayer', 'clk', 'm3')"],
             schelp="""
             Technology agnostic metal layer to be used for parasitic
@@ -3383,7 +3383,7 @@ def schema_asic(cfg):
     scparam(cfg,['asic', 'libarch'],
             sctype='str',
             shorthelp="ASIC: library architecture",
-            switch="-asic_library '<str>'",
+            switch="-asic_libarch '<str>'",
             example=[
                 "cli: -asic_libarch '12track'",
                 "api: chip.set('asic','libarch','12track')"],
@@ -3399,7 +3399,7 @@ def schema_asic(cfg):
             shorthelp="ASIC: Footprint name aliases",
             switch="-asic_footprint_alias 'key <str>'",
             example=[
-                "cli: -footprint_alias '12track FreeCell'",
+                "cli: -asic_footprint_alias '12track FreeCell'",
                 "api: chip.set('asic','footprint','12track','alias','FreeCell')"],
             schelp="""
             Alias for the footprint key that is sometimes needed when the footprint can
@@ -3506,7 +3506,7 @@ def schema_constraint(cfg, scenario='default'):
             scope='job',
             copy='true',
             shorthelp="Constraint files",
-            switch="-constraint_constraint 'scenario <file>'",
+            switch="-constraint_file 'scenario <file>'",
             example=["cli: -constraint_file 'worst hello.sdc'",
                      "api: chip.set('constraint','worst','file', 'hello.sdc')"],
             schelp="""List of timing constraint files to use for the scenario. The

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1616,9 +1616,9 @@ def schema_arg(cfg):
             sctype='[str]',
             scope='scratch',
             shorthelp="ARG: Flow argument",
-            switch="-arg_flow 'key <str>",
+            switch="-arg_flow 'key <str>'",
             example=[
-                "cli: -arg_flow 'n 100",
+                "cli: -arg_flow 'n 100'",
                 "api: chip.set('arg','flow','n', 100)"],
             schelp="""
             Parameter passed in as key/value pair to the flow target

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -40,7 +40,7 @@
             "default": {
                 "defvalue": [],
                 "example": [
-                    "cli: -arg_pdk 'mimcap true",
+                    "cli: -arg_pdk 'mimcap true'",
                     "api: chip.set('arg','pdk','mimcap','true')"
                 ],
                 "help": "Parameter passed in as key/value pair to the technology target\nreferenced in the load_pdk() API call. See the target technology\nfor specific guidelines regarding configuration parameters.",
@@ -539,7 +539,7 @@
                 "alias": {
                     "defvalue": [],
                     "example": [
-                        "cli: -footprint_alias '12track FreeCell'",
+                        "cli: -asic_footprint_alias '12track FreeCell'",
                         "api: chip.set('asic','footprint','12track','alias','FreeCell')"
                     ],
                     "help": "Alias for the footprint key that is sometimes needed when the footprint can\nbe referenced by multiple names. The key is the 'official' footprint.",
@@ -619,7 +619,7 @@
             "scope": "job",
             "shorthelp": "ASIC: library architecture",
             "signature": null,
-            "switch": "-asic_library '<str>'",
+            "switch": "-asic_libarch '<str>'",
             "type": "str",
             "value": null
         },
@@ -766,7 +766,7 @@
             "default": {
                 "defvalue": null,
                 "example": [
-                    "cli: -asic_ndr_width 'clk (0.2,0.2)",
+                    "cli: -asic_ndr 'clk (0.2,0.2)'",
                     "api: chip.set('asic','ndr','clk', (0.2,0.2))"
                 ],
                 "help": "Definitions of non-default routing rule specified on a per\nnet basis. Constraints are entered as a (width,space) tuples\nspecified in microns.",
@@ -819,7 +819,7 @@
             "default": {
                 "defvalue": null,
                 "example": [
-                    "cli: -asic_rclayer 'clk m3",
+                    "cli: -asic_rclayer 'clk m3'",
                     "api: chip.set('asic', 'rclayer', 'clk', 'm3')"
                 ],
                 "help": "Technology agnostic metal layer to be used for parasitic\nextraction estimation during APR for the wire type specified\nCurrent the supported wire types are: clk, data. The metal\nlayers can be specified as technology agnostic SC layers\nstarting with m1 or as hard PDK specific layer names.",
@@ -913,7 +913,7 @@
                 "dataformat": {
                     "defvalue": null,
                     "example": [
-                        "cli: -checklist_dataformat 'README'",
+                        "cli: -checklist_dataformat 'ISO D000 dataformat README'",
                         "api: chip.set('checklist','ISO','D000','dataformat','README')"
                     ],
                     "help": "Free text description of the type of data files acceptable as\nchecklist signoff validation.",
@@ -1098,7 +1098,7 @@
                 "scope": "job",
                 "shorthelp": "Constraint files",
                 "signature": [],
-                "switch": "-constraint_constraint 'scenario <file>'",
+                "switch": "-constraint_file 'scenario <file>'",
                 "type": "[file]",
                 "value": []
             },
@@ -1232,7 +1232,7 @@
                 "junctiontemp": {
                     "defvalue": null,
                     "example": [
-                        "cli: -datasheet_junctiontemp 'mydevice (-40,125)>'",
+                        "cli: -datasheet_junctiontemp 'mydevice (-40,125)'",
                         "api: chip.set('datasheet','mydevice','limits','junctiontemp',(-40,125))"
                     ],
                     "help": "Device absolute junction temperature limits not to be exceeded.",
@@ -1249,7 +1249,7 @@
                 "storagetemp": {
                     "defvalue": null,
                     "example": [
-                        "cli: -datasheet_storagetemp 'mydevice (-40,125)>'",
+                        "cli: -datasheet_storagetemp 'mydevice (-40,125)'",
                         "api: chip.set('datasheet','mydevice','limits','storagetemp',(-40,125))"
                     ],
                     "help": "Device absolute storage temperature limits not to be exceeded.",
@@ -1267,7 +1267,7 @@
                     "default": {
                         "defvalue": null,
                         "example": [
-                            "cli: -datasheet_limits_voltage 'mydevice vdd (-0.4,1.1)>'",
+                            "cli: -datasheet_limits_voltage 'mydevice vdd (-0.4,1.1)'",
                             "api: chip.set('datasheet','mydevice','limits','voltage','vdd', (-0.4,1.1))"
                         ],
                         "help": "Device absolute minimum/maximum voltage not to be\nexceeded, specified on a per pin basis.",
@@ -2069,7 +2069,7 @@
                     "tool": {
                         "defvalue": null,
                         "example": [
-                            "cli: -flowgraph_tool 'asicflow place openroad'",
+                            "cli: -flowgraph_tool 'asicflow place 0 openroad'",
                             "api: chip.set('flowgraph','asicflow','place','0','tool','openroad')"
                         ],
                         "help": "Name of the tool name used for task execution. Builtin tool names\nassociated bound to core API functions include: minimum, maximum, join,\nverify, mux.",
@@ -2473,7 +2473,7 @@
                 "holdslack": {
                     "defvalue": null,
                     "example": [
-                        "cli: -metric_holdslack 'place 0 goal 0.01'",
+                        "cli: -metric_holdslack 'place 0 0.01'",
                         "api: chip.set('metric','place','0','holdslack', 0.01)"
                     ],
                     "help": "Metric tracking the worst hold slack (positive or negative) on a per step and index basis.",
@@ -2491,7 +2491,7 @@
                 "holdtns": {
                     "defvalue": null,
                     "example": [
-                        "cli: -metric_holdtns 'place 0 goal 0.01'",
+                        "cli: -metric_holdtns 'place 0 0.01'",
                         "api: chip.set('metric','place','0','holdtns', 0.01)"
                     ],
                     "help": "Metric tracking the total negative hold slack (TNS) on a per step and index basis.",
@@ -2509,7 +2509,7 @@
                 "holdwns": {
                     "defvalue": null,
                     "example": [
-                        "cli: -metric_holdwns 'place 0 goal 0.01'",
+                        "cli: -metric_holdwns 'place 0 0.01'",
                         "api: chip.set('metric','place','0','holdwns', 0.01)"
                     ],
                     "help": "Metric tracking the worst negative hold slack (positive values truncated to zero) on a per step and index basis.",
@@ -2754,7 +2754,7 @@
                 "setupslack": {
                     "defvalue": null,
                     "example": [
-                        "cli: -metric_setupslack 'place 0 goal 0.01'",
+                        "cli: -metric_setupslack 'place 0 0.01'",
                         "api: chip.set('metric','place','0','setupslack', 0.01)"
                     ],
                     "help": "Metric tracking the worst setup slack (positive or negative) on a per step and index basis.",
@@ -2772,7 +2772,7 @@
                 "setuptns": {
                     "defvalue": null,
                     "example": [
-                        "cli: -metric_setuptns 'place 0 goal 0.01'",
+                        "cli: -metric_setuptns 'place 0 0.01'",
                         "api: chip.set('metric','place','0','setuptns', 0.01)"
                     ],
                     "help": "Metric tracking the total negative setup slack (TNS) on a per step and index basis.",
@@ -2790,7 +2790,7 @@
                 "setupwns": {
                     "defvalue": null,
                     "example": [
-                        "cli: -metric_setupwns 'place 0 goal 0.01'",
+                        "cli: -metric_setupwns 'place 0 0.01'",
                         "api: chip.set('metric','place','0','setupwns', 0.01)"
                     ],
                     "help": "Metric tracking the worst negative setup slack (positive values truncated to zero) on a per step and index basis.",
@@ -3443,7 +3443,7 @@
         "idir": {
             "defvalue": [],
             "example": [
-                "cli: '+incdir+./mylib'",
+                "cli: +incdir+./mylib",
                 "api: chip.set('option','idir','./mylib')"
             ],
             "help": "Search paths to look for files included in the design using\nthe ```include`` statement.",
@@ -4536,7 +4536,7 @@
             "scope": "global",
             "shorthelp": "Package: sponsoring organization",
             "signature": [],
-            "switch": "-package_organzation <str>",
+            "switch": "-package_organization <str>",
             "type": "[str]",
             "value": []
         },
@@ -6185,7 +6185,7 @@
                         "default": {
                             "defvalue": [],
                             "example": [
-                                "cli: -tool_regex 'openroad place 0 error -v ERROR",
+                                "cli: -tool_regex 'openroad place 0 error -v ERROR'",
                                 "api: chip.set('tool','openroad','regex','place','0','error','-v ERROR')"
                             ],
                             "help": " A list of piped together grep commands. Each entry represents a set\nof command line arguments for grep including the regex pattern to\nmatch. Starting with the first list entry, each grep output is piped\ninto the following grep command in the list. Supported grep options\ninclude, -t, -i, -E, -x, -e. Patterns starting with \"-\" should be\ndirectly preceeded by the \"-e\" option. The following example\nillustrates the concept.\n\nUNIX grep:\n>> grep WARNING place.log | grep -v \"bbox\" > place.warnings\n\nsiliconcompiler:\nchip.set('tool','openroad','regex','place',0','warnings',[\"WARNING\",\"-v bbox\"])\n\nDefines a set of tool specific environment variables used by the executables\nthat depend on license key servers to control access. For multiple servers,\nseparate each server by a 'colon'. The named license variable are read at\nruntime (run()) and the environment variables are set.",

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -4,7 +4,7 @@
             "default": {
                 "defvalue": [],
                 "example": [
-                    "cli: -arg_flow 'n 100",
+                    "cli: -arg_flow 'n 100'",
                     "api: chip.set('arg','flow','n', 100)"
                 ],
                 "help": "Parameter passed in as key/value pair to the flow target\nreferenced in the load_flow() API call. See the target flow\nfor specific guidelines regarding configuration parameters.",
@@ -14,7 +14,7 @@
                 "scope": "scratch",
                 "shorthelp": "ARG: Flow argument",
                 "signature": [],
-                "switch": "-arg_flow 'key <str>",
+                "switch": "-arg_flow 'key <str>'",
                 "type": "[str]",
                 "value": []
             }

--- a/tests/core/test_create_cmdline.py
+++ b/tests/core/test_create_cmdline.py
@@ -1,3 +1,5 @@
+import re
+
 import siliconcompiler
 
 def do_cli_test(args, monkeypatch, switchlist=None):
@@ -60,3 +62,77 @@ def test_limited_switchlist(monkeypatch):
 
     assert chip.get('option', 'loglevel') == 'DEBUG'
     assert chip.get('arg', 'flow', 'foo') == ['bar']
+
+def _cast(val, sctype):
+    if sctype.startswith('['):
+        # TODO: doesn't handle examples w/ multiple list items (we do not have
+        # currently)
+        subtype = sctype.strip('[]')
+        return [_cast(val.strip('[]'), subtype)]
+    elif sctype.startswith('('):
+        vals = val.strip('()').split(',')
+        subtypes = sctype.strip('()').split(',')
+        return tuple(_cast(v.strip(), subtype.strip()) for v, subtype in zip(vals, subtypes))
+    elif sctype == 'float':
+        return float(val)
+    elif sctype == 'int':
+        return int(val)
+    elif sctype == 'bool':
+        return bool(val)
+    else:
+        # everything else (str, file, dir) is treated like a string
+        return val
+
+def test_cli_examples(monkeypatch):
+    # Need to mock this function, since our cfg CLI example will try to call it
+    # on a fake manifest.
+    def _mock_read_manifest(chip, manifest, clobber=False, clear=False):
+        # nop
+        pass
+    monkeypatch.setattr(siliconcompiler.Chip, 'read_manifest', _mock_read_manifest)
+
+    chip = siliconcompiler.Chip('test')
+    for keypath in chip.getkeys():
+        examples = chip.get(*keypath, field='example')
+        for example in examples:
+            if not example.startswith('cli'):
+                continue
+
+            match = re.match(r'cli\: (\S+)(?:\s(.*))?', example)
+            assert match is not None, f'Invalid CLI example: {example}'
+
+            switch, value = match.groups()
+            if value is None:
+                value = ''
+
+            if len(value.split(' ')) > 1:
+                assert value[0] == "'" and value[-1] == "'", f'Multi-word value must be surrounded by quotes: {example}'
+            value = value.strip("'")
+
+            default_count = keypath.count('default')
+            assert len(value.split(' ')) >= default_count + 1, f'Not enough values to fill in default keys: {keypath}'
+            *free_keys, expected_val = value.split(' ', default_count)
+            typestr = chip.get(*keypath, field='type')
+            replaced_keypath = [free_keys.pop(0) if key == 'default' else key for key in keypath]
+
+            # Special cases
+            if keypath == ['option', 'optmode']:
+                expected_val = switch.lstrip('-')
+            elif keypath == ['option', 'define']:
+                expected_val = switch[len('-D'):]
+            elif switch.startswith('+incdir+'):
+                expected_val = switch[len('+incdir+'):]
+            elif switch.startswith('+libext+'):
+                expected_val = switch[len('+libext+'):]
+
+            args = ['sc', switch]
+            if value:
+                args.append(value)
+
+            c = do_cli_test(args, monkeypatch)
+
+            if expected_val:
+                assert c.get(*replaced_keypath) == _cast(expected_val, typestr)
+            else:
+                assert typestr == 'bool', 'Implicit value only alowed for boolean'
+                assert c.get(*replaced_keypath) == True

--- a/tests/core/test_create_cmdline.py
+++ b/tests/core/test_create_cmdline.py
@@ -1,9 +1,9 @@
 import siliconcompiler
 
-def do_cli_test(args, monkeypatch):
+def do_cli_test(args, monkeypatch, switchlist=None):
     chip = siliconcompiler.Chip('test')
     monkeypatch.setattr('sys.argv', args)
-    chip.create_cmdline('sc')
+    chip.create_cmdline('sc', switchlist=switchlist)
     return chip
 
 def test_cli_multi_source(monkeypatch):
@@ -43,3 +43,20 @@ def test_optmode(monkeypatch):
     chip = do_cli_test(args, monkeypatch)
 
     assert chip.get('option', 'optmode') == 'O3'
+
+def test_spaces_in_value(monkeypatch):
+    desc = 'My package description'
+    args = ['sc', '-package_description', desc]
+
+    chip = do_cli_test(args, monkeypatch)
+
+    assert chip.get('package', 'description') == desc
+
+def test_limited_switchlist(monkeypatch):
+    chip = siliconcompiler.Chip('test')
+
+    args = ['sc', '-loglevel', 'DEBUG', '-arg_flow', 'foo bar']
+    chip = do_cli_test(args, monkeypatch, switchlist=['-loglevel', '-arg_flow'])
+
+    assert chip.get('option', 'loglevel') == 'DEBUG'
+    assert chip.get('arg', 'flow', 'foo') == ['bar']


### PR DESCRIPTION
In preparation for adding filetype inference to create_cmdline() in a future PR, I took a refactor pass to fix some of our backlog CLI items.

**Improvements**

1: Simplified code by constructing argparse 'dest' key directly from keypath. This eliminated the need for `switchmap` and the logic for constructing `dest`.

2: Made `switchlist` based on actual switches. The docstring said that switchlist should match switches without the '-', but the existing behavior didn't match this. I also tweaked the spec to require the '-', since treating the hyphen specially seems inconsistent given we have keys without hyphens (e.g. `+libext+`).

3: Fixed #996: if a keypath has N 'default' keys, the logic now splits out only the first N words from the value provided on the command line, and treats the entire remainder as the value to store. 

```
sc -package_description "My package description"
...
| INFO    | Command line argument entered: ['package', 'description'] Value: My package description
```

Also added a nice error in case a user messes up the formatting of parameters with 'default':
```
$ sc -pdk_grid_xpitch 5
...
| ERROR   | Invalid value 5 for switch -pdk_grid_xpitch. Expected format 'pdkname stackup layer <float>'.
```

4: Removed ['design'], ['arg', 'step'], and ['option', 'mode'] priority, since I don't think there's a need for this anymore?

5: Added 'metavar' to argparse so that user can see the expected format for complex keypaths in the help message. Let me know if you like this.

E.g.
```
$sc-show --help
usage: sc-show [-h] [-design <str>] [-input 'filetype <file>'] [-cfg <file>] [-loglevel <str>] [-version]

...

optional arguments:
  -h, --help            show this help message and exit
  -design <str>         Design top module name
  -input 'filetype <file>'
                        Input files
  -cfg <file>           Configuration manifest
  -loglevel <str>       Logging level
  -version              show program's version number and exit
```