### PR TITLE
add release version to git clone commands

### DIFF
--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -168,13 +168,13 @@ installs packages on your machine.
 
 Finally, to clone and install SiliconCompiler, run the following:
 
-.. code-block:: bash
+.. parsed-literal::
 
-   git clone https://github.com/siliconcompiler/siliconcompiler
-   cd siliconcompiler
-   pip install -r requirements.txt
-   python -m pip install -e .
-   export SCPATH=<the full path for your siliconcompiler/siliconcompiler directory>
+   (venv) git clone -b v\ |release| https://github.com/siliconcompiler/siliconcompiler
+   (venv) cd siliconcompiler
+   (venv) pip install -r requirements.txt
+   (venv) python -m pip install -e .
+   (venv) export SCPATH=<the full path for your siliconcompiler/siliconcompiler directory>
 
 .. include:: installation/installation_confirm_version.rst
 	     

--- a/docs/user_guide/installation/installation_prep_path.rst
+++ b/docs/user_guide/installation/installation_prep_path.rst
@@ -1,6 +1,7 @@
 If you don't already have PDKs and tools set up, prepare your path to get set up with examples and PDKs to run:
 
-.. code-block:: bash
 
-   (venv) git clone https://github.com/siliconcompiler/siliconcompiler
+.. parsed-literal::
+
+   (venv) git clone -b v\ |release| https://github.com/siliconcompiler/siliconcompiler
    (venv) export SCPATH=<the full path for your siliconcompiler/siliconcompiler directory>

--- a/docs/user_guide/quickstart.rst
+++ b/docs/user_guide/quickstart.rst
@@ -53,9 +53,9 @@ Directory`, and :ref:`Targets Directory` sections of the reference manual and re
    environment variable ``SCPATH`` pointing at the ``siliconcompiler/``
    directory inside of it:
 
-   .. code-block:: bash
+   .. parsed-literal::
 
-     git clone https://github.com/siliconcompiler/siliconcompiler
+     git clone -b v\ |release| https://github.com/siliconcompiler/siliconcompiler
      export SCPATH=$PWD/siliconcompiler/siliconcompiler
 
    To simplify tool/PDK installation and job scheduling, SiliconCompiler supports a


### PR DESCRIPTION
Per discussion with @gadfort, I added the release version to the `git clone` commands. Also a minor update to developer install instructions to be consistent with other install instructions