### PR TITLE
Update OpenROAD version

### DIFF
--- a/siliconcompiler/tools/openroad/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/sc_apr.tcl
@@ -156,12 +156,13 @@ if {[dict exists $sc_cfg "input" def]} {
             read_def $def
         }
     }
-} elseif {[file exists "inputs/$sc_design.odb"]} {
-    # Prioritize ODB files over DEF, if available.
-    read_db "inputs/$sc_design.odb"
 } elseif {[file exists "inputs/$sc_design.def"]} {
     # Fallback to DEF if no OpenDB file is available.
     read_def "inputs/$sc_design.def"
+} elseif {[file exists "inputs/$sc_design.odb"]} {
+    # TODO: We should prioritize ODB files over DEF, if available.
+    # Currently, doing that causes netgen errors.
+    read_db "inputs/$sc_design.odb"
 } elseif {$sc_step == "showdef"} {
     read_def $env(SC_FILENAME)
 }

--- a/siliconcompiler/tools/openroad/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/sc_apr.tcl
@@ -148,12 +148,7 @@ if {$sc_step == "floorplan"} {
     link_design $sc_design
 }
 
-# Read ODB
-if {[file exists "inputs/$sc_design.odb"]} {
-    read_db "inputs/$sc_design.odb"
-}
-
-# Read DEF
+# Read ODB or DEF
 if {[dict exists $sc_cfg "input" def]} {
     if {$sc_step != "floorplan"} {
         # Floorplan initialize handled separately in sc_floorplan.tcl
@@ -161,7 +156,11 @@ if {[dict exists $sc_cfg "input" def]} {
             read_def $def
         }
     }
+} elseif {[file exists "inputs/$sc_design.odb"]} {
+    # Prioritize ODB files over DEF, if available.
+    read_db "inputs/$sc_design.odb"
 } elseif {[file exists "inputs/$sc_design.def"]} {
+    # Fallback to DEF if no OpenDB file is available.
     read_def "inputs/$sc_design.def"
 } elseif {$sc_step == "showdef"} {
     read_def $env(SC_FILENAME)

--- a/siliconcompiler/tools/openroad/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/sc_apr.tcl
@@ -148,6 +148,11 @@ if {$sc_step == "floorplan"} {
     link_design $sc_design
 }
 
+# Read ODB
+if {[file exists "inputs/$sc_design.odb"]} {
+    read_db "inputs/$sc_design.odb"
+}
+
 # Read DEF
 if {[dict exists $sc_cfg "input" def]} {
     if {$sc_step != "floorplan"} {

--- a/siliconcompiler/tools/openroad/sc_route.tcl
+++ b/siliconcompiler/tools/openroad/sc_route.tcl
@@ -51,8 +51,7 @@ check_antennas -report_file "reports/${sc_design}_antenna.rpt"
 
 set_thread_count $sc_threads
 
-# Detailed routing must include -guide parameter!
-detailed_route -guide "route.guide" \
+detailed_route -save_guide_updates \
                -output_drc "reports/${sc_design}_drc.rpt" \
                -output_maze "reports/${sc_design}_maze.log" \
                -output_guide "reports/${sc_design}_guide.mode" \

--- a/siliconcompiler/tools/openroad/sc_write.tcl
+++ b/siliconcompiler/tools/openroad/sc_write.tcl
@@ -1,3 +1,4 @@
+write_db "outputs/$sc_design.odb"
 write_def "outputs/$sc_design.def"
 write_sdc "outputs/$sc_design.sdc"
 write_verilog -include_pwr_gnd "outputs/$sc_design.vg"

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -32,21 +32,18 @@ def test_py(setup_example_test):
     # "Found unsupported expression..." (x72) + 2 ABC Warnings
     assert chip.get('metric', 'syn', '0', 'warnings') == 74
 
-    # "Core area lower left snapped to..."
-    assert chip.get('metric', 'floorplan', '0', 'warnings') == 1
+    assert chip.get('metric', 'floorplan', '0', 'warnings') == 0
 
     assert chip.get('metric', 'physyn', '0', 'warnings') == 0
 
-    # "Could not find power special net"
-    assert chip.get('metric', 'place', '0', 'warnings') == 1
+    assert chip.get('metric', 'place', '0', 'warnings') == 0
 
     # "1584 wires are pure wire and no slew degradation"
     # "Creating fake entries in the LUT"
     # "Could not find power special net" (x2)
-    assert chip.get('metric', 'cts', '0', 'warnings') == 4
+    assert chip.get('metric', 'cts', '0', 'warnings') == 2
 
-    # "No OR_DEFAULT vias defined"
-    assert chip.get('metric', 'route', '0', 'warnings') == 1
+    assert chip.get('metric', 'route', '0', 'warnings') == 0
 
     assert chip.get('metric', 'dfm', '0', 'warnings') == 0
 


### PR DESCRIPTION
Wenting recently noticed that our build scripts are incompatible with new versions of OpenROAD, because of a change to the `detail_route` API.

On the same note, @maliberty mentioned in #1103 that OpenROAD is starting to store interstitial data in OpenDB files rather than DEFs.

So it seems like a good time to update the version of OpenROAD that we support. I added `write_db` and `read_db` calls to our tool drivers, but I did not remove or modify our existing `read_def` calls. I am assuming that re-reading data which is captured by both formats won't cause issues.

I will need to update the version of OpenROAD which is installed on our test runner to make the CI tests pass, but doing that will also cause test failures on new PRs until this change is merged, so I'm holding off until we have a chance to discuss it.