### PR TITLE
Pin setuptools version to fix editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=42,<64",
     "wheel",
     "cython",
     "scikit-build>=0.12",


### PR DESCRIPTION
The latest version of setuptools breaks our editable install, due to this issue in scikit-build: https://github.com/scikit-build/scikit-build/issues/740. Until this issue is fixed (or we change how the leflib build works), we need to pin setuptools to an older version. 