### PR TITLE
Adjust behavior of ['tool', <tool>, 'continue'] to always fail on fatal error

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -54,11 +54,8 @@ def remote_preprocess(chip):
     for index in indexlist:
         tool = chip.get('flowgraph', flow, local_step, index, 'tool')
         # Setting up tool is optional (step may be a builtin function)
-        if tool:
-            chip.set('arg', 'step', local_step)
-            chip.set('arg', 'index', index)
-            func = chip.find_function(tool, 'setup', 'tools')
-            func(chip)
+        if tool and tool not in chip.builtin:
+            chip._setup_tool(tool, local_step, index)
 
         # Need to override steplist here to make sure check_manifest() doesn't
         # check steps that haven't been setup.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4120,18 +4120,22 @@ class Chip:
             sys.exit(1)
         func(self)
 
+        # Add logfile as a report for errors/warnings if they have associated
+        # regexes.
         if self.valid('tool', tool, 'regex', step, index, 'default'):
             re_keys = self.getkeys('tool', tool, 'regex', step, index)
             logfile = f'{step}.log'
             if (
                 'errors' in re_keys and
-                logfile not in self.get('tool', tool, 'report', step, index, 'errors')
+                (not self.valid('tool', tool, 'report', step, index, 'errors') or
+                 logfile not in self.get('tool', tool, 'report', step, index, 'errors'))
             ):
                 self.add('tool', tool, 'report', step, index, 'errors', logfile)
 
             if (
                 'warnings' in re_keys and
-                logfile not in self.get('tool', tool, 'report', step, index, 'warnings')
+                (not self.valid('tool', tool, 'report', step, index, 'warnings') or
+                 logfile not in self.get('tool', tool, 'report', step, index, 'warnings'))
             ):
                 self.add('tool', tool, 'report', step, index, 'warnings', logfile)
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3982,8 +3982,7 @@ class Chip:
 
             if retcode != 0:
                 self.logger.warning('Command failed with code %d. See log file %s', retcode, os.path.abspath(logfile))
-                if not self.get('tool', tool, 'continue'):
-                    self._haltstep(step, index)
+                self._haltstep(step, index)
 
         ##################
         # 16. Capture cpu runtime and memory footprint.
@@ -4001,8 +4000,8 @@ class Chip:
                 post_error = func(self)
                 if post_error:
                     self.logger.error('Post-processing check failed')
-                    if not self.get('tool', tool, 'continue'):
-                        self._haltstep(step, index)
+                    # TODO: add option to control halt behavior
+                    self._haltstep(step, index)
 
         ##################
         # 18. Check log file (must be after post-process)
@@ -4044,8 +4043,8 @@ class Chip:
         ##################
         # 23. Stop if there are errors
         if self.get('metric',step, index, 'errors') > 0:
-            if not self.get('tool', tool, 'continue'):
-                self._haltstep(step, index)
+            # TODO: add option to control halt behavior
+            self._haltstep(step, index)
 
         ##################
         # 24. Clean up non-essential files

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4037,8 +4037,7 @@ class Chip:
 
         ##################
         # 23. Stop if there are errors
-        if self.get('metric',step, index, 'errors') > 0:
-            # TODO: add option to control halt behavior
+        if self.get('metric', step, index, 'errors') > 0 and not self.get('option', 'flowcontinue'):
             self._haltstep(step, index)
 
         ##################

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3992,16 +3992,11 @@ class Chip:
         self.set('metric', step, index, 'memory', max_mem_bytes)
 
         ##################
-        # 17. Post process (could fail)
-        post_error = 0
+        # 17. Post process
         if (tool not in self.builtin) and (not self.get('option', 'skipall')) :
             func = self.find_function(tool, 'post_process', 'tools')
             if func:
-                post_error = func(self)
-                if post_error:
-                    self.logger.error('Post-processing check failed')
-                    # TODO: add option to control halt behavior
-                    self._haltstep(step, index)
+                func(self)
 
         ##################
         # 18. Check log file (must be after post-process)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4037,7 +4037,9 @@ class Chip:
 
         ##################
         # 23. Stop if there are errors
-        if self.get('metric', step, index, 'errors') > 0 and not self.get('option', 'flowcontinue'):
+        errors = self.get('metric', step, index, 'errors')
+        if errors > 0 and not self.get('option', 'flowcontinue'):
+            self.logger.error(f'{tool} reported {errors} errors during {step}{index}')
             self._haltstep(step, index)
 
         ##################

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1380,8 +1380,8 @@ def schema_tool(cfg, tool='default', step='default', index='default'):
             shorthelp="Tool: regex filter",
             switch="-tool_regex 'tool step index suffix <str>'",
             example=[
-                "cli: -tool_regex 'openroad place 0 error -v ERROR'",
-                "api: chip.set('tool','openroad','regex','place','0','error','-v ERROR')"],
+                "cli: -tool_regex 'openroad place 0 errors -v ERROR'",
+                "api: chip.set('tool','openroad','regex','place','0','errors','-v ERROR')"],
             schelp="""
             A list of piped together grep commands. Each entry represents a set
             of command line arguments for grep including the regex pattern to
@@ -1400,7 +1400,12 @@ def schema_tool(cfg, tool='default', step='default', index='default'):
             SiliconCompiler::
 
                 chip.set('tool', 'openroad', 'regex', 'place', '0', 'warnings', ["WARNING", "-v bbox"])
-            """)
+
+            The "errors" and "warnings" suffixes are special cases. When set,
+            the number of matches found for these regexes will be added to the
+            errors and warnings metrics for the task, respectively. This will
+            also cause the logfile to be added to the :keypath:`tool, <tool>,
+            report` parameter for those metrics, if not already present.""")
 
 
     scparam(cfg, ['tool', tool, 'option', step, index],

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2694,6 +2694,18 @@ def schema_option(cfg):
             the file varies and depends on the tool used. SC simply passes on
             the filepath toe the tool executable.""")
 
+    scparam(cfg,['option', 'flowcontinue'],
+            sctype='bool',
+            shorthelp="Continue flow on error",
+            switch='-flowcontinue',
+            example=["cli: -flowcontinue",
+                     "api: chip.set('option', 'flowcontinue', True)"],
+            schelp="""
+            Continue executing flow after a tool logs errors. The default
+            behavior is to quit executing the flow if a task ends and the errors
+            metric is greater than 0. Note that the flow will always cease
+            executing if the tool returns a nonzero status code. """)
+
     return cfg
 
 ############################################

--- a/siliconcompiler/tools/bambu/bambu.py
+++ b/siliconcompiler/tools/bambu/bambu.py
@@ -30,8 +30,8 @@ def setup(chip):
 
     # Standard Setup
     refdir = 'tools/'+tool
-    chip.set('tool', tool, 'exe', 'bambu', clobber=False)
-    chip.set('tool', tool, 'vswitch', '--version', clobber=False)
+    chip.set('tool', tool, 'exe', 'bambu')
+    chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=0.9.6', clobber=False)
     chip.set('tool', tool, 'refdir', step, index, refdir, clobber=False)
     chip.set('tool', tool, 'threads', step, index, os.cpu_count(), clobber=False)
@@ -77,5 +77,3 @@ def post_process(chip):
     '''
     design = chip.get('design')
     shutil.copy(f'{design}.v', os.path.join('outputs', f'{design}.v'))
-
-    return 0

--- a/siliconcompiler/tools/bluespec/bluespec.py
+++ b/siliconcompiler/tools/bluespec/bluespec.py
@@ -44,10 +44,10 @@ def setup(chip):
 
     # Standard Setup
     refdir = 'tools/'+tool
-    chip.set('tool', tool, 'exe', 'bsc', clobber=False)
+    chip.set('tool', tool, 'exe', 'bsc')
     # This is technically the 'verbose' flag, but used alone it happens to give
-    # us the version # and exit cleanly, so we'll use it here.
-    chip.set('tool', tool, 'vswitch', '-v', clobber=False)
+    # us the version and exit cleanly, so we'll use it here.
+    chip.set('tool', tool, 'vswitch', '-v')
     chip.set('tool', tool, 'version', '>=2021.07', clobber=False)
     chip.set('tool', tool, 'refdir', step, index,  refdir, clobber=False)
     chip.set('tool', tool, 'threads', step, index,  os.cpu_count(), clobber=False)
@@ -121,5 +121,3 @@ def post_process(chip):
         for src in os.listdir(VLOG_DIR):
             with open(os.path.join(VLOG_DIR, src), 'r') as vlog_mod:
                 pickled_vlog.write(vlog_mod.read())
-
-    return 0

--- a/siliconcompiler/tools/chisel/chisel.py
+++ b/siliconcompiler/tools/chisel/chisel.py
@@ -43,8 +43,8 @@ def setup(chip):
 
     # Standard Setup
     refdir = 'tools/'+tool
-    chip.set('tool', tool, 'exe', 'sbt', clobber=False)
-    chip.set('tool', tool, 'vswitch', '--version', clobber=False)
+    chip.set('tool', tool, 'exe', 'sbt')
+    chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=1.5.5', clobber=False)
     chip.set('tool', tool, 'refdir', step, index,  refdir, clobber=False)
     chip.set('tool', tool, 'threads', step, index,  os.cpu_count(), clobber=False)
@@ -103,12 +103,3 @@ def pre_process(chip):
         src = os.path.join(refdir, filename)
         dst = filename
         shutil.copyfile(src, dst)
-
-################################
-# Post_process (post executable)
-################################
-
-def post_process(chip):
-    ''' Tool specific function to run after step execution
-    '''
-    return 0

--- a/siliconcompiler/tools/echo/echo.py
+++ b/siliconcompiler/tools/echo/echo.py
@@ -3,7 +3,7 @@ def setup(chip):
     step = chip.get('arg','step')
     index = chip.get('arg','index')
 
-    chip.set('tool', tool, 'exe', tool, clobber=False)
+    chip.set('tool', tool, 'exe', tool)
     chip.set('tool', tool, 'option',  step, index, step + index, clobber=False)
 
 def parse_version(stdout):
@@ -12,6 +12,3 @@ def parse_version(stdout):
     Depends on tool reported string
     '''
     return '0'
-
-def post_process(chip):
-    return 0

--- a/siliconcompiler/tools/ghdl/ghdl.py
+++ b/siliconcompiler/tools/ghdl/ghdl.py
@@ -1,4 +1,3 @@
-import os
 import siliconcompiler
 
 #####################################################################
@@ -42,8 +41,8 @@ def setup(chip):
     step = chip.get('arg','step')
     index = chip.get('arg','index')
 
-    chip.set('tool', tool, 'exe', 'ghdl', clobber=clobber)
-    chip.set('tool', tool, 'vswitch', '--version', clobber=clobber)
+    chip.set('tool', tool, 'exe', 'ghdl')
+    chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=2.0.0-dev', clobber=clobber)
     chip.set('tool', tool, 'threads', step, index, '4', clobber=clobber)
     chip.set('tool', tool, 'option', step, index, '', clobber=clobber)
@@ -65,9 +64,6 @@ def runtime_options(chip):
 
     ''' Custom runtime options, returnst list of command line options.
     '''
-
-    step = chip.get('arg', 'step')
-    index = chip.get('arg', 'index')
 
     options = []
 
@@ -98,16 +94,6 @@ def parse_version(stdout):
     # '*-dev' is interpreted by packaging.version as a "developmental release",
     # which has the correct semantics. e.g. Version('2.0.0') > Version('2.0.0-dev')
     return stdout.split()[1]
-
-################################
-# Post_process (post executable)
-################################
-
-def post_process(chip):
-    ''' Tool specific function to run after step execution
-    '''
-
-    return 0
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/tools/icarus/icarus.py
+++ b/siliconcompiler/tools/icarus/icarus.py
@@ -1,9 +1,6 @@
 import os
-import subprocess
-import re
-import sys
+
 import siliconcompiler
-import shutil
 
 ####################################################################
 # Make Docs
@@ -45,8 +42,8 @@ def setup(chip):
     design = chip.get('design')
 
     # Standard Setup
-    chip.set('tool', tool, 'exe', 'iverilog', clobber=False)
-    chip.set('tool', tool, 'vswitch', '-V', clobber=False)
+    chip.set('tool', tool, 'exe', 'iverilog')
+    chip.set('tool', tool, 'vswitch', '-V')
     chip.set('tool', tool, 'version', '>=10.3', clobber=False)
     chip.set('tool', tool, 'threads', step, index, os.cpu_count(), clobber=False)
 
@@ -68,9 +65,6 @@ def runtime_options(chip):
 
     ''' Custom runtime options, returnst list of command line options.
     '''
-
-    step = chip.get('arg','step')
-    index = chip.get('arg','index')
 
     cmdlist = []
 
@@ -97,17 +91,6 @@ def runtime_options(chip):
 def parse_version(stdout):
     # First line: Icarus Verilog version 10.1 (stable) ()
     return stdout.split()[3]
-
-################################
-# Post_process (post executable)
-################################
-
-def post_process(chip):
-    ''' Tool specific function to run after step execution
-    '''
-
-    return 0
-
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/tools/icepack/icepack.py
+++ b/siliconcompiler/tools/icepack/icepack.py
@@ -1,7 +1,3 @@
-import os
-import importlib
-import re
-import sys
 import siliconcompiler
 
 #####################################################################
@@ -39,7 +35,7 @@ def setup(chip):
     step = chip.get('arg','step')
     index = chip.get('arg','index')
     clobber = False
-    chip.set('tool', tool, 'exe', tool, clobber=clobber)
+    chip.set('tool', tool, 'exe', tool)
     chip.set('tool', tool, 'option', step, index, "", clobber=clobber)
 
     design = chip.get('design')
@@ -54,8 +50,6 @@ def runtime_options(chip):
     ''' Custom runtime options, returnst list of command line options.
     '''
 
-    step = chip.get('arg','step')
-    index = chip.get('arg','index')
     topmodule = chip.get('design')
 
     cmdlist = []
@@ -63,14 +57,6 @@ def runtime_options(chip):
     cmdlist.append("outputs/" + topmodule + ".bit")
 
     return cmdlist
-
-################################
-# Post_process (post executable)
-################################
-def post_process(chip):
-    ''' Tool specific function to run after step execution
-    '''
-    return 0
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -1,9 +1,9 @@
 import os
-import platform
-import re
-import shutil
-import siliconcompiler
 from pathlib import Path
+import platform
+import shutil
+
+import siliconcompiler
 
 ####################################################################
 # Make Docs
@@ -87,8 +87,8 @@ def setup(chip, mode="batch"):
         script = 'klayout_export.py'
         option = ['-zz', '-r']
 
-    chip.set('tool', tool, 'exe', klayout_exe, clobber=True)
-    chip.set('tool', tool, 'vswitch', ['-zz', '-v'], clobber=clobber)
+    chip.set('tool', tool, 'exe', klayout_exe)
+    chip.set('tool', tool, 'vswitch', ['-zz', '-v'])
     # Versions < 0.27.6 may be bundled with an incompatible version of Python.
     chip.set('tool', tool, 'version', '>=0.27.6', clobber=clobber)
     chip.set('tool', tool, 'format', 'json', clobber=clobber)
@@ -130,10 +130,6 @@ def setup(chip, mode="batch"):
     chip.set('tool', tool, 'regex', step, index, 'warnings', "WARNING", clobber=False)
     chip.set('tool', tool, 'regex', step, index, 'errors', "ERROR", clobber=False)
 
-    # Reports
-    for metric in ('errors', 'warnings'):
-        chip.set('tool', tool, 'report', step, index, metric, logfile)
-
 ################################
 #  Environment setup
 ################################
@@ -166,15 +162,6 @@ def parse_version(stdout):
     # KLayout 0.26.11
     return stdout.split()[1]
 
-
-################################
-# Post_process (post executable)
-################################
-
-def post_process(chip):
-    ''' Tool specific function to run after step execution
-    '''
-    return 0
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -1,6 +1,5 @@
-import os
 import re
-import shutil
+
 import siliconcompiler
 
 ####################################################################
@@ -53,11 +52,11 @@ def setup(chip):
 
     chip.set('tool', tool, 'exe', tool)
     chip.set('tool', tool, 'vswitch', '--version')
-    chip.set('tool', tool, 'version', '>=8.3.196')
+    chip.set('tool', tool, 'version', '>=8.3.196', clobber=False)
     chip.set('tool', tool, 'format', 'tcl')
-    chip.set('tool', tool, 'threads', step, index,  4)
-    chip.set('tool', tool, 'refdir', step, index,  refdir)
-    chip.set('tool', tool, 'script', step, index,  script)
+    chip.set('tool', tool, 'threads', step, index,  4, clobber=False)
+    chip.set('tool', tool, 'refdir', step, index,  refdir, clobber=False)
+    chip.set('tool', tool, 'script', step, index,  script, clobber=False)
 
     # set options
     options = []
@@ -73,10 +72,8 @@ def setup(chip):
     if step == 'extspice':
         chip.add('tool', tool, 'output', step, index, f'{design}.spice')
 
-    # TODO: actually parse errors/warnings in post_process()
-    logfile = f"{step}.log"
-    chip.set('tool', tool, 'report', step, index, 'errors', logfile)
-    chip.set('tool', tool, 'report', step, index, 'warnings', logfile)
+    chip.set('tool', tool, 'regex', step, index, 'errors', r'^Error', clobber=False)
+    chip.set('tool', tool, 'regex', step, index, 'warnings', r'warning', clobber=False)
 
     if step == 'drc':
         report_path = f'reports/{design}.drc'

--- a/siliconcompiler/tools/nextpnr/nextpnr.py
+++ b/siliconcompiler/tools/nextpnr/nextpnr.py
@@ -1,4 +1,3 @@
-import os
 import siliconcompiler
 
 #####################################################################
@@ -37,8 +36,8 @@ def setup(chip):
     index = chip.get('arg','index')
 
     clobber = False
-    chip.set('tool', tool, 'exe', 'nextpnr-ice40', clobber=clobber)
-    chip.set('tool', tool, 'vswitch', '--version', clobber=clobber)
+    chip.set('tool', tool, 'exe', 'nextpnr-ice40')
+    chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=0.2', clobber=clobber)
     chip.set('tool', tool, 'option', step, index, "", clobber=clobber)
 
@@ -53,9 +52,6 @@ def setup(chip):
 def runtime_options(chip):
     ''' Custom runtime options, returns list of command line options.
     '''
-
-    step = chip.get('arg','step')
-    index = chip.get('arg','index')
 
     partname = chip.get('fpga', 'partname')
     topmodule = chip.get('design')
@@ -86,16 +82,3 @@ def parse_version(stdout):
         return version.split('-')[1]
     else:
         return version
-
-################################
-# Setup Tool (pre executable)
-################################
-
-def post_process(chip):
-    ''' Tool specific function to run after step execution
-    '''
-    step = chip.get('arg','step')
-    index = chip.get('arg','index')
-
-    #TODO: return error code
-    return 0

--- a/siliconcompiler/tools/openfpgaloader/openfpgaloader.py
+++ b/siliconcompiler/tools/openfpgaloader/openfpgaloader.py
@@ -1,8 +1,3 @@
-import os
-import subprocess
-import re
-import sys
-import shutil
 import siliconcompiler
 
 ####################################################################
@@ -47,7 +42,7 @@ def setup(chip):
     index = chip.get('arg','index')
 
     # tool setup
-    chip.set('tool', tool, 'exe', tool, clobber=False)
+    chip.set('tool', tool, 'exe', tool)
     chip.set('tool', tool, 'vswitch', '--Version', clobber=False)
     chip.set('tool', tool, 'version', '0.5.0', clobber=False)
 

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -1,11 +1,8 @@
 import os
-import subprocess
-import re
 import sys
 import shutil
 
 import siliconcompiler
-from siliconcompiler import utils
 
 ####################################################################
 # Make Docs
@@ -49,8 +46,8 @@ def setup(chip):
         exe = f'{tool}.exe'
 
     # Standard Setup
-    chip.set('tool', tool, 'exe', exe, clobber=False)
-    chip.set('tool', tool, 'vswitch', '--version', clobber=False)
+    chip.set('tool', tool, 'exe', exe)
+    chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=1.13', clobber=False)
     chip.set('tool', tool, 'threads', step, index,  os.cpu_count(), clobber=False)
 
@@ -80,11 +77,6 @@ def setup(chip):
     chip.set('tool', tool, 'regex', step, index, 'warnings', r'^\[WRN:', clobber=False)
     chip.set('tool', tool, 'regex', step, index, 'errors', r'^\[(ERR|FTL|SNT):', clobber=False)
 
-    # Output reprts for deep dive
-    for metric in ('errors', 'warnings'):
-        chip.set('tool', tool, 'report', step, index, metric, f"{step}.log")
-
-
 def parse_version(stdout):
     # Surelog --version output looks like:
     # VERSION: 1.13
@@ -101,9 +93,6 @@ def runtime_options(chip):
 
     ''' Custom runtime options, returnst list of command line options.
     '''
-
-    step = chip.get('arg','step')
-    index = chip.get('arg','index')
 
     cmdlist = []
 
@@ -141,8 +130,6 @@ def post_process(chip):
     ''' Tool specific function to run after step execution
     '''
     step = chip.get('arg', 'step')
-    index = chip.get('arg', 'index')
-    tool = 'surelog'
 
     if step != 'import':
         return 0
@@ -160,9 +147,6 @@ def post_process(chip):
                 outfile.write(infile.read())
             # in case end of file is missing a newline
             outfile.write('\n')
-
-
-    return 0
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -77,8 +77,8 @@ def setup(chip):
         chip.set('tool', tool, 'path', surelog_path, clobber=False)
 
     # Log file parsing
-    chip.set('tool', tool, 'regex', step, index, 'warnings', "WARNING")
-    chip.set('tool', tool, 'regex', step, index, 'errors', "ERROR")
+    chip.set('tool', tool, 'regex', step, index, 'warnings', r'^\[WRN:', clobber=False)
+    chip.set('tool', tool, 'regex', step, index, 'errors', r'^\[(ERR|FTL|SNT):', clobber=False)
 
     # Output reprts for deep dive
     for metric in ('errors', 'warnings'):
@@ -161,8 +161,6 @@ def post_process(chip):
             # in case end of file is missing a newline
             outfile.write('\n')
 
-
-    #TODO: find errors/warnings during import
 
     return 0
 

--- a/siliconcompiler/tools/sv2v/sv2v.py
+++ b/siliconcompiler/tools/sv2v/sv2v.py
@@ -1,7 +1,3 @@
-import os
-import subprocess
-import re
-import sys
 import siliconcompiler
 
 ####################################################################
@@ -49,8 +45,8 @@ def setup(chip):
 
     chip.set('tool', tool, 'exe', tool)
     chip.set('tool', tool, 'vswitch', '--numeric-version')
-    chip.set('tool', tool, 'version', '>=0.0.9')
-    chip.set('tool', tool, 'threads', step, index,  4)
+    chip.set('tool', tool, 'version', '>=0.0.9', clobber=False)
+    chip.set('tool', tool, 'threads', step, index,  4, clobber=False)
 
     # Since we run sv2v after the import/preprocess step, there should be no
     # need for specifying include dirs/defines. However we don't want to pass
@@ -72,15 +68,6 @@ def setup(chip):
 def parse_version(stdout):
     # 0.0.7-130-g1aa30ea
     return '-'.join(stdout.split('-')[:-1])
-
-################################
-# Post_process (post executable)
-################################
-
-def post_process(chip):
-    ''' Tool specific function to run after step execution
-    '''
-    return 0
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/tools/template/template.py
+++ b/siliconcompiler/tools/template/template.py
@@ -1,4 +1,5 @@
 import os
+
 import siliconcompiler
 
 def make_docs():
@@ -45,8 +46,8 @@ def setup(chip):
     index = chip.get('arg','index')
 
     # Required for all
-    chip.set('tool', tool, 'exe', tool, clobber=False)
-    chip.set('tool', tool, 'vswitch', '-version', clobber=False)
+    chip.set('tool', tool, 'exe', exe)
+    chip.set('tool', tool, 'vswitch', '-version')
     chip.set('tool', tool, 'version', 'v2.0', clobber=False)
     chip.set('tool', tool, 'format', 'tcl', clobber=False)
     chip.set('tool', tool, 'option',  step, index, options, clobber=False)
@@ -87,16 +88,13 @@ def pre_process(chip):
     '''
     Logic to run prior to executable
     '''
-    return 0
+    pass
 
 def post_process(chip):
     '''
-    Logic to run  executable
+    Logic to run after executable
     '''
-
-    # return 0 if successful
-
-    return 0
+    pass
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/tools/vivado/vivado.py
+++ b/siliconcompiler/tools/vivado/vivado.py
@@ -58,16 +58,3 @@ def setup(chip, mode='batch'):
     chip.set('tool', tool, 'script', step, index, script, clobber=clobber)
     chip.set('tool', tool, 'threads', step, index, os.cpu_count(), clobber=clobber)
     chip.set('tool', tool, 'option', step, index, option, clobber=clobber)
-
-################################
-# Post_process (post executable)
-################################
-
-def post_process(chip):
-     ''' Tool specific function to run after step execution
-     '''
-     step = chip.get('arg','step')
-     index = chip.get('arg','index')
-
-     #Return 0 if successful
-     return 0

--- a/siliconcompiler/tools/vpr/vpr.py
+++ b/siliconcompiler/tools/vpr/vpr.py
@@ -1,4 +1,5 @@
 import os
+
 import siliconcompiler
 
 ######################################################################
@@ -43,7 +44,7 @@ def setup(chip):
      step = chip.get('arg','step')
      index = chip.get('arg','index')
 
-     chip.set('tool', tool, 'exe', tool, clobber=False)
+     chip.set('tool', tool, 'exe', tool)
      chip.set('tool', tool, 'version', '0.0', clobber=False)
      chip.set('tool', tool, 'threads', step, index, os.cpu_count(), clobber=False)
 
@@ -57,19 +58,6 @@ def setup(chip):
      options.append(blif)
 
      chip.add('tool', tool, 'option', step, index,  options)
-
-################################
-# Post_process (post executable)
-################################
-
-def post_process(chip):
-    ''' Tool specific function to run after step execution
-    '''
-    step = chip.get('arg','step')
-    index = chip.get('arg','index')
-
-    #TODO: return error code
-    return 0
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/tools/xyce/xyce.py
+++ b/siliconcompiler/tools/xyce/xyce.py
@@ -1,4 +1,5 @@
 import os
+
 import siliconcompiler
 
 
@@ -36,24 +37,13 @@ def make_docs():
 def setup(chip):
 
      tool = 'xyce'
-     refdir = 'tools/'+tool
      step = chip.get('arg','step')
      index = chip.get('arg','index')
      clobber = False
 
-     chip.set('tool', tool, 'exe', tool, clobber=clobber)
+     chip.set('tool', tool, 'exe', tool)
      chip.set('tool', tool, 'version', '0.0', clobber=clobber)
      chip.set('tool', tool, 'threads', step, index, os.cpu_count(), clobber=clobber)
-
-################################
-# Post_process (post executable)
-################################
-def post_process(chip):
-    ''' Tool specific function to run after step execution
-    '''
-
-    #TODO: return error code
-    return 0
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -100,7 +100,7 @@ def setup(chip):
         chip.add('tool', tool, 'require', step, index, ",".join(['fpga','partname']))
 
     # Setting up regex patterns
-    chip.set('tool', tool, 'regex', step, index, 'warnings', "Warning", clobber=False)
+    chip.set('tool', tool, 'regex', step, index, 'warnings', "Warning:", clobber=False)
     chip.set('tool', tool, 'regex', step, index, 'errors', "Error", clobber=False)
 
     # Reports
@@ -145,19 +145,14 @@ def post_process(chip):
 
     # Extracting
     if step == 'syn':
-        #TODO: looks like Yosys exits on error, so no need to check metric
-        chip.set('metric', step, index, 'errors', 0, clobber=True)
         with open(step + ".log") as f:
             for line in f:
                 area = re.search(r'Chip area for module.*\:\s+(.*)', line)
                 cells = re.search(r'Number of cells\:\s+(.*)', line)
-                warnings = re.search(r'Warnings.*\s(\d+)\s+total', line)
                 if area:
                     chip.set('metric', step, index, 'cellarea', round(float(area.group(1)),2), clobber=True)
                 elif cells:
                     chip.set('metric', step, index, 'cells', int(cells.group(1)), clobber=True)
-                elif warnings:
-                    chip.set('metric', step, index, 'warnings', int(warnings.group(1)), clobber=True)
     elif step == 'lec':
         with open(step + ".log") as f:
             for line in f:

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -1,6 +1,4 @@
-import os
 import re
-import sys
 import defusedxml.ElementTree as ET
 
 import siliconcompiler
@@ -47,8 +45,8 @@ def setup(chip):
     index = chip.get('arg','index')
 
     # Standard Setup
-    chip.set('tool', tool, 'exe', 'yosys', clobber=False)
-    chip.set('tool', tool, 'vswitch', '--version', clobber=False)
+    chip.set('tool', tool, 'exe', 'yosys')
+    chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=0.13', clobber=False)
     chip.set('tool', tool, 'format', 'tcl', clobber=False)
     chip.set('tool', tool, 'option', step, index, '-c', clobber=False)
@@ -110,16 +108,6 @@ def setup(chip):
                    'cells', 'registers', 'buffers', 'nets', 'pins'):
         chip.set('tool', tool, 'report', step, index, metric, f"{step}.log")
 
-#############################################
-# Runtime pre processing
-#############################################
-
-def pre_process(chip):
-
-    tool = 'yosys'
-    step = chip.get('arg','step')
-    index = chip.get('arg','index')
-
 ################################
 # Version Check
 ################################
@@ -165,10 +153,6 @@ def post_process(chip):
                     num_errors = int(errors.group(1))
                     chip.set('metric', step, index, 'drvs', num_errors, clobber=True)
 
-
-
-    #Return 0 if successful
-    return 0
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -162,13 +162,13 @@ def post_process(chip):
         with open(step + ".log") as f:
             for line in f:
                 if line.endswith('Equivalence successfully proven!'):
-                    chip.set('metric', step, index, 'errors', 0, clobber=True)
+                    chip.set('metric', step, index, 'drvs', 0, clobber=True)
                     continue
 
                 errors = re.search(r'Found a total of (\d+) unproven \$equiv cells.', line)
                 if errors is not None:
                     num_errors = int(errors.group(1))
-                    chip.set('metric', step, index, 'errors', num_errors, clobber=True)
+                    chip.set('metric', step, index, 'drvs', num_errors, clobber=True)
 
 
 

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -6219,10 +6219,10 @@
                         "default": {
                             "defvalue": [],
                             "example": [
-                                "cli: -tool_regex 'openroad place 0 error -v ERROR'",
-                                "api: chip.set('tool','openroad','regex','place','0','error','-v ERROR')"
+                                "cli: -tool_regex 'openroad place 0 errors -v ERROR'",
+                                "api: chip.set('tool','openroad','regex','place','0','errors','-v ERROR')"
                             ],
-                            "help": "A list of piped together grep commands. Each entry represents a set\nof command line arguments for grep including the regex pattern to\nmatch. Starting with the first list entry, each grep output is piped\ninto the following grep command in the list. Supported grep options\ninclude ``-v`` and ``-e``. Patterns starting with \"-\" should be\ndirectly preceeded by the ``-e`` option. The following example\nillustrates the concept.\n\nUNIX grep:\n\n.. code-block:: bash\n\n    $ grep WARNING place.log | grep -v \"bbox\" > place.warnings\n\nSiliconCompiler::\n\n    chip.set('tool', 'openroad', 'regex', 'place', '0', 'warnings', [\"WARNING\", \"-v bbox\"])",
+                            "help": "A list of piped together grep commands. Each entry represents a set\nof command line arguments for grep including the regex pattern to\nmatch. Starting with the first list entry, each grep output is piped\ninto the following grep command in the list. Supported grep options\ninclude ``-v`` and ``-e``. Patterns starting with \"-\" should be\ndirectly preceeded by the ``-e`` option. The following example\nillustrates the concept.\n\nUNIX grep:\n\n.. code-block:: bash\n\n    $ grep WARNING place.log | grep -v \"bbox\" > place.warnings\n\nSiliconCompiler::\n\n    chip.set('tool', 'openroad', 'regex', 'place', '0', 'warnings', [\"WARNING\", \"-v bbox\"])\n\nThe \"errors\" and \"warnings\" suffixes are special cases. When set,\nthe number of matches found for these regexes will be added to the\nerrors and warnings metrics for the task, respectively. This will\nalso cause the logfile to be added to the :keypath:`tool, <tool>,\nreport` parameter for those metrics, if not already present.",
                             "lock": "false",
                             "notes": null,
                             "require": null,

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -3406,6 +3406,23 @@
             "type": "str",
             "value": null
         },
+        "flowcontinue": {
+            "defvalue": "false",
+            "example": [
+                "cli: -flowcontinue",
+                "api: chip.set('option', 'flowcontinue', True)"
+            ],
+            "help": "Continue executing flow after a tool logs errors. The default\nbehavior is to quit executing the flow if a task ends and the errors\nmetric is greater than 0. Note that the flow will always cease\nexecuting if the tool returns a nonzero status code.",
+            "lock": "false",
+            "notes": null,
+            "require": "all",
+            "scope": "job",
+            "shorthelp": "Continue flow on error",
+            "signature": null,
+            "switch": "-flowcontinue",
+            "type": "bool",
+            "value": "false"
+        },
         "frontend": {
             "defvalue": "verilog",
             "example": [

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -26,6 +26,33 @@ def test_py(setup_example_test):
 
     assert chip.get('tool', 'yosys', 'report', 'syn', '0', 'cellarea') == ['syn.log']
 
+    # "No timescale set..."
+    assert chip.get('metric', 'import', '0', 'warnings') == 10
+
+    # "Found unsupported expression..." (x72) + 2 ABC Warnings
+    assert chip.get('metric', 'syn', '0', 'warnings') == 74
+
+    # "Core area lower left snapped to..."
+    assert chip.get('metric', 'floorplan', '0', 'warnings') == 1
+
+    assert chip.get('metric', 'physyn', '0', 'warnings') == 0
+
+    # "Could not find power special net"
+    assert chip.get('metric', 'place', '0', 'warnings') == 1
+
+    # "1584 wires are pure wire and no slew degradation"
+    # "Creating fake entries in the LUT"
+    # "Could not find power special net" (x2)
+    assert chip.get('metric', 'cts', '0', 'warnings') == 4
+
+    # "No OR_DEFAULT vias defined"
+    assert chip.get('metric', 'route', '0', 'warnings') == 1
+
+    assert chip.get('metric', 'dfm', '0', 'warnings') == 0
+
+    # "no fill config specified"
+    assert chip.get('metric', 'export', '0', 'warnings') == 1
+
 @pytest.mark.eda
 @pytest.mark.quick
 def test_cli(setup_example_test):

--- a/tests/tools/test_yosys.py
+++ b/tests/tools/test_yosys.py
@@ -23,7 +23,7 @@ def test_yosys_lec(datadir):
 
     chip.run()
 
-    errors = chip.get('metric', 'lec', '0', 'errors')
+    errors = chip.get('metric', 'lec', '0', 'drvs')
 
     assert errors == 0
 
@@ -43,14 +43,12 @@ def test_yosys_lec_broken(datadir):
     chip.edge(flow, 'import', 'lec')
     chip.set('option','flow', flow)
 
-    chip.set('tool', 'yosys', 'continue', True)
-
     chip.add('input', 'verilog', os.path.join(lec_dir, 'foo_broken.v'))
     chip.add('input', 'netlist', os.path.join(lec_dir, 'foo_broken.vg'))
 
     chip.run()
 
-    errors = chip.get('metric', 'lec', '0', 'errors')
+    errors = chip.get('metric', 'lec', '0', 'drvs')
 
     assert errors == 2
 


### PR DESCRIPTION
I think the current behavior of `['tool', <tool> ,'continue']` is unideal. It's necessary in some cases because your tool produces nonfatal errors, but even in these cases I think you don't want the flow to continue running if the tool errors out with a nonzero status, since in that case future steps are probably pretty likely to fail.

This PR proposes the simplest possible change, which is to always kill the flow if the tool exits with a nonzero status. Another proposal that I'd be happy to implement would be to make 'continue' take a few possible values, something like:
- "never": always quit on any error condition
- "nonfatal": only quit on fatal errors (always continue if tool quits successfully)
- "always": flow always continues