### PR TITLE
Add filetype inference to command line apps

### DIFF
--- a/examples/blinky/run.sh
+++ b/examples/blinky/run.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-sc  -input "verilog blinky.v" \
+sc blinky.v icebreaker.pcf \
     -fpga_partname "ice40up5k-sg48" \
     -target "fpgaflow_demo" \
-    -input "pcf icebreaker.pcf" \
     -design "blinky"

--- a/examples/fibone/run.sh
+++ b/examples/fibone/run.sh
@@ -1,2 +1,2 @@
-sc -input "bsv FibOne.bsv" -design mkFibOne -frontend bluespec
+sc FibOne.bsv -design mkFibOne -frontend bluespec
 sc-show -design mkFibOne

--- a/examples/gcd/run.sh
+++ b/examples/gcd/run.sh
@@ -5,9 +5,8 @@
 # https://stackoverflow.com/a/246128
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-sc -design gcd \
-   -input "verilog gcd.v" \
-   -input "sdc gcd.sdc" \
+sc gcd.v gcd.sdc \
+   -design gcd \
    -package_version "0.0.0" \
    -package_description "GCD test package" \
    -package_license "MIT" \

--- a/examples/gcd/run_asap7.sh
+++ b/examples/gcd/run_asap7.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
-sc -design gcd \
-   -input "verilog gcd.v" \
-   -input "sdc gcd.sdc" \
+sc gcd.v gcd.sdc \
+   -design gcd \
    -package_version "0.0.0" \
    -package_description "GCD test package" \
    -package_license "MIT" \

--- a/examples/gcd_chisel/run.sh
+++ b/examples/gcd_chisel/run.sh
@@ -1,2 +1,2 @@
-sc -input "scala GCD.scala" -frontend chisel
+sc GCD.scala -frontend chisel
 sc-show -design GCD

--- a/examples/gcd_hls/run.sh
+++ b/examples/gcd_hls/run.sh
@@ -1,2 +1,2 @@
-sc -input "c gcd.c" -frontend c
+sc gcd.c -frontend c
 sc-show -design gcd

--- a/examples/heartbeat/run.sh
+++ b/examples/heartbeat/run.sh
@@ -1,1 +1,1 @@
-sc -input "verilog heartbeat.v" -input "sdc heartbeat.sdc" -design heartbeat -target "freepdk45_demo"
+sc heartbeat.v heartbeat.sdc -design heartbeat -target "freepdk45_demo"

--- a/siliconcompiler/apps/sc.py
+++ b/siliconcompiler/apps/sc.py
@@ -40,6 +40,7 @@ def main():
     input_map = {
         # HDL
         'v': 'verilog',
+        'sv': 'verilog',
         'vhdl': 'vhdl',
         'c': 'c',
         'bsv': 'bsv',

--- a/siliconcompiler/apps/sc.py
+++ b/siliconcompiler/apps/sc.py
@@ -37,14 +37,31 @@ def main():
     # Create a base chip class.
     chip = siliconcompiler.Chip(UNSET_DESIGN)
 
+    input_map = {
+        # HDL
+        'v': 'verilog',
+        'vhdl': 'vhdl',
+        'c': 'c',
+        'bsv': 'bsv',
+        'scala': 'scala',
+
+        # ASIC "side files"
+        'sdc': 'sdc',
+        'def': 'floorplan.def',
+
+        # FPGA "side files"
+        'pcf': 'pcf'
+    }
+
     # Read command-line inputs and generate Chip objects to run the flow on.
     chip.create_cmdline(progname,
-                        description=description)
+                        description=description,
+                        input_map=input_map)
 
     # Set design if none specified
     if chip.get('design') == UNSET_DESIGN:
         topfile = None
-        for sourcetype in ('verilog', 'scala', 'c'):
+        for sourcetype in ('verilog', 'vhdl', 'c', 'bsv', 'scala'):
             if chip.valid('input', sourcetype):
                 sources = chip.get('input', sourcetype)
                 if sources:

--- a/siliconcompiler/apps/sc_show.py
+++ b/siliconcompiler/apps/sc_show.py
@@ -17,7 +17,7 @@ def main():
     sc-show -design adder
     (displays build/job0/adder/export/0/outputs/adder.gds)
 
-    sc-show -read_def "show 0 build/job0/adder/route/1/outputs/adder.def"
+    sc-show build/job0/adder/route/1/outputs/adder.def
     (displays build/job0/adder/route/1/outputs/adder.def)
 
     """
@@ -30,9 +30,14 @@ def main():
     # Create a base chip class.
     chip = siliconcompiler.Chip(UNSET_DESIGN)
 
+    input_map = {
+        'def': 'def',
+        'gds': 'gds',
+    }
     chip.create_cmdline(progname,
                         switchlist=['-design', '-input', '-loglevel', '-cfg'],
-                        description=description)
+                        description=description,
+                        input_map=input_map)
 
     #Error checking
     design = chip.get('design') != UNSET_DESIGN

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -250,8 +250,8 @@ class Chip:
                 in this list.
             input_map (dict of str): Dictionary mapping file extensions to input
                 filetypes. This is used to automatically assign positional
-                source arguments to ['input'] parameters keypath based on their
-                file extension. If None, the CLI will not accept positional
+                source arguments to ['input', ...] keypaths based on their file
+                extension. If None, the CLI will not accept positional source
                 arguments.
 
         Examples:


### PR DESCRIPTION
This PR adds a parameter to `create_cmdline()` that allows for configurable filetype inference of positional source arguments. This gives `sc` a CLI more similar to pre-0.9, where sources can be provided directly without having to prefix them with a flag. In fact, the interface is even cleaner now, since we have a mechanism to provide things like SDCs, DEFs, etc. directly as well!

The configurable `input_map` allows apps to set up mappings in a context-dependent manner. For example, `sc` maps all filetypes accepted by the asicflow and fpgaflow, whereas `sc-show` maps filetypes that are displayable in KLayout. 

