### PR TITLE
Remove setup workaround for old Surelog git repo URL

### DIFF
--- a/setup/install-surelog.sh
+++ b/setup/install-surelog.sh
@@ -10,13 +10,6 @@ cd ${src_path}/..
 git submodule update --init --recursive third_party/tools/surelog
 cd third_party/tools/surelog
 
-# Workaround: Surelog's antlr4 dependency clones a git:// repo during its build process.
-# GitHub recently deprecated some ways of cloning via git://, so we need to use https:// instead.
-# We don't want to overwrite the user's global git config, so use $HOME to set global search path.
-# In git v2.32+, we'll be able to use $GIT_CONFIG_GLOBAL, but not many systems will support that.
-git config --file $(pwd)/.gitconfig url."https://".insteadOf git://
-export HOME=$(pwd)
-
 make
 sudo make install
 cd -


### PR DESCRIPTION
Since Noah has updated the version of Surelog that we are using, I don't think we need this workaround in the install script anymore.

We added it because Surelog's `antlr4` submodule used a `git://` URL for the repository, and GitHub stopped supporting anonymous pulls from some SSH endpoints. Newer versions of Surelog use an `https://` URL, so we don't need to explicitly specify that anymore.