### PR TITLE
Make 'tool' schema group configurable per-node

### DIFF
--- a/examples/ghdl_fsynopsys/build.py
+++ b/examples/ghdl_fsynopsys/build.py
@@ -5,7 +5,7 @@ def main():
     chip.input('binary_4_bit_adder_top.vhd')
     # this is to set -fsynopsys
     # see PR #1015 (https://github.com/siliconcompiler/siliconcompiler/pull/1015)
-    chip.set('tool', 'ghdl', 'task', 'import', 'var', 'import', '0', 'extraopts', '-fsynopsys')
+    chip.set('tool', 'ghdl', 'task', 'import', 'var', 'extraopts', '-fsynopsys')
 
     chip.load_target("freepdk45_demo")
     flow = 'vhdlsyn'

--- a/examples/heartbeat/parallel.py
+++ b/examples/heartbeat/parallel.py
@@ -11,6 +11,7 @@ def run_design(design, M, job):
 
     chip = siliconcompiler.Chip(design, loglevel='INFO')
     chip.input(design+'.v')
+    chip.input(design+'.sdc')
     chip.set('option', 'jobname', job)
     chip.set('option', 'relax', True)
     chip.set('option', 'quiet', True)

--- a/examples/heartbeat_caravel_wrapper/tools/addvias/addvias.py
+++ b/examples/heartbeat_caravel_wrapper/tools/addvias/addvias.py
@@ -13,8 +13,8 @@ def setup(chip):
     #TODO fix
     task = step
 
-    chip.set('tool', tool, 'task', task, 'input', step, index, f'{design}.vg')
-    chip.set('tool', tool, 'task', task,  'output', step, index, f'{design}.vg')
+    chip.set('tool', tool, 'task', task, 'input', f'{design}.vg', step=step, index=index)
+    chip.set('tool', tool, 'task', task,  'output', f'{design}.vg', step=step, index=index)
 
 def run(chip):
     design = chip.get('design')

--- a/examples/heartbeat_caravel_wrapper/tools/fixdef/fixdef.py
+++ b/examples/heartbeat_caravel_wrapper/tools/fixdef/fixdef.py
@@ -16,8 +16,8 @@ def setup(chip):
     index = chip.get('arg', 'index')
     task = step
 
-    chip.set('tool', tool, 'task', task, 'input', step, index, f'{design}.def')
-    chip.set('tool', tool, 'task', task, 'output', step, index, f'{design}.def')
+    chip.set('tool', tool, 'task', task, 'input', f'{design}.def', step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'output', f'{design}.def', step=step, index=index)
 
 def run(chip):
     design = chip.get('design')

--- a/examples/heartbeat_padring/floorplan_build.py
+++ b/examples/heartbeat_padring/floorplan_build.py
@@ -513,8 +513,8 @@ def build_core():
 
     # Configure the Chip object for a full build.
     core_chip.set('input', 'asic', 'floorplan.def', 'heartbeat.def', clobber=True)
-    core_chip.set('tool', 'openroad', 'task', 'floorplan', 'var', 'floorplan', '0', 'pdn_enable', 'False', clobber=True)
-    core_chip.set('tool', 'openroad', 'task', 'floorplan', 'var', 'place', '0', 'place_density', '0.1', clobber=True)
+    core_chip.set('tool', 'openroad', 'task', 'floorplan', 'var', 'pdn_enable', 'False', clobber=True)
+    core_chip.set('tool', 'openroad', 'task', 'floorplan', 'var', 'place_density', '0.1', clobber=True)
     core_chip.input('heartbeat.v')
     core_chip.clock(pin='clk', period=20)
 

--- a/examples/picorv32_ram/picorv32_ram.py
+++ b/examples/picorv32_ram/picorv32_ram.py
@@ -35,11 +35,11 @@ def build_top(remote=False):
     chip.add('asic', 'macrolib', 'sky130_sram_2k')
 
     # SRAM pins are inside the macro boundary; no routing blockage padding is needed.
-    chip.set('tool', 'openroad', 'task', 'route', 'var', 'route', '0', 'grt_macro_extension', '0')
+    chip.set('tool', 'openroad', 'task', 'route', 'var', 'grt_macro_extension', '0')
     # Disable CDL file generation until we can find a CDL file for the SRAM block.
-    chip.set('tool', 'openroad', 'task', 'export', 'var', 'export', '1', 'write_cdl', 'false')
+    chip.set('tool', 'openroad', 'task', 'export', 'var', 'write_cdl', 'false')
     # Reduce placement density a bit to ease routing congestion and hopefully speed up the route step.
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '0', 'place_density', '0.5')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', '0.5')
 
     # Place macro instance.
     chip.set('constraint', 'component', 'sram', 'placement', (500.0, 250.0, 0.0))

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4416,10 +4416,11 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             envvars['PATH'] = self.get('tool', tool, 'path') + os.pathsep + os.environ['PATH']
         else:
             envvars['PATH'] = os.environ['PATH']
-        if (step in self.getkeys('tool', tool, 'task', task, 'env') and
-            index in self.getkeys('tool', tool, 'task', task, 'env', step)):
-            for key in self.getkeys('tool', tool, 'task', task, 'env', step, index):
-                envvars[key] = self.get('tool', tool, 'task', task, 'env', key, step=step, index=index)
+
+        for key in self.getkeys('tool', tool, 'task', task, 'env'):
+            val = self.get('tool', tool, 'task', task, 'env', key, step=step, index=index)
+            if val:
+                envvars[key] = val
 
         if is_posix:
             nice = None

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3732,13 +3732,13 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         # Hash files
         if (not is_builtin) and self.get('option', 'hash'):
             # hash all outputs
-            self.hash_files('tool', tool, 'task', task, 'output', step, index)
+            # TODO: only hash outputs from this step
+            self.hash_files('tool', tool, 'task', task, 'output')
             # hash all requirements
-            if self.valid('tool', tool, 'task', task, 'require', step, index):
-                for item in self.get('tool', tool, 'task', task, 'require', step, index):
-                    args = item.split(',')
-                    if 'file' in self.get(*args, field='type'):
-                        self.hash_files(*args)
+            for item in self.get('tool', tool, 'task', task, 'require', step=step, index=index):
+                args = item.split(',')
+                if 'file' in self.get(*args, field='type'):
+                    self.hash_files(*args)
 
         ##################
         # Capture wall runtime and cpu cores
@@ -4344,7 +4344,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 success = self.find_result('png', step)
             else:
                 success = True
-        except SiliconCompilerError:
+        except SiliconCompilerError as e:
+            self.logger.error(e)
             success = False
 
         # restore environment

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -6,7 +6,7 @@ import re
 
 from .utils import trim
 
-SCHEMA_VERSION = '0.22.0'
+SCHEMA_VERSION = '0.23.0'
 
 #############################################################################
 # PARAM DEFINITION

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -1291,7 +1291,7 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             switch="-tool_task_input 'task <str>'",
             example=[
                 "cli: -tool_task_input 'openroad place oh_add.def'",
-                "api: chip.set('tool','openroad','task','place','input','oh_add.def')"],
+                "api: chip.set('tool','openroad','task','place','input','oh_add.def', step='place', index='0')"],
             schelp="""
             List of data files to be copied from previous flowgraph steps 'output'
             directory. The list of steps to copy files from is defined by the
@@ -1306,7 +1306,7 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             switch="-tool_task_output 'task step index <str>'",
             example=[
                 "cli: -tool_task_output 'openroad place oh_add.def'",
-                "api: chip.set('tool','openroad','task','place','output','oh_add.def')"],
+                "api: chip.set('tool','openroad','task','place','output','oh_add.def', step='place', index='0')"],
             schelp="""
             List of data files to be copied from previous flowgraph steps 'output'
             directory. The list of steps to copy files from is defined by the
@@ -1393,7 +1393,7 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             switch="-tool_task_report 'task metric <str>'",
             example=[
                  "cli: -tool_task_report 'openroad place holdtns place.log'",
-                "api: chip.set('tool','openroad','task','place','report','holdtns','place.log')"],
+                "api: chip.set('tool','openroad','task','place','report','holdtns','place.log', step='place', index='0')"],
             schelp="""
             List of report files associated with a specific 'metric'. The file path
             specified is relative to the run directory of the current task.""")

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -1082,6 +1082,7 @@ def schema_tool(cfg, tool='default'):
 
     scparam(cfg, ['tool', tool, 'path'],
             sctype='dir',
+            pernode='optional',
             shorthelp="Tool: executable path",
             switch="-tool_path 'tool <dir>'",
             example=["cli: -tool_path 'openroad /usr/local/bin'",
@@ -1117,6 +1118,7 @@ def schema_tool(cfg, tool='default'):
 
     scparam(cfg, ['tool', tool, 'version'],
             sctype='[str]',
+            pernode='optional',
             shorthelp="Tool: version",
             switch="-tool_version 'tool <str>'",
             example=["cli: -tool_version 'openroad >=v2.0'",
@@ -1146,6 +1148,7 @@ def schema_tool(cfg, tool='default'):
     key = 'default'
     scparam(cfg, ['tool', tool, 'licenseserver', key],
             sctype='[str]',
+            pernode='optional',
             shorthelp="Tool: license servers",
             switch="-tool_licenseserver 'name key <str>'",
             example=[
@@ -1165,13 +1168,14 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
     key = 'default'
     suffix = 'default'
 
-    scparam(cfg, ['tool', tool, 'task', task, 'warningoff', step, index],
+    scparam(cfg, ['tool', tool, 'task', task, 'warningoff'],
             sctype='[str]',
+            pernode='optional',
             shorthelp="Task: warning filter",
-            switch="-tool_task_warningoff 'tool task step index <str>'",
+            switch="-tool_task_warningoff 'tool task <str>'",
             example=[
-                "cli: -tool_task_warningoff 'verilator lint lint 0 COMBDLY'",
-                "api: chip.set('tool','verilator','task','lint','warningoff','lint','0','COMBDLY')"],
+                "cli: -tool_task_warningoff 'verilator lint COMBDLY'",
+                "api: chip.set('tool','verilator','task','lint','warningoff','COMBDLY')"],
             schelp="""
             A list of tool warnings for which printing should be suppressed.
             Generally this is done on a per design basis after review has
@@ -1179,24 +1183,26 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             off warnings can be found in the specific task reference manual.
             """)
 
-    scparam(cfg, ['tool', tool, 'task', task, 'continue', step, index],
+    scparam(cfg, ['tool', tool, 'task', task, 'continue'],
             sctype='bool',
+            pernode='optional',
             shorthelp="Task: continue option",
-            switch="-tool_task_continue 'tool task step index <bool>'",
+            switch="-tool_task_continue 'tool task <bool>'",
             example=[
-                "cli: -tool_task_continue 'verilator lint lint 0 true'",
-                "api: chip.set('tool','verilator','task','lint','continue','lint','0', true)"],
+                "cli: -tool_task_continue 'verilator lint true'",
+                "api: chip.set('tool','verilator','task','lint','continue',True)"],
             schelp="""
             Directs flow to continue even if errors are encountered during task. The default
             behavior is for SC to exit on error.""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'regex', step, index, suffix],
+    scparam(cfg, ['tool', tool, 'task', task, 'regex', suffix],
             sctype='[str]',
+            pernode='optional',
             shorthelp="Task: regex filter",
-            switch="-tool_task_regex 'tool task step index suffix <str>'",
+            switch="-tool_task_regex 'tool task suffix <str>'",
             example=[
-                "cli: -tool_task_regex 'openroad place place 0 errors -v ERROR'",
-                "api: chip.set('tool','openroad','task','place','regex','errors','place','0','-v ERROR')"],
+                "cli: -tool_task_regex 'openroad place errors -v ERROR'",
+                "api: chip.set('tool','openroad','task','place','regex','errors','-v ERROR')"],
             schelp="""
             A list of piped together grep commands. Each entry represents a set
             of command line arguments for grep including the regex pattern to
@@ -1223,50 +1229,54 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             task, <task>, report` parameter for those metrics, if not already present.""")
 
     # Configuration: cli-option, tcl var, env var, file
-    scparam(cfg, ['tool', tool, 'task', task, 'option', step, index],
+    scparam(cfg, ['tool', tool, 'task', task, 'option'],
             sctype='[str]',
+            pernode='optional',
             shorthelp="Task: executable options",
-            switch="-tool_task_option 'tool task step index <str>'",
+            switch="-tool_task_option 'tool task <str>'",
             example=[
-                "cli: -tool_task_option 'openroad cts cts 0 -no_init'",
-                "api: chip.set('tool','openroad','task','cts','option','cts','0','-no_init')"],
+                "cli: -tool_task_option 'openroad cts -no_init'",
+                "api: chip.set('tool','openroad','task','cts','option','-no_init')"],
             schelp="""
             List of command line options for the task executable, specified on
             a per task and per step basis. Options must not include spaces.
             For multiple argument options, each option is a separate list element.
             """)
 
-    scparam(cfg, ['tool', tool, 'task', task, 'var', step, index, key],
+    scparam(cfg, ['tool', tool, 'task', task, 'var', key],
             sctype='[str]',
+            pernode='optional',
             shorthelp="Task: script variables",
-            switch="-tool_task_variable 'tool task step index key <str>'",
+            switch="-tool_task_variable 'tool task key <str>'",
             example=[
-                "cli: -tool_task_variable 'openroad cts cts 0 myvar 42'",
-                "api: chip.set('tool','openroad','task','cts','var','cts','0','myvar','42')"],
+                "cli: -tool_task_variable 'openroad cts myvar 42'",
+                "api: chip.set('tool','openroad','task','cts','var','myvar','42')"],
             schelp="""
             Task script variables specified as key value pairs. Variable
             names and value types must match the name and type of task and reference
             script consuming the variable.""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'env', step, index, key],
+    scparam(cfg, ['tool', tool, 'task', task, 'env', key],
             sctype='str',
+            pernode='optional',
             shorthelp="Task: environment variables",
             switch="-tool_task_env 'tool task step index name <str>'",
             example=[
-                "cli: -tool_task_env 'openroad cts cts 0 MYVAR 42'",
-                "api: chip.set('tool','openroad','task','cts','env','cts','0','MYVAR','42')"],
+                "cli: -tool_task_env 'openroad cts MYVAR 42'",
+                "api: chip.set('tool','openroad','task','cts','env','MYVAR','42')"],
             schelp="""
             Environment variables to set for individual tasks. Keys and values
             should be set in accordance with the task's documentation. Most
             tasks do not require extra environment variables to function.""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'file', step, index, key],
+    scparam(cfg, ['tool', tool, 'task', task, 'file', key],
             sctype='[file]',
+            pernode='optional',
             shorthelp="Task: setup files",
-            switch="-tool_task_file 'tool task step index key <file>'",
+            switch="-tool_task_file 'tool task key <file>'",
             example=[
-                "cli: -tool_task_file 'openroad floorplan floorplan 0 macroplace macroplace.tcl'",
-                "api: chip.set('tool','openroad','task','floorplan','file','floorplan','0','macroplace', 'macroplace.tcl')"],
+                "cli: -tool_task_file 'openroad floorplan macroplace macroplace.tcl'",
+                "api: chip.set('tool','openroad','task','floorplan','file','macroplace', 'macroplace.tcl')"],
             schelp="""
             Paths to user supplied files mapped to keys. Keys and filetypes must
             match what's expected by the task/reference script consuming the
@@ -1274,13 +1284,14 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             """)
 
     # Defintions of inputs, putputs, requirements
-    scparam(cfg, ['tool', tool, 'task', task, 'input', step, index],
+    scparam(cfg, ['tool', tool, 'task', task, 'input'],
             sctype='[file]',
+            pernode='required',
             shorthelp="Task: inputs",
-            switch="-tool_task_input 'task step index <str>'",
+            switch="-tool_task_input 'task <str>'",
             example=[
-                "cli: -tool_task_input 'openroad place place 0 oh_add.def'",
-                "api: chip.set('tool','openroad','task','place','input','place','0','oh_add.def')"],
+                "cli: -tool_task_input 'openroad place oh_add.def'",
+                "api: chip.set('tool','openroad','task','place','input','oh_add.def')"],
             schelp="""
             List of data files to be copied from previous flowgraph steps 'output'
             directory. The list of steps to copy files from is defined by the
@@ -1288,13 +1299,14 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             All files must be available for flow to continue. If a file
             is missing, the program exists on an error.""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'output', step, index],
+    scparam(cfg, ['tool', tool, 'task', task, 'output'],
             sctype='[file]',
+            pernode='required',
             shorthelp="Task: outputs",
             switch="-tool_task_output 'task step index <str>'",
             example=[
-                "cli: -tool_task_output 'openroad place place 0 oh_add.def'",
-                "api: chip.set('tool','openroad','task','place','output','place','0','oh_add.def')"],
+                "cli: -tool_task_output 'openroad place oh_add.def'",
+                "api: chip.set('tool','openroad','task','place','output','oh_add.def')"],
             schelp="""
             List of data files to be copied from previous flowgraph steps 'output'
             directory. The list of steps to copy files from is defined by the
@@ -1302,14 +1314,15 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             All files must be available for flow to continue. If a file
             is missing, the program exists on an error.""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'stdout', step, index, 'destination'],
+    scparam(cfg, ['tool', tool, 'task', task, 'stdout', 'destination'],
             sctype='str',
             defvalue='log',
             scope='job',
+            pernode='optional',
             shorthelp="Task: Destination for stdout",
-            switch="-tool_task_stdout_destination 'task step index [log|output|none]'",
-            example=["cli: -tool_task_stdout_destination 'ghdl import import 0 log'",
-                    "api: chip.set('tool','ghdl','task','import','stdout','import','0','destination','log')"],
+            switch="-tool_task_stdout_destination 'task [log|output|none]'",
+            example=["cli: -tool_task_stdout_destination 'ghdl import log'",
+                    "api: chip.set('tool','ghdl','task','import','stdout','destination','log')"],
             schelp="""
             Defines where to direct the output generated over stdout.
             Supported options are:
@@ -1318,25 +1331,27 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             it is additionally dumped to the display output: the generated stream is stored
             in outputs/<design>.<suffix>""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'stdout', step, index, 'suffix'],
+    scparam(cfg, ['tool', tool, 'task', task, 'stdout', 'suffix'],
             sctype='str',
             defvalue='log',
             scope='job',
+            pernode='optional',
             shorthelp="Task: File suffix for redirected stdout",
-            switch="-tool_task_stdout_suffix 'task step index <str>'",
-            example=["cli: -tool_task_stdout_suffix 'ghdl import import 0 log'",
-                    "api: chip.set('tool',ghdl','task','import','stdout','import','0','suffix','log')"],
+            switch="-tool_task_stdout_suffix 'task <str>'",
+            example=["cli: -tool_task_stdout_suffix 'ghdl import log'",
+                    "api: chip.set('tool',ghdl','task','import','stdout','suffix','log')"],
             schelp="""
             Specifies the file extension for the content redirected from stdout.""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'stderr', step, index, 'destination'],
+    scparam(cfg, ['tool', tool, 'task', task, 'stderr', 'destination'],
             sctype='str',
             defvalue='log',
             scope='job',
+            pernode='optional',
             shorthelp="Task: Destination for stderr",
-            switch="-tool_task_stderr_destination 'task step index [log|output|none]'",
-            example=["cli: -tool_task_stderr_destination 'ghdl import import 0 log'",
-                    "api: chip.set('tool',ghdl','task','import','stderr','import','0','destination','log')"],
+            switch="-tool_task_stderr_destination 'task [log|output|none]'",
+            example=["cli: -tool_task_stderr_destination 'ghdl import log'",
+                    "api: chip.set('tool',ghdl','task','import','stderr','destination','log')"],
             schelp="""
             Defines where to direct the output generated over stderr.
             Supported options are:
@@ -1345,70 +1360,76 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             it is additionally dumped to the display output: the generated stream is
             stored in outputs/<design>.<suffix>""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'stderr', step, index, 'suffix'],
+    scparam(cfg, ['tool', tool, 'task', task, 'stderr', 'suffix'],
             sctype='str',
             defvalue='log',
             scope='job',
+            pernode='optional',
             shorthelp="Task: File suffix for redirected stderr",
-            switch="-tool_task_stderr_suffix 'task step index <str>'",
-            example=["cli: -tool_task_stderr_suffix 'ghdl import import 0 log'",
-                    "api: chip.set('tool','ghdl','task','import','stderr','import','0','suffix','log')"],
+            switch="-tool_task_stderr_suffix 'task <str>'",
+            example=["cli: -tool_task_stderr_suffix 'ghdl import log'",
+                    "api: chip.set('tool','ghdl','task','import','stderr','suffix','log')"],
             schelp="""
             Specifies the file extension for the content redirected from stderr.""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'require', step, index],
+    scparam(cfg, ['tool', tool, 'task', task, 'require'],
             sctype='[str]',
+            pernode='optional',
             shorthelp="Task: parameter requirements",
             switch="-tool_task_require 'task step index <str>'",
             example=[
-                "cli: -tool_task_require 'openroad cts cts 0 design'",
-                "api: chip.set('tool','openroad', 'task','cts','require','cts','0','design')"],
+                "cli: -tool_task_require 'openroad cts design'",
+                "api: chip.set('tool','openroad', 'task','cts','require','design')"],
             schelp="""
             List of keypaths to required task parameters. The list is used
             by check() to verify that all parameters have been set up before
             step execution begins.""")
 
     metric = 'default'
-    scparam(cfg, ['tool', tool, 'task', task, 'report', step, index, metric],
+    scparam(cfg, ['tool', tool, 'task', task, 'report', metric],
             sctype='[file]',
+            pernode='required',
             shorthelp="Task: reports",
-            switch="-tool_task_report 'task step index metric <str>'",
+            switch="-tool_task_report 'task metric <str>'",
             example=[
-                 "cli: -tool_task_report 'openroad place place 0 holdtns place.log'",
-                "api: chip.set('tool','openroad','task','place','report','place','0','holdtns','place.log')"],
+                 "cli: -tool_task_report 'openroad place holdtns place.log'",
+                "api: chip.set('tool','openroad','task','place','report','holdtns','place.log')"],
             schelp="""
             List of report files associated with a specific 'metric'. The file path
             specified is relative to the run directory of the current task.""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'refdir', step, index],
+    scparam(cfg, ['tool', tool, 'task', task, 'refdir'],
             sctype='[dir]',
+            pernode='optional',
             shorthelp="Task: script directory",
-            switch="-tool_task_refdir 'task step index <dir>'",
+            switch="-tool_task_refdir 'task <dir>'",
             example=[
-                "cli: -tool_task_refdir 'yosys syn syn 0 ./myref'",
-                "api:  chip.set('tool','yosys','task','syn_asic','refdir','syn','0','./myref')"],
+                "cli: -tool_task_refdir 'yosys syn ./myref'",
+                "api:  chip.set('tool','yosys','task','syn_asic','refdir','./myref')"],
             schelp="""
             Path to directories containing reference flow scripts, specified
             on a per step and index basis.""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'script', step, index],
+    scparam(cfg, ['tool', tool, 'task', task, 'script'],
             sctype='[file]',
+            pernode='optional',
             shorthelp="Task: entry script",
             switch="-tool_task_script 'task step index <file>'",
             example=[
-                "cli: -tool_task_script 'yosys syn syn 0 syn.tcl'",
-                "api: chip.set('tool','yosys','task','syn_asic','script','syn','0','syn.tcl')"],
+                "cli: -tool_task_script 'yosys syn syn.tcl'",
+                "api: chip.set('tool','yosys','task','syn_asic','script','syn.tcl')"],
             schelp="""
             Path to the entry script called by the executable specified
             on a per task and per step basis.""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'prescript', step, index],
+    scparam(cfg, ['tool', tool, 'task', task, 'prescript'],
             sctype='[file]',
+            pernode='optional',
             shorthelp="Task: pre-step script",
-            switch="-tool_task_prescript 'task step index <file>'",
+            switch="-tool_task_prescript 'task <file>'",
             example=[
-                "cli: -tool_task_prescript 'yosys syn syn 0 syn_pre.tcl'",
-                "api: chip.set('tool','yosys','task','syn_asic','prescript','syn','0','syn_pre.tcl')"],
+                "cli: -tool_task_prescript 'yosys syn syn_pre.tcl'",
+                "api: chip.set('tool','yosys','task','syn_asic','prescript','syn_pre.tcl')"],
             schelp="""
             Path to a user supplied script to execute after reading in the design
             but before the main execution stage of the step. Exact entry point
@@ -1416,13 +1437,14 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             of a prescript entry point would be immediately before global
             placement.""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'postscript', step, index],
+    scparam(cfg, ['tool', tool, 'task', task, 'postscript'],
             sctype='[file]',
+            pernode='optional',
             shorthelp="Task: post-step script",
-            switch="-tool_task_postscript 'task step index <file>'",
+            switch="-tool_task_postscript 'task <file>'",
             example=[
-                "cli: -tool_task_postscript 'yosys syn syn 0 syn_post.tcl'",
-                "api: chip.set('tool','yosys','task','syn_asic','postscript','syn','0','syn_post.tcl')"],
+                "cli: -tool_task_postscript 'yosys syn syn_post.tcl'",
+                "api: chip.set('tool','yosys','task','syn_asic','postscript','syn_post.tcl')"],
             schelp="""
             Path to a user supplied script to execute after the main execution
             stage of the step but before the design is saved.
@@ -1430,23 +1452,25 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             executed. An example of a postscript entry point would be immediately
             after global placement.""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'keep', step, index],
+    scparam(cfg, ['tool', tool, 'task', task, 'keep'],
             sctype='[str]',
+            pernode='optional',
             shorthelp="Task: files to keep",
-            switch="-tool_task_keep 'task step index <str>'",
+            switch="-tool_task_keep 'task <str>'",
             example=[
-                "cli: -tool_task_keep 'surelog import import 0 slp_all'",
-                "api: chip.set('tool','surelog','task','import','script','import','0','slpp_all')"],
+                "cli: -tool_task_keep 'surelog import slp_all'",
+                "api: chip.set('tool','surelog','task','import','script','slpp_all')"],
             schelp="""
             Names of additional files and directories in the work directory that
             should be kept when :keypath:`option, clean` is true.""")
 
-    scparam(cfg, ['tool', tool, 'task', task, 'threads', step, index],
+    scparam(cfg, ['tool', tool, 'task', task, 'threads'],
             sctype='int',
+            pernode='optional',
             shorthelp="Task: thread parallelism",
-            switch="-tool_task_threads 'task step index <int>'",
-            example=["cli: -tool_task_threads 'magic drc drc 0 64'",
-                     "api: chip.set('tool','magic','task', 'drc','threads','drc','0','64')"],
+            switch="-tool_task_threads 'task <int>'",
+            example=["cli: -tool_task_threads 'magic drc 64'",
+                     "api: chip.set('tool','magic','task', 'drc','threads','64')"],
             schelp="""
             Thread parallelism to use for execution specified on a per task and per
             step basis. If not specified, SC queries the operating system and sets

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -552,7 +552,7 @@ class Schema:
 
         return None
 
-    def _search(self, *keypath, insert_defaults=False, traverse_defaults=True, job=None):
+    def _search(self, *keypath, insert_defaults=False, job=None):
         if job is not None:
             cfg = self.cfg['history'][job]
         else:
@@ -573,9 +573,6 @@ class Schema:
                     cfg = cfg[key]
                 else:
                     cfg = cfg['default']
-                # elif traverse_defaults:
-                #     cfg = cfg['default']
-                #     raise ValueError(f'Invalid keypath {keypath}: unexpected key: {key}')
             else:
                 raise ValueError(f'Invalid keypath {keypath}: unexpected key: {key}')
 

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -88,6 +88,8 @@ class Schema:
 
         if isinstance(index, int):
             index = str(index)
+        if step is not None and index is None:
+            index = 'default'
 
         if field == 'value':
             if cfg['pernode'] == 'required':
@@ -98,8 +100,6 @@ class Schema:
 
             if step in cfg['nodevalue'] and index in cfg['nodevalue'][step]:
                 return cfg['nodevalue'][step][index]
-            elif step in cfg['nodevalue']:
-                return cfg['nodevalue'][step]['default']
             elif Schema._is_set(cfg):
                 return cfg['value']
             else:
@@ -552,7 +552,7 @@ class Schema:
 
         return None
 
-    def _search(self, *keypath, insert_defaults=False, job=None):
+    def _search(self, *keypath, insert_defaults=False, traverse_defaults=True, job=None):
         if job is not None:
             cfg = self.cfg['history'][job]
         else:
@@ -573,6 +573,9 @@ class Schema:
                     cfg = cfg[key]
                 else:
                     cfg = cfg['default']
+                # elif traverse_defaults:
+                #     cfg = cfg['default']
+                #     raise ValueError(f'Invalid keypath {keypath}: unexpected key: {key}')
             else:
                 raise ValueError(f'Invalid keypath {keypath}: unexpected key: {key}')
 

--- a/siliconcompiler/tools/bambu/import.py
+++ b/siliconcompiler/tools/bambu/import.py
@@ -18,13 +18,12 @@ def setup(chip):
 
     chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=False)
     chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=False)
-    chip.set('tool', tool, 'task', task, 'option', [], step=step, index=index)
 
     # Input/Output requirements
     chip.add('tool', tool, 'task', task, 'output', chip.top() + '.v', step=step, index=index)
 
     # Schema requirements
-    chip.add('tool', tool, 'task', task, 'require', 'input,hll,c', step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'require', 'input,hll,c')
 
 ################################
 # Post_process (post executable)

--- a/siliconcompiler/tools/bambu/import.py
+++ b/siliconcompiler/tools/bambu/import.py
@@ -16,15 +16,15 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=0.9.6', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'refdir', step, index, refdir, clobber=False)
-    chip.set('tool', tool, 'task', task, 'threads', step, index, os.cpu_count(), clobber=False)
-    chip.set('tool', tool, 'task', task, 'option', step, index, [])
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'option', [], step=step, index=index)
 
     # Input/Output requirements
-    chip.add('tool', tool, 'task', task, 'output', step, index, chip.top() + '.v')
+    chip.add('tool', tool, 'task', task, 'output', chip.top() + '.v', step=step, index=index)
 
     # Schema requirements
-    chip.add('tool', tool, 'task', task, 'require', step, index, 'input,hll,c')
+    chip.add('tool', tool, 'task', task, 'require', 'input,hll,c', step=step, index=index)
 
 ################################
 # Post_process (post executable)

--- a/siliconcompiler/tools/bambu/import.py
+++ b/siliconcompiler/tools/bambu/import.py
@@ -16,8 +16,8 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=0.9.6', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'refdir', refdir, clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=False)
     chip.set('tool', tool, 'task', task, 'option', [], step=step, index=index)
 
     # Input/Output requirements

--- a/siliconcompiler/tools/bluespec/import.py
+++ b/siliconcompiler/tools/bluespec/import.py
@@ -23,13 +23,12 @@ def setup(chip):
 
     chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=False)
     chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=False)
-    chip.set('tool', tool, 'task', task, 'option', [], step=step, index=index, clobber=False)
 
     # Input/Output requirements
     chip.add('tool', tool, 'task', task,'output', chip.top() + '.v', step=step, index=index)
 
     # Schema requirements
-    chip.add('tool', tool, 'task', task, 'require', 'input,hll,bsv', step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'require', 'input,hll,bsv')
 
 ################################
 # Pre-process

--- a/siliconcompiler/tools/bluespec/import.py
+++ b/siliconcompiler/tools/bluespec/import.py
@@ -26,10 +26,10 @@ def setup(chip):
     chip.set('tool', tool, 'task', task, 'option',  [], clobber=False, step=step, index=index)
 
     # Input/Output requirements
-    chip.add('tool', tool, 'task', task,'output', step, index, chip.top() + '.v')
+    chip.add('tool', tool, 'task', task,'output', chip.top() + '.v', step=step, index=index)
 
     # Schema requirements
-    chip.add('tool', tool, 'task', task,'require', step, index, 'input,hll,bsv')
+    chip.add('tool', tool, 'task', task, 'require', 'input,hll,bsv', step=step, index=index)
 
 ################################
 # Pre-process

--- a/siliconcompiler/tools/bluespec/import.py
+++ b/siliconcompiler/tools/bluespec/import.py
@@ -21,9 +21,9 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '-v')
     chip.set('tool', tool, 'version', '>=2021.07', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'refdir',  refdir, step=step, index=index, clobber=False)
-    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), step=step, index=index, clobber=False)
-    chip.set('tool', tool, 'task', task, 'option',  [], step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'option', [], step=step, index=index, clobber=False)
 
     # Input/Output requirements
     chip.add('tool', tool, 'task', task,'output', chip.top() + '.v', step=step, index=index)

--- a/siliconcompiler/tools/bluespec/import.py
+++ b/siliconcompiler/tools/bluespec/import.py
@@ -21,9 +21,9 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '-v')
     chip.set('tool', tool, 'version', '>=2021.07', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'refdir',  refdir, clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'option',  [], clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'refdir',  refdir, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'option',  [], step=step, index=index, clobber=False)
 
     # Input/Output requirements
     chip.add('tool', tool, 'task', task,'output', chip.top() + '.v', step=step, index=index)

--- a/siliconcompiler/tools/bluespec/import.py
+++ b/siliconcompiler/tools/bluespec/import.py
@@ -21,9 +21,9 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '-v')
     chip.set('tool', tool, 'version', '>=2021.07', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'refdir', step, index,  refdir, clobber=False)
-    chip.set('tool', tool, 'task', task, 'threads', step, index,  os.cpu_count(), clobber=False)
-    chip.set('tool', tool, 'task', task, 'option', step, index,  [], clobber=False)
+    chip.set('tool', tool, 'task', task, 'refdir',  refdir, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'option',  [], clobber=False, step=step, index=index)
 
     # Input/Output requirements
     chip.add('tool', tool, 'task', task,'output', step, index, chip.top() + '.v')

--- a/siliconcompiler/tools/chisel/import.py
+++ b/siliconcompiler/tools/chisel/import.py
@@ -16,17 +16,17 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=1.5.5', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'refdir', step, index,  refdir, clobber=False)
-    chip.set('tool', tool, 'task', task, 'threads', step, index,  os.cpu_count(), clobber=False)
+    chip.set('tool', tool, 'task', task, 'refdir',  refdir, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), clobber=False, step=step, index=index)
 
     design = chip.top()
     option = f'"runMain SCDriver --module {design} -o ../outputs/{design}.v"'
-    chip.set('tool', tool, 'task', task, 'option', step, index,  option)
+    chip.set('tool', tool, 'task', task, 'option',  option, step=step, index=index)
 
     # Input/Output requirements
-    chip.add('tool', tool, 'task', task, 'output', step, index, chip.top() + '.v')
+    chip.add('tool', tool, 'task', task, 'output', chip.top() + '.v', step=step, index=index)
 
-    chip.set('tool', tool, 'task', task, 'keep', step, index, ['build.sbt', 'SCDriver.scala'])
+    chip.set('tool', tool, 'task', task, 'keep', ['build.sbt', 'SCDriver.scala'], step=step, index=index)
 
 def pre_process(chip):
     tool = 'chisel'

--- a/siliconcompiler/tools/chisel/import.py
+++ b/siliconcompiler/tools/chisel/import.py
@@ -16,8 +16,8 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=1.5.5', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'refdir',  refdir, step=step, index=index, clobber=False)
-    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=False)
 
     design = chip.top()
     option = f'"runMain SCDriver --module {design} -o ../outputs/{design}.v"'

--- a/siliconcompiler/tools/chisel/import.py
+++ b/siliconcompiler/tools/chisel/import.py
@@ -16,8 +16,8 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=1.5.5', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'refdir',  refdir, clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'refdir',  refdir, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), step=step, index=index, clobber=False)
 
     design = chip.top()
     option = f'"runMain SCDriver --module {design} -o ../outputs/{design}.v"'

--- a/siliconcompiler/tools/chisel/import.py
+++ b/siliconcompiler/tools/chisel/import.py
@@ -33,7 +33,7 @@ def pre_process(chip):
     step = chip.get('arg', 'step')
     index = chip.get('arg', 'index')
     task = step
-    refdir = chip.find_files('tool', tool, 'task', task, 'refdir', step, index)[0]
+    refdir = chip.find_files('tool', tool, 'task', task, 'refdir', step=step, index=index)[0]
 
     for filename in ('build.sbt', 'SCDriver.scala'):
         src = os.path.join(refdir, filename)

--- a/siliconcompiler/tools/echo/echo.py
+++ b/siliconcompiler/tools/echo/echo.py
@@ -5,7 +5,7 @@ def setup(chip):
     task = chip._get_task(step, index)
 
     chip.set('tool', tool, 'exe', tool)
-    chip.set('tool', tool, 'task', task, 'option',  step, index, step + index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'option',  step + index, step=step, index=index, clobber=False)
 
 def parse_version(stdout):
     '''

--- a/siliconcompiler/tools/genfasm/bitstream.py
+++ b/siliconcompiler/tools/genfasm/bitstream.py
@@ -12,7 +12,7 @@ def setup(chip):
     chip.set('tool', tool, 'exe', tool, clobber=False)
     chip.set('tool', tool, 'version', '0.0', clobber=False)
 
-    chip.set('tool', tool,  'task', task, 'threads', os.cpu_count(), clobber=False, step=step, index=index)
+    chip.set('tool', tool,  'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=False)
 
     topmodule = chip.top()
     blif = f"inputs/{topmodule}.blif"

--- a/siliconcompiler/tools/genfasm/bitstream.py
+++ b/siliconcompiler/tools/genfasm/bitstream.py
@@ -12,7 +12,7 @@ def setup(chip):
     chip.set('tool', tool, 'exe', tool, clobber=False)
     chip.set('tool', tool, 'version', '0.0', clobber=False)
 
-    chip.set('tool', tool,  'task', task, 'threads', step, index, os.cpu_count(), clobber=False)
+    chip.set('tool', tool,  'task', task, 'threads', os.cpu_count(), clobber=False, step=step, index=index)
 
     topmodule = chip.top()
     blif = f"inputs/{topmodule}.blif"

--- a/siliconcompiler/tools/genfasm/bitstream.py
+++ b/siliconcompiler/tools/genfasm/bitstream.py
@@ -28,7 +28,7 @@ def setup(chip):
                 f"--place_file inputs/{topmodule}.place",
                 f"--route_file inputs/{topmodule}.route"])
 
-    chip.add('tool', tool, 'task', task, 'option', step, index,  options)
+    chip.add('tool', tool, 'task', task, 'option',  options, step=step, index=index)
 
 #############################################
 # Runtime pre processing
@@ -40,7 +40,7 @@ def pre_process(chip):
     task = chip._get_task(step, index)
     tool = "genfasm"
 
-    chip.add('tool', tool, 'task', task, 'option', step, index,  [f"--route_chan_width {find_chann_width()}" ])
+    chip.add('tool', tool, 'task', task, 'option',  [f"--route_chan_width {find_chann_width()}" ], step=step, index=index)
 
 ################################
 # Find the final channel width from the VPR report

--- a/siliconcompiler/tools/ghdl/ghdl.py
+++ b/siliconcompiler/tools/ghdl/ghdl.py
@@ -57,13 +57,12 @@ def runtime_options(chip):
     # currently only -fsynopsys and --latches supported
     valid_extraopts = ['-fsynopsys', '--latches']
 
-    if chip.valid('tool', 'ghdl', 'task', task, 'var', step, index, 'extraopts'):
-        extra_opts = chip.get('tool', 'ghdl', 'task', task, 'var', step, index, 'extraopts')
-        for opt in extra_opts:
-            if opt in valid_extraopts:
-                options.append(opt)
-            else:
-                chip.error('Unsupported option ' + opt)
+    extra_opts = chip.get('tool', 'ghdl', 'task', task, 'var', 'extraopts', step=step, index=index)
+    for opt in extra_opts:
+        if opt in valid_extraopts:
+            options.append(opt)
+        else:
+            chip.error('Unsupported option ' + opt)
 
     # Add sources
     for value in chip.find_files('input', 'rtl', 'vhdl'):

--- a/siliconcompiler/tools/ghdl/import.py
+++ b/siliconcompiler/tools/ghdl/import.py
@@ -1,3 +1,4 @@
+import os
 
 def setup(chip):
     ''' Per tool function that returns a dynamic options string based on
@@ -17,7 +18,7 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=2.0.0-dev', clobber=clobber)
 
-    chip.set('tool', tool, 'task', task, 'threads', '4', step=step, index=index, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=clobber)
     chip.set('tool', tool, 'task', task, 'option', '', step=step, index=index, clobber=clobber)
     chip.set('tool', tool, 'task', task, 'stdout', 'destination', 'output', step=step, index=index)
     chip.set('tool', tool, 'task', task, 'stdout', 'suffix', 'v', step=step, index=index)

--- a/siliconcompiler/tools/ghdl/import.py
+++ b/siliconcompiler/tools/ghdl/import.py
@@ -17,14 +17,14 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=2.0.0-dev', clobber=clobber)
 
-    chip.set('tool', tool, 'task', task, 'threads', step, index, '4', clobber=clobber)
-    chip.set('tool', tool, 'task', task, 'option', step, index, '', clobber=clobber)
-    chip.set('tool', tool, 'task', task, 'stdout', step, index, 'destination', 'output')
-    chip.set('tool', tool, 'task', task, 'stdout', step, index, 'suffix', 'v')
+    chip.set('tool', tool, 'task', task, 'threads', '4', clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'option', '', clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'stdout', 'destination', 'output', step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'stdout', 'suffix', 'v', step=step, index=index)
 
     # Schema requirements
-    chip.add('tool', tool, 'task', task, 'require', step, index, 'input,rtl,vhdl')
+    chip.add('tool', tool, 'task', task, 'require', 'input,rtl,vhdl', step=step, index=index)
 
     design = chip.top()
 
-    chip.set('tool', tool, 'task', task, 'output', step, index, f'{design}.v')
+    chip.set('tool', tool, 'task', task, 'output', f'{design}.v', step=step, index=index)

--- a/siliconcompiler/tools/ghdl/import.py
+++ b/siliconcompiler/tools/ghdl/import.py
@@ -17,8 +17,8 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=2.0.0-dev', clobber=clobber)
 
-    chip.set('tool', tool, 'task', task, 'threads', '4', clobber=clobber, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'option', '', clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'threads', '4', step=step, index=index, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'option', '', step=step, index=index, clobber=clobber)
     chip.set('tool', tool, 'task', task, 'stdout', 'destination', 'output', step=step, index=index)
     chip.set('tool', tool, 'task', task, 'stdout', 'suffix', 'v', step=step, index=index)
 

--- a/siliconcompiler/tools/icarus/compile.py
+++ b/siliconcompiler/tools/icarus/compile.py
@@ -20,4 +20,4 @@ def setup(chip):
     # Only one task (compile)
     chip.add('tool', tool, 'task', task, 'require', 'input,rtl,verilog', step=step, index=index)
     chip.set('tool', tool, 'task', task, 'option', '-o outputs/'+design+'.vvp', step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=False)

--- a/siliconcompiler/tools/icarus/compile.py
+++ b/siliconcompiler/tools/icarus/compile.py
@@ -19,5 +19,5 @@ def setup(chip):
 
     # Only one task (compile)
     chip.add('tool', tool, 'task', task, 'require', 'input,rtl,verilog', step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'option', step, index,'-o outputs/'+design+'.vvp')
+    chip.set('tool', tool, 'task', task, 'option', '-o outputs/'+design+'.vvp', step=step, index=index)
     chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), clobber=False, step=step, index=index)

--- a/siliconcompiler/tools/icarus/compile.py
+++ b/siliconcompiler/tools/icarus/compile.py
@@ -18,6 +18,6 @@ def setup(chip):
     chip.set('tool', tool, 'version', '>=10.3', clobber=False)
 
     # Only one task (compile)
-    chip.add('tool', tool, 'task', task, 'require', step, index, 'input,rtl,verilog')
+    chip.add('tool', tool, 'task', task, 'require', 'input,rtl,verilog', step=step, index=index)
     chip.set('tool', tool, 'task', task, 'option', step, index,'-o outputs/'+design+'.vvp')
-    chip.set('tool', tool, 'task', task, 'threads', step, index, os.cpu_count(), clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), clobber=False, step=step, index=index)

--- a/siliconcompiler/tools/icepack/bitstream.py
+++ b/siliconcompiler/tools/icepack/bitstream.py
@@ -12,6 +12,6 @@ def setup(chip):
 
     chip.set('tool', tool, 'exe', tool)
 
-    chip.set('tool', tool, 'task', task, 'option', "", clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'option', "", step=step, index=index, clobber=clobber)
     chip.set('tool', tool, 'task', task, 'input', f'{design}.asc', step=step, index=index)
     chip.set('tool', tool, 'task', task, 'output', f'{design}.bit', step=step, index=index)

--- a/siliconcompiler/tools/icepack/bitstream.py
+++ b/siliconcompiler/tools/icepack/bitstream.py
@@ -12,6 +12,6 @@ def setup(chip):
 
     chip.set('tool', tool, 'exe', tool)
 
-    chip.set('tool', tool, 'task', task, 'option', step, index, "", clobber=clobber)
-    chip.set('tool', tool, 'task', task, 'input', step, index, f'{design}.asc')
-    chip.set('tool', tool, 'task', task, 'output', step, index, f'{design}.bit')
+    chip.set('tool', tool, 'task', task, 'option', "", clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'input', f'{design}.asc', step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'output', f'{design}.bit', step=step, index=index)

--- a/siliconcompiler/tools/klayout/export.py
+++ b/siliconcompiler/tools/klayout/export.py
@@ -17,8 +17,8 @@ def setup(chip):
 
     script = 'klayout_export.py'
     option = ['-b', '-r']
-    chip.set('tool', tool, 'task', task, 'script', step, index, script, clobber=clobber)
-    chip.set('tool', tool, 'task', task, 'option', step, index, option, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'script', script, clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'option', option, clobber=clobber, step=step, index=index)
 
     targetlibs = chip.get('asic', 'logiclib')
     stackup = chip.get('option', 'stackup')
@@ -26,13 +26,13 @@ def setup(chip):
     if bool(stackup) & bool(targetlibs):
         macrolibs = chip.get('asic', 'macrolib')
 
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['asic', 'logiclib']))
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['option', 'stackup']))
-        chip.add('tool', tool, 'task', task, 'require', step, index,  ",".join(['pdk', pdk, 'layermap', 'klayout', 'def','gds', stackup]))
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['asic', 'logiclib']), step=step, index=index)
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['option', 'stackup']), step=step, index=index)
+        chip.add('tool', tool, 'task', task, 'require',  ",".join(['pdk', pdk, 'layermap', 'klayout', 'def','gds', stackup]), step=step, index=index)
 
         for lib in (targetlibs + macrolibs):
-            chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['library', lib, 'output', stackup, 'gds']))
-            chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['library', lib, 'output', stackup, 'lef']))
+            chip.add('tool', tool, 'task', task, 'require', ",".join(['library', lib, 'output', stackup, 'gds']), step=step, index=index)
+            chip.add('tool', tool, 'task', task, 'require', ",".join(['library', lib, 'output', stackup, 'lef']), step=step, index=index)
     else:
         chip.error(f'Stackup and targetlib paremeters required for Klayout.')
 
@@ -40,5 +40,5 @@ def setup(chip):
     design = chip.top()
     if (not chip.valid('input', 'layout', 'def') or
         not chip.get('input', 'layout', 'def')):
-        chip.add('tool', tool, 'task', task, 'input', step, index, design + '.def')
-    chip.add('tool', tool, 'task', task, 'output', step, index, design + '.gds')
+        chip.add('tool', tool, 'task', task, 'input', design + '.def', step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'output', design + '.gds', step=step, index=index)

--- a/siliconcompiler/tools/klayout/export.py
+++ b/siliconcompiler/tools/klayout/export.py
@@ -17,8 +17,8 @@ def setup(chip):
 
     script = 'klayout_export.py'
     option = ['-b', '-r']
-    chip.set('tool', tool, 'task', task, 'script', script, clobber=clobber, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'option', option, clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'script', script, step=step, index=index, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'option', option, step=step, index=index, clobber=clobber)
 
     targetlibs = chip.get('asic', 'logiclib')
     stackup = chip.get('option', 'stackup')

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -90,7 +90,7 @@ def setup(chip, mode="batch"):
     chip.set('tool', tool, 'version', '>=0.27.6', clobber=clobber)
     chip.set('tool', tool, 'format', 'json', clobber=clobber)
 
-    chip.set('tool', tool, 'task', task, 'refdir', refdir, clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=clobber)
 
     # Export GDS with timestamps by default.
     chip.set('tool', tool, 'task', task, 'var', 'timestamps', 'true', step=step, index=index, clobber=False)

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -90,14 +90,14 @@ def setup(chip, mode="batch"):
     chip.set('tool', tool, 'version', '>=0.27.6', clobber=clobber)
     chip.set('tool', tool, 'format', 'json', clobber=clobber)
 
-    chip.set('tool', tool, 'task', task, 'refdir', step, index, refdir, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, clobber=clobber, step=step, index=index)
 
     # Export GDS with timestamps by default.
-    chip.set('tool', tool, 'task', task, 'var', step, index, 'timestamps', 'true', clobber=False)
+    chip.set('tool', tool, 'task', task, 'var', 'timestamps', 'true', clobber=False, step=step, index=index)
 
     # Log file parsing
-    chip.set('tool', tool, 'task', task, 'regex', step, index, 'warnings', r'(WARNING|warning)', clobber=False)
-    chip.set('tool', tool, 'task', task, 'regex', step, index, 'errors', r'ERROR', clobber=False)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'(WARNING|warning)', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'ERROR', clobber=False, step=step, index=index)
 
 def runtime_options(chip):
     # Provide KLayout with path to SC package so the driver can import the

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -93,11 +93,11 @@ def setup(chip, mode="batch"):
     chip.set('tool', tool, 'task', task, 'refdir', refdir, clobber=clobber, step=step, index=index)
 
     # Export GDS with timestamps by default.
-    chip.set('tool', tool, 'task', task, 'var', 'timestamps', 'true', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'timestamps', 'true', step=step, index=index, clobber=False)
 
     # Log file parsing
-    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'(WARNING|warning)', clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'ERROR', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'(WARNING|warning)', step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'ERROR', step=step, index=index, clobber=False)
 
 def runtime_options(chip):
     # Provide KLayout with path to SC package so the driver can import the

--- a/siliconcompiler/tools/klayout/klayout_export.py
+++ b/siliconcompiler/tools/klayout/klayout_export.py
@@ -260,9 +260,9 @@ flow = schema.get('option', 'flow')
 
 sc_task = schema.get('flowgraph', flow, sc_step, sc_index, 'task')
 
-sc_klayout_vars = schema.getkeys('tool', 'klayout', 'task', sc_task, 'var', sc_step, sc_index)
+sc_klayout_vars = schema.getkeys('tool', 'klayout', 'task', sc_task, 'var')
 if 'timestamps' in sc_klayout_vars:
-  sc_timestamps = schema.get('tool', 'klayout', 'task', sc_task, 'var', sc_step, sc_index, 'timestamps') == ['true']
+  sc_timestamps = schema.get('tool', 'klayout', 'task', sc_task, 'var', 'timestamps', step=sc_step, index=sc_index) == ['true']
 else:
   sc_timestamps = False
 

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -20,22 +20,22 @@ step = schema.get('arg', 'step')
 index = schema.get('arg', 'index')
 task = schema.get('flowgraph', flow, step, index, 'task')
 
-if 'hide_layers' in schema.getkeys('tool', 'klayout', 'task', task, 'var', step, index):
-    sc_hide_layers = schema.get('tool', 'klayout', 'task', task, 'var', step, index, 'hide_layers')
+if 'hide_layers' in schema.getkeys('tool', 'klayout', 'task', task, 'var'):
+    sc_hide_layers = schema.get('tool', 'klayout', 'task', task, 'var', 'hide_layers', step=step, index=index)
 else:
     sc_hide_layers = []
 
-if 'show_filepath' in schema.getkeys('tool', 'klayout', 'task', task, 'var', step, index):
-    sc_filename = schema.get('tool', 'klayout', 'task', task, 'var', step, index, 'show_filepath')[0]
+if 'show_filepath' in schema.getkeys('tool', 'klayout', 'task', task, 'var'):
+    sc_filename = schema.get('tool', 'klayout', 'task', task, 'var', 'show_filepath', step=step, index=index)[0]
 else:
-    sc_fileext = schema.get('tool', 'klayout', 'task', task, 'var', step, index, 'show_filetype')[0]
+    sc_fileext = schema.get('tool', 'klayout', 'task', task, 'var', 'show_filetype', step=step, index=index)[0]
     sc_filename = f"inputs/{design}.{sc_fileext}"
 sc_pdk = schema.get('option', 'pdk')
 sc_stackup = schema.get('option', 'stackup')
 sc_mainlib = schema.get('asic', 'logiclib')[0]
 sc_libtype = schema.get('library', sc_mainlib, 'asic', 'libarch')
 
-sc_exit = schema.get('tool', 'klayout', 'task', task, 'var', step, index, 'show_exit') == ["true"]
+sc_exit = schema.get('tool', 'klayout', 'task', task, 'var', 'show_exit', step=step, index=index) == ["true"]
 
 tech_file = schema.get('pdk', sc_pdk, 'layermap', 'klayout', 'def', 'gds', sc_stackup)
 if tech_file:
@@ -126,8 +126,8 @@ for layer in layout_view.each_layer():
 # If 'screenshot' mode is set, save image and exit.
 if step == 'screenshot':
     # Save a screenshot. TODO: Get aspect ratio from sc_cfg?
-    horizontal_resolution = int(schema.get('tool', 'klayout', 'task', task, 'var', step, index, 'show_horizontal_resolution')[0])
-    vertical_resolution = int(schema.get('tool', 'klayout', 'task', task, 'var', step, index, 'show_vertical_resolution')[0])
+    horizontal_resolution = int(schema.get('tool', 'klayout', 'task', task, 'var', 'show_horizontal_resolution', step=step, index=index)[0])
+    vertical_resolution = int(schema.get('tool', 'klayout', 'task', task, 'var', 'show_vertical_resolution', step=step, index=index)[0])
     gds_img = layout_view.get_image(horizontal_resolution, vertical_resolution)
     gds_img.save(f'outputs/{design}.png', 'PNG')
 

--- a/siliconcompiler/tools/klayout/screenshot.py
+++ b/siliconcompiler/tools/klayout/screenshot.py
@@ -18,23 +18,23 @@ def setup(chip):
 
     script = 'klayout_show.py'
     option = ['-nc', '-z', '-rm']
-    chip.set('tool', tool, 'task', task, 'script', step, index, script, clobber=clobber)
-    chip.set('tool', tool, 'task', task, 'option', step, index, option, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'script', script, clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'option', option, clobber=clobber, step=step, index=index)
 
     pdk = chip.get('option', 'pdk')
     stackup = chip.get('option', 'stackup')
     if chip.valid('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup):
         layers_to_hide = chip.get('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup)
-        chip.add('tool', tool, 'task', task, 'var', step, index, 'hide_layers', layers_to_hide)
-    if chip.valid('tool', tool, 'task', task, 'var', step, index, 'show_filepath'):
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', step, index, 'show_filepath']))
+        chip.add('tool', tool, 'task', task, 'var', 'hide_layers', layers_to_hide, step=step, index=index)
+    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath'):
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', 'show_filepath']), step=step, index=index)
     else:
         incoming_ext = find_incoming_ext(chip)
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', step, index, 'show_filetype']))
-        chip.set('tool', tool, 'task', task, 'var', step, index, 'show_filetype', incoming_ext)
-        chip.add('tool', tool, 'task', task, 'input', step, index, f'{design}.{incoming_ext}')
-    chip.set('tool', tool, 'task', task, 'var', step, index, 'show_exit', "true", clobber=False)
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', 'show_filetype']), step=step, index=index)
+        chip.set('tool', tool, 'task', task, 'var', 'show_filetype', incoming_ext, step=step, index=index)
+        chip.add('tool', tool, 'task', task, 'input', f'{design}.{incoming_ext}', step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'show_exit', "true", clobber=False, step=step, index=index)
 
-    chip.add('tool', tool, 'task', task, 'output', step, index, design + '.png')
-    chip.set('tool', tool, 'task', task, 'var', step, index, 'show_horizontal_resolution', '1024', clobber=False)
-    chip.set('tool', tool, 'task', task, 'var', step, index, 'show_vertical_resolution', '1024', clobber=False)
+    chip.add('tool', tool, 'task', task, 'output', design + '.png', step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'show_horizontal_resolution', '1024', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'show_vertical_resolution', '1024', clobber=False, step=step, index=index)

--- a/siliconcompiler/tools/klayout/screenshot.py
+++ b/siliconcompiler/tools/klayout/screenshot.py
@@ -33,8 +33,8 @@ def setup(chip):
         chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', 'show_filetype']), step=step, index=index)
         chip.set('tool', tool, 'task', task, 'var', 'show_filetype', incoming_ext, step=step, index=index)
         chip.add('tool', tool, 'task', task, 'input', f'{design}.{incoming_ext}', step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'var', 'show_exit', "true", clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'show_exit', "true", step=step, index=index, clobber=False)
 
     chip.add('tool', tool, 'task', task, 'output', design + '.png', step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'var', 'show_horizontal_resolution', '1024', clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'var', 'show_vertical_resolution', '1024', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'show_horizontal_resolution', '1024', step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'var', 'show_vertical_resolution', '1024', step=step, index=index, clobber=False)

--- a/siliconcompiler/tools/klayout/screenshot.py
+++ b/siliconcompiler/tools/klayout/screenshot.py
@@ -18,8 +18,8 @@ def setup(chip):
 
     script = 'klayout_show.py'
     option = ['-nc', '-z', '-rm']
-    chip.set('tool', tool, 'task', task, 'script', script, clobber=clobber, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'option', option, clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'script', script, step=step, index=index, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'option', option, step=step, index=index, clobber=clobber)
 
     pdk = chip.get('option', 'pdk')
     stackup = chip.get('option', 'stackup')

--- a/siliconcompiler/tools/klayout/show.py
+++ b/siliconcompiler/tools/klayout/show.py
@@ -17,19 +17,19 @@ def setup(chip):
 
     script = 'klayout_show.py'
     option = ['-nc', '-rm']
-    chip.set('tool', tool, 'task', task, 'script', step, index, script, clobber=clobber)
-    chip.set('tool', tool, 'task', task, 'option', step, index, option, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'script', script, clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'option', option, clobber=clobber, step=step, index=index)
 
     pdk = chip.get('option', 'pdk')
     stackup = chip.get('option', 'stackup')
     if chip.valid('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup):
         layers_to_hide = chip.get('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup)
-        chip.add('tool', tool, 'task', task, 'var', step, index, 'hide_layers', layers_to_hide)
-    if chip.valid('tool', tool, 'task', task, 'var', step, index, 'show_filepath'):
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', step, index, 'show_filepath']))
+        chip.add('tool', tool, 'task', task, 'var', 'hide_layers', layers_to_hide, step=step, index=index)
+    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath', step=step, index=index):
+        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', 'show_filepath']), step=step, index=index)
     else:
         incoming_ext = find_incoming_ext(chip)
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', step, index, 'show_filetype']))
-        chip.set('tool', tool, 'task', task, 'var', step, index, 'show_filetype', incoming_ext)
-        chip.add('tool', tool, 'task', task, 'input', step, index, f'{design}.{incoming_ext}')
-    chip.set('tool', tool, 'task', task, 'var', step, index, 'show_exit', "false", clobber=False)
+        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', 'show_filetype']), step=step, index=index)
+        chip.set('tool', tool, 'task', task, 'var', 'show_filetype', incoming_ext, step=step, index=index)
+        chip.add('tool', tool, 'task', task, 'input', f'{design}.{incoming_ext}', step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'show_exit', "false", clobber=False, step=step, index=index)

--- a/siliconcompiler/tools/klayout/show.py
+++ b/siliconcompiler/tools/klayout/show.py
@@ -25,8 +25,8 @@ def setup(chip):
     if chip.valid('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup):
         layers_to_hide = chip.get('pdk', pdk, 'var', 'klayout', 'hide_layers', stackup)
         chip.add('tool', tool, 'task', task, 'var', 'hide_layers', layers_to_hide, step=step, index=index)
-    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath', step=step, index=index):
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', 'show_filepath']), step=step, index=index)
+    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath'):
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', 'show_filepath']), step=step, index=index)
     else:
         incoming_ext = find_incoming_ext(chip)
         chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', 'show_filetype']), step=step, index=index)

--- a/siliconcompiler/tools/klayout/show.py
+++ b/siliconcompiler/tools/klayout/show.py
@@ -17,8 +17,8 @@ def setup(chip):
 
     script = 'klayout_show.py'
     option = ['-nc', '-rm']
-    chip.set('tool', tool, 'task', task, 'script', script, clobber=clobber, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'option', option, clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'script', script, step=step, index=index, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'option', option, step=step, index=index, clobber=clobber)
 
     pdk = chip.get('option', 'pdk')
     stackup = chip.get('option', 'stackup')

--- a/siliconcompiler/tools/klayout/show.py
+++ b/siliconcompiler/tools/klayout/show.py
@@ -32,4 +32,4 @@ def setup(chip):
         chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', 'show_filetype']), step=step, index=index)
         chip.set('tool', tool, 'task', task, 'var', 'show_filetype', incoming_ext, step=step, index=index)
         chip.add('tool', tool, 'task', task, 'input', f'{design}.{incoming_ext}', step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'var', 'show_exit', "false", clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'show_exit', "false", step=step, index=index, clobber=False)

--- a/siliconcompiler/tools/magic/drc.py
+++ b/siliconcompiler/tools/magic/drc.py
@@ -16,7 +16,7 @@ def setup(chip):
     design = chip.top()
 
     report_path = f'reports/{design}.drc'
-    chip.set('tool', tool, 'task', task, 'report', step, index, 'drvs', report_path)
+    chip.set('tool', tool, 'task', task, 'report', 'drvs', report_path, step=step, index=index)
 
 ################################
 # Post_process (post executable)

--- a/siliconcompiler/tools/magic/extspice.py
+++ b/siliconcompiler/tools/magic/extspice.py
@@ -14,4 +14,4 @@ def setup(chip):
     task = 'extspice'
     design = chip.top()
 
-    chip.add('tool', tool, 'task', task, 'output', step, index, f'{design}.spice')
+    chip.add('tool', tool, 'task', task, 'output', f'{design}.spice', step=step, index=index)

--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -62,15 +62,15 @@ def setup(chip):
     chip.set('tool', tool, 'version', '>=8.3.196', clobber=False)
     chip.set('tool', tool, 'format', 'tcl')
 
-    chip.set('tool', tool, 'task', task, 'threads',  4, clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'refdir',  refdir, clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'script',  script, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'threads',  4, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'refdir',  refdir, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'script',  script, step=step, index=index, clobber=False)
 
     # set options
     options = []
     options.append('-noc')
     options.append('-dnull')
-    chip.set('tool', tool, 'task', task, 'option',  options, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'option',  options, step=step, index=index, clobber=False)
 
     design = chip.top()
     if chip.valid('input', 'layout', 'gds'):
@@ -78,8 +78,8 @@ def setup(chip):
     else:
         chip.add('tool', tool, 'task', task, 'input', f'{design}.gds', step=step, index=index)
 
-    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'^Error', clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'warning', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'^Error', step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'warning', step=step, index=index, clobber=False)
 
 ################################
 # Version Check

--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -62,24 +62,24 @@ def setup(chip):
     chip.set('tool', tool, 'version', '>=8.3.196', clobber=False)
     chip.set('tool', tool, 'format', 'tcl')
 
-    chip.set('tool', tool, 'task', task, 'threads', step, index,  4, clobber=False)
-    chip.set('tool', tool, 'task', task, 'refdir', step, index,  refdir, clobber=False)
-    chip.set('tool', tool, 'task', task, 'script', step, index,  script, clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads',  4, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'refdir',  refdir, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'script',  script, clobber=False, step=step, index=index)
 
     # set options
     options = []
     options.append('-noc')
     options.append('-dnull')
-    chip.set('tool', tool, 'task', task, 'option', step, index,  options, clobber=False)
+    chip.set('tool', tool, 'task', task, 'option',  options, clobber=False, step=step, index=index)
 
     design = chip.top()
     if chip.valid('input', 'layout', 'gds'):
-        chip.add('tool', tool, 'task', task, 'require', step, index, ','.join(['input', 'layout', 'gds']))
+        chip.add('tool', tool, 'task', task, 'require', ','.join(['input', 'layout', 'gds']), step=step, index=index)
     else:
-        chip.add('tool', tool, 'task', task, 'input', step, index, f'{design}.gds')
+        chip.add('tool', tool, 'task', task, 'input', f'{design}.gds', step=step, index=index)
 
-    chip.set('tool', tool, 'task', task, 'regex', step, index, 'errors', r'^Error', clobber=False)
-    chip.set('tool', tool, 'task', task, 'regex', step, index, 'warnings', r'warning', clobber=False)
+    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'^Error', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'warning', clobber=False, step=step, index=index)
 
 ################################
 # Version Check

--- a/siliconcompiler/tools/magic/sc_drc.tcl
+++ b/siliconcompiler/tools/magic/sc_drc.tcl
@@ -23,8 +23,8 @@ set sc_design    [sc_top]
 set sc_macrolibs [dict get $sc_cfg asic macrolib]
 set sc_stackup  [dict get $sc_cfg option stackup]
 
-if {[dict exists $sc_cfg tool magic task $sc_task var $sc_step $sc_index exclude]} {
-    set sc_exclude  [dict get $sc_cfg tool magic task $sc_task var $sc_step $sc_index exclude]
+if {[dict exists $sc_cfg tool magic task $sc_task var exclude]} {
+    set sc_exclude  [dict get $sc_cfg tool magic task $sc_task var exclude]
 } else {
     set sc_exclude [list]
 }

--- a/siliconcompiler/tools/magic/sc_extspice.tcl
+++ b/siliconcompiler/tools/magic/sc_extspice.tcl
@@ -13,8 +13,8 @@ set sc_techlef [dict get $sc_cfg pdk $sc_pdk aprtech magic $sc_stackup $sc_libty
 set sc_liblef  [dict get $sc_cfg library $sc_mainlib output $sc_stackup lef]
 set sc_macrolibs [dict get $sc_cfg asic macrolib]
 
-if {[dict exists $sc_cfg tool magic task $sc_task var $sc_step $sc_index exclude]} {
-    set sc_exclude  [dict get $sc_cfg tool magic task $sc_task var $sc_step $sc_index exclude]
+if {[dict exists $sc_cfg tool magic task $sc_task var exclude]} {
+    set sc_exclude  [dict get $sc_cfg tool magic task $sc_task var exclude]
 } else {
     set sc_exclude [list]
 }

--- a/siliconcompiler/tools/netgen/lvs.py
+++ b/siliconcompiler/tools/netgen/lvs.py
@@ -20,7 +20,7 @@ def setup(chip):
     chip.set('tool', tool, 'version', '>=1.5.192', clobber=False)
     chip.set('tool', tool, 'format', 'tcl')
 
-    chip.set('tool', tool, 'task', task, 'threads', 4, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=False)
     chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=False)
     chip.set('tool', tool, 'task', task, 'script', script, step=step, index=index, clobber=False)
 

--- a/siliconcompiler/tools/netgen/lvs.py
+++ b/siliconcompiler/tools/netgen/lvs.py
@@ -20,34 +20,34 @@ def setup(chip):
     chip.set('tool', tool, 'version', '>=1.5.192', clobber=False)
     chip.set('tool', tool, 'format', 'tcl')
 
-    chip.set('tool', tool, 'task', task, 'threads', step, index, 4, clobber=False)
-    chip.set('tool', tool, 'task', task, 'refdir', step, index, refdir, clobber=False)
-    chip.set('tool', tool, 'task', task, 'script', step, index, script, clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads', 4, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'script', script, clobber=False, step=step, index=index)
 
     # set options
     options = []
     options.append('-batch')
     options.append('source')
-    chip.set('tool', tool, 'task', task, 'option', step, index, options, clobber=False)
+    chip.set('tool', tool, 'task', task, 'option', options, clobber=False, step=step, index=index)
 
     design = chip.top()
-    chip.add('tool', tool, 'task', task, 'input', step, index, f'{design}.spice')
+    chip.add('tool', tool, 'task', task, 'input', f'{design}.spice', step=step, index=index)
     if chip.valid('input', 'netlist', 'verilog'):
-        chip.add('tool', tool, 'task', task, 'require', step, index, ','.join(['input', 'netlist', 'verilog']))
+        chip.add('tool', tool, 'task', task, 'require', ','.join(['input', 'netlist', 'verilog']), step=step, index=index)
     else:
-        chip.add('tool', tool, 'task', task, 'input', step, index, f'{design}.vg')
+        chip.add('tool', tool, 'task', task, 'input', f'{design}.vg', step=step, index=index)
 
     # Netgen doesn't have a standard error prefix that we can grep for, but it
     # does print all errors to stderr, so we can redirect them to <step>.errors
     # and use that file to count errors.
-    chip.set('tool', tool, 'task', task, 'stderr', step, index, 'suffix', 'errors')
-    chip.set('tool', tool, 'task', task, 'report', step, index, 'errors', f'{step}.errors')
+    chip.set('tool', tool, 'task', task, 'stderr', 'suffix', 'errors', step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'report', 'errors', f'{step}.errors', step=step, index=index)
 
-    chip.set('tool', tool, 'task', task, 'regex', step, index, 'warnings', '^Warning:', clobber=False)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', '^Warning:', clobber=False, step=step, index=index)
 
     report_path = f'reports/{design}.lvs.out'
-    chip.set('tool', tool, 'task', task, 'report', step, index, 'drvs', report_path)
-    chip.set('tool', tool, 'task', task, 'report', step, index, 'warnings', report_path)
+    chip.set('tool', tool, 'task', task, 'report', 'drvs', report_path, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'report', 'warnings', report_path, step=step, index=index)
 
 ################################
 # Post_process (post executable)

--- a/siliconcompiler/tools/netgen/lvs.py
+++ b/siliconcompiler/tools/netgen/lvs.py
@@ -20,15 +20,15 @@ def setup(chip):
     chip.set('tool', tool, 'version', '>=1.5.192', clobber=False)
     chip.set('tool', tool, 'format', 'tcl')
 
-    chip.set('tool', tool, 'task', task, 'threads', 4, clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'refdir', refdir, clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'script', script, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'threads', 4, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'script', script, step=step, index=index, clobber=False)
 
     # set options
     options = []
     options.append('-batch')
     options.append('source')
-    chip.set('tool', tool, 'task', task, 'option', options, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'option', options, step=step, index=index, clobber=False)
 
     design = chip.top()
     chip.add('tool', tool, 'task', task, 'input', f'{design}.spice', step=step, index=index)
@@ -43,7 +43,7 @@ def setup(chip):
     chip.set('tool', tool, 'task', task, 'stderr', 'suffix', 'errors', step=step, index=index)
     chip.set('tool', tool, 'task', task, 'report', 'errors', f'{step}.errors', step=step, index=index)
 
-    chip.set('tool', tool, 'task', task, 'regex', 'warnings', '^Warning:', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', '^Warning:', step=step, index=index, clobber=False)
 
     report_path = f'reports/{design}.lvs.out'
     chip.set('tool', tool, 'task', task, 'report', 'drvs', report_path, step=step, index=index)

--- a/siliconcompiler/tools/netgen/sc_lvs.tcl
+++ b/siliconcompiler/tools/netgen/sc_lvs.tcl
@@ -10,8 +10,8 @@ set sc_stackup [dict get $sc_cfg option stackup]
 set sc_pdk [dict get $sc_cfg option pdk]
 set sc_runset [dict get $sc_cfg pdk $sc_pdk lvs runset netgen $sc_stackup basic]
 
-if {[dict exists $sc_cfg tool netgen task $sc_task var $sc_step $sc_index exclude]} {
-    set sc_exclude  [dict get $sc_cfg tool netgen task $sc_task var $sc_step $sc_index exclude]
+if {[dict exists $sc_cfg tool netgen task $sc_task var exclude]} {
+    set sc_exclude  [dict get $sc_cfg tool netgen task $sc_task var exclude]
 } else {
     set sc_exclude [list]
 }

--- a/siliconcompiler/tools/nextpnr/apr.py
+++ b/siliconcompiler/tools/nextpnr/apr.py
@@ -15,7 +15,7 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=0.2', clobber=clobber)
 
-    chip.set('tool', tool, 'task', task, 'option', "", clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'option', "", step=step, index=index, clobber=clobber)
     chip.set('tool', tool, 'task', task, 'input', f'{topmodule}_netlist.json', step=step, index=index)
     chip.set('tool', tool, 'task', task, 'output', f'{topmodule}.asc', step=step, index=index)
 

--- a/siliconcompiler/tools/nextpnr/apr.py
+++ b/siliconcompiler/tools/nextpnr/apr.py
@@ -15,7 +15,7 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '--version')
     chip.set('tool', tool, 'version', '>=0.2', clobber=clobber)
 
-    chip.set('tool', tool, 'task', task, 'option', step, index, "", clobber=clobber)
-    chip.set('tool', tool, 'task', task, 'input', step, index, f'{topmodule}_netlist.json')
-    chip.set('tool', tool, 'task', task, 'output', step, index, f'{topmodule}.asc')
+    chip.set('tool', tool, 'task', task, 'option', "", clobber=clobber, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'input', f'{topmodule}_netlist.json', step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'output', f'{topmodule}.asc', step=step, index=index)
 

--- a/siliconcompiler/tools/openfpgaloader/openfpgaloader.py
+++ b/siliconcompiler/tools/openfpgaloader/openfpgaloader.py
@@ -50,4 +50,4 @@ def setup(chip):
 
     options = []
     options.append("inputs" + chip.top() + ".bit")
-    chip.add('tool', tool, 'task', task, 'option', step, index,  options)
+    chip.add('tool', tool, 'task', task, 'option',  options, step=step, index=index)

--- a/siliconcompiler/tools/openroad/cts.py
+++ b/siliconcompiler/tools/openroad/cts.py
@@ -15,7 +15,7 @@ def setup(chip):
     step = chip.get('arg', 'step')
     index = chip.get('arg', 'index')
 
-    chip.add('tool', tool, 'task', task, 'input', step, index, design +'.def')
+    chip.add('tool', tool, 'task', task, 'input', design +'.def', step=step, index=index)
 
 def pre_process(chip):
     build_pex_corners(chip)

--- a/siliconcompiler/tools/openroad/dfm.py
+++ b/siliconcompiler/tools/openroad/dfm.py
@@ -15,7 +15,7 @@ def setup(chip):
     step = chip.get('arg', 'step')
     index = chip.get('arg', 'index')
 
-    chip.add('tool', tool, 'task', task, 'input', step, index, design +'.def')
+    chip.add('tool', tool, 'task', task, 'input', design +'.def', step=step, index=index)
 
 def pre_process(chip):
     build_pex_corners(chip)

--- a/siliconcompiler/tools/openroad/export.py
+++ b/siliconcompiler/tools/openroad/export.py
@@ -21,7 +21,7 @@ def setup(chip):
     macrolibs = chip.get('asic', 'macrolib')
 
     # Determine if exporting the cdl
-    chip.set('tool', tool, 'task', task, 'var', 'write_cdl', 'true', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'write_cdl', 'true', step=step, index=index, clobber=False)
     do_cdl = chip.get('tool', tool, 'task', task, 'var', 'write_cdl', step=step, index=index)[0] == 'true'
 
     if do_cdl:

--- a/siliconcompiler/tools/openroad/export.py
+++ b/siliconcompiler/tools/openroad/export.py
@@ -21,30 +21,30 @@ def setup(chip):
     macrolibs = chip.get('asic', 'macrolib')
 
     # Determine if exporting the cdl
-    chip.set('tool', tool, 'task', task, 'var', step, index, 'write_cdl', 'true', clobber=False)
-    do_cdl = chip.get('tool', tool, 'task', task, 'var', step, index, 'write_cdl')[0] == 'true'
+    chip.set('tool', tool, 'task', task, 'var', 'write_cdl', 'true', clobber=False, step=step, index=index)
+    do_cdl = chip.get('tool', tool, 'task', task, 'var', 'write_cdl', step=step, index=index)[0] == 'true'
 
     if do_cdl:
-        chip.add('tool', tool, 'task', task, 'output', step, index, design + '.cdl')
+        chip.add('tool', tool, 'task', task, 'output', design + '.cdl', step=step, index=index)
         for lib in targetlibs + macrolibs:
-            chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['library', lib, 'output', stackup, 'cdl']))
+            chip.add('tool', tool, 'task', task, 'require', ",".join(['library', lib, 'output', stackup, 'cdl']), step=step, index=index)
 
     # Require openrcx pex models
-    for corner in chip.get('tool', tool, 'task', task, 'var', step, index, 'pex_corners'):
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['pdk', pdk, 'pexmodel', 'openroad-openrcx', stackup, corner]))
+    for corner in chip.get('tool', tool, 'task', task, 'var', 'pex_corners', step=step, index=index):
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['pdk', pdk, 'pexmodel', 'openroad-openrcx', stackup, corner]), step=step, index=index)
 
-    chip.add('tool', tool, 'task', task, 'input', step, index, design +'.def')
+    chip.add('tool', tool, 'task', task, 'input', design +'.def', step=step, index=index)
 
     # Add outputs LEF
-    chip.add('tool', tool, 'task', task, 'output', step, index, design + '.lef')
+    chip.add('tool', tool, 'task', task, 'output', design + '.lef', step=step, index=index)
 
     # Add outputs SPEF in the format {design}.{pexcorner}.spef
-    for corner in chip.get('tool', tool, 'task', task, 'var', step, index, 'pex_corners'):
-        chip.add('tool', tool, 'task', task, 'output', step, index, design + '.' + corner + '.spef')
+    for corner in chip.get('tool', tool, 'task', task, 'var', 'pex_corners', step=step, index=index):
+        chip.add('tool', tool, 'task', task, 'output', design + '.' + corner + '.spef', step=step, index=index)
 
     # Add outputs liberty model in the format {design}.{libcorner}.lib
-    for corner in chip.get('tool', tool, 'task', task, 'var', step, index, 'timing_corners'):
-        chip.add('tool', tool, 'task', task, 'output', step, index, design + '.' + corner + '.lib')
+    for corner in chip.get('tool', tool, 'task', task, 'var', 'timing_corners', step=step, index=index):
+        chip.add('tool', tool, 'task', task, 'output', design + '.' + corner + '.lib', step=step, index=index)
 
 def pre_process(chip):
     build_pex_corners(chip)

--- a/siliconcompiler/tools/openroad/floorplan.py
+++ b/siliconcompiler/tools/openroad/floorplan.py
@@ -16,11 +16,11 @@ def setup(chip):
     index = chip.get('arg', 'index')
 
     if chip.valid('input', 'asic', 'floorplan'):
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['input', 'asic', 'floorplan']))
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['input', 'asic', 'floorplan']), step=step, index=index)
 
     if (not chip.valid('input', 'netlist', 'verilog') or
         not chip.get('input', 'netlist', 'verilog')):
-        chip.add('tool', tool, 'task', task, 'input', step, index, design +'.vg')
+        chip.add('tool', tool, 'task', task, 'input', design +'.vg', step=step, index=index)
 
 def pre_process(chip):
     build_pex_corners(chip)

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -456,7 +456,7 @@ def copy_show_files(chip):
     index = chip.get('arg', 'index')
     task = chip._get_task(step, index)
 
-    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath', step=step, index=index):
+    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath'):
         show_file = chip.get('tool', tool, 'task', task, 'var', 'show_filepath', step=step, index=index)[0]
         show_type = chip.get('tool', tool, 'task', task, 'var', 'show_filetype', step=step, index=index)[0]
         show_job = chip.get('tool', tool, 'task', task, 'var', 'show_job', step=step, index=index)[0]

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -94,29 +94,29 @@ def setup(chip, mode='batch'):
 
     # Input/Output requirements for default asicflow steps
 
-    chip.set('tool', tool, 'task', task, 'option',  step, index, option, clobber=clobber)
-    chip.set('tool', tool, 'task', task, 'refdir',  step, index, refdir, clobber=clobber)
-    chip.set('tool', tool, 'task', task, 'script',  step, index, script, clobber=clobber)
-    chip.set('tool', tool, 'task', task, 'threads', step, index, threads, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'option', option, step=step, index=index, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'script', script, step=step, index=index, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'threads', threads, step=step, index=index, clobber=clobber)
 
-    chip.add('tool', tool, 'task', task, 'output', step, index, design + '.sdc')
-    chip.add('tool', tool, 'task', task, 'output', step, index, design + '.vg')
-    chip.add('tool', tool, 'task', task, 'output', step, index, design + '.def')
-    chip.add('tool', tool, 'task', task, 'output', step, index, design + '.odb')
+    chip.add('tool', tool, 'task', task, 'output', design + '.sdc', step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'output', design + '.vg', step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'output', design + '.def', step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'output', design + '.odb', step=step, index=index)
 
     if chip.get('option', 'nodisplay'):
         # Tells QT to use the offscreen platform if nodisplay is used
-        chip.set('tool', tool, 'task', task, 'env', step, index, 'QT_QPA_PLATFORM', 'offscreen')
+        chip.set('tool', tool, 'task', task, 'env', 'QT_QPA_PLATFORM', 'offscreen', step=step, index=index)
 
     if delaymodel != 'nldm':
         chip.logger.error(f'{delaymodel} delay model is not supported by {tool}, only nldm')
 
     if stackup and targetlibs:
         #Note: only one footprint supported in mainlib
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['asic', 'logiclib']))
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['option', 'stackup',]))
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['library', mainlib, 'asic', 'site', libtype]))
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['pdk', pdkname, 'aprtech', 'openroad', stackup, libtype, 'lef']))
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['asic', 'logiclib']), step=step, index=index)
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['option', 'stackup',]), step=step, index=index)
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['library', mainlib, 'asic', 'site', libtype]), step=step, index=index)
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['pdk', pdkname, 'aprtech', 'openroad', stackup, libtype, 'lef']), step=step, index=index)
 
         # set tapcell file
         tapfile = None
@@ -125,38 +125,38 @@ def setup(chip, mode='batch'):
         elif chip.valid('pdk', pdkname, 'aprtech', tool, stackup, libtype, 'tapcells'):
             tapfile = chip.find_files('pdk', pdkname, 'aprtech', tool, stackup, libtype, 'tapcells')
         if tapfile:
-            chip.set('tool', tool, 'task', task, 'var', step, index, 'ifp_tapcell', tapfile, clobber=False)
+            chip.set('tool', tool, 'task', task, 'var', 'ifp_tapcell', tapfile, clobber=False, step=step, index=index)
 
         corners = get_corners(chip)
         for lib in targetlibs:
             for corner in corners:
-                chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['library', lib, 'output', corner, delaymodel]))
-            chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['library', lib, 'output', stackup, 'lef']))
+                chip.add('tool', tool, 'task', task, 'require', ",".join(['library', lib, 'output', corner, delaymodel]), step=step, index=index)
+            chip.add('tool', tool, 'task', task, 'require', ",".join(['library', lib, 'output', stackup, 'lef']), step=step, index=index)
         for lib in macrolibs:
             for corner in corners:
                 if chip.valid('library', lib, 'output', corner, delaymodel):
-                    chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['library', lib, 'output', corner, delaymodel]))
-            chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['library', lib, 'output', stackup, 'lef']))
+                    chip.add('tool', tool, 'task', task, 'require', ",".join(['library', lib, 'output', corner, delaymodel]), step=step, index=index)
+            chip.add('tool', tool, 'task', task, 'require', ",".join(['library', lib, 'output', stackup, 'lef']), step=step, index=index)
     else:
         chip.error(f'Stackup and logiclib parameters required for OpenROAD.')
 
-    chip.set('tool', tool, 'task', task, 'var', step, index, 'timing_corners', get_corners(chip), clobber=False)
-    chip.set('tool', tool, 'task', task, 'var', step, index, 'pex_corners', get_pex_corners(chip), clobber=False)
-    chip.set('tool', tool, 'task', task, 'var', step, index, 'power_corner', get_power_corner(chip), clobber=False)
-    chip.set('tool', tool, 'task', task, 'var', step, index, 'parasitics', "inputs/sc_parasitics.tcl", clobber=True)
+    chip.set('tool', tool, 'task', task, 'var', 'timing_corners', get_corners(chip), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'pex_corners', get_pex_corners(chip), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'power_corner', get_power_corner(chip), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'parasitics', "inputs/sc_parasitics.tcl", clobber=True, step=step, index=index)
 
     for var0, var1 in [('openroad_tiehigh_cell', 'openroad_tiehigh_port'), ('openroad_tiehigh_cell', 'openroad_tiehigh_port')]:
         key0 = ['library', mainlib, 'option', 'var', tool, var0]
         key1 = ['library', mainlib, 'option', 'var', tool, var1]
         if chip.valid(*key0):
-            chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(key1))
+            chip.add('tool', tool, 'task', task, 'require', ",".join(key1), step=step, index=index)
         if chip.valid(*key1):
-            chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(key0))
+            chip.add('tool', tool, 'task', task, 'require', ",".join(key0), step=step, index=index)
 
-    chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['pdk', pdkname, 'var', 'openroad', 'rclayer_signal', stackup]))
-    chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['pdk', pdkname, 'var', 'openroad', 'rclayer_clock', stackup]))
-    chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['pdk', pdkname, 'var', 'openroad', 'pin_layer_horizontal', stackup]))
-    chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['pdk', pdkname, 'var', 'openroad', 'pin_layer_vertical', stackup]))
+    chip.add('tool', tool, 'task', task, 'require', ",".join(['pdk', pdkname, 'var', 'openroad', 'rclayer_signal', stackup]), step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'require', ",".join(['pdk', pdkname, 'var', 'openroad', 'rclayer_clock', stackup]), step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'require', ",".join(['pdk', pdkname, 'var', 'openroad', 'pin_layer_horizontal', stackup]), step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'require', ",".join(['pdk', pdkname, 'var', 'openroad', 'pin_layer_vertical', stackup]), step=step, index=index)
 
     variables = (
         'place_density',
@@ -174,21 +174,21 @@ def setup(chip, mode='batch'):
             value = chip.get(*var_key)
             # Clobber needs to be False here, since a user might want to
             # overwrite these.
-            chip.set('tool', tool, 'task', task, 'var', step, index, variable, value,
-                     clobber=False)
+            chip.set('tool', tool, 'task', task, 'var', variable, value,
+                     step=step, index=index, clobber=False)
 
             keypath = ','.join(var_key)
-            chip.add('tool', tool, 'task', task, 'require', step, index, keypath)
+            chip.add('tool', tool, 'task', task, 'require', keypath, step=step, index=index)
 
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', step, index, variable]))
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', variable]), step=step, index=index)
 
     # Copy values from PDK if set
     for variable in ('detailed_route_default_via',
                      'detailed_route_unidirectional_layer'):
         if chip.valid('pdk', pdkname, 'var', tool, stackup, variable):
             value = chip.get('pdk', pdkname, 'var', tool, stackup, variable)
-            chip.set('tool', tool, 'task', task, 'var', step, index, variable, value,
-                     clobber=False)
+            chip.set('tool', tool, 'task', task, 'var', variable, value,
+                     step=step, index=index, clobber=False)
 
     # set default values for openroad
     for variable, value in [('ifp_tie_separation', '0'),
@@ -230,12 +230,12 @@ def setup(chip, mode='batch'):
                             ('fin_add_fill', 'true'),
                             ('psm_enable', 'true')
                             ]:
-        chip.set('tool', tool, 'task', task, 'var', step, index, variable, value, clobber=False)
+        chip.set('tool', tool, 'task', task, 'var', variable, value, clobber=False, step=step, index=index)
 
     for libvar, openroadvar in [('openroad_pdngen', 'pdn_config'),
                                 ('openroad_global_connect', 'global_connect')]:
-        if chip.valid('tool', tool, 'task', task, 'var', step, index, openroadvar) and \
-           not chip.get('tool', tool, 'task', task, 'var', step, index, openroadvar):
+        if chip.valid('tool', tool, 'task', task, 'var', openroadvar) and \
+           not chip.get('tool', tool, 'task', task, 'var', openroadvar, step=step, index=index):
             # value already set
             continue
 
@@ -243,18 +243,20 @@ def setup(chip, mode='batch'):
         for lib in targetlibs + macrolibs:
             if chip.valid('library', lib, 'option', 'file', libvar):
                 for pdn_config in chip.find_files('library', lib, 'option', 'file', libvar):
-                    chip.add('tool', tool, 'task', task, 'var', step, index, openroadvar, pdn_config)
+                    chip.add('tool', tool, 'task', task, 'var', openroadvar, pdn_config, step=step, index=index)
 
     # basic warning and error grep check on logfile
-    chip.set('tool', tool, 'task', task, 'regex', step, index, 'warnings', r'^\[WARNING|^Warning', clobber=False)
-    chip.set('tool', tool, 'task', task, 'regex', step, index, 'errors', r'^\[ERROR', clobber=False)
+    # print('warnings', step, index)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'^\[WARNING|^Warning', clobber=False, step=step, index=index)
+    # print(chip.getdict('tool', tool, 'task', task, 'regex', 'warnings'))
+    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'^\[ERROR', clobber=False, step=step, index=index)
 
     # reports
     for metric in ('vias', 'wirelength', 'cellarea', 'totalarea', 'utilization', 'setuptns', 'holdtns',
                    'setupslack', 'holdslack', 'setuppaths', 'holdpaths', 'unconstrained', 'peakpower',
                    'leakagepower', 'pins', 'cells', 'macros', 'nets', 'registers', 'buffers', 'drvs',
                    'setupwns', 'holdwns'):
-        chip.set('tool', tool, 'task', task, 'report', step, index, metric, "reports/metrics.json")
+        chip.set('tool', tool, 'task', task, 'report', metric, "reports/metrics.json", step=step, index=index)
 
 ################################
 # Version Check
@@ -417,7 +419,7 @@ def build_pex_corners(chip):
     if default_corner in corners:
         corners[None] = corners[default_corner]
 
-    with open(chip.get('tool', tool, 'task', task, 'var', step, index, 'parasitics')[0], 'w') as f:
+    with open(chip.get('tool', tool, 'task', task, 'var', 'parasitics', step=step, index=index)[0], 'w') as f:
         for libcorner, pexcorner in corners.items():
             if chip.valid('pdk', pdkname, 'pexmodel', tool, stackup, pexcorner):
                 pex_source_file = chip.find_files('pdk', pdkname, 'pexmodel', tool, stackup, pexcorner)[0]
@@ -454,12 +456,12 @@ def copy_show_files(chip):
     index = chip.get('arg', 'index')
     task = chip._get_task(step, index)
 
-    if chip.valid('tool', tool, 'task', task, 'var', step, index, 'show_filepath'):
-        show_file = chip.get('tool', tool, 'task', task, 'var', step, index, 'show_filepath')[0]
-        show_type = chip.get('tool', tool, 'task', task, 'var', step, index, 'show_filetype')[0]
-        show_job = chip.get('tool', tool, 'task', task, 'var', step, index, 'show_job')[0]
-        show_step = chip.get('tool', tool, 'task', task, 'var', step, index, 'show_step')[0]
-        show_index = chip.get('tool', tool, 'task', task, 'var', step, index, 'show_index')[0]
+    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath', step=step, index=index):
+        show_file = chip.get('tool', tool, 'task', task, 'var', 'show_filepath', step=step, index=index)[0]
+        show_type = chip.get('tool', tool, 'task', task, 'var', 'show_filetype', step=step, index=index)[0]
+        show_job = chip.get('tool', tool, 'task', task, 'var', 'show_job', step=step, index=index)[0]
+        show_step = chip.get('tool', tool, 'task', task, 'var', 'show_step', step=step, index=index)[0]
+        show_index = chip.get('tool', tool, 'task', task, 'var', 'show_index', step=step, index=index)[0]
 
         # copy source in to keep sc_apr.tcl simple
         dst_file = "inputs/"+chip.top()+"."+show_type

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -125,7 +125,7 @@ def setup(chip, mode='batch'):
         elif chip.valid('pdk', pdkname, 'aprtech', tool, stackup, libtype, 'tapcells'):
             tapfile = chip.find_files('pdk', pdkname, 'aprtech', tool, stackup, libtype, 'tapcells')
         if tapfile:
-            chip.set('tool', tool, 'task', task, 'var', 'ifp_tapcell', tapfile, clobber=False, step=step, index=index)
+            chip.set('tool', tool, 'task', task, 'var', 'ifp_tapcell', tapfile, step=step, index=index, clobber=False)
 
         corners = get_corners(chip)
         for lib in targetlibs:
@@ -140,10 +140,10 @@ def setup(chip, mode='batch'):
     else:
         chip.error(f'Stackup and logiclib parameters required for OpenROAD.')
 
-    chip.set('tool', tool, 'task', task, 'var', 'timing_corners', get_corners(chip), clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'var', 'pex_corners', get_pex_corners(chip), clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'var', 'power_corner', get_power_corner(chip), clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'var', 'parasitics', "inputs/sc_parasitics.tcl", clobber=True, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'timing_corners', get_corners(chip), step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'var', 'pex_corners', get_pex_corners(chip), step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'var', 'power_corner', get_power_corner(chip), step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'var', 'parasitics', "inputs/sc_parasitics.tcl", step=step, index=index, clobber=True)
 
     for var0, var1 in [('openroad_tiehigh_cell', 'openroad_tiehigh_port'), ('openroad_tiehigh_cell', 'openroad_tiehigh_port')]:
         key0 = ['library', mainlib, 'option', 'var', tool, var0]
@@ -230,7 +230,7 @@ def setup(chip, mode='batch'):
                             ('fin_add_fill', 'true'),
                             ('psm_enable', 'true')
                             ]:
-        chip.set('tool', tool, 'task', task, 'var', variable, value, clobber=False, step=step, index=index)
+        chip.set('tool', tool, 'task', task, 'var', variable, value, step=step, index=index, clobber=False)
 
     for libvar, openroadvar in [('openroad_pdngen', 'pdn_config'),
                                 ('openroad_global_connect', 'global_connect')]:
@@ -247,9 +247,9 @@ def setup(chip, mode='batch'):
 
     # basic warning and error grep check on logfile
     # print('warnings', step, index)
-    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'^\[WARNING|^Warning', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'^\[WARNING|^Warning', step=step, index=index, clobber=False)
     # print(chip.getdict('tool', tool, 'task', task, 'regex', 'warnings'))
-    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'^\[ERROR', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'^\[ERROR', step=step, index=index, clobber=False)
 
     # reports
     for metric in ('vias', 'wirelength', 'cellarea', 'totalarea', 'utilization', 'setuptns', 'holdtns',

--- a/siliconcompiler/tools/openroad/physyn.py
+++ b/siliconcompiler/tools/openroad/physyn.py
@@ -15,7 +15,7 @@ def setup(chip):
     step = chip.get('arg', 'step')
     index = chip.get('arg', 'index')
 
-    chip.add('tool', tool, 'task', task, 'input', step, index, design +'.def')
+    chip.add('tool', tool, 'task', task, 'input', design +'.def', step=step, index=index)
 
 def pre_process(chip):
     build_pex_corners(chip)

--- a/siliconcompiler/tools/openroad/place.py
+++ b/siliconcompiler/tools/openroad/place.py
@@ -17,7 +17,7 @@ def setup(chip):
 
     if (not chip.valid('input', 'layout', 'def') or
         not chip.get('input', 'layout', 'def')):
-        chip.add('tool', tool, 'task', task, 'input', step, index, design +'.def')
+        chip.add('tool', tool, 'task', task, 'input', design +'.def', step=step, index=index)
 
 def pre_process(chip):
     build_pex_corners(chip)

--- a/siliconcompiler/tools/openroad/route.py
+++ b/siliconcompiler/tools/openroad/route.py
@@ -15,7 +15,7 @@ def setup(chip):
     step = chip.get('arg', 'step')
     index = chip.get('arg', 'index')
 
-    chip.add('tool', tool, 'task', task, 'input', step, index, design +'.def')
+    chip.add('tool', tool, 'task', task, 'input', design +'.def', step=step, index=index)
 
 def pre_process(chip):
     build_pex_corners(chip)

--- a/siliconcompiler/tools/openroad/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/sc_apr.tcl
@@ -49,7 +49,7 @@ set sc_index  [dict get $sc_cfg arg index]
 set sc_flow   [dict get $sc_cfg option flow]
 set sc_task   [dict get $sc_cfg flowgraph $sc_flow $sc_step $sc_index task]
 
-set sc_refdir [dict get $sc_cfg tool $sc_tool task $sc_task refdir $sc_step $sc_index ]
+set sc_refdir [dict get $sc_cfg tool $sc_tool task $sc_task refdir ]
 
 # Design
 set sc_design     [sc_top]
@@ -81,9 +81,9 @@ set sc_clkbuf       [dict get $sc_cfg library $sc_mainlib asic cells clkbuf]
 set sc_filler       [dict get $sc_cfg library $sc_mainlib asic cells filler]
 set sc_tap          [dict get $sc_cfg library $sc_mainlib asic cells tap]
 set sc_endcap       [dict get $sc_cfg library $sc_mainlib asic cells endcap]
-set sc_corners      [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index timing_corners]
-set sc_pex_corners  [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index pex_corners]
-set sc_power_corner [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index power_corner] 0]
+set sc_corners      [dict get $sc_cfg tool $sc_tool task $sc_task {var} timing_corners]
+set sc_pex_corners  [dict get $sc_cfg tool $sc_tool task $sc_task {var} pex_corners]
+set sc_power_corner [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} power_corner] 0]
 
 # PDK Design Rules
 set sc_techlef     [dict get $sc_cfg pdk $sc_pdk aprtech openroad $sc_stackup $sc_libtype lef]
@@ -94,11 +94,11 @@ if {[dict exists $sc_cfg datasheet $sc_design]} {
   set sc_pins    [list]
 }
 
-set sc_threads     [dict get $sc_cfg tool $sc_tool task $sc_task threads $sc_step $sc_index]
+set sc_threads [dict get $sc_cfg tool $sc_tool task $sc_task threads]
 
 set openroad_dont_touch {}
-if {[dict exists $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index dont_touch]} {
-  set openroad_dont_touch [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index dont_touch]
+if {[dict exists $sc_cfg tool $sc_tool task $sc_task {var} dont_touch]} {
+  set openroad_dont_touch [dict get $sc_cfg tool $sc_tool task $sc_task {var} dont_touch]
 }
 
 ###############################
@@ -195,74 +195,74 @@ if {[file exists "inputs/${sc_design}.sdc"]} {
 ###############################
 
 # Sweep parameters
-set openroad_ifp_tie_separation [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index ifp_tie_separation] 0]
+set openroad_ifp_tie_separation [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} ifp_tie_separation] 0]
 
-set openroad_pdn_enable [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index pdn_enable] 0]
+set openroad_pdn_enable [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} pdn_enable] 0]
 
-set openroad_psm_enable [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index psm_enable] 0]
+set openroad_psm_enable [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} psm_enable] 0]
 
-set openroad_mpl_macro_place_halo [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step  $sc_index macro_place_halo]
-set openroad_mpl_macro_place_channel [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index macro_place_channel]
+set openroad_mpl_macro_place_halo [dict get $sc_cfg tool $sc_tool task $sc_task {var} macro_place_halo]
+set openroad_mpl_macro_place_channel [dict get $sc_cfg tool $sc_tool task $sc_task {var} macro_place_channel]
 
-set openroad_gpl_place_density [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index place_density] 0]
-set openroad_gpl_padding [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index pad_global_place] 0]
-set openroad_gpl_routability_driven [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index gpl_routability_driven] 0]
-set openroad_gpl_timing_driven [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index gpl_timing_driven] 0]
+set openroad_gpl_place_density [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} place_density] 0]
+set openroad_gpl_padding [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} pad_global_place] 0]
+set openroad_gpl_routability_driven [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} gpl_routability_driven] 0]
+set openroad_gpl_timing_driven [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} gpl_timing_driven] 0]
 
-set openroad_dpo_enable [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index dpo_enable] 0]
-set openroad_dpo_max_displacement [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index dpo_max_displacement] 0]
+set openroad_dpo_enable [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} dpo_enable] 0]
+set openroad_dpo_max_displacement [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} dpo_max_displacement] 0]
 
-set openroad_dpl_max_displacement [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index dpl_max_displacement] 0]
-set openroad_dpl_padding [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index pad_detail_place] 0]
+set openroad_dpl_max_displacement [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} dpl_max_displacement] 0]
+set openroad_dpl_padding [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} pad_detail_place] 0]
 
-set openroad_cts_distance_between_buffers [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index cts_distance_between_buffers] 0]
-set openroad_cts_cluster_diameter [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index cts_cluster_diameter] 0]
-set openroad_cts_cluster_size [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index cts_cluster_size] 0]
-set openroad_cts_balance_levels [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index cts_balance_levels] 0]
+set openroad_cts_distance_between_buffers [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} cts_distance_between_buffers] 0]
+set openroad_cts_cluster_diameter [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} cts_cluster_diameter] 0]
+set openroad_cts_cluster_size [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} cts_cluster_size] 0]
+set openroad_cts_balance_levels [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} cts_balance_levels] 0]
 
-set openroad_ant_iterations [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index ant_iterations] 0]
-set openroad_ant_margin [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index ant_margin] 0]
+set openroad_ant_iterations [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} ant_iterations] 0]
+set openroad_ant_margin [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} ant_margin] 0]
 
-set openroad_grt_use_pin_access [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index grt_use_pin_access] 0]
-set openroad_grt_overflow_iter [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index grt_overflow_iter] 0]
-set openroad_grt_macro_extension [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index grt_macro_extension] 0]
-set openroad_grt_allow_congestion [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index grt_allow_congestion] 0]
-set openroad_grt_allow_overflow [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index grt_allow_overflow] 0]
-set openroad_grt_signal_min_layer [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index grt_signal_min_layer] 0]
-set openroad_grt_signal_max_layer [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index grt_signal_max_layer] 0]
-set openroad_grt_clock_min_layer [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index grt_clock_min_layer] 0]
-set openroad_grt_clock_max_layer [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index grt_clock_max_layer] 0]
+set openroad_grt_use_pin_access [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} grt_use_pin_access] 0]
+set openroad_grt_overflow_iter [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} grt_overflow_iter] 0]
+set openroad_grt_macro_extension [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} grt_macro_extension] 0]
+set openroad_grt_allow_congestion [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} grt_allow_congestion] 0]
+set openroad_grt_allow_overflow [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} grt_allow_overflow] 0]
+set openroad_grt_signal_min_layer [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} grt_signal_min_layer] 0]
+set openroad_grt_signal_max_layer [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} grt_signal_max_layer] 0]
+set openroad_grt_clock_min_layer [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} grt_clock_min_layer] 0]
+set openroad_grt_clock_max_layer [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} grt_clock_max_layer] 0]
 
-set openroad_drt_disable_via_gen [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index drt_disable_via_gen] 0]
-set openroad_drt_process_node [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index drt_process_node] 0]
-set openroad_drt_via_in_pin_bottom_layer [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index drt_via_in_pin_bottom_layer] 0]
-set openroad_drt_via_in_pin_top_layer [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index drt_via_in_pin_top_layer] 0]
-set openroad_drt_repair_pdn_vias [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index drt_repair_pdn_vias] 0]
-set openroad_drt_via_repair_post_route [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index drt_via_repair_post_route] 0]
+set openroad_drt_disable_via_gen [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} drt_disable_via_gen] 0]
+set openroad_drt_process_node [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} drt_process_node] 0]
+set openroad_drt_via_in_pin_bottom_layer [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} drt_via_in_pin_bottom_layer] 0]
+set openroad_drt_via_in_pin_top_layer [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} drt_via_in_pin_top_layer] 0]
+set openroad_drt_repair_pdn_vias [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} drt_repair_pdn_vias] 0]
+set openroad_drt_via_repair_post_route [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} drt_via_repair_post_route] 0]
 set openroad_drt_default_vias []
-if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index drt_default_via]} {
-  foreach via [dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index drt_default_via] {
+if {[dict exists $sc_cfg tool $sc_tool task $sc_task var drt_default_via]} {
+  foreach via [dict exists $sc_cfg tool $sc_tool task $sc_task var drt_default_via] {
     lappend openroad_drt_default_vias $via
   }
 }
 set openroad_drt_unifirectional_layers []
-if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index drt_unidirectional_layer]} {
-  foreach layer [dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index drt_unidirectional_layer] {
+if {[dict exists $sc_cfg tool $sc_tool task $sc_task var drt_unidirectional_layer]} {
+  foreach layer [dict exists $sc_cfg tool $sc_tool task $sc_task var drt_unidirectional_layer] {
     lappend openroad_drt_unifirectional_layers [sc_get_layer_name $layer]
   }
 }
 
-set openroad_rsz_setup_slack_margin [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index rsz_setup_slack_margin] 0]
-set openroad_rsz_hold_slack_margin [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index rsz_hold_slack_margin] 0]
-set openroad_rsz_slew_margin [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index rsz_slew_margin] 0]
-set openroad_rsz_cap_margin [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index rsz_cap_margin] 0]
-set openroad_rsz_buffer_inputs [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index rsz_buffer_inputs] 0]
-set openroad_rsz_buffer_outputs [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index rsz_buffer_outputs] 0]
+set openroad_rsz_setup_slack_margin [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} rsz_setup_slack_margin] 0]
+set openroad_rsz_hold_slack_margin [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} rsz_hold_slack_margin] 0]
+set openroad_rsz_slew_margin [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} rsz_slew_margin] 0]
+set openroad_rsz_cap_margin [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} rsz_cap_margin] 0]
+set openroad_rsz_buffer_inputs [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} rsz_buffer_inputs] 0]
+set openroad_rsz_buffer_outputs [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} rsz_buffer_outputs] 0]
 
-set openroad_sta_early_timing_derate [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index sta_early_timing_derate] 0]
-set openroad_sta_late_timing_derate [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index sta_late_timing_derate] 0]
+set openroad_sta_early_timing_derate [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} sta_early_timing_derate] 0]
+set openroad_sta_late_timing_derate [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} sta_late_timing_derate] 0]
 
-set openroad_fin_add_fill [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index fin_add_fill] 0]
+set openroad_fin_add_fill [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} fin_add_fill] 0]
 
 # PDK agnostic design rule translation
 set sc_minmetal [sc_get_layer_name $sc_minmetal]
@@ -297,7 +297,7 @@ if { [llength [all_clocks]] == 0} {
 
 set_dont_use $sc_dontuse
 
-set sc_parasitics [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index parasitics] 0]
+set sc_parasitics [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} parasitics] 0]
 source $sc_parasitics
 set_wire_rc -clock  -layer $sc_rc_clk
 set_wire_rc -signal -layer $sc_rc_signal
@@ -328,7 +328,7 @@ if { $sc_task == "show" || $sc_task == "screenshot" } {
     source "$sc_refdir/sc_screenshot.tcl"
   }
 
-  set show_exit [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index show_exit] 0]
+  set show_exit [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} show_exit] 0]
   if { $show_exit == "true" } {
     exit
   }
@@ -340,8 +340,8 @@ if { $sc_task == "show" || $sc_task == "screenshot" } {
   report_units_metric
 
   utl::set_metrics_stage "sc__prestep__{}"
-  if {[dict exists $sc_cfg tool $sc_tool task $sc_task prescript $sc_step $sc_index]} {
-    foreach sc_pre_script [dict get $sc_cfg tool $sc_tool task $sc_task prescript $sc_step $sc_index] {
+  if {[dict exists $sc_cfg tool $sc_tool task $sc_task prescript]} {
+    foreach sc_pre_script [dict get $sc_cfg tool $sc_tool task $sc_task prescript] {
       puts "Sourcing pre script: ${sc_pre_script}"
       source -echo $sc_pre_script
     }
@@ -363,8 +363,8 @@ if { $sc_task == "show" || $sc_task == "screenshot" } {
   utl::pop_metrics_stage
 
   utl::set_metrics_stage "sc__poststep__{}"
-  if {[dict exists $sc_cfg tool $sc_tool task $sc_task postscript $sc_step $sc_index]} {
-    foreach sc_post_script [dict get $sc_cfg tool $sc_tool task $sc_task postscript $sc_step $sc_index] {
+  if {[dict exists $sc_cfg tool $sc_tool task $sc_task postscript]} {
+    foreach sc_post_script [dict get $sc_cfg tool $sc_tool task $sc_task postscript] {
       puts "Sourcing post script: ${sc_post_script}"
       source -echo $sc_post_script
     }

--- a/siliconcompiler/tools/openroad/sc_export.tcl
+++ b/siliconcompiler/tools/openroad/sc_export.tcl
@@ -1,7 +1,7 @@
 # Write LEF
 write_abstract_lef "outputs/${sc_design}.lef"
 
-if { [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index write_cdl] 0] == "true" } {
+if { [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} write_cdl] 0] == "true" } {
   # Write CDL
   set sc_cdl_masters []
   foreach lib "$sc_targetlibs $sc_macrolibs" {

--- a/siliconcompiler/tools/openroad/sc_floorplan.tcl
+++ b/siliconcompiler/tools/openroad/sc_floorplan.tcl
@@ -245,16 +245,16 @@ if { $do_automatic_pins } {
   # Automatic Pin Placement
   ###########################
 
-  if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index pin_thickness_h]} {
-    set h_mult [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index pin_thickness_h] 0]
+  if {[dict exists $sc_cfg tool $sc_tool task $sc_task var pin_thickness_h]} {
+    set h_mult [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var pin_thickness_h] 0]
     set_pin_thick_multiplier -hor_multiplier $h_mult
   }
-  if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index pin_thickness_v]} {
-    set v_mult [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index pin_thickness_v] 0]
+  if {[dict exists $sc_cfg tool $sc_tool task $sc_task var pin_thickness_v]} {
+    set v_mult [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var pin_thickness_v] 0]
     set_pin_thick_multiplier -ver_multiplier $v_mult
   }
-  if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index ppl_constraints]} {
-    foreach pin_constraint [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index ppl_constraints] {
+  if {[dict exists $sc_cfg tool $sc_tool task $sc_task var ppl_constraints]} {
+    foreach pin_constraint [dict get $sc_cfg tool $sc_tool task $sc_task var ppl_constraints] {
       puts "Sourcing pin constraints: ${pin_constraint}"
       source $pin_constraint
     }
@@ -303,8 +303,8 @@ foreach tie_type "high low" {
 # Tap Cells
 ###########################
 
-if { [dict exists $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index ifp_tapcell] } {
-  set tapcell_file [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index ifp_tapcell] 0]
+if { [dict exists $sc_cfg tool $sc_tool task $sc_task {var} ifp_tapcell] } {
+  set tapcell_file [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} ifp_tapcell] 0]
   puts "Sourcing tapcell file: ${tapcell_file}"
   source $tapcell_file
 }
@@ -313,8 +313,8 @@ if { [dict exists $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index i
 # Global Connections
 ###########################
 
-if { [dict exists $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index global_connect] } {
-  foreach global_connect [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index global_connect] {
+if { [dict exists $sc_cfg tool $sc_tool task $sc_task {var} global_connect] } {
+  foreach global_connect [dict get $sc_cfg tool $sc_tool task $sc_task {var} global_connect] {
     puts "Sourcing global connect configuration: ${global_connect}"
     source $global_connect
   }
@@ -325,8 +325,8 @@ if { [dict exists $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index g
 ###########################
 
 if {$openroad_pdn_enable == "true" && \
-    [dict exists $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index pdn_config]} {
-  foreach pdnconfig [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index pdn_config] {
+    [dict exists $sc_cfg tool $sc_tool task $sc_task {var} pdn_config]} {
+  foreach pdnconfig [dict get $sc_cfg tool $sc_tool task $sc_task {var} pdn_config] {
     puts "Sourcing PDNGEN configuration: ${pdnconfig}"
     source $pdnconfig
   }

--- a/siliconcompiler/tools/openroad/sc_place.tcl
+++ b/siliconcompiler/tools/openroad/sc_place.tcl
@@ -20,16 +20,16 @@ global_placement {*}$openroad_gpl_args \
 # Refine Automatic Pin Placement
 ###########################
 
-if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index pin_thickness_h]} {
-  set h_mult [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index pin_thickness_h] 0]
+if {[dict exists $sc_cfg tool $sc_tool task $sc_task var pin_thickness_h]} {
+  set h_mult [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var pin_thickness_h] 0]
   set_pin_thick_multiplier -hor_multiplier $h_mult
 }
-if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index pin_thickness_v]} {
-  set v_mult [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index pin_thickness_v] 0]
+if {[dict exists $sc_cfg tool $sc_tool task $sc_task var pin_thickness_v]} {
+  set v_mult [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var pin_thickness_v] 0]
   set_pin_thick_multiplier -ver_multiplier $v_mult
 }
-if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index ppl_constraints]} {
-  foreach pin_constraint [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index ppl_constraints] {
+if {[dict exists $sc_cfg tool $sc_tool task $sc_task var ppl_constraints]} {
+  foreach pin_constraint [dict get $sc_cfg tool $sc_tool task $sc_task var ppl_constraints] {
     puts "Sourcing pin constraints: ${pin_constraint}"
     source $pin_constraint
   }

--- a/siliconcompiler/tools/openroad/sc_route.tcl
+++ b/siliconcompiler/tools/openroad/sc_route.tcl
@@ -28,13 +28,13 @@ insert_fillers
 # Setup detailed route options
 ######################
 
-if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index drt_default_via]} {
-  foreach via [dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index drt_default_via] {
+if {[dict exists $sc_cfg tool $sc_tool task $sc_task var drt_default_via]} {
+  foreach via [dict exists $sc_cfg tool $sc_tool task $sc_task var drt_default_via] {
     detailed_route_set_default_via $via
   }
 }
-if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index drt_unidirectional_layer]} {
-  foreach layer [dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index drt_unidirectional_layer] {
+if {[dict exists $sc_cfg tool $sc_tool task $sc_task var drt_unidirectional_layer]} {
+  foreach layer [dict exists $sc_cfg tool $sc_tool task $sc_task var drt_unidirectional_layer] {
     detailed_route_set_unidirectional_layer $via
   }
 }

--- a/siliconcompiler/tools/openroad/sc_screenshot.tcl
+++ b/siliconcompiler/tools/openroad/sc_screenshot.tcl
@@ -1,6 +1,6 @@
 gui::save_display_controls
 
-set sc_resolution [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} $sc_step $sc_index show_vertical_resolution] 0]
+set sc_resolution [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} show_vertical_resolution] 0]
 
 set height [[[ord::get_db_block] getBBox] getDY]
 set height [ord::dbu_to_microns $height]

--- a/siliconcompiler/tools/openroad/screenshot.py
+++ b/siliconcompiler/tools/openroad/screenshot.py
@@ -19,16 +19,16 @@ def setup(chip):
     clobber = True
     option = "-no_init -gui"
 
-    chip.add('tool', tool, 'task', task, 'output', step, index, design + '.png')
-    chip.set('tool', tool, 'task', task, 'var', step, index, 'show_vertical_resolution', '1024', clobber=False)
+    chip.add('tool', tool, 'task', task, 'output', design + '.png', step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'show_vertical_resolution', '1024', clobber=False, step=step, index=index)
 
-    chip.set('tool', tool, 'task', task, 'var', step, index, 'show_exit', "true", clobber=False)
-    if chip.valid('tool', tool, 'task', task, 'var', step, index, 'show_filepath'):
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', step, index, 'show_filepath']))
+    chip.set('tool', tool, 'task', task, 'var', 'show_exit', "true", clobber=False, step=step, index=index)
+    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath', step=step, index=index):
+        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', 'show_filepath']), step=step, index=index)
     else:
         incoming_ext = find_incoming_ext(chip)
-        chip.set('tool', tool, 'task', task, 'var', step, index, 'show_filetype', incoming_ext)
-        chip.add('tool', tool, 'task', task, 'input', step, index, f'{design}.{incoming_ext}')
+        chip.set('tool', tool, 'task', task, 'var', 'show_filetype', incoming_ext, step=step, index=index)
+        chip.add('tool', tool, 'task', task, 'input', f'{design}.{incoming_ext}', step=step, index=index)
 
     # Add to option string.
     cur_options = ' '.join(chip.get('tool', tool, 'task', task, 'option',  step, index))

--- a/siliconcompiler/tools/openroad/screenshot.py
+++ b/siliconcompiler/tools/openroad/screenshot.py
@@ -20,9 +20,9 @@ def setup(chip):
     option = "-no_init -gui"
 
     chip.add('tool', tool, 'task', task, 'output', design + '.png', step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'var', 'show_vertical_resolution', '1024', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'show_vertical_resolution', '1024', step=step, index=index, clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'var', 'show_exit', "true", clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'show_exit', "true", step=step, index=index, clobber=False)
     if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath'):
         chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', 'show_filepath']), step=step, index=index)
     else:

--- a/siliconcompiler/tools/openroad/screenshot.py
+++ b/siliconcompiler/tools/openroad/screenshot.py
@@ -23,17 +23,17 @@ def setup(chip):
     chip.set('tool', tool, 'task', task, 'var', 'show_vertical_resolution', '1024', clobber=False, step=step, index=index)
 
     chip.set('tool', tool, 'task', task, 'var', 'show_exit', "true", clobber=False, step=step, index=index)
-    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath', step=step, index=index):
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', 'show_filepath']), step=step, index=index)
+    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath'):
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', 'show_filepath']), step=step, index=index)
     else:
         incoming_ext = find_incoming_ext(chip)
         chip.set('tool', tool, 'task', task, 'var', 'show_filetype', incoming_ext, step=step, index=index)
         chip.add('tool', tool, 'task', task, 'input', f'{design}.{incoming_ext}', step=step, index=index)
 
     # Add to option string.
-    cur_options = ' '.join(chip.get('tool', tool, 'task', task, 'option',  step, index))
+    cur_options = ' '.join(chip.get('tool', tool, 'task', task, 'option', step=step, index=index))
     new_options = f'{cur_options} {option}'
-    chip.set('tool', tool, 'task', task, 'option',  step, index, new_options, clobber=True)
+    chip.set('tool', tool, 'task', task, 'option', new_options, step=step, index=index, clobber=True)
 
 def pre_process(chip):
     copy_show_files(chip)

--- a/siliconcompiler/tools/openroad/show.py
+++ b/siliconcompiler/tools/openroad/show.py
@@ -19,13 +19,13 @@ def setup(chip):
     clobber = True
     option = "-no_init -gui"
 
-    chip.set('tool', tool, 'task', task, 'var', step, index, 'show_exit', "false", clobber=False)
-    if chip.valid('tool', tool, 'task', task, 'var', step, index, 'show_filepath'):
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', step, index, 'show_filepath']))
+    chip.set('tool', tool, 'task', task, 'var', 'show_exit', "false", clobber=False, step=step, index=index)
+    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath', step=step, index=index):
+        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', 'show_filepath']), step=step, index=index)
     else:
         incoming_ext = find_incoming_ext(chip)
-        chip.set('tool', tool, 'task', task, 'var', step, index, 'show_filetype', incoming_ext)
-        chip.add('tool', tool, 'task', task, 'input', step, index, f'{design}.{incoming_ext}')
+        chip.set('tool', tool, 'task', task, 'var', 'show_filetype', incoming_ext, step=step, index=index)
+        chip.add('tool', tool, 'task', task, 'input', f'{design}.{incoming_ext}', step=step, index=index)
 
     # Add to option string.
     cur_options = ' '.join(chip.get('tool', tool, 'task', task, 'option',  step, index))

--- a/siliconcompiler/tools/openroad/show.py
+++ b/siliconcompiler/tools/openroad/show.py
@@ -19,7 +19,7 @@ def setup(chip):
     clobber = True
     option = "-no_init -gui"
 
-    chip.set('tool', tool, 'task', task, 'var', 'show_exit', "false", clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'show_exit', "false", step=step, index=index, clobber=False)
     if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath'):
         chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', 'show_filepath']), step=step, index=index)
     else:
@@ -30,7 +30,7 @@ def setup(chip):
     # Add to option string.
     cur_options = ' '.join(chip.get('tool', tool, 'task', task, 'option', step=step, index=index))
     new_options = f'{cur_options} {option}'
-    chip.set('tool', tool, 'task', task, 'option', new_options, clobber=True, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'option', new_options, step=step, index=index, clobber=True)
 
 def pre_process(chip):
     copy_show_files(chip)

--- a/siliconcompiler/tools/openroad/show.py
+++ b/siliconcompiler/tools/openroad/show.py
@@ -20,17 +20,17 @@ def setup(chip):
     option = "-no_init -gui"
 
     chip.set('tool', tool, 'task', task, 'var', 'show_exit', "false", clobber=False, step=step, index=index)
-    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath', step=step, index=index):
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', 'show_filepath']), step=step, index=index)
+    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath'):
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', 'show_filepath']), step=step, index=index)
     else:
         incoming_ext = find_incoming_ext(chip)
         chip.set('tool', tool, 'task', task, 'var', 'show_filetype', incoming_ext, step=step, index=index)
         chip.add('tool', tool, 'task', task, 'input', f'{design}.{incoming_ext}', step=step, index=index)
 
     # Add to option string.
-    cur_options = ' '.join(chip.get('tool', tool, 'task', task, 'option',  step, index))
+    cur_options = ' '.join(chip.get('tool', tool, 'task', task, 'option', step=step, index=index))
     new_options = f'{cur_options} {option}'
-    chip.set('tool', tool, 'task', task, 'option',  step, index, new_options, clobber=True)
+    chip.set('tool', tool, 'task', task, 'option', new_options, clobber=True, step=step, index=index)
 
 def pre_process(chip):
     copy_show_files(chip)

--- a/siliconcompiler/tools/surelog/import.py
+++ b/siliconcompiler/tools/surelog/import.py
@@ -16,7 +16,7 @@ def setup(chip):
     index = chip.get('arg','index')
 
     # Runtime parameters.
-    chip.set('tool', tool, 'task', task, 'threads', step, index,  os.cpu_count(), clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), clobber=False, step=step, index=index)
 
     # Command-line options.
     options = []
@@ -28,13 +28,13 @@ def setup(chip):
     # very big and takes a while to write out.
     options.append('-nouhdm')
     # Wite back options to cfg
-    chip.add('tool', tool, 'task', task, 'option', step, index, options)
+    chip.add('tool', tool, 'task', task, 'option', options, step=step, index=index)
 
     # Input/Output requirements
-    chip.add('tool', tool, 'task', task, 'output', step, index, chip.top() + '.v')
+    chip.add('tool', tool, 'task', task, 'output', chip.top() + '.v', step=step, index=index)
 
     # Schema requirements
-    chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['input', 'rtl', 'verilog']))
+    chip.add('tool', tool, 'task', task, 'require', ",".join(['input', 'rtl', 'verilog']), step=step, index=index)
 
 ##################################################
 def post_process(chip):

--- a/siliconcompiler/tools/surelog/import.py
+++ b/siliconcompiler/tools/surelog/import.py
@@ -16,7 +16,7 @@ def setup(chip):
     index = chip.get('arg','index')
 
     # Runtime parameters.
-    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), step=step, index=index, clobber=False)
 
     # Command-line options.
     options = []

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -73,8 +73,8 @@ def setup(chip):
         chip.set('tool', tool, 'path', surelog_path, clobber=False)
 
     # Log file parsing
-    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'^\[WRN:', clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'^\[(ERR|FTL|SNT):', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'^\[WRN:', step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'^\[(ERR|FTL|SNT):', step=step, index=index, clobber=False)
 
     #warnings_off = chip.get('tool', tool, 'warningoff')
     #for warning in warnings_off:

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -63,7 +63,7 @@ def setup(chip):
     options.append('-nocache')
 
     # Wite back options to cfg
-    chip.add('tool', tool, 'task', task, 'option', step, index, options)
+    chip.add('tool', tool, 'task', task, 'option', options, step=step, index=index)
 
     # We package SC wheels with a precompiled copy of Surelog installed to
     # tools/surelog/bin. If the user doesn't have Surelog installed on their
@@ -73,8 +73,8 @@ def setup(chip):
         chip.set('tool', tool, 'path', surelog_path, clobber=False)
 
     # Log file parsing
-    chip.set('tool', tool, 'task', task, 'regex', step, index, 'warnings', r'^\[WRN:', clobber=False)
-    chip.set('tool', tool, 'task', task, 'regex', step, index, 'errors', r'^\[(ERR|FTL|SNT):', clobber=False)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'^\[WRN:', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'^\[(ERR|FTL|SNT):', clobber=False, step=step, index=index)
 
     #warnings_off = chip.get('tool', tool, 'warningoff')
     #for warning in warnings_off:

--- a/siliconcompiler/tools/sv2v/convert.py
+++ b/siliconcompiler/tools/sv2v/convert.py
@@ -15,7 +15,7 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '--numeric-version')
     chip.set('tool', tool, 'version', '>=0.0.9', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'threads', step, index,  4, clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads',  4, clobber=False, step=step, index=index)
 
     # Since we run sv2v after the import/preprocess step, there should be no
     # need for specifying include dirs/defines. However we don't want to pass
@@ -27,9 +27,9 @@ def setup(chip):
     # set and we can read the pickled Verilog without accessing the original
     # sources
     topmodule = chip.top()
-    chip.set('tool', tool, 'task', task, 'option', step, index,  [])
-    chip.add('tool', tool, 'task', task, 'option', step, index,  "inputs/" + topmodule + ".v")
-    chip.add('tool', tool, 'task', task, 'option', step, index,  "--write=outputs/" + topmodule + ".v")
+    chip.set('tool', tool, 'task', task, 'option',  [], step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'option',  "inputs/" + topmodule + ".v", step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'option',  "--write=outputs/" + topmodule + ".v", step=step, index=index)
 
-    chip.set('tool', tool, 'task', task, 'input', step, index, f'{topmodule}.v')
-    chip.set('tool', tool, 'task', task, 'output', step, index, f'{topmodule}.v')
+    chip.set('tool', tool, 'task', task, 'input', f'{topmodule}.v', step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'output', f'{topmodule}.v', step=step, index=index)

--- a/siliconcompiler/tools/sv2v/convert.py
+++ b/siliconcompiler/tools/sv2v/convert.py
@@ -15,7 +15,7 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '--numeric-version')
     chip.set('tool', tool, 'version', '>=0.0.9', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'threads',  4, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'threads',  4, step=step, index=index, clobber=False)
 
     # Since we run sv2v after the import/preprocess step, there should be no
     # need for specifying include dirs/defines. However we don't want to pass

--- a/siliconcompiler/tools/template/template.py
+++ b/siliconcompiler/tools/template/template.py
@@ -55,13 +55,13 @@ def setup(chip):
     chip.set('tool', tool, 'format', 'tcl', clobber=False)
 
     #
-    chip.set('tool', tool, 'task', task, 'option',  step, index, options, clobber=False)
+    chip.set('tool', tool, 'task', task, 'option', options, step=step, index=index, clobber=False)
     chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=False)
 
     # Required for script based tools
 
-    chip.set('tool', tool, 'task', task, 'refdir',  step, index, refdir, clobber=False)
-    chip.set('tool', tool, 'task', task, 'script',  step, index, refdir + script, clobber=False)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'script', refdir + script, step=step, index=index, clobber=False)
     for key in variables:
         chip.set('tool', tool, 'task', task, 'var', key, variables[key], step=step, index=index, clobber=False)
 

--- a/siliconcompiler/tools/template/template.py
+++ b/siliconcompiler/tools/template/template.py
@@ -56,19 +56,19 @@ def setup(chip):
 
     #
     chip.set('tool', tool, 'task', task, 'option',  step, index, options, clobber=False)
-    chip.set('tool', tool, 'task', task, 'threads', step, index, os.cpu_count(), clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), clobber=False, step=step, index=index)
 
     # Required for script based tools
 
     chip.set('tool', tool, 'task', task, 'refdir',  step, index, refdir, clobber=False)
     chip.set('tool', tool, 'task', task, 'script',  step, index, refdir + script, clobber=False)
     for key in variables:
-        chip.set('tool', tool, 'task', task, 'var', step, index, key, variables[key], clobber=False)
+        chip.set('tool', tool, 'task', task, 'var', key, variables[key], clobber=False, step=step, index=index)
 
     # Required for checker
-    chip.add('tool', tool, 'task', task, 'output', step, index, outputs)
-    chip.add('tool', tool, 'task', task, 'output', step, index, inputs)
-    chip.add('tool', tool, 'task', task, 'require', step, index, requires)
+    chip.add('tool', tool, 'task', task, 'output', outputs, step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'output', inputs, step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'require', requires, step=step, index=index)
 
 def runtime_options(chip):
     '''

--- a/siliconcompiler/tools/template/template.py
+++ b/siliconcompiler/tools/template/template.py
@@ -56,14 +56,14 @@ def setup(chip):
 
     #
     chip.set('tool', tool, 'task', task, 'option',  step, index, options, clobber=False)
-    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=False)
 
     # Required for script based tools
 
     chip.set('tool', tool, 'task', task, 'refdir',  step, index, refdir, clobber=False)
     chip.set('tool', tool, 'task', task, 'script',  step, index, refdir + script, clobber=False)
     for key in variables:
-        chip.set('tool', tool, 'task', task, 'var', key, variables[key], clobber=False, step=step, index=index)
+        chip.set('tool', tool, 'task', task, 'var', key, variables[key], step=step, index=index, clobber=False)
 
     # Required for checker
     chip.add('tool', tool, 'task', task, 'output', outputs, step=step, index=index)

--- a/siliconcompiler/tools/verilator/compile.py
+++ b/siliconcompiler/tools/verilator/compile.py
@@ -15,9 +15,9 @@ def setup(chip):
     task = 'compile'
     design = chip.top()
 
-    chip.add('tool', tool, 'task', task, 'option', step, index,  ['--cc', '--exe'])
-    chip.set('tool', tool, 'task', task, 'input', step, index, f'{design}.v')
-    chip.add('tool', tool, 'task', task, 'option', step, index, f'-o ../outputs/{design}.vexe')
+    chip.add('tool', tool, 'task', task, 'option',  ['--cc', '--exe'], step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'input', f'{design}.v', step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'option', f'-o ../outputs/{design}.vexe', step=step, index=index)
 
 def post_process(chip):
     ''' Tool specific function to run after step execution

--- a/siliconcompiler/tools/verilator/import.py
+++ b/siliconcompiler/tools/verilator/import.py
@@ -16,11 +16,11 @@ def setup(chip):
     task = 'import'
     design = chip.top()
 
-    chip.add('tool', tool, 'task', task, 'option', step, index,  ['--lint-only', '--debug'])
-    chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['input', 'rtl', 'verilog']))
-    chip.add('tool', tool, 'task', task, 'output', step, index, f'{design}.v')
+    chip.add('tool', tool, 'task', task, 'option',  ['--lint-only', '--debug'], step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'require', ",".join(['input', 'rtl', 'verilog']), step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'output', f'{design}.v', step=step, index=index)
     for value in chip.get('option', 'define'):
-        chip.add('tool', tool, 'task', task, 'option', step, index, '-D' + value)
+        chip.add('tool', tool, 'task', task, 'option', '-D' + value, step=step, index=index)
 
 def post_process(chip):
     ''' Tool specific function to run after step execution

--- a/siliconcompiler/tools/verilator/lint.py
+++ b/siliconcompiler/tools/verilator/lint.py
@@ -14,5 +14,5 @@ def setup(chip):
     task = 'lint'
     design = chip.top()
 
-    chip.add('tool', tool, 'task', task, 'option', step, index,  ['--lint-only', '--debug'])
-    chip.set('tool', tool, 'task', task, 'input', step, index, f'inputs/{design}.v')
+    chip.add('tool', tool, 'task', task, 'option',  ['--lint-only', '--debug'], step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'input', f'inputs/{design}.v', step=step, index=index)

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -88,27 +88,27 @@ def setup(chip):
 
     # Common to all tasks
     # Max threads
-    chip.set('tool', tool, 'task', task, 'threads', step, index,  os.cpu_count(), clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), clobber=False, step=step, index=index)
 
     # Basic warning and error grep check on logfile
-    chip.set('tool', tool, 'task', task, 'regex', step, index, 'warnings', r"^\%Warning", clobber=False)
-    chip.set('tool', tool, 'task', task, 'regex', step, index, 'errors', r"^\%Error", clobber=False)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r"^\%Warning", clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'regex', 'errors', r"^\%Error", clobber=False, step=step, index=index)
 
     # Generic CLI options (for all steps)
-    chip.set('tool', tool, 'task', task, 'option', step, index,  '-sv')
-    chip.add('tool', tool, 'task', task, 'option', step, index, f'--top-module {design}')
+    chip.set('tool', tool, 'task', task, 'option',  '-sv', step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'option', f'--top-module {design}', step=step, index=index)
 
     # Make warnings non-fatal in relaxed mode
     if chip.get('option', 'relax'):
-        chip.add('tool', tool, 'task', task, 'option', step, index, ['-Wno-fatal', '-Wno-UNOPTFLAT'])
+        chip.add('tool', tool, 'task', task, 'option', ['-Wno-fatal', '-Wno-UNOPTFLAT'], step=step, index=index)
 
     # Converting user setting to verilator specific filter
     #for warning in chip.get('tool', tool, 'task', task, step, index, 'warningoff'):
-    #    chip.add('tool', tool, 'task', task, 'option', step, index, f'-Wno-{warning}')
+    #    chip.add('tool', tool, 'task', task, 'option', f'-Wno-{warning}', step=step, index=index)
 
     # User runtime option
     if chip.get('option', 'trace'):
-        chip.add('tool', tool, 'task', task, 'task', task, 'option', step, index, '--trace')
+        chip.add('tool', tool, 'task', task, 'task', task, 'option', '--trace', step=step, index=index)
 
 ################################
 #  Custom runtime options

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -1,6 +1,5 @@
 import importlib
 import os
-import subprocess
 
 import siliconcompiler
 
@@ -140,7 +139,7 @@ def runtime_options(chip):
     elif step == 'compile':
         for value in chip.find_files('input', 'hll', 'c'):
             cmdlist.append(value)
-        for value in chip.find_files('tool', tool, 'task', task, 'input', step, index):
+        for value in chip.find_files('tool', tool, 'task', task, 'input', step=step, index=index):
             cmdlist.append(value)
 
     return cmdlist

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -88,11 +88,11 @@ def setup(chip):
 
     # Common to all tasks
     # Max threads
-    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'threads',  os.cpu_count(), step=step, index=index, clobber=False)
 
     # Basic warning and error grep check on logfile
-    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r"^\%Warning", clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'regex', 'errors', r"^\%Error", clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r"^\%Warning", step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'regex', 'errors', r"^\%Error", step=step, index=index, clobber=False)
 
     # Generic CLI options (for all steps)
     chip.set('tool', tool, 'task', task, 'option',  '-sv', step=step, index=index)

--- a/siliconcompiler/tools/vivado/vivado.py
+++ b/siliconcompiler/tools/vivado/vivado.py
@@ -48,10 +48,10 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '-version', clobber=False)
     chip.set('tool', tool, 'format', 'tcl', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'refdir', refdir, clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'script', script, clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'option', option, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'script', script, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'option', option, step=step, index=index, clobber=False)
 
     for metric in ('setupwns', 'setuptns', 'holdwns', 'holdtns'):
         chip.set('tool', tool, 'task', task, 'report', metric, 'reports/timing_summary.rpt', step=step, index=index)
@@ -59,8 +59,8 @@ def setup(chip):
     for metric in ('luts', 'registers', 'bram', 'uram'):
         chip.set('tool', tool, 'task', task, 'report', metric, 'reports/total_utilization.rpt', step=step, index=index)
 
-    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'^ERROR:', clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'^(CRITICAL )?WARNING:', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'^ERROR:', step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'^(CRITICAL )?WARNING:', step=step, index=index, clobber=False)
 
 def parse_version(stdout):
     # Vivado v2021.2 (64-bit)

--- a/siliconcompiler/tools/vivado/vivado.py
+++ b/siliconcompiler/tools/vivado/vivado.py
@@ -48,19 +48,19 @@ def setup(chip):
     chip.set('tool', tool, 'vswitch', '-version', clobber=False)
     chip.set('tool', tool, 'format', 'tcl', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'refdir', step, index, refdir, clobber=False)
-    chip.set('tool', tool, 'task', task, 'script', step, index, script, clobber=False)
-    chip.set('tool', tool, 'task', task, 'threads', step, index, os.cpu_count(), clobber=False)
-    chip.set('tool', tool, 'task', task, 'option', step, index, option, clobber=False)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'script', script, clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'option', option, clobber=False, step=step, index=index)
 
     for metric in ('setupwns', 'setuptns', 'holdwns', 'holdtns'):
-        chip.set('tool', tool, 'task', task, 'report', step, index, metric, 'reports/timing_summary.rpt')
+        chip.set('tool', tool, 'task', task, 'report', metric, 'reports/timing_summary.rpt', step=step, index=index)
 
     for metric in ('luts', 'registers', 'bram', 'uram'):
-        chip.set('tool', tool, 'task', task, 'report', step, index, metric, 'reports/total_utilization.rpt')
+        chip.set('tool', tool, 'task', task, 'report', metric, 'reports/total_utilization.rpt', step=step, index=index)
 
-    chip.set('tool', tool, 'task', task, 'regex', step, index, 'errors', r'^ERROR:', clobber=False)
-    chip.set('tool', tool, 'task', task, 'regex', step, index, 'warnings', r'^(CRITICAL )?WARNING:', clobber=False)
+    chip.set('tool', tool, 'task', task, 'regex', 'errors', r'^ERROR:', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'^(CRITICAL )?WARNING:', clobber=False, step=step, index=index)
 
 def parse_version(stdout):
     # Vivado v2021.2 (64-bit)

--- a/siliconcompiler/tools/vpr/apr.py
+++ b/siliconcompiler/tools/vpr/apr.py
@@ -13,14 +13,14 @@ def setup(chip):
     chip.set('tool', tool, 'exe', tool, clobber=False)
     chip.set('tool', tool, 'version', '0.0', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'threads', step, index, os.cpu_count(), clobber=False)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), clobber=False, step=step, index=index)
 
     #TO-DO: PRIOROTIZE the post-routing packing results?
     design = chip.top()
-    chip.set('tool', tool, 'task', task, 'output', step, index, design + '.net')
-    chip.add('tool', tool, 'task', task, 'output', step, index, design + '.place')
-    chip.add('tool', tool, 'task', task, 'output', step, index, design + '.route')
-    chip.add('tool', tool, 'task', task, 'output', step, index, 'vpr_stdout.log')
+    chip.set('tool', tool, 'task', task, 'output', design + '.net', step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'output', design + '.place', step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'output', design + '.route', step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'output', 'vpr_stdout.log', step=step, index=index)
 
     topmodule = chip.top()
     blif = "inputs/" + topmodule + ".blif"
@@ -37,7 +37,7 @@ def setup(chip):
     threads = chip.get('tool', tool, 'task', task, 'threads', step, index)
     options.append(f"--num_workers {threads}")
 
-    chip.add('tool', tool, 'task', task, 'option', step, index,  options)
+    chip.add('tool', tool, 'task', task, 'option',  options, step=step, index=index)
 
 #############################################
 # Runtime pre processing

--- a/siliconcompiler/tools/vpr/apr.py
+++ b/siliconcompiler/tools/vpr/apr.py
@@ -13,7 +13,7 @@ def setup(chip):
     chip.set('tool', tool, 'exe', tool, clobber=False)
     chip.set('tool', tool, 'version', '0.0', clobber=False)
 
-    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=False)
 
     #TO-DO: PRIOROTIZE the post-routing packing results?
     design = chip.top()

--- a/siliconcompiler/tools/vpr/apr.py
+++ b/siliconcompiler/tools/vpr/apr.py
@@ -34,7 +34,7 @@ def setup(chip):
     if 'sdc' in chip.getkeys('input'):
         options.append(f"--sdc_file {chip.get('input', 'fpga', 'sdc')}")
 
-    threads = chip.get('tool', tool, 'task', task, 'threads', step, index)
+    threads = chip.get('tool', tool, 'task', task, 'threads', step=step, index=index)
     options.append(f"--num_workers {threads}")
 
     chip.add('tool', tool, 'task', task, 'option',  options, step=step, index=index)
@@ -72,7 +72,7 @@ def post_process(chip):
     index = chip.get('arg','index')
     task = chip._get_task(step, index)
 
-    for file in chip.get('tool', 'vpr', 'task', task, 'output', step, index):
+    for file in chip.get('tool', 'vpr', 'task', task, 'output', step=step, index=index):
         shutil.copy(file, 'outputs')
     design = chip.top()
     shutil.copy(f'inputs/{design}.blif', 'outputs')

--- a/siliconcompiler/tools/xyce/xyce.py
+++ b/siliconcompiler/tools/xyce/xyce.py
@@ -45,7 +45,7 @@ def setup(chip):
 
      chip.set('tool', tool, 'exe', tool)
      chip.set('tool', tool, 'version', '0.0', clobber=clobber)
-     chip.set('tool', tool, 'task', task, 'threads', step, index, os.cpu_count(), clobber=clobber)
+     chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), clobber=clobber, step=step, index=index)
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/tools/xyce/xyce.py
+++ b/siliconcompiler/tools/xyce/xyce.py
@@ -45,7 +45,7 @@ def setup(chip):
 
      chip.set('tool', tool, 'exe', tool)
      chip.set('tool', tool, 'version', '0.0', clobber=clobber)
-     chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), clobber=clobber, step=step, index=index)
+     chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(), step=step, index=index, clobber=clobber)
 
 ##################################################
 if __name__ == "__main__":

--- a/siliconcompiler/tools/yosys/lec.py
+++ b/siliconcompiler/tools/yosys/lec.py
@@ -24,7 +24,7 @@ def setup(chip):
     design = chip.top()
 
     # Set yosys script path.
-    chip.set('tool', tool, 'task', task, 'script', 'sc_lec.tcl', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'script', 'sc_lec.tcl', step=step, index=index, clobber=False)
 
     # Input/output requirements.
     if (not chip.valid('input', 'netlist', 'verilog') or

--- a/siliconcompiler/tools/yosys/lec.py
+++ b/siliconcompiler/tools/yosys/lec.py
@@ -24,15 +24,15 @@ def setup(chip):
     design = chip.top()
 
     # Set yosys script path.
-    chip.set('tool', tool, 'task', task, 'script', step, index, 'sc_lec.tcl', clobber=False)
+    chip.set('tool', tool, 'task', task, 'script', 'sc_lec.tcl', clobber=False, step=step, index=index)
 
     # Input/output requirements.
     if (not chip.valid('input', 'netlist', 'verilog') or
         not chip.get('input', 'netlist', 'verilog')):
-        chip.set('tool', tool, 'task', task, 'input', step, index, design + '.vg')
+        chip.set('tool', tool, 'task', task, 'input', design + '.vg', step=step, index=index)
     #if not chip.get('input', 'rtl', 'verilog'):
         # TODO: Not sure this logic makes sense? Seems like reverse of tcl
-        #chip.set('tool', tool, 'task', task, 'input', step, index, design + '.v')
+        #chip.set('tool', tool, 'task', task, 'input', design + '.v', step=step, index=index)
 
 ##################################################
 def post_process(chip):

--- a/siliconcompiler/tools/yosys/sc_lec.tcl
+++ b/siliconcompiler/tools/yosys/sc_lec.tcl
@@ -10,7 +10,7 @@ set sc_step   [dict get $sc_cfg arg step]
 set sc_index  [dict get $sc_cfg arg index]
 set sc_flow   [dict get $sc_cfg option flow]
 set sc_task   [dict get $sc_cfg flowgraph $sc_flow $sc_step $sc_index task]
-set sc_refdir [dict get $sc_cfg tool $sc_tool task $sc_task refdir $sc_step $sc_index ]
+set sc_refdir [dict get $sc_cfg tool $sc_tool task $sc_task refdir ]
 
 set sc_mode        [dict get $sc_cfg option mode]
 set sc_design      [sc_top]
@@ -23,8 +23,8 @@ set sc_scenarios   [dict keys [dict get $sc_cfg constraint timing]]
 set sc_libcorner [dict get $sc_cfg constraint timing [lindex $sc_scenarios 0] libcorner]
 set sc_liberty [dict get $sc_cfg library $lib output $sc_libcorner $sc_delaymodel]
 
-if {[dict exists $sc_cfg tool $sc_tool task $sc_task "variable" $sc_step $sc_index induction_steps]} {
-    set sc_induction_steps [lindex [dict get $sc_cfg tool $sc_tool task $sc_task "variable" $sc_step $sc_index induction_steps] 0]
+if {[dict exists $sc_cfg tool $sc_tool task $sc_task "variable" induction_steps]} {
+    set sc_induction_steps [lindex [dict get $sc_cfg tool $sc_tool task $sc_task "variable" induction_steps] 0]
 } else {
     # Yosys default
     set sc_induction_steps 4

--- a/siliconcompiler/tools/yosys/sc_syn.tcl
+++ b/siliconcompiler/tools/yosys/sc_syn.tcl
@@ -15,7 +15,7 @@ set sc_step   [dict get $sc_cfg arg step]
 set sc_index  [dict get $sc_cfg arg index]
 set sc_flow   [dict get $sc_cfg option flow]
 set sc_task   [dict get $sc_cfg flowgraph $sc_flow $sc_step $sc_index task]
-set sc_refdir [dict get $sc_cfg tool $sc_tool task $sc_task refdir $sc_step $sc_index]
+set sc_refdir [dict get $sc_cfg tool $sc_tool task $sc_task refdir]
 
 ####################
 # DESIGNER's CHOICE

--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -2,16 +2,16 @@
 # DESIGNER's CHOICE
 ####################
 
-set sc_libraries        [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index synthesis_libraries]
-if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index synthesis_libraries_macros]} {
-    set sc_macro_libraries [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index synthesis_libraries_macros]
+set sc_libraries        [dict get $sc_cfg tool $sc_tool task $sc_task var synthesis_libraries]
+if {[dict exists $sc_cfg tool $sc_tool task $sc_task var synthesis_libraries_macros]} {
+    set sc_macro_libraries [dict get $sc_cfg tool $sc_tool task $sc_task var synthesis_libraries_macros]
 } else {
     set sc_macro_libraries []
 }
 set sc_mainlib          [lindex [dict get $sc_cfg asic logiclib] 0]
 
-set sc_dff_library      [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index dff_liberty_file] 0]
-set sc_abc_constraints  [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index abc_constraint_file] 0]
+set sc_dff_library      [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var dff_liberty_file] 0]
+set sc_abc_constraints  [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var abc_constraint_file] 0]
 
 #########################
 # Schema helper functions
@@ -82,8 +82,8 @@ foreach lib_file "$sc_libraries $sc_macro_libraries" {
 yosys hierarchy -top $sc_design
 
 # Mark modules to keep from getting removed in flattening
-if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index preserve_modules]} {
-    foreach module [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index preserve_modules] {
+if {[dict exists $sc_cfg tool $sc_tool task $sc_task var preserve_modules]} {
+    foreach module [dict get $sc_cfg tool $sc_tool task $sc_task var preserve_modules] {
         yosys select -module $module
         yosys setattr -mod -set keep_hierarchy 1
         yosys select -clear
@@ -91,7 +91,7 @@ if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index pres
 }
 
 set synth_args []
-if {[dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index flatten] == "True"} {
+if {[dict get $sc_cfg tool $sc_tool task $sc_task var flatten] == "True"} {
     lappend synth_args "-flatten"
 }
 yosys synth {*}$synth_args -top $sc_design
@@ -107,8 +107,8 @@ proc post_techmap { { opt_args "" } } {
     # Quick optimization
     yosys opt {*}$opt_args -purge
 }
-if {[dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index map_adders] != "False"} {
-    set sc_adder_techmap [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index map_adders] 0]
+if {[dict get $sc_cfg tool $sc_tool task $sc_task var map_adders] != "False"} {
+    set sc_adder_techmap [lindex [dict get $sc_cfg tool $sc_tool task $sc_task var map_adders] 0]
     # extract the full adders
     yosys extract_fa
     # map full adders
@@ -116,14 +116,14 @@ if {[dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index map_add
     post_techmap -fast
 }
 
-if [dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index techmap] {
-    foreach mapfile [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index techmap] {
+if [dict exists $sc_cfg tool $sc_tool task $sc_task var techmap] {
+    foreach mapfile [dict get $sc_cfg tool $sc_tool task $sc_task var techmap] {
         yosys techmap -map $mapfile
         post_techmap -fast
     }
 }
 
-if {[dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index autoname] == "True"} {
+if {[dict get $sc_cfg tool $sc_tool task $sc_task var autoname] == "True"} {
     # use autoname to preserve some design naming
     # by doing it before dfflibmap the names will be slightly shorter since they will
     # only contain the $DFF_P names vs. the full library name of the associated flip-flop
@@ -138,8 +138,8 @@ post_techmap
 source "$sc_refdir/syn_strategies.tcl"
 
 set script ""
-if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index strategy]} {
-    set sc_strategy [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index strategy]
+if {[dict exists $sc_cfg tool $sc_tool task $sc_task var strategy]} {
+    set sc_strategy [dict get $sc_cfg tool $sc_tool task $sc_task var strategy]
     if { [dict exists $syn_strategies $sc_strategy] } {
         set script [dict get $syn_strategies $sc_strategy]
     } elseif { [string match "+*" $sc_strategy] } {
@@ -157,8 +157,8 @@ if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index stra
 #   user-provided constraint)
 
 set abc_args []
-if {[dict exists $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index abc_clock_period]} {
-    set abc_clock_period [dict get $sc_cfg tool $sc_tool task $sc_task var $sc_step $sc_index abc_clock_period]
+if {[dict exists $sc_cfg tool $sc_tool task $sc_task var abc_clock_period]} {
+    set abc_clock_period [dict get $sc_cfg tool $sc_tool task $sc_task var abc_clock_period]
     if { [llength $abc_clock_period] != 0 } {
         # assumes units are ps
         lappend abc_args "-D" $abc_clock_period

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -64,10 +64,10 @@ def setup(chip):
 
     # Task Setup
     # common to all
-    chip.set('tool', tool, 'task', task, 'option', '-c', clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'refdir', refdir, clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'regex', 'warnings', "Warning:", clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'regex', 'errors', "^ERROR", clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'option', '-c', step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'regex', 'warnings', "Warning:", step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'regex', 'errors', "^ERROR", step=step, index=index, clobber=False)
     for metric in ('cells', 'nets', 'pins'):
         chip.set('tool', tool, 'task', task, 'report', metric, "reports/stat.json", step=step, index=index)
     for metric in ('cellarea', 'errors', 'warnings', 'cellarea', 'drvs', 'coverage', 'security',
@@ -111,7 +111,7 @@ def setup_asic(chip):
     for option, value, additional_require in [('flatten', "True", None),
                                               ('autoname', "True", None),
                                               ('map_adders', "False", ['library', mainlib, 'option', 'file', 'yosys_addermap'])]:
-        chip.set('tool', tool, 'task', task, 'var', option, value, clobber=False, step=step, index=index)
+        chip.set('tool', tool, 'task', task, 'var', option, value, step=step, index=index, clobber=False)
         chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', option]), step=step, index=index)
         if additional_require is not None and chip.get('tool', tool, 'task', task, 'var', option, step=step, index=index)[0] != "False":
             chip.add('tool', tool, 'task', task, 'require', ",".join(additional_require), step=step, index=index)
@@ -138,21 +138,21 @@ def setup_asic(chip):
         if chip.valid(*key1):
             chip.add('tool', tool, 'task', task, 'require', ",".join(key0), step=step, index=index)
 
-    chip.set('tool', tool, 'task', task, 'var', 'synthesis_corner', get_synthesis_corner(chip), clobber=False, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'var', 'dff_liberty', get_dff_liberty_file(chip), clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'synthesis_corner', get_synthesis_corner(chip), step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'var', 'dff_liberty', get_dff_liberty_file(chip), step=step, index=index, clobber=False)
     chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', 'synthesis_corner']), step=step, index=index)
     chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', 'dff_liberty']), step=step, index=index)
 
     # Constants needed by yosys, do not allow overriding of values so force clobbering
-    chip.set('tool', tool, 'task', task, 'var', 'dff_liberty_file', "inputs/sc_dff_library.lib", clobber=True, step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'var', 'abc_constraint_file', "inputs/sc_abc.constraints", clobber=True, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'var', 'dff_liberty_file', "inputs/sc_dff_library.lib", step=step, index=index, clobber=True)
+    chip.set('tool', tool, 'task', task, 'var', 'abc_constraint_file', "inputs/sc_abc.constraints", step=step, index=index, clobber=True)
 
     abc_driver = get_abc_driver(chip)
     if abc_driver:
-        chip.set('tool', tool, 'task', task, 'var', 'abc_constraint_driver', abc_driver, clobber=False, step=step, index=index)
+        chip.set('tool', tool, 'task', task, 'var', 'abc_constraint_driver', abc_driver, step=step, index=index, clobber=False)
     abc_clock_period = get_abc_period(chip)
     if abc_clock_period:
-        chip.set('tool', tool, 'task', task, 'var', 'abc_clock_period', str(abc_clock_period), clobber=False, step=step, index=index)
+        chip.set('tool', tool, 'task', task, 'var', 'abc_clock_period', str(abc_clock_period), step=step, index=index, clobber=False)
         chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', 'abc_clock_period']), step=step, index=index)
 
     # document parameters
@@ -480,7 +480,7 @@ def syn_setup(chip):
     design = chip.top()
 
     # Set yosys script path.
-    chip.set('tool', tool, 'task', task, 'script', 'sc_syn.tcl', clobber=False, step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'script', 'sc_syn.tcl', step=step, index=index, clobber=False)
 
     # Input/output requirements.
     chip.set('tool', tool, 'task', task, 'input', design + '.v', step=step, index=index)

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -89,9 +89,9 @@ def setup_asic(chip):
     syn_corner = get_synthesis_corner(chip)
 
     if syn_corner is None:
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', 'synthesis_corner']), step=step, index=index)
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', 'synthesis_corner']), step=step, index=index)
     if get_dff_liberty_file(chip) is None:
-        chip.add('tool', tool, 'task', task, 'require', step, index, ",".join(['tool', tool, 'task', task, 'var', 'dff_liberty']), step=step, index=index)
+        chip.add('tool', tool, 'task', task, 'require', ",".join(['tool', tool, 'task', task, 'var', 'dff_liberty']), step=step, index=index)
 
     if syn_corner is not None:
     # add timing library requirements

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -335,8 +335,9 @@ def get_synthesis_corner(chip):
     index = chip.get('arg','index')
     task = chip._get_task(step, index)
 
-    if chip.valid('tool', tool, 'task', task, 'var', 'synthesis_corner'):
-        return chip.get('tool', tool, 'task', task, 'var', 'synthesis_corner', step=step, index=index)[0]
+    syn_corner = chip.get('tool', tool, 'task', task, 'var', 'synthesis_corner', step=step, index=index)
+    if syn_corner:
+        return syn_corner[0]
 
     # determine corner based on setup corner from constraints
     corner = None
@@ -362,8 +363,9 @@ def get_dff_liberty_file(chip):
     index = chip.get('arg','index')
     task = chip._get_task(step, index)
 
-    if chip.valid('tool', tool, 'task', task, 'var', 'dff_liberty'):
-        return chip.get('tool', tool, 'task', task, 'var', 'dff_liberty', step=step, index=index)[0]
+    dff_liberty = chip.get('tool', tool, 'task', task, 'var', 'dff_liberty', step=step, index=index)
+    if dff_liberty:
+        return dff_liberty[0]
 
     corner = get_synthesis_corner(chip)
     if corner is None:
@@ -389,10 +391,9 @@ def get_abc_period(chip):
     index = chip.get('arg','index')
     task = chip._get_task(step, index)
 
-    if chip.valid('tool', tool, 'task', task, 'var', 'abc_clock_period'):
-        abc_clock_period = chip.get('tool', tool, 'task', task, 'var', 'abc_clock_period', step=step, index=index)
-        if abc_clock_period:
-            return abc_clock_period[0]
+    abc_clock_period = chip.get('tool', tool, 'task', task, 'var', 'abc_clock_period', step=step, index=index)
+    if abc_clock_period:
+        return abc_clock_period[0]
 
     period = None
 
@@ -434,8 +435,9 @@ def get_abc_period(chip):
     if chip.get('unit', 'time')[0] == 'n':
         period *= 1000
 
-    if chip.valid('tool', tool, 'task', task, 'var', 'abc_clock_derating'):
-        derating = float(chip.get('tool', tool, 'task', task, 'var', 'abc_clock_derating', step=step, index=index)[0])
+    abc_clock_derating = chip.get('tool', tool, 'task', task, 'var', 'abc_clock_derating')
+    if abc_clock_derating:
+        derating = float(abc_clock_derating[0])
         if derating > 1:
             chip.logger.warning("abc_clock_derating is greater than 1.0")
         elif derating > 0:
@@ -452,16 +454,15 @@ def get_abc_driver(chip):
     index = chip.get('arg','index')
     task = chip._get_task(step, index)
 
-    abc_driver = None
-    if chip.valid('tool', tool, 'task', task, 'var', 'abc_constraint_driver') and \
-       chip.get('tool', tool, 'task', task, 'var', 'abc_constraint_driver', step=step, index=index):
-        abc_driver = chip.get('tool', tool, 'task', task, 'var', 'abc_constraint_driver', step=step, index=index)[0]
+    abc_driver = chip.get('tool', tool, 'task', task, 'var', 'abc_constraint_driver', step=step, index=index)
+    if abc_driver:
+        return abc_driver[0]
 
-    if abc_driver is None:
-        # get the first driver defined in the logic lib
-        for lib in chip.get('asic', 'logiclib'):
-            if chip.valid('library', lib, 'option', 'var', 'yosys_driver_cell') and not abc_driver:
-                abc_driver = chip.get('library', lib, 'option', 'var', 'yosys_driver_cell')[0]
+    abc_driver = None
+    # get the first driver defined in the logic lib
+    for lib in chip.get('asic', 'logiclib'):
+        if chip.valid('library', lib, 'option', 'var', 'yosys_driver_cell') and not abc_driver:
+            abc_driver = chip.get('library', lib, 'option', 'var', 'yosys_driver_cell')[0]
 
     return abc_driver
 

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -6757,7 +6757,7 @@
         }
     },
     "schemaversion": {
-        "defvalue": "0.22.0",
+        "defvalue": "0.23.0",
         "example": [
             "api: chip.get('schemaversion')"
         ],
@@ -6773,7 +6773,7 @@
         "signature": null,
         "switch": "-schemaversion <str>",
         "type": "str",
-        "value": "0.22.0"
+        "value": "0.23.0"
     },
     "tool": {
         "default": {

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -6937,7 +6937,7 @@
                         "defvalue": [],
                         "example": [
                             "cli: -tool_task_input 'openroad place oh_add.def'",
-                            "api: chip.set('tool','openroad','task','place','input','oh_add.def')"
+                            "api: chip.set('tool','openroad','task','place','input','oh_add.def', step='place', index='0')"
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
@@ -7002,7 +7002,7 @@
                         "defvalue": [],
                         "example": [
                             "cli: -tool_task_output 'openroad place oh_add.def'",
-                            "api: chip.set('tool','openroad','task','place','output','oh_add.def')"
+                            "api: chip.set('tool','openroad','task','place','output','oh_add.def', step='place', index='0')"
                         ],
                         "filehash": [],
                         "hashalgo": "sha256",
@@ -7120,7 +7120,7 @@
                             "defvalue": [],
                             "example": [
                                 "cli: -tool_task_report 'openroad place holdtns place.log'",
-                                "api: chip.set('tool','openroad','task','place','report','holdtns','place.log')"
+                                "api: chip.set('tool','openroad','task','place','report','holdtns','place.log', step='place', index='0')"
                             ],
                             "filehash": [],
                             "hashalgo": "sha256",

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -6828,7 +6828,7 @@
                     "lock": false,
                     "nodevalue": {},
                     "notes": null,
-                    "pernode": "never",
+                    "pernode": "optional",
                     "require": null,
                     "scope": "job",
                     "set": false,
@@ -6849,7 +6849,7 @@
                 "lock": false,
                 "nodevalue": {},
                 "notes": null,
-                "pernode": "never",
+                "pernode": "optional",
                 "require": null,
                 "scope": "job",
                 "set": false,
@@ -6862,549 +6862,473 @@
             "task": {
                 "default": {
                     "continue": {
-                        "default": {
-                            "default": {
-                                "defvalue": false,
-                                "example": [
-                                    "cli: -tool_task_continue 'verilator lint lint 0 true'",
-                                    "api: chip.set('tool','verilator','task','lint','continue','lint','0', true)"
-                                ],
-                                "help": "Directs flow to continue even if errors are encountered during task. The default\nbehavior is for SC to exit on error.",
-                                "lock": false,
-                                "nodevalue": {},
-                                "notes": null,
-                                "pernode": "never",
-                                "require": "all",
-                                "scope": "job",
-                                "set": false,
-                                "shorthelp": "Task: continue option",
-                                "signature": null,
-                                "switch": "-tool_task_continue 'tool task step index <bool>'",
-                                "type": "bool",
-                                "value": false
-                            }
-                        }
+                        "defvalue": false,
+                        "example": [
+                            "cli: -tool_task_continue 'verilator lint true'",
+                            "api: chip.set('tool','verilator','task','lint','continue',True)"
+                        ],
+                        "help": "Directs flow to continue even if errors are encountered during task. The default\nbehavior is for SC to exit on error.",
+                        "lock": false,
+                        "nodevalue": {},
+                        "notes": null,
+                        "pernode": "optional",
+                        "require": "all",
+                        "scope": "job",
+                        "set": false,
+                        "shorthelp": "Task: continue option",
+                        "signature": null,
+                        "switch": "-tool_task_continue 'tool task <bool>'",
+                        "type": "bool",
+                        "value": false
                     },
                     "env": {
                         "default": {
-                            "default": {
-                                "default": {
-                                    "defvalue": null,
-                                    "example": [
-                                        "cli: -tool_task_env 'openroad cts cts 0 MYVAR 42'",
-                                        "api: chip.set('tool','openroad','task','cts','env','cts','0','MYVAR','42')"
-                                    ],
-                                    "help": "Environment variables to set for individual tasks. Keys and values\nshould be set in accordance with the task's documentation. Most\ntasks do not require extra environment variables to function.",
-                                    "lock": false,
-                                    "nodevalue": {},
-                                    "notes": null,
-                                    "pernode": "never",
-                                    "require": null,
-                                    "scope": "job",
-                                    "set": false,
-                                    "shorthelp": "Task: environment variables",
-                                    "signature": null,
-                                    "switch": "-tool_task_env 'tool task step index name <str>'",
-                                    "type": "str",
-                                    "value": null
-                                }
-                            }
+                            "defvalue": null,
+                            "example": [
+                                "cli: -tool_task_env 'openroad cts MYVAR 42'",
+                                "api: chip.set('tool','openroad','task','cts','env','MYVAR','42')"
+                            ],
+                            "help": "Environment variables to set for individual tasks. Keys and values\nshould be set in accordance with the task's documentation. Most\ntasks do not require extra environment variables to function.",
+                            "lock": false,
+                            "nodevalue": {},
+                            "notes": null,
+                            "pernode": "optional",
+                            "require": null,
+                            "scope": "job",
+                            "set": false,
+                            "shorthelp": "Task: environment variables",
+                            "signature": null,
+                            "switch": "-tool_task_env 'tool task step index name <str>'",
+                            "type": "str",
+                            "value": null
                         }
                     },
                     "file": {
                         "default": {
-                            "default": {
-                                "default": {
-                                    "author": [],
-                                    "copy": false,
-                                    "date": [],
-                                    "defvalue": [],
-                                    "example": [
-                                        "cli: -tool_task_file 'openroad floorplan floorplan 0 macroplace macroplace.tcl'",
-                                        "api: chip.set('tool','openroad','task','floorplan','file','floorplan','0','macroplace', 'macroplace.tcl')"
-                                    ],
-                                    "filehash": [],
-                                    "hashalgo": "sha256",
-                                    "help": "Paths to user supplied files mapped to keys. Keys and filetypes must\nmatch what's expected by the task/reference script consuming the\nfile.",
-                                    "lock": false,
-                                    "nodevalue": {},
-                                    "notes": null,
-                                    "pernode": "never",
-                                    "require": null,
-                                    "scope": "job",
-                                    "set": false,
-                                    "shorthelp": "Task: setup files",
-                                    "signature": [],
-                                    "switch": "-tool_task_file 'tool task step index key <file>'",
-                                    "type": "[file]",
-                                    "value": []
-                                }
-                            }
+                            "author": [],
+                            "copy": false,
+                            "date": [],
+                            "defvalue": [],
+                            "example": [
+                                "cli: -tool_task_file 'openroad floorplan macroplace macroplace.tcl'",
+                                "api: chip.set('tool','openroad','task','floorplan','file','macroplace', 'macroplace.tcl')"
+                            ],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "help": "Paths to user supplied files mapped to keys. Keys and filetypes must\nmatch what's expected by the task/reference script consuming the\nfile.",
+                            "lock": false,
+                            "nodevalue": {},
+                            "notes": null,
+                            "pernode": "optional",
+                            "require": null,
+                            "scope": "job",
+                            "set": false,
+                            "shorthelp": "Task: setup files",
+                            "signature": [],
+                            "switch": "-tool_task_file 'tool task key <file>'",
+                            "type": "[file]",
+                            "value": []
                         }
                     },
                     "input": {
-                        "default": {
-                            "default": {
-                                "author": [],
-                                "copy": false,
-                                "date": [],
-                                "defvalue": [],
-                                "example": [
-                                    "cli: -tool_task_input 'openroad place place 0 oh_add.def'",
-                                    "api: chip.set('tool','openroad','task','place','input','place','0','oh_add.def')"
-                                ],
-                                "filehash": [],
-                                "hashalgo": "sha256",
-                                "help": "List of data files to be copied from previous flowgraph steps 'output'\ndirectory. The list of steps to copy files from is defined by the\nlist defined by the dictionary key ['flowgraph', step, index, 'input'].\nAll files must be available for flow to continue. If a file\nis missing, the program exists on an error.",
-                                "lock": false,
-                                "nodevalue": {},
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "set": false,
-                                "shorthelp": "Task: inputs",
-                                "signature": [],
-                                "switch": "-tool_task_input 'task step index <str>'",
-                                "type": "[file]",
-                                "value": []
-                            }
-                        }
+                        "author": [],
+                        "copy": false,
+                        "date": [],
+                        "defvalue": [],
+                        "example": [
+                            "cli: -tool_task_input 'openroad place oh_add.def'",
+                            "api: chip.set('tool','openroad','task','place','input','oh_add.def')"
+                        ],
+                        "filehash": [],
+                        "hashalgo": "sha256",
+                        "help": "List of data files to be copied from previous flowgraph steps 'output'\ndirectory. The list of steps to copy files from is defined by the\nlist defined by the dictionary key ['flowgraph', step, index, 'input'].\nAll files must be available for flow to continue. If a file\nis missing, the program exists on an error.",
+                        "lock": false,
+                        "nodevalue": {},
+                        "notes": null,
+                        "pernode": "required",
+                        "require": null,
+                        "scope": "job",
+                        "set": false,
+                        "shorthelp": "Task: inputs",
+                        "signature": [],
+                        "switch": "-tool_task_input 'task <str>'",
+                        "type": "[file]",
+                        "value": []
                     },
                     "keep": {
-                        "default": {
-                            "default": {
-                                "defvalue": [],
-                                "example": [
-                                    "cli: -tool_task_keep 'surelog import import 0 slp_all'",
-                                    "api: chip.set('tool','surelog','task','import','script','import','0','slpp_all')"
-                                ],
-                                "help": "Names of additional files and directories in the work directory that\nshould be kept when :keypath:`option, clean` is true.",
-                                "lock": false,
-                                "nodevalue": {},
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "set": false,
-                                "shorthelp": "Task: files to keep",
-                                "signature": [],
-                                "switch": "-tool_task_keep 'task step index <str>'",
-                                "type": "[str]",
-                                "value": []
-                            }
-                        }
+                        "defvalue": [],
+                        "example": [
+                            "cli: -tool_task_keep 'surelog import slp_all'",
+                            "api: chip.set('tool','surelog','task','import','script','slpp_all')"
+                        ],
+                        "help": "Names of additional files and directories in the work directory that\nshould be kept when :keypath:`option, clean` is true.",
+                        "lock": false,
+                        "nodevalue": {},
+                        "notes": null,
+                        "pernode": "optional",
+                        "require": null,
+                        "scope": "job",
+                        "set": false,
+                        "shorthelp": "Task: files to keep",
+                        "signature": [],
+                        "switch": "-tool_task_keep 'task <str>'",
+                        "type": "[str]",
+                        "value": []
                     },
                     "option": {
-                        "default": {
-                            "default": {
-                                "defvalue": [],
-                                "example": [
-                                    "cli: -tool_task_option 'openroad cts cts 0 -no_init'",
-                                    "api: chip.set('tool','openroad','task','cts','option','cts','0','-no_init')"
-                                ],
-                                "help": "List of command line options for the task executable, specified on\na per task and per step basis. Options must not include spaces.\nFor multiple argument options, each option is a separate list element.",
-                                "lock": false,
-                                "nodevalue": {},
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "set": false,
-                                "shorthelp": "Task: executable options",
-                                "signature": [],
-                                "switch": "-tool_task_option 'tool task step index <str>'",
-                                "type": "[str]",
-                                "value": []
-                            }
-                        }
+                        "defvalue": [],
+                        "example": [
+                            "cli: -tool_task_option 'openroad cts -no_init'",
+                            "api: chip.set('tool','openroad','task','cts','option','-no_init')"
+                        ],
+                        "help": "List of command line options for the task executable, specified on\na per task and per step basis. Options must not include spaces.\nFor multiple argument options, each option is a separate list element.",
+                        "lock": false,
+                        "nodevalue": {},
+                        "notes": null,
+                        "pernode": "optional",
+                        "require": null,
+                        "scope": "job",
+                        "set": false,
+                        "shorthelp": "Task: executable options",
+                        "signature": [],
+                        "switch": "-tool_task_option 'tool task <str>'",
+                        "type": "[str]",
+                        "value": []
                     },
                     "output": {
-                        "default": {
-                            "default": {
-                                "author": [],
-                                "copy": false,
-                                "date": [],
-                                "defvalue": [],
-                                "example": [
-                                    "cli: -tool_task_output 'openroad place place 0 oh_add.def'",
-                                    "api: chip.set('tool','openroad','task','place','output','place','0','oh_add.def')"
-                                ],
-                                "filehash": [],
-                                "hashalgo": "sha256",
-                                "help": "List of data files to be copied from previous flowgraph steps 'output'\ndirectory. The list of steps to copy files from is defined by the\nlist defined by the dictionary key ['flowgraph', step, index, 'output'].\nAll files must be available for flow to continue. If a file\nis missing, the program exists on an error.",
-                                "lock": false,
-                                "nodevalue": {},
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "set": false,
-                                "shorthelp": "Task: outputs",
-                                "signature": [],
-                                "switch": "-tool_task_output 'task step index <str>'",
-                                "type": "[file]",
-                                "value": []
-                            }
-                        }
+                        "author": [],
+                        "copy": false,
+                        "date": [],
+                        "defvalue": [],
+                        "example": [
+                            "cli: -tool_task_output 'openroad place oh_add.def'",
+                            "api: chip.set('tool','openroad','task','place','output','oh_add.def')"
+                        ],
+                        "filehash": [],
+                        "hashalgo": "sha256",
+                        "help": "List of data files to be copied from previous flowgraph steps 'output'\ndirectory. The list of steps to copy files from is defined by the\nlist defined by the dictionary key ['flowgraph', step, index, 'output'].\nAll files must be available for flow to continue. If a file\nis missing, the program exists on an error.",
+                        "lock": false,
+                        "nodevalue": {},
+                        "notes": null,
+                        "pernode": "required",
+                        "require": null,
+                        "scope": "job",
+                        "set": false,
+                        "shorthelp": "Task: outputs",
+                        "signature": [],
+                        "switch": "-tool_task_output 'task step index <str>'",
+                        "type": "[file]",
+                        "value": []
                     },
                     "postscript": {
-                        "default": {
-                            "default": {
-                                "author": [],
-                                "copy": false,
-                                "date": [],
-                                "defvalue": [],
-                                "example": [
-                                    "cli: -tool_task_postscript 'yosys syn syn 0 syn_post.tcl'",
-                                    "api: chip.set('tool','yosys','task','syn_asic','postscript','syn','0','syn_post.tcl')"
-                                ],
-                                "filehash": [],
-                                "hashalgo": "sha256",
-                                "help": "Path to a user supplied script to execute after the main execution\nstage of the step but before the design is saved.\nExact entry point depends on the step and main script being\nexecuted. An example of a postscript entry point would be immediately\nafter global placement.",
-                                "lock": false,
-                                "nodevalue": {},
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "set": false,
-                                "shorthelp": "Task: post-step script",
-                                "signature": [],
-                                "switch": "-tool_task_postscript 'task step index <file>'",
-                                "type": "[file]",
-                                "value": []
-                            }
-                        }
+                        "author": [],
+                        "copy": false,
+                        "date": [],
+                        "defvalue": [],
+                        "example": [
+                            "cli: -tool_task_postscript 'yosys syn syn_post.tcl'",
+                            "api: chip.set('tool','yosys','task','syn_asic','postscript','syn_post.tcl')"
+                        ],
+                        "filehash": [],
+                        "hashalgo": "sha256",
+                        "help": "Path to a user supplied script to execute after the main execution\nstage of the step but before the design is saved.\nExact entry point depends on the step and main script being\nexecuted. An example of a postscript entry point would be immediately\nafter global placement.",
+                        "lock": false,
+                        "nodevalue": {},
+                        "notes": null,
+                        "pernode": "optional",
+                        "require": null,
+                        "scope": "job",
+                        "set": false,
+                        "shorthelp": "Task: post-step script",
+                        "signature": [],
+                        "switch": "-tool_task_postscript 'task <file>'",
+                        "type": "[file]",
+                        "value": []
                     },
                     "prescript": {
-                        "default": {
-                            "default": {
-                                "author": [],
-                                "copy": false,
-                                "date": [],
-                                "defvalue": [],
-                                "example": [
-                                    "cli: -tool_task_prescript 'yosys syn syn 0 syn_pre.tcl'",
-                                    "api: chip.set('tool','yosys','task','syn_asic','prescript','syn','0','syn_pre.tcl')"
-                                ],
-                                "filehash": [],
-                                "hashalgo": "sha256",
-                                "help": "Path to a user supplied script to execute after reading in the design\nbut before the main execution stage of the step. Exact entry point\ndepends on the step and main script being executed. An example\nof a prescript entry point would be immediately before global\nplacement.",
-                                "lock": false,
-                                "nodevalue": {},
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "set": false,
-                                "shorthelp": "Task: pre-step script",
-                                "signature": [],
-                                "switch": "-tool_task_prescript 'task step index <file>'",
-                                "type": "[file]",
-                                "value": []
-                            }
-                        }
+                        "author": [],
+                        "copy": false,
+                        "date": [],
+                        "defvalue": [],
+                        "example": [
+                            "cli: -tool_task_prescript 'yosys syn syn_pre.tcl'",
+                            "api: chip.set('tool','yosys','task','syn_asic','prescript','syn_pre.tcl')"
+                        ],
+                        "filehash": [],
+                        "hashalgo": "sha256",
+                        "help": "Path to a user supplied script to execute after reading in the design\nbut before the main execution stage of the step. Exact entry point\ndepends on the step and main script being executed. An example\nof a prescript entry point would be immediately before global\nplacement.",
+                        "lock": false,
+                        "nodevalue": {},
+                        "notes": null,
+                        "pernode": "optional",
+                        "require": null,
+                        "scope": "job",
+                        "set": false,
+                        "shorthelp": "Task: pre-step script",
+                        "signature": [],
+                        "switch": "-tool_task_prescript 'task <file>'",
+                        "type": "[file]",
+                        "value": []
                     },
                     "refdir": {
-                        "default": {
-                            "default": {
-                                "defvalue": [],
-                                "example": [
-                                    "cli: -tool_task_refdir 'yosys syn syn 0 ./myref'",
-                                    "api:  chip.set('tool','yosys','task','syn_asic','refdir','syn','0','./myref')"
-                                ],
-                                "help": "Path to directories containing reference flow scripts, specified\non a per step and index basis.",
-                                "lock": false,
-                                "nodevalue": {},
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "set": false,
-                                "shorthelp": "Task: script directory",
-                                "signature": [],
-                                "switch": "-tool_task_refdir 'task step index <dir>'",
-                                "type": "[dir]",
-                                "value": []
-                            }
-                        }
+                        "defvalue": [],
+                        "example": [
+                            "cli: -tool_task_refdir 'yosys syn ./myref'",
+                            "api:  chip.set('tool','yosys','task','syn_asic','refdir','./myref')"
+                        ],
+                        "help": "Path to directories containing reference flow scripts, specified\non a per step and index basis.",
+                        "lock": false,
+                        "nodevalue": {},
+                        "notes": null,
+                        "pernode": "optional",
+                        "require": null,
+                        "scope": "job",
+                        "set": false,
+                        "shorthelp": "Task: script directory",
+                        "signature": [],
+                        "switch": "-tool_task_refdir 'task <dir>'",
+                        "type": "[dir]",
+                        "value": []
                     },
                     "regex": {
                         "default": {
-                            "default": {
-                                "default": {
-                                    "defvalue": [],
-                                    "example": [
-                                        "cli: -tool_task_regex 'openroad place place 0 errors -v ERROR'",
-                                        "api: chip.set('tool','openroad','task','place','regex','errors','place','0','-v ERROR')"
-                                    ],
-                                    "help": "A list of piped together grep commands. Each entry represents a set\nof command line arguments for grep including the regex pattern to\nmatch. Starting with the first list entry, each grep output is piped\ninto the following grep command in the list. Supported grep options\ninclude ``-v`` and ``-e``. Patterns starting with \"-\" should be\ndirectly preceded by the ``-e`` option. The following example\nillustrates the concept.\n\nUNIX grep:\n\n.. code-block:: bash\n\n    $ grep WARNING place.log | grep -v \"bbox\" > place.warnings\n\nSiliconCompiler::\n\n    chip.set('task', 'openroad', 'regex', 'place', '0', 'warnings', [\"WARNING\", \"-v bbox\"])\n\nThe \"errors\" and \"warnings\" suffixes are special cases. When set,\nthe number of matches found for these regexes will be added to the\nerrors and warnings metrics for the task, respectively. This will\nalso cause the logfile to be added to the :keypath:`tool, <tool>,\ntask, <task>, report` parameter for those metrics, if not already present.",
-                                    "lock": false,
-                                    "nodevalue": {},
-                                    "notes": null,
-                                    "pernode": "never",
-                                    "require": null,
-                                    "scope": "job",
-                                    "set": false,
-                                    "shorthelp": "Task: regex filter",
-                                    "signature": [],
-                                    "switch": "-tool_task_regex 'tool task step index suffix <str>'",
-                                    "type": "[str]",
-                                    "value": []
-                                }
-                            }
+                            "defvalue": [],
+                            "example": [
+                                "cli: -tool_task_regex 'openroad place errors -v ERROR'",
+                                "api: chip.set('tool','openroad','task','place','regex','errors','-v ERROR')"
+                            ],
+                            "help": "A list of piped together grep commands. Each entry represents a set\nof command line arguments for grep including the regex pattern to\nmatch. Starting with the first list entry, each grep output is piped\ninto the following grep command in the list. Supported grep options\ninclude ``-v`` and ``-e``. Patterns starting with \"-\" should be\ndirectly preceded by the ``-e`` option. The following example\nillustrates the concept.\n\nUNIX grep:\n\n.. code-block:: bash\n\n    $ grep WARNING place.log | grep -v \"bbox\" > place.warnings\n\nSiliconCompiler::\n\n    chip.set('task', 'openroad', 'regex', 'place', '0', 'warnings', [\"WARNING\", \"-v bbox\"])\n\nThe \"errors\" and \"warnings\" suffixes are special cases. When set,\nthe number of matches found for these regexes will be added to the\nerrors and warnings metrics for the task, respectively. This will\nalso cause the logfile to be added to the :keypath:`tool, <tool>,\ntask, <task>, report` parameter for those metrics, if not already present.",
+                            "lock": false,
+                            "nodevalue": {},
+                            "notes": null,
+                            "pernode": "optional",
+                            "require": null,
+                            "scope": "job",
+                            "set": false,
+                            "shorthelp": "Task: regex filter",
+                            "signature": [],
+                            "switch": "-tool_task_regex 'tool task suffix <str>'",
+                            "type": "[str]",
+                            "value": []
                         }
                     },
                     "report": {
                         "default": {
-                            "default": {
-                                "default": {
-                                    "author": [],
-                                    "copy": false,
-                                    "date": [],
-                                    "defvalue": [],
-                                    "example": [
-                                        "cli: -tool_task_report 'openroad place place 0 holdtns place.log'",
-                                        "api: chip.set('tool','openroad','task','place','report','place','0','holdtns','place.log')"
-                                    ],
-                                    "filehash": [],
-                                    "hashalgo": "sha256",
-                                    "help": "List of report files associated with a specific 'metric'. The file path\nspecified is relative to the run directory of the current task.",
-                                    "lock": false,
-                                    "nodevalue": {},
-                                    "notes": null,
-                                    "pernode": "never",
-                                    "require": null,
-                                    "scope": "job",
-                                    "set": false,
-                                    "shorthelp": "Task: reports",
-                                    "signature": [],
-                                    "switch": "-tool_task_report 'task step index metric <str>'",
-                                    "type": "[file]",
-                                    "value": []
-                                }
-                            }
+                            "author": [],
+                            "copy": false,
+                            "date": [],
+                            "defvalue": [],
+                            "example": [
+                                "cli: -tool_task_report 'openroad place holdtns place.log'",
+                                "api: chip.set('tool','openroad','task','place','report','holdtns','place.log')"
+                            ],
+                            "filehash": [],
+                            "hashalgo": "sha256",
+                            "help": "List of report files associated with a specific 'metric'. The file path\nspecified is relative to the run directory of the current task.",
+                            "lock": false,
+                            "nodevalue": {},
+                            "notes": null,
+                            "pernode": "required",
+                            "require": null,
+                            "scope": "job",
+                            "set": false,
+                            "shorthelp": "Task: reports",
+                            "signature": [],
+                            "switch": "-tool_task_report 'task metric <str>'",
+                            "type": "[file]",
+                            "value": []
                         }
                     },
                     "require": {
-                        "default": {
-                            "default": {
-                                "defvalue": [],
-                                "example": [
-                                    "cli: -tool_task_require 'openroad cts cts 0 design'",
-                                    "api: chip.set('tool','openroad', 'task','cts','require','cts','0','design')"
-                                ],
-                                "help": "List of keypaths to required task parameters. The list is used\nby check() to verify that all parameters have been set up before\nstep execution begins.",
-                                "lock": false,
-                                "nodevalue": {},
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "set": false,
-                                "shorthelp": "Task: parameter requirements",
-                                "signature": [],
-                                "switch": "-tool_task_require 'task step index <str>'",
-                                "type": "[str]",
-                                "value": []
-                            }
-                        }
+                        "defvalue": [],
+                        "example": [
+                            "cli: -tool_task_require 'openroad cts design'",
+                            "api: chip.set('tool','openroad', 'task','cts','require','design')"
+                        ],
+                        "help": "List of keypaths to required task parameters. The list is used\nby check() to verify that all parameters have been set up before\nstep execution begins.",
+                        "lock": false,
+                        "nodevalue": {},
+                        "notes": null,
+                        "pernode": "optional",
+                        "require": null,
+                        "scope": "job",
+                        "set": false,
+                        "shorthelp": "Task: parameter requirements",
+                        "signature": [],
+                        "switch": "-tool_task_require 'task step index <str>'",
+                        "type": "[str]",
+                        "value": []
                     },
                     "script": {
-                        "default": {
-                            "default": {
-                                "author": [],
-                                "copy": false,
-                                "date": [],
-                                "defvalue": [],
-                                "example": [
-                                    "cli: -tool_task_script 'yosys syn syn 0 syn.tcl'",
-                                    "api: chip.set('tool','yosys','task','syn_asic','script','syn','0','syn.tcl')"
-                                ],
-                                "filehash": [],
-                                "hashalgo": "sha256",
-                                "help": "Path to the entry script called by the executable specified\non a per task and per step basis.",
-                                "lock": false,
-                                "nodevalue": {},
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "set": false,
-                                "shorthelp": "Task: entry script",
-                                "signature": [],
-                                "switch": "-tool_task_script 'task step index <file>'",
-                                "type": "[file]",
-                                "value": []
-                            }
-                        }
+                        "author": [],
+                        "copy": false,
+                        "date": [],
+                        "defvalue": [],
+                        "example": [
+                            "cli: -tool_task_script 'yosys syn syn.tcl'",
+                            "api: chip.set('tool','yosys','task','syn_asic','script','syn.tcl')"
+                        ],
+                        "filehash": [],
+                        "hashalgo": "sha256",
+                        "help": "Path to the entry script called by the executable specified\non a per task and per step basis.",
+                        "lock": false,
+                        "nodevalue": {},
+                        "notes": null,
+                        "pernode": "optional",
+                        "require": null,
+                        "scope": "job",
+                        "set": false,
+                        "shorthelp": "Task: entry script",
+                        "signature": [],
+                        "switch": "-tool_task_script 'task step index <file>'",
+                        "type": "[file]",
+                        "value": []
                     },
                     "stderr": {
-                        "default": {
-                            "default": {
-                                "destination": {
-                                    "defvalue": "log",
-                                    "example": [
-                                        "cli: -tool_task_stderr_destination 'ghdl import import 0 log'",
-                                        "api: chip.set('tool',ghdl','task','import','stderr','import','0','destination','log')"
-                                    ],
-                                    "help": "Defines where to direct the output generated over stderr.\nSupported options are:\nnone: the stream generated to STDERR is ignored\nlog: the generated stream is stored in <step>.<suffix>; if not in quiet mode,\nit is additionally dumped to the display output: the generated stream is\nstored in outputs/<design>.<suffix>",
-                                    "lock": false,
-                                    "nodevalue": {},
-                                    "notes": null,
-                                    "pernode": "never",
-                                    "require": null,
-                                    "scope": "job",
-                                    "set": false,
-                                    "shorthelp": "Task: Destination for stderr",
-                                    "signature": null,
-                                    "switch": "-tool_task_stderr_destination 'task step index [log|output|none]'",
-                                    "type": "str",
-                                    "value": "log"
-                                },
-                                "suffix": {
-                                    "defvalue": "log",
-                                    "example": [
-                                        "cli: -tool_task_stderr_suffix 'ghdl import import 0 log'",
-                                        "api: chip.set('tool','ghdl','task','import','stderr','import','0','suffix','log')"
-                                    ],
-                                    "help": "Specifies the file extension for the content redirected from stderr.",
-                                    "lock": false,
-                                    "nodevalue": {},
-                                    "notes": null,
-                                    "pernode": "never",
-                                    "require": null,
-                                    "scope": "job",
-                                    "set": false,
-                                    "shorthelp": "Task: File suffix for redirected stderr",
-                                    "signature": null,
-                                    "switch": "-tool_task_stderr_suffix 'task step index <str>'",
-                                    "type": "str",
-                                    "value": "log"
-                                }
-                            }
+                        "destination": {
+                            "defvalue": "log",
+                            "example": [
+                                "cli: -tool_task_stderr_destination 'ghdl import log'",
+                                "api: chip.set('tool',ghdl','task','import','stderr','destination','log')"
+                            ],
+                            "help": "Defines where to direct the output generated over stderr.\nSupported options are:\nnone: the stream generated to STDERR is ignored\nlog: the generated stream is stored in <step>.<suffix>; if not in quiet mode,\nit is additionally dumped to the display output: the generated stream is\nstored in outputs/<design>.<suffix>",
+                            "lock": false,
+                            "nodevalue": {},
+                            "notes": null,
+                            "pernode": "optional",
+                            "require": null,
+                            "scope": "job",
+                            "set": false,
+                            "shorthelp": "Task: Destination for stderr",
+                            "signature": null,
+                            "switch": "-tool_task_stderr_destination 'task [log|output|none]'",
+                            "type": "str",
+                            "value": "log"
+                        },
+                        "suffix": {
+                            "defvalue": "log",
+                            "example": [
+                                "cli: -tool_task_stderr_suffix 'ghdl import log'",
+                                "api: chip.set('tool','ghdl','task','import','stderr','suffix','log')"
+                            ],
+                            "help": "Specifies the file extension for the content redirected from stderr.",
+                            "lock": false,
+                            "nodevalue": {},
+                            "notes": null,
+                            "pernode": "optional",
+                            "require": null,
+                            "scope": "job",
+                            "set": false,
+                            "shorthelp": "Task: File suffix for redirected stderr",
+                            "signature": null,
+                            "switch": "-tool_task_stderr_suffix 'task <str>'",
+                            "type": "str",
+                            "value": "log"
                         }
                     },
                     "stdout": {
-                        "default": {
-                            "default": {
-                                "destination": {
-                                    "defvalue": "log",
-                                    "example": [
-                                        "cli: -tool_task_stdout_destination 'ghdl import import 0 log'",
-                                        "api: chip.set('tool','ghdl','task','import','stdout','import','0','destination','log')"
-                                    ],
-                                    "help": "Defines where to direct the output generated over stdout.\nSupported options are:\nnone: the stream generated to STDOUT is ignored\nlog: the generated stream is stored in <step>.<suffix>; if not in quiet mode,\nit is additionally dumped to the display output: the generated stream is stored\nin outputs/<design>.<suffix>",
-                                    "lock": false,
-                                    "nodevalue": {},
-                                    "notes": null,
-                                    "pernode": "never",
-                                    "require": null,
-                                    "scope": "job",
-                                    "set": false,
-                                    "shorthelp": "Task: Destination for stdout",
-                                    "signature": null,
-                                    "switch": "-tool_task_stdout_destination 'task step index [log|output|none]'",
-                                    "type": "str",
-                                    "value": "log"
-                                },
-                                "suffix": {
-                                    "defvalue": "log",
-                                    "example": [
-                                        "cli: -tool_task_stdout_suffix 'ghdl import import 0 log'",
-                                        "api: chip.set('tool',ghdl','task','import','stdout','import','0','suffix','log')"
-                                    ],
-                                    "help": "Specifies the file extension for the content redirected from stdout.",
-                                    "lock": false,
-                                    "nodevalue": {},
-                                    "notes": null,
-                                    "pernode": "never",
-                                    "require": null,
-                                    "scope": "job",
-                                    "set": false,
-                                    "shorthelp": "Task: File suffix for redirected stdout",
-                                    "signature": null,
-                                    "switch": "-tool_task_stdout_suffix 'task step index <str>'",
-                                    "type": "str",
-                                    "value": "log"
-                                }
-                            }
+                        "destination": {
+                            "defvalue": "log",
+                            "example": [
+                                "cli: -tool_task_stdout_destination 'ghdl import log'",
+                                "api: chip.set('tool','ghdl','task','import','stdout','destination','log')"
+                            ],
+                            "help": "Defines where to direct the output generated over stdout.\nSupported options are:\nnone: the stream generated to STDOUT is ignored\nlog: the generated stream is stored in <step>.<suffix>; if not in quiet mode,\nit is additionally dumped to the display output: the generated stream is stored\nin outputs/<design>.<suffix>",
+                            "lock": false,
+                            "nodevalue": {},
+                            "notes": null,
+                            "pernode": "optional",
+                            "require": null,
+                            "scope": "job",
+                            "set": false,
+                            "shorthelp": "Task: Destination for stdout",
+                            "signature": null,
+                            "switch": "-tool_task_stdout_destination 'task [log|output|none]'",
+                            "type": "str",
+                            "value": "log"
+                        },
+                        "suffix": {
+                            "defvalue": "log",
+                            "example": [
+                                "cli: -tool_task_stdout_suffix 'ghdl import log'",
+                                "api: chip.set('tool',ghdl','task','import','stdout','suffix','log')"
+                            ],
+                            "help": "Specifies the file extension for the content redirected from stdout.",
+                            "lock": false,
+                            "nodevalue": {},
+                            "notes": null,
+                            "pernode": "optional",
+                            "require": null,
+                            "scope": "job",
+                            "set": false,
+                            "shorthelp": "Task: File suffix for redirected stdout",
+                            "signature": null,
+                            "switch": "-tool_task_stdout_suffix 'task <str>'",
+                            "type": "str",
+                            "value": "log"
                         }
                     },
                     "threads": {
-                        "default": {
-                            "default": {
-                                "defvalue": null,
-                                "example": [
-                                    "cli: -tool_task_threads 'magic drc drc 0 64'",
-                                    "api: chip.set('tool','magic','task', 'drc','threads','drc','0','64')"
-                                ],
-                                "help": "Thread parallelism to use for execution specified on a per task and per\nstep basis. If not specified, SC queries the operating system and sets\nthe threads based on the maximum thread count supported by the\nhardware.",
-                                "lock": false,
-                                "nodevalue": {},
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "set": false,
-                                "shorthelp": "Task: thread parallelism",
-                                "signature": null,
-                                "switch": "-tool_task_threads 'task step index <int>'",
-                                "type": "int",
-                                "value": null
-                            }
-                        }
+                        "defvalue": null,
+                        "example": [
+                            "cli: -tool_task_threads 'magic drc 64'",
+                            "api: chip.set('tool','magic','task', 'drc','threads','64')"
+                        ],
+                        "help": "Thread parallelism to use for execution specified on a per task and per\nstep basis. If not specified, SC queries the operating system and sets\nthe threads based on the maximum thread count supported by the\nhardware.",
+                        "lock": false,
+                        "nodevalue": {},
+                        "notes": null,
+                        "pernode": "optional",
+                        "require": null,
+                        "scope": "job",
+                        "set": false,
+                        "shorthelp": "Task: thread parallelism",
+                        "signature": null,
+                        "switch": "-tool_task_threads 'task <int>'",
+                        "type": "int",
+                        "value": null
                     },
                     "var": {
                         "default": {
-                            "default": {
-                                "default": {
-                                    "defvalue": [],
-                                    "example": [
-                                        "cli: -tool_task_variable 'openroad cts cts 0 myvar 42'",
-                                        "api: chip.set('tool','openroad','task','cts','var','cts','0','myvar','42')"
-                                    ],
-                                    "help": "Task script variables specified as key value pairs. Variable\nnames and value types must match the name and type of task and reference\nscript consuming the variable.",
-                                    "lock": false,
-                                    "nodevalue": {},
-                                    "notes": null,
-                                    "pernode": "never",
-                                    "require": null,
-                                    "scope": "job",
-                                    "set": false,
-                                    "shorthelp": "Task: script variables",
-                                    "signature": [],
-                                    "switch": "-tool_task_variable 'tool task step index key <str>'",
-                                    "type": "[str]",
-                                    "value": []
-                                }
-                            }
+                            "defvalue": [],
+                            "example": [
+                                "cli: -tool_task_variable 'openroad cts myvar 42'",
+                                "api: chip.set('tool','openroad','task','cts','var','myvar','42')"
+                            ],
+                            "help": "Task script variables specified as key value pairs. Variable\nnames and value types must match the name and type of task and reference\nscript consuming the variable.",
+                            "lock": false,
+                            "nodevalue": {},
+                            "notes": null,
+                            "pernode": "optional",
+                            "require": null,
+                            "scope": "job",
+                            "set": false,
+                            "shorthelp": "Task: script variables",
+                            "signature": [],
+                            "switch": "-tool_task_variable 'tool task key <str>'",
+                            "type": "[str]",
+                            "value": []
                         }
                     },
                     "warningoff": {
-                        "default": {
-                            "default": {
-                                "defvalue": [],
-                                "example": [
-                                    "cli: -tool_task_warningoff 'verilator lint lint 0 COMBDLY'",
-                                    "api: chip.set('tool','verilator','task','lint','warningoff','lint','0','COMBDLY')"
-                                ],
-                                "help": "A list of tool warnings for which printing should be suppressed.\nGenerally this is done on a per design basis after review has\ndetermined that warning can be safely ignored The code for turning\noff warnings can be found in the specific task reference manual.",
-                                "lock": false,
-                                "nodevalue": {},
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "set": false,
-                                "shorthelp": "Task: warning filter",
-                                "signature": [],
-                                "switch": "-tool_task_warningoff 'tool task step index <str>'",
-                                "type": "[str]",
-                                "value": []
-                            }
-                        }
+                        "defvalue": [],
+                        "example": [
+                            "cli: -tool_task_warningoff 'verilator lint COMBDLY'",
+                            "api: chip.set('tool','verilator','task','lint','warningoff','COMBDLY')"
+                        ],
+                        "help": "A list of tool warnings for which printing should be suppressed.\nGenerally this is done on a per design basis after review has\ndetermined that warning can be safely ignored The code for turning\noff warnings can be found in the specific task reference manual.",
+                        "lock": false,
+                        "nodevalue": {},
+                        "notes": null,
+                        "pernode": "optional",
+                        "require": null,
+                        "scope": "job",
+                        "set": false,
+                        "shorthelp": "Task: warning filter",
+                        "signature": [],
+                        "switch": "-tool_task_warningoff 'tool task <str>'",
+                        "type": "[str]",
+                        "value": []
                     }
                 }
             },
@@ -7438,7 +7362,7 @@
                 "lock": false,
                 "nodevalue": {},
                 "notes": null,
-                "pernode": "never",
+                "pernode": "optional",
                 "require": null,
                 "scope": "job",
                 "set": false,

--- a/tests/core/test_check_flowgraph_io.py
+++ b/tests/core/test_check_flowgraph_io.py
@@ -38,9 +38,9 @@ def test_check_flowgraph_join():
     chip.edge(flow, 'prejoin2', 'dojoin')
     chip.edge(flow, 'dojoin', 'postjoin')
 
-    chip.set('tool', 'fake_out', 'task', 'prejoin1', 'output', 'prejoin1', '0', 'a.v')
-    chip.set('tool', 'fake_out', 'task', 'prejoin2', 'output', 'prejoin2', '0', 'b.v')
-    chip.set('tool', 'fake_in', 'task', 'postjoin', 'input', 'postjoin', '0', ['a.v', 'b.v'])
+    chip.set('tool', 'fake_out', 'task', 'prejoin1', 'output', 'a.v', step='prejoin1', index='0')
+    chip.set('tool', 'fake_out', 'task', 'prejoin2', 'output', 'b.v', step='prejoin2', index='0')
+    chip.set('tool', 'fake_in', 'task', 'postjoin', 'input', ['a.v', 'b.v'], step='postjoin', index='0')
 
     assert chip._check_flowgraph_io()
 
@@ -59,9 +59,9 @@ def test_check_flowgraph_min():
     chip.edge(flow, 'premin', 'domin', tail_index=1)
     chip.edge(flow, 'domin', 'postmin')
 
-    chip.set('tool', 'fake_out', 'task', 'premin', 'output', 'premin', '0', ['a.v', 'common.v'])
-    chip.set('tool', 'fake_out', 'task', 'premin', 'output', 'premin', '1', ['b.v', 'common.v'])
-    chip.set('tool', 'fake_in', 'task', 'postmin', 'input', 'postmin', '0', 'common.v')
+    chip.set('tool', 'fake_out', 'task', 'premin', 'output', ['a.v', 'common.v'], step='premin', index='0')
+    chip.set('tool', 'fake_out', 'task', 'premin', 'output', ['b.v', 'common.v'], step='premin', index='1')
+    chip.set('tool', 'fake_in', 'task', 'postmin', 'input', 'common.v', step='postmin', index='0')
 
     assert chip._check_flowgraph_io()
 
@@ -80,8 +80,8 @@ def test_check_flowgraph_min_fail():
     chip.edge(flow, 'premin', 'domin', tail_index=1)
     chip.edge(flow, 'domin', 'postmin')
 
-    chip.set('tool', 'fake_out', 'task', 'premin', 'output', 'premin', '0', ['a.v'])
-    chip.set('tool', 'fake_out', 'task', 'premin', 'output', 'premin', '1', ['b.v'])
-    chip.set('tool', 'fake_in', 'task', 'postmin', 'input', 'postmin', '0', 'a.v')
+    chip.set('tool', 'fake_out', 'task', 'premin', 'output', ['a.v'], step='premin', index='0')
+    chip.set('tool', 'fake_out', 'task', 'premin', 'output', ['b.v'], step='premin', index='1')
+    chip.set('tool', 'fake_in', 'task', 'postmin', 'input', 'a.v', step='postmin', index='0')
 
     assert not chip._check_flowgraph_io()

--- a/tests/core/test_check_logfile.py
+++ b/tests/core/test_check_logfile.py
@@ -7,8 +7,8 @@ def test_check_logfile(datadir):
     chip.load_target('freepdk45_demo')
 
     # add regex
-    chip.add('tool', 'openroad', 'task', 'place', 'regex', 'place', '0', 'warnings', "WARNING")
-    chip.add('tool', 'openroad', 'task', 'place', 'regex', 'place', '0', 'warnings', "-v DPL")
+    chip.add('tool', 'openroad', 'task', 'place', 'regex', 'warnings', "WARNING", step='place', index='0')
+    chip.add('tool', 'openroad', 'task', 'place', 'regex', 'warnings', "-v DPL", step='place', index='0')
 
     # check log
     logfile = os.path.join(datadir, 'place.log')

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -86,8 +86,8 @@ def test_check_missing_file_param():
     chip.set('arg', 'step', 'syn')
     chip.set('arg', 'index', '0')
 
-    chip.set('tool', 'yosys', 'task', 'syn_asic', 'input', 'syn', '0', [])
-    chip.set('tool', 'yosys', 'task', 'syn_asic', 'output', 'syn', '0',[])
+    chip.set('tool', 'yosys', 'task', 'syn_asic', 'input', [], step='syn', index='0')
+    chip.set('tool', 'yosys', 'task', 'syn_asic', 'output', [], step='syn', index='0')
 
     # not real file, will cause error
     libname = 'nangate45'
@@ -117,13 +117,13 @@ def merge_flow_chip():
     chip.set('tool', 'bar', 'exe', 'foo')
     chip.set('tool', 'baz', 'exe', 'baz')
 
-    chip.set('tool', 'baz', 'task', 'export', 'input', 'export', '0', ['foo.out', 'bar.out'])
+    chip.set('tool', 'baz', 'task', 'export', 'input', ['foo.out', 'bar.out'], step='export', index='0')
 
     return chip
 
 def test_merged_graph_good(merge_flow_chip):
-    merge_flow_chip.set('tool', 'foo', 'task', 'parallel1', 'output', 'parallel1', '0', 'bar.out')
-    merge_flow_chip.set('tool', 'bar', 'task', 'parallel2', 'output', 'parallel2', '0', 'foo.out')
+    merge_flow_chip.set('tool', 'foo', 'task', 'parallel1', 'output', 'bar.out', step='parallel1', index='0')
+    merge_flow_chip.set('tool', 'bar', 'task', 'parallel2', 'output', 'foo.out', step='parallel2', index='0')
 
     assert merge_flow_chip.check_manifest()
 
@@ -154,14 +154,14 @@ def test_merged_graph_good_steplist():
 
 def test_merged_graph_bad_same(merge_flow_chip):
     # Two merged steps can't output the same thing
-    merge_flow_chip.set('tool', 'foo', 'task', 'parallel1', 'output', 'parallel1', '0', 'foo.out')
-    merge_flow_chip.set('tool', 'bar', 'task', 'parallel2', 'output', 'parallel2', '0', 'foo.out')
+    merge_flow_chip.set('tool', 'foo', 'task', 'parallel1', 'output', 'foo.out', step='parallel1', index='0')
+    merge_flow_chip.set('tool', 'bar', 'task', 'parallel2', 'output', 'foo.out', step='parallel2', index='0')
 
     assert not merge_flow_chip.check_manifest()
 
 def test_merged_graph_bad_missing(merge_flow_chip):
     # bar doesn't provide necessary output
-    merge_flow_chip.set('tool', 'foo', 'task', 'parallel1', 'output', 'parallel1', '0', 'foo.out')
+    merge_flow_chip.set('tool', 'foo', 'task', 'parallel1', 'output', 'foo.out', step='parallel1', index='0')
 
     assert not merge_flow_chip.check_manifest()
 

--- a/tests/core/test_checklist.py
+++ b/tests/core/test_checklist.py
@@ -1,8 +1,6 @@
 import os
-import pytest
 import siliconcompiler
 
-@pytest.mark.skip(reason="Deferring until new test/index change")
 def test_checklist():
     '''API test for help method
     '''
@@ -15,8 +13,8 @@ def test_checklist():
     with open('build/test/job0/syn/0/yosys.log', 'w') as f:
         f.write('test')
 
-    chip.set('metric','syn','0', 'errors', 1)
-    chip.set('tool', 'yosys', 'task', 'syn', 'report', 'syn', '0', 'errors', 'yosys.log')
+    chip.set('metric', 'errors', 1, step='syn', index='0')
+    chip.set('tool', 'yosys', 'task', 'syn_asic', 'report', 'errors', 'yosys.log', step='syn', index='0')
     chip.schema.record_history()
 
     #automated fail

--- a/tests/core/test_hash_files.py
+++ b/tests/core/test_hash_files.py
@@ -1,5 +1,4 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
-import os
 import siliconcompiler
 
 def test_hash_files():

--- a/tests/core/test_setget.py
+++ b/tests/core/test_setget.py
@@ -156,7 +156,7 @@ def test_get_no_side_effect():
     assert chip.getkeys('tool', 'surelog', 'task') == []
 
     # Able to recover default value
-    assert chip.get('tool', 'surelog', 'task', 'import', 'stdout', 'import', '0', 'suffix') == 'log'
+    assert chip.get('tool', 'surelog', 'task', 'import', 'stdout', 'suffix', step='import', index='0') == 'log'
 
     # Recovering default does not affect cfg
     assert chip.getkeys('tool', 'surelog', 'task') == []

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -24,7 +24,7 @@ def test_py(setup_example_test):
     chip = siliconcompiler.Chip('gcd')
     chip.read_manifest(manifest)
 
-    assert chip.get('tool', 'yosys', 'task', 'syn_asic', 'report', 'cellarea' step='syn', '0') == ['syn.log']
+    assert chip.get('tool', 'yosys', 'task', 'syn_asic', 'report', 'cellarea', step='syn', index='0') == ['syn.log']
 
     # "No timescale set..."
     assert chip.get('metric', 'warnings', step='import', index='0') == 10

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -24,7 +24,7 @@ def test_py(setup_example_test):
     chip = siliconcompiler.Chip('gcd')
     chip.read_manifest(manifest)
 
-    assert chip.get('tool', 'yosys', 'task', 'syn_asic', 'report', 'syn', '0', 'cellarea') == ['syn.log']
+    assert chip.get('tool', 'yosys', 'task', 'syn_asic', 'report', 'cellarea' step='syn', '0') == ['syn.log']
 
     # "No timescale set..."
     assert chip.get('metric', 'warnings', step='import', index='0') == 10

--- a/tests/examples/test_picorv32_ram.py
+++ b/tests/examples/test_picorv32_ram.py
@@ -27,6 +27,7 @@ def test_picorv32_sram(setup_example_test):
 # It is still useful to test for failures which can only occur in the remote flow, however.
 @pytest.mark.eda
 @pytest.mark.timeout(900)
+@pytest.mark.skip(reason='Long runtime, possibly causing transient failures')
 def test_picorv32_sram_remote(setup_example_test):
     setup_example_test('picorv32_ram')
 

--- a/tests/flows/test_flowstatus.py
+++ b/tests/flows/test_flowstatus.py
@@ -41,9 +41,9 @@ def test_flowstatus(scroot, steplist):
     chip.edge(flow, 'import', 'place', head_index='1')
 
     # Illegal value, so this branch will fail!
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '0', 'place_density', 'asdf')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', 'asdf', step='place', index='0')
     # Legal value, so this branch should succeed
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '1', 'place_density', '0.5')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', '0.5', step='place', index='1')
 
     # Perform minimum
     chip.node(flow, 'placemin', 'builtin', 'minimum')
@@ -98,9 +98,9 @@ def test_long_branch(scroot):
     chip.edge(flow, 'import', 'place', head_index='1')
 
     # Illegal value, so this branch will fail!
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '0', 'place_density', 'asdf')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', 'asdf', step='place', index='0')
     # Legal value, so this branch should succeed
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '1', 'place_density', '0.5')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', '0.5', step='place', index='1')
 
     chip.node(flow, 'cts', 'openroad', 'cts', index='0')
     chip.node(flow, 'cts', 'openroad', 'cts', index='1')
@@ -141,9 +141,9 @@ def test_remote(scroot):
 
     chip.set('arg', 'flow', 'place_np', '2')
     # Illegal value, so this branch will fail!
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '0', 'place_density', 'asdf')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', 'asdf', step='place', index='0')
     # Legal value, so this branch should succeed
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '1', 'place_density', '0.5')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', '0.5', step='place', index='1')
 
     chip.load_target('freepdk45_demo')
     flow = chip.get('option', 'flow')

--- a/tests/flows/test_multiple_tools.py
+++ b/tests/flows/test_multiple_tools.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 import siliconcompiler
 
 def create_fake_surelog():
@@ -13,6 +15,8 @@ def create_fake_surelog():
     # executable
     os.chmod('surelog', 0o755)
 
+@pytest.mark.eda
+@pytest.mark.quick
 def test_multiple_tools():
     '''Tests that we can tweak tool version, path, and licenseserver settings
     across different nodes.'''

--- a/tests/flows/test_multiple_tools.py
+++ b/tests/flows/test_multiple_tools.py
@@ -1,0 +1,49 @@
+import os
+
+import siliconcompiler
+
+def create_fake_surelog():
+    with open('surelog', 'w') as f:
+        # hardcoded to check that fake license server env is provided, then
+        # dump a version
+        f.write('#!/bin/sh\n')
+        f.write('set -o nounset\n') # quit early if script tries to expand unset var
+        f.write(': $ACME_LICENSE\n') # try to expand license server var
+        f.write('echo VERSION: 0.0\n')
+    # executable
+    os.chmod('surelog', 0o755)
+
+def test_multiple_tools():
+    '''Tests that we can tweak tool version, path, and licenseserver settings
+    across different nodes.'''
+    create_fake_surelog()
+
+    chip = siliconcompiler.Chip('test')
+    chip.load_target('freepdk45_demo')
+
+    flow = 'test'
+    chip.set('option', 'flow', flow)
+    chip.node(flow, 'import', 'builtin', 'import')
+    chip.node(flow, 'slog', 'surelog', 'import', index=0)
+    chip.node(flow, 'slog', 'surelog', 'import', index=1)
+    chip.edge(flow, 'import', 'slog', head_index=0)
+    chip.edge(flow, 'import', 'slog', head_index=1)
+
+    # Overwrite default path to make sure this would break if step/index weren't
+    # implemented
+    chip.set('tool', 'surelog', 'path', os.getcwd())
+
+    # Restore path for slog0 specifically
+    chip.set('tool', 'surelog', 'path', '', step='slog', index=0)
+    # Overwrite version for slog1
+    chip.set('tool', 'surelog', 'version', '==0.0', step='slog', index=1)
+
+    # Set fake license server for slog1
+    chip.set('tool', 'surelog', 'licenseserver', 'ACME_LICENSE', '1700@server', step='slog', index=1)
+
+    # Don't run tools, just vesion check
+    chip.set('option', 'skipall', True)
+    chip.run()
+
+    assert chip.get('flowgraph', flow, 'slog', '0', 'status') == siliconcompiler.core.TaskStatus.SUCCESS
+    assert chip.get('flowgraph', flow, 'slog', '1', 'status') == siliconcompiler.core.TaskStatus.SUCCESS

--- a/tests/flows/test_resume.py
+++ b/tests/flows/test_resume.py
@@ -6,7 +6,7 @@ import os
 @pytest.mark.eda
 def test_resume(gcd_chip):
     # Set a value that will cause place to break
-    gcd_chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '0', 'place_density', 'asdf')
+    gcd_chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', 'asdf', step='place', index='0')
 
     with pytest.raises(siliconcompiler.SiliconCompilerError):
         gcd_chip.run()
@@ -20,7 +20,7 @@ def test_resume(gcd_chip):
     assert gcd_chip.find_result('gds', step='export') is None
 
     # Fix place step and re-run
-    gcd_chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '0', 'place_density', '0.40')
+    gcd_chip.set('tool', 'openroad', 'task', 'place', 'var','place_density', '0.40', step='place', index='0')
     gcd_chip.set('option', 'resume', True)
     gcd_chip.run()
 

--- a/tests/flows/test_show.py
+++ b/tests/flows/test_show.py
@@ -14,7 +14,7 @@ def adjust_exe_options(chip, headless):
     for step in ('show', 'screenshot'):
         # adjust options to ensure programs exit
         for tool in ('klayout', 'openroad'):
-            chip.set('tool', tool, 'task', step, 'var', step, '0', 'show_exit', 'true')
+            chip.set('tool', tool, 'task', step, 'var', 'show_exit', 'true',)
 
 @pytest.fixture
 def display():

--- a/tests/flows/test_steplist.py
+++ b/tests/flows/test_steplist.py
@@ -38,13 +38,13 @@ def test_steplist_keep_reports(gcd_chip):
     # Initial run
     gcd_chip.set('option', 'steplist', ['import', 'syn'])
     gcd_chip.run()
-    assert gcd_chip.get('tool', 'yosys', 'task', 'syn_asic', 'report', 'syn', '0', 'cellarea') is not None
-    report = gcd_chip.get('tool', 'yosys', 'task', 'syn_asic', 'report', 'syn', '0', 'cellarea')
+    assert gcd_chip.get('tool', 'yosys', 'task', 'syn_asic', 'report', 'cellarea', step='syn', index='0') is not None
+    report = gcd_chip.get('tool', 'yosys', 'task', 'syn_asic', 'report', 'cellarea', step='syn', index='0')
 
     # Run a new step from a fresh chip object
     fresh_chip.set('option', 'steplist', ['floorplan'])
     fresh_chip.run()
-    assert fresh_chip.get('tool', 'yosys',  'task', 'syn_asic', 'report', 'syn', '0', 'cellarea') == report
+    assert fresh_chip.get('tool', 'yosys',  'task', 'syn_asic', 'report', 'cellarea', step='syn', index='0') == report
 
 @pytest.mark.eda
 def test_old_resume(gcd_chip):

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -23,8 +23,8 @@ def test_tool_option(scroot):
     chip.set('option','novercheck', 'true')
     chip.load_target('freepdk45_demo', place_np=2)
 
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '0',  'place_density', '0.4')
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '1',  'place_density', '0.3')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', '0.4', step='place', index='0')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', '0.3', step='place', index='1')
 
     # No need to run beyond place, we just want to check that setting place_density
     # doesn't break anything.
@@ -88,9 +88,9 @@ def test_failed_branch_min(chip):
     flow = chip.get('option', 'flow')
 
     # Illegal value, so this branch will fail!
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '0', 'place_density', 'asdf')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', 'asdf', step='place', index='0')
     # Legal value, so this branch should succeed
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '1', 'place_density', '0.5')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', '0.5', step='place', index='1')
 
     # Perform minimum
     chip.node(flow, 'placemin', 'builtin', 'minimum')
@@ -119,8 +119,7 @@ def test_all_failed_min(chip):
     flow = chip.get('option', 'flow')
 
     # Illegal values, so both branches should fail
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '0', 'place_density', 'asdf')
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '1', 'place_density', 'asdf')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', 'asdf')
 
     # Perform minimum
     chip.node(flow, 'placemin', 'builtin', 'minimum')
@@ -142,9 +141,9 @@ def test_branch_failed_join(chip):
     flow = chip.get('option','flow')
 
     # Illegal values, so branch should fail
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '0', 'place_density', 'asdf')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', 'asdf', step='place', index='0')
     # Legal value, so branch should succeed
-    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place', '1', 'place_density', '0.5')
+    chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', '0.5', step='place', index='1')
 
     # Perform join
     chip.node(flow, 'placemin', 'builtin', 'join')

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -29,7 +29,7 @@ def test_klayout(datadir):
     chip.edge(flow, 'import', 'export')
     chip.set('option', 'flow', flow)
 
-    chip.set('tool', 'klayout', 'task', 'export', 'var', 'export', '0', 'timestamps', 'false')
+    chip.set('tool', 'klayout', 'task', 'export', 'var', 'timestamps', 'false')
 
     chip.run()
 

--- a/tests/tools/test_surelog.py
+++ b/tests/tools/test_surelog.py
@@ -106,7 +106,7 @@ def test_replay(scroot):
     chip.set('option', 'flow', 'surelog')
     chip.set('option', 'quiet', True)
     chip.set('option', 'clean', True) # replay should work even with clean=True
-    chip.set('tool', 'surelog', 'task', step, 'env', step, '0', 'SLOG_ENV', 'SUCCESS')
+    chip.set('tool', 'surelog', 'task', step, 'env', 'SLOG_ENV', 'SUCCESS', step=step, index='0')
 
     chip.run()
 


### PR DESCRIPTION
This PR updates all the "tool" group parameters to match our desired per-node configuration settings. Sorry for the huge PR, this touches a lot of files! It's mostly mechanical refactor, but some things to highlight:

- This change removes `if valid('tool', ...)` guards in a lot of places. The `_search()` refactor (##1222) actually removes the need for this in most cases, since `get()` will now return the default value for a parameter if the supplied wildcards don't exist. The instances modified in this PR were caught because `valid()` doesn't accept step/index kwargs.
- Some new functionality is included, since the 'path', 'version', and 'licenseserver' parameters were not previously set on a step/index basis. I've added a test that exercises this new functionality.
- While most of these parameters use the 'optional' pernode configuration, I made 'input', 'output', and 'report' take in the required setting, since these parameters all refer to files in specific step directories (and `find_files` resolves them accordingly)
- Working on this PR revealed the file-hashing logic needs to be fixed (tracked in #1257), since the hashes are stored in a plain list that maps 1-to-1 with the values in a [file] type. This means we don't have a way to store the hashes for per-node files. Fixing this will require changes to the schema structure, so I'm deferring any fixes until we have a chance to discuss.
- TCL manifests still only include the value for a parameter associated with the current step/index. This doesn't break anything even with this PR, since the current show implementations don't access 'show_step'/'show_index' in scripts. 