### PR TITLE
Don't overwrite ['input', 'verilog'] on remote

### DIFF
--- a/siliconcompiler/server.py
+++ b/siliconcompiler/server.py
@@ -223,9 +223,6 @@ class Server:
         # Remove 'remote' JSON config value to run locally on compute node.
         chip.set('option', 'remote', False, clobber=True)
         chip.set('option', 'credentials', '', clobber=True)
-        # Rename source files in the config dict; the 'import' step already
-        # ran and collected the sources into a single Verilog file.
-        chip.set('input', 'verilog', '%s/import/%s/outputs/%s.v'%(build_dir, '0', chip.get('design')), clobber=True)
 
         # Write JSON config to shared compute storage.
         subprocess.run(['mkdir', '-p', '%s/configs'%build_dir])
@@ -411,11 +408,6 @@ class Server:
         build_dir = '/tmp/%s_%s'%(job_hash, job_nameid)
         jobs_dir = '%s/%s'%(build_dir, top_module)
         os.mkdir(build_dir)
-
-        # Rename source files in the config dict; the 'import' step already
-        # ran and collected the sources into a single Verilog file.
-        #TODO: This only works for import? (was current id)
-        chip.set('input', 'verilog', f"{build_dir}/{top_module}/{job_nameid}/import/0/outputs/{top_module}.v", clobber=True)
 
         run_cmd = ''
         if self.cfg['cluster']['value'][-1] == 'slurm':


### PR DESCRIPTION
I noticed these lines while trying to debug a test failure in my last PR. They weren't relevant, but they gave me pause - I don't think they're needed anymore. The inputs will be automatically resolved to the right directory by `find_files()` anyways.

Seem ok to delete?