### PR TITLE
Adding SBOM feature

### DIFF
--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from siliconcompiler.schema.utils import trim
 
-SCHEMA_VERSION = '0.30.0'
+SCHEMA_VERSION = '0.31.0'
 
 #############################################################################
 # PARAM DEFINITION
@@ -1085,6 +1085,8 @@ def schema_flowgraph(cfg, flow='default', step='default', index='default'):
 
 def schema_tool(cfg, tool='default'):
 
+    version = 'default'
+    
     scparam(cfg, ['tool', tool, 'exe'],
             sctype='str',
             shorthelp="Tool: executable name",
@@ -1093,13 +1095,29 @@ def schema_tool(cfg, tool='default'):
                      "api:  chip.set('tool','openroad','exe','openroad')"],
             schelp="""Tool executable name.""")
 
+    scparam(cfg, ['tool', tool, 'sbom', version],
+            sctype='[file]',
+            pernode='optional',
+            shorthelp="Tool: software BOM",
+            switch="-tool_sbom 'tool version <file>'",
+            example=[
+                "cli: -tool_sbom 'yosys 1.0.1 ys_sbom.json'",
+                "api:  chip.set('tool','yosys','sbom','1.0','ys_sbom.json')"],
+            schelp="""
+            Paths to software bill of material (SBOM) document file of the tool
+            specified on a per version basis. The SBOM includes critical
+            package information about the tool including the list of included 
+            components, licenses, and copyright. The SBOM file is generally 
+            provided as in a a standardized open data format such as SPDX.""")
+    
     scparam(cfg, ['tool', tool, 'path'],
             sctype='dir',
             pernode='optional',
             shorthelp="Tool: executable path",
             switch="-tool_path 'tool <dir>'",
-            example=["cli: -tool_path 'openroad /usr/local/bin'",
-                     "api:  chip.set('tool','openroad','path','/usr/local/bin')"],
+            example=[
+                "cli: -tool_path 'openroad /usr/local/bin'",
+                "api: chip.set('tool','openroad','path','/usr/local/bin')"],
             schelp="""
             File system path to tool executable. The path is prepended to the
             system PATH environment variable for batch and interactive runs. The

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -6407,7 +6407,7 @@
         }
     },
     "schemaversion": {
-        "defvalue": "0.30.0",
+        "defvalue": "0.31.0",
         "example": [
             "api: chip.get('schemaversion')"
         ],
@@ -6490,7 +6490,7 @@
                 "defvalue": null,
                 "example": [
                     "cli: -tool_path 'openroad /usr/local/bin'",
-                    "api:  chip.set('tool','openroad','path','/usr/local/bin')"
+                    "api: chip.set('tool','openroad','path','/usr/local/bin')"
                 ],
                 "help": "File system path to tool executable. The path is prepended to the\nsystem PATH environment variable for batch and interactive runs. The\npath parameter can be left blank if the 'exe' is already in the\nenvironment search path.",
                 "lock": false,
@@ -6504,6 +6504,29 @@
                     "-tool_path 'tool <dir>'"
                 ],
                 "type": "dir"
+            },
+            "sbom": {
+                "default": {
+                    "copy": false,
+                    "defvalue": [],
+                    "example": [
+                        "cli: -tool_sbom 'yosys 1.0.1 ys_sbom.json'",
+                        "api:  chip.set('tool','yosys','sbom','1.0','ys_sbom.json')"
+                    ],
+                    "hashalgo": "sha256",
+                    "help": "Paths to software bill of material (SBOM) document file of the tool\nspecified on a per version basis. The SBOM includes critical\npackage information about the tool including the list of included\ncomponents, licenses, and copyright. The SBOM file is generally\nprovided as in a a standardized open data format such as SPDX.",
+                    "lock": false,
+                    "node": {},
+                    "notes": null,
+                    "pernode": "optional",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Tool: software BOM",
+                    "switch": [
+                        "-tool_sbom 'tool version <file>'"
+                    ],
+                    "type": "[file]"
+                }
             },
             "task": {
                 "default": {

--- a/tests/core/test_hash_files.py
+++ b/tests/core/test_hash_files.py
@@ -10,6 +10,8 @@ def test_hash_files():
     chip.write_manifest("raw.json")
     allkeys = chip.allkeys()
     for keypath in allkeys:
+        if 'default' in keypath:
+            continue
         if 'file' in chip.get(*keypath, field='type'):
             for vals, step, index in chip.schema._getvals(*keypath):
                 hashes = chip.hash_files(*keypath, step=step, index=index)


### PR DESCRIPTION
This change is inspired by a hallway conversation with @mithro.
 
It has become clear that I have not spent nearly enough time studying the existing the state of practice in the software domain.
There is no point inventing a new format/standard, when a perfectly good one exists.

This PR is adding an SBOM to the executable as a fist class parameter.

https://spdx.dev/
https://github.com/opensbom-generator/spdx-sbom-generator
https://github.com/spdx/spdx-examples

Next PR will explore removing the package information and replacing that section of the scema with an SBOM. This change goes along with our general philosophy to only put the minimal of information in the schema. Whenever there is an undisputed open standard, we prefer using that standard. In the case of the SBOM, it does create one level of indirection of provenance data...but the value of having a standardized format for SBOMs far outweigh the disadvantage. 
