### PR TITLE
update core to use tasks instead of step names

### DIFF
--- a/examples/gcd/gcd_skywater.py
+++ b/examples/gcd/gcd_skywater.py
@@ -63,12 +63,14 @@ def main():
     for step in chip.getkeys('flowgraph', 'asicflow'):
         for index in chip.getkeys('flowgraph', 'asicflow', step):
             tool = chip.get('flowgraph', 'asicflow', step, index, 'tool')
-            if tool not in chip.builtin:
+            task = chip._get_task(step, index, flow='asicflow')
+            if not chip._is_builtin(tool, task):
                 chip.add('checklist', 'oh_tapeout', 'errors_warnings', 'task', ('rtl2gds', step, index))
     for step in chip.getkeys('flowgraph', 'signoffflow'):
         for index in chip.getkeys('flowgraph', 'signoffflow', step):
             tool = chip.get('flowgraph', 'signoffflow', step, index, 'tool')
-            if tool not in chip.builtin:
+            task = chip._get_task(step, index, flow='signoffflow')
+            if not chip._is_builtin(tool, task):
                 chip.add('checklist', 'oh_tapeout', 'errors_warnings', 'task', ('signoff', step, index))
 
     status = chip.check_checklist('oh_tapeout')

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3491,17 +3491,17 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         score = 0
 
         if is_builtin:
-            self.logger.info(f"Running built in task '{tool}'")
+            self.logger.info(f"Running builtin task '{task}'")
             # Figure out which inputs to select
-            if tool == 'minimum':
+            if task == 'minimum':
                 (score, sel_inputs) = self.minimum(*inputs)
-            elif tool == "maximum":
+            elif task == "maximum":
                 (score, sel_inputs) = self.maximum(*inputs)
-            elif tool == "mux":
+            elif task == "mux":
                 (score, sel_inputs) = self.mux(*inputs, selector=args)
-            elif tool == "join":
+            elif task == "join":
                 sel_inputs = self.join(*inputs)
-            elif tool == "verify":
+            elif task == "verify":
                 if not self.verify(*input, assertion=args):
                     self._haltstep(step, index)
         else:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3626,6 +3626,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         max_mem_bytes = 0
 
         retcode = 0
+        cmdlist = []
         if is_builtin:
             utils.copytree(f"inputs", 'outputs', dirs_exist_ok=True, link=True)
         elif run_func and not self.get('option', 'skipall'):

--- a/siliconcompiler/flows/asicflow.py
+++ b/siliconcompiler/flows/asicflow.py
@@ -87,17 +87,17 @@ def setup(chip, flowname='asicflow'):
     tools = {
         'import' : ['surelog', 'import'],
         'syn' : ['yosys','syn_asic'],
-        'synmin' : ['minimum', 'synmin'],
+        'synmin' : ['builtin','minimum'],
         'floorplan' : ['openroad','floorplan'],
-        'floorplanmin' : ['minimum','floorplanmin'],
+        'floorplanmin' : ['builtin','minimum'],
         'physyn' : ['openroad','physyn'],
-        'physynmin' : ['minimum','physynmin'],
+        'physynmin' : ['builtin','minimum'],
         'place' : ['openroad','place'],
-        'placemin' : ['minimum','placemin'],
+        'placemin' : ['builtin','minimum'],
         'cts' : ['openroad','cts'],
-        'ctsmin' : ['minimum','ctsmin'],
+        'ctsmin' : ['builtin','minimum'],
         'route' : ['openroad','route'],
-        'routemin' : ['minimum','routemin'],
+        'routemin' : ['builtin','minimum'],
         'dfm' : ['openroad','dfm'],
         'export' : ['klayout', 'export']
     }
@@ -109,7 +109,7 @@ def setup(chip, flowname='asicflow'):
     #Remove built in steps where appropriate
     flowpipe = []
     for step in longpipe:
-        if re.search(r'join|maximum|minimum|verify', tools[step][0]):
+        if tools[step][0] == 'builtin':
             if bool(prevstep + "_np" in chip.getkeys('arg','flow')):
                 flowpipe.append(step)
         else:
@@ -139,7 +139,7 @@ def setup(chip, flowname='asicflow'):
             # nodes
             chip.node(flowname, step, tool, task, index=index)
             # edges
-            if re.search(r'join|maximum|minimum|verify', tool):
+            if tool == 'builtin':
                 prevparam = prevstep + "_np"
                 fanin  = int(chip.get('arg', 'flow', prevparam)[0])
                 for i in range(fanin):

--- a/siliconcompiler/flows/asictopflow.py
+++ b/siliconcompiler/flows/asictopflow.py
@@ -17,7 +17,7 @@ def setup(chip):
     chip.node(flow, 'import', 'surelog', 'import')
     chip.node(flow, 'syn', 'yosys', 'syn_asic')
     chip.node(flow, 'export', 'klayout', 'export')
-    chip.node(flow, 'merge', 'join', 'merge')
+    chip.node(flow, 'merge', 'builtin', 'join')
 
     chip.edge(flow, 'import', 'export')
     chip.edge(flow, 'import', 'syn')

--- a/siliconcompiler/flows/fpgaflow.py
+++ b/siliconcompiler/flows/fpgaflow.py
@@ -96,7 +96,7 @@ def setup(chip, flowname='fpgaflow'):
     for step,tool,task in flowtools:
         # Flow
         chip.node(flowname, step, tool,task)
-        if step != 'import':
+        if task != 'import':
             chip.edge(flowname, prevstep, step)
         # Hard goals
         for metric in ('errors','warnings','drvs','unconstrained',

--- a/siliconcompiler/flows/lintflow.py
+++ b/siliconcompiler/flows/lintflow.py
@@ -37,7 +37,7 @@ def setup(chip):
 
     for step, tool, task in pipe:
         chip.node(flowname, step, tool, task)
-        if step != 'import':
+        if task != 'import':
             chip.edge(flowname, prevstep, step)
         prevstep = step
 

--- a/siliconcompiler/flows/showflow.py
+++ b/siliconcompiler/flows/showflow.py
@@ -86,7 +86,7 @@ def setup(chip, flowname='showflow'):
     if flowname in chip.getkeys('flowgraph'):
         del chip.schema.cfg['flowgraph'][flowname]
 
-    chip.node(flowname, 'import', 'nop', 'nop')
+    chip.node(flowname, 'import', 'builtin', 'import')
 
     show_tool = chip.get('option', 'showtool', filetype)
 

--- a/siliconcompiler/flows/signoffflow.py
+++ b/siliconcompiler/flows/signoffflow.py
@@ -17,12 +17,12 @@ def setup(chip):
     flow = 'signoffflow'
 
     # nop import since we don't need to pull in any sources
-    chip.node(flow, 'import', 'nop', 'nop')
+    chip.node(flow, 'import', 'builtin', 'import')
 
     chip.node(flow, 'extspice', 'magic', 'extspice')
     chip.node(flow, 'drc', 'magic', 'drc')
     chip.node(flow, 'lvs', 'netgen', 'lvs')
-    chip.node(flow, 'signoff', 'join', 'signoff')
+    chip.node(flow, 'signoff', 'builtin', 'join')
 
     chip.edge(flow, 'import', 'drc')
     chip.edge(flow, 'import', 'extspice')

--- a/tests/core/test_check_flowgraph_io.py
+++ b/tests/core/test_check_flowgraph_io.py
@@ -31,7 +31,7 @@ def test_check_flowgraph_join():
     chip.set('option', 'flow', flow)
     chip.node(flow, 'prejoin1', 'fake_out', 'prejoin1')
     chip.node(flow, 'prejoin2', 'fake_out', 'prejoin2')
-    chip.node(flow, 'dojoin', 'join', 'dojoin')
+    chip.node(flow, 'dojoin', 'builtin', 'join')
     chip.node(flow, 'postjoin', 'fake_in', 'postjoin')
 
     chip.edge(flow, 'prejoin1', 'dojoin')
@@ -52,7 +52,7 @@ def test_check_flowgraph_min():
     chip.set('option', 'flow', flow)
     chip.node(flow, 'premin', 'fake_out', 'premin', index=0)
     chip.node(flow, 'premin', 'fake_out', 'premin', index=1)
-    chip.node(flow, 'domin', 'minimum', 'domin')
+    chip.node(flow, 'domin', 'builtin', 'minimum')
     chip.node(flow, 'postmin', 'fake_in', 'postmin')
 
     chip.edge(flow, 'premin', 'domin', tail_index=0)
@@ -73,7 +73,7 @@ def test_check_flowgraph_min_fail():
     chip.set('option', 'flow', flow)
     chip.node(flow, 'premin', 'fake_out', 'premin', index=0)
     chip.node(flow, 'premin', 'fake_out', 'premin', index=1)
-    chip.node(flow, 'domin', 'minimum', 'domin')
+    chip.node(flow, 'domin', 'builtin', 'minimum')
     chip.node(flow, 'postmin', 'fake_in', 'postmin')
 
     chip.edge(flow, 'premin', 'domin', tail_index=0)

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -102,7 +102,7 @@ def merge_flow_chip():
     chip = siliconcompiler.Chip('test')
 
     flow = 'test'
-    chip.node(flow, 'import', 'nop', 'nop')
+    chip.node(flow, 'import', 'builtin', 'import')
     chip.node(flow, 'parallel1', 'foo', 'parallel1')
     chip.node(flow, 'parallel2', 'bar', 'parallel2')
     chip.edge(flow, 'import', 'parallel1')
@@ -130,7 +130,7 @@ def test_merged_graph_good(merge_flow_chip):
 def test_merged_graph_good_steplist():
     chip = siliconcompiler.Chip('test')
     flow = 'test'
-    chip.node(flow, 'import', 'nop', 'nop')
+    chip.node(flow, 'import', 'builtin', 'import')
     chip.node(flow, 'parallel1', 'echo', 'parallel1')
     chip.node(flow, 'parallel2', 'echo', 'parallel2')
     chip.node(flow, 'merge', 'echo', 'merge')
@@ -141,7 +141,6 @@ def test_merged_graph_good_steplist():
     chip.edge(flow, 'parallel2', 'merge')
     chip.edge(flow, 'merge', 'export')
     chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, 'import', '0', 'task', 'echo')
     chip.set('flowgraph', flow, 'merge', '0', 'task', 'echo')
     chip.set('flowgraph', flow, 'export', '0', 'task', 'echo')
     chip.set('flowgraph', flow, 'parallel1', '0', 'task', 'echo')

--- a/tests/core/test_jobincr.py
+++ b/tests/core/test_jobincr.py
@@ -6,8 +6,7 @@ def test_jobincr():
     chip = siliconcompiler.Chip('test')
     flow = 'test'
     chip.set('option', 'flow', flow)
-    chip.node(flow, 'import', 'echo', 'import')
-    chip.set('flowgraph', flow, 'import', '0', 'task', 'echo')
+    chip.node(flow, 'import', 'builtin', 'import')
 
     chip.set('option', 'jobincr', True)
 

--- a/tests/flows/test_flowstatus.py
+++ b/tests/flows/test_flowstatus.py
@@ -32,7 +32,7 @@ def test_flowstatus(scroot, steplist):
 
     flow = 'test'
     # no-op import since we're not preprocessing source files
-    chip.node(flow, 'import', 'join', 'import')
+    chip.node(flow, 'import', 'builtin', 'import')
 
     chip.node(flow, 'place', 'openroad', 'place', index='0')
     chip.node(flow, 'place', 'openroad', 'place', index='1')
@@ -46,7 +46,7 @@ def test_flowstatus(scroot, steplist):
     chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '1', 'place_density', '0.5')
 
     # Perform minimum
-    chip.node(flow, 'placemin', 'minimum', 'placemin')
+    chip.node(flow, 'placemin', 'builtin', 'minimum')
     chip.edge(flow, 'place', 'placemin', tail_index='0')
     chip.edge(flow, 'place', 'placemin', tail_index='1')
 
@@ -89,7 +89,7 @@ def test_long_branch(scroot):
 
     flow = 'test'
     # no-op import since we're not preprocessing source files
-    chip.node(flow, 'import', 'join', 'import')
+    chip.node(flow, 'import', 'builtin', 'import')
 
     chip.node(flow, 'place', 'openroad', 'place', index='0')
     chip.node(flow, 'place', 'openroad', 'place', index='1')

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -70,7 +70,7 @@ def chip(scroot):
     flow = chip.get('option', 'flow')
 
     # no-op import since we're not preprocessing source files
-    chip.node(flow, 'import', 'join', 'join')
+    chip.node(flow, 'import', 'builtin', 'import')
 
     chip.node(flow, 'place', 'openroad', 'place', index=0)
     chip.edge(flow, 'import', 'place', head_index=0)
@@ -94,7 +94,7 @@ def test_failed_branch_min(chip):
     chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '1', 'place_density', '0.5')
 
     # Perform minimum
-    chip.node(flow, 'placemin', 'minimum', 'minimum')
+    chip.node(flow, 'placemin', 'builtin', 'minimum')
     chip.edge(flow, 'place', 'placemin', tail_index=0)
     chip.edge(flow, 'place', 'placemin', tail_index=1)
 
@@ -124,7 +124,7 @@ def test_all_failed_min(chip):
     chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '1', 'place_density', 'asdf')
 
     # Perform minimum
-    chip.node(flow, 'placemin', 'minimum', 'minimum')
+    chip.node(flow, 'placemin', 'builtin', 'minimum')
     chip.edge(flow, 'place', 'placemin', tail_index=0)
     chip.edge(flow, 'place', 'placemin', tail_index=1)
 
@@ -148,7 +148,7 @@ def test_branch_failed_join(chip):
     chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '1', 'place_density', '0.5')
 
     # Perform join
-    chip.node(flow, 'placemin', 'join', 'join')
+    chip.node(flow, 'placemin', 'builtin', 'join')
     chip.edge(flow, 'place', 'placemin', tail_index=0)
     chip.edge(flow, 'place', 'placemin', tail_index=1)
 

--- a/tests/tools/test_icarus.py
+++ b/tests/tools/test_icarus.py
@@ -18,7 +18,7 @@ def test_icarus(oh_dir):
     chip.set('option', 'mode', 'sim')
 
     flow = 'sim'
-    chip.node(flow, 'import', 'nop', 'nop')
+    chip.node(flow, 'import', 'builtin', 'import')
     chip.node(flow, 'compile', 'icarus', 'compile')
     chip.edge(flow, 'import', 'compile')
     chip.set('option', 'flow', flow)

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -25,7 +25,7 @@ def test_openroad(scroot):
 
     # set up tool for floorplan
     flow = 'floorplan'
-    chip.node(flow, 'import', 'nop', 'nop')
+    chip.node(flow, 'import', 'builtin', 'import')
     chip.node(flow, 'floorplan', 'openroad', 'floorplan')
     chip.edge(flow, 'import', 'floorplan')
     chip.set('option', 'flow', flow)

--- a/tests/tools/test_yosys.py
+++ b/tests/tools/test_yosys.py
@@ -13,7 +13,7 @@ def test_yosys_lec(datadir):
     chip.set('option', 'mode', 'asic')
 
     flow = 'lec'
-    chip.node(flow, 'import', 'nop', 'nop')
+    chip.node(flow, 'import', 'builtin', 'import')
     chip.node(flow, 'lec', 'yosys', 'lec')
     chip.edge(flow, 'import', 'lec')
     chip.set('option', 'flow', flow)
@@ -38,7 +38,7 @@ def test_yosys_lec_broken(datadir):
     chip.set('option', 'mode', 'asic')
 
     flow = 'lec'
-    chip.node(flow, 'import', 'nop', 'nop')
+    chip.node(flow, 'import', 'builtin', 'import')
     chip.node(flow, 'lec', 'yosys', 'lec')
     chip.edge(flow, 'import', 'lec')
     chip.set('option','flow', flow)


### PR DESCRIPTION
Fixes:
- Updates left over references to steps to be specific to tasks instead.

Changes:
- Changes names of builtin tasks to be a tool name of `builtin` with the associated task and adds `import` as a task which behaves like a `nop` but is needed for flow validation.
