### PR TITLE
Fix a bug caused by tuples not being serializable in JSON

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1735,7 +1735,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         for step in self.getkeys('flowgraph', flow):
             for index in self.getkeys('flowgraph', flow, step):
                 nodes.add((step, index))
-                nodes.update(self.get('flowgraph', flow, step, index, 'input'))
+                input_tasks = self.get('flowgraph', flow, step, index, 'input')
+                for task in input_tasks:
+                    nodes.add((task[0], task[1]))
 
         error = False
         for step, index in nodes:


### PR DESCRIPTION
This change fixes an immediate symptom of the following problem, but the root cause probably merits a deeper investigation.

We use tuple data structures in some areas of the Schema, but it turns out that tuples are not serializable as JSON; they get silently converted to lists.

I'm a little bit surprised that this hasn't caused some sort of problem already, but tuples and lists can be accessed in very similar ways, and Python is not statically typed. In this case, the bug only surfaced because we add a Schema keypath directly to a set, which requires hashing the object. Tuples can be hashed, but lists cannot, so when we call `chip.run()` after loading in a JSON-based Schema, this part of the code would raise a `TypeError`.

For now, we can convert the `[step, index]` lists from the JSON-ified Schema into `(step, index)` tuples. But we may want to reconsider the use of tuples in the Schema, since we want the manifests to be easy to [de]serialize.