### PR TITLE
Clean up `summary()`/HTML report logic

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2790,7 +2790,10 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             data.append(row)
 
         df = pandas.DataFrame(data, row_labels, column_labels)
-        print(df.to_string())
+        if not df.empty:
+            print(df.to_string())
+        else:
+            print(' No metrics to display!')
         print("-"*135)
 
         # Create a report for the Chip object which can be viewed in a web browser.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2717,26 +2717,18 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         print("-"*135)
         print(info, "\n")
 
-        # Stepping through all steps/indices and printing out metrics
-        data = []
+        # Collections for data
+        nodes = []
+        errors = {}
+        metrics = {}
+        reports = {}
 
-        #Creating Header
-        header = []
-        indices_to_show = {}
-        colwidth = 8
+        # Build ordered list of nodes in flowgraph
         for step in steplist:
-            if show_all_indices:
-                indices_to_show[step] = self.getkeys('flowgraph', flow, step)
-            else:
-                indices_to_show[step] = []
-                for index in self.getkeys('flowgraph', flow, step):
-                    if (step, index) in selected_tasks:
-                        indices_to_show[step].append(index)
-
-        # header for data frame
-        for step in steplist:
-            for index in indices_to_show[step]:
-                header.append(f'{step}{index}'.center(colwidth))
+            for index in self.getkeys('flowgraph', flow, step):
+                nodes.append((step, index))
+                metrics[step, index] = {}
+                reports[step, index] = {}
 
         # Gather data and determine which metrics to show
         # We show a metric if:
@@ -2748,34 +2740,56 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             if metric in self.get('option', 'metricoff'):
                 continue
 
-            row = []
             show_metric = False
-            for step in steplist:
-                for index in indices_to_show[step]:
-                    if (
-                        metric in self.getkeys('flowgraph', flow, step, index, 'weight') and
-                        self.get('flowgraph', flow, step, index, 'weight', metric)
-                    ):
-                        show_metric = True
+            for step, index in nodes:
+                if (
+                    metric in self.getkeys('flowgraph', flow, step, index, 'weight') and
+                    self.get('flowgraph', flow, step, index, 'weight', metric)
+                ):
+                    show_metric = True
 
-                    value = self.get('metric', step, index, metric)
-                    if value is None:
-                        value = '---'
-                    else:
-                        value = str(value)
-                        show_metric = True
+                value = self.get('metric', step, index, metric)
+                if value is not None:
+                    show_metric = True
+                tool = self.get('flowgraph', flow, step, index, 'tool')
+                task = self._get_task(step, index, flow=flow)
+                rpts = self.get('tool', tool, 'task', task, 'report', step, index, metric)
 
-                    row.append(" " + value.center(colwidth))
+                errors[step, index] = self.get('flowgraph', flow, step, index, 'status') == TaskStatus.ERROR
+                metrics[step, index][metric] = value
+                reports[step, index][metric] = rpts
 
             if show_metric:
                 metrics_to_show.append(metric)
-                data.append(row)
 
+        # Display data
         pandas.set_option('display.max_rows', 500)
         pandas.set_option('display.max_columns', 500)
         pandas.set_option('display.width', 100)
-        metrics = [" " + metric for metric in metrics_to_show]
-        df = pandas.DataFrame(data, metrics, header)
+
+        if show_all_indices:
+            nodes_to_show = nodes
+        else:
+            nodes_to_show = [n for n in nodes if n in selected_tasks]
+
+        colwidth = 8 # minimum col width
+        row_labels = [' ' + metric for metric in metrics_to_show]
+        column_labels = [f'{step}{index}'.center(colwidth) for step, index in nodes_to_show]
+
+        data = []
+        for metric in metrics_to_show:
+            row = []
+            for node in nodes_to_show:
+                value = metrics[node][metric]
+                if value is None:
+                    value = '---'
+                else:
+                    value = str(value)
+                value = ' ' + value.center(colwidth)
+                row.append(value)
+            data.append(row)
+
+        df = pandas.DataFrame(data, row_labels, column_labels)
         print(df.to_string())
         print("-"*135)
 
@@ -2786,11 +2800,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             # Gather essential variables.
             templ_dir = os.path.join(self.scroot, 'templates', 'report')
             design = self.top()
-            flow = self.get('option', 'flow')
-            flow_steps = steplist
-            flow_tasks = {}
-            for step in flow_steps:
-                flow_tasks[step] = self.getkeys('flowgraph', flow, step)
 
             # Call 'show()' to generate a low-res PNG of the design.
             img_data = None
@@ -2821,11 +2830,14 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             # default encoding is not UTF-8.
             with open(results_page, 'w', encoding='utf-8') as wf:
                 wf.write(env.get_template('sc_report.j2').render(
+                    design = design,
+                    nodes = nodes,
+                    errors = errors,
+                    metrics = metrics,
+                    reports = reports,
                     manifest = self.schema.cfg,
                     pruned_cfg = pruned_cfg,
                     metric_keys = metrics_to_show,
-                    metrics = self.schema.cfg['metric'],
-                    tasks = flow_tasks,
                     img_data = img_data,
                 ))
 

--- a/siliconcompiler/templates/report/sc_report.j2
+++ b/siliconcompiler/templates/report/sc_report.j2
@@ -211,7 +211,7 @@
           {% endfor %}
 
           // Send the updated JSON manifest back to the client as a "download" from RAM to disk.
-          saveTemplateAsFile('{{ manifest["design"]["value"] }}.json', cur_manifest);
+          saveTemplateAsFile('{{ design }}.json', cur_manifest);
         });
 
         // Setup the 'upload manifest' button listener.
@@ -231,25 +231,20 @@
         });
 
         // Setup links in the metrics tables. Each metric is associated with at least one log file.
-        {% for mk in metric_keys %}
-          {% for step in tasks %}
-            {% for index in tasks[step] %}
-              {% set report = manifest['tool'][manifest['flowgraph'][manifest['option']['flow']['value']][step][index]['tool']['value']]['report'] %}
-              {% if (step in report) and (index in report[step]) and (mk in report[step][index]) %}
-                var sim_log_btn = document.getElementById("{{ step }}{{ index }}_{{ mk }}_metlink");
-                sim_log_btn.addEventListener('click', () => {
-                  // TODO: clean up... >_>
-                  log_link = "{{ step }}/{{ index }}/{{ manifest['tool'][manifest['flowgraph'][manifest['option']['flow']['value']][step][index]['tool']['value']]['report'][step][index][mk]['value'][0] }}";
-                  window.open(log_link, "_blank");
-                });
-                var sim_log_btn = document.getElementById("{{ step }}{{ index }}_{{ mk }}_ddmetlink");
-                sim_log_btn.addEventListener('click', () => {
-                  // TODO: clean up... >_>
-                  log_link = "{{ step }}/{{ index }}/{{ manifest['tool'][manifest['flowgraph'][manifest['option']['flow']['value']][step][index]['tool']['value']]['report'][step][index][mk]['value'][0] }}";
-                  window.open(log_link, "_blank");
-                });
-              {% endif %}
-            {% endfor %}
+        {% for metric in metric_keys %}
+          {% for step, index in nodes %}
+            {% if reports[step, index][metric] %}
+              var sim_log_btn = document.getElementById("{{ step }}{{ index }}_{{ metric }}_metlink");
+              sim_log_btn.addEventListener('click', () => {
+                log_link = "{{ step }}/{{ index }}/{{ reports[step, index][metric][0] }}";
+                window.open(log_link, "_blank");
+              });
+              var sim_log_btn = document.getElementById("{{ step }}{{ index }}_{{ metric }}_ddmetlink");
+              sim_log_btn.addEventListener('click', () => {
+                log_link = "{{ step }}/{{ index }}/{{ reports[step, index][metric][0] }}";
+                window.open(log_link, "_blank");
+              });
+            {% endif %}
           {% endfor %}
         {% endfor %}
       });
@@ -262,7 +257,7 @@
     </script>
 
     <div style="text-align: center; width: 100%;">
-      <h1>Design Summary: "{{ manifest['design']['value'] }}"</h1>
+      <h1>Design Summary: "{{ design }}"</h1>
     </div>
 
     <span style="width: 33%; float: left;">
@@ -295,38 +290,35 @@
       </a></div>
 
       <div id="metrics_table_div" class="collapse" style="text-align: center;">
-        <h2>Full {{ manifest["design"]["value"] }} Metrics</h2>
+        <h2>Full {{ design }} Metrics</h2>
         <table id="metrics_table" class="table table-dark table-striped table-bordered">
             <tr>
               <th>-</th>
-              {% for step in tasks %}
-                {% for index in tasks[step] %}
-                  <th>{{ step }}{{ index }}</th>
-                {% endfor %}
+              {% for step, index in nodes %}
+                <th>{{ step }}{{ index }}</th>
               {% endfor %}
             </tr>
-            {% for mk in metric_keys %}
+            {% for metric in metric_keys %}
               <tr>
-                <th>{{ mk }}</th>
-                {% for step in tasks %}
-                  {% for index in tasks[step] %}
-                    {% if manifest['flowgraph'][manifest['option']['flow']['value']][step][index]['status']['value'] == 'error' %}
-                      <td>(failed)</td>
+                <th>{{ metric }}</th>
+                {% for step, index in nodes %}
+                  {% if errors[step, index] %}
+                    <td>(failed)</td>
+                  {% else %}
+                    {% set value = metrics[step, index][metric] %}
+                    {% if value is not none %}
+                      {% set valuestr = value %}
                     {% else %}
-                      {% set value = manifest["metric"][step][index][mk]["value"] %}
-                      {% if value is not none %}
-                        {% set valuestr = value %}
-                      {% else %}
-                        {% set valuestr = "---" %}
-                      {% endif %}
-
-                      {% if step in manifest['tool'][manifest['flowgraph'][manifest['option']['flow']['value']][step][index]['tool']['value']]['report'] and mk in manifest['tool'][manifest['flowgraph'][manifest['option']['flow']['value']][step][index]['tool']['value']]['report'][step][index] %}
-                        <td><a href="#" class="link-success" id="{{ step }}{{ index }}_{{ mk }}_metlink">{{ valuestr }}</a></td>
-                      {% else %}
-                        <td>{{ valuestr }}</td>
-                      {% endif %}
+                      {% set valuestr = "---" %}
                     {% endif %}
-                  {% endfor %}
+
+                    {% if reports[step, index][metric] %}
+                      {% set href_id = [step + index, metric, "metlink"] | join("_") %}
+                      <td><a href="#" class="link-success" id="{{ href_id }}">{{ valuestr }}</a></td>
+                    {% else %}
+                      <td>{{ valuestr }}</td>
+                    {% endif %}
+                  {% endif %}
                 {% endfor %}
               </tr>
             {% endfor %}
@@ -338,44 +330,43 @@
       </a></div>
 
       <div id="metrics_dropdowns_div" class="collapse" style="text-align: center;">
-        <h2>Metrics for {{ manifest["design"]["value"] }} Tasks</h2>
-        {% for step in tasks %}
-          {% for index in tasks[step] %}
-            <div>
-              <a class="btn btn-success" data-bs-toggle="collapse" href="#{{ step }}{{ index }}_dropdown_div", role="button", aria-controls="{{ step }}{{ index }}_dropdown_div">
-                Toggle {{ step }}{{ index }} Metrics
-              </a>
-            </div>
-            <div id="{{ step }}{{ index }}_dropdown_div" class="collapse">
-              <table id="{{ step }}{{ index }}_metrics_table" class="table table-dark table-striped table-bordered">
-                <tr>
-                  {% for mk in metric_keys %}
-                    <th>{{ mk }}</th>
-                  {% endfor %}
-                </tr>
-                <tr>
-                  {% for mk in metric_keys %}
-                    {% if manifest['flowgraph'][manifest['option']['flow']['value']][step][index]['status']['value'] == 'error' %}
-                      <td>(failed)</td>
+        <h2>Metrics for {{ design }} Tasks</h2>
+        {% for step, index in nodes %}
+          <div>
+            <a class="btn btn-success" data-bs-toggle="collapse" href="#{{ step }}{{ index }}_dropdown_div", role="button", aria-controls="{{ step }}{{ index }}_dropdown_div">
+              Toggle {{ step }}{{ index }} Metrics
+            </a>
+          </div>
+          <div id="{{ step }}{{ index }}_dropdown_div" class="collapse">
+            <table id="{{ step }}{{ index }}_metrics_table" class="table table-dark table-striped table-bordered">
+              <tr>
+                {% for metric in metric_keys %}
+                  <th>{{ metric }}</th>
+                {% endfor %}
+              </tr>
+              <tr>
+                {% for metric in metric_keys %}
+                  {% if errors[step, index] %}
+                    <td>(failed)</td>
+                  {% else %}
+                    {% set value = metrics[step, index][metric] %}
+                    {% if value is not none %}
+                      {% set valuestr = value %}
                     {% else %}
-                      {% set value = manifest["metric"][step][index][mk]["value"] %}
-                      {% if value is not none %}
-                        {% set valuestr = value %}
-                      {% else %}
-                        {% set valuestr = "---" %}
-                      {% endif %}
-
-                      {% if step in manifest['tool'][manifest['flowgraph'][manifest['option']['flow']['value']][step][index]['tool']['value']]['report'] and mk in manifest['tool'][manifest['flowgraph'][manifest['option']['flow']['value']][step][index]['tool']['value']]['report'][step][index] %}
-                        <td><a href="#" class="link-success" id="{{ step }}{{ index }}_{{ mk }}_ddmetlink">{{ valuestr }}</a></td>
-                      {% else %}
-                        <td>{{ valuestr }}</td>
-                      {% endif %}
+                      {% set valuestr = "---" %}
                     {% endif %}
-                  {% endfor %}
-                </tr>
-              </table>
-            </div>
-          {% endfor %}
+
+                    {% if reports[step, index][metric] %}
+                      {% set href_id = [step + index, metric, "ddmetlink"] | join("_") %}
+                      <td><a href="#" class="link-success" id="{{ href_id }}">{{ valuestr }}</a></td>
+                    {% else %}
+                      <td>{{ valuestr }}</td>
+                    {% endif %}
+                  {% endif %}
+                {% endfor %}
+              </tr>
+            </table>
+          </div>
         {% endfor %}
       </div>
 

--- a/tests/core/test_summary.py
+++ b/tests/core/test_summary.py
@@ -1,5 +1,4 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
-import os
 import siliconcompiler
 
 import pytest
@@ -31,6 +30,7 @@ def test_steplist(gcd_with_metrics, capfd):
 
     gcd_with_metrics.summary()
     stdout, _ = capfd.readouterr()
+    print(stdout)
 
     assert 'import0' not in stdout
     assert 'syn0' in stdout
@@ -38,12 +38,11 @@ def test_steplist(gcd_with_metrics, capfd):
 def test_parallel_path(capfd):
     with capfd.disabled():
         chip = siliconcompiler.Chip('test')
-        chip.set('design', 'test')
 
         flow = 'test'
         chip.set('option','flow', flow)
-        chip.node(flow, 'import', 'nop', 'nop')
-        chip.node(flow, 'ctsmin', 'minimum', 'ctsmin')
+        chip.node(flow, 'import', 'builtin', 'nop')
+        chip.node(flow, 'ctsmin', 'builtin', 'minimum')
 
         chip.set('flowgraph', flow, 'import', '0', 'status', siliconcompiler.TaskStatus.SUCCESS)
         chip.set('flowgraph', flow, 'ctsmin', '0', 'status', siliconcompiler.TaskStatus.SUCCESS)
@@ -62,6 +61,9 @@ def test_parallel_path(capfd):
 
             chip.set('flowgraph', flow, 'place', i, 'select', ('import', '0'))
             chip.set('flowgraph', flow, 'cts', i, 'select', ('place', i))
+
+            chip.set('metric', 'place', i, 'errors', 0)
+            chip.set('metric', 'cts', i, 'errors', 0)
 
     chip.write_flowgraph('test_graph.png')
 

--- a/tests/core/test_summary.py
+++ b/tests/core/test_summary.py
@@ -30,6 +30,7 @@ def test_steplist(gcd_with_metrics, capfd):
 
     gcd_with_metrics.summary()
     stdout, _ = capfd.readouterr()
+    # Summary output is hidden by capfd, so we print it to aid in debugging
     print(stdout)
 
     assert 'import0' not in stdout
@@ -69,6 +70,7 @@ def test_parallel_path(capfd):
 
     chip.summary()
     stdout, _ = capfd.readouterr()
+    # Summary output is hidden by capfd, so we print it to aid in debugging
     print(stdout)
     assert 'place1' in stdout
     assert 'cts1' in stdout


### PR DESCRIPTION
This PR cleans up the `summary()`/HTML report logic a bit in preparation for step/index-related changes. 

The primary change is to reduce the HTML report template's reliance on direct access to the schema so that we can abstract away the step/index-related schema changes. The Python logic in `summary()` is now responsible for directly passing relevant values to the template in a more concise form. 

Unfortunately we can't fully abstract away the manifest from the HTML report, since it also has functionality for viewing the entire tree/modifying checklist values and re-exporting the manifest. Eventually at least some of this logic will need to be updated for our new step/index abstraction scheme, but this is lower priority since it doesn't block switching over to the new scheme.

As part of this change, I also refactored `summary()` a bit to separate out the ASCII table display logic from the actual data extraction logic, since we want to have raw data to feed into the template, as opposed to formatted strings.