### PR TITLE
docs: switch to use setup() or module for documentation

### DIFF
--- a/siliconcompiler/checklists/oh_tapeout.py
+++ b/siliconcompiler/checklists/oh_tapeout.py
@@ -1,14 +1,14 @@
 import siliconcompiler
 
 def make_docs():
-    '''Subset of OH! library tapeout checklist.
-
-    https://github.com/aolofsson/oh/blob/master/docs/tapeout_checklist.md
-    '''
     chip = siliconcompiler.Chip('<design>')
     return setup(chip)
 
 def setup(chip):
+    '''Subset of OH! library tapeout checklist.
+
+    https://github.com/aolofsson/oh/blob/master/docs/tapeout_checklist.md
+    '''
     standard = 'oh_tapeout'
 
     checklist = siliconcompiler.Checklist(chip, standard)

--- a/siliconcompiler/flows/asicflow.py
+++ b/siliconcompiler/flows/asicflow.py
@@ -7,6 +7,14 @@ from siliconcompiler.flows._common import setup_frontend
 ############################################################################
 
 def make_docs():
+    chip = siliconcompiler.Chip('<topmodule>')
+    n = 3
+    return setup(chip, syn_np=n, floorplan_np=n, physyn_np=n, place_np=n, cts_np=n, route_np=n)
+
+###########################################################################
+# Flowgraph Setup
+############################################################################
+def setup(chip, flowname='asicflow', syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1):
     '''
     A configurable ASIC compilation flow.
 
@@ -37,22 +45,6 @@ def make_docs():
     * place_np : Number of parallel place jobs to launch
     * cts_np : Number of parallel clock tree synthesis jobs to launch
     * route_np : Number of parallel routing jobs to launch
-    '''
-
-    chip = siliconcompiler.Chip('<topmodule>')
-    n = 3
-    return setup(chip, syn_np=n, floorplan_np=n, physyn_np=n, place_np=n, cts_np=n, route_np=n)
-
-###########################################################################
-# Flowgraph Setup
-############################################################################
-def setup(chip, flowname='asicflow', syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1):
-    '''
-    Setup function for 'asicflow' ASIC compilation execution flowgraph.
-
-    Args:
-        chip (object): SC Chip object
-
     '''
 
     flow = siliconcompiler.Flow(chip, flowname)

--- a/siliconcompiler/flows/asictopflow.py
+++ b/siliconcompiler/flows/asictopflow.py
@@ -1,23 +1,22 @@
 import siliconcompiler
 
 def make_docs():
+    chip = siliconcompiler.Chip('<topmodule>')
+    chip.set('option', 'flow', 'asictopflow')
+    return setup(chip)
+
+def setup(chip):
     '''A flow for stitching together hardened blocks without doing any automated
     place-and-route.
 
     This flow generates a GDS and a netlist for passing to a
     verification/signoff flow.
     '''
-    chip = siliconcompiler.Chip('<topmodule>')
-    chip.set('option', 'flow', 'asictopflow')
-    return setup(chip)
-
-def setup(chip):
     flow = siliconcompiler.Flow(chip, 'asictopflow')
 
     flow.node(flow.design, 'import', 'surelog', 'import')
     flow.node(flow.design, 'syn', 'yosys', 'syn_asic')
     flow.node(flow.design, 'export', 'klayout', 'export')
-    flow.node(flow.design, 'merge', 'builtin', 'join')
 
     flow.edge(flow.design, 'import', 'export')
     flow.edge(flow.design, 'import', 'syn')

--- a/siliconcompiler/flows/dvflow.py
+++ b/siliconcompiler/flows/dvflow.py
@@ -5,6 +5,14 @@ import siliconcompiler
 ############################################################################
 
 def make_docs():
+    chip = siliconcompiler.Chip('<topmodule>')
+    chip.set('option', 'flow', 'dvflow')
+    return setup(chip, np=5)
+
+#############################################################################
+# Flowgraph Setup
+#############################################################################
+def setup(chip, np=1):
     '''
     A configurable constrained random stimulus DV flow.
 
@@ -21,19 +29,6 @@ def make_docs():
     The dvflow can be parametrized using a single 'np' parameter.
     Setting 'np' > 1 results in multiple independent verificaiton
     pipelines to be launched.
-
-    '''
-
-    chip = siliconcompiler.Chip('<topmodule>')
-    chip.set('option', 'flow', 'dvflow')
-    return setup(chip, np=5)
-
-#############################################################################
-# Flowgraph Setup
-#############################################################################
-def setup(chip, np=1):
-    '''
-    Setup function for 'dvflow'
     '''
 
     # Definting a flow

--- a/siliconcompiler/flows/fpgaflow.py
+++ b/siliconcompiler/flows/fpgaflow.py
@@ -8,6 +8,15 @@ from siliconcompiler.flows._common import setup_frontend
 ############################################################################
 
 def make_docs():
+    chip = siliconcompiler.Chip('<topmodule>')
+    chip.set('option', 'flow', 'fpgaflow')
+    chip.set('fpga', 'partname', 'ice40')
+    return setup(chip)
+
+############################################################################
+# Flowgraph Setup
+############################################################################
+def setup(chip, flowname='fpgaflow'):
     '''
     A configurable FPGA compilation flow.
 
@@ -35,24 +44,6 @@ def make_docs():
 
     * ['fpga', 'partname']: Used to select partname to vendor and tool flow
     * ['fpga', 'program']: Used to turn on/off HW programming step
-
-    '''
-
-    chip = siliconcompiler.Chip('<topmodule>')
-    chip.set('option', 'flow', 'fpgaflow')
-    chip.set('fpga', 'partname', 'ice40')
-    return setup(chip)
-
-############################################################################
-# Flowgraph Setup
-############################################################################
-def setup(chip, flowname='fpgaflow'):
-    '''
-    Setup function for 'fpgaflow'
-
-    Args:
-        chip (object): SC Chip object
-
     '''
 
     flow = siliconcompiler.Flow(chip, flowname)

--- a/siliconcompiler/flows/lintflow.py
+++ b/siliconcompiler/flows/lintflow.py
@@ -5,11 +5,6 @@ import siliconcompiler
 ############################################################################
 
 def make_docs():
-    '''
-    A configurable RTL linting flow.
-
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     chip.set('option', 'flow', 'lintflow')
     return setup(chip)
@@ -19,11 +14,7 @@ def make_docs():
 ############################################################################
 def setup(chip):
     '''
-    Setup function RTL linting flow
-
-    Args:
-        chip (object): SC Chip object
-
+    An RTL linting flow.
     '''
 
     flowname = 'lintflow'

--- a/siliconcompiler/flows/showflow.py
+++ b/siliconcompiler/flows/showflow.py
@@ -5,6 +5,13 @@ import siliconcompiler
 ############################################################################
 
 def make_docs():
+    chip = siliconcompiler.Chip('<topmodule>')
+    return setup(chip, filetype='gds', np=3)
+
+###########################################################################
+# Flowgraph Setup
+############################################################################
+def setup(chip, flowname='showflow', filetype=None, screenshot=False, np=1):
     '''
     A flow to show the output files generated from other flows.
 
@@ -16,21 +23,6 @@ def make_docs():
 
     * np : Number of parallel show jobs to launch
     * screenshot : true/false, indicate if this should be configured as a screenshot
-    '''
-
-    chip = siliconcompiler.Chip('<topmodule>')
-    return setup(chip, filetype='gds', np=3)
-
-###########################################################################
-# Flowgraph Setup
-############################################################################
-def setup(chip, flowname='showflow', filetype=None, screenshot=False, np=1):
-    '''
-    Setup function for 'showflow' execution flowgraph.
-
-    Args:
-        chip (object): SC Chip object
-        flowname (str): name for the flow
     '''
 
     flow = siliconcompiler.Flow(chip, flowname)

--- a/siliconcompiler/flows/signoffflow.py
+++ b/siliconcompiler/flows/signoffflow.py
@@ -1,6 +1,11 @@
 import siliconcompiler
 
 def make_docs():
+    chip = siliconcompiler.Chip('<topmodule>')
+    chip.set('option', 'flow', 'signoffflow')
+    return setup(chip)
+
+def setup(chip):
     '''A flow for running LVS/DRC signoff on a GDS layout.
 
     Inputs must be passed to this flow as follows::
@@ -8,11 +13,6 @@ def make_docs():
         flow.input('<path-to-layout>.gds')
         flow.input('<path-to-netlist>.vg')
     '''
-    chip = siliconcompiler.Chip('<topmodule>')
-    chip.set('option', 'flow', 'signoffflow')
-    return setup(chip)
-
-def setup(chip):
     flowname = 'signoffflow'
 
     flow = siliconcompiler.Flow(chip, flowname)

--- a/siliconcompiler/libs/asap7sc7p5t.py
+++ b/siliconcompiler/libs/asap7sc7p5t.py
@@ -2,9 +2,6 @@ import os
 import siliconcompiler
 
 def make_docs():
-    '''
-    ASAP 7 7.5-track standard cell library.
-    '''
     chip =  siliconcompiler.Chip('<design>')
     return setup(chip)
 
@@ -106,6 +103,9 @@ def _setup_lib(chip, libname, suffix):
     return lib
 
 def setup(chip):
+    '''
+    ASAP 7 7.5-track standard cell library.
+    '''
     all_libs = {
         'asap7sc7p5t_rvt' : 'R',
         'asap7sc7p5t_lvt' : 'L',

--- a/siliconcompiler/libs/nangate45.py
+++ b/siliconcompiler/libs/nangate45.py
@@ -2,13 +2,13 @@ import os
 import siliconcompiler
 
 def make_docs():
-    '''
-    Nangate open standard cell library for FreePDK45.
-    '''
     chip = siliconcompiler.Chip('<design>')
     return setup(chip)
 
 def setup(chip):
+    '''
+    Nangate open standard cell library for FreePDK45.
+    '''
     libname = 'nangate45'
     foundry = 'virtual'
     process = 'freepdk45'

--- a/siliconcompiler/libs/sky130hd.py
+++ b/siliconcompiler/libs/sky130hd.py
@@ -2,13 +2,13 @@ import os
 import siliconcompiler
 
 def make_docs():
-    '''
-    Skywater130 standard cell library.
-    '''
     chip = siliconcompiler.Chip('<design>')
     return setup(chip)
 
 def setup(chip):
+    '''
+    Skywater130 standard cell library.
+    '''
     foundry = 'skywater'
     process = 'skywater130'
     stackup = '5M1LI'

--- a/siliconcompiler/libs/sky130io.py
+++ b/siliconcompiler/libs/sky130io.py
@@ -2,13 +2,13 @@ import os
 import siliconcompiler
 
 def make_docs():
-    '''
-    Skywater130 I/O library.
-    '''
     chip = siliconcompiler.Chip('<design>')
     return setup(chip)
 
 def setup(chip):
+    '''
+    Skywater130 I/O library.
+    '''
     process = 'skywater130'
     libname = 'sky130io'
     stackup = '5M1LI'

--- a/siliconcompiler/pdks/asap7.py
+++ b/siliconcompiler/pdks/asap7.py
@@ -2,6 +2,11 @@ import os
 import siliconcompiler
 
 def make_docs():
+    chip = siliconcompiler.Chip('asap7')
+
+    return setup(chip)
+
+def setup(chip):
     '''
     The asap7 PDK was developed at ASU in collaboration with ARM Research.
     With funding from the DARPA IDEA program, the PDK was released
@@ -36,16 +41,6 @@ def make_docs():
 
     .. warning::
        Work in progress (not ready for use)
-
-    '''
-
-    chip = siliconcompiler.Chip('asap7')
-
-    return setup(chip)
-
-def setup(chip):
-    '''
-    TODO: Add process information
     '''
 
     foundry = 'virtual'

--- a/siliconcompiler/pdks/freepdk45.py
+++ b/siliconcompiler/pdks/freepdk45.py
@@ -7,6 +7,14 @@ import siliconcompiler
 ############################################################################
 
 def make_docs():
+    chip = siliconcompiler.Chip('freepdk45')
+    return setup(chip)
+
+####################################################
+# PDK Setup
+####################################################
+
+def setup(chip):
     '''
     The freepdk45 PDK is a virtual PDK derived from the work done at
     NCSU (NCSU_TechLib_FreePDK45.)  It supplies techfiles, display
@@ -23,21 +31,6 @@ def make_docs():
 
     More information:
     * https://www.eda.ncsu.edu/wiki/FreePDK45:Manual
-
-    '''
-
-    chip = siliconcompiler.Chip('freepdk45')
-
-    return setup(chip)
-
-
-####################################################
-# PDK Setup
-####################################################
-
-def setup(chip):
-    '''
-    Setup function for the freepdk45 PDK.
     '''
 
     ###############################################

--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -7,11 +7,19 @@ import siliconcompiler
 ############################################################################
 
 def make_docs():
+    chip = siliconcompiler.Chip('skywater130')
+    return setup(chip)
+
+####################################################
+# PDK Setup
+####################################################
+
+def setup(chip):
     '''
     The 'skywater130' Open Source PDK is a collaboration between Google and
     SkyWater Technology Foundry to provide a fully open source Process
     Design Kit and related resources, which can be used to create
-    manufacturable designs at SkyWater’s facility.
+    manufacturable designs at SkyWater's facility.
 
     Skywater130 Process Highlights:
     * 130nm process
@@ -30,20 +38,6 @@ def make_docs():
 
     Sources:
     * https://github.com/google/skywater-pdk
-
-    '''
-
-    chip = siliconcompiler.Chip('skywater130')
-
-    return setup(chip)
-
-####################################################
-# PDK Setup
-####################################################
-
-def setup(chip):
-    '''
-    Setup function for the skywater130 PDK.
     '''
 
     foundry = 'skywater'

--- a/siliconcompiler/sphinx_ext/dynamicgen.py
+++ b/siliconcompiler/sphinx_ext/dynamicgen.py
@@ -446,6 +446,9 @@ class ToolGen(DynamicGen):
         '''
         modules = []
         for toolname in os.listdir(module_dir):
+            if (toolname == "template"):
+                # No need to include empty template in documentation
+                continue
             # skip over directories/files that don't match the structure of tool
             # directories (otherwise we'll get confused by Python metadata like
             # __init__.py or __pycache__/)

--- a/siliconcompiler/tools/bambu/bambu.py
+++ b/siliconcompiler/tools/bambu/bambu.py
@@ -1,3 +1,6 @@
+'''
+'''
+
 import importlib
 
 import siliconcompiler
@@ -6,9 +9,6 @@ import siliconcompiler
 # Make Docs
 ####################################################################
 def make_docs():
-    '''
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     step = 'import'
     index = '0'

--- a/siliconcompiler/tools/bluespec/bluespec.py
+++ b/siliconcompiler/tools/bluespec/bluespec.py
@@ -1,3 +1,18 @@
+
+'''
+Bluespec is a high-level hardware description language. It has a variety of
+advanced features including a powerful type system that can prevent errors
+prior to synthesis time, and its most distinguishing feature, Guarded Atomic
+Actions, allow you to define hardware components in a modular manner based
+on their invariants, and let the compiler pick a scheduler.
+
+Documentation: https://github.com/B-Lang-org/bsc#documentation
+
+Sources: https://github.com/B-Lang-org/bsc
+
+Installation: https://github.com/B-Lang-org/bsc#download
+'''
+
 import importlib
 
 import siliconcompiler
@@ -6,20 +21,6 @@ import siliconcompiler
 # Make Docs
 ####################################################################
 def make_docs():
-    '''
-    Bluespec is a high-level hardware description language. It has a variety of
-    advanced features including a powerful type system that can prevent errors
-    prior to synthesis time, and its most distinguishing feature, Guarded Atomic
-    Actions, allow you to define hardware components in a modular manner based
-    on their invariants, and let the compiler pick a scheduler.
-
-    Documentation: https://github.com/B-Lang-org/bsc#documentation
-
-    Sources: https://github.com/B-Lang-org/bsc
-
-    Installation: https://github.com/B-Lang-org/bsc#download
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     step = 'import'
     index = '0'

--- a/siliconcompiler/tools/chisel/chisel.py
+++ b/siliconcompiler/tools/chisel/chisel.py
@@ -1,3 +1,19 @@
+'''
+Chisel is a hardware design language that facilitates advanced circuit
+generation and design reuse for both ASIC and FPGA digital logic designs.
+Chisel adds hardware construction primitives to the Scala programming
+language, providing designers with the power of a modern programming
+language to write complex, parameterizable circuit generators that produce
+synthesizable Verilog.
+
+Documentation: https://www.chisel-lang.org/chisel3/docs/introduction.html
+
+Sources: https://github.com/chipsalliance/chisel3
+
+Installation: The Chisel plugin relies on having the Scala Build Tool (sbt)
+installed. Instructions: https://www.scala-sbt.org/download.html.
+'''
+
 import importlib
 
 import siliconcompiler
@@ -6,22 +22,6 @@ import siliconcompiler
 # Make Docs
 ####################################################################
 def make_docs():
-    '''
-    Chisel is a hardware design language that facilitates advanced circuit
-    generation and design reuse for both ASIC and FPGA digital logic designs.
-    Chisel adds hardware construction primitives to the Scala programming
-    language, providing designers with the power of a modern programming
-    language to write complex, parameterizable circuit generators that produce
-    synthesizable Verilog.
-
-    Documentation: https://www.chisel-lang.org/chisel3/docs/introduction.html
-
-    Sources: https://github.com/chipsalliance/chisel3
-
-    Installation: The Chisel plugin relies on having the Scala Build Tool (sbt)
-    installed. Instructions: https://www.scala-sbt.org/download.html.
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     step = 'import'
     index = '0'

--- a/siliconcompiler/tools/genfasm/genfasm.py
+++ b/siliconcompiler/tools/genfasm/genfasm.py
@@ -1,3 +1,7 @@
+'''
+To-Do: Add details here
+'''
+
 import siliconcompiler
 
 ######################################################################
@@ -5,10 +9,6 @@ import siliconcompiler
 ######################################################################
 
 def make_docs():
-    '''
-    To-Do: Add details here
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     step = 'bitstream'
     index = '<index>'

--- a/siliconcompiler/tools/ghdl/ghdl.py
+++ b/siliconcompiler/tools/ghdl/ghdl.py
@@ -1,3 +1,17 @@
+
+'''
+GHDL is an open-source analyzer, compiler, simulator and
+(experimental) synthesizer for VHDL. It allows you to analyse
+and elaborate sources for generating machine code from your design.
+Native program execution is the only way for high speed simulation.
+
+Documentation: https://ghdl.readthedocs.io/en/latest
+
+Sources: https://github.com/ghdl/ghdl
+
+Installation: https://github.com/ghdl/ghdl
+'''
+
 import importlib
 
 import siliconcompiler
@@ -7,20 +21,6 @@ import siliconcompiler
 #####################################################################
 
 def make_docs():
-    '''
-    GHDL is an open-source analyzer, compiler, simulator and
-    (experimental) synthesizer for VHDL. It allows you to analyse
-    and elaborate sources for generating machine code from your design.
-    Native program execution is the only way for high speed simulation.
-
-    Documentation: https://ghdl.readthedocs.io/en/latest
-
-    Sources: https://github.com/ghdl/ghdl
-
-    Installation: https://github.com/ghdl/ghdl
-
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     step = 'import'
     index = '<index>'

--- a/siliconcompiler/tools/icarus/icarus.py
+++ b/siliconcompiler/tools/icarus/icarus.py
@@ -1,3 +1,16 @@
+
+'''
+Icarus is a verilog simulator with full support for Verilog
+IEEE-1364. Icarus can simulate synthesizable as well as
+behavioral Verilog.
+
+Documentation: http://iverilog.icarus.com
+
+Sources: https://github.com/steveicarus/iverilog.git
+
+Installation: https://github.com/steveicarus/iverilog.git
+'''
+
 import siliconcompiler
 
 ####################################################################
@@ -5,18 +18,6 @@ import siliconcompiler
 ####################################################################
 
 def make_docs():
-    '''
-    Icarus is a verilog simulator with full support for Verilog
-    IEEE-1364. Icarus can simulate synthesizable as well as
-    behavioral Verilog.
-
-    Documentation: http://iverilog.icarus.com
-
-    Sources: https://github.com/steveicarus/iverilog.git
-
-    Installation: https://github.com/steveicarus/iverilog.git
-
-    '''
 
     chip = siliconcompiler.Chip('<design>')
     step = 'compile'

--- a/siliconcompiler/tools/icepack/icepack.py
+++ b/siliconcompiler/tools/icepack/icepack.py
@@ -1,3 +1,15 @@
+
+'''
+Icepack converts an ASCII bitstream file to a .bin file for the
+ICE40 FPGA.
+
+Documentation: http://bygone.clairexen.net/icestorm/
+
+Sources: https://github.com/YosysHQ/icestorm
+
+Installation: https://github.com/YosysHQ/icestorm
+'''
+
 import siliconcompiler
 
 #####################################################################
@@ -5,18 +17,6 @@ import siliconcompiler
 #####################################################################
 
 def make_docs():
-    '''
-    Icepack converts an ASCII bitstream file to a .bin file for the
-    ICE40 FPGA.
-
-    Documentation: http://bygone.clairexen.net/icestorm/
-
-    Sources: https://github.com/YosysHQ/icestorm
-
-    Installation: https://github.com/YosysHQ/icestorm
-
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     step = 'bitstream'
     index = '<index>'

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -1,3 +1,15 @@
+
+'''
+Klayout is a production grade viewer and editor of GDSII and
+Oasis data with customizable Python and Ruby interfaces.
+
+Documentation: https://www.klayout.de
+
+Sources: https://github.com/KLayout/klayout
+
+Installation: https://www.klayout.de/build.html
+'''
+
 import os
 from pathlib import Path
 import platform
@@ -10,18 +22,6 @@ import siliconcompiler
 ####################################################################
 
 def make_docs():
-    '''
-    Klayout is a production grade viewer and editor of GDSII and
-    Oasis data with customizable Python and Ruby interfaces.
-
-    Documentation: https://www.klayout.de
-
-    Sources: https://github.com/KLayout/klayout
-
-    Installation: https://www.klayout.de/build.html
-
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     chip.load_target('freepdk45_demo')
     step = 'export'

--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -1,21 +1,20 @@
+'''
+Magic is a chip layout viewer, editor, and circuit verifier with
+built in DRC and LVS engines.
+
+Documentation: http://opencircuitdesign.com/magic/userguide.html
+
+Installation: https://github.com/RTimothyEdwards/magic
+
+Sources: https://github.com/RTimothyEdwards/magic
+'''
+
 import siliconcompiler
 
 ####################################################################
 # Make Docs
 ####################################################################
 def make_docs():
-    '''
-    Magic is a chip layout viewer, editor, and circuit verifier with
-    built in DRC and LVS engines.
-
-    Documentation: http://opencircuitdesign.com/magic/userguide.html
-
-    Installation: https://github.com/RTimothyEdwards/magic
-
-    Sources: https://github.com/RTimothyEdwards/magic
-
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     from pdks import skywater130
     chip.use(skywater130)

--- a/siliconcompiler/tools/netgen/netgen.py
+++ b/siliconcompiler/tools/netgen/netgen.py
@@ -1,22 +1,22 @@
+
+'''
+Netgen is a tool for comparing netlists. By comparing a Verilog netlist with
+one extracted from a circuit layout, it can be used to perform LVS
+verification.
+
+Documentation: http://www.opencircuitdesign.com/netgen/
+
+Installation: https://github.com/RTimothyEdwards/netgen
+
+Sources: https://github.com/RTimothyEdwards/netgen
+'''
+
 import siliconcompiler
 
 ####################################################################
 # Make Docs
 ####################################################################
 def make_docs():
-    '''
-    Netgen is a tool for comparing netlists. By comparing a Verilog netlist with
-    one extracted from a circuit layout, it can be used to perform LVS
-    verification.
-
-    Documentation: http://www.opencircuitdesign.com/netgen/
-
-    Installation: https://github.com/RTimothyEdwards/netgen
-
-    Sources: https://github.com/RTimothyEdwards/netgen
-
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     from pdks import skywater130
     chip.use(skywater130)

--- a/siliconcompiler/tools/nextpnr/nextpnr.py
+++ b/siliconcompiler/tools/nextpnr/nextpnr.py
@@ -1,3 +1,14 @@
+'''
+nextpnr is a vendor neutral FPGA place and route tool with
+support for the ICE40, ECP5, and Nexus devices from Lattice.
+
+Documentation: https://github.com/YosysHQ/nextpnr
+
+Sources: https://github.com/YosysHQ/nextpnr
+
+Installation: https://github.com/YosysHQ/nextpnr
+'''
+
 import siliconcompiler
 
 #####################################################################
@@ -5,18 +16,6 @@ import siliconcompiler
 #####################################################################
 
 def make_docs():
-    '''
-    nextpnr is a vendor neutral FPGA place and route tool with
-    support for the ICE40, ECP5, and Nexus devices from Lattice.
-
-    Documentation: https://github.com/YosysHQ/nextpnr
-
-    Sources: https://github.com/YosysHQ/nextpnr
-
-    Installation: https://github.com/YosysHQ/nextpnr
-
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     step = 'apr'
     index = '<index>'

--- a/siliconcompiler/tools/openfpgaloader/openfpgaloader.py
+++ b/siliconcompiler/tools/openfpgaloader/openfpgaloader.py
@@ -1,3 +1,19 @@
+'''
+The OpenFPGALoader is a universal utility for programming
+FPGAs. Compatible with many boards, cables and FPGA from
+major manufacturers (Xilinx, Altera/Intel, Lattice, Gowin,
+Efinix, Anlogic). openFPGALoader works on Linux, Windows and
+macOS.
+
+Documentation: https://github.com/trabucayre/openFPGALoader
+
+Sources: https://github.com/trabucayre/openFPGALoader
+
+Installation: https://github.com/trabucayre/openFPGALoader
+
+Status: SC integration WIP
+'''
+
 import siliconcompiler
 
 ####################################################################
@@ -5,23 +21,6 @@ import siliconcompiler
 ####################################################################
 
 def make_docs():
-    '''
-    The OpenFPGALoader is a universal utility for programming
-    FPGAs. Compatible with many boards, cables and FPGA from
-    major manufacturers (Xilinx, Altera/Intel, Lattice, Gowin,
-    Efinix, Anlogic). openFPGALoader works on Linux, Windows and
-    macOS.
-
-    Documentation: https://github.com/trabucayre/openFPGALoader
-
-    Sources: https://github.com/trabucayre/openFPGALoader
-
-    Installation: https://github.com/trabucayre/openFPGALoader
-
-    Status: SC integration WIP
-
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     chip.set('arg','step','program')
     chip.set('arg','index','0')

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -1,3 +1,16 @@
+'''
+OpenROAD is an automated physical design platform for
+integrated circuit design with a complete set of features
+needed to translate a synthesized netlist to a tapeout ready
+GDSII.
+
+Documentation: https://openroad.readthedocs.io/
+
+Sources: https://github.com/The-OpenROAD-Project/OpenROAD
+
+Installation: https://github.com/The-OpenROAD-Project/OpenROAD
+'''
+
 import math
 import os
 import json
@@ -10,19 +23,6 @@ import siliconcompiler
 ####################################################################
 
 def make_docs():
-    '''
-    OpenROAD is an automated physical design platform for
-    integrated circuit design with a complete set of features
-    needed to translate a synthesized netlist to a tapeout ready
-    GDSII.
-
-    Documentation: https://openroad.readthedocs.io/
-
-    Sources: https://github.com/The-OpenROAD-Project/OpenROAD
-
-    Installation: https://github.com/The-OpenROAD-Project/OpenROAD
-
-    '''
 
     chip = siliconcompiler.Chip('<design>')
     step = '<step>'

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -1,3 +1,15 @@
+'''
+Surelog is a SystemVerilog pre-processor, parser, elaborator,
+and UHDM compiler that provdes IEEE design and testbench
+C/C++ VPI and a Python AST API.
+
+Documentation: https://github.com/chipsalliance/Surelog
+
+Sources: https://github.com/chipsalliance/Surelog
+
+Installation: https://github.com/chipsalliance/Surelog
+'''
+
 import os
 import sys
 import shutil
@@ -8,18 +20,6 @@ import siliconcompiler
 # Make Docs
 ####################################################################
 def make_docs():
-    '''
-    Surelog is a SystemVerilog pre-processor, parser, elaborator,
-    and UHDM compiler that provdes IEEE design and testbench
-    C/C++ VPI and a Python AST API.
-
-    Documentation: https://github.com/chipsalliance/Surelog
-
-    Sources: https://github.com/chipsalliance/Surelog
-
-    Installation: https://github.com/chipsalliance/Surelog
-
-    '''
 
     chip = siliconcompiler.Chip('<design>')
     chip.load_target('freepdk45_demo')

--- a/siliconcompiler/tools/sv2v/sv2v.py
+++ b/siliconcompiler/tools/sv2v/sv2v.py
@@ -1,3 +1,19 @@
+'''
+sv2v converts SystemVerilog (IEEE 1800-2017) to Verilog
+(IEEE 1364-2005), with an emphasis on supporting synthesizable
+language constructs. The primary goal of this project is to
+create a completely free and open-source tool for converting
+SystemVerilog to Verilog. While methods for performing this
+conversion already exist, they generally either rely on
+commercial tools, or are limited in scope.
+
+Documentation: https://github.com/zachjs/sv2v
+
+Sources: https://github.com/zachjs/sv2v
+
+Installation: https://github.com/zachjs/sv2v
+'''
+
 import importlib
 
 import siliconcompiler
@@ -6,23 +22,6 @@ import siliconcompiler
 # Make Docs
 ####################################################################
 def make_docs():
-    '''
-    sv2v converts SystemVerilog (IEEE 1800-2017) to Verilog
-    (IEEE 1364-2005), with an emphasis on supporting synthesizable
-    language constructs. The primary goal of this project is to
-    create a completely free and open-source tool for converting
-    SystemVerilog to Verilog. While methods for performing this
-    conversion already exist, they generally either rely on
-    commercial tools, or are limited in scope.
-
-    Documentation: https://github.com/zachjs/sv2v
-
-    Sources: https://github.com/zachjs/sv2v
-
-    Installation: https://github.com/zachjs/sv2v
-
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     step = '<step>'
     index = '<index>'

--- a/siliconcompiler/tools/template/template.py
+++ b/siliconcompiler/tools/template/template.py
@@ -1,16 +1,17 @@
-import os
+'''
+Tool description
 
+Documentation:https://
+
+Sources: https://
+
+Installation: https://
+'''
+
+import os
 import siliconcompiler
 
 def make_docs():
-    '''
-    Tool description
-
-    Documentation:https://
-    Sources: https://
-    Installation: https://
-
-    '''
 
     chip = siliconcompiler.Chip('<design>')
     chip.set('arg','step','<step>')

--- a/siliconcompiler/tools/verilator/compile.py
+++ b/siliconcompiler/tools/verilator/compile.py
@@ -3,7 +3,14 @@ import subprocess
 from siliconcompiler.tools.verilator.verilator import setup as setup_tool
 
 def setup(chip):
-    ''' Helper method to load configs specific to compile tasks.
+    '''
+    Compiles Verilog and C/C++ sources into an executable.  Takes in a single
+    pickled Verilog file from ``inputs/<design>.v`` and a set of C/C++ sources
+    from :keypath:`input, c`. Outputs an executable in
+    ``outputs/<design>.vexe``.
+
+    This step supports using the :keypath:`option, trace` parameter to enable
+    Verilator's ``--trace`` flag.
     '''
 
     # Generic tool setup.

--- a/siliconcompiler/tools/verilator/import.py
+++ b/siliconcompiler/tools/verilator/import.py
@@ -4,7 +4,17 @@ import subprocess
 from siliconcompiler.tools.verilator.verilator import setup as setup_tool
 
 def setup(chip):
-    ''' Helper method to load configs specific to compile tasks.
+    '''
+    Preprocesses and pickles Verilog sources. Takes in a set of Verilog source
+    files supplied via :keypath:`input, verilog` and reads the following
+    parameters:
+
+    * :keypath:`option, ydir`
+    * :keypath:`option, vlib`
+    * :keypath:`option, idir`
+    * :keypath:`option, cmdfile`
+
+    Outputs a single Verilog file in ``outputs/<design>.v``.
     '''
 
     # Generic tool setup.

--- a/siliconcompiler/tools/verilator/lint.py
+++ b/siliconcompiler/tools/verilator/lint.py
@@ -2,7 +2,10 @@
 from siliconcompiler.tools.verilator.verilator import setup as setup_tool
 
 def setup(chip):
-    ''' Helper method to load configs specific to compile tasks.
+    '''
+    Lints Verilog source. Takes in a single pickled Verilog file from
+    ``inputs/<design>.v`` and produces no outputs. Results of linting can be
+    programatically queried using errors/warnings metrics.
     '''
 
     # Generic tool setup.

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -1,3 +1,19 @@
+'''
+Verilator is a free and open-source software tool which converts Verilog (a
+hardware description language) to a cycle-accurate behavioral model in C++
+or SystemC.
+
+For all steps, this driver runs Verilator using the ``-sv`` switch to enable
+parsing a subset of SystemVerilog features. All steps also support using
+:keypath:`option, relax` to make warnings nonfatal.
+
+Documentation: https://verilator.org/guide/latest
+
+Sources: https://github.com/verilator/verilator
+
+Installation: https://verilator.org/guide/latest/install.html
+'''
+
 import importlib
 import os
 
@@ -8,55 +24,6 @@ import siliconcompiler
 ####################################################################
 
 def make_docs():
-    '''
-    Verilator is a free and open-source software tool which converts Verilog (a
-    hardware description language) to a cycle-accurate behavioral model in C++
-    or SystemC.
-
-    Steps supported
-    ---------------
-
-    **import**
-
-    Preprocesses and pickles Verilog sources. Takes in a set of Verilog source
-    files supplied via :keypath:`input, verilog` and reads the following
-    parameters:
-
-    * :keypath:`option, ydir`
-    * :keypath:`option, vlib`
-    * :keypath:`option, idir`
-    * :keypath:`option, cmdfile`
-
-    Outputs a single Verilog file in ``outputs/<design>.v``.
-
-    **lint**
-
-    Lints Verilog source. Takes in a single pickled Verilog file from
-    ``inputs/<design>.v`` and produces no outputs. Results of linting can be
-    programatically queried using errors/warnings metrics.
-
-    **compile**
-
-    Compiles Verilog and C/C++ sources into an executable.  Takes in a single
-    pickled Verilog file from ``inputs/<design>.v`` and a set of C/C++ sources
-    from :keypath:`input, c`. Outputs an executable in
-    ``outputs/<design>.vexe``.
-
-    This step supports using the :keypath:`option, trace` parameter to enable
-    Verilator's ``--trace`` flag.
-
-    For all steps, this driver runs Verilator using the ``-sv`` switch to enable
-    parsing a subset of SystemVerilog features. All steps also support using
-    :keypath:`option, relax` to make warnings nonfatal.
-
-    Documentation: https://verilator.org/guide/latest
-
-    Sources: https://github.com/verilator/verilator
-
-    Installation: https://verilator.org/guide/latest/install.html
-
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     step = 'import'
     index = '<index>'

--- a/siliconcompiler/tools/vivado/vivado.py
+++ b/siliconcompiler/tools/vivado/vivado.py
@@ -1,3 +1,10 @@
+'''
+Vivado is an FPGA programming tool suite from Xilinx used to
+program Xilinx devices.
+
+Documentation: https://www.xilinx.com/products/design-tools/vivado.html
+'''
+
 import json
 import os
 import re
@@ -9,14 +16,6 @@ import siliconcompiler
 ####################################################################
 
 def make_docs():
-    '''
-    Vivado is an FPGA programming tool suite from Xilinx used to
-    program Xilinx devices.
-
-    Documentation: https://www.xilinx.com/products/design-tools/vivado.html
-
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     chip.set('arg','step', 'compile')
     chip.set('arg','index', '<index>')

--- a/siliconcompiler/tools/vpr/vpr.py
+++ b/siliconcompiler/tools/vpr/vpr.py
@@ -1,3 +1,21 @@
+'''
+VPR (Versatile Place and Route) is an open source CAD
+tool designed for the exploration of new FPGA architectures and
+CAD algorithms, at the packing, placement and routing phases of
+the CAD flow. VPR takes, as input, a description of an FPGA
+architecture along with a technology-mapped user circuit. It
+then performs packing, placement, and routing to map the
+circuit onto the FPGA. The output of VPR includes the FPGA
+configuration needed to implement the circuit and statistics about
+the final mapped design (eg. critical path delay, area, etc).
+
+Documentation: https://docs.verilogtorouting.org/en/latest
+
+Sources: https://github.com/verilog-to-routing/vtr-verilog-to-routing
+
+Installation: https://github.com/verilog-to-routing/vtr-verilog-to-routing
+'''
+
 import siliconcompiler
 
 ######################################################################
@@ -5,24 +23,7 @@ import siliconcompiler
 ######################################################################
 
 def make_docs():
-    '''
-    VPR (Versatile Place and Route) is an open source CAD
-    tool designed for the exploration of new FPGA architectures and
-    CAD algorithms, at the packing, placement and routing phases of
-    the CAD flow. VPR takes, as input, a description of an FPGA
-    architecture along with a technology-mapped user circuit. It
-    then performs packing, placement, and routing to map the
-    circuit onto the FPGA. The output of VPR includes the FPGA
-    configuration needed to implement the circuit and statistics about
-    the final mapped design (eg. critical path delay, area, etc).
 
-    Documentation: https://docs.verilogtorouting.org/en/latest
-
-    Sources: https://github.com/verilog-to-routing/vtr-verilog-to-routing
-
-    Installation: https://github.com/verilog-to-routing/vtr-verilog-to-routing
-
-    '''
 
     chip = siliconcompiler.Chip('<design>')
     step = 'apr'

--- a/siliconcompiler/tools/xyce/xyce.py
+++ b/siliconcompiler/tools/xyce/xyce.py
@@ -1,3 +1,19 @@
+'''
+Xyce is a high performance SPICE-compatible circuit simulator
+capable capable of solving extremely large circuit problems by
+supporting large-scale parallel computing platforms. It also
+supports serial execution on all common desktop platforms,
+and small-scale parallel runs on Unix-like systems.
+
+Documentation: https://xyce.sandia.gov/documentation
+
+Sources: https://github.com/Xyce/Xyce
+
+Installation: https://xyce.sandia.gov/documentation/BuildingGuide.html
+
+Status: SC integration WIP
+'''
+
 import os
 
 import siliconcompiler
@@ -8,23 +24,6 @@ import siliconcompiler
 #####################################################################
 
 def make_docs():
-    '''
-    Xyce is a high performance SPICE-compatible circuit simulator
-    capable capable of solving extremely large circuit problems by
-    supporting large-scale parallel computing platforms. It also
-    supports serial execution on all common desktop platforms,
-    and small-scale parallel runs on Unix-like systems.
-
-    Documentation: https://xyce.sandia.gov/documentation
-
-    Sources: https://github.com/Xyce/Xyce
-
-    Installation: https://xyce.sandia.gov/documentation/BuildingGuide.html
-
-    Status: SC integration WIP
-
-    '''
-
     chip = siliconcompiler.Chip('<design>')
     chip.set('arg','step', 'spice')
     chip.set('arg','index', '<index>')

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -1,3 +1,18 @@
+'''
+Yosys is a framework for RTL synthesis that takes synthesizable
+Verilog-2005 design and converts it to BLIF, EDIF, BTOR, SMT,
+Verilog netlist etc. The tool supports logical synthesis and
+tech mapping to ASIC standard cell libraries, FPGA architectures.
+In addition it has built in formal methods for property and
+equivalence checking.
+
+Documentation: https://yosyshq.readthedocs.io/projects/yosys/en/latest/
+
+Sources: https://github.com/YosysHQ/yosys
+
+Installation: https://github.com/YosysHQ/yosys
+'''
+
 import os
 import re
 import json
@@ -12,21 +27,7 @@ import siliconcompiler.tools.yosys.markDontUse as markDontUse
 ######################################################################
 
 def make_docs():
-    '''
-    Yosys is a framework for RTL synthesis that takes synthesizable
-    Verilog-2005 design and converts it to BLIF, EDIF, BTOR, SMT,
-    Verilog netlist etc. The tool supports logical synthesis and
-    tech mapping to ASIC standard cell libraries, FPGA architectures.
-    In addition it has built in formal methods for property and
-    equivalence checking.
 
-    Documentation: http://www.clifford.at/yosys/documentation.html
-
-    Sources: https://github.com/YosysHQ/yosys
-
-    Installation: https://github.com/YosysHQ/yosys
-
-    '''
 
     chip = siliconcompiler.Chip('<design>')
     # TODO: docs split by task


### PR DESCRIPTION
Changes:
- uses `setup()` instead of `make_docs()` for documentation + associated changes in tools/pdks/libs/checklists/flows

Note:
- This is a step towards making `make_docs()` or a similar function optional