### PR TITLE
Add an option to hide layers by default in show and screenshot tasks

### DIFF
--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -112,6 +112,9 @@ def setup(chip):
     chip.set('pdk', process, 'var', 'openroad', 'pin_layer_vertical', stackup, 'met2')
     chip.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'met3')
 
+    # Hide the 81/4 'areaid.standardc' layer by default; it puts opaque purple over most core areas.
+    chip.set('pdk', process, 'var', 'klayout', 'hide_layers', stackup, ['81/4'])
+
     # PEX
     chip.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
         pdkdir + '/pex/openroad/typical.tcl')

--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -113,7 +113,7 @@ def setup(chip):
     chip.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'met3')
 
     # Hide the 81/4 'areaid.standardc' layer by default; it puts opaque purple over most core areas.
-    chip.set('pdk', process, 'var', 'klayout', 'hide_layers', stackup, ['81/4'])
+    chip.set('pdk', process, 'var', 'klayout', 'hide_layers', stackup, ['areaid.standardc'])
 
     # PEX
     chip.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -112,8 +112,9 @@ if lyp_path:
 
 # Hide layers that shouldn't be shown in the current view.
 for layer in layout_view.each_layer():
-    layer_name = f'{layer.source_layer}/{layer.source_datatype}'
-    if layer_name in sc_hide_layers:
+    layer_name = layer.name[ : layer.name.find(' - ')]
+    layer_ldt = layer.name[(layer.name.find(' - ') + len(' - ')) : ]
+    if (layer_name in sc_hide_layers) or (layer_ldt in sc_hide_layers):
         layer.visible = False
 
 # If 'screenshot' mode is set, save image and exit.

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -110,7 +110,7 @@ if lyp_path:
     # KLayout's extra outline, blockage, and obstruction layers appear.
     layout_view.load_layer_props(lyp_path, True)
 
-# Hide layers that shouldn't be shown in the screenshot.
+# Hide layers that shouldn't be shown in the current view.
 for layer in layout_view.each_layer():
     layer_name = f'{layer.source_layer}/{layer.source_datatype}'
     if layer_name in sc_hide_layers:

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -14,6 +14,11 @@ step = chip.get('arg', 'step')
 index = chip.get('arg', 'index')
 task = chip.get('flowgraph', flow, step, index, 'task')
 
+if 'hide_layers' in chip.getkeys('tool', 'klayout', 'task', task, 'var', step, index):
+    sc_hide_layers = chip.get('tool', 'klayout', 'task', task, 'var', step, index, 'hide_layers')
+else:
+    sc_hide_layers = []
+
 if 'show_filepath' in chip.getkeys('tool', 'klayout', 'task', task, 'var', step, index):
     sc_filename = chip.get('tool', 'klayout', 'task', task, 'var', step, index, 'show_filepath')[0]
 else:
@@ -104,6 +109,12 @@ if lyp_path:
     # Set layer properties -- setting second argument to True ensures things like
     # KLayout's extra outline, blockage, and obstruction layers appear.
     layout_view.load_layer_props(lyp_path, True)
+
+# Hide layers that shouldn't be shown in the screenshot.
+for layer in layout_view.each_layer():
+    layer_name = f'{layer.source_layer}/{layer.source_datatype}'
+    if layer_name in sc_hide_layers:
+        layer.visible = False
 
 # If 'screenshot' mode is set, save image and exit.
 if step == 'screenshot':

--- a/siliconcompiler/tools/klayout/screenshot.py
+++ b/siliconcompiler/tools/klayout/screenshot.py
@@ -24,8 +24,8 @@ def setup(chip):
     pdk = chip.get('option', 'pdk')
     stackup = chip.get('option', 'stackup')
     if chip.valid('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup):
-        scrot_hide_layers = chip.get('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup)
-        chip.add('tool', tool, 'task', task, 'var', step, index, 'hide_layers', scrot_hide_layers)
+        layers_to_hide = chip.get('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup)
+        chip.add('tool', tool, 'task', task, 'var', step, index, 'hide_layers', layers_to_hide)
     if chip.valid('tool', tool, 'task', task, 'var', step, index, 'show_filepath'):
         chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', step, index, 'show_filepath']))
     else:

--- a/siliconcompiler/tools/klayout/screenshot.py
+++ b/siliconcompiler/tools/klayout/screenshot.py
@@ -21,6 +21,11 @@ def setup(chip):
     chip.set('tool', tool, 'task', task, 'script', step, index, script, clobber=clobber)
     chip.set('tool', tool, 'task', task, 'option', step, index, option, clobber=clobber)
 
+    pdk = chip.get('option', 'pdk')
+    stackup = chip.get('option', 'stackup')
+    if chip.valid('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup):
+        scrot_hide_layers = chip.get('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup)
+        chip.add('tool', tool, 'task', task, 'var', step, index, 'hide_layers', scrot_hide_layers)
     if chip.valid('tool', tool, 'task', task, 'var', step, index, 'show_filepath'):
         chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', step, index, 'show_filepath']))
     else:

--- a/siliconcompiler/tools/klayout/show.py
+++ b/siliconcompiler/tools/klayout/show.py
@@ -23,8 +23,8 @@ def setup(chip):
     pdk = chip.get('option', 'pdk')
     stackup = chip.get('option', 'stackup')
     if chip.valid('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup):
-        scrot_hide_layers = chip.get('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup)
-        chip.add('tool', tool, 'task', task, 'var', step, index, 'hide_layers', scrot_hide_layers)
+        show_hide_layers = chip.get('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup)
+        chip.add('tool', tool, 'task', task, 'var', step, index, 'hide_layers', show_hide_layers)
     if chip.valid('tool', tool, 'task', task, 'var', step, index, 'show_filepath'):
         chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', step, index, 'show_filepath']))
     else:

--- a/siliconcompiler/tools/klayout/show.py
+++ b/siliconcompiler/tools/klayout/show.py
@@ -20,6 +20,11 @@ def setup(chip):
     chip.set('tool', tool, 'task', task, 'script', step, index, script, clobber=clobber)
     chip.set('tool', tool, 'task', task, 'option', step, index, option, clobber=clobber)
 
+    pdk = chip.get('option', 'pdk')
+    stackup = chip.get('option', 'stackup')
+    if chip.valid('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup):
+        scrot_hide_layers = chip.get('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup)
+        chip.add('tool', tool, 'task', task, 'var', step, index, 'hide_layers', scrot_hide_layers)
     if chip.valid('tool', tool, 'task', task, 'var', step, index, 'show_filepath'):
         chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', step, index, 'show_filepath']))
     else:

--- a/siliconcompiler/tools/klayout/show.py
+++ b/siliconcompiler/tools/klayout/show.py
@@ -23,8 +23,8 @@ def setup(chip):
     pdk = chip.get('option', 'pdk')
     stackup = chip.get('option', 'stackup')
     if chip.valid('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup):
-        show_hide_layers = chip.get('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup)
-        chip.add('tool', tool, 'task', task, 'var', step, index, 'hide_layers', show_hide_layers)
+        layers_to_hide = chip.get('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup)
+        chip.add('tool', tool, 'task', task, 'var', step, index, 'hide_layers', layers_to_hide)
     if chip.valid('tool', tool, 'task', task, 'var', step, index, 'show_filepath'):
         chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', step, index, 'show_filepath']))
     else:


### PR DESCRIPTION
I'm not a marketer, but I think that our auto-generated Skywater130 design screenshots would look better if the details weren't obscured by blocks of bright magenta. I could see an argument for only applying this to the `screenshot` task, and not `show`, but users can override the default visibility settings in the KLayout GUI.

Before (`picorv32`/`sky130hd`, all open-source):

![picorv32_top_meh](https://user-images.githubusercontent.com/5217539/216217012-500e8ab0-5e3a-406d-bdd3-1ec954668b0d.png)

After:

![picorv32_top](https://user-images.githubusercontent.com/5217539/216217034-a5a1dc9c-dc7a-4fd7-b584-20deea91431c.png)