### PR TITLE
Make sure child processes quit when ctrl-c received during run

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4041,7 +4041,7 @@ class Chip:
                                     sys.stdout.write(stderr_reader.read())
                             if timeout is not None and time.time() - cmd_start_time > timeout:
                                 self.logger.error(f'Step timed out after {timeout} seconds')
-                                proc.terminate()
+                                utils.terminate_process(proc.pid)
                                 self._haltstep(step, index)
                             time.sleep(0.1)
                     except KeyboardInterrupt:

--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -1,8 +1,10 @@
 import os
 import shutil
+import psutil
 import sys
 import xml.etree.ElementTree as ET
 import re
+
 def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
     '''Simple implementation of shutil.copytree to give us a dirs_exist_ok
     option in Python < 3.8.
@@ -57,59 +59,81 @@ def trim(docstring):
     # Return a single string:
     return '\n'.join(trimmed)
 
+def terminate_process(pid, timeout=3):
+    '''Terminates a process and all its (grand+)children.
+
+    Based on https://psutil.readthedocs.io/en/latest/#psutil.wait_procs and
+    https://psutil.readthedocs.io/en/latest/#kill-process-tree.
+    '''
+    assert pid != os.getpid(), "won't terminate myself"
+    parent = psutil.Process(pid)
+    children = parent.children(recursive=True)
+    children.append(parent)
+    for p in children:
+        try:
+            p.terminate()
+        except psutil.NoSuchProcess:
+            # Process may have terminated on its own in the meantime
+            pass
+
+    _, alive = psutil.wait_procs(children, timeout=timeout)
+    for p in alive:
+        # If processes are still alive after timeout seconds, send more
+        # aggressive signal.
+        p.kill()
 
 # This class holds all the information about a single primitive defined in the FPGA arch file
 class PbPrimitive:
-     
+
     def __init__ (self, name, blif_model):
         self.name = name
         self.blif_model = blif_model
-        self.ports = []    
-        
+        self.ports = []
+
     def add_port(self, port):
-        
+
         port_type = port.tag # can be input | output | clock
         port_name = port.attrib['name']
         num_pins = port.attrib['num_pins']
         port_class = port.attrib.get('port_class')
-        
+
         new_port = { 'port_type': port_type,
                      'port_name': port_name,
                      'num_pins': num_pins,
                      'port_class': port_class }
-        
+
         self.ports.append(new_port)
-        
+
     def find_port(self, port_name):
 
         for port in self.ports:
             if re.match(port_name, port['port_name']):
                 return port
         return None
- 
- # This class parses the FPGA architecture file and stores all the information provided for every primitive   
+
+ # This class parses the FPGA architecture file and stores all the information provided for every primitive
 class Arch:
-    
+
     def __init__(self, arch_file_name):
         self.arch_file = ET.parse(arch_file_name)
         self.complexblocklist = self.arch_file.find("complexblocklist") # finding the tag that contains all the pb_types
         self.pb_primitives = []
         self.find_pb_primitives(self.complexblocklist) # only the primitives (pb_types that have the blif_model attribute) will be stored
-    
+
     # Find the pb_types that possess the 'blif_model' attribute and add them to the pb_primitives list
-    def find_pb_primitives(self, root):  
+    def find_pb_primitives(self, root):
         for pb_type in root.iter('pb_type'):
             if "blif_model" in pb_type.attrib:
                 self.add_pb_primitive(pb_type)
-    
-    # Parses the given primitive tag and stores the extracted info            
-    def add_pb_primitive(self, pb_type): 
+
+    # Parses the given primitive tag and stores the extracted info
+    def add_pb_primitive(self, pb_type):
         new_pb = PbPrimitive(pb_type.tag, pb_type.attrib["blif_model"])
         for port in pb_type.iter():
             if port.tag in ['input', 'output', 'clock']:
                 new_pb.add_port(port)
         self.pb_primitives.append(new_pb)
-        
+
     # Finds all the lut primitives to return the size of the largest lut
     def find_max_lut_size(self):
         max_lut_size = 0
@@ -118,9 +142,9 @@ class Arch:
                 in_port = pb_type.find_port("in")
                 lut_size = in_port["num_pins"]
                 max_lut_size = max(max_lut_size, int(lut_size))
-                
+
         return max_lut_size
-    
+
     # Finds all the memory primitives to return the maximum address length
     def find_memory_addr_width(self):
         max_add_size = 0
@@ -129,9 +153,9 @@ class Arch:
                 add_port = pb_type.find_port("^addr")
                 add_size = add_port["num_pins"]
                 max_add_size = max(max_add_size, int(add_size))
-                
+
         return max_add_size
- 
+
 def get_file_ext(filename):
     '''Get base file extension for a given path, disregarding .gz.'''
     if filename.endswith('.gz'):


### PR DESCRIPTION
Some EDA tools leave zombie processes around when a SC job is interrupted by ctrl-c. This PR adds some logic to wait for up to 5 minutes to ensure that an EDA tool has terminated when ctrl-c is received. If it doesn't, it goes through and cleans up the tool's process as well as any child processes the tool has spawned.

This should work on both *nix/Windows since it relies on `psutil` (which has multi-platform support), although it hasn't been tested on Windows.