### PR TITLE
Update yosys error regex

### DIFF
--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -103,7 +103,7 @@ def setup(chip):
 
     # Setting up regex patterns
     chip.set('tool', tool, 'regex', step, index, 'warnings', "Warning:", clobber=False)
-    chip.set('tool', tool, 'regex', step, index, 'errors', "Error", clobber=False)
+    chip.set('tool', tool, 'regex', step, index, 'errors', "^ERROR", clobber=False)
 
     # Reports
     for metric in ('errors', 'warnings', 'drvs', 'coverage', 'security',


### PR DESCRIPTION
Our yosys tool driver erroneously reports synthesis errors for the tinyRocket OpenROAD-flow-scripts example. It turns out the errors are stemming from our error-checking regex flagging some bus signals called "TSError" in the synthesis logs.

"^ERROR" seems like a better pattern for the yosys logs; it may not be universal, but when I tried inducing a simple error in a yosys tcl script, I got the following output:

`ERROR: Option -top requires an additional argument!`