### PR TITLE
Making libcorner a list

### DIFF
--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -3490,16 +3490,14 @@ def schema_constraint(cfg, scenario='default'):
             schelp="""Chip temperature applied to the scenario specified in degrees C.""")
 
     scparam(cfg,['constraint', scenario, 'libcorner'],
-            sctype='str',
+            sctype='[str]',
             scope='job',
             shorthelp="Constraint library corner",
             switch="-constraint_libcorner 'scenario <str>'",
             example=["cli: -constraint_libcorner 'worst ttt'",
                     "api: chip.set('constraint', 'worst', 'libcorner', 'ttt')"],
-            schelp="""Library corner applied to the scenario to scale
-            library timing models based on the libcorner value for models
-            that support it. The parameter is ignored for libraries that
-            have one hard coded model per libcorner.""")
+            schelp="""List of characterization corners used to select
+            timing files for all logiclibs and macrolibs.""")
 
     scparam(cfg,['constraint', scenario, 'pexcorner'],
             sctype='str',

--- a/siliconcompiler/tools/openroad/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/sc_apr.tcl
@@ -121,12 +121,12 @@ read_lef  $sc_techlef
 
 # Read Liberty
 foreach item $sc_scenarios {
-    set corner [dict get $sc_cfg constraint $item libcorner]
-    foreach lib "$sc_targetlibs $sc_macrolibs" {
-	#Liberty
-	if {[dict exists $sc_cfg library $lib model timing $sc_delaymodel]} {
-	    set lib_file [dict get $sc_cfg library $lib model timing $sc_delaymodel $corner]
-	    read_liberty $lib_file
+    foreach corner [dict get $sc_cfg constraint $item libcorner] {
+	foreach lib "$sc_targetlibs $sc_macrolibs" {
+	    if {[dict exists $sc_cfg library $lib model timing $sc_delaymodel $corner]} {
+		set lib_file [dict get $sc_cfg library $lib model timing $sc_delaymodel $corner]
+		read_liberty $lib_file
+	    }
 	}
     }
 }

--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -15,16 +15,22 @@ set sc_scenarios   [dict keys [dict get $sc_cfg constraint]]
 ########################################################
 
 set stat_libs ""
+
 foreach item $sc_scenarios {
     foreach libcorner [dict get $sc_cfg constraint $item libcorner] {
 	foreach lib $sc_targetlibs {
-	    if [dict exists dict get $sc_cfg library $lib model timing $sc_delaymodel $libcorner] {
+	    if {[dict exists $sc_cfg library $lib model timing $sc_delaymodel $libcorner]} {
+		puts "SC Reading liberty file (corner=$libcorner, lib=$lib, mode=$sc_delaymodel)"
 		set lib_file [dict get $sc_cfg library $lib model timing $sc_delaymodel $libcorner]
 		yosys read_liberty -lib $lib_file
 	    }
 	}
+	# Yosys doesn't handle macro PG pins properly, so we don't use the .libs here
+	# Instead we use black boxes for all macros.
+	set sc_macrolibs []
 	foreach lib $sc_macrolibs {
-	    if [dict exists dict get $sc_cfg library $lib model timing $sc_delaymodel $libcorner] {
+	    if {[dict exists $sc_cfg library $lib model timing $sc_delaymodel $libcorner]} {
+		puts "SC: Reading liberty file (corner=$libcorner, lib=$lib, mode=$sc_delaymodel)"
 		set lib_file [dict get $sc_cfg library $lib model timing $sc_delaymodel $libcorner]
 		yosys read_liberty -lib $lib_file
 		append stat_libs "-liberty $lib_file "
@@ -62,7 +68,7 @@ if [dict exists dict get $sc_cfg library $sc_mainlib asic "file" $sc_tool techma
 }
 
 #TODO: Fix better
-set libcorner    [dict get $sc_cfg constraint [lindex $sc_scenarios 0] libcorner]
+set libcorner    [lindex [dict get $sc_cfg constraint [lindex $sc_scenarios 0] libcorner] 0]
 set mainlib      [dict get $sc_cfg library $sc_mainlib model timing $sc_delaymodel $libcorner]
 
 yosys dfflibmap -liberty $mainlib

--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -27,7 +27,6 @@ foreach item $sc_scenarios {
 	}
 	# Yosys doesn't handle macro PG pins properly, so we don't use the .libs here
 	# Instead we use black boxes for all macros.
-	set sc_macrolibs []
 	foreach lib $sc_macrolibs {
 	    if {[dict exists $sc_cfg library $lib model timing $sc_delaymodel $libcorner]} {
 		puts "SC: Reading liberty file (corner=$libcorner, lib=$lib, mode=$sc_delaymodel)"

--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -16,21 +16,23 @@ set sc_scenarios   [dict keys [dict get $sc_cfg constraint]]
 
 set stat_libs ""
 foreach item $sc_scenarios {
-    set libcorner [dict get $sc_cfg constraint $item libcorner]
-    foreach lib $sc_targetlibs {
-	puts "$item $libcorner $sc_delaymodel $lib"
-        set lib_file [dict get $sc_cfg library $lib model timing $sc_delaymodel $libcorner]
-        yosys read_liberty -lib $lib_file
-    }
-    foreach lib $sc_macrolibs {
-        if [dict exists dict get $sc_cfg library $lib model timing $sc_delaymodel $libcorner] {
-            set lib_file [dict get $sc_cfg library $lib model timing $sc_delaymodel $libcorner]
-            yosys read_liberty -lib $lib_file
-            append stat_libs "-liberty $lib_file "
-        }
+    foreach libcorner [dict get $sc_cfg constraint $item libcorner] {
+	foreach lib $sc_targetlibs {
+	    if [dict exists dict get $sc_cfg library $lib model timing $sc_delaymodel $libcorner] {
+		set lib_file [dict get $sc_cfg library $lib model timing $sc_delaymodel $libcorner]
+		yosys read_liberty -lib $lib_file
+	    }
+	}
+	foreach lib $sc_macrolibs {
+	    if [dict exists dict get $sc_cfg library $lib model timing $sc_delaymodel $libcorner] {
+		set lib_file [dict get $sc_cfg library $lib model timing $sc_delaymodel $libcorner]
+		yosys read_liberty -lib $lib_file
+		append stat_libs "-liberty $lib_file "
+	    }
+	}
     }
 }
-puts "HELLO $sc_mode"
+
 ########################################################
 # Synthesis
 ########################################################

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1103,21 +1103,21 @@
                 "value": []
             },
             "libcorner": {
-                "defvalue": null,
+                "defvalue": [],
                 "example": [
                     "cli: -constraint_libcorner 'worst ttt'",
                     "api: chip.set('constraint', 'worst', 'libcorner', 'ttt')"
                 ],
-                "help": "Library corner applied to the scenario to scale\nlibrary timing models based on the libcorner value for models\nthat support it. The parameter is ignored for libraries that\nhave one hard coded model per libcorner.",
+                "help": "List of characterization corners used to select\ntiming files for all logiclibs and macrolibs.",
                 "lock": "false",
                 "notes": null,
                 "require": null,
                 "scope": "job",
                 "shorthelp": "Constraint library corner",
-                "signature": null,
+                "signature": [],
                 "switch": "-constraint_libcorner 'scenario <str>'",
-                "type": "str",
-                "value": null
+                "type": "[str]",
+                "value": []
             },
             "mode": {
                 "defvalue": null,


### PR DESCRIPTION
- Address the scenario of having multiple different corners applied to a single scecnario, which is needed in cases like multi-voltage IO. For example, we might have multiple IO models, one for 0.9V internal and 1.8V external, or 0.9V internal and 1.72V external. With a large number of IO standardards and on chip voltages, we need a way to group these library corners together within a single scenario.