### PR TITLE
Tweaks to file path resolution

### DIFF
--- a/docs/user_guide/targets.rst
+++ b/docs/user_guide/targets.rst
@@ -5,10 +5,10 @@ To facilitate encapsulation and reuse of schema parameters related to design tar
 
 :meth:`.load_target()` takes in a string ``targetname``, and it will search for the path ``targets/<targetname>.py`` in the following locations, in this order:
 
-  #. The root of the SiliconCompiler Python package, wherever it is installed.
   #. The working directory from where the CLI app was called or the :class:`.Chip()` object instantiated.
   #. Paths specified in the :keypath:`option, scpath` schema parameter, separated by the OS-specific path separator (``:`` on Linux/macOS, ``;`` on Windows).
   #. Paths specified in the $SCPATH environment variable, separated by the OS-specific path separator.
+  #. The root of the SiliconCompiler Python package, wherever it is installed.
 
 The ability to configure the search paths via a schema parameter or environment variable enables users to create custom targets and place them anywhere on their filesystem. Note that this file resolution scheme is also used by SC for resolving all other relative paths, not just target modules.
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -968,7 +968,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         filename = self._resolve_env_vars(filename)
 
         # If we have an absolute path, pass-through here
-        if os.path.isabs(filename):
+        if os.path.isabs(filename) and os.path.exists(filename):
             return filename
 
         # Otherwise, search relative to scpaths

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -967,15 +967,16 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         # Replacing environment variables
         filename = self._resolve_env_vars(filename)
 
-        # If we have a path relative to our cwd or an abs path, pass-through here
-        if os.path.exists(os.path.abspath(filename)):
-            return os.path.abspath(filename)
+        # If we have an absolute path, pass-through here
+        if os.path.isabs(filename):
+            return filename
 
         # Otherwise, search relative to scpaths
-        scpaths = [self.scroot, self.cwd]
+        scpaths = [self.cwd]
         scpaths.extend(self.get('option', 'scpath'))
         if 'SCPATH' in os.environ:
             scpaths.extend(os.environ['SCPATH'].split(os.pathsep))
+        scpaths.append(self.scroot)
 
         searchdirs = ', '.join(scpaths)
         self.logger.debug(f"Searching for file {filename} in {searchdirs}")

--- a/tests/core/test_find_file.py
+++ b/tests/core/test_find_file.py
@@ -50,6 +50,16 @@ def test_find_sc_file_relative(datadir):
 
     assert chip._find_sc_file('test.txt', missing_ok=True) is not None
 
+def test_find_sc_file_cwd():
+    chip = siliconcompiler.Chip('test')
+    mydir = os.getcwd()
+
+    os.mkdir('test')
+    os.chdir('test')
+    # Should be relative to starting directory
+    assert chip._find_sc_file('.') == mydir
+    os.chdir(mydir)
+
 #########################
 if __name__ == "__main__":
     from tests.fixtures import datadir


### PR DESCRIPTION
1. Change order of resolution
2. Only bypass resolution if value is truly an absolute path, otherwise the code will return the path itself relative to the CWD when `_find_sc_file()` is called

Closes #1178 