### PR TITLE
Fix Surelog build for Apple Silicon

### DIFF
--- a/.github/workflows/bin/install_surelog_macos.sh
+++ b/.github/workflows/bin/install_surelog_macos.sh
@@ -9,7 +9,9 @@ cd surelog
 git checkout $(python3 setup/_tools.py --tool surelog --field git-commit)
 git submodule update --init --recursive
 
+cmake --version # must be >=3.19
+
 # Point to Python, build universal binary (supporting Intel and Apple Silicon-based Macs)
-export ADDITIONAL_CMAKE_OPTIONS="-DPython3_ROOT_DIR=${pythonLocation} -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
+export ADDITIONAL_CMAKE_OPTIONS="-DPython3_ROOT_DIR=${pythonLocation} -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64'"
 make
 make install PREFIX=$GITHUB_WORKSPACE/siliconcompiler/tools/surelog

--- a/.github/workflows/bin/install_surelog_macos.sh
+++ b/.github/workflows/bin/install_surelog_macos.sh
@@ -9,6 +9,7 @@ cd surelog
 git checkout $(python3 setup/_tools.py --tool surelog --field git-commit)
 git submodule update --init --recursive
 
-export ADDITIONAL_CMAKE_OPTIONS=-DPython3_ROOT_DIR=${pythonLocation}
+# Point to Python, build universal binary (supporting Intel and Apple Silicon-based Macs)
+export ADDITIONAL_CMAKE_OPTIONS="-DPython3_ROOT_DIR=${pythonLocation} -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
 make
 make install PREFIX=$GITHUB_WORKSPACE/siliconcompiler/tools/surelog


### PR DESCRIPTION
This change was verified by a manual workflow run: https://github.com/siliconcompiler/siliconcompiler/actions/runs/4309851810.

The manual run was performed on a branch with these changes + caching removed and #1340 merged in. The package_offline part failed because of how I hacked up the actions script, but I downloaded the generated wheels, extracted the Surelog binary, and verified that it runs on an Intel-based Mac and an ARM-based Mac.