### PR TITLE
Hardcode UTF-8 encoding for HTML report

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3153,7 +3153,12 @@ class Chip:
                 del pruned_cfg['history']
             if 'library' in pruned_cfg:
                 del pruned_cfg['library']
-            with open(results_page, 'w') as wf:
+
+            # Hardcode the encoding, since there's a Unicode character in a
+            # Bootstrap CSS file inlined in this template. Without this setting,
+            # this write may raise an encoding error on machines where the
+            # default encoding is not UTF-8.
+            with open(results_page, 'w', encoding='utf-8') as wf:
                 wf.write(env.get_template('sc_report.j2').render(
                     manifest = self.cfg,
                     pruned_cfg = pruned_cfg,


### PR DESCRIPTION
There's a non-ASCII character (emdash) in the Bootstrap CSS file that gets inlined into our HTML report: https://github.com/siliconcompiler/siliconcompiler/blob/main/siliconcompiler/templates/report/bootstrap.min.css. 

On systems where the default encoding is UTF-8, this isn't a problem. However, when the default encoding is something else, the `wf.write(...)` call may raise a `UnicodeEncodeError`. Hardcoding the encoding to UTF-8 should fix this problem.

Thanks to @arlpetergadfort for reporting and finding the root cause of this issue! Closes #1072. 