### PR TITLE
Make report self-contained

### DIFF
--- a/siliconcompiler/templates/report/sc_report.j2
+++ b/siliconcompiler/templates/report/sc_report.j2
@@ -15,7 +15,9 @@
 
     <title>SiliconCompiler Manifest Viewer</title>
 
-    <link href="bootstrap.min.css" rel="stylesheet">
+    <style>
+      {% include 'bootstrap.min.css' %}
+    </style>
 
     <style>
       /* Styles related to manifest tree view.
@@ -137,13 +139,15 @@
   </head>
 
   <body>
-    <script src="bootstrap.min.js"></script>
+    <script>
+      {% include 'bootstrap.min.js' %}
+    </script>
 
-    <span style="width: 33%; float: left;">
-      {% if results_fn %}
+    <span style="width: 33%; float: left;>
+      {% if img_data %}
         <div style="text-align: center; width: 100%;">
           <h2>GDS Preview</h2>
-          <img src="{{ manifest['design']['value'] }}.png" class="rounded mx-auto d-block" style="width: 100%;"></img>
+          <img src="data:image/jpeg;base64,{{img_data}}" class="rounded mx-auto d-block" style="width: 100%;"></img>
         </div>
       {% endif %}
 


### PR DESCRIPTION
This PR makes SC's generated HTML report a self-contained file that will look the same even if it is copied elsewhere in the filesystem (or sent to someone else).

This required two changes:
- Embedding the bootstrap CSS/JSS
- Embedding the layout preview as a base64 encoded image

I think this is a nice change, the main downside is that this makes the file a bit heavier. However, it looks like the size of the HTML dump of the entire manifest (for the tree viewer) dominates the size - these changes only result in an increase from 3.5MB->3.9MB for the GCD example.