### PR TITLE
sc: fix inference of design name from sources

### DIFF
--- a/siliconcompiler/apps/sc.py
+++ b/siliconcompiler/apps/sc.py
@@ -46,10 +46,12 @@ def main():
         topfile = None
         for sourceset in ('rtl', 'hll'):
             for filetype in chip.getkeys('input', sourceset):
-                sources = chip.schema._getvals('input', sourceset, filetype)
-                if sources:
-                    # triple index to get first of this structure: ([val], <step>, <index>)]
-                    topfile = sources[0][0][0]
+                all_vals = chip.schema._getvals('input', sourceset, filetype)
+                if all_vals:
+                    # just look at first value
+                    sources, _, _ = all_vals[0]
+                    # grab first source
+                    topfile = sources[0]
                     break
             if topfile:
                 break

--- a/siliconcompiler/apps/sc.py
+++ b/siliconcompiler/apps/sc.py
@@ -45,12 +45,12 @@ def main():
     if chip.get('design') == UNSET_DESIGN:
         topfile = None
         for sourceset in ('rtl', 'hll'):
-            if chip.valid('input', sourceset):
-                for filetype in chip.getkeys('input', sourceset):
-                    sources = chip.get('input', sourceset, filetype)
-                    if sources:
-                        topfile = sources[0]
-                        break
+            for filetype in chip.getkeys('input', sourceset):
+                sources = chip.schema._getvals('input', sourceset, filetype)
+                if sources:
+                    # triple index to get first of this structure: ([val], <step>, <index>)]
+                    topfile = sources[0][0][0]
+                    break
             if topfile:
                 break
 

--- a/tests/apps/test_sc.py
+++ b/tests/apps/test_sc.py
@@ -1,0 +1,14 @@
+import os
+import subprocess
+
+import pytest
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_design_inference(scroot):
+    '''Tests that sc CLI app can infer design name from filename.'''
+    source = os.path.join(scroot, 'tests', 'data', 'heartbeat.v')
+    # only run import, makes this quicker
+    subprocess.run(['sc', source, '-steplist', 'import', '-strict'])
+
+    assert os.path.isfile('build/heartbeat/job0/heartbeat.pkg.json')


### PR DESCRIPTION
It looks like we broke this functionality when adding the extra layer of nesting to the 'input' keypath. Added a test for it to prevent regressions in the future.

Also switched from using `get()` to `_getvals()` to make this compatible with PR #1289 