### PR TITLE
Early fixes for post-refactor remote client

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -37,7 +37,7 @@ def get_base_url(chip):
     return remote_protocol + remote_host
 
 ###################################
-def remote_preprocess(chip):
+def remote_preprocess(chip, steplist):
     '''Helper method to run a local import stage for remote jobs.
     '''
 
@@ -48,7 +48,7 @@ def remote_preprocess(chip):
 
     # Fetch a list of 'import' steps, and make sure they're all at the start of the flow.
     flow = chip.get('option', 'flow')
-    remote_steplist = chip.getkeys('flowgraph', flow)
+    remote_steplist = steplist.copy()
     import_tasks = chip._get_steps_by_task()['import']
     import_steps = []
     for task_tuple in import_tasks:

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -46,17 +46,31 @@ def remote_preprocess(chip):
         job_hash = uuid.uuid4().hex
         chip.status['jobhash'] = job_hash
 
-    # Setup up tools for all local functions
+    # Fetch a list of 'import' steps, and make sure they're all at the start of the flow.
     flow = chip.get('option', 'flow')
     remote_steplist = chip.getkeys('flowgraph', flow)
-    local_step = remote_steplist[0]
-    indexlist = chip.getkeys('flowgraph', flow, local_step)
-    for index in indexlist:
-        task = chip._get_task(local_step, index)
-        tool = chip.get('flowgraph', flow, local_step, index, 'tool')
-        # Setting up tool is optional (step may be a builtin function)
-        if tool and tool not in chip.builtin:
-            chip._setup_tool(tool, task, local_step, index)
+    import_tasks = chip._get_steps_by_task()['import']
+    import_steps = []
+    for task_tuple in import_tasks:
+        if not task_tuple[0] in import_steps:
+            import_steps.append(task_tuple[0])
+    chip.logger.warning(remote_steplist)
+    chip.logger.warning(import_steps)
+    if remote_steplist[:len(import_steps)] != import_steps:
+        chip.error('Remote flows must be organized such that the "import" task(s) are run before '
+                  f'all other steps.\nFull steplist: {remote_steplist}\n'
+                  f'Import steplist: {import_steps}', fatal=True)
+    # Setup up tools for all local functions
+    for local_step in import_steps:
+        indexlist = chip.getkeys('flowgraph', flow, local_step)
+        for index in indexlist:
+            task = chip._get_task(local_step, index)
+            tool = chip.get('flowgraph', flow, local_step, index, 'tool')
+            # Setting up tool is optional (step may be a builtin function)
+            if tool and not chip._is_builtin(tool, task):
+                chip._setup_tool(tool, task, local_step, index)
+        # Remove each local step from the list of steps to run on the server side.
+        remote_steplist.remove(local_step)
 
         # Need to override steplist here to make sure check_manifest() doesn't
         # check steps that haven't been setup.
@@ -69,9 +83,9 @@ def remote_preprocess(chip):
         chip._runtask(local_step, index, {})
 
     # Set 'steplist' to only the remote steps, for the future server-side run.
-    remote_steplist = remote_steplist[1:]
-    chip.set('arg', 'step', None, clobber=True)
-    chip.set('arg', 'index', None, clobber=True)
+    remote_steplist = remote_steplist
+    chip.unset('arg', 'step')
+    chip.unset('arg', 'index')
     chip.set('option', 'steplist', remote_steplist, clobber=True)
 
 ###################################

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -37,7 +37,7 @@ def get_base_url(chip):
     return remote_protocol + remote_host
 
 ###################################
-def remote_preprocess(chip, steplist):
+def remote_preprocess(chip):
     '''Helper method to run a local import stage for remote jobs.
     '''
 
@@ -48,7 +48,7 @@ def remote_preprocess(chip, steplist):
 
     # Fetch a list of 'import' steps, and make sure they're all at the start of the flow.
     flow = chip.get('option', 'flow')
-    remote_steplist = steplist.copy()
+    remote_steplist = chip.getkeys('flowgraph', flow)
     import_tasks = chip._get_steps_by_task()['import']
     import_steps = []
     for task_tuple in import_tasks:

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -54,8 +54,6 @@ def remote_preprocess(chip):
     for task_tuple in import_tasks:
         if not task_tuple[0] in import_steps:
             import_steps.append(task_tuple[0])
-    chip.logger.warning(remote_steplist)
-    chip.logger.warning(import_steps)
     if remote_steplist[:len(import_steps)] != import_steps:
         chip.error('Remote flows must be organized such that the "import" task(s) are run before '
                   f'all other steps.\nFull steplist: {remote_steplist}\n'

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -52,10 +52,11 @@ def remote_preprocess(chip):
     local_step = remote_steplist[0]
     indexlist = chip.getkeys('flowgraph', flow, local_step)
     for index in indexlist:
+        task = chip._get_task(local_step, index)
         tool = chip.get('flowgraph', flow, local_step, index, 'tool')
         # Setting up tool is optional (step may be a builtin function)
         if tool and tool not in chip.builtin:
-            chip._setup_tool(tool, local_step, index)
+            chip._setup_tool(tool, task, local_step, index)
 
         # Need to override steplist here to make sure check_manifest() doesn't
         # check steps that haven't been setup.
@@ -69,6 +70,8 @@ def remote_preprocess(chip):
 
     # Set 'steplist' to only the remote steps, for the future server-side run.
     remote_steplist = remote_steplist[1:]
+    chip.set('arg', 'step', None, clobber=True)
+    chip.set('arg', 'index', None, clobber=True)
     chip.set('option', 'steplist', remote_steplist, clobber=True)
 
 ###################################

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -81,7 +81,6 @@ def remote_preprocess(chip):
         chip._runtask(local_step, index, {})
 
     # Set 'steplist' to only the remote steps, for the future server-side run.
-    remote_steplist = remote_steplist
     chip.unset('arg', 'step')
     chip.unset('arg', 'index')
     chip.set('option', 'steplist', remote_steplist, clobber=True)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3994,8 +3994,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             # in-progress build directory to the remote server.
             # Data is encrypted if user / key were specified.
             # run remote process
-            pre_remote_steplist = self.get('option', 'steplist')
-            remote_preprocess(self, steplist)
+            remote_preprocess(self)
 
             # Run the job on the remote server, and wait for it to finish.
             remote_run(self)
@@ -4010,7 +4009,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 self.read_manifest(cfg, clobber=True, clear=True)
                 self.set('option', 'builddir', local_dir)
                 # Un-set steplist so 'show'/etc flows will work on returned results.
-                self.set('option', 'steplist', pre_remote_steplist)
+                self.unset('option', 'steplist')
             else:
                 # Hack to find first failed step by checking for presence of
                 # output manifests.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4008,6 +4008,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 local_dir = self.get('option','builddir')
                 self.read_manifest(cfg, clobber=True, clear=True)
                 self.set('option', 'builddir', local_dir)
+                # Un-set steplist so 'show'/etc flows will work on returned results.
+                self.unset('option', 'steplist')
             else:
                 # Hack to find first failed step by checking for presence of
                 # output manifests.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3994,7 +3994,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             # in-progress build directory to the remote server.
             # Data is encrypted if user / key were specified.
             # run remote process
-            remote_preprocess(self)
+            pre_remote_steplist = self.get('option', 'steplist')
+            remote_preprocess(self, steplist)
 
             # Run the job on the remote server, and wait for it to finish.
             remote_run(self)
@@ -4009,7 +4010,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 self.read_manifest(cfg, clobber=True, clear=True)
                 self.set('option', 'builddir', local_dir)
                 # Un-set steplist so 'show'/etc flows will work on returned results.
-                self.unset('option', 'steplist')
+                self.set('option', 'steplist', pre_remote_steplist)
             else:
                 # Hack to find first failed step by checking for presence of
                 # output manifests.

--- a/tests/flows/test_server.py
+++ b/tests/flows/test_server.py
@@ -10,7 +10,6 @@ from unittest.mock import Mock
 ###########################
 @pytest.mark.eda
 @pytest.mark.quick
-@pytest.mark.skip(reason='Temporary until server update')
 def test_gcd_server(gcd_chip):
     '''Basic sc-server test: Run a local instance of a server, and build the GCD
        example using loopback network calls to that server.


### PR DESCRIPTION
A few small SiliconCompiler updates which are needed to get the minimal `heartbeat` example running remotely with our recent `Chip`/`Schema` updates.

I like the new `Schema.unset` method - it's more clear than overwriting the value to `None` or `[]`.

There might be a couple more PRs like this as I move on to testing the server-side scheduler functionality.