### PR TITLE
Fix polarity on builtin check

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1392,7 +1392,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 self.logger.error(f'Required input {filename} not received for {step}{index}.')
                 error = True
 
-        if (self._is_builtin(tool, task)) and self.valid('tool', tool,'task', task,  'require', step, index):
+        if (not self._is_builtin(tool, task)) and self.valid('tool', tool,'task', task,  'require', step, index):
             all_required = self.get('tool', tool, 'task', task, 'require', step, index)
             for item in all_required:
                 keypath = item.split(',')

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -81,13 +81,13 @@ def test_check_missing_file_param():
     chip = siliconcompiler.Chip('gcd')
     chip.load_target("freepdk45_demo")
 
-    chip._setup_tool('yosys', 'syn', 'syn', '0')
+    chip._setup_tool('yosys', 'syn_asic', 'syn', '0')
 
     chip.set('arg', 'step', 'syn')
     chip.set('arg', 'index', '0')
 
-    chip.set('tool', 'yosys', 'task', 'syn', 'input', 'syn', '0', [])
-    chip.set('tool', 'yosys', 'task', 'syn', 'output', 'syn', '0',[])
+    chip.set('tool', 'yosys', 'task', 'syn_asic', 'input', 'syn', '0', [])
+    chip.set('tool', 'yosys', 'task', 'syn_asic', 'output', 'syn', '0',[])
 
     # not real file, will cause error
     libname = 'nangate45'


### PR DESCRIPTION
Looks like this got flipped during the switch to builtins: https://github.com/siliconcompiler/siliconcompiler/commit/cab52cdce87490637d643b727c15d72a3a46951c#diff-0a7b686d579b6f3a831a79a61fda4755be2fc2f5cfefc0d848da015810cb3f54L1453

Didn't get caught due to another bug in the test, but it should be captured by tests now.