### PR TITLE
Update `sc-configure`, and add tests

### DIFF
--- a/siliconcompiler/apps/sc_configure.py
+++ b/siliconcompiler/apps/sc_configure.py
@@ -33,10 +33,17 @@ def main():
             elif (oin == 'y') or (oin == 'Y'):
                 overwrite = True
 
-    # Get parameters from user input.
-    srv_addr = input('Remote server address: ').replace(" ","")
-    username = input('Remote username: ').replace(" ","")
-    user_pass = input('Remote password: ').replace(" ","")
+    # If a command-line argument is passed in, use that as a public server address.
+    if len(sys.argv) > 1:
+        print(f'Creating remote configuration file for public server: {sys.argv[1]}')
+        with open(cfg_file, 'w') as f:
+            f.write('{"address": "%s"}'%(sys.argv[1]))
+        return
+
+    # If no arguments were passed in, interactively request credentials from the user.
+    srv_addr = input('Remote server address:\n').replace(" ","")
+    username = input('Remote username (leave blank for public servers):\n').replace(" ","")
+    user_pass = input('Remote password (leave blank for public servers):\n').replace(" ","")
 
     # Save the values to the target config file in JSON format.
     with open(cfg_file, 'w') as f:

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -154,7 +154,8 @@ def request_remote_run(chip):
     }
     local_build_dir = chip._getworkdir()
     rcfg = chip.status['remote_cfg']
-    if ('username' in rcfg) and ('password' in rcfg):
+    if ('username' in rcfg) and ('password' in rcfg) and \
+       (rcfg['username']) and (rcfg['password']):
         post_params['params']['username'] = rcfg['username']
         post_params['params']['key'] = rcfg['password']
 

--- a/tests/apps/test_sc_configure.py
+++ b/tests/apps/test_sc_configure.py
@@ -1,0 +1,108 @@
+import json
+import os
+import pytest
+import sys
+
+from siliconcompiler.apps import sc_configure
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_sc_configure_cmdarg(monkeypatch):
+    os.environ['HOME'] = os.getcwd()
+    server_name = 'https://example.com'
+    monkeypatch.setattr('sys.argv', ['sc-configure', server_name])
+
+    sc_configure.main()
+
+    # Check that generated credentials match the expected values.
+    generated_creds = {}
+    with open('./.sc/credentials', 'r') as cf:
+        generated_creds = json.loads(cf.read())
+
+    assert generated_creds['address'] == server_name
+    assert not 'username' in generated_creds
+    assert not 'password' in generated_creds
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_sc_configure_interactive(monkeypatch):
+    os.environ['HOME'] = os.getcwd()
+    server_name = 'https://example.com'
+    username = 'ci_test_user'
+    password = 'ci_test_password'
+    monkeypatch.setattr('sys.argv', ['sc-configure'])
+
+    # Use sys.stdin to simulate user input.
+    with open('cfg_stdin.txt', 'w') as wf:
+         wf.write(f'{server_name}\n{username}\n{password}\n')
+    with open('cfg_stdin.txt', 'r') as rf:
+         sys.stdin = rf
+
+         sc_configure.main()
+
+    # Check that generated credentials match the expected values.
+    generated_creds = {}
+    with open('./.sc/credentials', 'r') as cf:
+        generated_creds = json.loads(cf.read())
+
+    assert generated_creds['address'] == server_name
+    assert generated_creds['username'] == username
+    assert generated_creds['password'] == password
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_sc_configure_override_y(monkeypatch):
+    os.makedirs('.sc')
+    with open('.sc/credentials', 'w') as cf:
+        cf.write('{"address": "old_example_address"}')
+    os.environ['HOME'] = os.getcwd()
+    server_name = 'https://example.com'
+    username = 'ci_test_user'
+    password = 'ci_test_password'
+    monkeypatch.setattr('sys.argv', ['sc-configure'])
+
+    # Use sys.stdin to simulate user input.
+    with open('cfg_stdin.txt', 'w') as wf:
+         wf.write(f'y\n{server_name}\n{username}\n{password}\n')
+    with open('cfg_stdin.txt', 'r') as rf:
+         sys.stdin = rf
+
+         sc_configure.main()
+
+    # Check that generated credentials match the expected values.
+    generated_creds = {}
+    with open('./.sc/credentials', 'r') as cf:
+        generated_creds = json.loads(cf.read())
+
+    assert generated_creds['address'] == server_name
+    assert generated_creds['username'] == username
+    assert generated_creds['password'] == password
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_sc_configure_override_n(monkeypatch):
+    os.makedirs('.sc')
+    with open('.sc/credentials', 'w') as cf:
+        cf.write('{"address": "old_example_address"}')
+    os.environ['HOME'] = os.getcwd()
+    server_name = 'https://example.com'
+    username = 'ci_test_user'
+    password = 'ci_test_password'
+    monkeypatch.setattr('sys.argv', ['sc-configure'])
+
+    # Use sys.stdin to simulate user input.
+    with open('cfg_stdin.txt', 'w') as wf:
+         wf.write(f'n\n{server_name}\n{username}\n{password}\n')
+    with open('cfg_stdin.txt', 'r') as rf:
+         sys.stdin = rf
+
+         sc_configure.main()
+
+    # Check that the existing credentials were not overridden.
+    generated_creds = {}
+    with open('./.sc/credentials', 'r') as cf:
+        generated_creds = json.loads(cf.read())
+
+    assert generated_creds['address'] != server_name
+    assert not 'username' in generated_creds
+    assert not 'password' in generated_creds


### PR DESCRIPTION
* Adds a simple one-line configuration for public servers (`sc-configure https://...`)
* Omits the `username` and `password` fields in `client.py` if either one is an empty string.
* Adds some tests for the `sc-configure` app.