### PR TITLE
Initial refresh of the Libraries documentation

### DIFF
--- a/docs/reference_manual/core_api.rst
+++ b/docs/reference_manual/core_api.rst
@@ -17,6 +17,7 @@ This chapter describes all public methods in the SiliconCompiler core Python API
     ~siliconcompiler.core.Chip.getdict
     ~siliconcompiler.core.Chip.valid
     ~siliconcompiler.core.Chip.help
+    ~siliconcompiler.core.Chip.use
 
 **Flowgraph execution:**
 
@@ -63,3 +64,7 @@ This chapter describes all public methods in the SiliconCompiler core Python API
 
 .. automodule:: siliconcompiler.core
     :members:
+
+.. automodule:: siliconcompiler.use
+    :members:
+

--- a/docs/user_guide/libraries.rst
+++ b/docs/user_guide/libraries.rst
@@ -1,30 +1,34 @@
 Libraries
 =========
 
-Efficient hardware and software development demands a robust eco-system of reusable high quality components. In SiliconCompiler, IP can be reused by importing a Chip configuration dictionary into a parent Chip object under the 'library' schema.
+Efficient hardware and software development demands a robust ecosystem of reusable high quality components. In SiliconCompiler, you can add new IP to your design by creating a :class:`.Library` object which can be passed into the :func:`Chip.use() <siliconcompiler.Chip.use>` function. The :class:`.Library` class contains its own Schema dictionary, which can describe a macro block or standard cell library.
 
-The general flow to create and import a library is to instantiate a library :class:`.Chip` object, set up any required sources (in the case of a soft library), or models and outputs (in case of a hardened library), and then import it into a parent design :class:`.Chip` object. To select which standard cell libraries to use during compilation, add their names to the :keypath:`asic, logiclib` parameter, and to select macro libraries, add their names to the :keypath:`asic, macrolib` parameter.
-Here's an example of setting up and importing a library object::
+The general flow to create and import a library is to instantiate a :class:`.Library` object, set up any required sources (in the case of a soft library), or models and outputs (in case of a hardened library), and then import it into a parent design :class:`.Chip` object.
 
-  lib = siliconcompiler.Chip('mylibrary')
-  lib.add('output', stackup, 'lef', 'mylibrary.lef')
-  # ... add more library sources
+To select which standard cell libraries to use during compilation, add their names to the :keypath:`asic, logiclib` parameter, and to select macro libraries, add their names to the :keypath:`asic, macrolib` parameter.
+
+Here's an example of setting up and importing a macro block as a :class:`.Library` object::
 
   chip = siliconcompiler.Chip('mydesign')
   chip.add('input', 'verilog', 'mydesign.v')
-  chip.import_library(lib)
+
+  lib = siliconcompiler.Library(chip, 'mymacro')
+  lib.add('output', stackup, 'lef', 'mylibrary.lef')
+  lib.add('output', stackup, 'gds', 'mylibrary.gds')
+  # ... add more library sources
+
+  chip.use(lib)
   chip.add('asic', 'macrolib', 'mylibrary')
+  chip.set('constraint', 'component', 'macro_instance1', 'placement', (20.0, 20.0, 0.0))
+  chip.set('constraint', 'component', 'macro_instance2', 'placement', (40.0, 20.0, 0.0))
+  chip.set('constraint', 'component', 'macro_instance2', 'rotation', 180)
   # ... perform more build configuration
 
-  run()
+  chip.run()
+
+This example assumes that the theoretical `mydesign.v` file contains at least two instances of a block named `mymacro`, named `macro_instance1` and `macro_instance2`. The physical design flow will be able to find the library's LEF and GDS files during the build process, and the macro placements for the named instances will be fixed.
 
 The same approach is used to configure standard cell libraries, which are primarily defined using :keypath:`output` settings. In leading edge process nodes, it's not uncommon to have 10's to 100's of STA signoff corners, with each corner consuming gigabytes of disk space. The SiliconCompiler schema is designed to enable efficient setup of all library file pointers and to allow designers to easily select which libraries and which corners to use in any single run. The run time selection of corners, libraries, and timing enables an agile approach to design, wherein the designer can choose the level of accuracy and performance based on need. For example, early in the architecture exploration phase, speed matters and the right choice for synthesis may be to compile using a single stdcell library, using a NLDM model, at a single timing corner. As the design is fine tuned, and the team closes in on tapeout of a mass produced device, the compilation and signoff verification may use many VT libraries, CCS timing models, and hundreds of timing scenarios. Being able to make these trade-offs with a unified library setup and a couple of lines of designer Python settings, greatly reduces physical design speed and risk.
-
-The following code snippet shows how library GDS and LEF files can be set up in the SC schema::
-
-    stackup = '<my-stackup>'
-    lib.add('output', stackup, 'lef', '$FREEPDK45/lef/NangateOpenCellLibrary.lef')
-    lib.add('output', stackup, 'gds', '$FREEPDK45/gds/NangateOpenCellLibrary.gds')
 
 SiliconCompiler also supports referencing soft libraries (RTL, C-code, etc), in which case many of the physical IP parameters can be omitted.
 
@@ -40,22 +44,22 @@ Similarly to :ref:`PDKs<PDKs>`, library modules must implement the following fun
 
    * - Function
      - Description
-     - Arg
+     - Args
      - Returns
      - Used by
      - Required
 
    * - **setup**
      - Library setup function
-     - chip
-     - chip
+     - chip, lib_name
+     - lib
      - :meth:`.load_lib()`
      - yes
 
    * - **make_docs**
      - Doc generator
      - None
-     - chip
+     - lib
      - sphinx
      - yes
 

--- a/docs/user_guide/libraries.rst
+++ b/docs/user_guide/libraries.rst
@@ -1,7 +1,7 @@
 Libraries
 =========
 
-Efficient hardware and software development demands a robust ecosystem of reusable high quality components. In SiliconCompiler, you can add new IP to your design by creating a :class:`.Library` object which can be passed into the :func:`Chip.use() <siliconcompiler.Chip.use>` function. The :class:`.Library` class contains its own Schema dictionary, which can describe a macro block or standard cell library.
+Efficient hardware and software development demands a robust ecosystem of reusable high quality components. In SiliconCompiler, you can add new IP to your design by creating a :class:`.Library` object which can be passed into the :meth:`.use()` function. The :class:`.Library` class contains its own Schema dictionary, which can describe a macro block or standard cell library.
 
 The general flow to create and import a library is to instantiate a :class:`.Library` object, set up any required sources (in the case of a soft library), or models and outputs (in case of a hardened library), and then import it into a parent design :class:`.Chip` object.
 
@@ -13,8 +13,8 @@ Here's an example of setting up and importing a macro block as a :class:`.Librar
   chip.add('input', 'verilog', 'mydesign.v')
 
   lib = siliconcompiler.Library(chip, 'mymacro')
-  lib.add('output', stackup, 'lef', 'mylibrary.lef')
-  lib.add('output', stackup, 'gds', 'mylibrary.gds')
+  lib.add('output', stackup, 'lef', 'mymacro.lef')
+  lib.add('output', stackup, 'gds', 'mymacro.gds')
   # ... add more library sources
 
   chip.use(lib)
@@ -28,7 +28,7 @@ Here's an example of setting up and importing a macro block as a :class:`.Librar
 
 This example assumes that the theoretical `mydesign.v` file contains at least two instances of a block named `mymacro`, named `macro_instance1` and `macro_instance2`. The physical design flow will be able to find the library's LEF and GDS files during the build process, and the macro placements for the named instances will be fixed.
 
-The same approach is used to configure standard cell libraries, which are primarily defined using :keypath:`output` settings. In leading edge process nodes, it's not uncommon to have 10's to 100's of STA signoff corners, with each corner consuming gigabytes of disk space. The SiliconCompiler schema is designed to enable efficient setup of all library file pointers and to allow designers to easily select which libraries and which corners to use in any single run. The run time selection of corners, libraries, and timing enables an agile approach to design, wherein the designer can choose the level of accuracy and performance based on need. For example, early in the architecture exploration phase, speed matters and the right choice for synthesis may be to compile using a single stdcell library, using a NLDM model, at a single timing corner. As the design is fine tuned, and the team closes in on tapeout of a mass produced device, the compilation and signoff verification may use many VT libraries, CCS timing models, and hundreds of timing scenarios. Being able to make these trade-offs with a unified library setup and a couple of lines of designer Python settings, greatly reduces physical design speed and risk.
+The same approach is used to configure standard cell libraries, which are primarily defined using :keypath:`output` settings. In leading edge process nodes, it's not uncommon to have 10's to 100's of STA signoff corners, with each corner consuming gigabytes of disk space. The SiliconCompiler schema is designed to enable efficient setup of all library file pointers and to allow designers to easily select which libraries and which corners to use in any single run. The run time selection of corners, libraries, and timing enables an agile approach to design, wherein the designer can choose the level of accuracy and performance based on need. For example, early in the architecture exploration phase, speed matters and the right choice for synthesis may be to compile using a single stdcell library, using a NLDM model, at a single timing corner. As the design is fine tuned, and the team closes in on tapeout of a mass produced device, the compilation and signoff verification may use many Vt libraries, CCS timing models, and hundreds of timing scenarios. Being able to make these trade-offs with a unified library setup and a couple of lines of designer Python settings, greatly reduces physical design speed and risk.
 
 SiliconCompiler also supports referencing soft libraries (RTL, C-code, etc), in which case many of the physical IP parameters can be omitted.
 
@@ -51,16 +51,16 @@ Similarly to :ref:`PDKs<PDKs>`, library modules must implement the following fun
 
    * - **setup**
      - Library setup function
-     - chip, lib_name
+     - chip
      - lib
-     - :meth:`.load_lib()`
+     - :meth:`.use()`
      - yes
 
    * - **make_docs**
      - Doc generator
-     - None
+     - chip
      - lib
      - sphinx
-     - yes
+     - no
 
 A complete set of supported standard cell libraries for SC's included open PDKs can be found in the :ref:`Libraries Directory`.

--- a/docs/user_guide/libraries.rst
+++ b/docs/user_guide/libraries.rst
@@ -51,15 +51,15 @@ Similarly to :ref:`PDKs<PDKs>`, library modules must implement the following fun
 
    * - **setup**
      - Library setup function
-     - chip
-     - lib
+     - :class:`.Chip`
+     - :class:`.Library`
      - :meth:`.use()`
      - yes
 
    * - **make_docs**
      - Doc generator
-     - chip
-     - lib
+     - :class:`.Chip`
+     - :class:`.Library`
      - sphinx
      - no
 

--- a/docs/user_guide/libraries.rst
+++ b/docs/user_guide/libraries.rst
@@ -18,7 +18,7 @@ Here's an example of setting up and importing a macro block as a :class:`.Librar
   # ... add more library sources
 
   chip.use(lib)
-  chip.add('asic', 'macrolib', 'mylibrary')
+  chip.add('asic', 'macrolib', 'mymacro')
   chip.set('constraint', 'component', 'macro_instance1', 'placement', (20.0, 20.0, 0.0))
   chip.set('constraint', 'component', 'macro_instance2', 'placement', (40.0, 20.0, 0.0))
   chip.set('constraint', 'component', 'macro_instance2', 'rotation', 180)


### PR DESCRIPTION
I've rendered this and checked that the links work. When we have a "large" integration app note which contains a hard macro block, we might want to link to it here as a more concrete example than the basic `'mydesign'` code block.

This also adds the the `siliconcompiler.use` classes to the "Core API" section of the reference manual. Should we do more to indicate that those classes inherit the Chip/Schema's `get`/`set`/`add`/etc methods?