### PR TITLE
python: don't catch BaseException, such as KeyboardInterruptException

### DIFF
--- a/siliconcompiler/apps/sc_ping.py
+++ b/siliconcompiler/apps/sc_ping.py
@@ -42,7 +42,7 @@ def main():
            (not 'address' in remote_cfg):
             print('Error reading remote configuration file.')
             sys.exit(1)
-    except:
+    except Exception:
         print('Error reading remote configuration file.')
         sys.exit(1)
 
@@ -79,7 +79,7 @@ def main():
         print(f'  Remaining compute time: {(user_info["compute_time"]/60.0):.2f} minutes')
         print(f'  Remaining results bandwidth: {user_info["bandwidth_kb"]} KiB')
         return
-    except:
+    except Exception:
         print('Error fetching user information from the remote server.')
         sys.exit(1)
 

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -115,7 +115,7 @@ def remote_run(chip):
               else:
                   chip.logger.info(f"Job is still running (%d seconds, step: unknown)"%(
                                    int(time.monotonic() - step_start)))
-      except:
+      except Exception:
           # Sometimes an exception is raised if the request library cannot
           # reach the server due to a transient network issue.
           # Retrying ensures that jobs don't break off when the connection drops.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -545,7 +545,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             else:
                 function = None
             return function
-        except:
+        except Exception:
             traceback.print_exc()
             self.error(f"Module setup failed for '{modulename}'")
 

--- a/siliconcompiler/floorplan.py
+++ b/siliconcompiler/floorplan.py
@@ -26,7 +26,7 @@ def _layer_i(layer):
     '''Helper function to go from SC layer name to layer position in stackup.'''
     try:
         return int(layer.lstrip('m'))
-    except:
+    except Exception:
         raise ValueError(f'Invalid routing layer {layer}.')
 
 def _get_rect_intersection(r1, r2):

--- a/siliconcompiler/leflib/__init__.py
+++ b/siliconcompiler/leflib/__init__.py
@@ -1,6 +1,6 @@
 try:
     from ._leflib import parse as _parse
-except:
+except Exception:
     import sys
     print("WARNING! leflib hasn't been built properly. SC installation may malfunction.", file=sys.stderr)
 

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -429,13 +429,13 @@ class Schema:
                     elif (cfgtype == 'float'):
                         try:
                             float(item)
-                        except:
+                        except ValueError:
                             errormsg = "Type mismatch. Cannot cast item to float."
                             ok = False
                     elif (cfgtype == 'int'):
                         try:
                             int(item)
-                        except:
+                        except ValueError:
                             errormsg = "Type mismatch. Cannot cast item to int."
                             ok = False
                     elif item is not None:

--- a/siliconcompiler/server.py
+++ b/siliconcompiler/server.py
@@ -73,7 +73,7 @@ class Server:
                         'priv_key': mapping['priv_key'],
                         'password': mapping['password'],
                     }
-            except:
+            except Exception:
                 self.logger.warning("Could not find well-formatted 'users.json' "\
                                     "file in the server's working directory. "\
                                     "(User : Key) mappings were not imported.")

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -104,6 +104,6 @@ try:
         gds_img.save(f'../{design}/{jobname}/{design}.png', 'PNG')
         # Done, exit.
         app.exit(0)
-except:
+except Exception:
     # 'screenshot' var may not be defined.
     pass

--- a/tests/flows/test_server.py
+++ b/tests/flows/test_server.py
@@ -45,7 +45,7 @@ def test_gcd_server(gcd_chip):
     # Run the remote job.
     try:
         gcd_chip.run()
-    except:
+    except Exception:
         # Failures will be printed, and noted in the following assert.
         traceback.print_exc()
 


### PR DESCRIPTION
"except:" will catch e.g. KeyboardInterruptException, which can result in unintended effects like ctrl-c not working.

Instead use "except Exception:".

The code could be further refined to catch narrower exceptions than all exceptions, such as dealing with file not found differently than problems parsing a .yaml file, but that's for another pull request.

https://docs.python.org/3/library/exceptions.html