### PR TITLE
Adding .vh extension

### DIFF
--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -144,7 +144,7 @@ def runtime_options(chip):
     cmdlist.append('-top ' + chip.top())
     # make sure we can find .sv files in ydirs
     # TODO: need to add libext
-    cmdlist.append('+libext+.sv+.v')
+    cmdlist.append('+libext+.sv+.v+.vh')
 
     # Set up user-provided parameters to ensure we elaborate the correct modules
     for param in chip.getkeys('option', 'param'):


### PR DESCRIPTION
 - Commonly used methodology for non-module verilog 2001 header files (by me and others).
 - https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md