### PR TITLE
Surelog driver tweaks/fix Github Actions

### DIFF
--- a/.github/workflows/on_push_tests.yml
+++ b/.github/workflows/on_push_tests.yml
@@ -33,9 +33,8 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          # Workaround for Github Actions issue
-          # https://github.com/actions/virtual-environments/issues/5237
-          (sudo apt-get -y update || true) && sudo apt-get install graphviz
+          sudo apt-get update
+          sudo apt-get install graphviz
 
       - name: Set up Python ${{ matrix.version.python }}
         uses: actions/setup-python@v2

--- a/.github/workflows/on_push_tests.yml
+++ b/.github/workflows/on_push_tests.yml
@@ -23,11 +23,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ {python: "3.6", os: "ubuntu-20.04"}
-                   {python: "3.7", os: "ubuntu-latest"}
-                   {python: "3.8", os: "ubuntu-latest"}
-                   {python: "3.9", os: "ubuntu-latest"}
-                   {python: "3.10", os: "ubuntu-latest"} ]
+        version:
+          - {python: "3.6", os: "ubuntu-20.04"}
+          - {python: "3.7", os: "ubuntu-latest"}
+          - {python: "3.8", os: "ubuntu-latest"}
+          - {python: "3.9", os: "ubuntu-latest"}
+          - {python: "3.10", os: "ubuntu-latest"}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/on_push_tests.yml
+++ b/.github/workflows/on_push_tests.yml
@@ -18,12 +18,16 @@ jobs:
 
   python_test_job:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.version.os }}
     name: 'Pure Python tests'
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        version: [ {python: "3.6", os: "ubuntu-20.04"}
+                   {python: "3.7", os: "ubuntu-latest"}
+                   {python: "3.8", os: "ubuntu-latest"}
+                   {python: "3.9", os: "ubuntu-latest"}
+                   {python: "3.10", os: "ubuntu-latest"} ]
     steps:
       - uses: actions/checkout@v2
 
@@ -33,10 +37,10 @@ jobs:
           # https://github.com/actions/virtual-environments/issues/5237
           (sudo apt-get -y update || true) && sudo apt-get install graphviz
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.version.python }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.version.python }}
 
       - run: |
           pip install $GITHUB_WORKSPACE/.[test]

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -62,6 +62,10 @@ def setup(chip):
     # TODO: why?
     options.append('-nocache')
 
+    # We don't use UHDM currently, so disable. For large designs, this file is
+    # very big and takes a while to write out.
+    options.append('-nouhdm')
+
     # Wite back options to cfg
     chip.add('tool', tool, 'option', step, index, options)
 
@@ -81,6 +85,10 @@ def setup(chip):
     # Log file parsing
     chip.set('tool', tool, 'regex', step, index, 'warnings', r'^\[WRN:', clobber=False)
     chip.set('tool', tool, 'regex', step, index, 'errors', r'^\[(ERR|FTL|SNT):', clobber=False)
+
+    warnings_off = chip.get('tool', tool, 'warningoff')
+    for warning in warnings_off:
+        chip.add('tool', tool, 'regex', step, index, 'warnings', f'-v {warning}')
 
 def parse_version(stdout):
     # Surelog --version output looks like:


### PR DESCRIPTION
This PR implements some Surelog driver tweaks:

- Disable UHDM output
- Implement warningoff

I also included a fix to our Github Actions workflow to fix a breakage due to recent changes on Github's part - their 22.04 Ubuntu runners don't support Python 3.6, so we have to run those tests on a fixed version.