### PR TITLE
move _collect call to after import to prevent multiple local files from getting sourced in surelog

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -82,6 +82,12 @@ def remote_preprocess(chip, steplist):
         # step should have none.
         chip._runtask(local_step, index, {})
 
+        # Collect inputs into import directory only for remote runs, since
+        # we need to send inputs up to the server. Otherwise, it's simpler
+        # for debugging to leave inputs in place.
+        # TODO: if more than one import is present this might not work
+        chip._collect(local_step, index)
+
     # Set 'steplist' to only the remote steps, for the future server-side run.
     chip.unset('arg', 'step')
     chip.unset('arg', 'index')

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2293,7 +2293,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         '''
 
-        indir = 'inputs'
+        indir = os.path.join(self._getworkdir(step=step, index=index), 'inputs')
 
         if not os.path.exists(indir):
             os.makedirs(indir)
@@ -3608,12 +3608,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         ##################
         # Copy (link) output data from previous steps
-
-        if task == 'import' and self.get('option', 'remote'):
-            # Collect inputs into import directory only for remote runs, since
-            # we need to send inputs up to the server. Otherwise, it's simpler
-            # for debugging to leave inputs in place.
-            self._collect(step, index)
 
         if not self.get('flowgraph', flow, step, index,'input'):
             all_inputs = []


### PR DESCRIPTION
Fixes:
- imported files getting found multiple times by surelog with include paths. Since import always runs locally, we do not need to run this until after the import step has completed.