### PR TITLE
return to load_target

### DIFF
--- a/examples/aes/aes.py
+++ b/examples/aes/aes.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import importlib
 import os
 import siliconcompiler
 
@@ -18,8 +17,7 @@ def rtl2gds(design='aes',
     chip = siliconcompiler.Chip(design)
 
     # TARGET
-    target_module = importlib.import_module(f'targets.{target}')
-    chip.use(target_module)
+    chip.load_target(target)
 
     # FLOW OVERLOAD
     rootdir = os.path.dirname(__file__)

--- a/examples/benchmark/benchmark.py
+++ b/examples/benchmark/benchmark.py
@@ -1,9 +1,7 @@
 import os
-import sys
 import time
 import siliconcompiler
 from siliconcompiler.flows import asicflow
-from siliconcompiler.targets import skywater130_demo
 
 # Setting up the experiment
 
@@ -28,7 +26,7 @@ def main():
             wall_start = time.time()
             chip = siliconcompiler.Chip(design)
             chip.set('jobname', f"job{n}")
-            chip.use(skywater130_demo)
+            chip.load_target("skywater130_demo")
             chip.set('relax', True)
             chip.set('quiet', True)
             chip.set('remote',False)

--- a/examples/blinky/blinky.py
+++ b/examples/blinky/blinky.py
@@ -1,12 +1,11 @@
 import siliconcompiler
-from siliconcompiler.targets import fpgaflow_demo
 
 def main():
     chip = siliconcompiler.Chip('blinky')
     chip.input('blinky.v')
     chip.input('icebreaker.pcf')
     chip.set('fpga', 'partname', 'ice40up5k-sg48')
-    chip.use(fpgaflow_demo)
+    chip.load_target("fpgaflow_demo")
 
     chip.run()
     chip.summary()

--- a/examples/fibone/fibone.py
+++ b/examples/fibone/fibone.py
@@ -1,5 +1,4 @@
 import siliconcompiler
-from siliconcompiler.targets import freepdk45_demo
 
 def main():
     chip = siliconcompiler.Chip('mkFibOne')
@@ -7,7 +6,7 @@ def main():
     chip.set('option', 'frontend', 'bluespec')
     # default Bluespec clock pin is 'CLK'
     chip.clock(pin='CLK', period=5)
-    chip.use(freepdk45_demo)
+    chip.load_target("freepdk45_demo")
     chip.run()
     chip.summary()
     chip.show()

--- a/examples/gcd/gcd.py
+++ b/examples/gcd/gcd.py
@@ -3,7 +3,6 @@
 
 import os
 import siliconcompiler
-from siliconcompiler.targets import freepdk45_demo
 
 def main(root='.'):
     '''Simple asicflow example.'''
@@ -19,7 +18,7 @@ def main(root='.'):
     chip.set('option', 'nodisplay', True)
     chip.set('constraint', 'outline', [(0,0), (100.13,100.8)])
     chip.set('constraint', 'corearea', [(10.07,11.2), (90.25,91)])
-    chip.use(freepdk45_demo)
+    chip.load_target("freepdk45_demo")
     chip.run()
     chip.summary()
 

--- a/examples/gcd/gcd_multiflow.py
+++ b/examples/gcd/gcd_multiflow.py
@@ -2,7 +2,6 @@
 # This test does not work at the moment (Jan 4, 2023)
 
 import siliconcompiler
-from siliconcompiler.targets import skywater130_demo
 
 def main():
     '''GCD example with multiflow.'''
@@ -16,7 +15,7 @@ def main():
     chip.set('option', 'quiet', True)
     chip.set('option', 'skipcheck', True)
 
-    chip.use(skywater130_demo)
+    chip.load_target("skywater130_demo")
 
     #IMPORT
     #APR

--- a/examples/gcd/gcd_skywater.py
+++ b/examples/gcd/gcd_skywater.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import siliconcompiler
-from siliconcompiler.targets import skywater130_demo
 
 import os
 import sys
@@ -20,7 +19,7 @@ def main():
 
     chip.clock('clk', period=5)
 
-    chip.use(skywater130_demo)
+    chip.load_target("skywater130_demo")
 
     chip.set('datasheet', chip.top(), 'pin', 'vdd', 'type', 'global', 'power')
     chip.set('datasheet', chip.top(), 'pin', 'vss', 'type', 'global', 'ground')

--- a/examples/gcd_chisel/gcd_chisel.py
+++ b/examples/gcd_chisel/gcd_chisel.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import siliconcompiler
-from siliconcompiler.targets import freepdk45_demo
 
 def main():
     chip = siliconcompiler.Chip('GCD')
@@ -9,7 +8,7 @@ def main():
     chip.set('option', 'frontend', 'chisel')
     # default Chisel clock pin is 'clock'
     chip.clock(pin='clock', period=5)
-    chip.use(freepdk45_demo)
+    chip.load_target("freepdk45_demo")
     chip.run()
     chip.summary()
     chip.show()

--- a/examples/gcd_hls/gcd_hls.py
+++ b/examples/gcd_hls/gcd_hls.py
@@ -1,5 +1,4 @@
 import siliconcompiler
-from siliconcompiler.targets import freepdk45_demo
 
 def main():
     chip = siliconcompiler.Chip('gcd')
@@ -7,7 +6,7 @@ def main():
     chip.set('option', 'frontend', 'c')
     # default Bambu clock pin is 'clock'
     chip.clock(pin='clock', period=5)
-    chip.use(freepdk45_demo)
+    chip.load_target("freepdk45_demo")
     chip.run()
     chip.summary()
     chip.show()

--- a/examples/ghdl_fsynopsys/build.py
+++ b/examples/ghdl_fsynopsys/build.py
@@ -1,6 +1,4 @@
-import os
 import siliconcompiler
-from siliconcompiler.targets import freepdk45_demo
 
 def main():
     chip = siliconcompiler.Chip('binary_4_bit_adder_top')
@@ -9,7 +7,7 @@ def main():
     # see PR #1015 (https://github.com/siliconcompiler/siliconcompiler/pull/1015)
     chip.set('tool', 'ghdl', 'task', 'import', 'var', 'import', '0', 'extraopts', '-fsynopsys')
 
-    chip.use(freepdk45_demo)
+    chip.load_target("freepdk45_demo")
     flow = 'vhdlsyn'
     chip.node(flow, 'import', 'ghdl')
     chip.node(flow, 'syn', 'yosys')

--- a/examples/heartbeat/heartbeat.py
+++ b/examples/heartbeat/heartbeat.py
@@ -6,8 +6,7 @@ def main():
     chip = siliconcompiler.Chip('heartbeat')  # create chip object
     chip.input('heartbeat.v')                 # define list of source files
     chip.input('heartbeat.sdc')               # set constraints file
-    from targets import freepdk45_demo        # import predefined target
-    chip.use(freepdk45_demo)                  # load predefined target
+    chip.load_target("freepdk45_demo")        # load predefined target
     chip.run()                                # run compilation
     chip.summary()                            # print results summary
     chip.show()                               # show layout file

--- a/examples/heartbeat/parallel.py
+++ b/examples/heartbeat/parallel.py
@@ -6,8 +6,6 @@ import multiprocessing
 import siliconcompiler
 import time
 
-from siliconcompiler.targets import freepdk45_demo
-
 # Shared setup routine
 def run_design(design, M, job):
 
@@ -20,7 +18,7 @@ def run_design(design, M, job):
     chip.set('arg', 'flow','place_np', str(M))
     chip.set('arg', 'flow','cts_np', str(M))
     chip.set('arg', 'flow','route_np', str(M))
-    chip.use(freepdk45_demo)
+    chip.load_target("freepdk45_demo")
     chip.run()
 
 def main():

--- a/examples/heartbeat_caravel_wrapper/build.py
+++ b/examples/heartbeat_caravel_wrapper/build.py
@@ -3,9 +3,7 @@ import os
 import shutil
 
 from siliconcompiler.core import Chip
-from siliconcompiler.floorplan import Floorplan
 from siliconcompiler.flows import mpwflow
-from siliconcompiler.targets import skywater130_demo
 
 ###
 # Example Skywater130 / "Caravel" macro hardening with SiliconCompiler
@@ -43,7 +41,7 @@ CARAVEL_ROOT = '/path/to/caravel'
 def configure_chip(design):
     # Minimal Chip object construction.
     chip = Chip(design)
-    chip.use(skywater130_demo)
+    chip.target("skywater130_demo")
     chip.use(mpwflow)
     chip.set('option', 'flow', 'mpwflow')
     return chip

--- a/examples/heartbeat_migen/heartbeat_migen.py
+++ b/examples/heartbeat_migen/heartbeat_migen.py
@@ -2,7 +2,6 @@ from migen import *
 from migen.fhdl.verilog import convert
 
 import siliconcompiler
-from siliconcompiler.targets import freepdk45_demo
 
 class Heartbeat(Module):
   def __init__(self, N=8):
@@ -22,7 +21,7 @@ def main():
     chip.input('heartbeat.v')
     # default Migen clock pin is named 'sys_clk'
     chip.clock(pin='sys_clk', period=1)
-    chip.use(freepdk45_demo)
+    chip.load_target("freepdk45_demo")
     chip.run()
     chip.summary()
     chip.show()

--- a/examples/heartbeat_padring/build.py
+++ b/examples/heartbeat_padring/build.py
@@ -4,7 +4,6 @@ import shutil
 
 from siliconcompiler.core import Chip
 from siliconcompiler.libs import sky130io
-from siliconcompiler.targets import skywater130_demo
 
 ###
 # Example build script: 'heartbeat' example with padring and pre-made .def floorplans.
@@ -23,7 +22,7 @@ SKY130IO_PREFIX = f'{SCROOT}/third_party/pdks/skywater/skywater130/libs/sky130io
 def configure_chip(design):
     # Minimal Chip object construction.
     chip = Chip(design)
-    chip.use(skywater130_demo)
+    chip.load_target("skywater130_demo")
 
     # Include I/O macro lib.
     chip.use(sky130io)

--- a/examples/heartbeat_padring/floorplan_build.py
+++ b/examples/heartbeat_padring/floorplan_build.py
@@ -6,7 +6,6 @@ import shutil
 from siliconcompiler.core import Chip
 from siliconcompiler.floorplan import Floorplan
 from siliconcompiler.libs import sky130io
-from siliconcompiler.targets import skywater130_demo
 
 ###
 # Example build script: 'heartbeat' example with padring and scripted floorplan.
@@ -35,7 +34,7 @@ SKY130IO_PREFIX = f'{SCROOT}/third_party/pdks/skywater/skywater130/libs/sky130io
 def configure_chip(design):
     # Minimal Chip object construction.
     chip = Chip(design)
-    chip.use(skywater130_demo)
+    chip.load_target("skywater130_demo")
 
     # Include I/O macro lib.
     chip.use(sky130io)

--- a/examples/microwatt/build.py
+++ b/examples/microwatt/build.py
@@ -1,6 +1,5 @@
 import os
 import siliconcompiler
-from siliconcompiler.targets import freepdk45_demo
 
 microwatt_wd = "../../third_party/designs/microwatt/"
 
@@ -65,7 +64,7 @@ def main():
     chip.add('option', 'define', 'CLK_INPUT=50000000')
     chip.add('option', 'define', 'CLK_FREQUENCY=40000000')
 
-    chip.use(freepdk45_demo)
+    chip.load_target("freepdk45_demo")
 
     # TODO: add in synthesis step once we can get an output that passes thru
     # Yosys.

--- a/examples/oh_experiments/adder_sweep.py
+++ b/examples/oh_experiments/adder_sweep.py
@@ -1,6 +1,5 @@
 import os
 import siliconcompiler
-from siliconcompiler.targets import freepdk45_demo
 
 try:
     import matplotlib.pyplot as plt
@@ -20,7 +19,7 @@ def main():
     area = []
     for n in datawidths:
         chip = siliconcompiler.Chip(design)
-        chip.use(freepdk45_demo)
+        chip.load_target("freepdk45_demo")
         chip.input(source)
         chip.set('option', 'quiet', True)
         chip.set('option','relax', True)

--- a/examples/oh_experiments/check_area.py
+++ b/examples/oh_experiments/check_area.py
@@ -1,7 +1,6 @@
 import siliconcompiler
 
 import glob
-import importlib
 import os
 import re
 import sys
@@ -22,8 +21,7 @@ def checkarea(filelist, libdir, target):
     for item in filelist:
           design = re.match(r'.*/(\w+)\.v',item).group(1)
           chip = siliconcompiler.Chip(design)
-          target_module = importlib.import_module(f'targets.{target}')
-          chip.use(target_module)
+          chip.load_target(target)
           chip.input(item)
           chip.add('option', 'ydir', libdir)
           chip.set('option','quiet', True)

--- a/examples/oh_experiments/parallel_adder_sweep.py
+++ b/examples/oh_experiments/parallel_adder_sweep.py
@@ -3,7 +3,6 @@
 import os
 import multiprocessing
 import siliconcompiler
-from siliconcompiler.targets import freepdk45_demo
 
 # Setting up the experiment
 
@@ -18,7 +17,7 @@ def run_design(rootdir, design, N, job):
     chip.set('option', 'relax', True)
     chip.set('option', 'quiet', True)
     chip.set('option', 'steplist', ['import', 'syn'])
-    chip.use(freepdk45_demo)
+    chip.load_target("freepdk45_demo")
     chip.run()
     #chip.summary()
 

--- a/examples/picorv32/picorv32.py
+++ b/examples/picorv32/picorv32.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import importlib
 import os
 import siliconcompiler
 
@@ -18,8 +17,7 @@ def rtl2gds(design='picorv32',
     chip = siliconcompiler.Chip(design)
 
     # SETUP
-    target_module = importlib.import_module(f'targets.{target}')
-    chip.use(target_module)
+    chip.load_target(target)
     rootdir = os.path.dirname(__file__)
     if rtl is None:
         chip.input(os.path.join(rootdir, f"{design}.v"))

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -571,9 +571,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         """
 
-        # TODO: Blergh, this method is called from a whole bunch of tests.
-        target_module = importlib.import_module(f'targets.{name}')
-        self.use(target_module)
+        load_function = self.find_function(name, 'setup', 'targets')
+        load_function(self)
 
     ##########################################################################
     def use(self, module):

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -5,8 +5,7 @@ import pytest
 def test_target_valid():
     '''Basic test of target function.'''
     chip = siliconcompiler.Chip('test')
-    from targets import freepdk45_demo
-    chip.use(freepdk45_demo)
+    chip.load_target("freepdk45_demo")
 
     assert chip.get('option', 'mode') == 'asic'
 

--- a/tests/core/test_write_flowgraph.py
+++ b/tests/core/test_write_flowgraph.py
@@ -9,8 +9,7 @@ def test_write_flowgraph():
     ################################################
 
     chip = siliconcompiler.Chip('test')
-    from targets import freepdk45_demo
-    chip.use(freepdk45_demo)
+    chip.load_target("freepdk45_demo")
     chip.write_flowgraph('serial.png')
 
     assert os.path.isfile('serial.png')
@@ -23,7 +22,7 @@ def test_write_flowgraph():
     chip.set('arg', 'flow', 'syn_np', "4")
     chip.set('arg', 'flow', 'place_np', "4")
     chip.set('arg', 'flow', 'route_np', "4")
-    chip.use(freepdk45_demo)
+    chip.load_target("freepdk45_demo")
     chip.write_flowgraph('forkjoin.png')
 
     assert os.path.isfile('forkjoin.png')


### PR DESCRIPTION
Changes:
- since `load_target` will not use `.use`, this returns all instances of it back to the previous method