### PR TITLE
Implementation of .use()

### DIFF
--- a/docs/user_guide/flows.rst
+++ b/docs/user_guide/flows.rst
@@ -50,8 +50,6 @@ Flows that support SiliconCompiler metric functions (minimum, maximum, summary) 
   for metric in ('cellarea', 'peakpower', 'standbypower'):
     chip.set('flowgraph', flow, step, index, 'weight', metric, 1.0)
 
-Note that the :keypath:`arg, flow` dictionary in the schema can be used to pass named arguments to configure flow setup. For example, the built-in asicflow and fpgaflow use the 'techarg', 'sv' parameter to enable or disable a SystemVerilog to Verilog conversion step.
-
 For a complete working example, see the `asicflow <https://github.com/siliconcompiler/siliconcompiler/blob/main/siliconcompiler/flows/asicflow.py>`_ and `fpgaflow <https://github.com/siliconcompiler/siliconcompiler/blob/main/siliconcompiler/flows/fpgaflow.py>`_ source code.
 
 make_docs()

--- a/docs/user_guide/pdks.rst
+++ b/docs/user_guide/pdks.rst
@@ -62,8 +62,6 @@ To support standard RTL2GDS flows, the PDK setup will also need to specify point
     chip.set('pdk', process, 'grid', <stackup>, <sc_name>, 'ypitch',  0.14)
     chip.set('pdk', process, 'grid', <stackup>, <sc_name>, 'adj',     1.0)
 
-Note that the :keypath:`arg, pdk` dictionary in the schema can be used to pass named arguments to configure PDK setup.
-
 make_docs()
 -----------------
 The make_docs() function is used by the projects auto-doc generation. The function should include a descriptive docstring and a call to the setup function to populate the schema with all settings::

--- a/docs/user_guide/programming_model.rst
+++ b/docs/user_guide/programming_model.rst
@@ -17,11 +17,11 @@ Compilation is based on a single chip object that follows the design from start 
 Setup
 ----------------
 
-Once the chip object has been created, functions and data are all contained within that object. A compilation is set up by accessing methods and parameters from the chip object. Parameters can generally be configured in any order during setup. The exceptions are :keypath:`arg,flow` and :keypath:`arg,pdk` parameters, which must be set before calling :meth:`chip.load_flow() <.load_flow>` or :meth:`chip.load_pdk() <.load_pdk>`, respectively.
+Once the chip object has been created, functions and data are all contained within that object. A compilation is set up by accessing methods and parameters from the chip object. Parameters can generally be configured in any order during setup.
 
 The snippet of code below shows the basic principles. ::
 
-  chip.set('input', 'verilog', '<file>.v')
+  chip.set('input', 'verilog', 'rtl', '<file>.v')
 
 
 Run

--- a/siliconcompiler/__init__.py
+++ b/siliconcompiler/__init__.py
@@ -1,11 +1,5 @@
 from siliconcompiler.core import *
-#from siliconcompiler.floorplan import *
-#from siliconcompiler.leflib import *
-#from siliconcompiler.deflib import *
 
 from siliconcompiler._metadata import version as __version__
 
-from siliconcompiler.use import PDK
-from siliconcompiler.use import Library
-from siliconcompiler.use import Flow
-from siliconcompiler.use import Checklist
+from siliconcompiler.use import PDK, Library, Flow, Checklist

--- a/siliconcompiler/__init__.py
+++ b/siliconcompiler/__init__.py
@@ -4,3 +4,8 @@ from siliconcompiler.core import *
 #from siliconcompiler.deflib import *
 
 from siliconcompiler._metadata import version as __version__
+
+from siliconcompiler.use import PDK
+from siliconcompiler.use import Library
+from siliconcompiler.use import Flow
+from siliconcompiler.use import Checklist

--- a/siliconcompiler/checklists/oh_tapeout/oh_tapeout.py
+++ b/siliconcompiler/checklists/oh_tapeout/oh_tapeout.py
@@ -1,35 +1,40 @@
 import siliconcompiler
 
+from siliconcompiler import Checklist
+
 def make_docs():
     '''Subset of OH! library tapeout checklist.
 
     https://github.com/aolofsson/oh/blob/master/docs/tapeout_checklist.md
     '''
     chip = siliconcompiler.Chip()
-    setup(chip)
-    return chip
+    return setup(chip)
 
 def setup(chip):
     standard = 'oh_tapeout'
 
+    checklist = Checklist(chip, standard)
+
     # Automated
-    chip.set('checklist', standard, 'drc_clean', 'description',
-             'Is block DRC clean?')
-    chip.set('checklist', standard, 'drc_clean', 'criteria', 'drvs==0')
+    checklist.set('checklist', standard, 'drc_clean', 'description',
+                  'Is block DRC clean?')
+    checklist.set('checklist', standard, 'drc_clean', 'criteria', 'drvs==0')
 
-    chip.set('checklist', standard, 'lvs_clean', 'description',
-             'Is block LVS clean?')
-    chip.set('checklist', standard, 'lvs_clean', 'criteria', 'drvs==0')
+    checklist.set('checklist', standard, 'lvs_clean', 'description',
+                  'Is block LVS clean?')
+    checklist.set('checklist', standard, 'lvs_clean', 'criteria', 'drvs==0')
 
-    chip.set('checklist', standard, 'setup_time', 'description',
-             'Setup time met?')
-    chip.set('checklist', standard, 'setup_time', 'criteria', 'setupslack>=0')
+    checklist.set('checklist', standard, 'setup_time', 'description',
+                  'Setup time met?')
+    checklist.set('checklist', standard, 'setup_time', 'criteria', 'setupslack>=0')
 
-    chip.set('checklist', standard, 'errors_warnings', 'description',
-             'Are all EDA warnings/errors acceptable?')
-    chip.set('checklist', standard, 'errors_warnings', 'criteria',
-              ['errors==0', 'warnings==0'])
+    checklist.set('checklist', standard, 'errors_warnings', 'description',
+                  'Are all EDA warnings/errors acceptable?')
+    checklist.set('checklist', standard, 'errors_warnings', 'criteria',
+                  ['errors==0', 'warnings==0'])
 
     # Manual
-    chip.set('checklist', standard, 'spec', 'description',
-        'Is there a written specification?')
+    checklist.set('checklist', standard, 'spec', 'description',
+                  'Is there a written specification?')
+
+    return checklist

--- a/siliconcompiler/checklists/oh_tapeout/oh_tapeout.py
+++ b/siliconcompiler/checklists/oh_tapeout/oh_tapeout.py
@@ -1,7 +1,5 @@
 import siliconcompiler
 
-from siliconcompiler import Checklist
-
 def make_docs():
     '''Subset of OH! library tapeout checklist.
 
@@ -13,7 +11,7 @@ def make_docs():
 def setup(chip):
     standard = 'oh_tapeout'
 
-    checklist = Checklist(chip, standard)
+    checklist = siliconcompiler.Checklist(chip, standard)
 
     # Automated
     checklist.set('checklist', standard, 'drc_clean', 'description',

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -85,10 +85,6 @@ class Chip:
             self.error("""SiliconCompiler must be run from a directory that exists.
 If you are sure that your working directory is valid, try running `cd $(pwd)`.""", fatal=True)
 
-        # Indicates that the chip object is marked as read only and should not
-        # allow modifications to schema
-        self._readonly = False
-
         self.schema = Schema()
 
         # The 'status' dictionary can be used to store ephemeral config values.
@@ -593,14 +589,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         from siliconcompiler import Library
         from siliconcompiler import Checklist
 
-        # Mark self as read only
-        self._readonly = True
-
         # Call the module setup function.
         use_modules = module.setup(self, **kwargs)
-
-        # Reset readonly flag
-        self._readonly = False
 
         # Make it a list for consistency
         if not isinstance(use_modules, list):
@@ -873,9 +863,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         if keypath == ['option', 'loglevel'] and field == 'value':
             self.logger.setLevel(value)
 
-        if self._readonly:
-            raise SiliconCompilerError("Chip object is read only.")
-
         try:
             if not self.schema.set(
                 *keypath, value, field=field, clobber=clobber, step=step, index=index
@@ -904,9 +891,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             keypath (list): Parameter keypath to clear.
         '''
         self.logger.debug(f'Unsetting {keypath}')
-
-        if self._readonly:
-            raise SiliconCompilerError("Chip object is read only.")
 
         if not self.schema.unset(*keypath, step=step, index=index):
             self.logger.debug(f'Failed to unset value for {keypath}: parameter is locked')
@@ -938,9 +922,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         keypath = args[:-1]
         value = args[-1]
         self.logger.debug(f'Appending value {value} to {keypath}')
-
-        if self._readonly:
-            raise SiliconCompilerError("Chip object is read only.")
 
         try:
             if not self.schema.add(*args, field=field, step=step, index=index):

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -85,6 +85,10 @@ class Chip:
             self.error("""SiliconCompiler must be run from a directory that exists.
 If you are sure that your working directory is valid, try running `cd $(pwd)`.""", fatal=True)
 
+        # Indicates that the chip object is marked as read only and should not
+        # allow modifications to schema
+        self._readonly = False
+
         self.schema = Schema()
 
         # The 'status' dictionary can be used to store ephemeral config values.
@@ -825,6 +829,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         if keypath == ['option', 'loglevel'] and field == 'value':
             self.logger.setLevel(value)
 
+        if self._readonly:
+            raise SiliconCompilerError("Chip object is read only.")
+
         try:
             if not self.schema.set(
                 *keypath, value, field=field, clobber=clobber, step=step, index=index
@@ -853,6 +860,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             keypath (list): Parameter keypath to clear.
         '''
         self.logger.debug(f'Unsetting {keypath}')
+
+        if self._readonly:
+            raise SiliconCompilerError("Chip object is read only.")
 
         if not self.schema.unset(*keypath, step=step, index=index):
             self.logger.debug(f'Failed to unset value for {keypath}: parameter is locked')
@@ -884,6 +894,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         keypath = args[:-1]
         value = args[-1]
         self.logger.debug(f'Appending value {value} to {keypath}')
+
+        if self._readonly:
+            raise SiliconCompilerError("Chip object is read only.")
 
         try:
             if not self.schema.add(*args, field=field, step=step, index=index):

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4323,17 +4323,13 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         saved_config = self.schema.copy()
 
-        # Setup flow parameters
-        self.set('arg', 'flow', 'show_filetype', filetype)
-        self.set('arg', 'flow', 'show_screenshot', "true" if screenshot else "false")
-
         taskname = 'show'
         if screenshot:
             taskname = 'screenshot'
 
         try:
             from flows import showflow
-            self.use(showflow)
+            self.use(showflow, filetype=filetype, screenshot=screenshot)
         except:
             # restore environment
             self.schema = saved_config

--- a/siliconcompiler/flows/asicflow.py
+++ b/siliconcompiler/flows/asicflow.py
@@ -46,7 +46,7 @@ def make_docs():
 ###########################################################################
 # Flowgraph Setup
 ############################################################################
-def setup(chip, flowname='asicflow', syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1, dfm_np=1):
+def setup(chip, flowname='asicflow', syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1):
     '''
     Setup function for 'asicflow' ASIC compilation execution flowgraph.
 
@@ -98,8 +98,7 @@ def setup(chip, flowname='asicflow', syn_np=1, floorplan_np=1, physyn_np=1, plac
         "physyn": physyn_np,
         "place": place_np,
         "cts": cts_np,
-        "route": route_np,
-        "dfm": dfm_np
+        "route": route_np
     }
 
     #Remove built in steps where appropriate

--- a/siliconcompiler/flows/asicflow.py
+++ b/siliconcompiler/flows/asicflow.py
@@ -1,7 +1,7 @@
 import siliconcompiler
-import re
 
 from siliconcompiler.flows._common import setup_frontend
+from siliconcompiler import Flow
 
 ############################################################################
 # DOCS
@@ -29,7 +29,7 @@ def make_docs():
     * **drc**: Design rule check (signoff)
 
     The syn, physyn, place, cts, route steps supports per process
-    options that can be set up by setting the 'arg, flow,'<step>_np'
+    options that can be set up by setting '<step>_np'
     arg to a value > 1, as detailed below:
 
     * syn_np : Number of parallel synthesis jobs to launch
@@ -41,23 +41,13 @@ def make_docs():
     '''
 
     chip = siliconcompiler.Chip('<topmodule>')
-    n = '3'
-    chip.set('arg', 'flow', 'verify','true')
-    chip.set('arg', 'flow', 'syn_np', n)
-    chip.set('arg', 'flow', 'floorplan_np', n)
-    chip.set('arg', 'flow', 'physyn_np', n)
-    chip.set('arg', 'flow', 'place_np', n)
-    chip.set('arg', 'flow', 'cts_np', n)
-    chip.set('arg', 'flow', 'route_np', n)
-    chip.set('option', 'flow', 'asicflow')
-    setup(chip)
-
-    return chip
+    n = 3
+    return setup(chip, syn_np=n, floorplan_np=n, physyn_np=n, place_np=n, cts_np=n, route_np=n)
 
 ###########################################################################
 # Flowgraph Setup
 ############################################################################
-def setup(chip, flowname='asicflow'):
+def setup(chip, flowname='asicflow', syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1, dfm_np=1):
     '''
     Setup function for 'asicflow' ASIC compilation execution flowgraph.
 
@@ -65,6 +55,8 @@ def setup(chip, flowname='asicflow'):
         chip (object): SC Chip object
 
     '''
+
+    flow = Flow(chip, flowname)
 
     # Linear flow, up until branch to run parallel verification steps.
     longpipe = ['syn',
@@ -81,7 +73,6 @@ def setup(chip, flowname='asicflow'):
                 'routemin',
                 'dfm',
                 'export']
-
 
     #step -->(tool, task)
     tools = {
@@ -102,15 +93,21 @@ def setup(chip, flowname='asicflow'):
         'export' : ['klayout', 'export']
     }
 
-    # Clear old flowgraph if it exists
-    if flowname in chip.getkeys('flowgraph'):
-        del chip.schema.cfg['flowgraph'][flowname]
+    np = {
+        "syn": syn_np,
+        "floorplan": floorplan_np,
+        "physyn": physyn_np,
+        "place": place_np,
+        "cts": cts_np,
+        "route": route_np,
+        "dfm": dfm_np
+    }
 
     #Remove built in steps where appropriate
     flowpipe = []
     for step in longpipe:
         if tools[step][0] == 'builtin':
-            if bool(prevstep + "_np" in chip.getkeys('arg','flow')):
+            if prevstep in np and np[prevstep] > 1:
                 flowpipe.append(step)
         else:
             flowpipe.append(step)
@@ -122,23 +119,22 @@ def setup(chip, flowname='asicflow'):
 
     # Programatically build linear portion of flowgraph and fanin/fanout args
     for step,tool,task in flowtools:
-        #TODO: Fix
-        param = step + "_np"
         fanout = 1
-        if param in chip.getkeys('arg', 'flow'):
-            fanout = int(chip.get('arg', 'flow', param)[0])
+        if step in np:
+            fanout = np[step]
         # create nodes
         for index in range(fanout):
             # nodes
-            chip.node(flowname, step, tool, task, index=index)
+            flow.node(flowname, step, tool, task, index=index)
             # edges
             if tool == 'builtin':
-                prevparam = prevstep + "_np"
-                fanin  = int(chip.get('arg', 'flow', prevparam)[0])
+                fanin = 1
+                if prevstep in np:
+                    fanin = np[prevstep]
                 for i in range(fanin):
-                    chip.edge(flowname, prevstep, step, tail_index=i)
+                    flow.edge(flowname, prevstep, step, tail_index=i)
             elif step != 'import':
-                chip.edge(flowname, prevstep, step, head_index=index)
+                flow.edge(flowname, prevstep, step, head_index=index)
             # metrics
             goal_metrics = ()
             weight_metrics = ()
@@ -150,12 +146,14 @@ def setup(chip, flowname='asicflow'):
                 weight_metrics = ('cellarea', 'peakpower', 'leakagepower')
 
             for metric in goal_metrics:
-                chip.set('flowgraph', flowname, step, str(index), 'goal', metric, 0)
+                flow.set('flowgraph', flowname, step, str(index), 'goal', metric, 0)
             for metric in weight_metrics:
-                chip.set('flowgraph', flowname, step, str(index), 'weight', metric, 1.0)
+                flow.set('flowgraph', flowname, step, str(index), 'weight', metric, 1.0)
         prevstep = step
+
+    return flow
 
 ##################################################
 if __name__ == "__main__":
     chip = make_docs()
-    chip.write_flowgraph("asicflow.png")
+    chip.write_flowgraph("asicflow.png", flow='asicflow')

--- a/siliconcompiler/flows/asicflow.py
+++ b/siliconcompiler/flows/asicflow.py
@@ -1,7 +1,6 @@
 import siliconcompiler
 
 from siliconcompiler.flows._common import setup_frontend
-from siliconcompiler import Flow
 
 ############################################################################
 # DOCS
@@ -56,7 +55,7 @@ def setup(chip, flowname='asicflow', syn_np=1, floorplan_np=1, physyn_np=1, plac
 
     '''
 
-    flow = Flow(chip, flowname)
+    flow = siliconcompiler.Flow(chip, flowname)
 
     # Linear flow, up until branch to run parallel verification steps.
     longpipe = ['syn',

--- a/siliconcompiler/flows/asictopflow.py
+++ b/siliconcompiler/flows/asictopflow.py
@@ -1,5 +1,4 @@
 import siliconcompiler
-from siliconcompiler import Flow
 
 def make_docs():
     '''A flow for stitching together hardened blocks without doing any automated
@@ -13,7 +12,7 @@ def make_docs():
     return setup(chip)
 
 def setup(chip):
-    flow = Flow(chip, 'asictopflow')
+    flow = siliconcompiler.Flow(chip, 'asictopflow')
 
     flow.node(flow.design, 'import', 'surelog', 'import')
     flow.node(flow.design, 'syn', 'yosys', 'syn_asic')

--- a/siliconcompiler/flows/asictopflow.py
+++ b/siliconcompiler/flows/asictopflow.py
@@ -1,4 +1,5 @@
 import siliconcompiler
+from siliconcompiler import Flow
 
 def make_docs():
     '''A flow for stitching together hardened blocks without doing any automated
@@ -9,22 +10,21 @@ def make_docs():
     '''
     chip = siliconcompiler.Chip('<topmodule>')
     chip.set('option', 'flow', 'asictopflow')
-    setup(chip)
-    return chip
+    return setup(chip)
 
 def setup(chip):
-    flow = 'asictopflow'
-    chip.node(flow, 'import', 'surelog', 'import')
-    chip.node(flow, 'syn', 'yosys', 'syn_asic')
-    chip.node(flow, 'export', 'klayout', 'export')
-    chip.node(flow, 'merge', 'builtin', 'join')
+    flow = Flow(chip, 'asictopflow')
 
-    chip.edge(flow, 'import', 'export')
-    chip.edge(flow, 'import', 'syn')
+    flow.node(flow.design, 'import', 'surelog', 'import')
+    flow.node(flow.design, 'syn', 'yosys', 'syn_asic')
+    flow.node(flow.design, 'export', 'klayout', 'export')
+    flow.node(flow.design, 'merge', 'builtin', 'join')
 
-    chip.edge(flow, 'export', 'merge')
-    chip.edge(flow, 'syn', 'merge')
+    flow.edge(flow.design, 'import', 'export')
+    flow.edge(flow.design, 'import', 'syn')
 
     # Set default goal
-    for step in chip.getkeys('flowgraph', flow):
-        chip.set('flowgraph', flow, step, '0', 'goal', 'errors', 0)
+    for step in flow.getkeys('flowgraph', flow.design):
+        flow.set('flowgraph', flow.design, step, '0', 'goal', 'errors', 0)
+
+    return flow

--- a/siliconcompiler/flows/dvflow.py
+++ b/siliconcompiler/flows/dvflow.py
@@ -1,5 +1,4 @@
 import siliconcompiler
-from siliconcompiler import Library
 
 ############################################################################
 # DOCS
@@ -39,7 +38,7 @@ def setup(chip, np=1):
 
     # Definting a flow
     flowname = 'dvflow'
-    flow = Library(chip, flowname)
+    flow = siliconcompiler.Flow(chip, flowname)
 
     # A simple linear flow
     flowpipe = ['import',

--- a/siliconcompiler/flows/fpgaflow.py
+++ b/siliconcompiler/flows/fpgaflow.py
@@ -2,7 +2,6 @@ import siliconcompiler
 import re
 
 from siliconcompiler.flows._common import setup_frontend
-from siliconcompiler import Flow
 
 ############################################################################
 # DOCS
@@ -56,7 +55,7 @@ def setup(chip, flowname='fpgaflow'):
 
     '''
 
-    flow = Flow(chip, flowname)
+    flow = siliconcompiler.Flow(chip, flowname)
 
     # Check that fpga arch has been set for vpr flow or partname has been set for others
     flowtype = ''

--- a/siliconcompiler/flows/lintflow.py
+++ b/siliconcompiler/flows/lintflow.py
@@ -1,5 +1,5 @@
 import siliconcompiler
-import re
+from siliconcompiler import Flow
 
 ############################################################################
 # DOCS
@@ -13,8 +13,7 @@ def make_docs():
 
     chip = siliconcompiler.Chip('<design>')
     chip.set('option', 'flow', 'lintflow')
-    setup(chip)
-    return chip
+    return setup(chip)
 
 ###########################################################################
 # Flowgraph Setup
@@ -29,6 +28,7 @@ def setup(chip):
     '''
 
     flowname = 'lintflow'
+    flow = Flow(chip, flowname)
 
     # Linear flow, up until branch to run parallel verification steps.
     pipe = [('import', 'surelog', 'import'),
@@ -36,10 +36,12 @@ def setup(chip):
             ('export', 'nop', 'nop')]
 
     for step, tool, task in pipe:
-        chip.node(flowname, step, tool, task)
+        flow.node(flowname, step, tool, task)
         if task != 'import':
-            chip.edge(flowname, prevstep, step)
+            flow.edge(flowname, prevstep, step)
         prevstep = step
+
+    return flow
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/flows/lintflow.py
+++ b/siliconcompiler/flows/lintflow.py
@@ -1,5 +1,4 @@
 import siliconcompiler
-from siliconcompiler import Flow
 
 ############################################################################
 # DOCS
@@ -28,7 +27,7 @@ def setup(chip):
     '''
 
     flowname = 'lintflow'
-    flow = Flow(chip, flowname)
+    flow = siliconcompiler.Flow(chip, flowname)
 
     # Linear flow, up until branch to run parallel verification steps.
     pipe = [('import', 'surelog', 'import'),

--- a/siliconcompiler/flows/showflow.py
+++ b/siliconcompiler/flows/showflow.py
@@ -1,5 +1,4 @@
 import siliconcompiler
-from siliconcompiler import Flow
 
 ############################################################################
 # DOCS
@@ -34,7 +33,7 @@ def setup(chip, flowname='showflow', filetype=None, screenshot=False, np=1):
         flowname (str): name for the flow
     '''
 
-    flow = Flow(chip, flowname)
+    flow = siliconcompiler.Flow(chip, flowname)
 
     # Get required parameters first
     if not filetype:

--- a/siliconcompiler/flows/signoffflow.py
+++ b/siliconcompiler/flows/signoffflow.py
@@ -1,5 +1,4 @@
 import siliconcompiler
-from siliconcompiler import Flow
 
 def make_docs():
     '''A flow for running LVS/DRC signoff on a GDS layout.
@@ -16,7 +15,7 @@ def make_docs():
 def setup(chip):
     flowname = 'signoffflow'
 
-    flow = Flow(chip, flowname)
+    flow = siliconcompiler.Flow(chip, flowname)
 
     # nop import since we don't need to pull in any sources
     flow.node(flowname, 'import', 'builtin', 'import')

--- a/siliconcompiler/flows/signoffflow.py
+++ b/siliconcompiler/flows/signoffflow.py
@@ -1,35 +1,39 @@
 import siliconcompiler
+from siliconcompiler import Flow
 
 def make_docs():
     '''A flow for running LVS/DRC signoff on a GDS layout.
 
     Inputs must be passed to this flow as follows::
 
-        chip.set('input', 'gds', '<path-to-layout>.gds')
-        chip.set('input', 'netlist', '<path-to-netlist>.vg')
+        flow.input('<path-to-layout>.gds')
+        flow.input('<path-to-netlist>.vg')
     '''
     chip = siliconcompiler.Chip('<topmodule>')
     chip.set('option', 'flow', 'signoffflow')
-    setup(chip)
-    return chip
+    return setup(chip)
 
 def setup(chip):
-    flow = 'signoffflow'
+    flowname = 'signoffflow'
+
+    flow = Flow(chip, flowname)
 
     # nop import since we don't need to pull in any sources
-    chip.node(flow, 'import', 'builtin', 'import')
+    flow.node(flowname, 'import', 'builtin', 'import')
 
-    chip.node(flow, 'extspice', 'magic', 'extspice')
-    chip.node(flow, 'drc', 'magic', 'drc')
-    chip.node(flow, 'lvs', 'netgen', 'lvs')
-    chip.node(flow, 'signoff', 'builtin', 'join')
+    flow.node(flowname, 'extspice', 'magic', 'extspice')
+    flow.node(flowname, 'drc', 'magic', 'drc')
+    flow.node(flowname, 'lvs', 'netgen', 'lvs')
+    flow.node(flowname, 'signoff', 'builtin', 'join')
 
-    chip.edge(flow, 'import', 'drc')
-    chip.edge(flow, 'import', 'extspice')
-    chip.edge(flow, 'extspice', 'lvs')
-    chip.edge(flow, 'lvs', 'signoff')
-    chip.edge(flow, 'drc', 'signoff')
+    flow.edge(flowname, 'import', 'drc')
+    flow.edge(flowname, 'import', 'extspice')
+    flow.edge(flowname, 'extspice', 'lvs')
+    flow.edge(flowname, 'lvs', 'signoff')
+    flow.edge(flowname, 'drc', 'signoff')
 
     # Set default goal
-    for step in chip.getkeys('flowgraph', flow):
-        chip.set('flowgraph', flow, step, '0', 'goal', 'errors', 0)
+    for step in flow.getkeys('flowgraph', flowname):
+        flow.set('flowgraph', flowname, step, '0', 'goal', 'errors', 0)
+
+    return flow

--- a/siliconcompiler/libs/asap7sc7p5t.py
+++ b/siliconcompiler/libs/asap7sc7p5t.py
@@ -1,16 +1,17 @@
 import os
 import siliconcompiler
 
+from siliconcompiler import Library
+
 def make_docs():
     '''
     ASAP 7 7.5-track standard cell library.
     '''
     chip =  siliconcompiler.Chip('<design>')
-    setup(chip)
-    return chip
+    return setup(chip)
 
-def _setup_lib(libname, suffix):
-    lib = siliconcompiler.Chip(libname)
+def _setup_lib(chip, libname, suffix):
+    lib = Library(chip, libname)
 
     group = 'asap7sc7p5t'
     vt = 'rvt'
@@ -110,6 +111,8 @@ def setup(chip):
         'asap7sc7p5t_slvt' : 'SL'
     }
 
+    libs = []
     for libname, suffix in all_libs.items():
-        lib = _setup_lib(libname, suffix)
-        chip.import_library(lib)
+        libs.append(_setup_lib(chip, libname, suffix))
+
+    return libs

--- a/siliconcompiler/libs/asap7sc7p5t.py
+++ b/siliconcompiler/libs/asap7sc7p5t.py
@@ -1,8 +1,6 @@
 import os
 import siliconcompiler
 
-from siliconcompiler import Library
-
 def make_docs():
     '''
     ASAP 7 7.5-track standard cell library.
@@ -11,7 +9,7 @@ def make_docs():
     return setup(chip)
 
 def _setup_lib(chip, libname, suffix):
-    lib = Library(chip, libname)
+    lib = siliconcompiler.Library(chip, libname)
 
     group = 'asap7sc7p5t'
     vt = 'rvt'

--- a/siliconcompiler/libs/nangate45.py
+++ b/siliconcompiler/libs/nangate45.py
@@ -1,14 +1,14 @@
 import os
-import copy
 import siliconcompiler
+
+from siliconcompiler import Library
 
 def make_docs():
     '''
     Nangate open standard cell library for FreePDK45.
     '''
     chip = siliconcompiler.Chip('<design>')
-    setup(chip)
-    return chip
+    return setup(chip)
 
 def setup(chip):
     libname = 'nangate45'
@@ -18,7 +18,8 @@ def setup(chip):
     libtype = '10t'
     version = 'r1p0'
     corner = 'typical'
-    objectives = ['setup']
+
+    lib = Library(chip, libname)
 
     libdir = os.path.join('..',
                           'third_party',
@@ -28,10 +29,6 @@ def setup(chip):
                           'libs',
                           libname,
                           version)
-
-
-    # create local chip object
-    lib = siliconcompiler.Chip(libname)
 
     # version
     lib.set('package', 'version', version)
@@ -110,7 +107,7 @@ def setup(chip):
         lib.set('option', 'var', f'{tool}_tielow_cell', "LOGIC0_X1")
         lib.set('option', 'var', f'{tool}_tielow_port', "Z")
 
-    chip.import_library(lib)
+    return lib
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/libs/nangate45.py
+++ b/siliconcompiler/libs/nangate45.py
@@ -1,8 +1,6 @@
 import os
 import siliconcompiler
 
-from siliconcompiler import Library
-
 def make_docs():
     '''
     Nangate open standard cell library for FreePDK45.
@@ -19,7 +17,7 @@ def setup(chip):
     version = 'r1p0'
     corner = 'typical'
 
-    lib = Library(chip, libname)
+    lib = siliconcompiler.Library(chip, libname)
 
     libdir = os.path.join('..',
                           'third_party',

--- a/siliconcompiler/libs/sky130hd.py
+++ b/siliconcompiler/libs/sky130hd.py
@@ -1,13 +1,13 @@
 import os
 import siliconcompiler
+from siliconcompiler import Library
 
 def make_docs():
     '''
     Skywater130 standard cell library.
     '''
     chip = siliconcompiler.Chip('<design>')
-    setup(chip)
-    return chip
+    return setup(chip)
 
 def setup(chip):
     foundry = 'skywater'
@@ -20,7 +20,7 @@ def setup(chip):
 
     libdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'libs', libname, version)
 
-    lib = siliconcompiler.Chip(libname)
+    lib = Library(chip, libname)
 
     # version
     lib.set('package', 'version', version)
@@ -124,7 +124,7 @@ def setup(chip):
         lib.set('option', 'var', f'{tool}_tielow_cell', "sky130_fd_sc_hd__conb_1")
         lib.set('option', 'var', f'{tool}_tielow_port', "LO")
 
-    chip.import_library(lib)
+    return lib
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/libs/sky130hd.py
+++ b/siliconcompiler/libs/sky130hd.py
@@ -1,6 +1,5 @@
 import os
 import siliconcompiler
-from siliconcompiler import Library
 
 def make_docs():
     '''
@@ -20,7 +19,7 @@ def setup(chip):
 
     libdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'libs', libname, version)
 
-    lib = Library(chip, libname)
+    lib = siliconcompiler.Library(chip, libname)
 
     # version
     lib.set('package', 'version', version)

--- a/siliconcompiler/libs/sky130io.py
+++ b/siliconcompiler/libs/sky130io.py
@@ -1,14 +1,13 @@
 import os
-
 import siliconcompiler
+from siliconcompiler import Library
 
 def make_docs():
     '''
     Skywater130 I/O library.
     '''
     chip = siliconcompiler.Chip('<design>')
-    setup(chip)
-    return chip
+    return setup(chip)
 
 def setup(chip):
     process = 'skywater130'
@@ -16,7 +15,7 @@ def setup(chip):
     stackup = '5M1LI'
     corner = 'typical'
 
-    lib = siliconcompiler.Chip(libname)
+    lib = Library(chip, libname)
 
     libdir = os.path.join('..',
                           'third_party',
@@ -36,4 +35,4 @@ def setup(chip):
     lib.add('output', stackup, 'gds', os.path.join(libdir, 'sky130_fd_io.gds'))
     lib.add('output', stackup, 'gds', os.path.join(libdir, 'sky130_ef_io__gpiov2_pad_wrapped.gds'))
 
-    chip.import_library(lib)
+    return lib

--- a/siliconcompiler/libs/sky130io.py
+++ b/siliconcompiler/libs/sky130io.py
@@ -1,6 +1,5 @@
 import os
 import siliconcompiler
-from siliconcompiler import Library
 
 def make_docs():
     '''
@@ -15,7 +14,7 @@ def setup(chip):
     stackup = '5M1LI'
     corner = 'typical'
 
-    lib = Library(chip, libname)
+    lib = siliconcompiler.Library(chip, libname)
 
     libdir = os.path.join('..',
                           'third_party',

--- a/siliconcompiler/pdks/asap7.py
+++ b/siliconcompiler/pdks/asap7.py
@@ -1,8 +1,6 @@
 import os
 import siliconcompiler
 
-from siliconcompiler import PDK
-
 def make_docs():
     '''
     The asap7 PDK was developed at ASU in collaboration with ARM Research.
@@ -59,7 +57,7 @@ def setup(chip):
     libtype = '7p5t'
     pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
 
-    pdk = PDK(chip, process)
+    pdk = siliconcompiler.PDK(chip, process)
 
     # process name
     pdk.set('pdk', process, 'foundry', foundry)

--- a/siliconcompiler/pdks/asap7.py
+++ b/siliconcompiler/pdks/asap7.py
@@ -1,7 +1,7 @@
 import os
-import sys
-import re
 import siliconcompiler
+
+from siliconcompiler import PDK
 
 def make_docs():
     '''
@@ -42,9 +42,8 @@ def make_docs():
     '''
 
     chip = siliconcompiler.Chip('asap7')
-    setup(chip)
 
-    return chip
+    return setup(chip)
 
 def setup(chip):
     '''
@@ -60,24 +59,26 @@ def setup(chip):
     libtype = '7p5t'
     pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
 
+    pdk = PDK(chip, process)
+
     # process name
-    chip.set('pdk', process, 'foundry', foundry)
-    chip.set('pdk', process, 'node', node)
-    chip.set('pdk', process, 'wafersize', wafersize)
-    chip.set('pdk', process, 'version', rev)
-    chip.set('pdk', process, 'stackup', stackup)
+    pdk.set('pdk', process, 'foundry', foundry)
+    pdk.set('pdk', process, 'node', node)
+    pdk.set('pdk', process, 'wafersize', wafersize)
+    pdk.set('pdk', process, 'version', rev)
+    pdk.set('pdk', process, 'stackup', stackup)
 
     # APR tech file
     for tool in ('openroad', 'klayout', 'magic'):
-        chip.set('pdk', process, 'aprtech', tool, stackup, libtype, 'lef',
-                 pdkdir+'/apr/asap7_tech.lef')
+        pdk.set('pdk', process, 'aprtech', tool, stackup, libtype, 'lef',
+                pdkdir+'/apr/asap7_tech.lef')
 
-    chip.set('pdk', process, 'minlayer', stackup, 'M2')
-    chip.set('pdk', process, 'maxlayer', stackup, 'M7')
+    pdk.set('pdk', process, 'minlayer', stackup, 'M2')
+    pdk.set('pdk', process, 'maxlayer', stackup, 'M7')
 
     # Klayout setup file
-    chip.set('pdk', process, 'layermap','klayout','def','gds',stackup,
-             pdkdir+'/setup/klayout/asap7.lyt')
+    pdk.set('pdk', process, 'layermap','klayout','def','gds',stackup,
+            pdkdir+'/setup/klayout/asap7.lyt')
 
     # Openroad global routing grid derating
     openroad_layer_adjustments = {
@@ -92,17 +93,19 @@ def setup(chip):
         'M9': 0.4
     }
     for layer, adj in openroad_layer_adjustments.items():
-        chip.set('pdk', process, 'var', 'openroad', f'{layer}_adjustment', stackup, str(adj))
+        pdk.set('pdk', process, 'var', 'openroad', f'{layer}_adjustment', stackup, str(adj))
 
-    chip.set('pdk', process, 'var', 'openroad', 'rclayer_signal', stackup, 'M3')
-    chip.set('pdk', process, 'var', 'openroad', 'rclayer_clock', stackup, 'M5')
+    pdk.set('pdk', process, 'var', 'openroad', 'rclayer_signal', stackup, 'M3')
+    pdk.set('pdk', process, 'var', 'openroad', 'rclayer_clock', stackup, 'M5')
 
-    chip.set('pdk', process, 'var', 'openroad', 'pin_layer_vertical', stackup, 'M5')
-    chip.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'M4')
+    pdk.set('pdk', process, 'var', 'openroad', 'pin_layer_vertical', stackup, 'M5')
+    pdk.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'M4')
 
     # PEX
-    chip.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
+    pdk.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
         pdkdir + '/pex/openroad/typical.tcl')
+
+    return pdk
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/pdks/freepdk45.py
+++ b/siliconcompiler/pdks/freepdk45.py
@@ -2,8 +2,6 @@
 import os
 import siliconcompiler
 
-from siliconcompiler import PDK
-
 ############################################################################
 # DOCS
 ############################################################################
@@ -60,7 +58,7 @@ def setup(chip):
 
     pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
 
-    pdk = PDK(chip, process)
+    pdk = siliconcompiler.PDK(chip, process)
 
     # process name
     pdk.set('pdk', process, 'foundry', foundry)

--- a/siliconcompiler/pdks/freepdk45.py
+++ b/siliconcompiler/pdks/freepdk45.py
@@ -1,9 +1,8 @@
 
 import os
-import sys
-import re
 import siliconcompiler
 
+from siliconcompiler import PDK
 
 ############################################################################
 # DOCS
@@ -30,9 +29,8 @@ def make_docs():
     '''
 
     chip = siliconcompiler.Chip('freepdk45')
-    setup(chip)
 
-    return chip
+    return setup(chip)
 
 
 ####################################################
@@ -62,30 +60,32 @@ def setup(chip):
 
     pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
 
+    pdk = PDK(chip, process)
+
     # process name
-    chip.set('pdk', process, 'foundry', foundry)
-    chip.set('pdk', process, 'node', node)
-    chip.set('pdk', process, 'version', rev)
-    chip.set('pdk', process, 'stackup', stackup)
-    chip.set('pdk', process, 'wafersize', wafersize)
-    chip.set('pdk', process, 'edgemargin', edgemargin)
-    chip.set('pdk', process, 'hscribe', hscribe)
-    chip.set('pdk', process, 'vscribe', vscribe)
-    chip.set('pdk', process, 'd0', d0)
+    pdk.set('pdk', process, 'foundry', foundry)
+    pdk.set('pdk', process, 'node', node)
+    pdk.set('pdk', process, 'version', rev)
+    pdk.set('pdk', process, 'stackup', stackup)
+    pdk.set('pdk', process, 'wafersize', wafersize)
+    pdk.set('pdk', process, 'edgemargin', edgemargin)
+    pdk.set('pdk', process, 'hscribe', hscribe)
+    pdk.set('pdk', process, 'vscribe', vscribe)
+    pdk.set('pdk', process, 'd0', d0)
 
     # APR Setup
     for tool in ('openroad', 'klayout', 'magic'):
-        chip.set('pdk', process, 'aprtech', tool, stackup, libtype, 'lef',
-                 pdkdir+'/apr/freepdk45.tech.lef')
+        pdk.set('pdk', process, 'aprtech', tool, stackup, libtype, 'lef',
+                pdkdir+'/apr/freepdk45.tech.lef')
 
-    chip.set('pdk', process, 'minlayer', stackup, 'metal1')
-    chip.set('pdk', process, 'maxlayer', stackup, 'metal10')
+    pdk.set('pdk', process, 'minlayer', stackup, 'metal1')
+    pdk.set('pdk', process, 'maxlayer', stackup, 'metal10')
 
     # Klayout setup file
-    chip.set('pdk', process, 'layermap', 'klayout', 'def', 'gds', stackup,
-             pdkdir+'/setup/klayout/freepdk45.lyt')
+    pdk.set('pdk', process, 'layermap', 'klayout', 'def', 'gds', stackup,
+            pdkdir+'/setup/klayout/freepdk45.lyt')
 
-    chip.set('pdk', process, 'display', 'klayout', stackup,
+    pdk.set('pdk', process, 'display', 'klayout', stackup,
             pdkdir + '/setup/klayout/freepdk45.lyp')
 
     # Openroad global routing grid derating
@@ -102,17 +102,19 @@ def setup(chip):
         'metal10': 0.4
     }
     for layer, adj in openroad_layer_adjustments.items():
-        chip.set('pdk', process, 'var', 'openroad', f'{layer}_adjustment', stackup, str(adj))
+        pdk.set('pdk', process, 'var', 'openroad', f'{layer}_adjustment', stackup, str(adj))
 
-    chip.set('pdk', process, 'var', 'openroad', 'rclayer_signal', stackup, 'metal3')
-    chip.set('pdk', process, 'var', 'openroad', 'rclayer_clock', stackup, 'metal5')
+    pdk.set('pdk', process, 'var', 'openroad', 'rclayer_signal', stackup, 'metal3')
+    pdk.set('pdk', process, 'var', 'openroad', 'rclayer_clock', stackup, 'metal5')
 
-    chip.set('pdk', process, 'var', 'openroad', 'pin_layer_vertical', stackup, 'metal2')
-    chip.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'metal3')
+    pdk.set('pdk', process, 'var', 'openroad', 'pin_layer_vertical', stackup, 'metal2')
+    pdk.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'metal3')
 
     # PEX
-    chip.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
+    pdk.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
         pdkdir + '/pex/openroad/typical.tcl')
+
+    return pdk
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -1,8 +1,8 @@
 
 import os
-import sys
-import re
 import siliconcompiler
+
+from siliconcompiler import PDK
 
 ############################################################################
 # DOCS
@@ -36,9 +36,8 @@ def make_docs():
     '''
 
     chip = siliconcompiler.Chip('skywater130')
-    setup(chip)
 
-    return chip
+    return setup(chip)
 
 ####################################################
 # PDK Setup
@@ -65,34 +64,36 @@ def setup(chip):
 
     pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
 
+    pdk = PDK(chip, process)
+
     # process name
-    chip.set('pdk', process, 'foundry', foundry)
-    chip.set('pdk', process, 'node', node)
-    chip.set('pdk', process, 'version', rev)
-    chip.set('pdk', process, 'stackup', stackup)
-    chip.set('pdk', process, 'wafersize', wafersize)
-    chip.set('pdk', process, 'edgemargin', edgemargin)
-    chip.set('pdk', process, 'hscribe', hscribe)
-    chip.set('pdk', process, 'vscribe', vscribe)
+    pdk.set('pdk', process, 'foundry', foundry)
+    pdk.set('pdk', process, 'node', node)
+    pdk.set('pdk', process, 'version', rev)
+    pdk.set('pdk', process, 'stackup', stackup)
+    pdk.set('pdk', process, 'wafersize', wafersize)
+    pdk.set('pdk', process, 'edgemargin', edgemargin)
+    pdk.set('pdk', process, 'hscribe', hscribe)
+    pdk.set('pdk', process, 'vscribe', vscribe)
 
     # APR Setup
     # TODO: remove libtype
     for tool in ('openroad', 'klayout', 'magic'):
-        chip.set('pdk', process,'aprtech',tool,stackup, libtype,'lef',
-                 pdkdir+'/apr/sky130_fd_sc_hd.tlef')
+        pdk.set('pdk', process,'aprtech',tool,stackup, libtype,'lef',
+                pdkdir+'/apr/sky130_fd_sc_hd.tlef')
 
-    chip.set('pdk', process, 'minlayer', stackup, 'met1')
-    chip.set('pdk', process, 'maxlayer', stackup, 'met5')
+    pdk.set('pdk', process, 'minlayer', stackup, 'met1')
+    pdk.set('pdk', process, 'maxlayer', stackup, 'met5')
 
     # DRC Runsets
-    chip.set('pdk', process,'drc', 'runset', 'magic', stackup, 'basic', pdkdir+'/setup/magic/sky130A.tech')
+    pdk.set('pdk', process,'drc', 'runset', 'magic', stackup, 'basic', pdkdir+'/setup/magic/sky130A.tech')
 
     # LVS Runsets
-    chip.set('pdk', process,'lvs', 'runset', 'netgen', stackup, 'basic', pdkdir+'/setup/netgen/lvs_setup.tcl')
+    pdk.set('pdk', process,'lvs', 'runset', 'netgen', stackup, 'basic', pdkdir+'/setup/netgen/lvs_setup.tcl')
 
     # Layer map and display file
-    chip.set('pdk', process, 'layermap', 'klayout', 'def', 'gds', stackup, pdkdir+'/setup/klayout/skywater130.lyt')
-    chip.set('pdk', process, 'display', 'klayout', stackup, pdkdir+'/setup/klayout/sky130A.lyp')
+    pdk.set('pdk', process, 'layermap', 'klayout', 'def', 'gds', stackup, pdkdir+'/setup/klayout/skywater130.lyt')
+    pdk.set('pdk', process, 'display', 'klayout', stackup, pdkdir+'/setup/klayout/sky130A.lyp')
 
     # Openroad global routing grid derating
     openroad_layer_adjustments = {
@@ -104,20 +105,22 @@ def setup(chip):
         'met5': 0.5,
     }
     for layer, adj in openroad_layer_adjustments.items():
-        chip.set('pdk', process, 'var', 'openroad', f'{layer}_adjustment', stackup, str(adj))
+        pdk.set('pdk', process, 'var', 'openroad', f'{layer}_adjustment', stackup, str(adj))
 
-    chip.set('pdk', process, 'var', 'openroad', 'rclayer_signal', stackup, 'met3')
-    chip.set('pdk', process, 'var', 'openroad', 'rclayer_clock', stackup, 'met4')
+    pdk.set('pdk', process, 'var', 'openroad', 'rclayer_signal', stackup, 'met3')
+    pdk.set('pdk', process, 'var', 'openroad', 'rclayer_clock', stackup, 'met4')
 
-    chip.set('pdk', process, 'var', 'openroad', 'pin_layer_vertical', stackup, 'met2')
-    chip.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'met3')
+    pdk.set('pdk', process, 'var', 'openroad', 'pin_layer_vertical', stackup, 'met2')
+    pdk.set('pdk', process, 'var', 'openroad', 'pin_layer_horizontal', stackup, 'met3')
 
     # Hide the 81/4 'areaid.standardc' layer by default; it puts opaque purple over most core areas.
-    chip.set('pdk', process, 'var', 'klayout', 'hide_layers', stackup, ['areaid.standardc'])
+    pdk.set('pdk', process, 'var', 'klayout', 'hide_layers', stackup, ['areaid.standardc'])
 
     # PEX
-    chip.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
+    pdk.set('pdk', process, 'pexmodel', 'openroad', stackup, 'typical',
         pdkdir + '/pex/openroad/typical.tcl')
+
+    return pdk
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -2,8 +2,6 @@
 import os
 import siliconcompiler
 
-from siliconcompiler import PDK
-
 ############################################################################
 # DOCS
 ############################################################################
@@ -64,7 +62,7 @@ def setup(chip):
 
     pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
 
-    pdk = PDK(chip, process)
+    pdk = siliconcompiler.PDK(chip, process)
 
     # process name
     pdk.set('pdk', process, 'foundry', foundry)

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -6,7 +6,7 @@ import re
 
 from siliconcompiler import utils
 
-SCHEMA_VERSION = '0.21.0'
+SCHEMA_VERSION = '0.22.0'
 
 #############################################################################
 # PARAM DEFINITION
@@ -1460,33 +1460,6 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
 ###########################################################################
 
 def schema_arg(cfg):
-
-    key = 'default'
-    scparam(cfg, ['arg', 'pdk', key],
-            sctype='[str]',
-            scope='scratch',
-            shorthelp="ARG: PDK argument",
-            switch="-arg_pdk 'key <str>",
-            example=[
-                "cli: -arg_pdk 'mimcap true'",
-                "api: chip.set('arg','pdk','mimcap',True)"],
-            schelp="""
-            Parameter passed in as key/value pair to the technology target
-            referenced in the load_pdk() API call. See the target technology
-            for specific guidelines regarding configuration parameters.""")
-
-    scparam(cfg, ['arg', 'flow', key],
-            sctype='[str]',
-            scope='scratch',
-            shorthelp="ARG: Flow argument",
-            switch="-arg_flow 'key <str>'",
-            example=[
-                "cli: -arg_flow 'n 100'",
-                "api: chip.set('arg','flow','n', 100)"],
-            schelp="""
-            Parameter passed in as key/value pair to the flow target
-            referenced in the load_flow() API call. See the target flow
-            for specific guidelines regarding configuration parameters.""")
 
     scparam(cfg, ['arg', 'step'],
             sctype='str',

--- a/siliconcompiler/targets/asap7_demo.py
+++ b/siliconcompiler/targets/asap7_demo.py
@@ -11,17 +11,26 @@ def make_docs():
     setup(chip)
     return chip
 
-def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1, dfm_np=1):
+def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1):
     '''
     ASAP7 Demo Target
     '''
+
+    asic_flow_args = {
+        "syn_np": syn_np,
+        "floorplan_np": floorplan_np,
+        "physyn_np": physyn_np,
+        "place_np": place_np,
+        "cts_np": cts_np,
+        "route_np": route_np
+    }
 
     #1. Load PDK, flow, libs combo
     from pdks import asap7
     from flows import asicflow
     from libs import asap7sc7p5t
     chip.use(asap7)
-    chip.use(asicflow, syn_np=syn_np, floorplan_np=floorplan_np, physyn_np=physyn_np, place_np=place_np, cts_np=cts_np, route_np=route_np, dfm_np=dfm_np)
+    chip.use(asicflow, **asic_flow_args)
     chip.use(asap7sc7p5t)
 
     #2. Setup default show tools

--- a/siliconcompiler/targets/asap7_demo.py
+++ b/siliconcompiler/targets/asap7_demo.py
@@ -11,7 +11,7 @@ def make_docs():
     setup(chip)
     return chip
 
-def setup(chip):
+def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1, dfm_np=1):
     '''
     ASAP7 Demo Target
     '''
@@ -21,7 +21,7 @@ def setup(chip):
     from flows import asicflow
     from libs import asap7sc7p5t
     chip.use(asap7)
-    chip.use(asicflow)
+    chip.use(asicflow, syn_np=syn_np, floorplan_np=floorplan_np, physyn_np=physyn_np, place_np=place_np, cts_np=cts_np, route_np=route_np, dfm_np=dfm_np)
     chip.use(asap7sc7p5t)
 
     #2. Setup default show tools

--- a/siliconcompiler/targets/freepdk45_demo.py
+++ b/siliconcompiler/targets/freepdk45_demo.py
@@ -20,10 +20,19 @@ def make_docs():
 # PDK Setup
 ####################################################
 
-def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1, dfm_np=1):
+def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1):
     '''
     Target setup
     '''
+
+    asic_flow_args = {
+        "syn_np": syn_np,
+        "floorplan_np": floorplan_np,
+        "physyn_np": physyn_np,
+        "place_np": place_np,
+        "cts_np": cts_np,
+        "route_np": route_np
+    }
 
     #1. Load PDK, flow, libs combo
     from pdks import freepdk45
@@ -31,7 +40,7 @@ def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, rou
     from libs import nangate45
     chip.use(freepdk45)
     chip.use(lintflow)
-    chip.use(asicflow, syn_np=syn_np, floorplan_np=floorplan_np, physyn_np=physyn_np, place_np=place_np, cts_np=cts_np, route_np=route_np, dfm_np=dfm_np)
+    chip.use(asicflow, **asic_flow_args)
     chip.use(asictopflow)
     chip.use(nangate45)
 

--- a/siliconcompiler/targets/freepdk45_demo.py
+++ b/siliconcompiler/targets/freepdk45_demo.py
@@ -20,7 +20,7 @@ def make_docs():
 # PDK Setup
 ####################################################
 
-def setup(chip):
+def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1, dfm_np=1):
     '''
     Target setup
     '''
@@ -31,9 +31,8 @@ def setup(chip):
     from libs import nangate45
     chip.use(freepdk45)
     chip.use(lintflow)
-    chip.use(asicflow)
+    chip.use(asicflow, syn_np=syn_np, floorplan_np=floorplan_np, physyn_np=physyn_np, place_np=place_np, cts_np=cts_np, route_np=route_np, dfm_np=dfm_np)
     chip.use(asictopflow)
-    chip.use(asicflow)
     chip.use(nangate45)
 
     #2. Setup default show tools

--- a/siliconcompiler/targets/skywater130_demo.py
+++ b/siliconcompiler/targets/skywater130_demo.py
@@ -20,10 +20,19 @@ def make_docs():
 # PDK Setup
 ####################################################
 
-def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1, dfm_np=1):
+def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1):
     '''
     Skywater130 Demo Target
     '''
+
+    asic_flow_args = {
+        "syn_np": syn_np,
+        "floorplan_np": floorplan_np,
+        "physyn_np": physyn_np,
+        "place_np": place_np,
+        "cts_np": cts_np,
+        "route_np": route_np
+    }
 
     #1. Load PDK, flow, libs
     from pdks import skywater130
@@ -31,7 +40,7 @@ def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, rou
     from libs import sky130hd
     from checklists.oh_tapeout import oh_tapeout
     chip.use(skywater130)
-    chip.use(asicflow, syn_np=syn_np, floorplan_np=floorplan_np, physyn_np=physyn_np, place_np=place_np, cts_np=cts_np, route_np=route_np, dfm_np=dfm_np)
+    chip.use(asicflow, **asic_flow_args)
     chip.use(asictopflow)
     chip.use(signoffflow)
     chip.use(sky130hd)

--- a/siliconcompiler/targets/skywater130_demo.py
+++ b/siliconcompiler/targets/skywater130_demo.py
@@ -20,7 +20,7 @@ def make_docs():
 # PDK Setup
 ####################################################
 
-def setup(chip):
+def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1, dfm_np=1):
     '''
     Skywater130 Demo Target
     '''
@@ -31,7 +31,7 @@ def setup(chip):
     from libs import sky130hd
     from checklists.oh_tapeout import oh_tapeout
     chip.use(skywater130)
-    chip.use(asicflow)
+    chip.use(asicflow, syn_np=syn_np, floorplan_np=floorplan_np, physyn_np=physyn_np, place_np=place_np, cts_np=cts_np, route_np=route_np, dfm_np=dfm_np)
     chip.use(asictopflow)
     chip.use(signoffflow)
     chip.use(sky130hd)

--- a/siliconcompiler/use.py
+++ b/siliconcompiler/use.py
@@ -1,0 +1,79 @@
+# Copyright 2023 Silicon Compiler Authors. All Rights Reserved.
+
+from siliconcompiler import Chip
+
+class PDK(Chip):
+    """
+    Object for configuring a process development kit.
+    This is the main object used for configuration and data for a PDK
+    within the SiliconCompiler platform.
+
+    This inherits all methods from :class:`~siliconcompiler.Chip`.
+
+    Args:
+        chip (Chip): A real only copy of the parent chip.
+        name (string): Name of the PDK.
+    Examples:
+        >>> siliconcompiler.PDK(chip, "asap7")
+        Creates a flow object with name "asap7".
+    """
+    def __init__(self, chip, name):
+        super().__init__(name)
+        self.logger = chip.logger
+
+class Library(Chip):
+    """
+    Object for configuring a library.
+    This is the main object used for configuration and data for a library
+    within the SiliconCompiler platform.
+
+    This inherits all methods from :class:`~siliconcompiler.Chip`.
+
+    Args:
+        chip (Chip): A real only copy of the parent chip.
+        name (string): Name of the library.
+    Examples:
+        >>> siliconcompiler.Library(chip, "asap7sc7p5t")
+        Creates a library object with name "asap7sc7p5t".
+    """
+    def __init__(self, chip, name):
+        super().__init__(name)
+        self.logger = chip.logger
+
+class Flow(Chip):
+    """
+    Object for configuring a flow.
+    This is the main object used for configuration and data for a flow
+    within the SiliconCompiler platform.
+
+    This inherits all methods from :class:`~siliconcompiler.Chip`.
+
+    Args:
+        chip (Chip): A real only copy of the parent chip.
+        name (string): Name of the flow.
+    Examples:
+        >>> siliconcompiler.Flow(chip, "asicflow")
+        Creates a flow object with name "asicflow".
+    """
+    def __init__(self, chip, name):
+        super().__init__(name)
+        self.logger = chip.logger
+
+class Checklist(Chip):
+    """
+    Object for configuring a checklist.
+    This is the main object used for configuration and data for a checklist
+    within the SiliconCompiler platform.
+
+    This inherits all methods from :class:`~siliconcompiler.Chip`.
+
+    Args:
+        chip (Chip): A real only copy of the parent chip.
+        name (string): Name of the checklist.
+    Examples:
+        >>> siliconcompiler.Checklist(chip, "tapeout")
+        Creates a checklist object with name "tapeout".
+    """
+    def __init__(self, chip, name):
+        super().__init__(name)
+        self.logger = chip.logger

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1,27 +1,5 @@
 {
     "arg": {
-        "flow": {
-            "default": {
-                "defvalue": [],
-                "example": [
-                    "cli: -arg_flow 'n 100'",
-                    "api: chip.set('arg','flow','n', 100)"
-                ],
-                "help": "Parameter passed in as key/value pair to the flow target\nreferenced in the load_flow() API call. See the target flow\nfor specific guidelines regarding configuration parameters.",
-                "lock": false,
-                "nodevalue": {},
-                "notes": null,
-                "pernode": "never",
-                "require": null,
-                "scope": "scratch",
-                "set": false,
-                "shorthelp": "ARG: Flow argument",
-                "signature": [],
-                "switch": "-arg_flow 'key <str>'",
-                "type": "[str]",
-                "value": []
-            }
-        },
         "index": {
             "defvalue": null,
             "example": [
@@ -41,28 +19,6 @@
             "switch": "-arg_index <str>",
             "type": "str",
             "value": null
-        },
-        "pdk": {
-            "default": {
-                "defvalue": [],
-                "example": [
-                    "cli: -arg_pdk 'mimcap true'",
-                    "api: chip.set('arg','pdk','mimcap',True)"
-                ],
-                "help": "Parameter passed in as key/value pair to the technology target\nreferenced in the load_pdk() API call. See the target technology\nfor specific guidelines regarding configuration parameters.",
-                "lock": false,
-                "nodevalue": {},
-                "notes": null,
-                "pernode": "never",
-                "require": null,
-                "scope": "scratch",
-                "set": false,
-                "shorthelp": "ARG: PDK argument",
-                "signature": [],
-                "switch": "-arg_pdk 'key <str>",
-                "type": "[str]",
-                "value": []
-            }
         },
         "step": {
             "defvalue": null,
@@ -6805,7 +6761,7 @@
         }
     },
     "schemaversion": {
-        "defvalue": "0.21.0",
+        "defvalue": "0.22.0",
         "example": [
             "api: chip.get('schemaversion')"
         ],
@@ -6821,7 +6777,7 @@
         "signature": null,
         "switch": "-schemaversion <str>",
         "type": "str",
-        "value": "0.21.0"
+        "value": "0.22.0"
     },
     "tool": {
         "default": {

--- a/tests/core/test_create_cmdline.py
+++ b/tests/core/test_create_cmdline.py
@@ -56,11 +56,11 @@ def test_spaces_in_value(monkeypatch):
     assert chip.get('package', 'description') == desc
 
 def test_limited_switchlist(monkeypatch):
-    args = ['sc', '-loglevel', 'DEBUG', '-arg_flow', 'foo bar']
-    chip = do_cli_test(args, monkeypatch, switchlist=['-loglevel', '-arg_flow'])
+    args = ['sc', '-loglevel', 'DEBUG', '-var', 'foo bar']
+    chip = do_cli_test(args, monkeypatch, switchlist=['-loglevel', '-var'])
 
     assert chip.get('option', 'loglevel') == 'DEBUG'
-    assert chip.get('arg', 'flow', 'foo') == ['bar']
+    assert chip.get('option', 'var', 'foo') == ['bar']
 
 def _cast(val, sctype):
     if sctype.startswith('['):

--- a/tests/core/test_write_flowgraph.py
+++ b/tests/core/test_write_flowgraph.py
@@ -19,10 +19,7 @@ def test_write_flowgraph():
     ################################################
 
     chip = siliconcompiler.Chip('test')
-    chip.set('arg', 'flow', 'syn_np', "4")
-    chip.set('arg', 'flow', 'place_np', "4")
-    chip.set('arg', 'flow', 'route_np', "4")
-    chip.load_target("freepdk45_demo")
+    chip.load_target("freepdk45_demo", syn_np=4, place_np=4, route_np=4)
     chip.write_flowgraph('forkjoin.png')
 
     assert os.path.isfile('forkjoin.png')
@@ -32,11 +29,10 @@ def test_write_flowgraph():
     ################################################
 
     chip = siliconcompiler.Chip('test')
-    chip.set('arg', 'flow', 'np', "10")
     from pdks import freepdk45
     from flows import dvflow
     chip.use(freepdk45)
-    chip.use(dvflow)
+    chip.use(dvflow, np=10)
     chip.set('option', 'flow', 'dvflow')
     chip.write_flowgraph('pipes.png')
 

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -21,8 +21,7 @@ def test_tool_option(scroot):
     chip.set('option', 'quiet', 'true')
     chip.set('option','relax', 'true')
     chip.set('option','novercheck', 'true')
-    chip.set('arg', 'flow', 'place_np', ['2'])
-    chip.load_target('freepdk45_demo')
+    chip.load_target('freepdk45_demo', place_np=2)
 
     chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '0',  'place_density', '0.4')
     chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '1',  'place_density', '0.3')


### PR DESCRIPTION
Changes:
- Implements .use() for PDKs/Libraries/Flows/Checklists
- both `.use` and `.load_target` can take a `**kwargs` to pass long parameters needed to configure flows, etc
- removal of ['arg', 'flow'/'pdk'] from schema'
- Updates docs to build with the new return types

Notes:
- many of the files in flows/, libs/ pdks/, targets/, and checklists/ are mostly modified to account for the change in use model, but should not have any functional changes.
