### PR TITLE
Support step/index overrides in command line

### DIFF
--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -1288,9 +1288,9 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             sctype='[file]',
             pernode='required',
             shorthelp="Task: inputs",
-            switch="-tool_task_input 'task <str>'",
+            switch="-tool_task_input 'tool task step index <str>'",
             example=[
-                "cli: -tool_task_input 'openroad place oh_add.def'",
+                "cli: -tool_task_input 'openroad place place 0 oh_add.def'",
                 "api: chip.set('tool','openroad','task','place','input','oh_add.def', step='place', index='0')"],
             schelp="""
             List of data files to be copied from previous flowgraph steps 'output'
@@ -1303,9 +1303,9 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             sctype='[file]',
             pernode='required',
             shorthelp="Task: outputs",
-            switch="-tool_task_output 'task step index <str>'",
+            switch="-tool_task_output 'tool task step index <str>'",
             example=[
-                "cli: -tool_task_output 'openroad place oh_add.def'",
+                "cli: -tool_task_output 'openroad place place 0 oh_add.def'",
                 "api: chip.set('tool','openroad','task','place','output','oh_add.def', step='place', index='0')"],
             schelp="""
             List of data files to be copied from previous flowgraph steps 'output'
@@ -1390,9 +1390,9 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             sctype='[file]',
             pernode='required',
             shorthelp="Task: reports",
-            switch="-tool_task_report 'task metric <str>'",
+            switch="-tool_task_report 'task metric step index <str>'",
             example=[
-                 "cli: -tool_task_report 'openroad place holdtns place.log'",
+                 "cli: -tool_task_report 'openroad place holdtns place 0 place.log'",
                 "api: chip.set('tool','openroad','task','place','report','holdtns','place.log', step='place', index='0')"],
             schelp="""
             List of report files associated with a specific 'metric'. The file path

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -1201,7 +1201,7 @@ def schema_task(cfg, tool='default', task='default', step='default', index='defa
             shorthelp="Task: regex filter",
             switch="-tool_task_regex 'tool task suffix <str>'",
             example=[
-                "cli: -tool_task_regex 'openroad place errors -v ERROR'",
+                "cli: -tool_task_regex 'openroad place errors \"-v ERROR\"'",
                 "api: chip.set('tool','openroad','task','place','regex','errors','-v ERROR')"],
             schelp="""
             A list of piped together grep commands. Each entry represents a set
@@ -3291,7 +3291,7 @@ def schema_constraint(cfg):
             shorthelp="Constraint: timing checks",
             switch="-constraint_timing_check 'scenario <str>'",
             example=[
-                "cli: -constraint_timing_check 'worst check setup'",
+                "cli: -constraint_timing_check 'worst setup'",
                 "api: chip.add('constraint', 'timing', 'worst','check','setup')"],
             schelp="""
             List of checks for to perform for the scenario. The checks must

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1132,7 +1132,7 @@
                 "check": {
                     "defvalue": [],
                     "example": [
-                        "cli: -constraint_timing_check 'worst check setup'",
+                        "cli: -constraint_timing_check 'worst setup'",
                         "api: chip.add('constraint', 'timing', 'worst','check','setup')"
                     ],
                     "help": "List of checks for to perform for the scenario. The checks must\nalign with the capabilities of the EDA tools and flow being used.\nChecks generally include objectives like meeting setup and hold goals\nand minimize power. Standard check names include setup, hold, power,\nnoise, reliability.",
@@ -6936,7 +6936,7 @@
                         "date": [],
                         "defvalue": [],
                         "example": [
-                            "cli: -tool_task_input 'openroad place oh_add.def'",
+                            "cli: -tool_task_input 'openroad place place 0 oh_add.def'",
                             "api: chip.set('tool','openroad','task','place','input','oh_add.def', step='place', index='0')"
                         ],
                         "filehash": [],
@@ -6951,7 +6951,7 @@
                         "set": false,
                         "shorthelp": "Task: inputs",
                         "signature": [],
-                        "switch": "-tool_task_input 'task <str>'",
+                        "switch": "-tool_task_input 'tool task step index <str>'",
                         "type": "[file]",
                         "value": []
                     },
@@ -7001,7 +7001,7 @@
                         "date": [],
                         "defvalue": [],
                         "example": [
-                            "cli: -tool_task_output 'openroad place oh_add.def'",
+                            "cli: -tool_task_output 'openroad place place 0 oh_add.def'",
                             "api: chip.set('tool','openroad','task','place','output','oh_add.def', step='place', index='0')"
                         ],
                         "filehash": [],
@@ -7016,7 +7016,7 @@
                         "set": false,
                         "shorthelp": "Task: outputs",
                         "signature": [],
-                        "switch": "-tool_task_output 'task step index <str>'",
+                        "switch": "-tool_task_output 'tool task step index <str>'",
                         "type": "[file]",
                         "value": []
                     },
@@ -7094,7 +7094,7 @@
                         "default": {
                             "defvalue": [],
                             "example": [
-                                "cli: -tool_task_regex 'openroad place errors -v ERROR'",
+                                "cli: -tool_task_regex 'openroad place errors \"-v ERROR\"'",
                                 "api: chip.set('tool','openroad','task','place','regex','errors','-v ERROR')"
                             ],
                             "help": "A list of piped together grep commands. Each entry represents a set\nof command line arguments for grep including the regex pattern to\nmatch. Starting with the first list entry, each grep output is piped\ninto the following grep command in the list. Supported grep options\ninclude ``-v`` and ``-e``. Patterns starting with \"-\" should be\ndirectly preceded by the ``-e`` option. The following example\nillustrates the concept.\n\nUNIX grep:\n\n.. code-block:: bash\n\n    $ grep WARNING place.log | grep -v \"bbox\" > place.warnings\n\nSiliconCompiler::\n\n    chip.set('task', 'openroad', 'regex', 'place', '0', 'warnings', [\"WARNING\", \"-v bbox\"])\n\nThe \"errors\" and \"warnings\" suffixes are special cases. When set,\nthe number of matches found for these regexes will be added to the\nerrors and warnings metrics for the task, respectively. This will\nalso cause the logfile to be added to the :keypath:`tool, <tool>,\ntask, <task>, report` parameter for those metrics, if not already present.",
@@ -7119,7 +7119,7 @@
                             "date": [],
                             "defvalue": [],
                             "example": [
-                                "cli: -tool_task_report 'openroad place holdtns place.log'",
+                                "cli: -tool_task_report 'openroad place holdtns place 0 place.log'",
                                 "api: chip.set('tool','openroad','task','place','report','holdtns','place.log', step='place', index='0')"
                             ],
                             "filehash": [],
@@ -7134,7 +7134,7 @@
                             "set": false,
                             "shorthelp": "Task: reports",
                             "signature": [],
-                            "switch": "-tool_task_report 'task metric <str>'",
+                            "switch": "-tool_task_report 'task metric step index <str>'",
                             "type": "[file]",
                             "value": []
                         }

--- a/tests/core/test_create_cmdline.py
+++ b/tests/core/test_create_cmdline.py
@@ -62,6 +62,23 @@ def test_limited_switchlist(monkeypatch):
     assert chip.get('option', 'loglevel') == 'DEBUG'
     assert chip.get('option', 'var', 'foo') == ['bar']
 
+def test_pernode_optional(monkeypatch):
+    '''Ensure we can specify pernode overrides from CLI, and that they support
+    spaces in values.'''
+    args = ['sc']
+    args += ['-asic_logiclib', 'syn "syn lib"']
+    args += ['-asic_logiclib', 'syn 1 "\\"syn1\\" lib"']
+    args += ['-asic_logiclib', '"my lib"']
+
+    chip = do_cli_test(args, monkeypatch)
+
+    assert chip.get('asic', 'logiclib') == ['my lib']
+    assert chip.get('asic', 'logiclib', step='syn') == ['syn lib']
+    assert chip.get('asic', 'logiclib', step='syn', index=1) == ['"syn1" lib']
+
+def test_pernode_required(monkeypatch):
+    pass
+
 def _cast(val, sctype):
     if sctype.startswith('['):
         # TODO: doesn't handle examples w/ multiple list items (we do not have
@@ -80,7 +97,7 @@ def _cast(val, sctype):
         return bool(val)
     else:
         # everything else (str, file, dir) is treated like a string
-        return val
+        return val.strip('"')
 
 def test_cli_examples(monkeypatch):
     # Need to mock this function, since our cfg CLI example will try to call it


### PR DESCRIPTION
This PR adds support for providing step/index for per-node parameters via the CLI. 

The syntax is to add the step and index name prior to the value. These must always be included for "required" pernode parameters:

- `sc -record_distro 'import 0 ubuntu'` (good)
- `sc -record_distro ubuntu` (error)

You are still allowed to supply string values with spaces for required pernode parameters, as before:

- `sc -record_distro 'import 0 my distro name'` -> stores "my distro name" in [record, distro]

For optional parameters, you can omit the step and index, provide a step only, or provide a step and an index:

- `sc -asic_logiclib mylib`
- `sc -asic_logiclib 'syn synlib'`
- `sc -asic_logiclib 'syn 1 syn1lib'`

Values with spaces for optional parameters must be wrapped in quotes now:

- `sc -asic_logiclib 'syn "syn lib"'` 


