### PR TITLE
Add try/except to external calls

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3872,6 +3872,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 cmdlist = [exe]
                 cmdlist.extend(veropt)
                 proc = subprocess.run(cmdlist, stdout=PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
+                if proc.returncode != 0:
+                    self.logger.error(f'Version check on {tool} failed with code {retcode}.')
+                    self._haltstep(step, index)
                 parse_version = self.find_function(tool, 'parse_version', 'tools')
                 if parse_version is None:
                     self.logger.error(f'{tool} does not implement parse_version.')

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -643,7 +643,11 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         setup_func = getattr(module, 'setup', None)
         if (setup_func):
             # Call the module setup function.
-            use_modules = setup_func(self, **kwargs)
+            try:
+                use_modules = setup_func(self, **kwargs)
+            except Exception as e:
+                self.logger.error(f'Unable to run setup() for {module.__name__}')
+                raise e
         else:
             # Import directly
             use_modules = module

--- a/tests/core/test_runtime_exception.py
+++ b/tests/core/test_runtime_exception.py
@@ -21,9 +21,5 @@ def test_version():
 
     chip.load_target('asic_demo')
 
-    try:
+    with pytest.raises(siliconcompiler.SiliconCompilerError):
         chip.run()
-    except siliconcompiler.SiliconCompilerError:
-        assert True
-        return
-    assert False

--- a/tests/core/test_runtime_exception.py
+++ b/tests/core/test_runtime_exception.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
+import csv
+
+import pytest
+
+import siliconcompiler
+
+def test_version():
+    chip = siliconcompiler.Chip('test')
+
+    org_find_func = siliconcompiler.Chip.find_function
+    # Replace find_function so we can throw an error
+    def find_function(modulename, funcname, moduletype=None, moduletask=None):
+        if funcname == 'parse_version':
+            def parse_version(text):
+                raise IndexError('This is an index error')
+            return parse_version
+        else:
+            return org_find_func(chip, modulename, funcname, moduletype=moduletype, moduletask=moduletask)
+    chip.find_function = find_function
+
+    chip.load_target('asic_demo')
+
+    try:
+        chip.run()
+    except siliconcompiler.SiliconCompilerError:
+        assert True
+        return
+    assert False


### PR DESCRIPTION
Changes:
- Adds a try/except block around calls to external code to help enable better error messaging.
- Check return code for --version checks to ensure failures are caught.