### PR TITLE
Bump Surelog version

### DIFF
--- a/.github/workflows/bin/install_surelog_macos.sh
+++ b/.github/workflows/bin/install_surelog_macos.sh
@@ -6,5 +6,6 @@ pip3 install orderedmultidict
 # Install Surelog
 git submodule update --init --recursive third_party/tools/surelog
 cd third_party/tools/surelog
+export ADDITIONAL_CMAKE_OPTIONS=-DPython3_ROOT_DIR=${pythonLocation}
 make
 make install PREFIX=$GITHUB_WORKSPACE/siliconcompiler/tools/surelog

--- a/.github/workflows/bin/install_surelog_win.bat
+++ b/.github/workflows/bin/install_surelog_win.bat
@@ -17,6 +17,7 @@ set MAKE_DIR=C:\make\bin
 set TCL_DIR=%PROGRAMFILES%\Git\mingw64\bin
 set SWIG_DIR=%PROGRMDATA%\chocolatey\lib\swig\tools\install\swigwin-3.0.12
 set PATH=%pythonLocation%;%SWIG_DIR%;%JAVA_HOME%\bin;%MAKE_DIR%;%TCL_DIR%;%PATH%
+set ADDITIONAL_CMAKE_OPTIONS=-DPython3_ROOT_DIR=%pythonLocation%
 
 set
 where cmake && cmake --version

--- a/.github/workflows/bin/install_surelog_win.bat
+++ b/.github/workflows/bin/install_surelog_win.bat
@@ -26,6 +26,9 @@ where java && java -version
 where python && python --version
 where ninja && ninja --version
 
+:: Required for Surelog
+pip3 install orderedmultidict
+
 git submodule update --init --recursive third_party/tools/surelog
 chdir third_party/tools/surelog
 

--- a/.github/workflows/bin/install_surelog_win.bat
+++ b/.github/workflows/bin/install_surelog_win.bat
@@ -4,7 +4,7 @@ choco install -y swig --side-by-side --version=3.0.12
 
 :: Build Surelog
 :: Based on Surelog CI script: https://github.com/chipsalliance/Surelog/blob/master/.github/workflows/main.yml
-call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
 
 set CMAKE_GENERATOR=Ninja
 set CC=cl

--- a/.github/workflows/bin/setup_wheel_env_linux.sh
+++ b/.github/workflows/bin/setup_wheel_env_linux.sh
@@ -9,6 +9,9 @@ wget --no-check-certificate https://www.klayout.org/downloads/CentOS_7/klayout-0
 yum install -y python3 ruby qt-x11
 rpm -i klayout-0.27.5-0.x86_64.rpm
 
+# Required for Surelog
+pip3 install orderedmultidict
+
 # Build surelog (install prefix defined outside file)
 git submodule update --init --recursive third_party/tools/surelog
 cd third_party/tools/surelog

--- a/.github/workflows/bin/setup_wheel_env_linux.sh
+++ b/.github/workflows/bin/setup_wheel_env_linux.sh
@@ -2,7 +2,7 @@
 
 # Install dependencies
 yum --disablerepo=epel -y update ca-certificates
-yum install -y libuuid-devel zlib-devel java-1.8.0-openjdk-devel graphviz xorg-x11-server-Xvfb wget
+yum install -y libuuid-devel zlib-devel java-11-openjdk-devel graphviz xorg-x11-server-Xvfb wget
 
 # Install Klayout (for chip.show() test)
 wget --no-check-certificate https://www.klayout.org/downloads/CentOS_7/klayout-0.27.5-0.x86_64.rpm
@@ -12,8 +12,6 @@ rpm -i klayout-0.27.5-0.x86_64.rpm
 # Build surelog (install prefix defined outside file)
 git submodule update --init --recursive third_party/tools/surelog
 cd third_party/tools/surelog
-# Fix insecure Git protocol
-sed -i 's/git:\/\/github.com\/nemtrif\/utfcpp/https:\/\/github.com\/nemtrif\/utfcpp/g' third_party/antlr4_fast/runtime/Cpp/runtime/CMakeLists.txt
 
 export LDFLAGS="-lrt"
 make

--- a/.github/workflows/bin/setup_wheel_env_linux.sh
+++ b/.github/workflows/bin/setup_wheel_env_linux.sh
@@ -21,7 +21,3 @@ make
 make install
 
 cd -
-
-# Hack because Surelog does not search lib64 install directory
-mkdir -p siliconcompiler/tools/surelog/lib/surelog/sv/
-cp siliconcompiler/tools/surelog/lib64/surelog/sv/builtin.sv siliconcompiler/tools/surelog/lib/surelog/sv/builtin.sv

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,6 +42,11 @@ jobs:
         java-version: 11
         java-package: jre
         architecture: x64
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+        architecture: x64
 
     - name: Setup env (Windows)
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,6 +34,15 @@ jobs:
           siliconcompiler/tools/surelog/lib/surelog/sv/builtin.sv
         key: ${{ matrix.os }}-${{ steps.get-surelog.outputs.version }}
 
+    # Needed for Surelog
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 11
+        java-package: jre
+        architecture: x64
+
     - name: Setup env (Windows)
       if: matrix.os == 'windows-latest'
       run: |

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -57,7 +57,12 @@ def setup(chip):
     options = []
     options.append('-parse')
 
-    # Wite back options tp cfg
+    # With newer versions of Surelog (at least 1.35 and up), this option is
+    # necessary to make bundled versions work.
+    # TODO: why?
+    options.append('-nocache')
+
+    # Wite back options to cfg
     chip.add('tool', tool, 'option', step, index, options)
 
     # Input/Output requirements


### PR DESCRIPTION
Fixes #1117

This one was kind of a struggle to get working. For some reason the bundled Surelog only works w/ Linux if we add the `-nocache` option. I'll need to revisit that when I get a chance. I also think it might be worth revisiting our approach to bundling Surelog, since upgrading is a pretty high burden. 