### PR TITLE
Make the yosys and klayout tool drivers less strict, to accommodate custom flows.

### DIFF
--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -99,11 +99,12 @@ def setup(chip, mode="batch"):
     # Export GDS with timestamps by default.
     chip.set('tool', tool, 'var', step, index, 'timestamps', 'true', clobber=False)
 
-    # Input/Output requirements
-    if (not chip.valid('input', 'def') or
-        not chip.get('input', 'def')):
-        chip.add('tool', tool, 'input', step, index, chip.design + '.def')
-    chip.add('tool', tool, 'output', step, index, chip.design + '.gds')
+    # Input/Output requirements for default flow
+    if step in ['export']:
+        if (not chip.valid('input', 'def') or
+            not chip.get('input', 'def')):
+            chip.add('tool', tool, 'input', step, index, chip.design + '.def')
+        chip.add('tool', tool, 'output', step, index, chip.design + '.gds')
 
     # Adding requirements
     if mode != 'show':

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -57,7 +57,11 @@ def setup(chip):
     elif re.search(r'lec', step):
         script = 'sc_lec.tcl'
     else:
-        chip.logger.error(f'Yosys does not support step {step}.')
+        # Emit a warning for unsupported yosys step, but allow execution to proceed.
+        # Users can configure their own flows involving yosys, but they will be responsible for
+        # setting appropriate schema values, including 'script'.
+        script = ''
+        chip.logger.warning(f'Unsupported yosys step: {step}.')
 
     chip.set('tool', tool, 'script', step, index, script, clobber=False)
 


### PR DESCRIPTION
This change relaxes a couple of checks in the yosys and klayout tool drivers, for custom flows such as the ORFS scripts. It is similar to #1049.

One downside of using the step name to set KLayout's default I/O values is that `sc-show` looks in `export/` for the final GDS file. So if we use a custom step name for the final GDS-streaming step, we need to symlink that task directory to `[job_dir]/export/` in order to support the simplified `sc-show -design [...]` syntax.