### PR TITLE
Set PATH env var in the replay script even if 'path' parameter is not defined.

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4821,6 +4821,8 @@ class Chip:
                 envvars[item] = ':'.join(license_file)
         if self.get('tool', tool, 'path'):
             envvars['PATH'] = self.get('tool', tool, 'path') + os.pathsep + '$PATH'
+        else:
+            envvars['PATH'] = os.environ['PATH']
         if (step in self.getkeys('tool', tool, 'env') and
             index in self.getkeys('tool', tool, 'env', step)):
             for key in self.getkeys('tool', tool, 'env', step, index):


### PR DESCRIPTION
Sometimes it is necessary to use different versions of the same tool for different tasks. Our current `replay.sh` scripts will not work in that case, unless we include the value of the `$PATH` variable from when the task was originally run.