### PR TITLE
Add final tool CLI options to record schema

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4026,7 +4026,7 @@ class Chip:
         ##################
         # 21. Make a record if tracking is enabled
         if self.get('option', 'track'):
-            self._make_record(step, index, wall_start, wall_end, version, toolpath)
+            self._make_record(step, index, wall_start, wall_end, version, toolpath, cmdlist[1:])
 
         ##################
         # 22. Save a successful manifest
@@ -4802,7 +4802,7 @@ class Chip:
         return 'local'
 
     #######################################
-    def _make_record(self, step, index, start, end, toolversion, toolpath):
+    def _make_record(self, step, index, start, end, toolversion, toolpath, cli_args):
         '''
         Records provenance details for a runstep.
         '''
@@ -4868,6 +4868,9 @@ class Chip:
         self.set('record', step, index, 'arch', arch)
 
         self.set('record', step, index, 'toolpath', toolpath)
+
+        toolargs = ' '.join(f'"{arg}"' if ' ' in arg else arg for arg in cli_args)
+        self.set('record', step, index, 'toolargs', toolargs)
 
     #######################################
     def _safecompare(self, value, op, goal):

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1993,6 +1993,9 @@ def schema_record(cfg, step='default', index='default'):
                              '/usr/bin/openroad',
                              """Full path to tool executable used to run this
                              task."""],
+               'toolargs': ['tool CLI arguments',
+                            '-I include/ foo.v',
+                            'Arguments passed to tool via CLI.'],
                'osversion': ['O/S version',
                              '20.04.1-Ubuntu',
                              """Since there is not standard version system for operating

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -5882,6 +5882,23 @@
                     "type": "str",
                     "value": null
                 },
+                "toolargs": {
+                    "defvalue": null,
+                    "example": [
+                        "cli: -record_toolargs 'dfm 0 <-I include/ foo.v>'",
+                        "api: chip.set('record','dfm','0','toolargs', <-I include/ foo.v>)"
+                    ],
+                    "help": "Record tracking the tool CLI arguments per step and index basis. Arguments passed to tool via CLI.",
+                    "lock": "false",
+                    "notes": null,
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Record: tool CLI arguments",
+                    "signature": null,
+                    "switch": "-record_toolargs 'step index <str>'",
+                    "type": "str",
+                    "value": null
+                },
                 "toolpath": {
                     "defvalue": null,
                     "example": [


### PR DESCRIPTION
I realized we should probably be recording the final set of CLI arguments used to drive a tool for provenance purposes. The options parameter in the tool schema isn't complete, since we generate arguments on the fly using `runtime_options()`. 