### PR TITLE
Build Linux + ARM64 wheels with caching for all platforms

### DIFF
--- a/.github/workflows/bin/clean_surelog_build.py
+++ b/.github/workflows/bin/clean_surelog_build.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+'''Remove files from Surelog installation that aren't necessary for runtime.'''
+
+import glob
+import os
+
+for file in glob.glob('siliconcompiler/tools/surelog/**/*', recursive=True):
+    if not os.path.isfile(file): continue
+
+    if (
+        (not file.endswith('.py')) and
+        (not file.startswith('siliconcompiler/tools/surelog/bin/surelog')) and
+        file != 'siliconcompiler/tools/surelog/lib/surelog/sv/builtin.sv'
+    ):
+        os.remove(file)

--- a/.github/workflows/bin/install_surelog_linux.sh
+++ b/.github/workflows/bin/install_surelog_linux.sh
@@ -1,0 +1,29 @@
+ls /github/workspace/siliconcompiler/tools/surelog
+
+# Get directory of setup scripts
+src_path=$(cd -- "$(dirname "$0")/../../../" >/dev/null 2>&1 ; pwd -P)
+
+# mkdir -p setup
+# mv _tools.py setup/_tools.py
+# mv _tools.json setup/_tools.json
+
+yum install -y libuuid-devel java-11-openjdk-devel python3
+
+python3 -m venv .venv
+PYTHON_ROOT=$(realpath .venv)
+$PYTHON_ROOT/bin/python -m pip install orderedmultidict
+export ADDITIONAL_CMAKE_OPTIONS="-DPython3_ROOT_DIR=$PYTHON_ROOT -DPython3_FIND_STRATEGY=LOCATION"
+
+# Build surelog (install prefix defined outside file)
+git clone $(python3 ${src_path}/setup/_tools.py --tool surelog --field git-url) surelog
+cd surelog
+git checkout $(python3 ${src_path}/setup/_tools.py --tool surelog --field git-commit)
+git submodule update --init --recursive
+
+export LDFLAGS="-lrt"
+make
+make install PREFIX=/github/workspace/siliconcompiler/tools/surelog
+
+python3 ${src_path}/.github/workflows/bin/clean_surelog_build.py
+
+cd -

--- a/.github/workflows/bin/install_surelog_linux.sh
+++ b/.github/workflows/bin/install_surelog_linux.sh
@@ -1,5 +1,3 @@
-ls /github/workspace/siliconcompiler/tools/surelog
-
 # Get directory of setup scripts
 src_path=$(cd -- "$(dirname "$0")/../../../" >/dev/null 2>&1 ; pwd -P)
 

--- a/.github/workflows/bin/install_surelog_linux.sh
+++ b/.github/workflows/bin/install_surelog_linux.sh
@@ -3,10 +3,6 @@ ls /github/workspace/siliconcompiler/tools/surelog
 # Get directory of setup scripts
 src_path=$(cd -- "$(dirname "$0")/../../../" >/dev/null 2>&1 ; pwd -P)
 
-# mkdir -p setup
-# mv _tools.py setup/_tools.py
-# mv _tools.json setup/_tools.json
-
 yum install -y libuuid-devel java-11-openjdk-devel python3
 
 python3 -m venv .venv

--- a/.github/workflows/bin/install_surelog_macos.sh
+++ b/.github/workflows/bin/install_surelog_macos.sh
@@ -18,3 +18,4 @@ cmake --version # must be >=3.19
 export ADDITIONAL_CMAKE_OPTIONS="-DPython3_ROOT_DIR=${pythonLocation} -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64'"
 make
 make install PREFIX=$GITHUB_WORKSPACE/siliconcompiler/tools/surelog
+python3 ${src_path}/.github/workflows/bin/clean_surelog_build.py

--- a/.github/workflows/bin/install_surelog_macos.sh
+++ b/.github/workflows/bin/install_surelog_macos.sh
@@ -18,4 +18,5 @@ cmake --version # must be >=3.19
 export ADDITIONAL_CMAKE_OPTIONS="-DPython3_ROOT_DIR=${pythonLocation} -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64'"
 make
 make install PREFIX=$GITHUB_WORKSPACE/siliconcompiler/tools/surelog
+
 python3 ${src_path}/.github/workflows/bin/clean_surelog_build.py

--- a/.github/workflows/bin/install_surelog_win.bat
+++ b/.github/workflows/bin/install_surelog_win.bat
@@ -11,7 +11,6 @@ set CC=cl
 set CXX=cl
 set NO_TCMALLOC=On
 set PREFIX=%GITHUB_WORKSPACE%\siliconcompiler\tools\surelog
-set PREFIX=%GITHUB_WORKSPACE%\siliconcompiler\tools\surelog
 set CPU_CORES=%NUMBER_OF_PROCESSORS%
 
 set MAKE_DIR=C:\make\bin
@@ -41,4 +40,5 @@ git submodule update --init --recursive
 
 make
 make install
+
 python3 %GITHUB_WORKSPACE%\.github\workflows\bin\clean_surelog_build.py

--- a/.github/workflows/bin/install_surelog_win.bat
+++ b/.github/workflows/bin/install_surelog_win.bat
@@ -11,6 +11,7 @@ set CC=cl
 set CXX=cl
 set NO_TCMALLOC=On
 set PREFIX=%GITHUB_WORKSPACE%\siliconcompiler\tools\surelog
+set PREFIX=%GITHUB_WORKSPACE%\siliconcompiler\tools\surelog
 set CPU_CORES=%NUMBER_OF_PROCESSORS%
 
 set MAKE_DIR=C:\make\bin
@@ -40,3 +41,4 @@ git submodule update --init --recursive
 
 make
 make install
+python3 %GITHUB_WORKSPACE%\.github\workflows\bin\clean_surelog_build.py

--- a/.github/workflows/bin/setup_wheel_env_linux.sh
+++ b/.github/workflows/bin/setup_wheel_env_linux.sh
@@ -1,28 +1,11 @@
 #!/bin/bash
 
-# Get directory of setup scripts
-src_path=$(cd -- "$(dirname "$0")/../../../" >/dev/null 2>&1 ; pwd -P)
-
 # Install dependencies
 yum --disablerepo=epel -y update ca-certificates
-yum install -y libuuid-devel zlib-devel java-11-openjdk-devel graphviz xorg-x11-server-Xvfb wget
+yum install -y zlib-devel graphviz xorg-x11-server-Xvfb wget
 
 # Install Klayout (for chip.show() test)
 wget --no-check-certificate https://www.klayout.org/downloads/CentOS_7/klayout-0.28.3-0.x86_64.rpm
 yum install -y python3 ruby qt-x11
-rpm -i klayout-0.28.3-0.x86_64.rpm
-
-# Required for Surelog
-pip3 install orderedmultidict
-
-# Build surelog (install prefix defined outside file)
-git clone $(python3 ${src_path}/setup/_tools.py --tool surelog --field git-url) surelog
-cd surelog
-git checkout $(python3 ${src_path}/setup/_tools.py --tool surelog --field git-commit)
-git submodule update --init --recursive
-
-export LDFLAGS="-lrt"
-make
-make install
-
-cd -
+# This may fail on ARM64
+rpm -i klayout-0.28.3-0.x86_64.rpm || true

--- a/.github/workflows/on_push_tests.yml
+++ b/.github/workflows/on_push_tests.yml
@@ -1,4 +1,4 @@
-on: [workflow_dispatch, push]
+on: [workflow_dispatch]
 
 name: 'Quick CI Tests'
 

--- a/.github/workflows/on_push_tests.yml
+++ b/.github/workflows/on_push_tests.yml
@@ -1,4 +1,4 @@
-on: [workflow_dispatch]
+on: [workflow_dispatch, push]
 
 name: 'Quick CI Tests'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -130,14 +130,14 @@ jobs:
         CIBW_TEST_SKIP: "*_arm64"
         CIBW_TEST_EXTRAS: test
         CIBW_TEST_COMMAND: >
-          pytest --import-mode=append {package}/tests/ -m "not eda" --timeout 180 &&
-          pytest --import-mode=append {package}/tests/tools/test_surelog.py --timeout 180 &&
-          pytest --import-mode=append {package}/tests/flows/test_show.py -k "not openroad" --timeout 180
+          pytest --import-mode=append {package}/tests/ -m "not eda" &&
+          pytest --import-mode=append {package}/tests/tools/test_surelog.py &&
+          pytest --import-mode=append {package}/tests/flows/test_show.py -k "not openroad"
         # On Linux, check if KL is installed before running show tests (not included for ARM64)
         CIBW_TEST_COMMAND_LINUX:
-          pytest --import-mode=append {package}/tests/ -m "not eda" --timeout 180 &&
-          pytest --import-mode=append {package}/tests/tools/test_surelog.py --timeout 180 &&
-          if command -v klayout; then pytest --import-mode=append {package}/tests/flows/test_show.py -k "not openroad" --timeout 180; fi
+          pytest --import-mode=append {package}/tests/ -m "not eda" &&
+          pytest --import-mode=append {package}/tests/tools/test_surelog.py &&
+          if command -v klayout; then pytest --import-mode=append {package}/tests/flows/test_show.py -k "not openroad"; fi
 
     # "if: always()" ensures that we always upload any wheels that have
     # been created, even if a test fails

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,7 +1,6 @@
 name: Wheels
 
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
@@ -134,6 +133,11 @@ jobs:
           pytest --import-mode=append {package}/tests/ -m "not eda" --timeout 180 &&
           pytest --import-mode=append {package}/tests/tools/test_surelog.py --timeout 180 &&
           pytest --import-mode=append {package}/tests/flows/test_show.py -k "not openroad" --timeout 180
+        # On Linux, check if KL is installed before running show tests (not included for ARM64)
+        CIBW_TEST_COMMAND_LINUX:
+          pytest --import-mode=append {package}/tests/ -m "not eda" --timeout 180 &&
+          pytest --import-mode=append {package}/tests/tools/test_surelog.py --timeout 180 &&
+          if command -v klayout; then pytest --import-mode=append {package}/tests/flows/test_show.py -k "not openroad" --timeout 180; fi
 
     # "if: always()" ensures that we always upload any wheels that have
     # been created, even if a test fails

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,6 +1,7 @@
 name: Wheels
 
 on:
+  push:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
@@ -10,53 +11,95 @@ on:
 
 jobs:
   build_wheels:
-    name: Wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Wheels on ${{ matrix.platform.os }} ${{ matrix.platform.arch}}
+    runs-on: ${{ matrix.platform.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        platform:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-latest
+            arch: aarch64
+          - os: macos-latest
+            arch: universal
+          - os: windows-latest
+            arch: x86_64
+
+    env:
+      CIBW_ARCHS_LINUX: ${{ matrix.platform.arch }}
 
     steps:
     - uses: actions/checkout@v3
 
+    # This facilitates building Linux+arm64 wheels
+    # https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation
+    - name: Set up QEMU
+      if: runner.os == 'Linux'
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: all
+
+    # Explicitly use "shell: bash" to make this work on Windows
     - name: Get Surelog version
       id: get-surelog
       run: |
         echo "version=$(python3 setup/_tools.py --tool surelog --field git-commit)" >> $GITHUB_OUTPUT
+      shell: bash
 
     - uses: actions/cache@v3
       id: surelog-cache
-      if: matrix.os != 'ubuntu-latest'
       with:
         path: |
           siliconcompiler/tools/surelog/bin/surelog*
           siliconcompiler/tools/surelog/lib/surelog/sv/builtin.sv
-        key: ${{ matrix.os }}-${{ steps.get-surelog.outputs.version }}
+        key: ${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ steps.get-surelog.outputs.version }}
 
-    # Needed for Surelog
     - name: Setup Java
+      if: (matrix.platform.os == 'macos-latest' || matrix.platform.os == 'windows-latest') && steps.surelog-cache.outputs.cache-hit != 'true'
       uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: 11
         java-package: jre
         architecture: x64
+
     - name: Setup Python
+      if: (matrix.platform.os == 'macos-latest' || matrix.platform.os == 'windows-latest') && steps.surelog-cache.outputs.cache-hit != 'true'
       uses: actions/setup-python@v4
       with:
         python-version: 3.8
         architecture: x64
 
+    - name: Build Surelog (Windows)
+      if: matrix.platform.os == 'windows-latest' && steps.surelog-cache.outputs.cache-hit != 'true'
+      run: .github/workflows/bin/install_surelog_win.bat
+
+    - name: Build Surelog (macOS)
+      if: matrix.platform.os == 'macos-latest' && steps.surelog-cache.outputs.cache-hit != 'true'
+      run: .github/workflows/bin/install_surelog_macos.sh
+
+    - name: Build Surelog (Linux x86)
+      if: matrix.platform.os == 'ubuntu-latest' && matrix.platform.arch == 'x86_64'&& steps.surelog-cache.outputs.cache-hit != 'true'
+      uses: docker://quay.io/pypa/manylinux2014_x86_64:latest
+      with:
+        args: ./.github/workflows/bin/install_surelog_linux.sh
+
+    - name: Build Surelog (Linux arm64)
+      if: matrix.platform.os == 'ubuntu-latest' && matrix.platform.arch == 'aarch64' && steps.surelog-cache.outputs.cache-hit != 'true'
+      uses: docker://quay.io/pypa/manylinux2014_aarch64:latest
+      with:
+        args: ./.github/workflows/bin/install_surelog_linux.sh
+
     - name: Setup env (Windows)
-      if: matrix.os == 'windows-latest'
+      if: matrix.platform.os == 'windows-latest'
       run: |
         choco install -y graphviz winflexbison3
         vcpkg install zlib zlib:x64-windows
         .github/workflows/bin/install_klayout_win.bat
 
     - name: Setup env (macOS)
-      if: matrix.os == 'macos-latest'
+      if: matrix.platform.os == 'macos-latest'
       run: |
         brew install graphviz
         brew install bison
@@ -72,18 +115,9 @@ jobs:
         sudo chmod 1777 /tmp/.X11-unix
         sudo chown root /tmp/.X11-unix
 
-    - name: Build Surelog (Windows)
-      if: matrix.os == 'windows-latest' && steps.surelog-cache.outputs.cache-hit != 'true'
-      run: .github/workflows/bin/install_surelog_win.bat
-
-    - name: Build Surelog (macOS)
-      if: matrix.os == 'macos-latest' && steps.surelog-cache.outputs.cache-hit != 'true'
-      run: .github/workflows/bin/install_surelog_macos.sh
-
     - uses: pypa/cibuildwheel@v2.12.1
       env:
         CIBW_BEFORE_ALL_LINUX: >
-          export PREFIX={package}/siliconcompiler/tools/surelog &&
           {package}/.github/workflows/bin/setup_wheel_env_linux.sh
         CIBW_BEFORE_BUILD_WINDOWS: if exist "_skbuild\" rd /q /s  "_skbuild"
         CIBW_ENVIRONMENT_MACOS: >
@@ -97,11 +131,14 @@ jobs:
         CIBW_TEST_SKIP: "*_arm64"
         CIBW_TEST_EXTRAS: test
         CIBW_TEST_COMMAND: >
-          pytest --import-mode=append {package}/tests/ -m "not eda" &&
-          pytest --import-mode=append {package}/tests/tools/test_surelog.py &&
-          pytest --import-mode=append {package}/tests/flows/test_show.py -k "not openroad"
+          pytest --import-mode=append {package}/tests/ -m "not eda" --timeout 180 &&
+          pytest --import-mode=append {package}/tests/tools/test_surelog.py --timeout 180 &&
+          pytest --import-mode=append {package}/tests/flows/test_show.py -k "not openroad" --timeout 180
 
+    # "if: always()" ensures that we always upload any wheels that have
+    # been created, even if a test fails
     - name: Upload wheels
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         path: wheelhouse/*.whl
@@ -145,7 +182,7 @@ jobs:
       run: |
         mkdir scdeps
         $python -m pip download pip -d scdeps
-        $python -m pip download ./dist/siliconcompiler*${{matrix.python}}*linux*.whl -d scdeps
+        $python -m pip download ./dist/siliconcompiler*${{matrix.python}}*linux*x86_64.whl -d scdeps
         tar -czvf scdeps-${{matrix.python}}.tar.gz scdeps
       env:
         python: /opt/python/${{matrix.python}}/bin/python

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -140,7 +140,7 @@ jobs:
           if command -v klayout; then pytest --import-mode=append {package}/tests/flows/test_show.py -k "not openroad"; fi
 
     # "if: always()" ensures that we always upload any wheels that have
-    # been created, even if a test fails
+    # been created, even if cibuildwheel action fails
     - name: Upload wheels
       if: always()
       uses: actions/upload-artifact@v3

--- a/tests/core/test_create_cmdline.py
+++ b/tests/core/test_create_cmdline.py
@@ -6,7 +6,6 @@ import siliconcompiler
 
 def do_cli_test(args, monkeypatch, switchlist=None, input_map=None):
     chip = siliconcompiler.Chip('test')
-    print(chip.get('constraint', 'timing', 'worst', 'libcorner', step='syn', index='0'))
     monkeypatch.setattr('sys.argv', args)
     chip.create_cmdline('sc', switchlist=switchlist, input_map=input_map)
     return chip

--- a/tests/core/test_create_cmdline.py
+++ b/tests/core/test_create_cmdline.py
@@ -100,6 +100,7 @@ def _cast(val, sctype):
         # everything else (str, file, dir) is treated like a string
         return val.strip('"')
 
+@pytest.mark.timeout(500)
 def test_cli_examples(monkeypatch):
     # Need to mock this function, since our cfg CLI example will try to call it
     # on a fake manifest.

--- a/tests/core/test_create_cmdline.py
+++ b/tests/core/test_create_cmdline.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import pytest
 

--- a/tests/core/test_runtime_exception.py
+++ b/tests/core/test_runtime_exception.py
@@ -1,23 +1,24 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
-import csv
 
 import pytest
 
 import siliconcompiler
 
-def test_version():
+@pytest.mark.quick
+def test_version(monkeypatch):
     chip = siliconcompiler.Chip('test')
 
     org_find_func = siliconcompiler.Chip.find_function
     # Replace find_function so we can throw an error
-    def find_function(modulename, funcname, moduletype=None, moduletask=None):
+    def find_function(self, modulename, funcname, moduletype=None, moduletask=None):
         if funcname == 'parse_version':
             def parse_version(text):
                 raise IndexError('This is an index error')
             return parse_version
         else:
-            return org_find_func(chip, modulename, funcname, moduletype=moduletype, moduletask=moduletask)
-    chip.find_function = find_function
+            return org_find_func(self, modulename, funcname, moduletype=moduletype, moduletask=moduletask)
+
+    monkeypatch.setattr(siliconcompiler.Chip, 'find_function', find_function)
 
     chip.load_target('asic_demo')
 

--- a/tests/core/test_sup.py
+++ b/tests/core/test_sup.py
@@ -5,7 +5,7 @@ import shutil
 import os
 import sys
 
-@pytest.mark.timeout(180)
+@pytest.mark.skip(reason='Test takes a while and SUP logic is going to be modified')
 def test_sup():
     ''' SUP basic test
     '''
@@ -64,6 +64,7 @@ def test_sup():
     #chip.write_depgraph('tree.png')
 
 #########################
+@pytest.mark.skip(reason='SUP logic is going to be modified')
 def test_sup_circ_import():
     ''' Test that SUP detects circular imports, and throws an error without freezing.
     '''

--- a/tests/core/test_sup.py
+++ b/tests/core/test_sup.py
@@ -5,6 +5,7 @@ import shutil
 import os
 import sys
 
+@pytest.mark.timeout(180)
 def test_sup():
     ''' SUP basic test
     '''


### PR DESCRIPTION
This PR adds support for Linux+ARM64 [SC-214/SC-219] wheels and addresses a few other issues in the process:

- Adds Surelog build caching for Linux builds
- Fix Windows cache blank key [SC-200]
- Upload created wheels even when job fails (although wheels that fail tests still don't get uploaded, because it seems like cibuildwheel doesn't copy them to the final wheelhouse/ location until they pass)
- Clean up extraneous Surelog build artifacts
  - The Surelog build creates a bunch of extra artifacts that aren't necessary to run. The cache was previously acting like a filter since it's only applied to a few paths, but this meant that Linux wheels used to be consistently bloated, and macOS/Windows wheels would occasionally be large for the first build of a new Surelog version. Now the wheels should be uniform regardless of if there was a cache hit or not

Parallelization + caching does make this more palatable than the initial attempt, but the emulated ARM build is still so slow that it's a huge performance hit -the build time even with a Surelog cache hit is now ~2 hours, up from ~45 minutes.

I had to bump timeouts on a few long tests since they were failing for ARM. There's also no pre-built KL ARM package, so I skipped those tests on that platform for now. 

Full build (cache miss): https://github.com/siliconcompiler/siliconcompiler/actions/runs/4514876214
Build w/ cached Surelog: https://github.com/siliconcompiler/siliconcompiler/actions/runs/4534346464. 

Re-running to verify rebase on 3.11 changes: https://github.com/siliconcompiler/siliconcompiler/actions/runs/4536130720

[SC-200]: https://zeroasic.atlassian.net/browse/SC-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ