### PR TITLE
Fix pin sizes and PDN vias in Caravel wrapper example

### DIFF
--- a/examples/heartbeat_caravel_wrapper/build.py
+++ b/examples/heartbeat_caravel_wrapper/build.py
@@ -52,6 +52,8 @@ def build_core():
     core_chip = configure_chip('heartbeat')
     design = core_chip.get('design')
     core_chip.set('input', 'verilog', 'heartbeat.v')
+    core_chip.set('tool', 'openroad', 'var', 'floorplan', '0', 'pin_thickness_h', ['2'])
+    core_chip.set('tool', 'openroad', 'var', 'floorplan', '0', 'pin_thickness_v', ['2'])
     core_chip.set('tool', 'openroad', 'var', 'place', '0', 'place_density', ['0.15'])
     core_chip.set('tool', 'openroad', 'var', 'route', '0', 'grt_allow_congestion', ['true'])
     core_chip.clock('clk', period=20)
@@ -145,7 +147,7 @@ global_connect
 
 set_voltage_domain -name Core -power vccd1 -ground vssd1
 
-define_pdn_grid -name core_grid -macro -grid_over_boundary -default -voltage_domain Core
+define_pdn_grid -name core_grid -macro -grid_over_pg_pins -default -voltage_domain Core -starts_with POWER
 add_pdn_stripe -grid core_grid -layer met1 -width 0.48 -starts_with POWER -followpins
 add_pdn_connect -grid core_grid -layers {met1 met4}
 

--- a/siliconcompiler/tools/klayout/klayout_export.py
+++ b/siliconcompiler/tools/klayout/klayout_export.py
@@ -158,7 +158,7 @@ def gds_export(design_name, in_def, in_files, out_file, tech_file, foundry_lefs,
   print("[INFO] Clearing cells...")
   for i in main_layout.each_cell():
     if i.cell_index() != top_cell_index:
-      if i.parent_cells() == 0:
+      if not i.name.startswith("VIA"):
         i.clear()
 
   # Load in the gds to merge

--- a/siliconcompiler/tools/klayout/klayout_export.py
+++ b/siliconcompiler/tools/klayout/klayout_export.py
@@ -186,6 +186,14 @@ def gds_export(design_name, in_def, in_files, out_file, tech_file, foundry_lefs,
   if not missing_cell:
     print("[INFO] All LEF cells have matching GDS/OAS cells")
 
+  print("[INFO] Checking for orphan cell in the final layout...")
+  orphan_cell = False
+  for i in top_only_layout.each_cell():
+    if i.name != design_name and i.parent_cells() == 0:
+      orphan_cell = True
+      print("[ERROR] Found orphan cell '{0}'".format(i.name))
+      errors += 1
+
   if seal_file:
 
     top_cell = top_only_layout.top_cell()

--- a/siliconcompiler/tools/openroad/sc_floorplan.tcl
+++ b/siliconcompiler/tools/openroad/sc_floorplan.tcl
@@ -55,7 +55,7 @@ if {[expr ! [dict exists $sc_cfg "input" "floorplan.def"]]} {
     ###########################
     if [dict exists $sc_cfg tool $sc_tool var $sc_step $sc_index pin_thickness_h] {
         set h_mult [lindex [dict get $sc_cfg tool $sc_tool var $sc_step $sc_index pin_thickness_h] 0]
-        set_pin_thick_multiplier -ver_multiplier $h_mult
+        set_pin_thick_multiplier -hor_multiplier $h_mult
     }
     if [dict exists $sc_cfg tool $sc_tool var $sc_step $sc_index pin_thickness_v] {
         set v_mult [lindex [dict get $sc_cfg tool $sc_tool var $sc_step $sc_index pin_thickness_v] 0]

--- a/siliconcompiler/tools/openroad/sc_floorplan.tcl
+++ b/siliconcompiler/tools/openroad/sc_floorplan.tcl
@@ -53,6 +53,14 @@ if {[expr ! [dict exists $sc_cfg "input" "floorplan.def"]]} {
     ###########################
     # Automatic Pin Placement
     ###########################
+    if [dict exists $sc_cfg tool $sc_tool var $sc_step $sc_index pin_thickness_h] {
+        set h_mult [lindex [dict get $sc_cfg tool $sc_tool var $sc_step $sc_index pin_thickness_h] 0]
+        set_pin_thick_multiplier -ver_multiplier $h_mult
+    }
+    if [dict exists $sc_cfg tool $sc_tool var $sc_step $sc_index pin_thickness_v] {
+        set v_mult [lindex [dict get $sc_cfg tool $sc_tool var $sc_step $sc_index pin_thickness_v] 0]
+        set_pin_thick_multiplier -ver_multiplier $v_mult
+    }
 
     place_pins -hor_layers $sc_hpinmetal \
 	-ver_layers $sc_vpinmetal \


### PR DESCRIPTION
This PR fixes two issues with our Caravel wrapper example:

* While merging the heartbeat/Caravel example into main, I deleted a line in `sc_floorplan.tcl` which set custom pin sizes. The default sizes ended up triggering some metal grid offset DRCs in the MPW precheck scripts, so I added a way to set I/O signal sizes from the schema and added a fix to the example build script.

* When I was inspecting the final GDS results, I noticed that the top-level build was only adding vias between the PDN grid and standard cell rails outside of the core macro area. This did not cause DRC or LVS failures because the power signals were technically connected to the correct nets, but I would imagine that the voltage drop caused by the missing power vias would cause problems in a real chip. Fortunately, this can be fixed with a small adjustment to the PDN script.