### PR TITLE
Fix Verilator compile support, clean up driver

### DIFF
--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -88,8 +88,8 @@ def setup(chip):
     chip.set('tool', tool, 'threads', step, index,  os.cpu_count(), clobber=False)
 
     # Basic warning and error grep check on logfile
-    chip.set('tool', tool, 'regex', step, index, 'warnings', "\%Warning", clobber=False)
-    chip.set('tool', tool, 'regex', step, index, 'errors', "\%Error", clobber=False)
+    chip.set('tool', tool, 'regex', step, index, 'warnings', r"\%Warning", clobber=False)
+    chip.set('tool', tool, 'regex', step, index, 'errors', r"\%Error", clobber=False)
 
     # Errors/warnings are parsed out of logfile
     chip.set('tool', tool, 'report', step, index, 'errors', f'{step}.log')

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -96,13 +96,17 @@ def setup(chip):
         chip.add('tool', tool, 'option', step, index, ['-Wno-fatal', '-Wno-UNOPTFLAT'])
 
     # Step-based CLI options
-    if step in ('import', 'lint'):
+    if step == 'import':
         chip.add('tool', tool, 'option', step, index,  ['--lint-only', '--debug'])
-        if step == 'import':
-            for value in chip.get('option', 'define'):
-                chip.add('tool', tool, 'option', step, index, '-D' + value)
+        for value in chip.get('option', 'define'):
+            chip.add('tool', tool, 'option', step, index, '-D' + value)
+        # File-based arguments added in runtime_options()
+    elif step == 'lint':
+        chip.add('tool', tool, 'option', step, index,  ['--lint-only', '--debug'])
+        chip.add('tool', tool, 'option', step, index, f'inputs/{design}.v')
     elif step == 'compile':
         chip.add('tool', tool, 'option', step, index,  ['--cc', '--exe'])
+        chip.add('tool', tool, 'option', step, index, f'inputs/{design}.v')
         chip.add('tool', tool, 'option', step, index, f'-o ../outputs/{design}.vexe')
 
         if chip.valid('tool', tool, 'var', step, index, 'extraopts'):
@@ -111,6 +115,7 @@ def setup(chip):
                 if opt not in ('--trace'):
                     raise siliconcompiler.SiliconCompilerError(f'Illegal option {opt}')
                 chip.add('tool', tool, 'option', step, index, opt)
+        # File-based arguments added in runtime_options()
     else:
         chip.logger.error(f'Step {step} not supported for verilator')
         raise siliconcompiler.SiliconCompilerError(f'Step {step} not supported for verilator')

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -1,10 +1,8 @@
 import os
 import subprocess
 import re
-import sys
+
 import siliconcompiler
-import shutil
-from siliconcompiler import utils
 
 ####################################################################
 # Make Docs
@@ -12,17 +10,49 @@ from siliconcompiler import utils
 
 def make_docs():
     '''
-    Verilator is a free and open-source software tool which converts
-    Verilog (a hardware description language) to a cycle-accurate
-    behavioral model in C++ or SystemC. It is restricted to modeling
-    the synthesizable subset of Verilog and the generated models
-    are cycle-accurate, 2-state, with synthesis (zero delay) semantics.
-    As a consequence, the models typically offer higher performance
-    than the more widely used event-driven simulators, which can
-    process the entire Verilog language and model behavior within
-    the clock cycle. Verilator is now used within academic research,
-    open source projects and for commercial semiconductor
-    development. It is part of the growing body of free EDA software.
+    Verilator is a free and open-source software tool which converts Verilog (a
+    hardware description language) to a cycle-accurate behavioral model in C++
+    or SystemC.
+
+    Steps supported
+    ---------------
+
+    **import**
+
+    Preprocesses and pickles Verilog sources. Takes in a set of Verilog source
+    files supplied via :keypath:`input, verilog` and reads the following
+    parameters:
+
+    * :keypath:`option, ydir`
+    * :keypath:`option, vlib`
+    * :keypath:`option, idir`
+    * :keypath:`option, cmdfile`
+
+    Outputs a single Verilog file in ``outputs/<design>.v``.
+
+    **lint**
+
+    Lints Verilog source. Takes in a single pickled Verilog file from
+    ``inputs/<design>.v`` and produces no outputs. Results of linting can be
+    programatically queried using errors/warnings metrics.
+
+    **compile**
+
+    Compiles Verilog and C/C++ sources into an executable.  Takes in a single
+    pickled Verilog file from ``inputs/<design>.v`` and a set of C/C++ sources
+    from :keypath:`input, c`. Outputs an executable in
+    ``outputs/<design>.vexe``.
+
+    This steps accepts a restricted set of CLI switches in :keypath:`tool,
+    verilator, var, <step>, <index>, extraopts` that are passed through
+    directly to Verilator. Currently supported switches include:
+
+    * ``--trace``
+
+
+    For all steps, this driver runs Verilator using the ``-sv`` switch to enable
+    parsing a subset of SystemVerilog features. All steps also support using
+    :keypath:`option, relax` to make warnings nonfatal.
 
     Documentation: https://verilator.org/guide/latest
 
@@ -46,11 +76,10 @@ def setup(chip):
     ''' Per tool function that returns a dynamic options string based on
     the dictionary settings. Static setings only.
     '''
-
-    # If the 'lock' bit is set, don't reconfigure.
     tool = 'verilator'
     step = chip.get('arg','step')
     index = chip.get('arg','index')
+    design = chip.get('design')
 
     # Standard Setup
     chip.set('tool', tool, 'exe', 'verilator', clobber=False)
@@ -58,60 +87,79 @@ def setup(chip):
     chip.set('tool', tool, 'version', '>=4.028', clobber=False)
     chip.set('tool', tool, 'threads', step, index,  os.cpu_count(), clobber=False)
 
-    # Options driven on a per step basis (use 'set' on first call!)
-    chip.set('tool', tool, 'option', step, index,  '-sv', clobber=False)
+    # Generic CLI options (for all steps)
+    chip.set('tool', tool, 'option', step, index,  '-sv')
+    chip.add('tool', tool, 'option', step, index, f'--top-module {design}')
 
-    # Differentiate between import step and compilation
-    if step in ['import', 'lint']:
+    if chip.get('option', 'relax'):
+        # Make warnings non-fatal in relaxed mode
+        chip.add('tool', tool, 'option', step, index, ['-Wno-fatal', '-Wno-UNOPTFLAT'])
+
+    # Step-based CLI options
+    if step in ('import', 'lint'):
         chip.add('tool', tool, 'option', step, index,  ['--lint-only', '--debug'])
-    elif (step == 'compile'):
-        chip.add('tool', tool, 'option', step, index,  '--cc')
+        if step == 'import':
+            for value in chip.get('option', 'define'):
+                chip.add('tool', tool, 'option', step, index, '-D' + value)
+    elif step == 'compile':
+        chip.add('tool', tool, 'option', step, index,  ['--cc', '--exe'])
+        chip.add('tool', tool, 'option', step, index, f'-o ../outputs/{design}.vexe')
+
+        if chip.valid('tool', tool, 'var', step, index, 'extraopts'):
+            extra_opts = chip.get('tool', tool, 'var', step, index, 'extraopts')
+            for opt in extra_opts:
+                if opt not in ('--trace'):
+                    raise siliconcompiler.SiliconCompilerError(f'Illegal option {opt}')
+                chip.add('tool', tool, 'option', step, index, opt)
     else:
         chip.logger.error(f'Step {step} not supported for verilator')
         raise siliconcompiler.SiliconCompilerError(f'Step {step} not supported for verilator')
 
+   # I/O requirements
     if step == 'import':
-        design = chip.get('design')
+        chip.add('tool', tool, 'require', step, index, ",".join(['input', 'verilog']))
         chip.set('tool', tool, 'output', step, index, f'{design}.v')
+    elif step == 'lint':
+        chip.set('tool', tool, 'input', step, index, f'{design}.v')
+    elif step == 'compile':
+        chip.add('tool', tool, 'require', step, index, ",".join(['input', 'c']))
+        chip.set('tool', tool, 'input', step, index, f'{design}.v')
+        chip.set('tool', tool, 'output', step, index, f'{design}.vexe')
 
-    # Schema requirements
-    chip.add('tool', tool, 'require', step, index, ",".join(['input', 'verilog']))
-    # basic warning and error grep check on logfile
+    # Basic warning and error grep check on logfile
     chip.set('tool', tool, 'regex', step, index, 'warnings', "\%Warning", clobber=False)
     chip.set('tool', tool, 'regex', step, index, 'errors', "\%Error", clobber=False)
+
+    # Errors/warnings are parsed out of logfile
+    chip.set('tool', tool, 'report', step, index, 'errors', f'{step}.log')
+    chip.set('tool', tool, 'report', step, index, 'warnings', f'{step}.log')
 
 ################################
 #  Custom runtime options
 ################################
 
 def runtime_options(chip):
-
-    ''' Custom runtime options, returns list of command line options.
     '''
-
-    step = chip.get('arg','step')
-    index = chip.get('arg','index')
-    check_workdir = (step != 'import')
-
+    CLI options that involve filepaths (must be resolved at runtime, in case
+    we're running on a different machine than client).
+    '''
     cmdlist = []
+    step = chip.get('arg', 'step')
 
-    # source files
-    for value in chip.find_files('option', 'ydir'):
-        cmdlist.append('-y ' + value)
-    for value in chip.find_files('option', 'vlib'):
-        cmdlist.append('-v ' + value)
-    for value in chip.find_files('option', 'idir'):
-        cmdlist.append('-I' + value)
-    for value in chip.get('option', 'define'):
-        cmdlist.append('-D' + value)
-    for value in chip.find_files('option', 'cmdfile'):
-        cmdlist.append('-f ' + value)
-    for value in chip.find_files('input', 'verilog'):
-        cmdlist.append(value)
-
-    #  make warnings non-fatal in relaxed mode
-    if chip.get('option', 'relax'):
-        cmdlist.extend(['-Wno-fatal', '-Wno-UNOPTFLAT'])
+    if step == 'import':
+        for value in chip.find_files('option', 'ydir'):
+            cmdlist.append('-y ' + value)
+        for value in chip.find_files('option', 'vlib'):
+            cmdlist.append('-v ' + value)
+        for value in chip.find_files('option', 'idir'):
+            cmdlist.append('-I' + value)
+        for value in chip.find_files('option', 'cmdfile'):
+            cmdlist.append('-f ' + value)
+        for value in chip.find_files('input', 'verilog'):
+            cmdlist.append(value)
+    elif step == 'compile':
+        for value in chip.find_files('input', 'c'):
+            cmdlist.append(value)
 
     return cmdlist
 
@@ -131,24 +179,26 @@ def post_process(chip):
     ''' Tool specific function to run after step execution
     '''
 
+    design = chip.get('design')
     step = chip.get('arg','step')
     index = chip.get('arg','index')
     logfile = f"{step}.log"
 
-    # post-process hack to collect vpp files
-    if step in ['import', 'lint']:
+    if step == 'import':
+        # Post-process hack to collect vpp files
         # Creating single file "pickle' synthesis handoff
         subprocess.run('egrep -h -v "\\`begin_keywords" obj_dir/*.vpp > verilator.v',
                        shell=True)
 
         # Moving pickled file to outputs
         os.rename("verilator.v", f"outputs/{chip.design}.v")
+    elif step == 'compile':
+        # Run make to compile Verilated design into executable.
+        # If we upgrade our minimum supported Verilog, we can remove this and
+        # use the --build flag instead.
+        subprocess.run(['make', '-C', 'obj_dir', '-f', f'V{design}.mk'])
 
-        # Clean up
-        shutil.rmtree('obj_dir')
-
-
-    # check log file for errors and statistics
+    # Check log file for errors and statistics
     errors = 0
     warnings = 0
     with open(logfile) as f:
@@ -159,7 +209,7 @@ def post_process(chip):
             if errmatch:
                 errors = errors + 1
             elif warnmatch:
-                warnings = warnings +1
+                warnings = warnings + 1
 
     chip.set('metric', step, index, 'errors', errors, clobber=True)
     chip.set('metric', step, index, 'warnings', warnings, clobber=True)

--- a/tests/flows/data/heartbeat_tb.cpp
+++ b/tests/flows/data/heartbeat_tb.cpp
@@ -1,0 +1,28 @@
+#include "Vheartbeat.h"
+
+int main() {
+    Vheartbeat *tb = new Vheartbeat;
+
+    // Reset
+    tb->nreset = 1;
+    tb->eval();
+    tb->nreset = 0;
+    tb->eval();
+    tb->nreset = 1;
+
+    // Tick 256 times
+    for (int i=0; i<256; i++) {
+        tb->clk = 0;
+        tb->eval();
+        tb->clk = 1;
+        tb->eval();
+    }
+
+    if (tb->out == 1) {
+        printf("SUCCESS\n");
+    }  else {
+        printf("FAIL\n");
+    }
+
+    delete tb;
+}

--- a/tests/flows/test_verilator_sim.py
+++ b/tests/flows/test_verilator_sim.py
@@ -1,8 +1,11 @@
 import os
 import subprocess
 
+import pytest
+
 import siliconcompiler
 
+@pytest.mark.eda
 def test_basic(scroot, datadir):
     chip = siliconcompiler.Chip('heartbeat')
 

--- a/tests/flows/test_verilator_sim.py
+++ b/tests/flows/test_verilator_sim.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+
+import siliconcompiler
+
+def test_basic(scroot, datadir):
+    chip = siliconcompiler.Chip('heartbeat')
+
+    v_src = os.path.join(scroot, 'tests', 'data', 'heartbeat.v')
+    chip.set('input', 'verilog', v_src)
+    c_src = os.path.join(datadir, 'heartbeat_tb.cpp')
+    chip.set('input', 'c', c_src)
+
+    chip.set('option', 'mode', 'sim')
+
+    # Basic Verilator compilation flow
+    flow = 'verilator_compile'
+    chip.node(flow, 'import', 'surelog')
+    chip.node(flow, 'compile', 'verilator')
+    chip.edge(flow, 'import', 'compile')
+    chip.set('option', 'flow', flow)
+
+    chip.run()
+
+    exe_path = chip.find_result('vexe', step='compile')
+
+    proc = subprocess.run([exe_path], stdout=subprocess.PIPE)
+    output = proc.stdout.decode('utf-8')
+    print(output)
+
+    assert output == 'SUCCESS\n'


### PR DESCRIPTION
This PR fixes up the Verilator "compile" step, working towards supporting a Verilator-based simulation flow. Thanks to @sgherbst for trying out this functionality and providing feedback!

One design decision I wanted to highlight was making the input to "compile" an already preprocessed and pickled Verilog file, rather than reading input/include dirs/defines from the schema. This might seem odd given that Verilator can handle the preprocessing itself, but I did this for a few reasons:

1) We have standardized on Surelog for input preprocessing and elaboration, so a simulation pipeline that goes Surelog --> Verilator ensures any Surelog-related quirks that would be present in the implementation RTL will also be present in the simulation RTL. The Verilator driver still supports being used for "import" so we can also swap the two out for A/B debugging.
2) This makes it easier to support simulation of alternate frontends, which all generally produce a pickled Verilog file as output. 
3) It's more consistent with the intended interface for the "lint" step (based on flows/lintflow.py), although I had to fix the implementation of lint to make this the case.

I also took this chance to do a sweep of the driver and clean things up according to our current best-practices. Highlights:
- More precise docs
- Thoughtful use of clobber
- Set logfile as report for errors/warnings
- Using runtime_options() for file-based options only