### PR TITLE
schema_obj: update write_csv to handle per-node values

### DIFF
--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -274,8 +274,8 @@ class Schema:
         if cfg['pernode'] != 'never':
             for step in cfg['nodevalue']:
                 for index in cfg['nodevalue'][step]:
-                    if index == 'default': index = None
-                    vals.append((cfg['nodevalue'][step][index], step, index))
+                    index_arg = None if index == 'default' else index
+                    vals.append((cfg['nodevalue'][step][index], step, index_arg))
 
         return vals
 
@@ -689,12 +689,19 @@ class Schema:
         allkeys = self.allkeys()
         for key in allkeys:
             keypath = ','.join(key)
-            value = self.get(*key)
-            if isinstance(value,list):
-                for item in value:
-                    csvwriter.writerow([keypath, item])
-            else:
-                csvwriter.writerow([keypath, value])
+            for value, step, index in self._getvals(*key):
+                if step is None and index is None:
+                    keypath = ','.join(key)
+                elif index is None:
+                    keypath = ','.join(key + [step, 'default'] )
+                else:
+                    keypath = ','.join(key + [step, index])
+
+                if isinstance(value,list):
+                    for item in value:
+                        csvwriter.writerow([keypath, item])
+                else:
+                    csvwriter.writerow([keypath, value])
 
     ###########################################################################
     def copy(self):

--- a/tests/core/test_write_manifest.py
+++ b/tests/core/test_write_manifest.py
@@ -68,25 +68,26 @@ multiple lines, spaces, and TCL special characters. This package costs $5 {for r
 def test_csv():
     chip = siliconcompiler.Chip('test')
     chip.input('source.v')
+    chip.add('asic', 'logiclib', 'mainlib')
+    chip.add('asic', 'logiclib', 'synlib', step='syn')
+    chip.add('asic', 'logiclib', 'syn1lib', step='syn', index=1)
 
     chip.write_manifest('test.csv')
 
-    design_found = False
-    input_found = False
     with open('test.csv', 'r', newline='') as f:
         csvreader = csv.reader(f)
+        data = {}
         for row in csvreader:
             assert len(row) == 2
 
             keypath, val = row
-            if keypath == 'design':
-                assert val == 'test'
-                design_found = True
-            elif keypath == 'input,rtl,verilog':
-                assert val == 'source.v'
-                input_found = True
-    assert design_found
-    assert input_found
+            data[keypath] = val
+
+    assert data['design'] == 'test'
+    assert data['input,rtl,verilog'] == 'source.v'
+    assert data['asic,logiclib'] == 'mainlib'
+    assert data['asic,logiclib,syn,default'] == 'synlib'
+    assert data['asic,logiclib,syn,1'] == 'syn1lib'
 
 #########################
 if __name__ == "__main__":


### PR DESCRIPTION
This wasn't on my formal todo list, but I had the code for this already so I figured we might as well get it in (was going to be bundled with TCL manifest changes we're punting).

This PR adds some logic to the `write_csv` method to dump per-node values as well as the global values. Previous behavior was that per-node values get ignored.

Example:

```python
    chip.add('asic', 'logiclib', 'mainlib')
    chip.add('asic', 'logiclib', 'synlib', step='syn')
    chip.add('asic', 'logiclib', 'syn1lib', step='syn', index=1)
```

![after](https://user-images.githubusercontent.com/4412459/219486543-332d8847-883c-4a5d-af32-35dd176bc495.png)

