### PR TITLE
Return filepath from chip.archive()

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2620,6 +2620,8 @@ class Chip:
                         if os.path.isfile(logfile):
                             tar.add(os.path.abspath(logfile), arcname=logfile)
 
+        return archive_name
+
     ###########################################################################
     def hash_files(self, *keypath, algo='sha256', update=True):
         '''Generates hash values for a list of parameter files.


### PR DESCRIPTION
Just a small API tweak that I think is convenient -- make chip.archive() return the full path to the generated tarball (useful for scripts that call chip.archive() and then want to do something with the result).