### PR TITLE
Schema sub-classes

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -588,6 +588,11 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         # TODO: Move from 'module.setup(self)' to 'self.[merge](module.setup())'
         new_schema = module.setup(self)
 
+        # Process new values based on Schema sub-type.
+        # TODO: Remove 'chip' refs in setup() signature once all import types are converted.
+        if isinstance(new_schema, PDKSchema):
+            self._merge_manifest(new_schema)
+
         # TODO: Is this the best way to determine module type? Also, remove chip arg from all but target?
         if 'targets' in module.__name__:
             self.set('option', 'target', module.__name__[module.__name__.rfind('.')+1:])

--- a/siliconcompiler/pdks/asap7.py
+++ b/siliconcompiler/pdks/asap7.py
@@ -2,6 +2,7 @@ import os
 import sys
 import re
 import siliconcompiler
+from siliconcompiler.schema import PDKSchema
 
 def make_docs():
     '''
@@ -60,24 +61,26 @@ def setup(chip):
     libtype = '7p5t'
     pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
 
+    schema = PDKSchema()
+
     # process name
-    chip.set('pdk', process, 'foundry', foundry)
-    chip.set('pdk', process, 'node', node)
-    chip.set('pdk', process, 'wafersize', wafersize)
-    chip.set('pdk', process, 'version', rev)
-    chip.set('pdk', process, 'stackup', stackup)
+    schema.set('pdk', process, 'foundry', foundry)
+    schema.set('pdk', process, 'node', node)
+    schema.set('pdk', process, 'wafersize', wafersize)
+    schema.set('pdk', process, 'version', rev)
+    schema.set('pdk', process, 'stackup', stackup)
 
     # APR tech file
     for tool in ('openroad', 'klayout', 'magic'):
-        chip.set('pdk', process, 'aprtech', tool, stackup, libtype, 'lef',
+        schema.set('pdk', process, 'aprtech', tool, stackup, libtype, 'lef',
                  pdkdir+'/apr/asap7_tech.lef')
 
-    chip.set('pdk', process, 'minlayer', stackup, 'M2')
-    chip.set('pdk', process, 'maxlayer', stackup, 'M7')
+    schema.set('pdk', process, 'minlayer', stackup, 'M2')
+    schema.set('pdk', process, 'maxlayer', stackup, 'M7')
 
     # Klayout setup file
-    chip.set('pdk', process, 'layermap','klayout','def','gds',stackup,
-             pdkdir+'/setup/klayout/asap7.lyt')
+    schema.set('pdk', process, 'layermap','klayout','def','gds',stackup,
+               pdkdir+'/setup/klayout/asap7.lyt')
 
     # Openroad global routing grid derating
     openroad_layer_adjustments = {
@@ -92,17 +95,19 @@ def setup(chip):
         'M9': 0.4
     }
     for layer, adj in openroad_layer_adjustments.items():
-        chip.set('pdk', process, 'var', 'openroad', f'{layer}_adjustment', stackup, str(adj))
+        schema.set('pdk', process, 'var', 'openroad', f'{layer}_adjustment', stackup, str(adj))
 
-    chip.set('pdk', process, 'var', 'openroad', 'rclayer_signal', stackup, 'M3')
-    chip.set('pdk', process, 'var', 'openroad', 'rclayer_clock', stackup, 'M5')
+    schema.set('pdk', process, 'var', 'openroad', 'rclayer_signal', stackup, 'M3')
+    schema.set('pdk', process, 'var', 'openroad', 'rclayer_clock', stackup, 'M5')
 
-    chip.set('pdk', process, 'var', 'openroad', 'pin_layer_vertical', stackup, 'M5')
-    chip.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'M4')
+    schema.set('pdk', process, 'var', 'openroad', 'pin_layer_vertical', stackup, 'M5')
+    schema.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'M4')
 
     # PEX
-    chip.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
-        pdkdir + '/pex/openroad/typical.tcl')
+    schema.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
+               pdkdir + '/pex/openroad/typical.tcl')
+
+    return schema
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/pdks/freepdk45.py
+++ b/siliconcompiler/pdks/freepdk45.py
@@ -3,6 +3,7 @@ import os
 import sys
 import re
 import siliconcompiler
+from siliconcompiler.schema import PDKSchema
 
 
 ############################################################################
@@ -62,31 +63,33 @@ def setup(chip):
 
     pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
 
+    schema = PDKSchema()
+
     # process name
-    chip.set('pdk', process, 'foundry', foundry)
-    chip.set('pdk', process, 'node', node)
-    chip.set('pdk', process, 'version', rev)
-    chip.set('pdk', process, 'stackup', stackup)
-    chip.set('pdk', process, 'wafersize', wafersize)
-    chip.set('pdk', process, 'edgemargin', edgemargin)
-    chip.set('pdk', process, 'hscribe', hscribe)
-    chip.set('pdk', process, 'vscribe', vscribe)
-    chip.set('pdk', process, 'd0', d0)
+    schema.set('pdk', process, 'foundry', foundry)
+    schema.set('pdk', process, 'node', node)
+    schema.set('pdk', process, 'version', rev)
+    schema.set('pdk', process, 'stackup', stackup)
+    schema.set('pdk', process, 'wafersize', wafersize)
+    schema.set('pdk', process, 'edgemargin', edgemargin)
+    schema.set('pdk', process, 'hscribe', hscribe)
+    schema.set('pdk', process, 'vscribe', vscribe)
+    schema.set('pdk', process, 'd0', d0)
 
     # APR Setup
     for tool in ('openroad', 'klayout', 'magic'):
-        chip.set('pdk', process, 'aprtech', tool, stackup, libtype, 'lef',
-                 pdkdir+'/apr/freepdk45.tech.lef')
+        schema.set('pdk', process, 'aprtech', tool, stackup, libtype, 'lef',
+                   pdkdir+'/apr/freepdk45.tech.lef')
 
-    chip.set('pdk', process, 'minlayer', stackup, 'metal1')
-    chip.set('pdk', process, 'maxlayer', stackup, 'metal10')
+    schema.set('pdk', process, 'minlayer', stackup, 'metal1')
+    schema.set('pdk', process, 'maxlayer', stackup, 'metal10')
 
     # Klayout setup file
-    chip.set('pdk', process, 'layermap', 'klayout', 'def', 'gds', stackup,
-             pdkdir+'/setup/klayout/freepdk45.lyt')
+    schema.set('pdk', process, 'layermap', 'klayout', 'def', 'gds', stackup,
+                pdkdir+'/setup/klayout/freepdk45.lyt')
 
-    chip.set('pdk', process, 'display', 'klayout', stackup,
-            pdkdir + '/setup/klayout/freepdk45.lyp')
+    schema.set('pdk', process, 'display', 'klayout', stackup,
+               pdkdir + '/setup/klayout/freepdk45.lyp')
 
     # Openroad global routing grid derating
     openroad_layer_adjustments = {
@@ -102,17 +105,19 @@ def setup(chip):
         'metal10': 0.4
     }
     for layer, adj in openroad_layer_adjustments.items():
-        chip.set('pdk', process, 'var', 'openroad', f'{layer}_adjustment', stackup, str(adj))
+        schema.set('pdk', process, 'var', 'openroad', f'{layer}_adjustment', stackup, str(adj))
 
-    chip.set('pdk', process, 'var', 'openroad', 'rclayer_signal', stackup, 'metal3')
-    chip.set('pdk', process, 'var', 'openroad', 'rclayer_clock', stackup, 'metal5')
+    schema.set('pdk', process, 'var', 'openroad', 'rclayer_signal', stackup, 'metal3')
+    schema.set('pdk', process, 'var', 'openroad', 'rclayer_clock', stackup, 'metal5')
 
-    chip.set('pdk', process, 'var', 'openroad', 'pin_layer_vertical', stackup, 'metal2')
-    chip.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'metal3')
+    schema.set('pdk', process, 'var', 'openroad', 'pin_layer_vertical', stackup, 'metal2')
+    schema.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'metal3')
 
     # PEX
-    chip.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
-        pdkdir + '/pex/openroad/typical.tcl')
+    schema.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
+               pdkdir + '/pex/openroad/typical.tcl')
+
+    return schema
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/pdks/lambda.py
+++ b/siliconcompiler/pdks/lambda.py
@@ -4,6 +4,7 @@ import sys
 import re
 import numpy as np
 import siliconcompiler
+from siliconcompiler.schema import PDKSchema
 
 ####################################################
 # PDK Setup
@@ -17,14 +18,16 @@ def setup_pdk(chip):
     nodes.
     '''
 
+    schema = PDKSchema()
+
     ###############################################
     # Process
     ###############################################
 
     # Process details
-    chip.set('pdk','foundry', 'virtual')
-    chip.set('pdk','process', 'lambda')
-    chip.set('pdk','version', 'r1p0')
+    schema.set('pdk','foundry', 'virtual')
+    schema.set('pdk','process', 'lambda')
+    schema.set('pdk','version', 'r1p0')
 
     #User arguments
     if 'node' in chip.getkeys('techarg'):
@@ -34,8 +37,8 @@ def setup_pdk(chip):
         node = 45
         stackup = "M10"
 
-    chip.set('pdk','node', node)
-    chip.set('pdk','stackup', stackup)
+    schema.set('pdk','node', node)
+    schema.set('pdk','stackup', stackup)
 
     # Wafer Size
     if node > 130:
@@ -47,16 +50,16 @@ def setup_pdk(chip):
     # DPW Settings
     ##################
 
-    chip.set('pdk','edgemargin', 2)
-    chip.set('pdk','hscribe', 0.1)
-    chip.set('pdk','vscribe', 0.1)
-    chip.set('pdk','d0', 1.25)
+    schema.set('pdk','edgemargin', 2)
+    schema.set('pdk','hscribe', 0.1)
+    schema.set('pdk','vscribe', 0.1)
+    schema.set('pdk','d0', 1.25)
 
     # LUT + interpolation
     tapmax = 100
     tapoffset = 0
-    chip.set('pdk','tapmax', tapmax)
-    chip.set('pdk','tapoffset', tapoffset)
+    schema.set('pdk','tapmax', tapmax)
+    schema.set('pdk','tapoffset', tapoffset)
 
     ##################
     # APR Settings

--- a/siliconcompiler/pdks/lambda.py
+++ b/siliconcompiler/pdks/lambda.py
@@ -82,6 +82,8 @@ def setup_pdk(chip):
     # Methodology (TBD)
     ###############################################
 
+    return schema
+
 #########################
 if __name__ == "__main__":
 

--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -119,6 +119,8 @@ def setup(chip):
     schema.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
                pdkdir + '/pex/openroad/typical.tcl')
 
+    return schema
+
 #########################
 if __name__ == "__main__":
 

--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -3,6 +3,7 @@ import os
 import sys
 import re
 import siliconcompiler
+from siliconcompiler.schema import PDKSchema
 
 ############################################################################
 # DOCS
@@ -54,6 +55,8 @@ def setup(chip):
     rev = 'v0_0_2'
     stackup = '5M1LI'
 
+    schema = PDKSchema()
+
     # TODO: eventualy support hs libtype as well
     libtype = 'unithd'
     node = 130
@@ -66,33 +69,33 @@ def setup(chip):
     pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
 
     # process name
-    chip.set('pdk', process, 'foundry', foundry)
-    chip.set('pdk', process, 'node', node)
-    chip.set('pdk', process, 'version', rev)
-    chip.set('pdk', process, 'stackup', stackup)
-    chip.set('pdk', process, 'wafersize', wafersize)
-    chip.set('pdk', process, 'edgemargin', edgemargin)
-    chip.set('pdk', process, 'hscribe', hscribe)
-    chip.set('pdk', process, 'vscribe', vscribe)
+    schema.set('pdk', process, 'foundry', foundry)
+    schema.set('pdk', process, 'node', node)
+    schema.set('pdk', process, 'version', rev)
+    schema.set('pdk', process, 'stackup', stackup)
+    schema.set('pdk', process, 'wafersize', wafersize)
+    schema.set('pdk', process, 'edgemargin', edgemargin)
+    schema.set('pdk', process, 'hscribe', hscribe)
+    schema.set('pdk', process, 'vscribe', vscribe)
 
     # APR Setup
     # TODO: remove libtype
     for tool in ('openroad', 'klayout', 'magic'):
-        chip.set('pdk', process,'aprtech',tool,stackup, libtype,'lef',
-                 pdkdir+'/apr/sky130_fd_sc_hd.tlef')
+        schema.set('pdk', process,'aprtech',tool,stackup, libtype,'lef',
+                   pdkdir+'/apr/sky130_fd_sc_hd.tlef')
 
-    chip.set('pdk', process, 'minlayer', stackup, 'met1')
-    chip.set('pdk', process, 'maxlayer', stackup, 'met5')
+    schema.set('pdk', process, 'minlayer', stackup, 'met1')
+    schema.set('pdk', process, 'maxlayer', stackup, 'met5')
 
     # DRC Runsets
-    chip.set('pdk', process,'drc', 'runset', 'magic', stackup, 'basic', pdkdir+'/setup/magic/sky130A.tech')
+    schema.set('pdk', process,'drc', 'runset', 'magic', stackup, 'basic', pdkdir+'/setup/magic/sky130A.tech')
 
     # LVS Runsets
-    chip.set('pdk', process,'lvs', 'runset', 'netgen', stackup, 'basic', pdkdir+'/setup/netgen/lvs_setup.tcl')
+    schema.set('pdk', process,'lvs', 'runset', 'netgen', stackup, 'basic', pdkdir+'/setup/netgen/lvs_setup.tcl')
 
     # Layer map and display file
-    chip.set('pdk', process, 'layermap', 'klayout', 'def', 'gds', stackup, pdkdir+'/setup/klayout/skywater130.lyt')
-    chip.set('pdk', process, 'display', 'klayout', stackup, pdkdir+'/setup/klayout/sky130A.lyp')
+    schema.set('pdk', process, 'layermap', 'klayout', 'def', 'gds', stackup, pdkdir+'/setup/klayout/skywater130.lyt')
+    schema.set('pdk', process, 'display', 'klayout', stackup, pdkdir+'/setup/klayout/sky130A.lyp')
 
     # Openroad global routing grid derating
     openroad_layer_adjustments = {
@@ -104,17 +107,17 @@ def setup(chip):
         'met5': 0.5,
     }
     for layer, adj in openroad_layer_adjustments.items():
-        chip.set('pdk', process, 'var', 'openroad', f'{layer}_adjustment', stackup, str(adj))
+        schema.set('pdk', process, 'var', 'openroad', f'{layer}_adjustment', stackup, str(adj))
 
-    chip.set('pdk', process, 'var', 'openroad', 'rclayer_signal', stackup, 'met3')
-    chip.set('pdk', process, 'var', 'openroad', 'rclayer_clock', stackup, 'met4')
+    schema.set('pdk', process, 'var', 'openroad', 'rclayer_signal', stackup, 'met3')
+    schema.set('pdk', process, 'var', 'openroad', 'rclayer_clock', stackup, 'met4')
 
-    chip.set('pdk', process, 'var', 'openroad', 'pin_layer_vertical', stackup, 'met2')
-    chip.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'met3')
+    schema.set('pdk', process, 'var', 'openroad', 'pin_layer_vertical', stackup, 'met2')
+    schema.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'met3')
 
     # PEX
-    chip.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
-        pdkdir + '/pex/openroad/typical.tcl')
+    schema.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
+               pdkdir + '/pex/openroad/typical.tcl')
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/schema/__init__.py
+++ b/siliconcompiler/schema/__init__.py
@@ -1,2 +1,3 @@
 from .schema_cfg import SCHEMA_VERSION
 from .schema_obj import Schema
+from .schema_pdk import PDKSchema

--- a/siliconcompiler/schema/schema_pdk.py
+++ b/siliconcompiler/schema/schema_pdk.py
@@ -1,0 +1,49 @@
+# Copyright 2023 Silicon Compiler Authors. All Rights Reserved.
+
+from .schema_cfg import schema_cfg
+from .schema_obj import Schema
+
+class PDKSchema(Schema):
+    """
+    Schema sub-class for storing PDK keys.
+
+    This object is used to help construct a Chip object's configuration. In almost all cases,
+    the base Schema class should be used instead of this.
+
+    Attempts to set values outside of the top-level 'pdk' Schema key will cause errors,
+    which should help us to keep liberty/tool/etc configurations out of our PDK setup modules.
+    """
+
+    def __init__(self, cfg=None, manifest=None):
+        if cfg is not None and manifest is not None:
+            raise ValueError('You may not specify both cfg and manifest')
+
+        if cfg is not None:
+            self.cfg = copy.deepcopy(cfg)
+        elif manifest is not None:
+            self.cfg = Schema._read_manifest(manifest)
+        else:
+            self.cfg = schema_cfg()
+
+        # Only use PDK keys, and some minor bookkeeping.
+        # Convert to 'list' to prefetch keys, and avoid modifying the dict during iteration.
+        for k in list(self.cfg.keys()):
+            if not k in ('pdk', 'schemaversion'):
+                self.cfg.pop(k)
+
+    ##########################################################################
+    def record_history(self):
+        ''' Override 'record_history' method, since Schema subclasses are only used for imports.
+        '''
+        pass
+
+    ###########################################################################
+    def history(self, job):
+        ''' Override 'record_history' method, since Schema subclasses are only used for imports.
+        '''
+        return None
+
+    ###########################################################################
+    def copy(self):
+        '''Returns deep copy of PDKSchema object.'''
+        return PDKSchema(cfg=self.cfg)


### PR DESCRIPTION
Draft PR demonstrating how we can use sub-classes of the `Schema` object to detect the type of an imported module, and restrict which keys can be set by different types of modules.

If this implementation makes sense, we can do the same for `libs/`, `flows/`, and `checklists/`. Like we've discussed, `targets/` and `tools/` will be special cases, because tools are configured at runtime and targets can set values throughout the entire schema.