### PR TITLE
Fix wheels build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,7 +49,7 @@ jobs:
         # https://github.com/ponty/PyVirtualDisplay/blob/master/.github/workflows/main.yml#L45
         brew install --cask xquartz
         echo "/opt/X11/bin" >> $GITHUB_PATH
-        mkdir /tmp/.X11-unix
+        mkdir -p /tmp/.X11-unix
         sudo chmod 1777 /tmp/.X11-unix
         sudo chown root /tmp/.X11-unix
 


### PR DESCRIPTION
Looks like something must have changed on the MacOS Github environment that makes this directory already exist (causing the lack of `-p` flag to cause the `mkdir` command to fail).

This PR fixes the breakage. Manual run to verify: https://github.com/siliconcompiler/siliconcompiler/actions/runs/2680480664 (I think the error here is transient)