### PR TITLE
Read in manifests from previously completed tasks before running

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4292,6 +4292,10 @@ class Chip:
         # tasks that have already been run and are not going to be re-run. This
         # is necessary to capture tool setup from past tasks, since tool setup
         # is only performed for what's in the steplist.
+
+        # Hack to restore the value of the 'remote' parameter.
+        # TODO: remove this after #1146 is fixed.
+        remote = self.get('option', 'remote')
         for step in self.getkeys('flowgraph', flow):
             for index in self.getkeys('flowgraph', flow, step):
                 if step in steplist and index in indexlist[step]:
@@ -4302,6 +4306,7 @@ class Chip:
                             manifest = os.path.join(workdir, 'outputs', f'{self.design}.pkg.json')
                             if os.path.isfile(manifest):
                                 self.read_manifest(manifest, clobber=False)
+        self.set('option', 'remote', remote)
 
         # Reset flowgraph/records/metrics by probing build directory. We need
         # to set values to None for steps we may re-run so that merging

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2074,7 +2074,7 @@ class Chip:
         # TODO: better way to handle this?
         if 'library' in localcfg and not partial:
             for libname in localcfg['library'].keys():
-                self._import_library(libname, localcfg['library'][libname], job=job)
+                self._import_library(libname, localcfg['library'][libname], job=job, clobber=clobber)
 
     ###########################################################################
     def write_manifest(self, filename, prune=True, abspath=False, job=None):
@@ -2410,7 +2410,7 @@ class Chip:
         self._import_library(lib_chip.design, lib_chip.cfg)
 
     ###########################################################################
-    def _import_library(self, libname, libcfg, job=None):
+    def _import_library(self, libname, libcfg, job=None, clobber=True):
         '''Helper to import library with config 'libconfig' as a library
         'libname' in current Chip object.'''
         if job:
@@ -2419,7 +2419,10 @@ class Chip:
             cfg = self.cfg['library']
 
         if libname in cfg:
-            self.logger.warning(f'Overwriting existing library {libname}')
+            if clobber:
+                self.logger.warning(f'Overwriting existing library {libname}')
+            else:
+                return
 
         cfg[libname] = copy.deepcopy(libcfg)
         if 'pdk' in cfg:

--- a/tests/flows/test_steplist.py
+++ b/tests/flows/test_steplist.py
@@ -1,3 +1,6 @@
+import copy
+import os
+
 import siliconcompiler
 
 import pytest
@@ -25,6 +28,23 @@ def test_steplist(gcd_chip):
     gcd_chip.set('option', 'steplist', ['floorplan'])
     gcd_chip.run()
     assert gcd_chip.find_result('def', step='floorplan')
+
+@pytest.mark.eda
+def test_steplist_keep_reports(gcd_chip):
+    '''Regression test for making sure that reports from previous steps are
+    still mapped when a script is re-run with a steplist.'''
+    fresh_chip = copy.deepcopy(gcd_chip)
+
+    # Initial run
+    gcd_chip.set('option', 'steplist', ['import', 'syn'])
+    gcd_chip.run()
+    assert gcd_chip.get('tool', 'yosys', 'report', 'syn', '0', 'cellarea') is not None
+    report = gcd_chip.get('tool', 'yosys', 'report', 'syn', '0', 'cellarea')
+
+    # Run a new step from a fresh chip object
+    fresh_chip.set('option', 'steplist', ['floorplan'])
+    fresh_chip.run()
+    assert fresh_chip.get('tool', 'yosys', 'report', 'syn', '0', 'cellarea') == report
 
 @pytest.mark.eda
 def test_invalid(gcd_chip):


### PR DESCRIPTION
This PR fixes a bug where tool setup gets lost when a partially run flow is continued using the steplist. This means things like the tool report mappings are no longer fully captured when a flow is executed over multiple runs. 

That immediate problem is caused by the fact that the tool setup functions are executed at runtime, and only for the steps currently in the steplist for that run. Therefore, setup for tools from the steps that have already been run don't end up in the chip configuration.

One way to fix this could be to re-run setup() for all steps every time, but I think it would make more sense to capture the setup that was used to run those particular steps, in case the user changes something between re-runs. 

One cause of this problem was introducing the partial read_manifest between steps, so I was also considering adding some of the keypaths we want to carry forward as things that get copied by a partial read. However, reading in the entire manifest seems a little more comprehensive, even if a bit ugly.

