### PR TITLE
Make Surelog install script consistent w/ OpenROAD

### DIFF
--- a/setup/install-surelog.sh
+++ b/setup/install-surelog.sh
@@ -1,6 +1,12 @@
+#!/bin/sh
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
+
 sudo apt-get install -y build-essential cmake git pkg-config tclsh swig uuid-dev libgoogle-perftools-dev python3 python3-dev
 sudo apt-get install -y default-jre
 
+cd ${src_path}/..
 git submodule update --init --recursive third_party/tools/surelog
 cd third_party/tools/surelog
 
@@ -12,5 +18,5 @@ git config --file $(pwd)/.gitconfig url."https://".insteadOf git://
 export HOME=$(pwd)
 
 make
-make install
+sudo make install
 cd -


### PR DESCRIPTION
@jessimd pointed out a couple problems with the Surelog install script:
- Requires running from SC root
- Missing sudo on `make install`

install-openroad.sh script has a little trick to make sure the script is runnable from any location, and most of the scripts explicitly include sudo when run. These changes makes Surelog consistent with other scripts.
