### PR TITLE
Standardize clobber=False for flows in targets

### DIFF
--- a/siliconcompiler/targets/asap7_demo.py
+++ b/siliconcompiler/targets/asap7_demo.py
@@ -24,8 +24,9 @@ def setup(chip):
     chip.load_flow('asicflow')
     chip.load_lib('asap7sc7p5t')
 
-    #3. Select default flow
+    #3. Select default flow/PDK
     chip.set('option', 'flow', 'asicflow')
+    chip.set('option', 'pdk', 'asap7')
 
     #4. Select libraries
     chip.set('asic', 'logiclib', 'asap7sc7p5t_rvt')

--- a/siliconcompiler/targets/freepdk45_demo.py
+++ b/siliconcompiler/targets/freepdk45_demo.py
@@ -38,7 +38,7 @@ def setup(chip):
     chip.load_lib('nangate45')
 
     #3. Set flow and pdk
-    chip.set('option', 'flow', 'asicflow')
+    chip.set('option', 'flow', 'asicflow', clobber=False)
     chip.set('option', 'pdk', 'freepdk45')
 
     #4. Select libraries

--- a/siliconcompiler/targets/skywater130_demo.py
+++ b/siliconcompiler/targets/skywater130_demo.py
@@ -41,7 +41,7 @@ def setup(chip):
 
     #3. Set default targets
     chip.set('option', 'flow', 'asicflow', clobber=False)
-    chip.set('option', 'pdk', 'skywater130', clobber=False)
+    chip.set('option', 'pdk', 'skywater130')
 
     #4. Set project specific design choices
     chip.set('asic', 'logiclib', 'sky130hd')


### PR DESCRIPTION
Small cleanup thing: use `clobber=False` when setting ['option', 'flow'] for targets with more than one option, since a user might set it before `load_target()` is called.

I think we can skip `clobber=False` for targets that only have once choice.