### PR TITLE
Implement basic support for pure-Python tools

### DIFF
--- a/docs/user_guide/tools.rst
+++ b/docs/user_guide/tools.rst
@@ -52,7 +52,7 @@ SiliconCompiler execution depends on implementing adapter code "drivers" for eac
    * - **post_process**
      - Post-executable logic
      - chip
-     - exit code
+     - n/a
      - run()
      - yes
 
@@ -61,6 +61,13 @@ SiliconCompiler execution depends on implementing adapter code "drivers" for eac
      - None
      - chip
      - sphinx
+     - no
+
+   * - **run**
+     - Pure Python tool
+     - chip
+     - exit code
+     - run()
      - no
 
 For a complete example of a tool setup module, see `OpenROAD <https://github.com/siliconcompiler/siliconcompiler/blob/main/siliconcompiler/tools/openroad/openroad.py>`_. For more in depth information about the various :keypath:`tool` parameters, see the :ref:`Schema <SiliconCompiler Schema>` section of the reference manual.
@@ -148,15 +155,6 @@ The post_process function can also be used to post process the output data in th
             # in case end of file is missing a newline
             outfile.write('\n')
 
-    # Copy files from inputs to outputs. Need to skip pickled Verilog and
-    # manifest since new versions of those are written.
-    utils.copytree("inputs", "outputs", dirs_exist_ok=True, link=True,
-                   ignore=[f'{design}.v', f'{design}.pkg.json'])
-
-    return 0
-
-Note that the return value of the post_process() function is interpreted as an integer error code where zero indicates success. This can be used to signal errors that should halt execution but do not trigger a non-zero exit status from the executable itself.
-
 runtime_options(chip)
 -----------------------
 The distributed execution model of SiliconCompiler mandates that absolute paths be resolved at task run time. The setup() function is run at :meth:`.run()` launch to check flow validity, so we need a second function interface (runtime_options) to create the final commandline options. The runtime_options() function inspects the Schema and returns a cmdlist to be used by the 'exe' during task execution. The sequence of items used to generate the final command line invocation is as follows:
@@ -226,6 +224,19 @@ The SiliconCompiler includes automated document generators that search all tool 
     setup(chip)
     return chip
 
+run(chip)
+------------
+
+SiliconCompiler supports pure-Python tools that execute a Python function rather than an executable. To define a pure-Python tool, add a function called ``run()`` in your tool driver, which takes in a Chip object and implements your tool's desired functionality. This function should return an integer exit code, with zero indicating success.
+
+Note that pure-Python tool drivers still require a ``setup()`` function, but most :keypath:`tool` fields will not be meaningful. At the moment, pure-Python tools do not support the following features:
+
+* Version checking
+* Replay scripts
+* Task timeout
+* Memory usage tracking
+* Breakpoints
+* Output redirection/regex-based logfile parsing
 
 TCL interface
 --------------

--- a/examples/heartbeat_caravel_wrapper/flows/mpwflow.py
+++ b/examples/heartbeat_caravel_wrapper/flows/mpwflow.py
@@ -1,5 +1,15 @@
 import siliconcompiler
 
+def make_docs():
+    '''An RTL2GDS flow for the eFabless MPW shuttle. This flow is based off the
+    basic serial asicflow, with the addition of fixdef and addvias steps for
+    doing MPW-specific fixes to the post-routing DEF and gate-level netlist,
+    respectively.'''
+    chip = siliconcompiler.Chip('<design>')
+    setup(chip)
+    chip.set('option', 'flow', 'mpwflow')
+    return chip
+
 def setup(chip):
     flow = 'mpwflow'
 
@@ -28,7 +38,5 @@ def setup(chip):
     chip.edge(flow, 'dfm', 'addvias')
 
 if __name__ == '__main__':
-    chip = siliconcompiler.Chip('mpwflow')
-    setup(chip)
-    chip.set('option', 'flow', 'mpwflow')
+    chip = make_docs()
     chip.write_flowgraph('mpwflow.png')

--- a/examples/heartbeat_caravel_wrapper/flows/mpwflow.py
+++ b/examples/heartbeat_caravel_wrapper/flows/mpwflow.py
@@ -1,0 +1,34 @@
+import siliconcompiler
+
+def setup(chip):
+    flow = 'mpwflow'
+
+    flowpipe = [
+        ('import', 'surelog'),
+        ('syn', 'yosys'),
+        ('floorplan', 'openroad'),
+        ('place', 'openroad'),
+        ('cts', 'openroad'),
+        ('route', 'openroad'),
+        ('fixdef', 'fixdef'),
+        ('dfm', 'openroad'),
+        ('export', 'klayout')
+    ]
+
+    step, tool = flowpipe[0]
+    chip.node(flow, step, tool)
+
+    prevstep = step
+    for step, tool in flowpipe[1:]:
+        chip.node(flow, step, tool)
+        chip.edge(flow, prevstep, step)
+        prevstep = step
+
+    chip.node(flow, 'addvias', 'addvias')
+    chip.edge(flow, 'dfm', 'addvias')
+
+if __name__ == '__main__':
+    chip = siliconcompiler.Chip('mpwflow')
+    setup(chip)
+    chip.set('option', 'flow', 'mpwflow')
+    chip.write_flowgraph('mpwflow.png')

--- a/examples/heartbeat_caravel_wrapper/tools/addvias/addvias.py
+++ b/examples/heartbeat_caravel_wrapper/tools/addvias/addvias.py
@@ -1,0 +1,56 @@
+import siliconcompiler
+
+def make_docs():
+    '''Utility for adding via definitions to a gate-level netlist.'''
+    chip = siliconcompiler.Chip('<design>')
+    return setup(chip)
+
+def setup(chip):
+    tool = 'addvias'
+    design = chip.get('design')
+    step = chip.get('arg', 'step')
+    index = chip.get('arg', 'index')
+
+    chip.set('tool', tool, 'input', step, index, f'{design}.vg')
+    chip.set('tool', tool, 'output', step, index, f'{design}.vg')
+
+def run(chip):
+    design = chip.get('design')
+
+    in_mod = False
+    done_mod = False
+    with open(f'outputs/{design}.vg', 'w') as wf:
+      with open(f'inputs/{design}.vg', 'r') as rf:
+        for line in rf.readlines():
+          if in_mod:
+            if line.strip().startswith('endmodule'):
+              wf.write(''' VIA_L1M1_PR(vssd1);
+ VIA_L1M1_PR(vccd1);
+ VIA_L1M1_PR_MR(vssd1);
+ VIA_L1M1_PR_MR(vccd1);
+ VIA_M1M2_PR(vssd1);
+ VIA_M1M2_PR(vccd1);
+ VIA_M1M2_PR_MR(vssd1);
+ VIA_M1M2_PR_MR(vccd1);
+ VIA_M2M3_PR(vssd1);
+ VIA_M2M3_PR(vccd1);
+ VIA_M2M3_PR_MR(vssd1);
+ VIA_M2M3_PR_MR(vccd1);
+ VIA_M3M4_PR(vssd1);
+ VIA_M3M4_PR(vccd1);
+ VIA_M3M4_PR_MR(vssd1);
+ VIA_M3M4_PR_MR(vccd1);
+ VIA_via2_3_3100_480_1_9_320_320(vssd1);
+ VIA_via2_3_3100_480_1_9_320_320(vccd1);
+ VIA_via3_4_3100_480_1_7_400_400(vssd1);
+ VIA_via3_4_3100_480_1_7_400_400(vccd1);
+ VIA_via4_3100x3100(vssd1);
+ VIA_via4_3100x3100(vccd1);
+ VIA_via4_5_3100_480_1_7_400_400(vssd1);
+ VIA_via4_5_3100_480_1_7_400_400(vccd1);\n''')
+          elif not done_mod:
+            if line.strip().startswith(f'module {design}'):
+              in_mod = True
+          wf.write(line)
+
+    return 0

--- a/examples/heartbeat_caravel_wrapper/tools/fixdef/fixdef.py
+++ b/examples/heartbeat_caravel_wrapper/tools/fixdef/fixdef.py
@@ -1,0 +1,109 @@
+import siliconcompiler
+
+def make_docs():
+    '''Utility for covering 'pin' data types with 'drawing' data types in a DEF
+    file. This is required for the eFabless MPW prechecks, because the mask
+    production process does not include 'pin' data types, and the main DRCs can
+    miss open circuits by counting those data types as valid connections.
+    '''
+    chip = siliconcompiler.Chip('<design>')
+    return setup(chip)
+
+def setup(chip):
+    tool = 'fixdef'
+    design = chip.get('design')
+    step = chip.get('arg', 'step')
+    index = chip.get('arg', 'index')
+
+    chip.set('tool', tool, 'input', step, index, f'{design}.def')
+    chip.set('tool', tool, 'output', step, index, f'{design}.def')
+
+def run(chip):
+    design = chip.get('design')
+    with open(f'inputs/{design}.def') as f:
+        with open(f'outputs/{design}.def', 'w') as wf:
+            # State-tracking variables for parsing the file.
+            in_pins = 0
+            in_pin = ''
+            in_net = ''
+            in_layer = ''
+            pin_w = 0
+            pin_h = 0
+            pin_locs = {}
+
+            # Process the file one line at a time:
+            # 1. Gather information about pin polys.
+            # 2. Add overlaps in the 'SPECIALNETS' section.
+            # Assumptions: 'PINS' comes before 'SPECIALNETS', and there is only one 'PINS' section.
+            for line in f:
+                l = line
+
+                # We don't care about lines before the 'PINS' section; write them verbatim to new DEF.
+                if not in_pins:
+                    wf.write(l)
+                    # Start paying attention at the start of the 'PINS' section.
+                    if l.strip().startswith('PINS'):
+                        in_pins = 1
+                # Note name, dimensions, and net of each non-power pin. (Power nets should go thru PDN)
+                elif in_pins == 1:
+                    wf.write(l)
+                    if l.strip().startswith('END PINS'):
+                        in_pins = 2
+                    elif l.strip().startswith('-'):
+                        la = l.strip().split()
+                        in_pin = la[1]
+                        in_net = la[4]
+                    # TODO: We should not use hardcoded prefixes for power nets to ignore.
+                    elif ('LAYER' in l) and (not 'vcc' in in_pin) and (not 'vss' in in_pin):
+                        la = l.strip().split()
+                        in_layer = la[2]
+                        pin_w = abs(int(la[8]) - int(la[4]))
+                        pin_h = abs(int(la[9]) - int(la[5]))
+                    elif ('PLACED' in l) and (not 'vcc' in in_pin) and (not 'vss' in in_pin):
+                        la = l.strip().split()
+                        pin_locs[in_pin] = {'layer': in_layer,
+                                            'net': in_net,
+                                            'x': int(la[3]),
+                                            'y': int(la[4]),
+                                            'w': pin_w,
+                                            'h': pin_h}
+                # After the 'PINS' section, look for 'SPECIALNETS' section and add tracks over each pin.
+                # This section may not exist; create it if we find 'END NETS' before 'SPECIALNETS'
+                elif in_pins == 2:
+                    if l.strip().startswith('SPECIALNETS'):
+                        la = l.strip().split()
+                        numnets = int(la[1]) + len(pin_locs)
+                        wf.write('SPECIALNETS %i ;\n'%numnets)
+                    # (There may not be a SPECIALNETS section in the DEF output)
+                    elif l.strip().startswith('END NETS'):
+                        wf.write(l)
+                        numnets = len(pin_locs)
+                        wf.write('SPECIALNETS %i ;\n'%numnets)
+                    elif (l.strip() == 'END SPECIALNETS') or (l.strip() == 'END DESIGN'):
+                        for k, v in pin_locs.items():
+                            ml = 0
+                            if v['layer'] == 'met2':
+                                ml = v['w']
+                                xl = v['x']
+                                xr = v['x']
+                                yb = int(v['y'] - v['h'] / 2)
+                                yu = int(v['y'] + v['h'] / 2)
+                            elif v['layer'] == 'met3':
+                                ml = v['h']
+                                xl = int(v['x'] - v['w'] / 2)
+                                xr = int(v['x'] + v['w'] / 2)
+                                yb = v['y']
+                                yu = v['y']
+                            wf.write('    - %s ( PIN %s ) + USE SIGNAL\n'%(v['net'], k))
+                            wf.write('      + ROUTED %s %i + SHAPE STRIPE ( %i %i ) ( %i %i )\n'%(v['layer'], int(ml), xl, yb, xr, yu))
+                            wf.write('      NEW %s %i + SHAPE STRIPE ( %i %i ) ( %i %i ) ;\n'%(v['layer'], int(ml), xl, yb, xr, yu))
+                        if l.strip() == 'END DESIGN':
+                            wf.write('END SPECIALNETS\n')
+                        wf.write(l)
+                        in_pins = 3
+                    else:
+                        wf.write(l)
+                elif in_pins == 3:
+                    wf.write(l)
+
+    return 0

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1849,9 +1849,10 @@ class Chip:
                             if self._keypath_empty(keypath):
                                 error = True
                                 self.logger.error(f"Value empty for [{keypath}] for {tool}.")
-                    if self._keypath_empty(['tool', tool, 'exe']):
+                    run_func = self.find_function(tool, 'run', 'tools')
+                    if self._keypath_empty(['tool', tool, 'exe']) and run_func is None:
                         error = True
-                        self.logger.error(f'Executable not specified for tool {tool}')
+                        self.logger.error(f'No executable or run() function specified for tool {tool}')
 
         if 'SC_VALID_PATHS' in os.environ:
             if not self._check_files():
@@ -3828,6 +3829,8 @@ class Chip:
             for item in self.getkeys('tool', tool, 'env', step, index):
                 os.environ[item] = self.get('tool', tool, 'env', step, index, item)
 
+        run_func = self.find_function(tool, 'run', 'tools')
+
         ##################
         # 12. Check exe version
 
@@ -3853,7 +3856,7 @@ class Chip:
                     self._haltstep(step, index)
             else:
                 self.logger.info(f"Tool '{exe_base}' found in directory '{exe_path}'")
-        elif tool not in self.builtin:
+        elif tool not in self.builtin and run_func is None:
             exe_base = self.get('tool', tool, 'exe')
             self.logger.error(f'Executable {exe_base} not found')
             self._haltstep(step, index)
@@ -3876,8 +3879,11 @@ class Chip:
         # TODO: Currently no memory usage tracking in breakpoints, builtins, or unexpected errors.
         max_mem_bytes = 0
 
+        retcode = 0
         if tool in self.builtin:
             utils.copytree(f"inputs", 'outputs', dirs_exist_ok=True, link=True)
+        elif run_func and not self.get('option', 'skipall'):
+            retcode = run_func(self)
         elif not self.get('option', 'skipall'):
             cmdlist = self._makecmd(tool, step, index)
             exe_base = os.path.basename(cmdlist[0])
@@ -3977,9 +3983,9 @@ class Chip:
                             sys.stdout.write(stderr_reader.read())
                     retcode = proc.returncode
 
-            if retcode != 0:
-                self.logger.warning('Command failed with code %d. See log file %s', retcode, os.path.abspath(logfile))
-                self._haltstep(step, index)
+        if retcode != 0:
+            self.logger.warning('Command failed with code %d. See log file %s', retcode, os.path.abspath(logfile))
+            self._haltstep(step, index)
 
         ##################
         # 16. Capture cpu runtime and memory footprint.
@@ -3997,7 +4003,7 @@ class Chip:
 
         ##################
         # 18. Check log file (must be after post-process)
-        if (tool not in self.builtin) and (not self.get('option', 'skipall')) :
+        if (tool not in self.builtin) and (not self.get('option', 'skipall')) and (run_func is None):
             matches = self.check_logfile(step=step, index=index, display=not quiet)
             if 'errors' in matches:
                 errors = self.get('metric', step, index, 'errors')

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1849,8 +1849,9 @@ class Chip:
                             if self._keypath_empty(keypath):
                                 error = True
                                 self.logger.error(f"Value empty for [{keypath}] for {tool}.")
-                    run_func = self.find_function(tool, 'run', 'tools')
-                    if self._keypath_empty(['tool', tool, 'exe']) and run_func is None:
+
+                    if (self._keypath_empty(['tool', tool, 'exe']) and
+                        self.find_function(tool, 'run', 'tools') is None):
                         error = True
                         self.logger.error(f'No executable or run() function specified for tool {tool}')
 
@@ -3829,7 +3830,9 @@ class Chip:
             for item in self.getkeys('tool', tool, 'env', step, index):
                 os.environ[item] = self.get('tool', tool, 'env', step, index, item)
 
-        run_func = self.find_function(tool, 'run', 'tools')
+        run_func = None
+        if tool not in self.builtin:
+            run_func = self.find_function(tool, 'run', 'tools')
 
         ##################
         # 12. Check exe version


### PR DESCRIPTION
This PR implements support for pure-Python tools, a feature we talked about a while back when discussing how to more cleanly port other flows into SC. With both the ORFS and Caravel flows, we've noticed cases where we need to do some intermediate processing on files being passed around the flow. The existing options we explored each have flaws:

- Modify `pre_process()` or `post_process()` in a tool driver
  - This isn't great since we want to keep these functions as flow-agnostic as possible, so that we can reuse the tool drivers broadly. Forking the tool drivers per-flow isn't a great solution either, since this results in lots of code duplication.
- Break the run into multiple `run()` calls that each use a partial steplist, with Python logic in between
  - This is what the Caravel example currently does, but it breaks some of SC's nice features for debugging (steplist is overwritten, flowgraph viz doesn't capture intermediate processing, the intermediate processing results aren't captured in the build directory)

Natively supporting pure Python steps seems like a cleaner solution to this problem. As a basic approach, I changed SC to treat any tool driver that defines a `run(chip)` function as a pure-Python tool. The SC runtime will then call this function instead of an executable. 

The one problem with this implementation is that it introduces a third code path that doesn't include support for some nice features, like output redirection, memory tracking, and task timeouts. If we run into a situation where we want these features, I think we could explore running these tools in a separate process that can then be monitored by the runtime in order to provide this functionality, but this was the simplest first approach.

As a proof-of-concept, I updated the Caravel example to use these features. To validate the changes, I ran the flow before and after and made sure the input DEF to KLayout and that the final DEF passed into KLayout are the same. If you'd like more certainty that the changes don't break anything, I can try re-running the MPW prechecks using the new flow.