### PR TITLE
Improve error handling for some kinds of chip.get / chip.getkeys failures.

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -909,7 +909,7 @@ class Chip:
             if not isinstance(key,str):
                 self.logger.error(f"Key [{key}] is not a string [{args}]")
 
-        keypathstr = ','.join(args[:-1])
+        keypathstr = f'{args[:-1]}'
         all_args = list(args)
 
         # Special case to ensure loglevel is updated ASAP
@@ -953,7 +953,7 @@ class Chip:
             if not isinstance(key,str):
                 self.logger.error(f"Key [{key}] is not a string [{args}]")
 
-        keypathstr = ','.join(args[:-1])
+        keypathstr = f'{args[:-1]}'
         all_args = list(args)
 
         self.logger.debug(f'Appending value {args[-1]} to [{keypathstr}]')
@@ -1011,6 +1011,7 @@ class Chip:
                 self.error(
                     f'Invalid keypath: {keypath}\n'
                     'Your Chip configuration may be missing a parameter which is expected by your build script.')
+                return None
 
         #set/add leaf cell (all_args=(param,val))
         if (mode in ('set', 'add')) & (len(all_args) == 2):

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -795,7 +795,7 @@ class Chip:
 
         keypathstr = f'{keypath}'
 
-        self.logger.debug(f"Reading from [{keypathstr}]. Field = '{field}'")
+        self.logger.debug(f"Reading from {keypathstr}. Field = '{field}'")
         return self._search(cfg, keypathstr, *keypath, field=field, mode='get')
 
     ###########################################################################
@@ -904,11 +904,6 @@ class Chip:
         if cfg is None:
             cfg = self.cfg
 
-        # Verify that all keys are strings
-        for key in args[:-1]:
-            if not isinstance(key,str):
-                self.logger.error(f"Key [{key}] is not a string [{args}]")
-
         keypathstr = f'{args[:-1]}'
         all_args = list(args)
 
@@ -916,7 +911,7 @@ class Chip:
         if len(args) == 3 and args[1] == 'loglevel' and field == 'value':
             self.logger.setLevel(args[2])
 
-        self.logger.debug(f"Setting [{keypathstr}] to {args[-1]}")
+        self.logger.debug(f"Setting {keypathstr} to {args[-1]}")
         return self._search(cfg, keypathstr, *all_args, field=field, mode='set', clobber=clobber)
 
     ###########################################################################
@@ -948,15 +943,10 @@ class Chip:
         if cfg is None:
             cfg = self.cfg
 
-        # Verify that all keys are strings
-        for key in args[:-1]:
-            if not isinstance(key,str):
-                self.logger.error(f"Key [{key}] is not a string [{args}]")
-
         keypathstr = f'{args[:-1]}'
         all_args = list(args)
 
-        self.logger.debug(f'Appending value {args[-1]} to [{keypathstr}]')
+        self.logger.debug(f'Appending value {args[-1]} to {keypathstr}')
         return self._search(cfg, keypathstr, *all_args, field=field, mode='add')
 
 
@@ -1017,7 +1007,7 @@ class Chip:
         if (mode in ('set', 'add')) & (len(all_args) == 2):
             # clean error if key not found
             if (not param in cfg) & (not 'default' in cfg):
-                self.error(f"Set/Add keypath [{keypath}] does not exist.")
+                self.error(f"Set/Add keypath {keypath} does not exist.")
             else:
                 # making an 'instance' of default if not found
                 if (not param in cfg) & ('default' in cfg):
@@ -1025,7 +1015,7 @@ class Chip:
                 list_type =bool(re.match(r'\[', cfg[param]['type']))
                 # checking for illegal fields
                 if not field in cfg[param] and (field != 'value'):
-                    self.error(f"Field '{field}' for keypath [{keypath}]' is not a valid field.")
+                    self.error(f"Field '{field}' for keypath {keypath}' is not a valid field.")
                 # check legality of value
                 if field == 'value':
                     (type_ok,type_error) = self._typecheck(cfg[param], param, val)
@@ -1042,7 +1032,7 @@ class Chip:
                 selval = cfg[param]['value']
                 # updating values
                 if cfg[param]['lock'] == "true":
-                    self.logger.debug("Ignoring {mode}{} to [{keypath}]. Lock bit is set.")
+                    self.logger.debug("Ignoring {mode}{} to {keypath}. Lock bit is set.")
                 elif (mode == 'set'):
                     if (field != 'value') or (selval in empty) or clobber:
                         if field in ('copy', 'lock'):
@@ -1082,9 +1072,9 @@ class Chip:
                             else:
                                 cfg[param][field] = val
                         else:
-                            self.error(f"Assigning list to scalar for [{keypath}]")
+                            self.error(f"Assigning list to scalar for {keypath}")
                     else:
-                        self.logger.debug(f"Ignoring set() to [{keypath}], value already set. Use clobber=true to override.")
+                        self.logger.debug(f"Ignoring set() to {keypath}, value already set. Use clobber=true to override.")
                 elif (mode == 'add'):
                     if field in ('filehash', 'date', 'author', 'signature'):
                         cfg[param][field].append(str(val))
@@ -1095,19 +1085,19 @@ class Chip:
                     elif list_type & isinstance(val, list):
                         cfg[param][field].extend(val)
                     else:
-                        self.error(f"Illegal use of add() for scalar parameter [{keypath}].")
+                        self.error(f"Illegal use of add() for scalar parameter {keypath}.")
                 return cfg[param][field]
         #get leaf cell (all_args=param)
         elif len(all_args) == 1:
             if not param in cfg:
-                self.error(f"Get keypath [{keypath}] does not exist.")
+                self.error(f"Get keypath {keypath} does not exist.")
             elif mode == 'getcfg':
                 return cfg[param]
             elif mode == 'getkeys':
                 return cfg[param].keys()
             else:
                 if not (field in cfg[param]) and (field!='value'):
-                    self.error(f"Field '{field}' not found for keypath [{keypath}]")
+                    self.error(f"Field '{field}' not found for keypath {keypath}")
                 elif field == 'value':
                     #Select default if no value has been set
                     if field not in cfg[param]:
@@ -1171,7 +1161,7 @@ class Chip:
             if not param in cfg and 'default' in cfg:
                 cfg[param] = copy.deepcopy(cfg['default'])
             elif not param in cfg:
-                self.error(f"Get keypath [{keypath}] does not exist.")
+                self.error(f"Get keypath {keypath} does not exist.")
                 return None
             all_args.pop(0)
             return self._search(cfg[param], keypath, *all_args, field=field, mode=mode, clobber=clobber)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -787,6 +787,15 @@ class Chip:
 
         """
 
+        # Ensure that all keypath values are strings.
+        # Scripts may accidentally pass in [None] if a prior schema entry was unexpectedly empty.
+        for kp in keypath:
+            if not type(kp) == str:
+                self.error(\
+f'''An invalid keypath was passed to "chip.get":
+{keypath}
+Your Chip configuration may be missing a parameter which is expected by your build script.''')
+
         if cfg is None:
             if job is not None:
                 cfg = self.cfg['history'][job]
@@ -823,6 +832,15 @@ class Chip:
             >>> keylist = chip.getkeys()
             Returns all list of all keypaths in the schema.
         """
+
+        # Ensure that all keypath values are strings.
+        # Scripts may accidentally pass in [None] if a prior schema entry was unexpectedly empty.
+        for kp in keypath:
+            if not type(kp) == str:
+                self.error(\
+f'''An invalid keypath was passed to "chip.getkeys":
+{keypath}
+Your Chip configuration may be missing a parameter which is expected by your build script.''')
 
         if cfg is None:
             if job is None:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -787,22 +787,13 @@ class Chip:
 
         """
 
-        # Ensure that all keypath values are strings.
-        # Scripts may accidentally pass in [None] if a prior schema entry was unexpectedly empty.
-        for kp in keypath:
-            if not type(kp) == str:
-                self.error(\
-f'''An invalid keypath was passed to "chip.get":
-{keypath}
-Your Chip configuration may be missing a parameter which is expected by your build script.''')
-
         if cfg is None:
             if job is not None:
                 cfg = self.cfg['history'][job]
             else:
                 cfg = self.cfg
 
-        keypathstr = ','.join(keypath)
+        keypathstr = f'{keypath}'
 
         self.logger.debug(f"Reading from [{keypathstr}]. Field = '{field}'")
         return self._search(cfg, keypathstr, *keypath, field=field, mode='get')
@@ -833,15 +824,6 @@ Your Chip configuration may be missing a parameter which is expected by your bui
             Returns all list of all keypaths in the schema.
         """
 
-        # Ensure that all keypath values are strings.
-        # Scripts may accidentally pass in [None] if a prior schema entry was unexpectedly empty.
-        for kp in keypath:
-            if not type(kp) == str:
-                self.error(\
-f'''An invalid keypath was passed to "chip.getkeys":
-{keypath}
-Your Chip configuration may be missing a parameter which is expected by your build script.''')
-
         if cfg is None:
             if job is None:
                 cfg = self.cfg
@@ -849,7 +831,7 @@ Your Chip configuration may be missing a parameter which is expected by your bui
                 cfg = self.cfg['history'][job]
 
         if len(list(keypath)) > 0:
-            keypathstr = ','.join(keypath)
+            keypathstr = f'{keypath}'
             self.logger.debug('Getting schema parameter keys for: %s', keypathstr)
             keys = list(self._search(cfg, keypathstr, *keypath, mode='getkeys'))
             if 'default' in keys:
@@ -1017,6 +999,18 @@ Your Chip configuration may be missing a parameter which is expected by your bui
         param = all_args[0]
         val = all_args[-1]
         empty = [None, 'null', [], 'false']
+
+        # Ensure that all keypath values are strings.
+        # Scripts may accidentally pass in [None] if a prior schema entry was unexpectedly empty.
+        keys_to_check = args
+        if mode in ['set', 'add']:
+            # Ignore the value parameter for 'set' and 'add' operations.
+            keys_to_check = args[:-1]
+        for key in keys_to_check:
+            if not isinstance(key, str):
+                self.error(
+                    f'Invalid keypath: {keypath}\n'
+                    'Your Chip configuration may be missing a parameter which is expected by your build script.')
 
         #set/add leaf cell (all_args=(param,val))
         if (mode in ('set', 'add')) & (len(all_args) == 2):

--- a/tests/core/test_setget.py
+++ b/tests/core/test_setget.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
-import siliconcompiler
+import pytest
 import re
+import siliconcompiler
 
 def _cast(val, sctype):
     if sctype.startswith('['):
@@ -77,6 +78,40 @@ def test_set_field_bool():
     chip = siliconcompiler.Chip('test')
     chip.set('input', 'txt', False, field='copy')
     assert chip.get('input', 'txt', field='copy') is False
+
+def test_getkeys_invalid_field():
+    chip = siliconcompiler.Chip('test')
+    with pytest.raises(siliconcompiler.core.SiliconCompilerError):
+        chip.getkeys('option', None)
+
+def test_add_invalid_field():
+    chip = siliconcompiler.Chip('test')
+    with pytest.raises(siliconcompiler.core.SiliconCompilerError):
+        chip.add('option', None, 'test_val')
+
+def test_set_invalid_field():
+    chip = siliconcompiler.Chip('test')
+    with pytest.raises(siliconcompiler.core.SiliconCompilerError):
+        chip.set('option', None, 'test_val')
+
+def test_get_invalid_field():
+    chip = siliconcompiler.Chip('test')
+    with pytest.raises(siliconcompiler.core.SiliconCompilerError):
+        chip.get('option', None)
+
+def test_get_invalid_field_continue():
+    chip = siliconcompiler.Chip('test')
+    chip.set('option', 'continue', True)
+    ret_val = chip.get('option', None)
+    assert ret_val == None
+
+def test_set_valid_field_to_none():
+    chip = siliconcompiler.Chip('test')
+    chip.set('option', 'jobscheduler', 'slurm')
+    chip.set('option', 'jobscheduler', None)
+    jobscheduler = chip.get('option', 'jobscheduler')
+    assert jobscheduler == None
+    assert chip._error == False
 
 def test_set_field_error():
     chip = siliconcompiler.Chip('test')


### PR DESCRIPTION
I've run into a few situations where it has been difficult to debug the source of an error, because a generic exception is thrown at [this line](https://github.com/siliconcompiler/siliconcompiler/blob/fcbf3f7f75b786f0577311fc0714d27db0b1faa5/siliconcompiler/core.py#L796) in a `chip.get` or `chip.getkeys` call:

    keypathstr = ','.join(keypath)

The errors typically come from a `None` value in the keypath which gets passed into the method, along the lines of:

    TypeError: sequence item 1: expected str instance, NoneType found

Usually, this happens because a previous `chip.get` call received a value of `None` when the build script was expecting a valid string. The easiest way to observe this kind of error is:

    import siliconcompiler
    siliconcompiler.Chip('my_design').run()

Tracking down the unexpectedly empty value from a generic Python error is difficult, so I think we should add some checks to make sure that the keypath is valid at the top of the `chip.get` and `chip.getkeys` functions.

With this change, the invalid key path will be printed out, which should help the user determine which value is missing. In the above example, the invalid path is `('flowgraph', None)`, which points towards the root cause that no EDA flow was selected.