### PR TITLE
Adding footprint parameter to datasheet schema

### DIFF
--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -6,7 +6,7 @@ import re
 
 from siliconcompiler import utils
 
-SCHEMA_VERSION = '0.11.0'
+SCHEMA_VERSION = '0.12.0'
 
 #############################################################################
 # PARAM DEFINITION
@@ -837,6 +837,19 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 f"api: chip.set('datasheet','mydevice','feature','ram', 1e9)"],
             schelp=f"""Quantity of a specified feature. The 'unit'
             field should be used to specify the units used when unclear.""")
+
+    # Device Footprint
+    scparam(cfg, ['datasheet', design, 'footprint'],
+            sctype='[str]',
+            shorthelp=f"Datasheet: device footprint",
+            switch=f"-datasheet_footprint 'design <str>'",
+            example=[
+                f"cli: -datasheet_footprint 'mydsp bga169'",
+                f"api: chip.set('datasheet','mydsp', 'footprint','bga169')"],
+            schelp=f"""List of available physical footprints for the named
+            device specified as strings. Strings can either be official
+            standard footprint names or a custom naming methodology used in
+            conjunction with 'fileset' names in the output parameter.""")
 
     # Absolute max voltage
     scparam(cfg, ['datasheet', design, 'limits', 'voltage', name],

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1323,6 +1323,23 @@
                     "value": null
                 }
             },
+            "footprint": {
+                "defvalue": [],
+                "example": [
+                    "cli: -datasheet_footprint 'mydsp bga169'",
+                    "api: chip.set('datasheet','mydsp', 'footprint','bga169')"
+                ],
+                "help": "List of available physical footprints for the named\ndevice specified as strings. Strings can either be official\nstandard footprint names or a custom naming methodology used in\nconjunction with 'fileset' names in the output parameter.",
+                "lock": "false",
+                "notes": null,
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: device footprint",
+                "signature": [],
+                "switch": "-datasheet_footprint 'design <str>'",
+                "type": "[str]",
+                "value": []
+            },
             "limits": {
                 "junctiontemp": {
                     "defvalue": null,
@@ -5924,7 +5941,7 @@
         }
     },
     "schemaversion": {
-        "defvalue": "0.11.0",
+        "defvalue": "0.12.0",
         "example": [
             "api: chip.get('schemaversion')"
         ],
@@ -5937,7 +5954,7 @@
         "signature": null,
         "switch": "-schemaversion <str>",
         "type": "str",
-        "value": "0.11.0"
+        "value": "0.12.0"
     },
     "tool": {
         "default": {


### PR DESCRIPTION
- A footprint is a a must have parameter for all physical designs and it is a datasheet level parameter. (ie would be in the PDF).  https://www.jedec.org/category/technology-focus-area/jc-10/registered-outlines-jep95

 - The parameter is currently embedded in the asic group which is too limited.
 - This should be able to serve the need of the 'asic' 'footprint' as well...