### PR TITLE
Filter out manifests when checking flowgraph I/O

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4178,6 +4178,9 @@ class Chip:
         '''
 
         flow = self.get('option', 'flow')
+        if flow is None:
+            self.error("['option', 'flow'] must be set before calling run()",
+                       fatal=True)
 
         # Re-init logger to include run info after setting up flowgraph.
         self._init_logger(in_run=True)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1928,9 +1928,6 @@ class Chip:
         if not steplist:
             steplist = self.list_steps()
 
-        if len(steplist) < 2:
-            return True
-
         for step in steplist:
             for index in self.getkeys('flowgraph', flow, step):
                 # For each task, check input requirements.
@@ -1956,7 +1953,10 @@ class Chip:
                             in_job = jobname
                         workdir = self._getworkdir(jobname=in_job, step=in_step, index=in_index)
                         in_step_out_dir = os.path.join(workdir, 'outputs')
-                        inputs = os.listdir(in_step_out_dir)
+
+                        design = self.get('design')
+                        manifest = f'{design}.pkg.json'
+                        inputs = [inp for inp in os.listdir(in_step_out_dir) if inp != manifest]
                     else:
                         inputs = self._gather_outputs(in_step, in_index)
 

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -119,6 +119,27 @@ def test_merged_graph_good(merge_flow_chip):
 
     assert merge_flow_chip.check_manifest()
 
+def test_merged_graph_good_steplist():
+    chip = siliconcompiler.Chip('test')
+    flow = 'test'
+    chip.node(flow, 'import', 'nop')
+    chip.node(flow, 'parallel1', 'echo')
+    chip.node(flow, 'parallel2', 'echo')
+    chip.node(flow, 'merge', 'echo')
+    chip.node(flow, 'export', 'echo')
+    chip.edge(flow, 'import', 'parallel1')
+    chip.edge(flow, 'import', 'parallel2')
+    chip.edge(flow, 'parallel1', 'merge')
+    chip.edge(flow, 'parallel2', 'merge')
+    chip.edge(flow, 'merge', 'export')
+    chip.set('option', 'flow', 'test')
+
+    chip.run()
+
+    chip.set('option', 'steplist', ['merge', 'export'])
+
+    assert chip.check_manifest()
+
 def test_merged_graph_bad_same(merge_flow_chip):
     # Two merged steps can't output the same thing
     merge_flow_chip.set('tool', 'foo', 'output', 'parallel1', '0', 'foo.out')


### PR DESCRIPTION
This PR fixes a `check_manifest()` bug when checking a run that uses a steplist to re-run a task that joins 2+ other tasks. The logic that checks what inputs the task will receive needs to filter out the manifest (since this isn't copied forward), otherwise the checker complains that the task will receive a manifest from both.

Also a couple other small changes I noticed:
- Helpful error message when you forget ['option', 'flow']
- We don't need to quit early with a steplist length 1, it's still useful to check that a single node receives the required inputs

Closes #1077