### PR TITLE
Add more file entries to tool schema

### DIFF
--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1572,6 +1572,47 @@ def schema_tool(cfg, tool='default', step='default', index='default'):
             Path to the entry script called by the executable specified
             on a per tool and per step basis.""")
 
+    scparam(cfg, ['tool', tool, 'prescript', step, index],
+            sctype='[file]',
+            shorthelp="Tool: pre-step script",
+            switch="-tool_prescript 'tool step index <file>'",
+            example=[
+                "cli: -tool_prescript 'yosys syn 0 syn_pre.tcl'",
+                "api: chip.set('tool','yosys','prescript','syn','0','syn_pre.tcl')"],
+            schelp="""
+            Path to a user supplied script to execute after reading in the design
+            but before the main execution stage of the step. Exact entry point
+            depends on the step and main script being executed. An example
+            of a prescript entry point would be immediately before global
+            placement.""")
+
+    scparam(cfg, ['tool', tool, 'postscript', step, index],
+            sctype='[file]',
+            shorthelp="Tool: post-step script",
+            switch="-tool_postscript 'tool step index <file>'",
+            example=[
+                "cli: -tool_postscript 'yosys syn 0 syn_post.tcl'",
+                "api: chip.set('tool','yosys','postscript','syn','0','syn_post.tcl')"],
+            schelp="""
+            Path to a user supplied script to execute after the main execution
+            stage of the step but before the design is saved.
+            Exact entry point depends on the step and main script being
+            executed. An example of a postscript entry point would be immediately
+            after global placement.""")
+
+    scparam(cfg, ['tool', tool, 'file', step, index, 'default'],
+            sctype='[file]',
+            shorthelp="Tool: user file",
+            switch="-tool_file 'tool step index key <file>'",
+            example=[
+                "cli: -tool_file 'openroad floorplan 0 macroplace macroplace.tcl'",
+                "api: chip.set('tool','openroad','file','floorplan','0','macroplace','macroplace.tcl')"],
+            schelp="""
+            Paths to user supplied files mapped to keys. Keys and filetypes must
+            match what's expected by the tool/reference script consuming the
+            file.
+            """)
+
     scparam(cfg, ['tool', tool, 'keep', step, index],
             sctype='[str]',
             shorthelp="Tool: files to keep",

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -6062,6 +6062,34 @@
                 "type": "str",
                 "value": null
             },
+            "file": {
+                "default": {
+                    "default": {
+                        "default": {
+                            "author": [],
+                            "copy": "false",
+                            "date": [],
+                            "defvalue": [],
+                            "example": [
+                                "cli: -tool_file 'openroad floorplan 0 macroplace macroplace.tcl'",
+                                "api: chip.set('tool','openroad','file','floorplan','0','macroplace','macroplace.tcl')"
+                            ],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "help": "Paths to user supplied files mapped to keys. Keys and filetypes must\nmatch what's expected by the tool/reference script consuming the\nfile.",
+                            "lock": "false",
+                            "notes": null,
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool: user file",
+                            "signature": [],
+                            "switch": "-tool_file 'tool step index key <file>'",
+                            "type": "[file]",
+                            "value": []
+                        }
+                    }
+                }
+            },
             "format": {
                 "defvalue": null,
                 "example": [
@@ -6208,6 +6236,58 @@
                 "switch": "-tool_path 'tool <dir>'",
                 "type": "dir",
                 "value": null
+            },
+            "postscript": {
+                "default": {
+                    "default": {
+                        "author": [],
+                        "copy": "false",
+                        "date": [],
+                        "defvalue": [],
+                        "example": [
+                            "cli: -tool_postscript 'yosys syn 0 syn_post.tcl'",
+                            "api: chip.set('tool','yosys','postscript','syn','0','syn_post.tcl')"
+                        ],
+                        "filehash": [],
+                        "hashalgo": "sha256",
+                        "help": "Path to a user supplied script to execute after the main execution\nstage of the step but before the design is saved.\nExact entry point depends on the step and main script being\nexecuted. An example of a postscript entry point would be immediately\nafter global placement.",
+                        "lock": "false",
+                        "notes": null,
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Tool: post-step script",
+                        "signature": [],
+                        "switch": "-tool_postscript 'tool step index <file>'",
+                        "type": "[file]",
+                        "value": []
+                    }
+                }
+            },
+            "prescript": {
+                "default": {
+                    "default": {
+                        "author": [],
+                        "copy": "false",
+                        "date": [],
+                        "defvalue": [],
+                        "example": [
+                            "cli: -tool_prescript 'yosys syn 0 syn_pre.tcl'",
+                            "api: chip.set('tool','yosys','prescript','syn','0','syn_pre.tcl')"
+                        ],
+                        "filehash": [],
+                        "hashalgo": "sha256",
+                        "help": "Path to a user supplied script to execute after reading in the design\nbut before the main execution stage of the step. Exact entry point\ndepends on the step and main script being executed. An example\nof a prescript entry point would be immediately before global\nplacement.",
+                        "lock": "false",
+                        "notes": null,
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Tool: pre-step script",
+                        "signature": [],
+                        "switch": "-tool_prescript 'tool step index <file>'",
+                        "type": "[file]",
+                        "value": []
+                    }
+                }
             },
             "refdir": {
                 "default": {


### PR DESCRIPTION
This PR adds back dedicated pre/post scripts, as well as a free file entry.

I was thinking another way to do this could be to add a free key after 'script', and standardize on values "entry", "pre", "post", and then allow free keys otherwise. This is a bit painful for backwards compatibility though. 