### PR TITLE
klayout: don't automatically read LEFs next to DEF

### DIFF
--- a/siliconcompiler/tools/klayout/klayout_export.py
+++ b/siliconcompiler/tools/klayout/klayout_export.py
@@ -146,6 +146,7 @@ def gds_export(design_name, in_def, in_files, out_file, tech_file, foundry_lefs,
     pathed_files.append(lef)
 
   layoutOptions.lefdef_config.lef_files = pathed_files
+  layoutOptions.lefdef_config.read_lef_with_def = False
 
   # Load def file
   main_layout = pya.Layout()


### PR DESCRIPTION
The file collection change introduced a regression in the heartbeat padring example. Turns out KLayout's default behavior is to automatically try to read any LEF files that are next to the input DEF. Now that the input isn't being read from imports, KLayout is reading the LEF files next to it in the original source directory and throwing an error due to duplicate macros when it reads in the LEFs we pass explicitly.

The solution is to disable this behavior, since we always pass in LEFs explicitly.