### PR TITLE
core: change the order of searching SCPATH

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -972,10 +972,11 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             return os.path.abspath(filename)
 
         # Otherwise, search relative to scpaths
-        scpaths = [self.scroot, self.cwd]
+        scpaths = [self.cwd]
         scpaths.extend(self.get('option', 'scpath'))
         if 'SCPATH' in os.environ:
             scpaths.extend(os.environ['SCPATH'].split(os.pathsep))
+        scpaths.append(self.scroot)
 
         searchdirs = ', '.join(scpaths)
         self.logger.debug(f"Searching for file {filename} in {searchdirs}")


### PR DESCRIPTION
Changes:
- SC search order to: 'cwd / scpath / ::env(SCPATH) / scroot' instead of 'scroot / cwd / scpath / ::env(SCPATH)'
