### PR TITLE
Simplify collection of input files

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1392,7 +1392,7 @@ class Chip:
                 name = self._get_imported_filename(path)
                 abspath = os.path.join(self._getworkdir(jobname=job, step='import'), 'inputs', name)
                 if os.path.isfile(abspath):
-                    # if copy is True and file is found in import outputs,
+                    # if copy is True and file is found in import inputs,
                     # continue. Otherwise, fall through to _find_sc_file (the
                     # file may not have been gathered in imports yet)
                     result.append(abspath)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2529,7 +2529,6 @@ class Chip:
         '''
 
         indir = 'inputs'
-        flow = self.get('option', 'flow')
 
         if not os.path.exists(indir):
             os.makedirs(indir)
@@ -2544,10 +2543,6 @@ class Chip:
                 shutil.copy(abspath, os.path.join(indir, filename))
             else:
                 self._haltstep(step, index)
-
-        outdir = 'outputs'
-        if not os.path.exists(outdir):
-            os.makedirs(outdir)
 
     ###########################################################################
     def archive(self, step=None, index=None, all_files=False):

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2500,6 +2500,8 @@ class Chip:
         copyall = self.get('option', 'copyall')
         allkeys = self.getkeys()
         for key in allkeys:
+            if key[0] == 'history':
+                continue
             leaftype = self.get(*key, field='type')
             if re.search('file', leaftype):
                 copy = self.get(*key, field='copy')

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1390,7 +1390,7 @@ class Chip:
         for path in paths:
             if (copyall or copy) and ('file' in paramtype):
                 name = self._get_imported_filename(path)
-                abspath = os.path.join(self._getworkdir(jobname=job, step='import'), 'outputs', name)
+                abspath = os.path.join(self._getworkdir(jobname=job, step='import'), 'inputs', name)
                 if os.path.isfile(abspath):
                     # if copy is True and file is found in import outputs,
                     # continue. Otherwise, fall through to _find_sc_file (the
@@ -2546,23 +2546,6 @@ class Chip:
         outdir = 'outputs'
         if not os.path.exists(outdir):
             os.makedirs(outdir)
-
-        # Logic to make links from outputs/ to inputs/, skipping anything that
-        # will be output by the tool as well as the manifest. We put this here
-        # so that tools used for the import stage don't have to duplicate this
-        # logic. We skip this logic for 'join'-based single-step imports, since
-        # 'join' does the copy for us.
-        tool = self.get('flowgraph', flow, step, index, 'tool')
-        if tool not in self.builtin:
-            if self.valid('tool', tool, 'output', step, index):
-                outputs = self.get('tool', tool, 'output', step, index)
-            else:
-                outputs = []
-            design = self.get('design')
-            ignore = outputs + [f'{design}.pkg.json']
-            utils.copytree(indir, outdir, dirs_exist_ok=True, link=True, ignore=ignore)
-        elif tool not in ('join', 'nop'):
-            self.error(f'Invalid import step builtin {tool}. Must be tool or join.')
 
     ###########################################################################
     def archive(self, step=None, index=None, all_files=False):
@@ -3800,7 +3783,10 @@ class Chip:
         ##################
         # 8. Copy (link) output data from previous steps
 
-        if step == 'import':
+        if step == 'import' and self.get('option', 'remote'):
+            # Collect inputs into import directory only for remote runs, since
+            # we need to send inputs up to the server. Otherwise, it's simpler
+            # for debugging to leave inputs in place.
             self._collect(step, index)
 
         if not self.get('flowgraph', flow, step, index,'input'):

--- a/siliconcompiler/tools/chisel/chisel.py
+++ b/siliconcompiler/tools/chisel/chisel.py
@@ -103,3 +103,7 @@ def pre_process(chip):
         src = os.path.join(refdir, filename)
         dst = filename
         shutil.copyfile(src, dst)
+
+    # Hack: Chisel driver relies on Scala files being collected into '$CWD/inputs'
+    chip.set('input', 'scala', True, field='copy')
+    chip._collect(step, index)

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -35,9 +35,12 @@ def test_check_allowed_filepaths_pass(scroot, monkeypatch):
     chip.set('input', 'verilog', os.path.join(scroot, 'examples', 'gcd', 'gcd.v'))
     chip.load_target("freepdk45_demo")
 
-    # run an import just to collect files
-    chip.set('option', 'steplist', 'import')
-    chip.run()
+    # collect input files
+    workdir = chip._getworkdir(step='import', index='0')
+    os.makedirs(workdir)
+    os.chdir(workdir)
+    chip._collect('import', '0')
+    os.chdir(chip.cwd)
 
     env = {
         'SC_VALID_PATHS': os.path.join(scroot, 'third_party', 'pdks'),
@@ -57,9 +60,12 @@ def test_check_allowed_filepaths_fail(scroot, monkeypatch):
     chip.set('input', 'sdc', False, field='copy')
     chip.load_target("freepdk45_demo")
 
-    # run an import just to collect files
-    chip.set('option', 'steplist', 'import')
-    chip.run()
+    # collect input files
+    workdir = chip._getworkdir(step='import', index='0')
+    os.makedirs(workdir)
+    os.chdir(workdir)
+    chip._collect('import', '0')
+    os.chdir(chip.cwd)
 
     env = {
         'SC_VALID_PATHS': os.path.join(scroot, 'third_party', 'pdks'),

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -36,11 +36,12 @@ def test_check_allowed_filepaths_pass(scroot, monkeypatch):
     chip.load_target("freepdk45_demo")
 
     # collect input files
+    cwd = os.getcwd()
     workdir = chip._getworkdir(step='import', index='0')
     os.makedirs(workdir)
     os.chdir(workdir)
     chip._collect('import', '0')
-    os.chdir(chip.cwd)
+    os.chdir(cwd)
 
     env = {
         'SC_VALID_PATHS': os.path.join(scroot, 'third_party', 'pdks'),
@@ -62,10 +63,11 @@ def test_check_allowed_filepaths_fail(scroot, monkeypatch):
 
     # collect input files
     workdir = chip._getworkdir(step='import', index='0')
+    cwd = os.getcwd()
     os.makedirs(workdir)
     os.chdir(workdir)
     chip._collect('import', '0')
-    os.chdir(chip.cwd)
+    os.chdir(cwd)
 
     env = {
         'SC_VALID_PATHS': os.path.join(scroot, 'third_party', 'pdks'),


### PR DESCRIPTION
This PR is a simple proposal to fix issue #1063. 

It makes two changes:
- Only collect files for remote runs
- Don't copy collected files from `import/0/inputs/` to `import/0/outputs/`

This was a pretty easy change, since `find_files()` automatically falls back to searching the original file path for any copied file that's not in the file collection directory.

Here are the before and after results.

**Before**
```console
$ ls build/gcd/job0/import/0/inputs/
gcd_0a998a746037a840df8d7f2133c57f4846e3405f.v  gcd_9fb1319e7d576ade53f9b17ec8e05417afa27bca.sdc

$ ls build/gcd/job0/import/0/outputs/
gcd_0a998a746037a840df8d7f2133c57f4846e3405f.v    gcd.pkg.json
gcd_9fb1319e7d576ade53f9b17ec8e05417afa27bca.sdc  gcd.v

$ cat build/gcd/job0/import/0/replay.sh
#!/bin/bash
surelog -parse /home/noah/code/siliconcompiler/build/gcd/job0/import/0/outputs/gcd_0a998a746037a840df8d7f2133c57f4846e3405f.v -top gcd +libext+.sv+.v
```

**After**
```console
$ ls build/gcd/job0/import/0/inputs/

$ ls build/gcd/job0/import/0/outputs/
gcd.pkg.json  gcd.v

$ cat build/gcd/job0/import/0/replay.sh
#!/bin/bash
surelog -parse /home/noah/code/siliconcompiler/examples/gcd/gcd.v -top gcd +libext+.sv+.v
``` 

This makes the results from a remote run a little different, but that seems acceptable to me. It also helps that the `import/0/outputs` directory is cleaner:
```console
$ ls build/gcd/job0/import/0/inputs/                          
gcd_0a998a746037a840df8d7f2133c57f4846e3405f.v  gcd_9fb1319e7d576ade53f9b17ec8e05417afa27bca.sdc

$ ls build/gcd/job0/import/0/outputs/ 
gcd.pkg.json  gcd.v

$ cat build/gcd/job0/import/0/replay.sh  
#!/bin/bash
surelog -parse /home/noah/code/siliconcompiler/build/gcd/job0/import/0/inputs/gcd_0a998a746037a840df8d7f2133c57f4846e3405f.v -top gcd +libext+.sv+.v
```

In a future change, it may be good have to `archive()` call `_collect()` now, if we care about capturing inputs in the archive.

Closes  #1063. 