### PR TITLE
Remove stdin requirement from yosys setup script

### DIFF
--- a/setup/install-yosys.sh
+++ b/setup/install-yosys.sh
@@ -4,7 +4,7 @@
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
 
 # From: https://github.com/YosysHQ/yosys/blob/f2c689403ace0637b7455bac8f1e8d4bc312e74f/README.md
-sudo apt-get install build-essential clang bison flex \
+sudo apt-get install -y build-essential clang bison flex \
 	libreadline-dev gawk tcl-dev libffi-dev git \
 	graphviz xdot pkg-config python3 libboost-system-dev \
 	libboost-python-dev libboost-filesystem-dev zlib1g-dev


### PR DESCRIPTION
Currently, the yosys setup script requires you to enter 'y' in response to the apt-get install command. This is a bit inconvenient for headless install methods.