### PR TITLE
Prepare for 0.9.2 release

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,11 +14,13 @@ SiliconCompiler 0.9.2 (2022-07-08)
 **Major:**
 
 * Schema: Added ['option', 'flowcontinue'] to control whether flow continues when a tool reports errors.
+
   * This used to be controlled by ['tool', \<tool\>, 'continue'], but this parameter is meant to feed directly into tools (rather than controlling the SC runtime).
 * Schema: Added ['option', 'continue'] parameter to control whether errors in the Python API are fatal.
+
   * The default value makes errors fatal, setting this parameter to True reverts to the old behavior.
 * Added VPR-based FPGA bitstream generation flow.
-* Added logic to set errors and warnings metrics based on [tool', \<tool\>, 'regex', ...] matches. This reduces tool driver boilerplate and makes the metrics consistent with the generated regex match files.
+* Added logic to set errors and warnings metrics based on ['tool', \<tool\>, 'regex', ...] matches. This reduces tool driver boilerplate and makes the metrics consistent with the generated regex match files.
 
 **Minor:**
 

--- a/Changes
+++ b/Changes
@@ -8,6 +8,28 @@ The changes in each SiliconCompiler release version are described below. Commit
 version shown in (). Where applicable, the contributors that suggested a given
 feature are shown in [].
 
+SiliconCompiler 0.9.2 (2022-07-08)
+=========================================
+
+**Major:**
+
+* Schema: Added ['option', 'flowcontinue'] to control whether flow continues when a tool reports errors.
+  * This used to be controlled by ['tool', \<tool\>, 'continue'], but this parameter is meant to feed directly into tools (rather than controlling the SC runtime).
+* Schema: Added ['option', 'continue'] parameter to control whether errors in the Python API are fatal.
+  * The default value makes errors fatal, setting this parameter to True reverts to the old behavior.
+* Added VPR-based FPGA bitstream generation flow.
+* Added logic to set errors and warnings metrics based on [tool', \<tool\>, 'regex', ...] matches. This reduces tool driver boilerplate and makes the metrics consistent with the generated regex match files.
+
+**Minor:**
+
+* Changed default technology target for ``sc`` app.
+* Changed KLayout show script to always use a dark background.
+* Changed ``check_manifest()`` to allow tool tasks to have multiple inputs (behaving as if they were merged with a "join" builtin).
+* Changed ``check_manifest()`` to return True on success rather than 0 (the previous behavior didn't match the documentation).
+* Changed Yosys and OpenROAD tool drivers to make them easier to use in flows with alternate step names.
+* Changed GHDL tool driver to allow additional CLI options via ['tool', \<tool\>, 'var', ..., 'extraopts'].
+* Removed return codes from ``post_process()``.
+
 SiliconCompiler 0.9.1 (2022-06-21)
 =========================================
 

--- a/docs/user_guide/examples/heartbeat.v
+++ b/docs/user_guide/examples/heartbeat.v
@@ -1,1 +1,23 @@
-../../../examples/heartbeat/heartbeat.v
+module heartbeat #(parameter N = 8)
+   (
+    //inputs
+    input      clk,// clock
+    input      nreset,//async active low reset
+    output reg out //heartbeat
+    );
+
+   reg [N-1:0] counter_reg;
+
+   always @ (posedge clk or negedge nreset)
+     if(!nreset)
+       begin
+	  counter_reg <= 'b0;
+	  out <= 1'b0;
+       end
+     else
+       begin
+	  counter_reg[N-1:0] <= counter_reg[N-1:0] + 1'b1;
+	  out <= (counter_reg[N-1:0]=={(N){1'b1}});
+       end
+
+endmodule

--- a/siliconcompiler/_metadata.py
+++ b/siliconcompiler/_metadata.py
@@ -1,5 +1,5 @@
 # Version number following semver standard.
-version = '0.9.1'
+version = '0.9.2'
 
 # This is the list of significant contributors to SiliconCompiler in
 # chronological order.

--- a/siliconcompiler/apps/sc.py
+++ b/siliconcompiler/apps/sc.py
@@ -4,9 +4,7 @@
 import os
 import sys
 
-#Shorten siliconcompiler as sc
 import siliconcompiler
-import siliconcompiler.client
 
 ###########################
 def main():
@@ -78,7 +76,7 @@ def main():
 
     # Set demo target if none specified
     if not chip.get('option', 'target'):
-        chip.load_target("freepdk45_demo")
+        chip.load_target('skywater130_demo')
 
     # Storing user entered steplist/args before running
     if chip.get('arg','step'):

--- a/siliconcompiler/targets/skywater130_demo.py
+++ b/siliconcompiler/targets/skywater130_demo.py
@@ -62,8 +62,7 @@ def setup(chip):
     chip.set('asic', 'vpinlayer', "m2")
     chip.set('asic', 'density', 10)
     chip.set('asic', 'aspectratio', 1)
-    # Least common multiple of std. cell width (0.46) and height (2.72)
-    chip.set('asic', 'coremargin', 62.56)
+    chip.set('asic', 'coremargin', 4.6)
 
     #5. Timing corners
     corner = 'typical'

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -70,7 +70,7 @@ layoutOptions.lefdef_config.produce_obstructions = True
 
 app = pya.Application.instance()
 
-# Opionated default KLayout configuration
+# Opinionated default KLayout configuration
 # see ~/.klayout/klayoutrc for a list of configuration keys
 
 # show all cells

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -69,12 +69,18 @@ layoutOptions.lefdef_config.produce_cell_outlines = True
 layoutOptions.lefdef_config.produce_obstructions = True
 
 app = pya.Application.instance()
+
+# Opionated default KLayout configuration
+# see ~/.klayout/klayoutrc for a list of configuration keys
+
 # show all cells
 app.set_config('full-hierarchy-new-cell', 'true')
 # no tip pop-ups
 app.set_config('tip-window-hidden', 'only-top-level-shown-by-default=3,editor-mode=4,editor-mode=0')
 # hide text
 app.set_config('text-visible', 'false')
+# dark background
+app.set_config('background-color', '#212121')
 
 # Display the file!
 cell_view = pya.MainWindow.instance().load_layout(filename, layoutOptions, 0)


### PR DESCRIPTION
A bit of a hodge-podge PR, with all the small things we discussed today:

- Change `sc` app to use Skywater as default target
  - Also made the default coremargin smaller, since it was particularly large compared to the small heartbeat die
- Made `sc-show` use a dark background for KLayout
- Reverted the copy of heartbeat.v in the user guide directory back to a real file from a symlink, in order to fix our business cards...
- Release notes and version bump to prep for a 0.9.2 release