### PR TITLE
Support partial steplists in remote flow.

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -37,7 +37,7 @@ def get_base_url(chip):
     return remote_protocol + remote_host
 
 ###################################
-def remote_preprocess(chip):
+def remote_preprocess(chip, steplist):
     '''Helper method to run a local import stage for remote jobs.
     '''
 
@@ -48,7 +48,7 @@ def remote_preprocess(chip):
 
     # Fetch a list of 'import' steps, and make sure they're all at the start of the flow.
     flow = chip.get('option', 'flow')
-    remote_steplist = chip.getkeys('flowgraph', flow)
+    remote_steplist = steplist.copy()
     import_tasks = chip._get_steps_by_task()['import']
     import_steps = []
     for task_tuple in import_tasks:

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -54,10 +54,11 @@ def remote_preprocess(chip, steplist):
     for task_tuple in import_tasks:
         if not task_tuple[0] in import_steps:
             import_steps.append(task_tuple[0])
-    if remote_steplist[:len(import_steps)] != import_steps:
+    if (remote_steplist[:len(import_steps)] != import_steps) or (len(remote_steplist) == 1):
         chip.error('Remote flows must be organized such that the "import" task(s) are run before '
-                  f'all other steps.\nFull steplist: {remote_steplist}\n'
-                  f'Import steplist: {import_steps}', fatal=True)
+                   'all other steps, and at least one import and EDA task are included.\n'
+                  f'Full steplist: {remote_steplist}\nImport steplist: {import_steps}',
+                   fatal=True)
     # Setup up tools for all local functions
     for local_step in import_steps:
         indexlist = chip.getkeys('flowgraph', flow, local_step)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3989,7 +3989,10 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 self.error('Cannot pass "-step" parameter into remote flow. A steplist including '
                            'an "import" task and at least one EDA task is required.',
                            fatal=True)
-            pre_remote_steplist = self.get('option', 'steplist')
+            pre_remote_steplist = {
+                'steplist': self.get('option', 'steplist'),
+                'set': self.get('option', 'steplist', field='set'),
+            }
             remote_preprocess(self, steplist)
 
             # Run the job on the remote server, and wait for it to finish.
@@ -4005,7 +4008,10 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 self.read_manifest(cfg, clobber=True, clear=True)
                 self.set('option', 'builddir', local_dir)
                 # Un-set steplist so 'show'/etc flows will work on returned results.
-                self.set('option', 'steplist', pre_remote_steplist)
+                if pre_remote_steplist['set']:
+                    self.set('option', 'steplist', pre_remote_steplist['steplist'])
+                else:
+                    self.unset('option', 'steplist')
             else:
                 # Hack to find first failed step by checking for presence of
                 # output manifests.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3985,6 +3985,10 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             # in-progress build directory to the remote server.
             # Data is encrypted if user / key were specified.
             # run remote process
+            if self.get('arg', 'step'):
+                self.error('Cannot pass "-step" parameter into remote flow. A steplist including '
+                           'an "import" task and at least one EDA task is required.',
+                           fatal=True)
             pre_remote_steplist = self.get('option', 'steplist')
             remote_preprocess(self, steplist)
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3985,7 +3985,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             # in-progress build directory to the remote server.
             # Data is encrypted if user / key were specified.
             # run remote process
-            remote_preprocess(self)
+            pre_remote_steplist = self.get('option', 'steplist')
+            remote_preprocess(self, steplist)
 
             # Run the job on the remote server, and wait for it to finish.
             remote_run(self)
@@ -4000,7 +4001,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 self.read_manifest(cfg, clobber=True, clear=True)
                 self.set('option', 'builddir', local_dir)
                 # Un-set steplist so 'show'/etc flows will work on returned results.
-                self.unset('option', 'steplist')
+                self.set('option', 'steplist', pre_remote_steplist)
             else:
                 # Hack to find first failed step by checking for presence of
                 # output manifests.

--- a/tests/flows/test_server.py
+++ b/tests/flows/test_server.py
@@ -198,9 +198,7 @@ if __name__ == "__main__":
     from tests.fixtures import gcd_chip
     if os.path.isdir('local_server_work'):
         os.rmdir('local_server_work')
-    test_gcd_server(gcd_chip())
-    test_gcd_server_partial(gcd_chip())
-    test_gcd_server_partial_noimport(gcd_chip())
-    test_gcd_server_partial_noeda(gcd_chip())
-    test_gcd_server_error(gcd_chip())
-    test_gcd_server_argstep_error(gcd_chip())
+    cur_dir = os.getcwd()
+    os.chdir(os.path.dirname(__file__))
+    pytest.main(['test_server.py'])
+    os.chdir(cur_dir)

--- a/tests/flows/test_server.py
+++ b/tests/flows/test_server.py
@@ -8,17 +8,18 @@ import time
 
 from unittest.mock import Mock
 
-###########################
-@pytest.mark.eda
-@pytest.mark.quick
-def test_gcd_server(gcd_chip):
-    '''Basic sc-server test: Run a local instance of a server, and build the GCD
-       example using loopback network calls to that server.
-    '''
+@pytest.fixture
+def gcd_remote_test(gcd_chip, request):
+    # Get the port number; avoid re-use to enable parallel tests.
+    if 'port' in request.keywords:
+        port = request.keywords["port"]
+    else:
+        port = '8080'
 
     # Start running an sc-server instance.
     os.mkdir('local_server_work')
     srv_proc = subprocess.Popen(['sc-server',
+                                 '-port', port,
                                  '-nfs_mount', './local_server_work',
                                  '-cluster', 'local'])
     time.sleep(3)
@@ -33,15 +34,39 @@ def test_gcd_server(gcd_chip):
     gcd_chip._runtask = Mock()
     gcd_chip._runtask.side_effect = mocked_runtask
 
-    # Ensure that klayout doesn't open its GUI after results are retrieved.
-    os.environ['DISPLAY'] = ''
-
     # Create the temporary credentials file, and set the Chip to use it.
     tmp_creds = '.test_remote_cfg'
     with open(tmp_creds, 'w') as tmp_cred_file:
-        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8080}))
+        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': int(port)}))
     gcd_chip.set('option', 'remote', True)
     gcd_chip.set('option', 'credentials', os.path.abspath(tmp_creds))
+
+    # Ensure that klayout doesn't open its GUI after results are retrieved.
+    os.environ['DISPLAY'] = ''
+
+    try:
+        yield gcd_chip
+    except Exception as e:
+        # Kill the server process.
+        srv_proc.kill()
+        # Re-raise the exception.
+        raise e
+
+    # Kill the server process.
+    srv_proc.kill()
+
+
+###########################
+@pytest.mark.eda
+@pytest.mark.quick
+@pytest.mark.remote_test(port='8080')
+def test_gcd_server(gcd_remote_test):
+    '''Basic sc-server test: Run a local instance of a server, and build the GCD
+       example using loopback network calls to that server.
+    '''
+
+    # Get the partially-configured GCD Chip object from the fixture.
+    gcd_chip = gcd_remote_test
 
     # Run the remote job.
     try:
@@ -50,49 +75,22 @@ def test_gcd_server(gcd_chip):
         # Failures will be printed, and noted in the following assert.
         traceback.print_exc()
 
-    # Kill the server process.
-    srv_proc.kill()
-
     # Verify that GDS and SVG files were generated and returned.
     assert os.path.isfile('build/gcd/job0/export/0/outputs/gcd.gds')
 
 ###########################
 @pytest.mark.eda
 @pytest.mark.quick
-def test_gcd_server_partial(gcd_chip):
+@pytest.mark.remote_test(port='8081')
+def test_gcd_server_partial(gcd_remote_test):
     '''Basic sc-server test: Run a local instance of a server, and build the GCD
        example using loopback network calls to that server.
 
        This test runs a partial flowgraph on the remote server.
     '''
 
-    # Start running an sc-server instance.
-    os.mkdir('local_server_work')
-    srv_proc = subprocess.Popen(['sc-server',
-                                 '-port', '8081',
-                                 '-nfs_mount', './local_server_work',
-                                 '-cluster', 'local'])
-    time.sleep(3)
-
-    # Mock the _runstep method.
-    old__runtask = gcd_chip._runtask
-    def mocked_runtask(*args, **kwargs):
-        if args[0] == 'import':
-            old__runtask(*args)
-        else:
-            gcd_chip.logger.error('Non-import step run locally in remote job!')
-    gcd_chip._runtask = Mock()
-    gcd_chip._runtask.side_effect = mocked_runtask
-
-    # Ensure that klayout doesn't open its GUI after results are retrieved.
-    os.environ['DISPLAY'] = ''
-
-    # Create the temporary credentials file, and set the Chip to use it.
-    tmp_creds = '.test_remote_cfg'
-    with open(tmp_creds, 'w') as tmp_cred_file:
-        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8081}))
-    gcd_chip.set('option', 'remote', True)
-    gcd_chip.set('option', 'credentials', os.path.abspath(tmp_creds))
+    # Get the partially-configured GCD Chip object from the fixture.
+    gcd_chip = gcd_remote_test
 
     # Set a steplist to limit how many steps are run on the remote host.
     gcd_chip.set('option', 'steplist', ['import', 'syn', 'floorplan'])
@@ -104,9 +102,6 @@ def test_gcd_server_partial(gcd_chip):
         # Failures will be printed, and noted in the following assert.
         traceback.print_exc()
 
-    # Kill the server process.
-    srv_proc.kill()
-
     # Verify that OpenDB file was created for the floorplan task.
     assert os.path.isfile('build/gcd/job0/floorplan/0/outputs/gcd.odb')
     # Verify that the following physyn step was not run.
@@ -115,40 +110,16 @@ def test_gcd_server_partial(gcd_chip):
 ###########################
 @pytest.mark.eda
 @pytest.mark.quick
-def test_gcd_server_partial_noeda(gcd_chip):
+@pytest.mark.remote_test(port='8082')
+def test_gcd_server_partial_noeda(gcd_remote_test):
     '''Basic sc-server test: Run a local instance of a server, and build the GCD
        example using loopback network calls to that server.
 
        This test attempts to run a remote job with no EDA tasks, which should produce an error.
     '''
 
-    # Start running an sc-server instance.
-    os.mkdir('local_server_work')
-    srv_proc = subprocess.Popen(['sc-server',
-                                 '-port', '8082',
-                                 '-nfs_mount', './local_server_work',
-                                 '-cluster', 'local'])
-    time.sleep(3)
-
-    # Mock the _runstep method.
-    old__runtask = gcd_chip._runtask
-    def mocked_runtask(*args, **kwargs):
-        if args[0] == 'import':
-            old__runtask(*args)
-        else:
-            gcd_chip.logger.error('Non-import step run locally in remote job!')
-    gcd_chip._runtask = Mock()
-    gcd_chip._runtask.side_effect = mocked_runtask
-
-    # Ensure that klayout doesn't open its GUI after results are retrieved.
-    os.environ['DISPLAY'] = ''
-
-    # Create the temporary credentials file, and set the Chip to use it.
-    tmp_creds = '.test_remote_cfg'
-    with open(tmp_creds, 'w') as tmp_cred_file:
-        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8082}))
-    gcd_chip.set('option', 'remote', True)
-    gcd_chip.set('option', 'credentials', os.path.abspath(tmp_creds))
+    # Get the partially-configured GCD Chip object from the fixture.
+    gcd_chip = gcd_remote_test
 
     # Set the steplist to only run the import task.
     gcd_chip.set('option', 'steplist', ['import'])
@@ -157,46 +128,19 @@ def test_gcd_server_partial_noeda(gcd_chip):
     with pytest.raises(siliconcompiler.core.SiliconCompilerError):
         gcd_chip.run()
 
-    # Kill the server process.
-    srv_proc.kill()
-
 ###########################
 @pytest.mark.eda
 @pytest.mark.quick
-def test_gcd_server_partial_noimport(gcd_chip):
+@pytest.mark.remote_test(port='8083')
+def test_gcd_server_partial_noimport(gcd_remote_test):
     '''Basic sc-server test: Run a local instance of a server, and build the GCD
        example using loopback network calls to that server.
 
        This test attempts to run a remote job with no import tasks, which should produce an error.
     '''
 
-    # Start running an sc-server instance.
-    os.mkdir('local_server_work')
-    srv_proc = subprocess.Popen(['sc-server',
-                                 '-port', '8083',
-                                 '-nfs_mount', './local_server_work',
-                                 '-cluster', 'local'])
-    time.sleep(3)
-
-    # Mock the _runstep method.
-    old__runtask = gcd_chip._runtask
-    def mocked_runtask(*args, **kwargs):
-        if args[0] == 'import':
-            old__runtask(*args)
-        else:
-            gcd_chip.logger.error('Non-import step run locally in remote job!')
-    gcd_chip._runtask = Mock()
-    gcd_chip._runtask.side_effect = mocked_runtask
-
-    # Ensure that klayout doesn't open its GUI after results are retrieved.
-    os.environ['DISPLAY'] = ''
-
-    # Create the temporary credentials file, and set the Chip to use it.
-    tmp_creds = '.test_remote_cfg'
-    with open(tmp_creds, 'w') as tmp_cred_file:
-        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8083}))
-    gcd_chip.set('option', 'remote', True)
-    gcd_chip.set('option', 'credentials', os.path.abspath(tmp_creds))
+    # Get the partially-configured GCD Chip object from the fixture.
+    gcd_chip = gcd_remote_test
 
     # Set the steplist to only run the synthesis task.
     gcd_chip.set('option', 'steplist', ['syn'])
@@ -205,13 +149,11 @@ def test_gcd_server_partial_noimport(gcd_chip):
     with pytest.raises(siliconcompiler.core.SiliconCompilerError):
         gcd_chip.run()
 
-    # Kill the server process.
-    srv_proc.kill()
-
 ###########################
 @pytest.mark.eda
 @pytest.mark.quick
-def test_gcd_server_error(gcd_chip):
+@pytest.mark.remote_test(port='8084')
+def test_gcd_server_error(gcd_remote_test):
     '''Basic sc-server test: Run a local instance of a server, and build the GCD
        example using loopback network calls to that server.
 
@@ -219,33 +161,8 @@ def test_gcd_server_error(gcd_chip):
        task between them. This should fail, because the current remote flow expects 'import' -> 'EDA'.
     '''
 
-    # Start running an sc-server instance.
-    os.mkdir('local_server_work')
-    srv_proc = subprocess.Popen(['sc-server',
-                                 '-port', '8084',
-                                 '-nfs_mount', './local_server_work',
-                                 '-cluster', 'local'])
-    time.sleep(3)
-
-    # Mock the _runstep method.
-    old__runtask = gcd_chip._runtask
-    def mocked_runtask(*args, **kwargs):
-        if args[0] == 'import':
-            old__runtask(*args)
-        else:
-            gcd_chip.logger.error('Non-import step run locally in remote job!')
-    gcd_chip._runtask = Mock()
-    gcd_chip._runtask.side_effect = mocked_runtask
-
-    # Ensure that klayout doesn't open its GUI after results are retrieved.
-    os.environ['DISPLAY'] = ''
-
-    # Create the temporary credentials file, and set the Chip to use it.
-    tmp_creds = '.test_remote_cfg'
-    with open(tmp_creds, 'w') as tmp_cred_file:
-        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8084}))
-    gcd_chip.set('option', 'remote', True)
-    gcd_chip.set('option', 'credentials', os.path.abspath(tmp_creds))
+    # Get the partially-configured GCD Chip object from the fixture.
+    gcd_chip = gcd_remote_test
 
     # Set an extra import step after the export step, to create an invalid flowgraph.
     gcd_chip.node('asicflow', 'importt', 'surelog', 'import', index='0')
@@ -255,13 +172,11 @@ def test_gcd_server_error(gcd_chip):
     with pytest.raises(siliconcompiler.core.SiliconCompilerError):
         gcd_chip.run()
 
-    # Kill the server process.
-    srv_proc.kill()
-
 ###########################
 @pytest.mark.eda
 @pytest.mark.quick
-def test_gcd_server_argstep_noimport(gcd_chip):
+@pytest.mark.remote_test(port='8085')
+def test_gcd_server_argstep_noimport(gcd_remote_test):
     '''Basic sc-server test: Run a local instance of a server, and build the GCD
        example using loopback network calls to that server.
 
@@ -269,33 +184,8 @@ def test_gcd_server_argstep_noimport(gcd_chip):
        one import task and one EDA task, so this should fail.
     '''
 
-    # Start running an sc-server instance.
-    os.mkdir('local_server_work')
-    srv_proc = subprocess.Popen(['sc-server',
-                                 '-port', '8085',
-                                 '-nfs_mount', './local_server_work',
-                                 '-cluster', 'local'])
-    time.sleep(3)
-
-    # Mock the _runstep method.
-    old__runtask = gcd_chip._runtask
-    def mocked_runtask(*args, **kwargs):
-        if args[0] == 'import':
-            old__runtask(*args)
-        else:
-            gcd_chip.logger.error('Non-import step run locally in remote job!')
-    gcd_chip._runtask = Mock()
-    gcd_chip._runtask.side_effect = mocked_runtask
-
-    # Ensure that klayout doesn't open its GUI after results are retrieved.
-    os.environ['DISPLAY'] = ''
-
-    # Create the temporary credentials file, and set the Chip to use it.
-    tmp_creds = '.test_remote_cfg'
-    with open(tmp_creds, 'w') as tmp_cred_file:
-        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8085}))
-    gcd_chip.set('option', 'remote', True)
-    gcd_chip.set('option', 'credentials', os.path.abspath(tmp_creds))
+    # Get the partially-configured GCD Chip object from the fixture.
+    gcd_chip = gcd_remote_test
 
     # Set the '-step' option.
     gcd_chip.set('arg', 'step', 'floorplan')
@@ -303,9 +193,6 @@ def test_gcd_server_argstep_noimport(gcd_chip):
     # Run the remote job.
     with pytest.raises(siliconcompiler.core.SiliconCompilerError):
         gcd_chip.run()
-
-    # Kill the server process.
-    srv_proc.kill()
 
 if __name__ == "__main__":
     from tests.fixtures import gcd_chip

--- a/tests/flows/test_server.py
+++ b/tests/flows/test_server.py
@@ -1,5 +1,6 @@
 import json
 import os
+import siliconcompiler
 import subprocess
 import traceback
 import pytest
@@ -55,8 +56,264 @@ def test_gcd_server(gcd_chip):
     # Verify that GDS and SVG files were generated and returned.
     assert os.path.isfile('build/gcd/job0/export/0/outputs/gcd.gds')
 
+###########################
+@pytest.mark.eda
+@pytest.mark.quick
+def test_gcd_server_partial(gcd_chip):
+    '''Basic sc-server test: Run a local instance of a server, and build the GCD
+       example using loopback network calls to that server.
+
+       This test runs a partial flowgraph on the remote server.
+    '''
+
+    # Start running an sc-server instance.
+    os.mkdir('local_server_work')
+    srv_proc = subprocess.Popen(['sc-server',
+                                 '-port', '8081',
+                                 '-nfs_mount', './local_server_work',
+                                 '-cluster', 'local'])
+    time.sleep(3)
+
+    # Mock the _runstep method.
+    old__runtask = gcd_chip._runtask
+    def mocked_runtask(*args, **kwargs):
+        if args[0] == 'import':
+            old__runtask(*args)
+        else:
+            gcd_chip.logger.error('Non-import step run locally in remote job!')
+    gcd_chip._runtask = Mock()
+    gcd_chip._runtask.side_effect = mocked_runtask
+
+    # Ensure that klayout doesn't open its GUI after results are retrieved.
+    os.environ['DISPLAY'] = ''
+
+    # Create the temporary credentials file, and set the Chip to use it.
+    tmp_creds = '.test_remote_cfg'
+    with open(tmp_creds, 'w') as tmp_cred_file:
+        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8081}))
+    gcd_chip.set('option', 'remote', True)
+    gcd_chip.set('option', 'credentials', os.path.abspath(tmp_creds))
+
+    # Set a steplist to limit how many steps are run on the remote host.
+    gcd_chip.set('option', 'steplist', ['import', 'syn', 'floorplan'])
+
+    # Run the remote job.
+    try:
+        gcd_chip.run()
+    except Exception:
+        # Failures will be printed, and noted in the following assert.
+        traceback.print_exc()
+
+    # Kill the server process.
+    srv_proc.kill()
+
+    # Verify that OpenDB file was created for the floorplan task.
+    assert os.path.isfile('build/gcd/job0/floorplan/0/outputs/gcd.odb')
+    # Verify that the following physyn step was not run.
+    assert not os.path.isfile('build/gcd/job0/physyn/0/outputs/gcd.odb')
+
+###########################
+@pytest.mark.eda
+@pytest.mark.quick
+def test_gcd_server_partial_noeda(gcd_chip):
+    '''Basic sc-server test: Run a local instance of a server, and build the GCD
+       example using loopback network calls to that server.
+
+       This test attempts to run a remote job with no EDA tasks, which should produce an error.
+    '''
+
+    # Start running an sc-server instance.
+    os.mkdir('local_server_work')
+    srv_proc = subprocess.Popen(['sc-server',
+                                 '-port', '8082',
+                                 '-nfs_mount', './local_server_work',
+                                 '-cluster', 'local'])
+    time.sleep(3)
+
+    # Mock the _runstep method.
+    old__runtask = gcd_chip._runtask
+    def mocked_runtask(*args, **kwargs):
+        if args[0] == 'import':
+            old__runtask(*args)
+        else:
+            gcd_chip.logger.error('Non-import step run locally in remote job!')
+    gcd_chip._runtask = Mock()
+    gcd_chip._runtask.side_effect = mocked_runtask
+
+    # Ensure that klayout doesn't open its GUI after results are retrieved.
+    os.environ['DISPLAY'] = ''
+
+    # Create the temporary credentials file, and set the Chip to use it.
+    tmp_creds = '.test_remote_cfg'
+    with open(tmp_creds, 'w') as tmp_cred_file:
+        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8082}))
+    gcd_chip.set('option', 'remote', True)
+    gcd_chip.set('option', 'credentials', os.path.abspath(tmp_creds))
+
+    # Set the steplist to only run the import task.
+    gcd_chip.set('option', 'steplist', ['import'])
+
+    # Run the remote job.
+    with pytest.raises(siliconcompiler.core.SiliconCompilerError):
+        gcd_chip.run()
+
+    # Kill the server process.
+    srv_proc.kill()
+
+###########################
+@pytest.mark.eda
+@pytest.mark.quick
+def test_gcd_server_partial_noimport(gcd_chip):
+    '''Basic sc-server test: Run a local instance of a server, and build the GCD
+       example using loopback network calls to that server.
+
+       This test attempts to run a remote job with no import tasks, which should produce an error.
+    '''
+
+    # Start running an sc-server instance.
+    os.mkdir('local_server_work')
+    srv_proc = subprocess.Popen(['sc-server',
+                                 '-port', '8083',
+                                 '-nfs_mount', './local_server_work',
+                                 '-cluster', 'local'])
+    time.sleep(3)
+
+    # Mock the _runstep method.
+    old__runtask = gcd_chip._runtask
+    def mocked_runtask(*args, **kwargs):
+        if args[0] == 'import':
+            old__runtask(*args)
+        else:
+            gcd_chip.logger.error('Non-import step run locally in remote job!')
+    gcd_chip._runtask = Mock()
+    gcd_chip._runtask.side_effect = mocked_runtask
+
+    # Ensure that klayout doesn't open its GUI after results are retrieved.
+    os.environ['DISPLAY'] = ''
+
+    # Create the temporary credentials file, and set the Chip to use it.
+    tmp_creds = '.test_remote_cfg'
+    with open(tmp_creds, 'w') as tmp_cred_file:
+        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8083}))
+    gcd_chip.set('option', 'remote', True)
+    gcd_chip.set('option', 'credentials', os.path.abspath(tmp_creds))
+
+    # Set the steplist to only run the synthesis task.
+    gcd_chip.set('option', 'steplist', ['syn'])
+
+    # Run the remote job.
+    with pytest.raises(siliconcompiler.core.SiliconCompilerError):
+        gcd_chip.run()
+
+    # Kill the server process.
+    srv_proc.kill()
+
+###########################
+@pytest.mark.eda
+@pytest.mark.quick
+def test_gcd_server_error(gcd_chip):
+    '''Basic sc-server test: Run a local instance of a server, and build the GCD
+       example using loopback network calls to that server.
+
+       This test attempts to run an invalid flow graph, with two 'import' tasks containing an EDA
+       task between them. This should fail, because the current remote flow expects 'import' -> 'EDA'.
+    '''
+
+    # Start running an sc-server instance.
+    os.mkdir('local_server_work')
+    srv_proc = subprocess.Popen(['sc-server',
+                                 '-port', '8084',
+                                 '-nfs_mount', './local_server_work',
+                                 '-cluster', 'local'])
+    time.sleep(3)
+
+    # Mock the _runstep method.
+    old__runtask = gcd_chip._runtask
+    def mocked_runtask(*args, **kwargs):
+        if args[0] == 'import':
+            old__runtask(*args)
+        else:
+            gcd_chip.logger.error('Non-import step run locally in remote job!')
+    gcd_chip._runtask = Mock()
+    gcd_chip._runtask.side_effect = mocked_runtask
+
+    # Ensure that klayout doesn't open its GUI after results are retrieved.
+    os.environ['DISPLAY'] = ''
+
+    # Create the temporary credentials file, and set the Chip to use it.
+    tmp_creds = '.test_remote_cfg'
+    with open(tmp_creds, 'w') as tmp_cred_file:
+        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8084}))
+    gcd_chip.set('option', 'remote', True)
+    gcd_chip.set('option', 'credentials', os.path.abspath(tmp_creds))
+
+    # Set an extra import step after the export step, to create an invalid flowgraph.
+    gcd_chip.node('asicflow', 'importt', 'surelog', 'import', index='0')
+    gcd_chip.edge('asicflow', 'export', 'importt', head_index='0')
+
+    # Run the remote job.
+    with pytest.raises(siliconcompiler.core.SiliconCompilerError):
+        gcd_chip.run()
+
+    # Kill the server process.
+    srv_proc.kill()
+
+###########################
+@pytest.mark.eda
+@pytest.mark.quick
+def test_gcd_server_argstep_noimport(gcd_chip):
+    '''Basic sc-server test: Run a local instance of a server, and build the GCD
+       example using loopback network calls to that server.
+
+       This test attempts to run a remote job with ('arg', 'step') set. Remote jobs need at least
+       one import task and one EDA task, so this should fail.
+    '''
+
+    # Start running an sc-server instance.
+    os.mkdir('local_server_work')
+    srv_proc = subprocess.Popen(['sc-server',
+                                 '-port', '8085',
+                                 '-nfs_mount', './local_server_work',
+                                 '-cluster', 'local'])
+    time.sleep(3)
+
+    # Mock the _runstep method.
+    old__runtask = gcd_chip._runtask
+    def mocked_runtask(*args, **kwargs):
+        if args[0] == 'import':
+            old__runtask(*args)
+        else:
+            gcd_chip.logger.error('Non-import step run locally in remote job!')
+    gcd_chip._runtask = Mock()
+    gcd_chip._runtask.side_effect = mocked_runtask
+
+    # Ensure that klayout doesn't open its GUI after results are retrieved.
+    os.environ['DISPLAY'] = ''
+
+    # Create the temporary credentials file, and set the Chip to use it.
+    tmp_creds = '.test_remote_cfg'
+    with open(tmp_creds, 'w') as tmp_cred_file:
+        tmp_cred_file.write(json.dumps({'address': 'localhost', 'port': 8085}))
+    gcd_chip.set('option', 'remote', True)
+    gcd_chip.set('option', 'credentials', os.path.abspath(tmp_creds))
+
+    # Set the '-step' option.
+    gcd_chip.set('arg', 'step', 'floorplan')
+
+    # Run the remote job.
+    with pytest.raises(siliconcompiler.core.SiliconCompilerError):
+        gcd_chip.run()
+
+    # Kill the server process.
+    srv_proc.kill()
+
 if __name__ == "__main__":
     from tests.fixtures import gcd_chip
     if os.path.isdir('local_server_work'):
         os.rmdir('local_server_work')
     test_gcd_server(gcd_chip())
+    test_gcd_server_partial(gcd_chip())
+    test_gcd_server_partial_noimport(gcd_chip())
+    test_gcd_server_partial_noeda(gcd_chip())
+    test_gcd_server_error(gcd_chip())
+    test_gcd_server_argstep_error(gcd_chip())


### PR DESCRIPTION
Like @nmoroze suggested in #1261, there's not much reason to exclude custom `steplist` parameters from the remote flow. It may not be useful for generic ASIC / bitstream builds, but it could help with design exploration, and the functionality is already built into `Chip.run` if we pass it through.

This could also work with a `from` / `to` specification, if we implement that.