### PR TITLE
Merge in manifests from all leaf tasks

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4472,7 +4472,7 @@ class Chip:
                 if not index_succeeded:
                     self.error('Run() failed, see previous errors.', fatal=True)
 
-            # On success, write out status dict to flowgraph status'. We do this
+            # On success, write out status dict to flowgraph status. We do this
             # since certain scenarios won't be caught by reading in manifests (a
             # failing step doesn't dump a manifest). For example, if the
             # steplist's final step has two indices and one fails.
@@ -4483,15 +4483,9 @@ class Chip:
                         self.set('flowgraph', flow, step, index, 'status', status[stepstr])
 
 
-            # Merge cfg back from last executed runsteps.
-            # Note: any information generated in steps that do not merge into the
-            # last step will not be picked up in this chip object.
-            # TODO: we might as well fix this? We can add a helper function to
-            # find all steps in the steplist that don't lead to others.
-
-            laststep = steplist[-1]
-            for index in indexlist[laststep]:
-                lastdir = self._getworkdir(step=laststep, index=index)
+            # Merge cfg back from last executed tasks.
+            for step, index in self._find_leaves(steplist):
+                lastdir = self._getworkdir(step=step, index=index)
 
                 # This no-op listdir operation is important for ensuring we have
                 # a consistent view of the filesystem when dealing with NFS.
@@ -4503,10 +4497,10 @@ class Chip:
                 os.listdir(os.path.dirname(lastdir))
 
                 lastcfg = f"{lastdir}/outputs/{self.get('design')}.pkg.json"
-                if status[laststep+index] == TaskStatus.SUCCESS:
+                if status[step+index] == TaskStatus.SUCCESS:
                     self._read_manifest(lastcfg, clobber=False, partial=True)
                 else:
-                    self.set('flowgraph', flow, laststep, index, 'status', TaskStatus.ERROR)
+                    self.set('flowgraph', flow, step, index, 'status', TaskStatus.ERROR)
 
         # Clear scratchpad args since these are checked on run() entry
         self.set('arg', 'step', None, clobber=True)


### PR DESCRIPTION
This PR implements an old TODO to merge in manifests from all "leaf" tasks at the end of run() (i.e. any task that doesn't have any further dependencies).

This is important to:
a) make the summary nice
b) capture all final metrics in one manifest

Even though we have had an informal requirement that all flows should merge into a final 'export' task, this has only been loosely followed, and it also doesn't help if someone runs a steplist that doesn't include the final export task. 

We already have the relevant helper function implemented from a previous fix to summary(), so this was a pretty easy change.

Demo of the difference this makes -

Example flow:
![flow](https://user-images.githubusercontent.com/4412459/181643733-39c75651-f438-47e0-a9df-798a6c0c6c21.png)

Summary before:
```
                   import0        syn0       syn1     floorplan0
 errors               0            0         ERR           0    
 warnings             10           74        ERR           1    
 drvs                 0            0         ERR           0    
 unconstrained        0            0         ERR           0    
 coverage            0.0          0.0        ERR          0.0   
 security            0.0          0.0        ERR          0.0   
...
```

Summary after:
```
                   import0        syn0         syn1     floorplan0
 errors               0            0            0            0    
 warnings             10           74           74           1    
 drvs                 0            0            0            0    
 unconstrained        0            0            0            0    
 coverage            0.0          0.0          0.0          0.0   
 security            0.0          0.0          0.0          0.0   
...
```

Closes  #1101
