### PR TITLE
Fix bug introduced by #1145

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1604,6 +1604,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             return True
         if keypath[0] == 'flowgraph' and keypath[4] in ('select', 'status'):
             return True
+        if keypath[0] == 'tool':
+            return True
         return False
 
     ###########################################################################
@@ -4297,26 +4299,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 indexlist[step] = self.get("option", 'indexlist')
             else:
                 indexlist[step] = self.getkeys('flowgraph', flow, step)
-
-        # Before running, we want to pick up any values that had been set in
-        # tasks that have already been run and are not going to be re-run. This
-        # is necessary to capture tool setup from past tasks, since tool setup
-        # is only performed for what's in the steplist.
-
-        # Hack to restore the value of the 'remote' parameter.
-        # TODO: remove this after #1146 is fixed.
-        remote = self.get('option', 'remote')
-        for step in self.getkeys('flowgraph', flow):
-            for index in self.getkeys('flowgraph', flow, step):
-                if step in steplist and index in indexlist[step]:
-                    in_job = self._get_in_job(step, index)
-                    for in_step, in_index in self.get('flowgraph', flow, step, index, 'input'):
-                        if in_step not in steplist or in_index not in indexlist[in_step]:
-                            workdir = self._getworkdir(jobname=in_job, step=in_step, index=in_index)
-                            manifest = os.path.join(workdir, 'outputs', f'{self.design}.pkg.json')
-                            if os.path.isfile(manifest):
-                                self.read_manifest(manifest, clobber=False)
-        self.set('option', 'remote', remote)
 
         # Reset flowgraph/records/metrics by probing build directory. We need
         # to set values to None for steps we may re-run so that merging


### PR DESCRIPTION
This commit takes a lighter approach to fixing the immediate bug that we attempted to fix with #1145, which is to ensure that tool setup persists across re-runs using steplist. Reading in the entire manifest before a run overwrites boolean options (such as resume), which can lead to unintuitive behavior. For example,

```python
...
chip.set('option', 'resume', True)
chip.run()

chip.set('option', 'resume', False)
chip.set('option', 'steplist', ['export'])
chip.run() # won't rerun export, behaves as if resume is still True
```

I still think there are better fixes down the road, but this seems like a better fix to go with in the meantime.