### PR TITLE
Fix and update scheduler.py

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3394,7 +3394,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         # (Run the initial 'import' stage[s] locally)
 
         if self.get('option', 'scheduler', 'name', step=step, index=index) and \
-           self.get('flowgraph', flow, step, index, 'input') and \
+           self.get('flowgraph', flow, step, index, 'input'):
             # Note: The _deferstep method blocks until the compute node
             # finishes processing this step, and it sets the active/error bits.
             _deferstep(self, step, index, status)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3393,9 +3393,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         # and send it to a compute node for deferred execution.
         # (Run the initial 'import' stage[s] locally)
 
-        if self.get('option', 'scheduler', 'name') and \
+        if self.get('option', 'scheduler', 'name', step=step, index=index) and \
            self.get('flowgraph', flow, step, index, 'input') and \
-           (self.get('option', 'scheduler', 'name') != 'none'):
             # Note: The _deferstep method blocks until the compute node
             # finishes processing this step, and it sets the active/error bits.
             _deferstep(self, step, index, status)
@@ -4030,7 +4029,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                     self.set('option', 'steplist', pre_remote_steplist['steplist'])
                 else:
                     self.unset('option', 'steplist')
-                self.unset('option', 'scheduler', 'name')
             else:
                 # Hack to find first failed step by checking for presence of
                 # output manifests.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3394,7 +3394,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         # (Run the initial 'import' stage[s] locally)
 
         if self.get('option', 'scheduler', 'name') and \
-           self.get('flowgraph', flow, step, index, 'input'):
+           self.get('flowgraph', flow, step, index, 'input') and \
+           (self.get('option', 'scheduler', 'name') != 'none'):
             # Note: The _deferstep method blocks until the compute node
             # finishes processing this step, and it sets the active/error bits.
             _deferstep(self, step, index, status)
@@ -4029,6 +4030,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                     self.set('option', 'steplist', pre_remote_steplist['steplist'])
                 else:
                     self.unset('option', 'steplist')
+                self.unset('option', 'scheduler', 'name')
             else:
                 # Hack to find first failed step by checking for presence of
                 # output manifests.

--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -16,7 +16,7 @@ def _deferstep(chip, step, index, status):
     '''
 
     # Determine which HPC job scheduler being used.
-    scheduler_type = chip.get('option', 'scheduler', 'name')
+    scheduler_type = chip.get('option', 'scheduler', 'name', step=step, index=index)
 
     # Determine which cluster parititon to use. (Default value can be overridden on per-step basis)
     if f'{step}_slurm_partition' in chip.status:
@@ -33,6 +33,7 @@ def _deferstep(chip, step, index, status):
     cfg_file = f'{cfg_dir}/{step}{index}.json'
     if not os.path.isdir(cfg_dir):
         os.mkdir(cfg_dir)
+    chip.unset('option', 'scheduler', 'name', step=step, index=index)
     chip.write_manifest(cfg_file)
 
     if scheduler_type == 'slurm':
@@ -71,7 +72,7 @@ def _deferstep(chip, step, index, status):
         sf.write('#!/bin/bash\n')
         sf.write(f'sc -cfg {shlex.quote(cfg_file)} -builddir {shlex.quote(chip.get("option", "builddir"))} '\
                     f'-arg_step {shlex.quote(step)} -arg_index {shlex.quote(index)} '\
-                    f"-scheduler 'none' -design {shlex.quote(chip.top())}\n")
+                    f"-design {shlex.quote(chip.top())}\n")
         # In case of error(s) which prevents the SC build script from completing, ensure the
         # file mutex for job completion is set in shared storage. This lockfile signals the server
         # to mark the job done, without putting load on the cluster reporting/accounting system.

--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -66,27 +66,12 @@ def _deferstep(chip, step, index, status):
         schedule_cmd = ['lsrun']
 
     # Create a command to defer execution to a compute node.
-    # Create a Python script to setup and run the task using a Chip object.
-    py_script_path = f'{cfg_dir}/{step}{index}.py'
-    with open(py_script_path, 'w') as sf:
-        sf.write(f'''
-import siliconcompiler
-
-chip = siliconcompiler.Chip("{chip.get('design')}")
-chip.read_manifest("{shlex.quote(cfg_file)}")
-chip.unset('option', 'scheduler', 'name')
-chip.set('arg', 'step', '{step}')
-chip.set('arg', 'index', '{index}')
-chip.set('option', 'builddir', '{chip.get("option", "builddir")}')
-
-chip.run()
-        ''')
-    # Create a bash script to run the script, and handle scheduler bookkeeping.
     script_path = f'{cfg_dir}/{step}{index}.sh'
     with open(script_path, 'w') as sf:
         sf.write('#!/bin/bash\n')
-        # Use 'python3' in case of old OS which still ships with Python2.x
-        sf.write(f'python3 {py_script_path}\n')
+        sf.write(f'sc -cfg {shlex.quote(cfg_file)} -builddir {shlex.quote(chip.get("option", "builddir"))} '\
+                    f'-arg_step {shlex.quote(step)} -arg_index {shlex.quote(index)} '\
+                    f"-jobscheduler 'none' -design {shlex.quote(chip.top())}\n")
         # In case of error(s) which prevents the SC build script from completing, ensure the
         # file mutex for job completion is set in shared storage. This lockfile signals the server
         # to mark the job done, without putting load on the cluster reporting/accounting system.

--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -71,7 +71,7 @@ def _deferstep(chip, step, index, status):
         sf.write('#!/bin/bash\n')
         sf.write(f'sc -cfg {shlex.quote(cfg_file)} -builddir {shlex.quote(chip.get("option", "builddir"))} '\
                     f'-arg_step {shlex.quote(step)} -arg_index {shlex.quote(index)} '\
-                    f"-jobscheduler 'none' -design {shlex.quote(chip.top())}\n")
+                    f"-scheduler 'none' -design {shlex.quote(chip.top())}\n")
         # In case of error(s) which prevents the SC build script from completing, ensure the
         # file mutex for job completion is set in shared storage. This lockfile signals the server
         # to mark the job done, without putting load on the cluster reporting/accounting system.

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -2637,7 +2637,7 @@ def schema_option(cfg):
     # job scheduler
     scparam(cfg, ['option', 'scheduler', 'name'],
             sctype='enum',
-            enum=["slurm", "lsf", "sge"],
+            enum=["none", "slurm", "lsf", "sge"],
             scope='job',
             shorthelp="Option: Scheduler platform",
             switch="-scheduler <str>",

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -2637,8 +2637,9 @@ def schema_option(cfg):
     # job scheduler
     scparam(cfg, ['option', 'scheduler', 'name'],
             sctype='enum',
-            enum=["none", "slurm", "lsf", "sge"],
+            enum=["slurm", "lsf", "sge"],
             scope='job',
+            pernode='optional',
             shorthelp="Option: Scheduler platform",
             switch="-scheduler <str>",
             example=[

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -4319,7 +4319,6 @@
             "name": {
                 "defvalue": null,
                 "enum": [
-                    "none",
                     "slurm",
                     "lsf",
                     "sge"
@@ -4332,7 +4331,7 @@
                 "lock": false,
                 "nodevalue": {},
                 "notes": null,
-                "pernode": "never",
+                "pernode": "optional",
                 "require": null,
                 "scope": "job",
                 "set": false,

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -4319,6 +4319,7 @@
             "name": {
                 "defvalue": null,
                 "enum": [
+                    "none",
                     "slurm",
                     "lsf",
                     "sge"


### PR DESCRIPTION
* Use the top-level 'scheduler' keypath in scheduler.py
* Run tasks on compute nodes using Python build scripts, instead of the `sc` command line.

Unfortunately, we don't have a way to un-set an enum Schema value from the command line. I can report that edge case bug, but it's probably not a priority to fix it right this moment, so for now we can use the Python API's `Chip.unset()` call to mark when a task has reached the node that it should run on.

This is probably a good change to make anyways, as it will give us more flexibility going forward.