### PR TITLE
Update surelog version

### DIFF
--- a/.github/workflows/bin/install_klayout_win.bat
+++ b/.github/workflows/bin/install_klayout_win.bat
@@ -1,3 +1,6 @@
-curl https://www.klayout.org/downloads/Windows/klayout-0.28.3-win64.zip --output klayout.zip
+
+for /f "tokens=* USEBACKQ" %%i in (`python3 setup/_tools.py --tool klayout --field version`) do set KLAYOUTVERSION=%%i
+
+curl https://www.klayout.org/downloads/Windows/klayout-%KLAYOUTVERSION%-win64.zip --output klayout.zip
 7z x klayout.zip
-xcopy /E klayout-0.28.3-win64 "C:\Program Files (x86)\KLayout\"
+xcopy /E klayout-%KLAYOUTVERSION%-win64 "C:\Program Files (x86)\KLayout\"

--- a/.github/workflows/bin/install_klayout_win.bat
+++ b/.github/workflows/bin/install_klayout_win.bat
@@ -1,4 +1,3 @@
-
 for /f "tokens=* USEBACKQ" %%i in (`python3 setup/_tools.py --tool klayout --field version`) do set KLAYOUTVERSION=%%i
 
 curl https://www.klayout.org/downloads/Windows/klayout-%KLAYOUTVERSION%-win64.zip --output klayout.zip

--- a/.github/workflows/bin/install_surelog_macos.sh
+++ b/.github/workflows/bin/install_surelog_macos.sh
@@ -5,6 +5,7 @@ src_path=$(cd -- "$(dirname "$0")/../../../" >/dev/null 2>&1 ; pwd -P)
 
 # Install dependencies
 pip3 install orderedmultidict
+pip3 install cmake
 
 # Install Surelog
 git clone $(python3 ${src_path}/setup/_tools.py --tool surelog --field git-url) surelog
@@ -12,7 +13,7 @@ cd surelog
 git checkout $(python3 ${src_path}/setup/_tools.py --tool surelog --field git-commit)
 git submodule update --init --recursive
 
-cmake --version # must be >=3.19
+cmake --version # must be >=3.20
 
 # Point to Python, build universal binary (supporting Intel and Apple Silicon-based Macs)
 export ADDITIONAL_CMAKE_OPTIONS="-DPython3_ROOT_DIR=${pythonLocation} -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64'"

--- a/.github/workflows/bin/install_surelog_macos.sh
+++ b/.github/workflows/bin/install_surelog_macos.sh
@@ -17,7 +17,7 @@ cmake --version # must be >=3.20
 
 # Point to Python, build universal binary (supporting Intel and Apple Silicon-based Macs)
 export ADDITIONAL_CMAKE_OPTIONS="-DPython3_ROOT_DIR=${pythonLocation} -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64'"
-make
+make -j2
 make install PREFIX=$GITHUB_WORKSPACE/siliconcompiler/tools/surelog
 
 python3 ${src_path}/.github/workflows/bin/clean_surelog_build.py

--- a/.github/workflows/bin/install_surelog_win.bat
+++ b/.github/workflows/bin/install_surelog_win.bat
@@ -29,6 +29,7 @@ where ninja && ninja --version
 
 :: Required for Surelog
 pip3 install orderedmultidict
+pip3 install cmake
 
 for /f "tokens=* USEBACKQ" %%i in (`python3 setup/_tools.py --tool surelog --field git-url`) do set GITURL=%%i
 for /f "tokens=* USEBACKQ" %%i in (`python3 setup/_tools.py --tool surelog --field git-commit`) do set GITCOMMIT=%%i

--- a/.github/workflows/bin/setup_wheel_env_linux.sh
+++ b/.github/workflows/bin/setup_wheel_env_linux.sh
@@ -5,7 +5,10 @@ yum --disablerepo=epel -y update ca-certificates
 yum install -y zlib-devel graphviz xorg-x11-server-Xvfb wget
 
 # Install Klayout (for chip.show() test)
-wget --no-check-certificate https://www.klayout.org/downloads/CentOS_7/klayout-0.28.3-0.x86_64.rpm
+klayout_version=$(python3 ${src_path}/setup/_tools.py --tool klayout --field version)
+wget --no-check-certificate \
+    -O klayout.rpm
+    "https://www.klayout.org/downloads/CentOS_7/klayout-${klayout_version}-0.x86_64.rpm"
 yum install -y python3 ruby qt-x11
 # This may fail on ARM64
-rpm -i klayout-0.28.3-0.x86_64.rpm || true
+rpm -i klayout.rpm || true

--- a/setup/_tools.json
+++ b/setup/_tools.json
@@ -6,7 +6,7 @@
   },
   "surelog": {
     "git-url": "https://github.com/chipsalliance/Surelog.git",
-    "git-commit": "ad83eedc7de32ec15a3f7b4e271c6b45ddf547eb"
+    "git-commit": "c05d42898793772a6dc0e8441501c6a30ff15ac9"
   },
   "netgen": {
     "git-url": "https://github.com/RTimothyEdwards/netgen.git",

--- a/setup/_tools.json
+++ b/setup/_tools.json
@@ -25,7 +25,7 @@
     "git-commit": "4cac6ebae076e8b8378597aba1d2119aa29ec419"
   },
   "klayout": {
-    "version": "0.28.3-1",
+    "version": "0.28.3",
     "docker-skip": true
   },
   "sv2v": {

--- a/setup/install-klayout.sh
+++ b/setup/install-klayout.sh
@@ -12,11 +12,11 @@ pkg_version=$(python3 ${src_path}/_tools.py --tool klayout --field version)
 version=$(lsb_release -sr)
 
 if [ "$version" = "18.04" ]; then
-    url=https://www.klayout.org/downloads/Ubuntu-18/klayout_${pkg_version}_amd64.deb
+    url="https://www.klayout.org/downloads/Ubuntu-18/klayout_${pkg_version}-1_amd64.deb"
 elif [ "$version" = "20.04" ]; then
-    url=https://www.klayout.org/downloads/Ubuntu-20/klayout_${pkg_version}_amd64.deb
+    url="https://www.klayout.org/downloads/Ubuntu-20/klayout_${pkg_version}-1_amd64.deb"
 elif [ "$version" = "22.04" ]; then
-    url=https://www.klayout.org/downloads/Ubuntu-22/klayout_${pkg_version}_amd64.deb
+    url="https://www.klayout.org/downloads/Ubuntu-22/klayout_${pkg_version}-1_amd64.deb"
 else
     echo "Script doesn't support Ubuntu version $version."
 fi

--- a/setup/install-surelog.sh
+++ b/setup/install-surelog.sh
@@ -12,6 +12,11 @@ pip3 install orderedmultidict
 mkdir -p deps
 cd deps
 
+# Update cmake to 3.20+
+wget -O cmake.sh https://cmake.org/files/v3.24/cmake-3.24.2-linux-x86_64.sh
+chmod +x cmake.sh
+./cmake.sh --skip-license --prefix=/usr/local
+
 git clone $(python3 ${src_path}/_tools.py --tool surelog --field git-url) surelog
 cd surelog
 git checkout $(python3 ${src_path}/_tools.py --tool surelog --field git-commit)

--- a/setup/install-surelog.sh
+++ b/setup/install-surelog.sh
@@ -8,14 +8,10 @@ src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
 # These dependencies are up-to-date with instructions from the INSTALL.md from the commit we are pinned to below
 sudo apt-get install -y build-essential cmake git pkg-config tclsh swig uuid-dev libgoogle-perftools-dev python3 python3-orderedmultidict python3-psutil python3-dev default-jre lcov
 pip3 install orderedmultidict
+pip3 install cmake
 
 mkdir -p deps
 cd deps
-
-# Update cmake to 3.20+
-wget -O cmake.sh https://cmake.org/files/v3.24/cmake-3.24.2-linux-x86_64.sh
-chmod +x cmake.sh
-./cmake.sh --skip-license --prefix=/usr/local
 
 git clone $(python3 ${src_path}/_tools.py --tool surelog --field git-url) surelog
 cd surelog

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -38,7 +38,7 @@ def setup(chip):
     # Standard Setup
     chip.set('tool', tool, 'exe', exe)
     chip.set('tool', tool, 'vswitch', '--version')
-    chip.set('tool', tool, 'version', '>=1.13', clobber=False)
+    chip.set('tool', tool, 'version', '>=1.51', clobber=False)
 
     # Command-line options.
     options = []


### PR DESCRIPTION
Changes:
- update surelog to 1.51 and set required version accordingly to ensure we get bug fixes
- Fix version of klayout to use _tools.json for wheels build

Wheels: https://github.com/siliconcompiler/siliconcompiler/actions/runs/4547388989