### PR TITLE
Remove make docs SC-49

### DIFF
--- a/siliconcompiler/checklists/oh_tapeout.py
+++ b/siliconcompiler/checklists/oh_tapeout.py
@@ -1,9 +1,5 @@
 import siliconcompiler
 
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    return setup(chip)
-
 def setup(chip):
     '''Subset of OH! library tapeout checklist.
 
@@ -36,3 +32,8 @@ def setup(chip):
                   'Is there a written specification?')
 
     return checklist
+
+##################################################
+if __name__ == "__main__":
+    checklist = setup(siliconcompiler.Chip('<checklist>'))
+    checklist.write_manifest(f"{checklist.top()}.json")

--- a/siliconcompiler/flows/asicflow.py
+++ b/siliconcompiler/flows/asicflow.py
@@ -5,7 +5,6 @@ from siliconcompiler.flows._common import setup_frontend
 ############################################################################
 # DOCS
 ############################################################################
-
 def make_docs():
     chip = siliconcompiler.Chip('<topmodule>')
     n = 3
@@ -149,5 +148,5 @@ def setup(chip, flowname='asicflow', syn_np=1, floorplan_np=1, physyn_np=1, plac
 
 ##################################################
 if __name__ == "__main__":
-    chip = make_docs()
-    chip.write_flowgraph("asicflow.png", flow='asicflow')
+    flow = make_docs()
+    flow.write_flowgraph(f"{flow.top()}.png", flow=flow.top())

--- a/siliconcompiler/flows/asicflow.py
+++ b/siliconcompiler/flows/asicflow.py
@@ -5,8 +5,7 @@ from siliconcompiler.flows._common import setup_frontend
 ############################################################################
 # DOCS
 ############################################################################
-def make_docs():
-    chip = siliconcompiler.Chip('<topmodule>')
+def make_docs(chip):
     n = 3
     return setup(chip, syn_np=n, floorplan_np=n, physyn_np=n, place_np=n, cts_np=n, route_np=n)
 
@@ -148,5 +147,5 @@ def setup(chip, flowname='asicflow', syn_np=1, floorplan_np=1, physyn_np=1, plac
 
 ##################################################
 if __name__ == "__main__":
-    flow = make_docs()
+    flow = make_docs(siliconcompiler.Chip('<flow>'))
     flow.write_flowgraph(f"{flow.top()}.png", flow=flow.top())

--- a/siliconcompiler/flows/asictopflow.py
+++ b/siliconcompiler/flows/asictopflow.py
@@ -1,10 +1,5 @@
 import siliconcompiler
 
-def make_docs():
-    chip = siliconcompiler.Chip('<topmodule>')
-    chip.set('option', 'flow', 'asictopflow')
-    return setup(chip)
-
 def setup(chip):
     '''A flow for stitching together hardened blocks without doing any automated
     place-and-route.
@@ -26,3 +21,8 @@ def setup(chip):
         flow.set('flowgraph', flow.design, step, '0', 'goal', 'errors', 0)
 
     return flow
+
+##################################################
+if __name__ == "__main__":
+    flow = setup(siliconcompiler.Chip('<flow>'))
+    flow.write_flowgraph(f"{flow.top()}.png", flow=flow.top())

--- a/siliconcompiler/flows/dvflow.py
+++ b/siliconcompiler/flows/dvflow.py
@@ -3,10 +3,7 @@ import siliconcompiler
 ############################################################################
 # DOCS
 ############################################################################
-
-def make_docs():
-    chip = siliconcompiler.Chip('<topmodule>')
-    chip.set('option', 'flow', 'dvflow')
+def make_docs(chip):
     return setup(chip, np=5)
 
 #############################################################################
@@ -85,5 +82,5 @@ def setup(chip, np=1):
 
 ##################################################
 if __name__ == "__main__":
-    flow = make_docs()
+    flow = make_docs(siliconcompiler.Chip('<flow>'))
     flow.write_flowgraph(f"{flow.top()}.png", flow=flow.top())

--- a/siliconcompiler/flows/dvflow.py
+++ b/siliconcompiler/flows/dvflow.py
@@ -85,5 +85,5 @@ def setup(chip, np=1):
 
 ##################################################
 if __name__ == "__main__":
-    chip = make_docs()
-    chip.write_flowgraph("dvflow.png")
+    flow = make_docs()
+    flow.write_flowgraph(f"{flow.top()}.png", flow=flow.top())

--- a/siliconcompiler/flows/fpgaflow.py
+++ b/siliconcompiler/flows/fpgaflow.py
@@ -6,9 +6,7 @@ from siliconcompiler.flows._common import setup_frontend
 ############################################################################
 # DOCS
 ############################################################################
-
-def make_docs():
-    chip = siliconcompiler.Chip('<topmodule>')
+def make_docs(chip):
     chip.set('fpga', 'partname', 'ice40')
     return setup(chip)
 
@@ -203,5 +201,5 @@ def tool_lookup(flow, step):
 
 ##################################################
 if __name__ == "__main__":
-    flow = make_docs()
+    flow = make_docs(siliconcompiler.Chip('<flow>'))
     flow.write_flowgraph(f"{flow.top()}.png", flow=flow.top())

--- a/siliconcompiler/flows/fpgaflow.py
+++ b/siliconcompiler/flows/fpgaflow.py
@@ -9,7 +9,6 @@ from siliconcompiler.flows._common import setup_frontend
 
 def make_docs():
     chip = siliconcompiler.Chip('<topmodule>')
-    chip.set('option', 'flow', 'fpgaflow')
     chip.set('fpga', 'partname', 'ice40')
     return setup(chip)
 
@@ -204,5 +203,5 @@ def tool_lookup(flow, step):
 
 ##################################################
 if __name__ == "__main__":
-    chip = make_docs()
-    chip.write_flowgraph("fpgaflow.png")
+    flow = make_docs()
+    flow.write_flowgraph(f"{flow.top()}.png", flow=flow.top())

--- a/siliconcompiler/flows/lintflow.py
+++ b/siliconcompiler/flows/lintflow.py
@@ -1,14 +1,5 @@
 import siliconcompiler
 
-############################################################################
-# DOCS
-############################################################################
-
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    chip.set('option', 'flow', 'lintflow')
-    return setup(chip)
-
 ###########################################################################
 # Flowgraph Setup
 ############################################################################
@@ -35,5 +26,5 @@ def setup(chip):
 
 ##################################################
 if __name__ == "__main__":
-    chip = make_docs()
-    chip.write_flowgraph("lintflow.png")
+    flow = setup(siliconcompiler.Chip('<flow>'))
+    flow.write_flowgraph(f"{flow.top()}.png", flow=flow.top())

--- a/siliconcompiler/flows/showflow.py
+++ b/siliconcompiler/flows/showflow.py
@@ -3,8 +3,7 @@ import siliconcompiler
 ############################################################################
 # DOCS
 ############################################################################
-def make_docs():
-    chip = siliconcompiler.Chip('<topmodule>')
+def make_docs(chip):
     return setup(chip, filetype='gds', np=3)
 
 ###########################################################################
@@ -46,5 +45,5 @@ def setup(chip, flowname='showflow', filetype=None, screenshot=False, np=1):
 
 ##################################################
 if __name__ == "__main__":
-    flow = make_docs()
+    flow = make_docs(siliconcompiler.Chip('<flow>'))
     flow.write_flowgraph(f"{flow.top()}.png", flow=flow.top())

--- a/siliconcompiler/flows/showflow.py
+++ b/siliconcompiler/flows/showflow.py
@@ -3,7 +3,6 @@ import siliconcompiler
 ############################################################################
 # DOCS
 ############################################################################
-
 def make_docs():
     chip = siliconcompiler.Chip('<topmodule>')
     return setup(chip, filetype='gds', np=3)
@@ -47,5 +46,5 @@ def setup(chip, flowname='showflow', filetype=None, screenshot=False, np=1):
 
 ##################################################
 if __name__ == "__main__":
-    chip = make_docs()
-    chip.write_flowgraph("showflow.png")
+    flow = make_docs()
+    flow.write_flowgraph(f"{flow.top()}.png", flow=flow.top())

--- a/siliconcompiler/flows/signoffflow.py
+++ b/siliconcompiler/flows/signoffflow.py
@@ -1,10 +1,5 @@
 import siliconcompiler
 
-def make_docs():
-    chip = siliconcompiler.Chip('<topmodule>')
-    chip.set('option', 'flow', 'signoffflow')
-    return setup(chip)
-
 def setup(chip):
     '''A flow for running LVS/DRC signoff on a GDS layout.
 
@@ -36,3 +31,8 @@ def setup(chip):
         flow.set('flowgraph', flowname, step, '0', 'goal', 'errors', 0)
 
     return flow
+
+##################################################
+if __name__ == "__main__":
+    flow = setup(siliconcompiler.Chip('<flow>'))
+    flow.write_flowgraph(f"{flow.top()}.png", flow=flow.top())

--- a/siliconcompiler/libs/asap7sc7p5t.py
+++ b/siliconcompiler/libs/asap7sc7p5t.py
@@ -1,10 +1,6 @@
 import os
 import siliconcompiler
 
-def make_docs():
-    chip =  siliconcompiler.Chip('<design>')
-    return setup(chip)
-
 def _setup_lib(chip, libname, suffix):
     lib = siliconcompiler.Library(chip, libname)
 
@@ -119,3 +115,8 @@ def setup(chip):
         libs.append(_setup_lib(chip, libname, suffix))
 
     return libs
+
+#########################
+if __name__ == "__main__":
+    for lib in setup(siliconcompiler.Chip('<lib>')):
+        lib.write_manifest(f'{lib.top()}.json')

--- a/siliconcompiler/libs/nangate45.py
+++ b/siliconcompiler/libs/nangate45.py
@@ -1,10 +1,6 @@
 import os
 import siliconcompiler
 
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    return setup(chip)
-
 def setup(chip):
     '''
     Nangate open standard cell library for FreePDK45.
@@ -113,6 +109,5 @@ def setup(chip):
 
 #########################
 if __name__ == "__main__":
-
-    lib = make_docs()
-    lib.write_manifest('nangate45.tcl')
+    lib = setup(siliconcompiler.Chip('<lib>'))
+    lib.write_manifest(f'{lib.top()}.json')

--- a/siliconcompiler/libs/sky130hd.py
+++ b/siliconcompiler/libs/sky130hd.py
@@ -1,10 +1,6 @@
 import os
 import siliconcompiler
 
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    return setup(chip)
-
 def setup(chip):
     '''
     Skywater130 standard cell library.
@@ -131,6 +127,5 @@ def setup(chip):
 
 #########################
 if __name__ == "__main__":
-
-    lib = make_docs()
-    lib.write_manifest('sky130.tcl')
+    lib = setup(siliconcompiler.Chip('<lib>'))
+    lib.write_manifest(f'{lib.top()}.json')

--- a/siliconcompiler/libs/sky130io.py
+++ b/siliconcompiler/libs/sky130io.py
@@ -1,10 +1,6 @@
 import os
 import siliconcompiler
 
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    return setup(chip)
-
 def setup(chip):
     '''
     Skywater130 I/O library.
@@ -38,3 +34,8 @@ def setup(chip):
     lib.add('output', stackup, 'gds', os.path.join(libdir, 'sky130_ef_io__gpiov2_pad_wrapped.gds'))
 
     return lib
+
+#########################
+if __name__ == "__main__":
+    lib = setup(siliconcompiler.Chip('<lib>'))
+    lib.write_manifest(f'{lib.top()}.json')

--- a/siliconcompiler/pdks/asap7.py
+++ b/siliconcompiler/pdks/asap7.py
@@ -1,11 +1,6 @@
 import os
 import siliconcompiler
 
-def make_docs():
-    chip = siliconcompiler.Chip('asap7')
-
-    return setup(chip)
-
 def setup(chip):
     '''
     The asap7 PDK was developed at ASU in collaboration with ARM Research.
@@ -105,6 +100,5 @@ def setup(chip):
 
 #########################
 if __name__ == "__main__":
-
-    chip = make_docs()
-    chip.write_manifest('asap7.tcl')
+    pdk = setup(siliconcompiler.Chip('<pdk>'))
+    pdk.write_manifest(f'{pdk.top()}.json')

--- a/siliconcompiler/pdks/freepdk45.py
+++ b/siliconcompiler/pdks/freepdk45.py
@@ -2,14 +2,6 @@
 import os
 import siliconcompiler
 
-############################################################################
-# DOCS
-############################################################################
-
-def make_docs():
-    chip = siliconcompiler.Chip('freepdk45')
-    return setup(chip)
-
 ####################################################
 # PDK Setup
 ####################################################
@@ -111,6 +103,5 @@ def setup(chip):
 
 #########################
 if __name__ == "__main__":
-
-    chip = make_docs()
-    chip.write_manifest('freepdk45.tcl')
+    pdk = setup(siliconcompiler.Chip('<pdk>'))
+    pdk.write_manifest(f'{pdk.top()}.json')

--- a/siliconcompiler/pdks/skywater130.py
+++ b/siliconcompiler/pdks/skywater130.py
@@ -2,14 +2,6 @@
 import os
 import siliconcompiler
 
-############################################################################
-# DOCS
-############################################################################
-
-def make_docs():
-    chip = siliconcompiler.Chip('skywater130')
-    return setup(chip)
-
 ####################################################
 # PDK Setup
 ####################################################
@@ -118,6 +110,5 @@ def setup(chip):
 
 #########################
 if __name__ == "__main__":
-
-    chip = make_docs()
-    chip.write_manifest('skywater130.tcl')
+    pdk = setup(siliconcompiler.Chip('<pdk>'))
+    pdk.write_manifest(f'{pdk.top()}.json')

--- a/siliconcompiler/sphinx_ext/dynamicgen.py
+++ b/siliconcompiler/sphinx_ext/dynamicgen.py
@@ -138,10 +138,9 @@ class DynamicGen(SphinxDirective):
             # Then use setup doc string
             self.generate_documentation_from_object(setup, path, s)
 
-        make_docs = self.get_make_docs_method(module)
-        if not make_docs:
+        chips = self.configure_chip_for_docs(module)
+        if not chips:
             return None
-        chips = make_docs()
 
         if not isinstance(chips, list):
             chips = [chips]
@@ -299,6 +298,25 @@ class DynamicGen(SphinxDirective):
 
     def get_setup_method(self, module):
         return getattr(module, 'setup', None)
+
+    def make_chip(self):
+        return siliconcompiler.Chip('<design>')
+
+    def configure_chip_for_docs(self, module):
+        make_docs = getattr(module, 'make_docs', None)
+        chip = self.make_chip()
+        if make_docs:
+            return make_docs()
+        else:
+            setup = self.get_setup_method(module)
+            if not setup:
+                return None
+            new_chip = setup(chip)
+            if new_chip:
+                return new_chip
+            else:
+                # Setup didn't return anything so return the Chip object
+                return chip
 
 #########################
 # Specialized extensions

--- a/siliconcompiler/sphinx_ext/dynamicgen.py
+++ b/siliconcompiler/sphinx_ext/dynamicgen.py
@@ -449,6 +449,28 @@ class LibGen(DynamicGen):
 class ToolGen(DynamicGen):
     PATH = 'tools'
 
+    def make_chip(self):
+        chip = super().make_chip()
+        self._setup_chip(chip, '<tool>', '<task>')
+
+        return chip
+
+    def _setup_chip(self, chip, tool_name, task_name):
+        step = chip.get('arg', 'step')
+        if not step:
+            step = '<step>'
+        index = chip.get('arg', 'index')
+        if not index:
+            index = '<index>'
+        chip.set('arg', 'step', step)
+        chip.set('arg', 'index', index)
+
+        flow = chip.get('option', 'flow')
+        if not flow:
+            flow = '<flow>'
+        chip.set('flowgraph', flow, step, index, 'tool', tool_name)
+        chip.set('flowgraph', flow, step, index, 'task', task_name)
+
     def configure_chip_for_docs(self, module, toolmodule=None):
         chip = self.make_chip()
         docs_chip, docs_configured = self._handle_make_docs(chip, module)
@@ -458,21 +480,13 @@ class ToolGen(DynamicGen):
             return docs_chip
 
         # set values for current step
-        step = '<step>'
-        index = '<index>'
-        chip.set('arg', 'step', step)
-        chip.set('arg', 'index', index)
-        flow = chip.get('option', 'flow')
-        if not flow:
-            flow = '<flow>'
+        toolname = module.__name__
         if self.__tool:
-            chip.set('flowgraph', flow, step, index, 'tool', self.__tool)
-        else:
-            chip.set('flowgraph', flow, step, index, 'tool', module.__name__)
+            toolname = self.__tool
+        taskname = '<task>'
         if self.__task:
-            chip.set('flowgraph', flow, step, index, 'task', self.__task)
-        else:
-            chip.set('flowgraph', flow, step, index, 'task', '<task>')
+            taskname = self.__task
+        self._setup_chip(chip, toolname, taskname)
 
         if toolmodule:
             return chip

--- a/siliconcompiler/targets/asap7_demo.py
+++ b/siliconcompiler/targets/asap7_demo.py
@@ -1,15 +1,9 @@
 import siliconcompiler
 from siliconcompiler.targets import utils
 
-def make_docs():
-    '''
-    Demonstration target for compiling ASICs with ASAP7 and the open-source
-    asicflow.
-    '''
-
-    chip = siliconcompiler.Chip('asap7_demo')
-    setup(chip)
-    return chip
+####################################################
+# Target Setup
+####################################################
 
 def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1):
     '''
@@ -70,5 +64,6 @@ def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, rou
 
 #########################
 if __name__ == "__main__":
-
-    chip = make_docs()
+    target = siliconcompiler.Chip('<target>')
+    setup(target)
+    target.write_manifest('asap7_demo.json')

--- a/siliconcompiler/targets/fpgaflow_demo.py
+++ b/siliconcompiler/targets/fpgaflow_demo.py
@@ -2,18 +2,18 @@ import siliconcompiler
 from siliconcompiler.targets import utils
 
 def make_docs():
-    '''
-    Demonstration target for running the open-source fpgaflow.
-    '''
-
-    chip = siliconcompiler.Chip('<design>')
+    chip = siliconcompiler.Chip('<target>')
     chip.set('fpga', 'partname', 'ice40up5k-sg48')
     setup(chip)
     return chip
 
+####################################################
+# Target Setup
+####################################################
+
 def setup(chip):
     '''
-    Target setup
+    Demonstration target for running the open-source fpgaflow.
     '''
 
     #1. Load flow
@@ -29,5 +29,5 @@ def setup(chip):
 
 #########################
 if __name__ == "__main__":
-
-    chip = make_docs()
+    target = make_docs()
+    target.write_manifest('fpgaflow_demo.json')

--- a/siliconcompiler/targets/fpgaflow_demo.py
+++ b/siliconcompiler/targets/fpgaflow_demo.py
@@ -1,11 +1,8 @@
 import siliconcompiler
 from siliconcompiler.targets import utils
 
-def make_docs():
-    chip = siliconcompiler.Chip('<target>')
+def make_docs(chip):
     chip.set('fpga', 'partname', 'ice40up5k-sg48')
-    setup(chip)
-    return chip
 
 ####################################################
 # Target Setup
@@ -29,5 +26,6 @@ def setup(chip):
 
 #########################
 if __name__ == "__main__":
-    target = make_docs()
+    target = make_docs(siliconcompiler.Chip('<target>'))
+    setup(target)
     target.write_manifest('fpgaflow_demo.json')

--- a/siliconcompiler/targets/freepdk45_demo.py
+++ b/siliconcompiler/targets/freepdk45_demo.py
@@ -1,23 +1,8 @@
 import siliconcompiler
 from siliconcompiler.targets import utils
 
-############################################################################
-# DOCS
-############################################################################
-
-def make_docs():
-    '''
-    Demonstration target for compiling ASICs with FreePDK45 and the open-source
-    asicflow.
-    '''
-
-    chip = siliconcompiler.Chip('<design>')
-    setup(chip)
-    return chip
-
-
 ####################################################
-# PDK Setup
+# Target Setup
 ####################################################
 
 def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1):
@@ -70,5 +55,6 @@ def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, rou
 
 #########################
 if __name__ == "__main__":
-
-    chip = make_docs()
+    target = siliconcompiler.Chip('<target>')
+    setup(target)
+    target.write_manifest('freepdk45_demo.json')

--- a/siliconcompiler/targets/skywater130_demo.py
+++ b/siliconcompiler/targets/skywater130_demo.py
@@ -1,23 +1,8 @@
 import siliconcompiler
 from siliconcompiler.targets import utils
 
-############################################################################
-# DOCS
-############################################################################
-
-def make_docs():
-    '''
-    Demonstration target for compiling ASICs with Skywater130 and the
-    open-source asicflow.
-    '''
-
-    chip = siliconcompiler.Chip('<design>')
-    setup(chip)
-    return chip
-
-
 ####################################################
-# PDK Setup
+# Target Setup
 ####################################################
 
 def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, route_np=1):
@@ -72,5 +57,6 @@ def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, rou
 
 #########################
 if __name__ == "__main__":
-
-    chip = make_docs()
+    target = siliconcompiler.Chip('<target>')
+    setup(target)
+    target.write_manifest('skywater130_demo.json')

--- a/siliconcompiler/tools/bambu/bambu.py
+++ b/siliconcompiler/tools/bambu/bambu.py
@@ -3,13 +3,10 @@
 
 import importlib
 
-import siliconcompiler
-
 ####################################################################
 # Make Docs
 ####################################################################
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
+def make_docs(chip):
     step = 'import'
     index = '0'
     flow = '<flow>'

--- a/siliconcompiler/tools/bambu/bambu.py
+++ b/siliconcompiler/tools/bambu/bambu.py
@@ -7,13 +7,6 @@ import importlib
 # Make Docs
 ####################################################################
 def make_docs(chip):
-    step = 'import'
-    index = '0'
-    flow = '<flow>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, step, index, 'task', '<task>')
     setup = getattr(importlib.import_module('tools.bambu.import'), 'setup')
     setup(chip)
     return chip

--- a/siliconcompiler/tools/bluespec/bluespec.py
+++ b/siliconcompiler/tools/bluespec/bluespec.py
@@ -15,13 +15,10 @@ Installation: https://github.com/B-Lang-org/bsc#download
 
 import importlib
 
-import siliconcompiler
-
 ####################################################################
 # Make Docs
 ####################################################################
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
+def make_docs(chip):
     step = 'import'
     index = '0'
     flow = '<flow>'

--- a/siliconcompiler/tools/bluespec/bluespec.py
+++ b/siliconcompiler/tools/bluespec/bluespec.py
@@ -19,13 +19,6 @@ import importlib
 # Make Docs
 ####################################################################
 def make_docs(chip):
-    step = 'import'
-    index = '0'
-    flow = '<flow>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, step, index, 'task', '<task>')
     setup = getattr(importlib.import_module('tools.bluespec.import'), 'setup')
     setup(chip)
     return chip

--- a/siliconcompiler/tools/chisel/chisel.py
+++ b/siliconcompiler/tools/chisel/chisel.py
@@ -20,13 +20,6 @@ import importlib
 # Make Docs
 ####################################################################
 def make_docs(chip):
-    step = 'import'
-    index = '0'
-    flow = '<flow>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, step, index, 'task', '<task>')
     setup = getattr(importlib.import_module('tools.chisel.import'), 'setup')
     setup(chip)
     return chip

--- a/siliconcompiler/tools/chisel/chisel.py
+++ b/siliconcompiler/tools/chisel/chisel.py
@@ -16,13 +16,10 @@ installed. Instructions: https://www.scala-sbt.org/download.html.
 
 import importlib
 
-import siliconcompiler
-
 ####################################################################
 # Make Docs
 ####################################################################
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
+def make_docs(chip):
     step = 'import'
     index = '0'
     flow = '<flow>'

--- a/siliconcompiler/tools/genfasm/genfasm.py
+++ b/siliconcompiler/tools/genfasm/genfasm.py
@@ -2,14 +2,10 @@
 To-Do: Add details here
 '''
 
-import siliconcompiler
-
 ######################################################################
 # Make Docs
 ######################################################################
-
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
+def make_docs(chip):
     step = 'bitstream'
     index = '<index>'
     flow = '<flow>'

--- a/siliconcompiler/tools/genfasm/genfasm.py
+++ b/siliconcompiler/tools/genfasm/genfasm.py
@@ -6,13 +6,6 @@ To-Do: Add details here
 # Make Docs
 ######################################################################
 def make_docs(chip):
-    step = 'bitstream'
-    index = '<index>'
-    flow = '<flow>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, step, index, 'task', '<task>')
     from tools.genfasm.bitstream import setup
     setup(chip)
     return chip

--- a/siliconcompiler/tools/ghdl/ghdl.py
+++ b/siliconcompiler/tools/ghdl/ghdl.py
@@ -19,9 +19,7 @@ import siliconcompiler
 #####################################################################
 # Make Docs
 #####################################################################
-
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
+def make_docs(chip):
     step = 'import'
     index = '<index>'
     flow = '<flow>'

--- a/siliconcompiler/tools/ghdl/ghdl.py
+++ b/siliconcompiler/tools/ghdl/ghdl.py
@@ -20,13 +20,6 @@ import siliconcompiler
 # Make Docs
 #####################################################################
 def make_docs(chip):
-    step = 'import'
-    index = '<index>'
-    flow = '<flow>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, step, index, 'task', '<task>')
     setup = getattr(importlib.import_module('tools.ghdl.import'), 'setup')
     setup(chip)
     return chip

--- a/siliconcompiler/tools/icarus/icarus.py
+++ b/siliconcompiler/tools/icarus/icarus.py
@@ -11,15 +11,10 @@ Sources: https://github.com/steveicarus/iverilog.git
 Installation: https://github.com/steveicarus/iverilog.git
 '''
 
-import siliconcompiler
-
 ####################################################################
 # Make Docs
 ####################################################################
-
-def make_docs():
-
-    chip = siliconcompiler.Chip('<design>')
+def make_docs(chip):
     step = 'compile'
     index = '<index>'
     flow = '<flow>'

--- a/siliconcompiler/tools/icarus/icarus.py
+++ b/siliconcompiler/tools/icarus/icarus.py
@@ -15,13 +15,6 @@ Installation: https://github.com/steveicarus/iverilog.git
 # Make Docs
 ####################################################################
 def make_docs(chip):
-    step = 'compile'
-    index = '<index>'
-    flow = '<flow>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, step, index, 'task', '<task>')
     from tools.icarus.compile import setup
     setup(chip)
     return chip

--- a/siliconcompiler/tools/icepack/icepack.py
+++ b/siliconcompiler/tools/icepack/icepack.py
@@ -13,19 +13,10 @@ Installation: https://github.com/YosysHQ/icestorm
 #####################################################################
 # Make Docs
 #####################################################################
-
 def make_docs(chip):
-    step = 'bitstream'
-    index = '<index>'
-    flow = '<flow>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, step, index, 'task', '<task>')
     from tools.icepack.bitstream import setup
     setup(chip)
     return chip
-
 
 ################################
 #  Custom runtime options

--- a/siliconcompiler/tools/icepack/icepack.py
+++ b/siliconcompiler/tools/icepack/icepack.py
@@ -10,14 +10,11 @@ Sources: https://github.com/YosysHQ/icestorm
 Installation: https://github.com/YosysHQ/icestorm
 '''
 
-import siliconcompiler
-
 #####################################################################
 # Make Docs
 #####################################################################
 
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
+def make_docs(chip):
     step = 'bitstream'
     index = '<index>'
     flow = '<flow>'

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -15,23 +15,11 @@ from pathlib import Path
 import platform
 import shutil
 
-import siliconcompiler
-
 ####################################################################
 # Make Docs
 ####################################################################
-
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    chip.load_target('freepdk45_demo')
-    step = 'export'
-    index = '<index>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('flowgraph', chip.get('option', 'flow'), step, index, 'task', '<task>')
-    setup(chip)
-
-    return chip
+def make_docs(chip):
+    chip.load_target("freepdk45_demo")
 
 ####################################################################
 # Setup tool

--- a/siliconcompiler/tools/klayout/screenshot.py
+++ b/siliconcompiler/tools/klayout/screenshot.py
@@ -1,19 +1,10 @@
-import siliconcompiler
+from siliconcompiler.tools.klayout import klayout
 from siliconcompiler.tools.klayout.klayout import setup as setup_tool
 from siliconcompiler.tools.klayout.show import find_incoming_ext
 
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    chip.load_target('freepdk45_demo')
-    step = 'screenshot'
-    index = '<index>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('flowgraph', chip.get('option', 'flow'), step, index, 'task', 'screenshot')
+def make_docs(chip):
+    klayout.make_docs(chip)
     chip.set('tool', 'klayout', 'task', 'screenshot', 'var', 'show_filepath', '<path>')
-    setup(chip)
-
-    return chip
 
 def setup(chip):
     ''' Helper method for configs specific to screenshot tasks.

--- a/siliconcompiler/tools/klayout/show.py
+++ b/siliconcompiler/tools/klayout/show.py
@@ -1,18 +1,9 @@
-import siliconcompiler
+from siliconcompiler.tools.klayout import klayout
 from siliconcompiler.tools.klayout.klayout import setup as setup_tool
 
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    chip.load_target('freepdk45_demo')
-    step = 'show'
-    index = '<index>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('flowgraph', chip.get('option', 'flow'), step, index, 'task', 'show')
+def make_docs(chip):
+    klayout.make_docs(chip)
     chip.set('tool', 'klayout', 'task', 'show', 'var', 'show_filepath', '<path>')
-    setup(chip)
-
-    return chip
 
 def setup(chip):
     ''' Helper method for configs specific to show tasks.

--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -9,33 +9,11 @@ Installation: https://github.com/RTimothyEdwards/magic
 Sources: https://github.com/RTimothyEdwards/magic
 '''
 
-import siliconcompiler
-
 ####################################################################
 # Make Docs
 ####################################################################
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    from pdks import skywater130
-    chip.use(skywater130)
-    index = '<index>'
-    flow = '<flow>'
-    chip.set('arg','index',index)
-    chip.set('option', 'flow', flow)
-
-    # check drc
-    from tools.magic.drc import setup as setup_drc
-    chip.set('arg','step', 'drc')
-    chip.set('flowgraph', flow, 'drc', index, 'task', 'drc')
-    setup_drc(chip)
-
-    # check lvs
-    from tools.magic.extspice import setup as setup_extspice
-    chip.set('arg','step', 'extspice')
-    chip.set('flowgraph', flow, 'extspice', index, 'task', 'extspice')
-    setup(chip)
-
-    return chip
+def make_docs(chip):
+    chip.load_target("freepdk45_demo")
 
 ################################
 # Setup Tool (pre executable)

--- a/siliconcompiler/tools/netgen/netgen.py
+++ b/siliconcompiler/tools/netgen/netgen.py
@@ -11,15 +11,11 @@ Installation: https://github.com/RTimothyEdwards/netgen
 Sources: https://github.com/RTimothyEdwards/netgen
 '''
 
-import siliconcompiler
-
 ####################################################################
 # Make Docs
 ####################################################################
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    from pdks import skywater130
-    chip.use(skywater130)
+def make_docs(chip):
+    chip.load_target('skywater130_demo')
     step = 'lvs'
     index = '<index>'
     flow = '<flow>'

--- a/siliconcompiler/tools/netgen/netgen.py
+++ b/siliconcompiler/tools/netgen/netgen.py
@@ -15,17 +15,8 @@ Sources: https://github.com/RTimothyEdwards/netgen
 # Make Docs
 ####################################################################
 def make_docs(chip):
-    chip.load_target('skywater130_demo')
-    step = 'lvs'
-    index = '<index>'
-    flow = '<flow>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, step, index, 'task', '<task>')
     from tools.netgen.lvs import setup
     setup(chip)
-
     return chip
 
 ################################

--- a/siliconcompiler/tools/nextpnr/nextpnr.py
+++ b/siliconcompiler/tools/nextpnr/nextpnr.py
@@ -13,13 +13,6 @@ Installation: https://github.com/YosysHQ/nextpnr
 # Make Docs
 #####################################################################
 def make_docs(chip):
-    step = 'apr'
-    index = '<index>'
-    flow = '<flow>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, step, index, 'task', '<task>')
     from tools.nextpnr.apr import setup
     setup(chip)
     return chip

--- a/siliconcompiler/tools/nextpnr/nextpnr.py
+++ b/siliconcompiler/tools/nextpnr/nextpnr.py
@@ -9,14 +9,10 @@ Sources: https://github.com/YosysHQ/nextpnr
 Installation: https://github.com/YosysHQ/nextpnr
 '''
 
-import siliconcompiler
-
 #####################################################################
 # Make Docs
 #####################################################################
-
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
+def make_docs(chip):
     step = 'apr'
     index = '<index>'
     flow = '<flow>'

--- a/siliconcompiler/tools/openfpgaloader/openfpgaloader.py
+++ b/siliconcompiler/tools/openfpgaloader/openfpgaloader.py
@@ -14,19 +14,6 @@ Installation: https://github.com/trabucayre/openFPGALoader
 Status: SC integration WIP
 '''
 
-import siliconcompiler
-
-####################################################################
-# Make Docs
-####################################################################
-
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    chip.set('arg','step','program')
-    chip.set('arg','index','0')
-    setup(chip)
-    return chip
-
 ################################
 # Setup Tool (pre executable)
 ################################

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -16,26 +16,11 @@ import os
 import json
 from jinja2 import Template
 
-import siliconcompiler
-
 ####################################################################
 # Make Docs
 ####################################################################
-
-def make_docs():
-
-    chip = siliconcompiler.Chip('<design>')
-    step = '<step>'
-    index = '<index>'
-    chip.set('arg', 'step', step)
-    chip.set('arg', 'index', index)
-    # TODO: how to make it clear in docs that certain settings are
-    # target-dependent?
-    chip.load_target('freepdk45_demo')
-    chip.set('flowgraph', chip.get('option', 'flow'), step, index, 'task', '<task>')
-    setup(chip)
-
-    return chip
+def make_docs(chip):
+    chip.load_target("asap7_demo")
 
 ################################
 # Setup Tool (pre executable)

--- a/siliconcompiler/tools/openroad/screenshot.py
+++ b/siliconcompiler/tools/openroad/screenshot.py
@@ -1,20 +1,14 @@
-import siliconcompiler
+from siliconcompiler.tools.openroad import openroad
 from siliconcompiler.tools.openroad.openroad import setup as setup_tool
 from siliconcompiler.tools.openroad.openroad import build_pex_corners
 from siliconcompiler.tools.openroad.show import copy_show_files, find_incoming_ext
 
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    chip.load_target('freepdk45_demo')
-    step = 'screenshot'
-    index = '<index>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('flowgraph', chip.get('option', 'flow'), step, index, 'task', 'screenshot')
+####################################################################
+# Make Docs
+####################################################################
+def make_docs(chip):
+    openroad.make_docs(chip)
     chip.set('tool', 'openroad', 'task', 'screenshot', 'var', 'show_filepath', '<path>')
-    setup(chip)
-
-    return chip
 
 def setup(chip):
     ''' Helper method for configs specific to screenshot tasks.

--- a/siliconcompiler/tools/openroad/show.py
+++ b/siliconcompiler/tools/openroad/show.py
@@ -1,21 +1,15 @@
-import siliconcompiler
 import shutil
 
+from siliconcompiler.tools.openroad import openroad
 from siliconcompiler.tools.openroad.openroad import setup as setup_tool
 from siliconcompiler.tools.openroad.openroad import build_pex_corners
 
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    chip.load_target('freepdk45_demo')
-    step = 'show'
-    index = '<index>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('flowgraph', chip.get('option', 'flow'), step, index, 'task', 'show')
+####################################################################
+# Make Docs
+####################################################################
+def make_docs(chip):
+    openroad.make_docs(chip)
     chip.set('tool', 'openroad', 'task', 'show', 'var', 'show_filepath', '<path>')
-    setup(chip)
-
-    return chip
 
 def setup(chip):
     ''' Helper method for configs specific to show tasks.

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -14,20 +14,6 @@ import os
 import sys
 import shutil
 
-import siliconcompiler
-
-####################################################################
-# Make Docs
-####################################################################
-def make_docs():
-
-    chip = siliconcompiler.Chip('<design>')
-    chip.load_target('freepdk45_demo')
-    chip.set('arg','step','import')
-    chip.set('arg','index','0')
-    setup(chip)
-    return chip
-
 ################################
 # Setup Tool (pre executable)
 ################################

--- a/siliconcompiler/tools/sv2v/sv2v.py
+++ b/siliconcompiler/tools/sv2v/sv2v.py
@@ -16,13 +16,10 @@ Installation: https://github.com/zachjs/sv2v
 
 import importlib
 
-import siliconcompiler
-
 ####################################################################
 # Make Docs
 ####################################################################
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
+def make_docs(chip):
     step = '<step>'
     index = '<index>'
     flow = '<flow>'

--- a/siliconcompiler/tools/sv2v/sv2v.py
+++ b/siliconcompiler/tools/sv2v/sv2v.py
@@ -20,13 +20,6 @@ import importlib
 # Make Docs
 ####################################################################
 def make_docs(chip):
-    step = '<step>'
-    index = '<index>'
-    flow = '<flow>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, step, index, 'task', '<task>')
     from tools.sv2v.convert import setup
     setup = getattr(importlib.import_module('tools.sv2v.convert'), 'setup')
     setup(chip)

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -14,27 +14,13 @@ Sources: https://github.com/verilator/verilator
 Installation: https://verilator.org/guide/latest/install.html
 '''
 
-import importlib
 import os
-
-import siliconcompiler
 
 ####################################################################
 # Make Docs
 ####################################################################
-
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    step = 'import'
-    index = '<index>'
-    flow = '<flow>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, step, index, 'task', '<task>')
-    setup = getattr(importlib.import_module('tools.verilator.import'), 'setup')
-    setup(chip)
-    return chip
+def make_docs(chip):
+    chip.load_target("freepdk45_demo")
 
 def setup(chip):
     ''' Per tool function that returns a dynamic options string based on

--- a/siliconcompiler/tools/vivado/vivado.py
+++ b/siliconcompiler/tools/vivado/vivado.py
@@ -14,14 +14,9 @@ import siliconcompiler
 ####################################################################
 # Make Docs
 ####################################################################
-
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    chip.set('arg','step', 'compile')
-    chip.set('arg','index', '<index>')
-    setup(chip)
-    return chip
-
+def make_docs(chip):
+    chip.set('fpga', 'partname', 'ice40up5k-sg48')
+    chip.load_target("fpgaflow_demo")
 
 ################################
 # Setup Tool (pre executable)

--- a/siliconcompiler/tools/vpr/vpr.py
+++ b/siliconcompiler/tools/vpr/vpr.py
@@ -21,8 +21,7 @@ import siliconcompiler
 ######################################################################
 # Make Docs
 ######################################################################
-
-def make_docs():
+def make_docs(chip):
 
 
     chip = siliconcompiler.Chip('<design>')

--- a/siliconcompiler/tools/vpr/vpr.py
+++ b/siliconcompiler/tools/vpr/vpr.py
@@ -16,22 +16,10 @@ Sources: https://github.com/verilog-to-routing/vtr-verilog-to-routing
 Installation: https://github.com/verilog-to-routing/vtr-verilog-to-routing
 '''
 
-import siliconcompiler
-
 ######################################################################
 # Make Docs
 ######################################################################
 def make_docs(chip):
-
-
-    chip = siliconcompiler.Chip('<design>')
-    step = 'apr'
-    index = '<index>'
-    flow = '<flow>'
-    chip.set('arg','step',step)
-    chip.set('arg','index',index)
-    chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, step, index, 'task', '<task>')
     from tools.vpr.apr import setup
     setup(chip)
     return chip

--- a/siliconcompiler/tools/xyce/xyce.py
+++ b/siliconcompiler/tools/xyce/xyce.py
@@ -16,20 +16,6 @@ Status: SC integration WIP
 
 import os
 
-import siliconcompiler
-
-
-#####################################################################
-# Make Docs
-#####################################################################
-
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    chip.set('arg','step', 'spice')
-    chip.set('arg','index', '<index>')
-    setup(chip)
-    return chip
-
 ################################
 # Setup Tool (pre executable)
 ################################

--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -1,16 +1,8 @@
 
 from siliconcompiler.tools.yosys.yosys import syn_setup, setup_asic, prepare_synthesis_libraries, create_abc_synthesis_constraints, syn_post_process
-import siliconcompiler
 
-def make_docs():
-    chip = siliconcompiler.Chip('<design>')
-    chip.load_target('freepdk45_demo')
-    chip.set('arg', 'step', '<step>')
-    chip.set('arg', 'index', '<index>')
-    chip.set('flowgraph', chip.get('option', 'flow'), '<step>', '<index>', 'tool', 'yosys')
-    chip.set('flowgraph', chip.get('option', 'flow'), '<step>', '<index>', 'task', 'syn_asic')
-    setup(chip)
-    return chip
+def make_docs(chip):
+    chip.load_target("asap7_demo")
 
 def setup(chip):
     ''' Helper method for configs specific to ASIC synthesis tasks.

--- a/siliconcompiler/tools/yosys/syn_fpga.py
+++ b/siliconcompiler/tools/yosys/syn_fpga.py
@@ -1,6 +1,10 @@
 
 from siliconcompiler.tools.yosys.yosys import syn_setup, create_vpr_lib, setup_fpga, syn_post_process
 
+def make_docs(chip):
+    chip.set('fpga', 'partname', 'ice40up5k-sg48')
+    chip.load_target("fpgaflow_demo")
+
 def setup(chip):
     ''' Helper method for configs specific to FPGA synthesis tasks.
     '''

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -19,27 +19,13 @@ import json
 import shutil
 import importlib
 from jinja2 import Template
-import siliconcompiler
 import siliconcompiler.tools.yosys.markDontUse as markDontUse
 
 ######################################################################
 # Make Docs
 ######################################################################
-
-def make_docs():
-
-
-    chip = siliconcompiler.Chip('<design>')
-    # TODO: docs split by task
-    step = 'syn_asic'
-    index = '<index>'
-    flow = '<flow>'
-    chip.set('arg','step', step)
-    chip.set('arg','index', index)
-    chip.set('option', 'flow', flow)
-    chip.set('flowgraph', flow, step, index, 'task', '<task>')
-    setup(chip)
-    return chip
+def make_docs(chip):
+    chip.load_target("asap7_demo")
 
 ################################
 # Setup Tool (pre executable)


### PR DESCRIPTION
Changes:
- Makes `make_docs` optional and removes `make_docs` from most pdks/libs/flows/targets/checklists
- The interface to `make_docs` changes from `make_docs()` to `make_docs(chip)` so the docs generator can pass in chip object (useful for tools).
- If `make_docs` does not return anything it's simply configuring the chip object (which the docs generator will pass into the setup function itself), otherwise it behaves as it did previously by returning a fully configured chip object for the docs to use.