### PR TITLE
Allow tool tasks to have more than one input

### DIFF
--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -280,7 +280,10 @@ def post_process(chip):
     #Temporary superhack!rm
     #Getting cell count and net number from the first available DEF file output (if any)
     out_def = ''
-    out_files = chip.get('tool', tool, 'output', step, index)
+    out_files = []
+    if chip.valid('tool', tool, 'output', step, index):
+        out_files = chip.get('tool', tool, 'output', step, index)
+
     if out_files:
         for fn in out_files:
             if fn.endswith('.def'):


### PR DESCRIPTION
This PR modifies the flowgraph I/O checker to allow tool tasks to have more than one input. As far as I can tell, the logic in `_runtask()` supports this (it works intuitively -- the outputs of each input task are combined into the inputs of the task at hand). However, the checker did not, and would output a nonfatal error.

I've updated the checker to no longer consider this an error, and also properly check the inputs (so it will throw an error if there are  duplicate input files, and it will throw an error if the sum total of all inputs does not provide all the files a task needs). I added tests for these cases.

I also bundled a small tweak to the OR post_process function that checks that the [... 'output' ...] keypath is valid. This cleans up the other nonfatal error we're seeing in the SC+ORFS project. 