### PR TITLE
SC client messaging update

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -113,9 +113,9 @@ def remote_run(chip):
                                    int(time.monotonic() - step_start), cur_step))
                   if cur_log:
                       chip.logger.info(f"Last 10 lines of logfile:\n{cur_log}\n")
-          else:
-              chip.logger.info(f"Job is still running (%d seconds, step: unknown)"%(
-                               int(time.monotonic() - step_start)))
+              else:
+                  chip.logger.info(f"Job is still running (%d seconds, step: unknown)"%(
+                                   int(time.monotonic() - step_start)))
       except:
           # Sometimes an exception is raised if the request library cannot
           # reach the server due to a transient network issue.

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -99,11 +99,23 @@ def remote_run(chip):
     # Check the job's progress periodically until it finishes.
     is_busy = True
     while is_busy:
-      chip.logger.info("Job is still running. (%d seconds)"%(
-                       int(time.monotonic() - step_start)))
       time.sleep(30)
       try:
-          is_busy = is_job_busy(chip)
+          is_busy_info = is_job_busy(chip)
+          is_busy = is_busy_info['busy']
+          if is_busy:
+              if (':' in is_busy_info['message']):
+                  chip.logger.info(f'MSG:\n{is_busy_info["message"]}\n')
+                  msg_lines = is_busy_info['message'].splitlines()
+                  cur_step = msg_lines[0][msg_lines[0].find(': ')+2:]
+                  cur_log = '\n'.join(msg_lines[1:])
+                  chip.logger.info("Job is still running (%d seconds, step: %s)."%(
+                                   int(time.monotonic() - step_start), cur_step))
+                  if cur_log:
+                      chip.logger.info(f"Last 10 lines of logfile:\n{cur_log}\n")
+          else:
+              chip.logger.info(f"Job is still running (%d seconds, step: unknown)"%(
+                               int(time.monotonic() - step_start)))
       except:
           # Sometimes an exception is raised if the request library cannot
           # reach the server due to a transient network issue.
@@ -190,6 +202,7 @@ def is_job_busy(chip):
         post_params['key'] = rcfg['password']
 
     # Make the request and print its response.
+    info = {}
     redirect_url = remote_run_url
     while redirect_url:
         resp = requests.post(redirect_url,
@@ -198,7 +211,9 @@ def is_job_busy(chip):
         if resp.status_code == 302:
             redirect_url = resp.headers['Location']
         else:
-            return (resp.text != "Job has no running steps.")
+            info['busy'] = (resp.text != "Job has no running steps.")
+            info['message'] = resp.text
+            return info
 
 ###################################
 def delete_job(chip):

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -105,7 +105,6 @@ def remote_run(chip):
           is_busy = is_busy_info['busy']
           if is_busy:
               if (':' in is_busy_info['message']):
-                  chip.logger.info(f'MSG:\n{is_busy_info["message"]}\n')
                   msg_lines = is_busy_info['message'].splitlines()
                   cur_step = msg_lines[0][msg_lines[0].find(': ')+2:]
                   cur_log = '\n'.join(msg_lines[1:])


### PR DESCRIPTION
In preparation for some SCServer updates, this change lets the client print a bit more information about an ongoing remote job run.

It will print the current step and a tail of the task's log if the server provides that information. If not, it will continue printing the generic "Job is still running" message for compatibility with old (and current) versions of the server.