### PR TITLE
Update picorv32 examples to include chip.summary

### DIFF
--- a/docs/tutorials/picorv32_ram.rst
+++ b/docs/tutorials/picorv32_ram.rst
@@ -34,7 +34,7 @@ Before we add the complexity of a RAM macro block, let's build the core design u
     chip.clock('clk', period=10)                # define clock speed of design
     chip.set('option', 'remote', True)          # run remote in the cloud
     chip.run()                                  # run chip compilation
-    chip.summary()                              # print results summary
+    chip.summary()                              # print results summary with PNG screenshot and HTML report
 
 Note in the code snippet above that :ref:`remote` is set to ``True``. This means it is set up for :ref:`remote processing`, and if you run this example as a Python script, it should take approximately 20 minutes to run if the servers are not too busy. We have not added a RAM macro yet, but this script will build the CPU core with I/O signals placed pseudo-randomly around the edges of the die area. Once the job finishes, you should receive a screenshot of your final design, and a report containing metrics related to the build in ``build/picorv32/job0/report.html``. SiliconCompiler will try to open the file after the job completes, but it may not be able to do so if you are running in a headless environment.
 

--- a/docs/tutorials/picorv32_ram.rst
+++ b/docs/tutorials/picorv32_ram.rst
@@ -28,12 +28,13 @@ Before we add the complexity of a RAM macro block, let's build the core design u
 
     import siliconcompiler
 
-    chip = siliconcompiler.Chip('picorv32')
-    chip.load_target('skywater130_demo')
-    chip.input('picorv32.v')
-    chip.clock('clk', period=10)
-    chip.set('option', 'remote', True)
-    chip.run()
+    chip = siliconcompiler.Chip('picorv32')     # create chip object
+    chip.load_target('skywater130_demo')        # load predefined target
+    chip.input('picorv32.v')                    # define list of source files
+    chip.clock('clk', period=10)                # define clock speed of design
+    chip.set('option', 'remote', True)          # run remote in the cloud
+    chip.run()                                  # run chip compilation
+    chip.summary()                              # print results summary
 
 Note in the code snippet above that :ref:`remote` is set to ``True``. This means it is set up for :ref:`remote processing`, and if you run this example as a Python script, it should take approximately 20 minutes to run if the servers are not too busy. We have not added a RAM macro yet, but this script will build the CPU core with I/O signals placed pseudo-randomly around the edges of the die area. Once the job finishes, you should receive a screenshot of your final design, and a report containing metrics related to the build in ``build/picorv32/job0/report.html``. SiliconCompiler will try to open the file after the job completes, but it may not be able to do so if you are running in a headless environment.
 
@@ -218,9 +219,10 @@ Finally, your core build script will need to be updated to import the new SRAM L
     chip.set('constraint', 'component', 'sram', 'placement', (500.0, 250.0, 0.0))
     chip.set('constraint', 'component', 'sram', 'rotation', 270)
 
-    # Build on a remote server.
+    # Build on a remote server and generate summary
     chip.set('option', 'remote', True)
     chip.run()
+    chip.summary()
 
 With all of that done, your project directory tree should look something like this::
 


### PR DESCRIPTION
Added `chip.summary()` to examples so that users will get png and reports generated if they run the tutorial