### PR TITLE
Provide logger to Schema object

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -235,9 +235,12 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         self.logger.addHandler(handler)
         self.logger.setLevel(loglevel)
 
+        self.schema.logger = self.logger
+
     ###########################################################################
     def _deinit_logger(self):
         self.logger = None
+        self.schema.logger = None
 
     ###########################################################################
     def _get_switches(self, schema, *keypath):
@@ -946,17 +949,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             self.logger.setLevel(value)
 
         try:
-            if not self.schema.set(
-                *keypath, value, field=field, clobber=clobber, step=step, index=index
-            ):
-                # TODO: this message should be pushed down into Schema.set()
-                # once we have a static logger.
-                if clobber:
-                    self.logger.debug(f'Failed to set value for {keypath}: '
-                        'parameter is locked')
-                else:
-                    self.logger.debug(f'Failed to set value for {keypath}: '
-                        'clobber is False and parameter may be locked')
+            self.schema.set(*keypath, value, field=field, clobber=clobber, step=step, index=index)
         except (ValueError, TypeError) as e:
             self.error(e)
 
@@ -978,8 +971,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         '''
         self.logger.debug(f'Unsetting {keypath}')
 
-        if not self.schema.unset(*keypath, step=step, index=index):
-            self.logger.debug(f'Failed to unset value for {keypath}: parameter is locked')
+        self.schema.unset(*keypath, step=step, index=index)
 
     ###########################################################################
     def add(self, *args, field='value', step=None, index=None):
@@ -1014,11 +1006,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         self.logger.debug(f'Appending value {value} to {keypath}')
 
         try:
-            if not self.schema.add(*args, field=field, step=step, index=index):
-                # TODO: this message should be pushed down into Schema.add()
-                # once we have a static logger.
-                self.logger.debug(f'Failed to add value for {keypath}: '
-                    'parameter may be locked')
+            self.schema.add(*args, field=field, step=step, index=index)
         except (ValueError, TypeError) as e:
             self.error(str(e))
 
@@ -2545,7 +2533,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         Args:
             step (str): name of the step to calculate the area from
             index (str): name of the step to calculate the area from
-        
+
         Returns:
             Design area (float).
 

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -8,6 +8,8 @@ import copy
 import csv
 import gzip
 import json
+import logging
+import uuid
 import os
 import re
 
@@ -53,6 +55,8 @@ class Schema:
             self.cfg = Schema._read_manifest(manifest)
         else:
             self.cfg = schema_cfg()
+
+        self.logger = logging.getLogger(uuid.uuid4().hex)
 
     ###########################################################################
     @staticmethod
@@ -155,11 +159,11 @@ class Schema:
             index = str(index)
 
         if cfg['lock']:
-            # TODO: log here
+            self.logger.debug(f'Failed to set value for {keypath}: parameter is locked')
             return False
 
         if Schema._is_set(cfg, step=step, index=index) and not clobber:
-            # TODO: log here
+            self.logger.debug(f'Failed to set value for {keypath}: clobber is False and parameter is set')
             return False
 
         allowed_values = None
@@ -211,7 +215,7 @@ class Schema:
                 raise ValueError(f'Invalid field {field}: add() must be called on a list')
 
         if cfg['lock']:
-            # TODO: log here
+            self.logger.debug(f'Failed to add value for {keypath}: parameter is locked')
             return False
 
         allowed_values = None
@@ -253,8 +257,7 @@ class Schema:
             raise ValueError(f'Invalid args to unset() of keypath {keypath}: {err}')
 
         if cfg['lock']:
-            # TODO: log here
-            return False
+            self.logger.debug(f'Failed to unset value for {keypath}: parameter is locked')
 
         if step is None:
             step = Schema.GLOBAL_KEY

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -258,6 +258,7 @@ class Schema:
 
         if cfg['lock']:
             self.logger.debug(f'Failed to unset value for {keypath}: parameter is locked')
+            return False
 
         if step is None:
             step = Schema.GLOBAL_KEY


### PR DESCRIPTION
I think this is the simplest fix to this long-standing annoyance, although the logging stuff as a whole could probably use some more love. 

I took a look at this since it's on the path to fixing the problem we noticed with the KLayout scripts, where using the Schema object directly has different behavior than going through the Chip object. I'd like to pull the `merge_manifest` logic into Schema, which will help solve that problem (and that requires a logger). 