### PR TITLE
Fix ['option', 'jobincr']

### DIFF
--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -2467,7 +2467,7 @@ def schema_option(cfg):
             schelp="""
             Forces an auto-update of the jobname parameter if a directory
             matching the jobname is found in the build directory. If the
-            jobname does not include a trailing digit, then a the number
+            jobname does not include a trailing digit, then the number
             '1' is added to the jobname before updating the jobname
             parameter.""")
 

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -3517,7 +3517,7 @@
                 "cli: -jobincr",
                 "api: chip.set('option','jobincr',True)"
             ],
-            "help": "Forces an auto-update of the jobname parameter if a directory\nmatching the jobname is found in the build directory. If the\njobname does not include a trailing digit, then a the number\n'1' is added to the jobname before updating the jobname\nparameter.",
+            "help": "Forces an auto-update of the jobname parameter if a directory\nmatching the jobname is found in the build directory. If the\njobname does not include a trailing digit, then the number\n'1' is added to the jobname before updating the jobname\nparameter.",
             "lock": "false",
             "notes": null,
             "require": "all",

--- a/tests/core/test_jobincr.py
+++ b/tests/core/test_jobincr.py
@@ -1,0 +1,15 @@
+import siliconcompiler
+
+def test_jobincr():
+    chip = siliconcompiler.Chip('test')
+    flow = 'test'
+    chip.set('option', 'flow', 'test')
+    chip.node(flow, 'import', 'echo')
+
+    chip.set('option', 'jobincr', True)
+
+    chip.run()
+    assert chip._getworkdir().endswith('build/test/job0')
+
+    chip.run()
+    assert chip._getworkdir().endswith('build/test/job1')


### PR DESCRIPTION
This PR fixes up some issues with ['option', 'jobincr'] and adds a test for it.

Changes:
- No more blanket `try... except` wrapper. This was hiding the fact that this block was writing to a keypath that no longer exists :). Inserted more specific error checking logic instead.
- Run before `_init_logger()`, otherwise pre-runtask logs use old jobname in messages
- Strip off any digits from existing jobname to handle case where the existing name includes digits already (`job0`) or not (`job`)

The behavior now matches the existing schema help string, including appending "1" if the existing build directory does not end in any digits.