### PR TITLE
Deduplicate Surelog file inputs

### DIFF
--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -104,23 +104,23 @@ def runtime_options(chip):
     # Deduplicated source files
     # Library directories.
     ydir_files = chip.find_files('option', 'ydir')
-    if ydir_files != list(set(ydir_files)):
+    if len(ydir_files) != len(set(ydir_files)):
         chip.logger.warning(f"Removing duplicate 'ydir' inputs from: {ydir_files}")
-    for value in list(set(ydir_files)):
+    for value in set(ydir_files):
         cmdlist.append('-y ' + value)
 
     # Library files.
     vlib_files = chip.find_files('option', 'vlib')
-    if vlib_files != list(set(vlib_files)):
+    if len(vlib_files) != len(set(vlib_files)):
         chip.logger.warning(f"Removing duplicate 'vlib' inputs from: {vlib_files}")
-    for value in list(set(vlib_files)):
+    for value in set(vlib_files):
         cmdlist.append('-v ' + value)
 
     # Include paths.
     idir_files = chip.find_files('option', 'idir')
-    if idir_files != list(set(idir_files)):
+    if len(idir_files) != len(set(idir_files)):
         chip.logger.warning(f"Removing duplicate 'idir' inputs from: {idir_files}")
-    for value in list(set(idir_files)):
+    for value in set(idir_files):
         cmdlist.append('-I' + value)
 
     # Extra environment variable defines (don't need deduplicating)
@@ -129,16 +129,16 @@ def runtime_options(chip):
 
     # Command-line argument file(s).
     cmdfiles = chip.find_files('option', 'cmdfile')
-    if cmdfiles != list(set(cmdfiles)):
+    if len(cmdfiles) != len(set(cmdfiles)):
         chip.logger.warning(f"Removing duplicate 'cmdfile' inputs from: {cmdfiles}")
-    for value in list(set(cmdfiles)):
+    for value in set(cmdfiles):
         cmdlist.append('-f ' + value)
 
     # Source files.
     src_files = chip.find_files('input', 'verilog')
-    if src_files != list(set(src_files)):
+    if len(src_files) != len(set(src_files)):
         chip.logger.warning(f"Removing duplicate source file inputs from: {src_files}")
-    for value in list(set(src_files)):
+    for value in set(src_files):
         cmdlist.append(value)
 
     cmdlist.append('-top ' + chip.top())

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -101,18 +101,44 @@ def runtime_options(chip):
 
     cmdlist = []
 
-    # source files
-    for value in chip.find_files('option', 'ydir'):
+    # Deduplicated source files
+    # Library directories.
+    ydir_files = chip.find_files('option', 'ydir')
+    if ydir_files != list(set(ydir_files)):
+        chip.logger.warning(f"Removing duplicate 'ydir' inputs from: {ydir_files}")
+    for value in list(set(ydir_files)):
         cmdlist.append('-y ' + value)
-    for value in chip.find_files('option', 'vlib'):
+
+    # Library files.
+    vlib_files = chip.find_files('option', 'vlib')
+    if vlib_files != list(set(vlib_files)):
+        chip.logger.warning(f"Removing duplicate 'vlib' inputs from: {vlib_files}")
+    for value in list(set(vlib_files)):
         cmdlist.append('-v ' + value)
-    for value in chip.find_files('option', 'idir'):
+
+    # Include paths.
+    idir_files = chip.find_files('option', 'idir')
+    if idir_files != list(set(idir_files)):
+        chip.logger.warning(f"Removing duplicate 'idir' inputs from: {idir_files}")
+    for value in list(set(idir_files)):
         cmdlist.append('-I' + value)
+
+    # Extra environment variable defines (don't need deduplicating)
     for value in chip.get('option', 'define'):
         cmdlist.append('-D' + value)
-    for value in chip.find_files('option', 'cmdfile'):
+
+    # Command-line argument file(s).
+    cmdfiles = chip.find_files('option', 'cmdfile')
+    if cmdfiles != list(set(cmdfiles)):
+        chip.logger.warning(f"Removing duplicate 'cmdfile' inputs from: {cmdfiles}")
+    for value in list(set(cmdfiles)):
         cmdlist.append('-f ' + value)
-    for value in chip.find_files('input', 'verilog'):
+
+    # Source files.
+    src_files = chip.find_files('input', 'verilog')
+    if src_files != list(set(src_files)):
+        chip.logger.warning(f"Removing duplicate source file inputs from: {src_files}")
+    for value in list(set(src_files)):
         cmdlist.append(value)
 
     cmdlist.append('-top ' + chip.top())

--- a/tests/tools/test_surelog.py
+++ b/tests/tools/test_surelog.py
@@ -35,6 +35,38 @@ def test_surelog(scroot, clean):
 
 @pytest.mark.eda
 @pytest.mark.quick
+def test_surelog_duplicate_inputs(scroot):
+    gcd_src = os.path.join(scroot, 'examples', 'gcd', 'gcd.v')
+    design = "gcd"
+    step = "import"
+
+    chip = siliconcompiler.Chip(design)
+    chip.load_target('freepdk45_demo')
+
+    # Set duplicate input files.
+    chip.add('input', 'verilog', gcd_src)
+    chip.add('input', 'verilog', gcd_src)
+
+    chip.set('option', 'mode', 'sim')
+    chip.set('option', 'clean', True)
+    chip.node('surelog', step, 'surelog')
+    chip.set('option', 'flow', 'surelog')
+
+    chip.run()
+
+    output = chip.find_result('v', step=step)
+    assert output is not None
+
+    # Ensure only one module is written to the output Verilog. (Two will be written if dedup fails)
+    module_count = 0
+    with open(output, 'r') as rf:
+        for line in rf.readlines():
+            if line.startswith('module gcd'):
+                module_count += 1
+    assert module_count == 1
+
+@pytest.mark.eda
+@pytest.mark.quick
 def test_surelog_preproc_regression(datadir):
     src = os.path.join(datadir, 'test_preproc.v')
     design = 'test_preproc'
@@ -95,4 +127,5 @@ if __name__ == "__main__":
     from tests.fixtures import scroot
     from tests.fixtures import datadir
     test_surelog(scroot())
+    test_surelog_duplicate_inputs(scroot())
     test_surelog_preproc_regression(datadir(__file__))


### PR DESCRIPTION
One more small change, to address #1135.

If the same Verilog file is added to a Chip object twice, Surelog will duplicate its content in the pickled output, which causes synthesis failures with Yosys.

Like the reporter suggested, we can de-duplicate the inputs when we are assembling the import step's Surelog command, and print a warning if any duplicate files are found.