### PR TITLE
Use jobname parameter instead of 'job0' in sc-show

### DIFF
--- a/siliconcompiler/apps/sc_show.py
+++ b/siliconcompiler/apps/sc_show.py
@@ -60,7 +60,7 @@ def main():
         dirlist =[chip.cwd,
                   'build',
                   chip.get('design'),
-                  'job0',
+                  chip.get('option', 'jobname'),
                   'import',
                   '0',
                   'outputs',


### PR DESCRIPTION
We have 'job0' hardcoded in the sc-show app, which prevents it from working if the job name is overridden.