### PR TITLE
Docs fixups

### DIFF
--- a/docs/_ext/schemagen.py
+++ b/docs/_ext/schemagen.py
@@ -14,23 +14,7 @@ class SchemaGen(SphinxDirective):
 
         schema = schema_cfg()
 
-        # Split up schema into root and nested keys so that we can add a custom
-        # header to the root entries.
-        basic_schema = {}
-        nested_schema = {}
-        for key, val in schema.items():
-            if is_leaf(val):
-                basic_schema[key] = val
-            else:
-                nested_schema[key] = val
-
-        basic_section = build_section('root', 'root')
-        for n in self.process_schema(basic_schema):
-            basic_section += n
-
-        nested_sections = self.process_schema(nested_schema)
-
-        return [basic_section] + nested_sections
+        return self.process_schema(schema)
 
     def process_schema(self, schema, parents=[]):
         if 'help' in schema:

--- a/docs/_ext/schemagen.py
+++ b/docs/_ext/schemagen.py
@@ -36,7 +36,7 @@ class SchemaGen(SphinxDirective):
                 if key == 'default':
                     for n in self.process_schema(schema['default'], parents=parents):
                         sections.append(n)
-                else:
+                elif key not in ('history', 'library'):
                     section_key = '-'.join(parents) + '-' + key
                     section = build_section(key, section_key)
                     for n in self.process_schema(schema[key], parents=parents+[key]):

--- a/docs/reference_manual/schema.rst
+++ b/docs/reference_manual/schema.rst
@@ -54,9 +54,27 @@ Parameter Fields
    type
        The parameter type. Supported types include Python compatible types ('int', 'float', and 'bool') and two custom file types ('file' and 'dir'). The 'file' and 'dir' type specify that the parameter is a 'regular' file or directory as described by Posix. All types except for the 'bool' types can be specified as a Python compatible list type by enclosing the type value in brackets. (ie. [str] specifies that the parameter is a list of strings). Additionally strings, integers, and floats can be tagged as tuples, using the Python parentheses like syntax (eg. [(float,float)] specifies a list of 2-float tuples). Input arguments and return values of the set/get/add core methods are encoded as native Python types. The JSON format does not natively support all of these data types, so to ensure platform interoperability, all SC schema parameters are converted to strings before being exported to a json file. Additionally, note that the parameter value 'None' gets translated to the "null", True gets translated to "true", and False gets translated to "false" before JSON export.
 
-
-
 Parameters
 ----------
 
 .. schemagen::
+
+Nested keypaths
+----------------
+
+The SC schema has two special top-level categories that store nested subsets of the schema rather than unique parameters.
+
+history
+++++++++
+
+The "history" prefix stores configuration from past runs, indexed by jobname. Values are stored automatically at the end of :meth:`run()`, and only parameters tagged with the 'job' scope are stored. This can be used to go back and inspect the results of old runs. As a shortcut for accessing these stored values, most of the schema access functions support an optional ``job`` keyword arg. For example, the following line returns the number of errors from a synthesis step run as part of a job called "job0"::
+
+    chip.get('metric', 'syn', '0', 'error', job='job0')
+
+library
+++++++++
+
+The "library" prefix stores the schema parameters of library chip objects that have been imported into the current chip object, keyed by library name. These values are accessed directly using the schema access functions. For example, the following line returns the path to a LEF file associated with a library called "mylib"::
+
+    chip.find_files('library', 'mylib', 'model', 'layout', 'lef', stackup)
+

--- a/docs/user_guide/libraries.rst
+++ b/docs/user_guide/libraries.rst
@@ -7,23 +7,24 @@ The general flow to create and import a library is to instantiate a library :cla
 Here's an example of setting up and importing a library object::
 
   lib = siliconcompiler.Chip('mylibrary')
-  lib.add('model', 'layout', 'lef', 'mylibrary.lef')
+  lib.add('model', 'layout', 'lef', stackup, 'mylibrary.lef')
   # ... add more library sources
 
   chip = siliconcompiler.Chip('mydesign')
   chip.add('input', 'verilog', 'mydesign.v')
   chip.import_library(lib)
-  chip.add('macrolib', 'mylibrary')
+  chip.add('asic', 'macrolib', 'mylibrary')
   # ... perform more build configuration
 
   run()
 
 The same approach is used to configure standard cell libraries, which are primarily defined using :keypath:`model` settings. In leading edge process nodes, it's not uncommon to have 10's to 100's of STA signoff corners, with each corner consuming gigabytes of disk space. The SiliconCompiler schema is designed to enable efficient setup of all library file pointers and to allow designers to easily select which libraries and which corners to use in any single run. The run time selection of corners, libraries, and timing enables an agile approach to design, wherein the designer can choose the level of accuracy and performance based on need. For example, early in the architecture exploration phase, speed matters and the right choice for synthesis may be to compile using a single stdcell library, using a NLDM model, at a single timing corner. As the design is fine tuned, and the team closes in on tapeout of a mass produced device, the compilation and signoff verification may use many VT libraries, CCS timing models, and hundreds of timing scenarios. Being able to make these trade-offs with a unified library setup and a couple of lines of designer Python settings, greatly reduces physical design speed and risk.
 
-The following code snippet shows how library gds and lef files can be set up in the SC schema::
+The following code snippet shows how library GDS and LEF files can be set up in the SC schema::
 
-    lib.add('model','layout','lef','$FREEPDK45/lef/NangateOpenCellLibrary.lef')
-    lib.add('model','layout','gds','$FREEPDK45/gds/NangateOpenCellLibrary.gds')
+    stackup = '<my-stackup>'
+    lib.add('model','layout','lef', stackup, '$FREEPDK45/lef/NangateOpenCellLibrary.lef')
+    lib.add('model','layout','gds', stackup, '$FREEPDK45/gds/NangateOpenCellLibrary.gds')
 
 SiliconCompiler also supports referencing soft libraries (RTL, C-code, etc), in which case many of the physical IP parameters can be omitted.
 

--- a/docs/user_guide/quickstart.rst
+++ b/docs/user_guide/quickstart.rst
@@ -44,15 +44,25 @@ Directory`, and :ref:`Targets Directory` sections of the reference manual and re
 
 .. note::
 
-   The example assumes that surelog, yosys, openroad, and klayout are all correctly
+   The example assumes that Surelog, Yosys, OpenROAD, and KLayout are all correctly
    installed. Links to individual tool installation instructions and platform
    limitations can be found in the :ref:`Tools directory`.
 
-   To simplify tool installation and job scheduling, SiliconCompiler supports a
+   It also requires downloading and pointing SC to FreePDK45, which is bundled
+   with the SiliconCompiler repo. To install, clone the repo and set up an
+   environment variable ``SCPATH`` pointing at the ``siliconcompiler/``
+   directory inside of it:
+
+   .. code-block:: bash
+
+     git clone https://github.com/siliconcompiler/siliconcompiler
+     export SCPATH=$PWD/siliconcompiler/siliconcompiler
+
+   To simplify tool/PDK installation and job scheduling, SiliconCompiler supports a
    "-remote" option, which directs the compiler to send all steps to a remote
    server for processing. The "-remote" option relies on a credentials file
-   located at ~/.sc/credentials on Linux or macOS, or
-   at C:\\Users\\USERNAME\\.sc\\credentials on Windows.
+   located at ``~/.sc/credentials`` on Linux or macOS, or
+   at ``C:\\Users\\USERNAME\\.sc\\credentials`` on Windows.
 
    Remote processing option is enabled by setting the :keypath:`option,remote`
    parameter to True. ::

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1102,7 +1102,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 example=[
                     f"cli: -datasheet_pin_{item} 'mydevice sclk global {val[1]}'",
                     f"api: chip.set('datasheet','mydevice','pin','sclk','{item}','global',{val[1]}"],
-                schelp=f"""Pin {val[0]}.""")
+                schelp=f"""Pin {val[0]}. Values are tuples of (min, typical, max).""")
 
     # AC Timing
     metrics = {'tsetup': ['setup time', (1e-9, 2e-9, 4e-9), 's'],
@@ -1123,7 +1123,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 example=[
                     f"cli: -datasheet_pin_{item} 'mydevice sclk global {val[1]}'",
                     f"api: chip.set('datasheet','mydevice','pin','sclk','{item}','global',{val[1]}"],
-                schelp=f"""Pin {val[0]}.""")
+                schelp=f"""Pin {val[0]}. Values are tuples of (min, typical, max).""")
 
     return cfg
 

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1292,7 +1292,7 @@
                                 "cli: -datasheet_pin_capacitance 'mydevice sclk global (1e-12, 1.2e-12, 1.5e-12)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','capacitance','global',(1e-12, 1.2e-12, 1.5e-12)"
                             ],
-                            "help": "Pin capacitance.",
+                            "help": "Pin capacitance. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1369,7 +1369,7 @@
                                 "cli: -datasheet_pin_dutycycle 'mydevice sclk global (45, 50, 55)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','dutycycle','global',(45, 50, 55)"
                             ],
-                            "help": "Pin duty cycle.",
+                            "help": "Pin duty cycle. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1408,7 +1408,7 @@
                                 "cli: -datasheet_pin_idrive 'mydevice sclk global (0.01, 0.012, 0.015)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','idrive','global',(0.01, 0.012, 0.015)"
                             ],
-                            "help": "Pin drive current.",
+                            "help": "Pin drive current. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1428,7 +1428,7 @@
                                 "cli: -datasheet_pin_iinject 'mydevice sclk global (0.001, 0.0012, 0.0015)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','iinject','global',(0.001, 0.0012, 0.0015)"
                             ],
-                            "help": "Pin injection current.",
+                            "help": "Pin injection current. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1448,7 +1448,7 @@
                                 "cli: -datasheet_pin_ileakage 'mydevice sclk global (1e-06, 1.2e-06, 1.5e-06)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','ileakage','global',(1e-06, 1.2e-06, 1.5e-06)"
                             ],
-                            "help": "Pin leakage current.",
+                            "help": "Pin leakage current. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1487,7 +1487,7 @@
                                 "cli: -datasheet_pin_rdiff 'mydevice sclk global (45, 50, 55)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','rdiff','global',(45, 50, 55)"
                             ],
-                            "help": "Pin differential pair resistance.",
+                            "help": "Pin differential pair resistance. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1526,7 +1526,7 @@
                                 "cli: -datasheet_pin_rpulldown 'mydevice sclk global (1000, 1200, 3000)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','rpulldown','global',(1000, 1200, 3000)"
                             ],
-                            "help": "Pin pulldown resistance.",
+                            "help": "Pin pulldown resistance. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1546,7 +1546,7 @@
                                 "cli: -datasheet_pin_rpullup 'mydevice sclk global (1000, 1200, 3000)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','rpullup','global',(1000, 1200, 3000)"
                             ],
-                            "help": "Pin pullup resistance.",
+                            "help": "Pin pullup resistance. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1604,7 +1604,7 @@
                                 "cli: -datasheet_pin_tfall 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','tfall','global',(1e-09, 2e-09, 4e-09)"
                             ],
-                            "help": "Pin fall transition.",
+                            "help": "Pin fall transition. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1624,7 +1624,7 @@
                                 "cli: -datasheet_pin_thold 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','thold','global',(1e-09, 2e-09, 4e-09)"
                             ],
-                            "help": "Pin hold time.",
+                            "help": "Pin hold time. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1644,7 +1644,7 @@
                                 "cli: -datasheet_pin_tjitter 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','tjitter','global',(1e-09, 2e-09, 4e-09)"
                             ],
-                            "help": "Pin rms jitter.",
+                            "help": "Pin rms jitter. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1664,7 +1664,7 @@
                                 "cli: -datasheet_pin_tperiod 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','tperiod','global',(1e-09, 2e-09, 4e-09)"
                             ],
-                            "help": "Pin minimum period.",
+                            "help": "Pin minimum period. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1684,7 +1684,7 @@
                                 "cli: -datasheet_pin_tpulse 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','tpulse','global',(1e-09, 2e-09, 4e-09)"
                             ],
-                            "help": "Pin pulse width.",
+                            "help": "Pin pulse width. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1704,7 +1704,7 @@
                                 "cli: -datasheet_pin_trise 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','trise','global',(1e-09, 2e-09, 4e-09)"
                             ],
-                            "help": "Pin rise transition.",
+                            "help": "Pin rise transition. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1724,7 +1724,7 @@
                                 "cli: -datasheet_pin_tsetup 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','tsetup','global',(1e-09, 2e-09, 4e-09)"
                             ],
-                            "help": "Pin setup time.",
+                            "help": "Pin setup time. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1763,7 +1763,7 @@
                                 "cli: -datasheet_pin_vcdm 'mydevice sclk global (100, 300, 500)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vcdm','global',(100, 300, 500)"
                             ],
-                            "help": "Pin human body model ESD tolerance.",
+                            "help": "Pin human body model ESD tolerance. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1783,7 +1783,7 @@
                                 "cli: -datasheet_pin_vcm 'mydevice sclk global (0.3, 1.2, 1.6)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vcm','global',(0.3, 1.2, 1.6)"
                             ],
-                            "help": "Pin common mode voltage.",
+                            "help": "Pin common mode voltage. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1803,7 +1803,7 @@
                                 "cli: -datasheet_pin_vdiff 'mydevice sclk global (0.2, 0.3, 0.9)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vdiff','global',(0.2, 0.3, 0.9)"
                             ],
-                            "help": "Pin differential voltage.",
+                            "help": "Pin differential voltage. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1823,7 +1823,7 @@
                                 "cli: -datasheet_pin_vhbm 'mydevice sclk global (100, 300, 500)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vhbm','global',(100, 300, 500)"
                             ],
-                            "help": "Pin machine model ESD tolerance.",
+                            "help": "Pin machine model ESD tolerance. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1843,7 +1843,7 @@
                                 "cli: -datasheet_pin_vih 'mydevice sclk global (1.4, 1.8, 2.2)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vih','global',(1.4, 1.8, 2.2)"
                             ],
-                            "help": "Pin high input voltage level.",
+                            "help": "Pin high input voltage level. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1863,7 +1863,7 @@
                                 "cli: -datasheet_pin_vil 'mydevice sclk global (-0.2, 0, 1.0)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vil','global',(-0.2, 0, 1.0)"
                             ],
-                            "help": "Pin low input voltage level.",
+                            "help": "Pin low input voltage level. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1883,7 +1883,7 @@
                                 "cli: -datasheet_pin_vnoise 'mydevice sclk global (0, 0.01, 0.1)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vnoise','global',(0, 0.01, 0.1)"
                             ],
-                            "help": "Pin random voltage noise.",
+                            "help": "Pin random voltage noise. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1903,7 +1903,7 @@
                                 "cli: -datasheet_pin_voh 'mydevice sclk global (4.6, 4.8, 5.2)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','voh','global',(4.6, 4.8, 5.2)"
                             ],
-                            "help": "Pin high output voltage level.",
+                            "help": "Pin high output voltage level. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,
@@ -1923,7 +1923,7 @@
                                 "cli: -datasheet_pin_vol 'mydevice sclk global (-0.2, 0, 0.2)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vol','global',(-0.2, 0, 0.2)"
                             ],
-                            "help": "Pin low output voltage level.",
+                            "help": "Pin low output voltage level. Values are tuples of (min, typical, max).",
                             "lock": "false",
                             "notes": null,
                             "require": null,


### PR DESCRIPTION
This PR fixes up some issues with the docs.

- Follow-up tasks from 0.9 upgrade
  - Get rid of "root" in Schema reference manual: all top-level items are now directly under "1.3 Parameters". 
  - Get rid of empty "history" and "library" sections, and replace with a new prose section describing these two keypaths.
  - Document min/typical/max for parameters that use this format under datasheet schema
- Tasks from public issues
  - #1022: specify that user must clone repo/set up SCPATH to run quickstart locally (thanks @arlted!)
  - #1035: fix errors in library user guide (thanks @ValeriiPlumerai!)