### PR TITLE
More Vivado/FPGA enhancements

### DIFF
--- a/examples/blinky/run.sh
+++ b/examples/blinky/run.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-sc -input "rtl verilog blinky.v" \
-   -input "fpga pcf icebreaker.pcf" \
+sc blinky.v icebreaker.pcf \
    -fpga_partname "ice40up5k-sg48" \
    -target "fpgaflow_demo" \
    -design "blinky"

--- a/examples/blinky/run_vivado.sh
+++ b/examples/blinky/run_vivado.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-sc -input "rtl verilog blinky_fusesoc.v" \
+sc blinky_fusesoc.v blinky_fusesoc.xdc \
    -fpga_partname "xc7a35ticsg324" \
    -target "fpgaflow_demo" \
    -relax \
-   -input "fpga xdc blinky_fusesoc.xdc" \
    -design "blinky"

--- a/siliconcompiler/tools/vivado/vivado.py
+++ b/siliconcompiler/tools/vivado/vivado.py
@@ -56,6 +56,9 @@ def setup(chip):
     for metric in ('luts', 'registers', 'bram', 'uram'):
         chip.set('tool', tool, 'report', step, index, metric, 'reports/total_utilization.rpt')
 
+    chip.set('tool', tool, 'regex', step, index, 'errors', r'^ERROR:', clobber=False)
+    chip.set('tool', tool, 'regex', step, index, 'warnings', r'^(CRITICAL )?WARNING:', clobber=False)
+
 def parse_version(stdout):
     # Vivado v2021.2 (64-bit)
     return stdout.split()[1]

--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -243,6 +243,10 @@ def get_default_iomap():
     # Constraint
     constraint_sdc = ('sdc', )
 
+    # FPGA constraints
+    fpga_xdc = ('xdc',)
+    fpga_pcf = ('pcf',)
+
     # Build default map with fileset and type
     default_iomap = {}
     default_iomap.update({ext: ('hll', 'c') for ext in hll_c})
@@ -267,6 +271,9 @@ def get_default_iomap():
     default_iomap.update({ext: ('waveform', 'vcd') for ext in waveform_vcd})
 
     default_iomap.update({ext: ('constraint', 'sdc') for ext in constraint_sdc})
+
+    default_iomap.update({ext: ('fpga', 'xdc') for ext in fpga_xdc})
+    default_iomap.update({ext: ('fpga', 'pcf') for ext in fpga_pcf})
 
     return default_iomap
 


### PR DESCRIPTION
This PR contains another grab bag of tweaks related to Vivado/FPGA flows.

- Make it optional to supply an XDC file to the Vivado flow
  - Suggested by @petergrossmann21, this will make it easy to stand up quick tests to estimate the area of a design.
  - Verified working by manually removing constraint from Blinky example and running
- Add FPGA constraint files to the I/O map so we can supply them directly to `sc`
- Add warnings/errors regexes to Vivado driver