### PR TITLE
Improve error messaging when results cannot be fetched.

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -320,7 +320,7 @@ def fetch_results_request(chip):
                 msg_json = {}
                 try: # (An unexpected server error may not return JSON with a message)
                     msg_json = resp.json()
-                    msg = f': {msg_json["message"]}'
+                    msg = f': {msg_json["message"]}' if 'message' in msg_json else '.'
                 except requests.exceptions.JSONDecodeError:
                     msg = '.'
                 chip.logger.warning(f'Could not fetch results{msg}')

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -279,6 +279,10 @@ def delete_job(chip):
 ###################################
 def fetch_results_request(chip):
     '''Helper method to fetch job results from a remote compute cluster.
+
+       Returns:
+       * 0 if no error was encountered.
+       * 1 if the results could not be retrieved.
     '''
 
     # Set the request URL.
@@ -312,13 +316,13 @@ def fetch_results_request(chip):
             elif resp.status_code == 200:
                 shutil.copyfileobj(resp.raw, zipf)
                 return 0
-            elif int(resp.status_code / 100) in [4, 5]:
+            else:
                 msg = '.'
                 try: # (An unexpected server error may not return JSON with a message)
                     msg = f': {resp.json()["message"]}'
                 except:
                     pass
-                chip.logger.warning(f'Error fetching results{msg}')
+                chip.logger.warning(f'Could not fetch results{msg}')
                 return 1
 
 ###################################


### PR DESCRIPTION
This updates the client to print relevant error messaging when the server doesn't return any results. I tested it by asking for the wrong job ID, but the behavior should be the same when the server encounters expected failures such as refusing to return over-sized results:

```
| INFO    | job0  | import     | 0  | Remote job run completed! Fetching results...
| WARNING | job0  | import     | 0  | Error fetching results: Job not found.
Traceback (most recent call last):
  File "sc_env/bin/sc", line 33, in <module>
    sys.exit(load_entry_point('siliconcompiler', 'console_scripts', 'sc')())
  File "siliconcompiler/apps/sc.py", line 77, in main
    chip.run()
  File "siliconcompiler/core.py", line 4293, in run
    fetch_results(self)
  File "siliconcompiler/client.py", line 341, in fetch_results
    chip.error("Sorry, something went wrong and your job results could not be retrieved.", fatal=True)
  File "siliconcompiler/core.py", line 5005, in error
    raise SiliconCompilerError(msg) from None
siliconcompiler.core.SiliconCompilerError: Sorry, something went wrong and your job results could not be retrieved.
```

This should be better than the "gzip failed, archive does not exist" errors that we were previously seeing in this case.