### PR TITLE
Add a bit more exposition to the client-side messages

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -143,7 +143,7 @@ def remote_run(chip):
           # Retrying ensures that jobs don't break off when the connection drops.
           is_busy = True
           chip.logger.info("Unknown network error encountered: retrying.")
-    chip.logger.info("Remote job run completed!")
+    chip.logger.info("Remote job run completed! Fetching results...")
 
 ###################################
 def request_remote_run(chip):
@@ -346,3 +346,6 @@ def fetch_results(chip):
                    local_dir,
                    dirs_exist_ok = True)
     shutil.rmtree(job_hash)
+
+    # Print a message pointing to the results.
+    chip.logger.info(f"Your job results are located in: {os.path.abspath(chip._getworkdir())}")


### PR DESCRIPTION
Like we discussed offline, it would be nice to have a final message pointing to where the results are located after a remote run finishes, in case the build script does not include a call to `chip.summary()`.

If the full build results are being returned, it can take a bit of time to retrieve and unzip the results, so I also added a quick mention of that call. The delay probably won't be noticeable when only the core reports are returned, though.