### PR TITLE
Fix `find_files()` job argument + more

### DIFF
--- a/docs/_ext/schemagen.py
+++ b/docs/_ext/schemagen.py
@@ -92,20 +92,9 @@ class CategorySummary(SphinxDirective):
 
         return new_doc
 
-def keypath_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
-    # Split and clean up keypath
-    keys = [key.strip() for key in text.split(',')]
-    try:
-        return [keypath(*keys)], []
-    except ValueError as e:
-        msg = inliner.reporter.error(f'{rawtext}: {e}', line=lineno)
-        prb = inliner.problematic(rawtext, rawtext, msg)
-        return [prb], [msg]
-
 def setup(app):
     app.add_directive('schemagen', SchemaGen)
     app.add_directive('schema_category_summary', CategorySummary)
-    app.add_role('keypath', keypath_role)
 
     return {
         'version': '0.1',

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1054,7 +1054,7 @@ class Chip:
                 if field == 'value':
                     (type_ok,type_error) = self._typecheck(cfg[param], param, val)
                     if not type_ok:
-                        self.error("%s", type_error)
+                        self.error(type_error)
                 # converting python True/False to lower case string
                 if (field == 'value') and (cfg[param]['type'] == 'bool'):
                     if val == True:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2255,7 +2255,8 @@ class Chip:
                 self.logger.error(f"Item {item} 'ok' field not checked")
                 error = True
 
-        self.logger.info('Check succeeded!')
+        if not error:
+            self.logger.info('Check succeeded!')
 
         return not error
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1351,13 +1351,16 @@ class Chip:
 
         """
         if cfg is None:
-            cfg = self.cfg
+            if job is not None:
+                cfg = self.cfg['history'][job]
+            else:
+                cfg = self.cfg
 
-        copyall = self.get('option', 'copyall', cfg=cfg, job=job)
-        paramtype = self.get(*keypath, field='type', cfg=cfg, job=job)
+        copyall = self.get('option', 'copyall', cfg=cfg)
+        paramtype = self.get(*keypath, field='type', cfg=cfg)
 
         if 'file' in paramtype:
-            copy = self.get(*keypath, field='copy', cfg=cfg, job=job)
+            copy = self.get(*keypath, field='copy', cfg=cfg)
         else:
             copy = False
 
@@ -1367,7 +1370,7 @@ class Chip:
 
         is_list = bool(re.match(r'\[', paramtype))
 
-        paths = self.get(*keypath, cfg=cfg, job=job)
+        paths = self.get(*keypath, cfg=cfg)
         # Convert to list if we have scalar
         if not is_list:
             paths = [paths]

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2078,13 +2078,10 @@ class Chip:
                                         clobber=clobber,
                                         partial=False)
 
+        # TODO: better way to handle this?
         if 'library' in localcfg and not partial:
             for libname in localcfg['library'].keys():
-                if libname in self.cfg['library']:
-                    # TODO: should we make this a proper merge?
-                    self.logger.warning(f'Overwriting existing library {libname} '
-                        f'in object with values read from {filename}.')
-                self._import_library(libname, localcfg['library'][libname])
+                self._import_library(libname, localcfg['library'][libname], job=job)
 
     ###########################################################################
     def write_manifest(self, filename, prune=True, abspath=False, job=None):
@@ -2420,12 +2417,20 @@ class Chip:
         self._import_library(lib_chip.design, lib_chip.cfg)
 
     ###########################################################################
-    def _import_library(self, libname, libcfg):
+    def _import_library(self, libname, libcfg, job=None):
         '''Helper to import library with config 'libconfig' as a library
         'libname' in current Chip object.'''
-        self.cfg['library'][libname] = copy.deepcopy(libcfg)
-        if 'pdk' in self.cfg['library'][libname]:
-            del self.cfg['library'][libname]['pdk']
+        if job:
+            cfg = self.cfg['history'][job]['library']
+        else:
+            cfg = self.cfg['library']
+
+        if libname in cfg:
+            self.logger.warning(f'Overwriting existing library {libname}')
+
+        cfg[libname] = copy.deepcopy(libcfg)
+        if 'pdk' in cfg:
+            del cfg[libname]['pdk']
 
     ###########################################################################
     def write_depgraph(self, filename):

--- a/siliconcompiler/sphinx_ext/dynamicgen.py
+++ b/siliconcompiler/sphinx_ext/dynamicgen.py
@@ -476,6 +476,16 @@ class ExampleGen(DynamicGen):
 
         return section
 
+def keypath_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    # Split and clean up keypath
+    keys = [key.strip() for key in text.split(',')]
+    try:
+        return [keypath(*keys)], []
+    except ValueError as e:
+        msg = inliner.reporter.error(f'{rawtext}: {e}', line=lineno)
+        prb = inliner.problematic(rawtext, rawtext, msg)
+        return [prb], [msg]
+
 def setup(app):
     app.add_directive('flowgen', FlowGen)
     app.add_directive('pdkgen', PDKGen)
@@ -484,6 +494,7 @@ def setup(app):
     app.add_directive('appgen', AppGen)
     app.add_directive('examplegen', ExampleGen)
     app.add_directive('targetgen', TargetGen)
+    app.add_role('keypath', keypath_role)
 
     return {
         'version': siliconcompiler.__version__,


### PR DESCRIPTION
This PR contains a slew of changes that I think should be in the next release. It got a bit more varied than I originally intended, let me know if you want me to break it up.

Summary:
- Fix `find_files()` behavior with job argument (fixes #1122)
  - Was passing along `job` args to each `set()`/`get()` call internally, but was also passing in a `cfg` arg that was hardcoded to `self.cfg`, and that always takes precedence over the job.
  -  I have a longer-term fix in the works that will refactor basic schema access into a separate class (which we discussed a while back), and that will let us remove the `cfg` arguments and make bugs like this less likely to occur in the future
- Adds reports/final manifest to `chip.archive()`
- Export custom Sphinx `:keypath:` directive 
  - Could be useful for documenting dynamic modules in a third-party collection
- Tweak how libraries are imported when calling `read_manifest()` with job arg
  - Puts them under `history, <jobname>, library, <libname>` instead of top-level libraries, which is more consistent with `record_history()`
  - Might want to move away from this going forward to reduce manifest size, but then would need a way to make sure that different jobs actually used the same library config for proper provenance
- Small misc. tweaks