### PR TITLE
Add a default remote server address, if one has not been configured.

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4134,12 +4134,13 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 # Use the default config file path.
                 cfg_dir = os.path.join(Path.home(), '.sc')
                 cfg_file = os.path.join(cfg_dir, 'credentials')
-            if (not os.path.isdir(cfg_dir)) or (not os.path.isfile(cfg_file)):
-                self.error('Could not find remote server configuration - '
-                    'please run "sc-configure" and enter your server address and '
-                    'credentials.', fatal=True)
-            with open(cfg_file, 'r') as cfgf:
-                self.status['remote_cfg'] = json.loads(cfgf.read())
+            if os.path.isdir(cfg_dir) and os.path.isfile(cfg_file):
+                with open(cfg_file, 'r') as cfgf:
+                    self.status['remote_cfg'] = json.loads(cfgf.read())
+            else:
+                self.logger.warning('Could not find remote server configuration: defaulting to '
+                                    'https://server.siliconcompiler.com')
+                self.status['remote_cfg'] = { "address": "https://server.siliconcompiler.com" }
             if (not 'address' in self.status['remote_cfg']):
                 self.error('Improperly formatted remote server configuration - '
                     'please run "sc-configure" and enter your server address and '


### PR DESCRIPTION
This change adds some logic to set the default server address to our public beta, if `sc-configure` has not been run.

The warning string is easy to miss if `('option', 'quiet')` is not set, since it gets printed before the local import step. I think this change should be paired with the more prominent "uploading to a public server" dialogs that we've discussed, once we agree on the phrasing of those messages.