### PR TITLE
Restrict which files get copied between tasks

### DIFF
--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1258,7 +1258,7 @@ def schema_flowgraph(cfg, flow='default', step='default', index='default'):
             switch="-flowgraph_file_input 'flow step index filetype filename <(str, str)>'",
             example= [
                 "cli: -flowgraph_file_input 'asicflow cts 0 def design.def (floorplan, 0)'",
-                "api:  chip.set('flowgraph','asicflow', 'cts','0','def', 'design.def', ('floorplan','0'))"],
+                "api:  chip.set('flowgraph','asicflow','cts','0','file','input','def','design.def',('floorplan','0'))"],
             schelp="""
             Which task is responsible for providing an input of a certain
             type/name to the current task. This can be used to restrict which

--- a/siliconcompiler/schema.py
+++ b/siliconcompiler/schema.py
@@ -1250,6 +1250,22 @@ def schema_flowgraph(cfg, flow='default', step='default', index='default'):
             List of selected inputs for the current step/index specified as
             (in_step,in_index) tuple.""")
 
+    filetype = 'default'
+    filename = 'default'
+    scparam(cfg,['flowgraph', flow, step, index, 'file', 'input', filetype, filename],
+            sctype='[(str,str)]',
+            shorthelp="Flowgraph: input file source",
+            switch="-flowgraph_file_input 'flow step index filetype filename <(str, str)>'",
+            example= [
+                "cli: -flowgraph_file_input 'asicflow cts 0 def design.def (floorplan, 0)'",
+                "api:  chip.set('flowgraph','asicflow', 'cts','0','def', 'design.def', ('floorplan','0'))"],
+            schelp="""
+            Which task is responsible for providing an input of a certain
+            type/name to the current task. This can be used to restrict which
+            output files of input tasks get copied into the inputs of the
+            current task. If this parameter is unused, then all outputs from the
+            input tasks will be copied.""")
+
     return cfg
 
 
@@ -1635,6 +1651,21 @@ def schema_tool(cfg, tool='default', step='default', index='default'):
             step basis. If not specified, SC queries the operating system and sets
             the threads based on the maximum thread count supported by the
             hardware.""")
+
+    filetype = 'default'
+    scparam(cfg, ['tool', tool, 'infile', step, index, filetype],
+            sctype='[str]',
+            shorthelp="Tool: input file path",
+            switch="-tool_infile 'tool step index filetype <str>'",
+            example=["cli: -tool_infile 'openroad floorplan 0 def floorplan.def'",
+                     "api: chip.set('tool','openroad','infile','floorplan','0','def','floorplan.def)"],
+            schelp="""
+            Paths to input files of a particular type. This gets set by the
+            runtime, and is currently only set by flows that use the
+            :keypath:`flowgraph,<flow>,<step>,<index>,file,input` parameter.
+            This parameter can be read by tool scripts or in a tool driver's
+            ``runtime_options()`` method to avoid hardcoding input file
+            names.""")
 
     return cfg
 

--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -4,8 +4,7 @@ import psutil
 import sys
 import xml.etree.ElementTree as ET
 import re
-
-def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
+def copytree(src, dst, include=None, ignore=None, dirs_exist_ok=False, link=False):
     '''Simple implementation of shutil.copytree to give us a dirs_exist_ok
     option in Python < 3.8.
 
@@ -15,7 +14,9 @@ def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
     os.makedirs(dst, exist_ok=dirs_exist_ok)
 
     for name in os.listdir(src):
-        if name in ignore:
+        if (include is not None) and (name not in include):
+            continue
+        if (ignore is not None) and (name in ignore):
             continue
 
         srcfile = os.path.join(src, name)

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1978,6 +1978,29 @@
                         "type": "[str]",
                         "value": []
                     },
+                    "file": {
+                        "input": {
+                            "default": {
+                                "default": {
+                                    "defvalue": [],
+                                    "example": [
+                                        "cli: -flowgraph_file_input 'asicflow cts 0 def design.def (floorplan, 0)'",
+                                        "api:  chip.set('flowgraph','asicflow', 'cts','0','def', 'design.def', ('floorplan','0'))"
+                                    ],
+                                    "help": "Which task is responsible for providing an input of a certain\ntype/name to the current task. This can be used to restrict which\noutput files of input tasks get copied into the inputs of the\ncurrent task. If this parameter is unused, then all outputs from the\ninput tasks will be copied.",
+                                    "lock": "false",
+                                    "notes": null,
+                                    "require": null,
+                                    "scope": "job",
+                                    "shorthelp": "Flowgraph: input file source",
+                                    "signature": [],
+                                    "switch": "-flowgraph_file_input 'flow step index filetype filename <(str, str)>'",
+                                    "type": "[(str,str)]",
+                                    "value": []
+                                }
+                            }
+                        }
+                    },
                     "goal": {
                         "default": {
                             "defvalue": null,
@@ -6106,6 +6129,29 @@
                 "switch": "-tool_format 'tool <file>'",
                 "type": "str",
                 "value": null
+            },
+            "infile": {
+                "default": {
+                    "default": {
+                        "default": {
+                            "defvalue": [],
+                            "example": [
+                                "cli: -tool_infile 'openroad floorplan 0 def floorplan.def'",
+                                "api: chip.set('tool','openroad','infile','floorplan','0','def','floorplan.def)"
+                            ],
+                            "help": "Paths to input files of a particular type. This gets set by the\nruntime, and is currently only set by flows that use the\n:keypath:`flowgraph,<flow>,<step>,<index>,file,input` parameter.\nThis parameter can be read by tool scripts or in a tool driver's\n``runtime_options()`` method to avoid hardcoding input file\nnames.",
+                            "lock": "false",
+                            "notes": null,
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Tool: input file path",
+                            "signature": [],
+                            "switch": "-tool_infile 'tool step index filetype <str>'",
+                            "type": "[str]",
+                            "value": []
+                        }
+                    }
+                }
             },
             "input": {
                 "default": {

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1985,7 +1985,7 @@
                                     "defvalue": [],
                                     "example": [
                                         "cli: -flowgraph_file_input 'asicflow cts 0 def design.def (floorplan, 0)'",
-                                        "api:  chip.set('flowgraph','asicflow', 'cts','0','def', 'design.def', ('floorplan','0'))"
+                                        "api:  chip.set('flowgraph','asicflow','cts','0','file','input','def','design.def',('floorplan','0'))"
                                     ],
                                     "help": "Which task is responsible for providing an input of a certain\ntype/name to the current task. This can be used to restrict which\noutput files of input tasks get copied into the inputs of the\ncurrent task. If this parameter is unused, then all outputs from the\ninput tasks will be copied.",
                                     "lock": "false",


### PR DESCRIPTION
This PR adds a couple schema parameters and basic functionality to enable:
- Restricting which files get copied between tasks
- Distinguishing types of input files to a task

For an example use case: imagine we wanted to run gate-to-gate LEC between `cts` and `place`. We could create a `lec` task that depends on both `place` and `cts`, but then we run into an issue: 

```
$ ls place/0/outputs/
design.def   design.place.vg

$ ls cts/0/outputs/
design.def design.cts.vg
```

Since these files will get copied directly by the runtime into `lec/0/inputs`, the checker will throw an error due to the duplicated `design.def` inputs. In addition, the LEC step has no way of distinguishing the two netlists to be compared.

This PR solves the problem by allowing a user to filter out a specific set of files to be copied between one step and another, which is exposed as an optional kwarg to the `edge()` API method. For this example, the flow definition might be tweaked to look like:

```python
chip.node(flow, 'lec', 'yosys')
chip.edge(flow, 'place', 'lec', files=[
  ('design.place.vg', 'netlist-ref')
])
chip.edge(flow, 'cts', 'lec', files=[
  ('design.cts.vg', 'netlist')
])
```

Then, during runtime two things will be different:
- Only `design.place.vg` and `design.cts.vg` will be copied into `lec/0/inputs`, solving the first problem.
- The new parameter `['tool', <tool>, 'infile', <step>, <index>, <filetype>]` will be set for this task to point to these inputs (with distinct filetypes of `netlist-ref` and `netlist`), solving the second problem.

We've previously discussed moving towards defining info about flow inputs/outputs directly in the flow definition ( #1087), and this PR enables the immediate use case in a backwards-compatible way while moving towards this broader change. To make this change forward-looking, the schema parameters proposed are a bit more complex than needed for just this functionality.

