### PR TITLE
KLayout show fixups

### DIFF
--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -12,7 +12,7 @@ with open('sc_manifest.json', 'r') as f:
 
 # Extract info from manifest
 sc_pdk = sc_cfg['option']['pdk']['value']
-sc_stackup = sc_cfg['pdk'][sc_pdk]['stackup']['value'][0]
+sc_stackup = sc_cfg['asic']['stackup']['value']
 sc_mainlib = sc_cfg['asic']['logiclib']['value'][0]
 sc_libtype = list(sc_cfg['library'][sc_mainlib]['asic']['footprint'].keys())[0]
 
@@ -61,6 +61,7 @@ if lib_lef is not None:
 
 # Overwrite LEFs specified in tech file with the LEFs we took from the manifest.
 layoutOptions.lefdef_config.lef_files = lefs
+print("LEFS", lefs)
 
 # These may be disabled in our KLayout tech file for reasons relating to GDS
 # export, but for the purposes of viewing we'll hardcode them to True.

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -61,7 +61,6 @@ if lib_lef is not None:
 
 # Overwrite LEFs specified in tech file with the LEFs we took from the manifest.
 layoutOptions.lefdef_config.lef_files = lefs
-print("LEFS", lefs)
 
 # These may be disabled in our KLayout tech file for reasons relating to GDS
 # export, but for the purposes of viewing we'll hardcode them to True.

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -69,6 +69,9 @@ layoutOptions.lefdef_config.produce_blockages = True
 layoutOptions.lefdef_config.produce_cell_outlines = True
 layoutOptions.lefdef_config.produce_obstructions = True
 
+# Always use LEF geometry even when LEF file contains FOREIGN statement.
+layoutOptions.lefdef_config.macro_resolution_mode = 1
+
 app = pya.Application.instance()
 
 # Opinionated default KLayout configuration


### PR DESCRIPTION
- Current logic just picks the first stackup of all possible, instead we should be taking the user-selected stackup.
- Tweak settings to always display macro/cell geometry from LEFs when viewing DEF, even if FOREIGN statement is set in LEF