### PR TITLE
openroad fixes

### DIFF
--- a/siliconcompiler/tools/openroad/export.py
+++ b/siliconcompiler/tools/openroad/export.py
@@ -22,7 +22,7 @@ def setup(chip):
     macrolibs = chip.get('asic', 'macrolib', step=step, index=index)
 
     # Determine if exporting the cdl
-    chip.set('tool', tool, 'task', task, 'var', 'write_cdl', 'true', step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'var', 'write_cdl', 'false', step=step, index=index, clobber=False)
     chip.set('tool', tool, 'task', task, 'var', 'write_cdl', 'true/false, when true enables writing the CDL file for the design', field='help')
     do_cdl = chip.get('tool', tool, 'task', task, 'var', 'write_cdl', step=step, index=index)[0] == 'true'
 

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -234,7 +234,7 @@ def setup(chip, mode='batch'):
     for libvar, openroadvar in [('openroad_pdngen', 'pdn_config'),
                                 ('openroad_global_connect', 'global_connect')]:
         if chip.valid('tool', tool, 'task', task, 'var', openroadvar) and \
-           not chip.get('tool', tool, 'task', task, 'var', openroadvar, step=step, index=index):
+           chip.get('tool', tool, 'task', task, 'var', openroadvar, step=step, index=index):
             # value already set
             continue
 


### PR DESCRIPTION
Fixes:
- incorrect check if a value was set

Changes:
- disable write_cdl by default for now as the PDKs only have partial support for this (mainly the macros and IOs). Once those are updated we can reenable.