### PR TITLE
Add an explanatory error message if SC is run from a non-existant directory

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -78,8 +78,12 @@ class Chip:
 
         # Local variables
         self.scroot = os.path.dirname(os.path.abspath(__file__))
-        self.cwd = os.getcwd()
         self._error = False
+        try:
+            self.cwd = os.getcwd()
+        except FileNotFoundError:
+            self.error("""SiliconCompiler must be run from a directory that exists.
+If you are sure that your working directory is valid, try running `cd $(pwd)`.""", fatal=True)
         self.cfg = schema_cfg()
         # The 'status' dictionary can be used to store ephemeral config values.
         # Its contents will not be saved, and can be set by parent scripts

--- a/tests/core/test_cwd.py
+++ b/tests/core/test_cwd.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
+import os
+import pytest
+import shutil
+import siliconcompiler
+
+@pytest.mark.quick
+def test_cwd():
+    os.mkdir('tmp_test_cwd')
+    os.chdir('tmp_test_cwd')
+    shutil.rmtree('../tmp_test_cwd')
+
+    # The act of creating a Chip object should raise a SiliconCompilerError
+    # if the current working directory does not exist.
+    with pytest.raises(siliconcompiler.SiliconCompilerError):
+        chip = siliconcompiler.Chip('my_design')
+
+#########################
+if __name__ == "__main__":
+    test_cwd()


### PR DESCRIPTION
Waiting for something to build, I thought I should get back into the habit of looking at small SC bugs when I have a spare minute.

This change should address #1134, by printing an explanatory error if SC is run from a directory that does not exist. It still involves  a stack trace because I used the `self.error` method, but it's a bit more user-friendly:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "siliconcompiler/siliconcompiler/core.py", line 85, in __init__
    self.error("""SiliconCompiler must be run from a directory that exists.
  File "siliconcompiler/siliconcompiler/core.py", line 5203, in error
    raise SiliconCompilerError(msg)
siliconcompiler.core.SiliconCompilerError: SiliconCompiler must be run from a directory that exists.
If you are sure that your working directory is valid, try running `cd $(pwd)`.
```