### PR TITLE
Set 'flowcontinue' on heartbeat_padring top level

### DIFF
--- a/examples/heartbeat_padring/build.py
+++ b/examples/heartbeat_padring/build.py
@@ -93,6 +93,9 @@ def build_top():
 
     chip.write_manifest('top_manifest.json')
 
+    # There are errors in KLayout export
+    chip.set('option', 'flowcontinue', True)
+
     # Run the top-level build.
     chip.run()
     # (Un-comment to display a summary report)

--- a/examples/heartbeat_padring/floorplan_build.py
+++ b/examples/heartbeat_padring/floorplan_build.py
@@ -568,6 +568,9 @@ def build_top():
     chip.add('input', 'verilog', f'{SKY130IO_PREFIX}/io/sky130_io.blackbox.v')
     chip.write_manifest('top_manifest.json')
 
+    # There are errors in KLayout export
+    chip.set('option', 'flowcontinue', True)
+
     # Run the top-level build.
     chip.run()
     # (Un-comment to display a summary report)


### PR DESCRIPTION
This PR fixes the new daily test failures. It turns out there was a nonfatal KLayout error in the heartbeat_padring builds:

```
[ERROR] LEF Cell 'sky130_fd_pr__gendlring__example_559591418081' has no matching GDS/OAS cell. Cell will be empty
```

With the change to make error regexes meaningful metrics-wise, this caused the flow to stop prematurely. I fixed this by making SC continue despite the error by adding `chip.set('option', 'flowcontinue', True)`. 

Note: I haven't re-run daily tests to avoid bogging down the runner, but this fixes the test for me locally. Github is also being a little odd for me this morning, and for some reason it's only run one of the tests (looks like Github actions is having service issues: https://www.githubstatus.com/). 