### PR TITLE
Add tasks to documentation

### DIFF
--- a/docs/_ext/schemagen.py
+++ b/docs/_ext/schemagen.py
@@ -77,7 +77,7 @@ class CategorySummary(SphinxDirective):
         new_doc = []
         section = nodes.section(ids = [nodes.make_id(f'{category}_summary')])
 
-        chip = siliconcompiler.Chip('<design>', loglevel='DEBUG')
+        chip = siliconcompiler.Chip('<design>')
 
         table = [[strong('parameter'), strong('description')]]
 

--- a/siliconcompiler/sphinx_ext/dynamicgen.py
+++ b/siliconcompiler/sphinx_ext/dynamicgen.py
@@ -160,6 +160,10 @@ class DynamicGen(SphinxDirective):
 
             s += self.display_config(chip, modname)
 
+        child_content = self.child_content(path, module, modname)
+        if child_content is not None:
+            s += child_content
+
         return s
 
     def run(self):
@@ -241,6 +245,9 @@ class DynamicGen(SphinxDirective):
         documentation in between a module's docstring and configuration table.
         Otherwise, if return value is None, don't add anything.
         '''
+        return None
+
+    def child_content(self, path, module, modname):
         return None
 
 #########################

--- a/siliconcompiler/sphinx_ext/dynamicgen.py
+++ b/siliconcompiler/sphinx_ext/dynamicgen.py
@@ -365,7 +365,23 @@ class ToolGen(DynamicGen):
         schema = Schema(cfg=cfg)
         schema.prune()
         pruned = schema.cfg
+        if 'task' in pruned:
+            # Remove task specific items since they will be documented
+            # by the task documentation
+            del pruned['task']
         table = build_schema_value_table(pruned, keypath_prefix=['tool', modname])
+        if table is not None:
+            return table
+        else:
+            return []
+
+    def task_display_config(self, chip, toolname, taskname):
+        '''Display config under `eda, <modname>` in a single table.'''
+        cfg = chip.getdict('tool', toolname, 'task', taskname)
+        schema = Schema(cfg=cfg)
+        schema.prune()
+        pruned = schema.cfg
+        table = build_schema_value_table(pruned, keypath_prefix=['tool', toolname, 'task', taskname])
         if table is not None:
             return table
         else:
@@ -394,6 +410,109 @@ class ToolGen(DynamicGen):
             modules.append((module, toolname))
 
         return modules
+
+    def document_task(self, path, toolmodule, taskmodule, taskname, toolname):
+        self.env.note_dependency(path)
+        s = build_section_with_target(taskname, f'{toolname}-{taskname}', self.state.document)
+
+        # Find setup function
+        task_setup = getattr(taskmodule, 'setup', None)
+        if not task_setup:
+            return None
+
+        # Find make_docs function, check task module first
+        make_docs = getattr(taskmodule, 'make_docs', None)
+        if not make_docs:
+            # Then check tool module
+            make_docs = getattr(toolmodule, 'make_docs', None)
+        if not make_docs:
+            return None
+
+        chip = make_docs()
+        # set values for current step
+        chip.set('arg', 'step', '<step>')
+        chip.set('arg', 'index', '<index>')
+        chip.set('flowgraph', chip.get('option', 'flow'), '<step>', '<index>', 'tool', toolname)
+        chip.set('flowgraph', chip.get('option', 'flow'), '<step>', '<index>', 'task', taskname)
+
+        print(f"Generating docs for task {toolname}/{taskname}...")
+
+        # raw docstrings have funky indentation (basically, each line is already
+        # indented as much as the function), so we call trim() helper function
+        # to clean it up
+        docstr = utils.trim(setup.__doc__)
+
+        if docstr:
+            self.parse_rst(docstr, s)
+
+        builtin = os.path.abspath(path).startswith(SC_ROOT)
+
+        if builtin:
+            relpath = path[len(SC_ROOT)+1:]
+            gh_root = 'https://github.com/siliconcompiler/siliconcompiler/blob/main'
+            gh_link = f'{gh_root}/{relpath}'
+            filename = os.path.basename(relpath)
+            p = para('Setup file: ')
+            p += link(gh_link, text=filename)
+            s += p
+
+        if chip.valid('option', 'target') and chip.get('option', 'target'):
+            p = docutils.nodes.inline('')
+            target = chip.get('option', 'target')
+            targetid = get_ref_id(target)
+            self.parse_rst(f"Built using target: :ref:`{target}<{targetid}>`", p)
+            s += p
+
+        try:
+            task_setup(chip)
+            s += self.task_display_config(chip, toolname, taskname)
+        except:
+            print('Failed to document task, Chip object probably not configured correctly.')
+            return None
+
+        return s
+
+    def child_content(self, path, module, modname):
+        sections = []
+        path = os.path.abspath(path)
+        module_dir = os.path.dirname(path)
+        for taskfile in os.listdir(module_dir):
+            if taskfile == "__init__.py":
+                # skip init
+                continue
+
+            task_path = os.path.join(module_dir, taskfile)
+            if path == task_path:
+                # skip tool module
+                continue
+
+            if not os.path.isfile(task_path):
+                # skip if not a file
+                continue
+
+            spec = importlib.util.spec_from_file_location(taskfile, task_path)
+            if not spec:
+                # unable to load, probably not a python file
+                continue
+            taskmodule = importlib.util.module_from_spec(spec)
+            try:
+                spec.loader.exec_module(taskmodule)
+            except:
+                # Module failed to load
+                # klayout imports pya which is only defined in klayout
+                continue
+
+            taskname = os.path.splitext(os.path.basename(task_path))[0]
+
+            task_doc = self.document_task(task_path, module, taskmodule, taskname, modname)
+            if task_doc:
+                sections.append((taskname, task_doc))
+
+        if len(sections) > 0:
+            sections = sorted(sections, key=lambda t: t[0])
+            # Strip off modname so we just return list of docutils sections
+            _, sections = zip(*sections)
+        return sections
 
 class TargetGen(DynamicGen):
     PATH = 'targets'

--- a/siliconcompiler/sphinx_ext/dynamicgen.py
+++ b/siliconcompiler/sphinx_ext/dynamicgen.py
@@ -122,7 +122,7 @@ class DynamicGen(SphinxDirective):
         '''Build section documenting given module and name.'''
         print(f'Generating docs for module {modname}...')
 
-        s = build_section_with_target(modname, f'{modname}-ref', self.state.document)
+        s = build_section_with_target(modname, f'{modname}', self.state.document)
 
         if not hasattr(module, 'make_docs'):
             return None
@@ -323,7 +323,12 @@ class LibGen(DynamicGen):
         pdk = chip.get('option', 'pdk')
 
         p = docutils.nodes.inline('')
-        self.parse_rst(f'Associated PDK: :ref:`{pdk}<{pdk}-ref>`', p)
+        pdk_ref = "None"
+        if pdk:
+            pdkid = get_ref_id(pdk)
+            pdk_ref = f":ref:`{pdk}<{pdkid}>`"
+        self.parse_rst(f'Associated PDK: {pdk_ref}', p)
+
         return [p]
 
     def display_config(self, chip, modname):
@@ -334,7 +339,7 @@ class LibGen(DynamicGen):
         libname = chip.design
 
         section_key = ['lib', libname]
-        settings = build_section_with_target(libname, '-'.join(section_key)+'-ref', self.state.document)
+        settings = build_section_with_target(libname, '-'.join(section_key), self.state.document)
 
         for key in ('asic', 'output', 'option'):
             cfg = chip.getdict(key)
@@ -394,8 +399,8 @@ class TargetGen(DynamicGen):
             for module in modules:
                 list_item = nodes.list_item()
                 # TODO: replace with proper docutils nodes: sphinx.addnodes.pending_xref
-                modkey = nodes.make_id(refprefix+module)
-                self.parse_rst(f':ref:`{module}<{modkey}-ref>`', list_item)
+                modkey = get_ref_id(refprefix+module)
+                self.parse_rst(f':ref:`{module}<{modkey}>`', list_item)
                 modlist += list_item
 
             section += modlist

--- a/siliconcompiler/sphinx_ext/utils.py
+++ b/siliconcompiler/sphinx_ext/utils.py
@@ -53,12 +53,12 @@ def build_table(items, colwidths=None, colspec=None):
     return return_nodes
 
 def build_section(text, key):
-    sec = nodes.section(ids=[nodes.make_id(key)])
+    sec = nodes.section(ids=[get_ref_id(key)])
     sec += nodes.title(text=text)
     return sec
 
 def build_section_with_target(text, key, ctx):
-    id = nodes.make_id(key)
+    id = get_ref_id(key)
     target = nodes.target('', '', ids=[id], names=[id])
     sec = nodes.section(ids=[id])
     sec += nodes.title(text=text)
@@ -68,6 +68,9 @@ def build_section_with_target(text, key, ctx):
     ctx.note_explicit_target(target)
 
     return sec
+
+def get_ref_id(key):
+    return nodes.make_id(key+"-ref")
 
 def para(text):
     return nodes.paragraph(text=text)

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -22,6 +22,7 @@ def make_docs():
     '''
 
     chip = siliconcompiler.Chip('<design>')
+    chip.load_target('freepdk45_demo')
     chip.set('arg','step','import')
     chip.set('arg','index','0')
     setup(chip)


### PR DESCRIPTION
Adds:
- initial support for loading the tasks into the documentation. This simply adds a subsection to each tool with one section per task.

The tasks are currently not well documented, so next we need to fix the doc strings there.