### PR TITLE
Add pip install for orderedmultidict back in for surelog install script since needed for venv

### DIFF
--- a/setup/install-surelog.sh
+++ b/setup/install-surelog.sh
@@ -7,6 +7,7 @@ src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
 
 # These dependencies are up-to-date with instructions from the INSTALL.md from the commit we are pinned to below
 sudo apt-get install -y build-essential cmake git pkg-config tclsh swig uuid-dev libgoogle-perftools-dev python3 python3-orderedmultidict python3-psutil python3-dev default-jre lcov
+pip3 install orderedmultidict
 
 mkdir -p deps
 cd deps


### PR DESCRIPTION
I tested out in a new VM (to avoid conflating dependencies from previous installs) and it looks like the orderedmultidict package is also needed in the venv packages area for the surelog install.