### PR TITLE
Enhance TCL manifest generation

### DIFF
--- a/siliconcompiler/tools/openroad/sc_constraints.sdc
+++ b/siliconcompiler/tools/openroad/sc_constraints.sdc
@@ -9,8 +9,7 @@ if {[dict exists $sc_cfg datasheet] && [dict exists $sc_cfg datasheet $sc_design
         if {[dict get $sc_cfg datasheet $sc_design pin $pin type global] == "clk"} {
             # If clock...
 
-            set period_str [dict get $sc_cfg datasheet $sc_design pin $pin tperiod global]
-            set periodtuple [regsub -all {[\,\)\(]} $period_str " "]
+            set periodtuple [dict get $sc_cfg datasheet $sc_design pin $pin tperiod global]
             set period [lindex $periodtuple 1]
             set period_ns [expr $period * pow(10, 9)]
 

--- a/siliconcompiler/tools/openroad/sc_floorplan.tcl
+++ b/siliconcompiler/tools/openroad/sc_floorplan.tcl
@@ -27,8 +27,8 @@ if {[expr ! [dict exists $sc_cfg "input" "floorplan.def"]]} {
     #NOTE: assuming a two tuple value as lower left, upper right
     set sc_diearea   [dict get $sc_cfg asic diearea]
     set sc_corearea  [dict get $sc_cfg asic corearea]
-    set sc_diesize   [regsub -all {[\,\)\(]} $sc_diearea " "]
-    set sc_coresize  [regsub -all {[\,\)\(]} $sc_corearea " "]
+    set sc_diesize "[lindex $sc_diearea 0] [lindex $sc_diearea 1]"
+    set sc_coresize "[lindex $sc_corearea 0] [lindex $sc_corearea 1]"
 
     initialize_floorplan -die_area $sc_diesize \
 	-core_area $sc_coresize \

--- a/tests/core/test_write_manifest.py
+++ b/tests/core/test_write_manifest.py
@@ -1,4 +1,6 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
+import pytest
+
 import siliconcompiler
 
 def test_write_manifest():
@@ -14,6 +16,55 @@ def test_write_manifest():
     chip.write_manifest('top.csv')
     chip.write_manifest('top.tcl', prune=False)
     chip.write_manifest('top.yaml')
+
+def test_advanced_tcl(monkeypatch):
+    # Tkinter module is part of Python standard library, but may not be
+    # available depending on if the system has the python3-tk installed. This
+    # line will import tkinter if it's available, and skip the test otherwise.
+    tkinter = pytest.importorskip('tkinter')
+
+    chip = siliconcompiler.Chip('top')
+
+    # Test complex strings
+    desc = '''This description is potentially problematic since it includes
+multiple lines, spaces, and TCL special characters. This package costs $5 {for real}!'''
+    chip.set('package', 'description', desc)
+
+    # Test tuples
+    chip.add('asic', 'diearea', (0, 0))
+    chip.add('asic', 'diearea', (30, 40))
+
+    # Test bools
+    chip.set('option', 'quiet', True)
+
+    # Test envvars
+    chip.set('input', 'verilog', 'rtl/$TOPMOD.v')
+
+    chip.write_manifest('top.tcl')
+
+    # Read from config in TCL as test
+    tcl = tkinter.Tcl()
+
+    # Set env var to test ['input', 'verilog']
+    monkeypatch.setenv('TOPMOD', 'design')
+
+    def tcl_eval(expr):
+        script = f'''
+        source top.tcl
+        return {expr}'''
+        return tcl.eval(script)
+
+    # When we call puts on a multiline string, it does get mangled a bit. It
+    # stays surrounded by {}, and {} within the string are still escaped.
+    # TODO: is this problematic? I think it is okay for now since we don't
+    # really read these strings within TCL, they just need to not break sourcing
+    # the manifest.
+    expected_desc = '{' + desc.replace('{', '\\{').replace('}', '\\}') + '}'
+    assert tcl_eval('[dict get $sc_cfg package description]') == expected_desc
+
+    assert tcl_eval('[lindex [lindex [dict get $sc_cfg asic diearea] 1] 0]') == '30.0'
+    assert tcl_eval('[dict get $sc_cfg option quiet]') == 'true'
+    assert tcl_eval('[dict get $sc_cfg input verilog]') == 'rtl/design.v'
 
 #########################
 if __name__ == "__main__":

--- a/tests/core/test_write_manifest.py
+++ b/tests/core/test_write_manifest.py
@@ -19,8 +19,9 @@ def test_write_manifest():
 
 def test_advanced_tcl(monkeypatch):
     # Tkinter module is part of Python standard library, but may not be
-    # available depending on if the system has the python3-tk installed. This
-    # line will import tkinter if it's available, and skip the test otherwise.
+    # available depending on if the system has the python3-tk package installed.
+    # This line will import tkinter if it's available, and skip the test
+    # otherwise.
     tkinter = pytest.importorskip('tkinter')
 
     chip = siliconcompiler.Chip('top')
@@ -54,12 +55,8 @@ multiple lines, spaces, and TCL special characters. This package costs $5 {for r
         return {expr}'''
         return tcl.eval(script)
 
-    # When we call puts on a multiline string, it does get mangled a bit. It
-    # stays surrounded by {}, and {} within the string are still escaped.
-    # TODO: is this problematic? I think it is okay for now since we don't
-    # really read these strings within TCL, they just need to not break sourcing
-    # the manifest.
-    expected_desc = '{' + desc.replace('{', '\\{').replace('}', '\\}') + '}'
+    # When the TCL shell displays a multiline string, it gets surrounded in {}.
+    expected_desc = '{' + desc + '}'
     assert tcl_eval('[dict get $sc_cfg package description]') == expected_desc
 
     assert tcl_eval('[lindex [lindex [dict get $sc_cfg asic diearea] 1] 0]') == '30.0'


### PR DESCRIPTION
This PR makes a couple changes to how TCL code is generated by `write_manifest()`. It addresses a few problems:

**Escaping strings**
We weren't escaping any special characters in strings besides semicolons. This became problematic when I had a multi-line value for a field. This caused a tool to error out after sourcing the sc_manifest.tcl file, because SC generated invalid TCL like this:
```tcl
[dict set $sc_cfg package description [list Description line 1
Description line 2]]
```

Along with this, spaces and special characters like '$' would have resulted in issues. The best solution I found was to wrap the entire string in quotes, and escape a few special characters, based on  https://stackoverflow.com/a/70082148 (and verified by looking at the TCL spec).

**Dump tuple as list**
We were previously dumping tuples as tuple-like strings (e.g. `"(1, 2)"`), which generally required regex parsing to consume. I think it makes more sense to dump these directly as a list: `[list 1 2]`, since it's easier to manipulate in the TCL code. 

**Fix envvar substition**
We were previously only matching `$` at the beginning of paths, but I think we should do a search for "$" and replace it with "$env()" anywhere in the paths.


I also added a self-checking test for this function - turns out that a Python interface to TCL is available as a standard library! (although it requires an extra package installed on the system). I wonder if there are other ways we can take advantage of this...