### PR TITLE
Fix bug in flowgraph I/O checking

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1933,7 +1933,7 @@ class Chip:
             else:
                 outputs = set()
 
-        if step == 'import':
+        if step == 'import' and self.get('option', 'remote'):
             imports = {self._get_imported_filename(p) for p in self._collect_paths()}
             outputs.update(imports)
 


### PR DESCRIPTION
The checker logic was still assuming that input files are always collected locally, but that only happens for remote runs now.