### PR TITLE
schema_cfg: add import fallback for generate_defaults

### DIFF
--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -4,9 +4,9 @@ import copy as pycopy
 import json
 import re
 
-# Default import must be relative, to facilitate KLayout's direct import of the
-# schema package. However, the fallback allows running this script directly to
-# generate defaults.json.
+# Default import must be relative, to facilitate tools with Python interfaces
+# (such as KLayout) directly importing the schema package. However, the fallback
+# allows running this script directly to generate defaults.json.
 try:
     from .utils import trim
 except ImportError:

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -4,7 +4,13 @@ import copy as pycopy
 import json
 import re
 
-from .utils import trim
+# Default import must be relative, to facilitate KLayout's direct import of the
+# schema package. However, the fallback allows running this script directly to
+# generate defaults.json.
+try:
+    from .utils import trim
+except ImportError:
+    from siliconcompiler.schema.utils import trim
 
 SCHEMA_VERSION = '0.24.0'
 


### PR DESCRIPTION
I noticed that the relative import required for our new KLayout scheme breaks the generate_defaults script - this PR fixes that.