### PR TITLE
Skip "no working directory" test on Windows

### DIFF
--- a/tests/core/test_cwd.py
+++ b/tests/core/test_cwd.py
@@ -3,6 +3,7 @@ import os
 import pytest
 import shutil
 import siliconcompiler
+import sys
 
 @pytest.mark.quick
 @pytest.mark.skipif(sys.platform=='win32', reason='Windows throws a permission denied error if we try to delete a directory which a process is currently inhabiting.')

--- a/tests/core/test_cwd.py
+++ b/tests/core/test_cwd.py
@@ -5,6 +5,7 @@ import shutil
 import siliconcompiler
 
 @pytest.mark.quick
+@pytest.mark.skipif(sys.platform=='win32', reason='Windows throws a permission denied error if we try to delete a directory which a process is currently inhabiting.')
 def test_cwd():
     os.mkdir('tmp_test_cwd')
     os.chdir('tmp_test_cwd')


### PR DESCRIPTION
Windows throws `PermissionError: [WinError 32]` if you try to delete a directory which a process is using, so the test for nonexistent working directories fails on that platform.

It seems like that makes it less likely for the "no current directory" bug to occur, so we can probably skip the test on Windows platforms.