### PR TITLE
Make `Schema()` behavior match `Chip()` in KL scripts

### DIFF
--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -859,7 +859,7 @@ class Schema:
 
         See :meth:`~siliconcompiler.core.Chip.read_manifest` for detailed documentation.
         """
-        self.read_manifest(filename, job=job, clear=clear, clobber=clobber)
+        self._read_manifest(filename, job=job, clear=clear, clobber=clobber)
 
     ###########################################################################
     def _read_manifest(self, filename, job=None, clear=True, clobber=True, partial=False):

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -45,14 +45,9 @@ class Schema:
     GLOBAL_KEY = 'global'
     PERNODE_FIELDS = ('value', 'filehash', 'date', 'author', 'signature')
 
-    def __init__(self, cfg=None, manifest=None):
-        if cfg is not None and manifest is not None:
-            raise ValueError('You may not specify both cfg and manifest')
-
+    def __init__(self, cfg=None):
         if cfg is not None:
             self.cfg = copy.deepcopy(cfg)
-        elif manifest is not None:
-            self.cfg = Schema._read_manifest(manifest)
         else:
             self.cfg = schema_cfg()
 
@@ -60,7 +55,8 @@ class Schema:
 
     ###########################################################################
     @staticmethod
-    def _read_manifest(filepath):
+    def _read_manifest_file(filepath):
+        '''Read manifest file and return configuration dictionary.'''
         if not os.path.isfile(filepath):
             raise ValueError(f'Manifest file not found {filepath}')
 
@@ -823,7 +819,7 @@ class Schema:
         return value_empty
 
     ###########################################################################
-    def history(self, job):
+    def _history(self, job):
         '''
         Returns a *mutable* reference to ['history', job] as a Schema object.
 
@@ -841,6 +837,144 @@ class Schema:
         schema = Schema()
         schema.cfg = self.cfg['history'][job]
         return schema
+
+    ###########################################################################
+    def _key_may_be_updated(self, keypath):
+        '''Helper that returns whether `keypath` can be updated mid-run.'''
+        # TODO: cleaner way to manage this?
+        if keypath[0] in ('metric', 'record'):
+            return True
+        if keypath[0] == 'flowgraph' and keypath[4] in ('select', 'status'):
+            return True
+        if keypath[0] == 'tool':
+            return True
+        if self.get(*keypath, field='type') in ['file', '[file]']:
+            return True
+        return False
+
+    ###########################################################################
+    def read_manifest(self, filename, job=None, clear=True, clobber=True):
+        """
+        Reads a manifest from disk and merges it with the current compilation manifest.
+
+        See :meth:`~siliconcompiler.core.Chip.read_manifest` for detailed documentation.
+        """
+        self.read_manifest(filename, job=job, clear=clear, clobber=clobber)
+
+    ###########################################################################
+    def _read_manifest(self, filename, job=None, clear=True, clobber=True, partial=False):
+        """
+        Internal read_manifest() implementation with `partial` arg.
+
+        partial (bool): If True, perform a partial merge, only merging keypaths
+        that may have been updated during run().
+        """
+        # Read from file into new schema object
+        cfg = Schema._read_manifest_file(filename)
+        schema = Schema(cfg)
+
+        # Merge data in schema with Chip configuration
+        self._merge_manifest(schema, job=job, clear=clear, clobber=clobber, partial=partial)
+
+        # Read history, if we're not already reading into a job
+        if 'history' in schema.getkeys() and not partial and not job:
+            for historic_job in schema.getkeys('history'):
+                self._merge_manifest(schema._history(historic_job),
+                                     job=historic_job,
+                                     clear=clear,
+                                     clobber=clobber,
+                                     partial=False)
+
+        # TODO: better way to handle this?
+        if 'library' in schema.getkeys() and not partial:
+            for libname in schema.getkeys('library'):
+                self._import_library(libname, schema.getdict('library', libname), job=job, clobber=clobber)
+
+    ###########################################################################
+    def _merge_manifest(self, src, job=None, clobber=True, clear=True, check=False, partial=False):
+        """
+        Merges a given manifest with the current compilation manifest.
+
+        All value fields in the provided schema dictionary are merged into the
+        current Schema object. Dictionaries with non-existent keypath produces a
+        logger error message and raises the Chip object error flag.
+
+        Args:
+            src (Schema): Schema object to merge
+            job (str): Specifies non-default job to merge into
+            clear (bool): If True, disables append operations for list type
+            clobber (bool): If True, overwrites existing parameter value
+            check (bool): If True, checks the validity of each key
+            partial (bool): If True, perform a partial merge, only merging
+                keypaths that may have been updated during run().
+        """
+        if job is not None:
+            dest = self._history(job)
+        else:
+            dest = self
+
+        for keylist in src.allkeys():
+            if partial and not self._key_may_be_updated(keylist):
+                continue
+            if keylist[0] in ('history', 'library'):
+                continue
+            #only read in valid keypaths without 'default'
+            key_valid = True
+            if check:
+                key_valid = dest.valid(*keylist, default_valid=True)
+                if not key_valid:
+                    self.logger.warning(f'Keypath {keylist} is not valid')
+            if key_valid and 'default' not in keylist:
+                typestr = src.get(*keylist, field='type')
+                should_append = re.match(r'\[', typestr) and not clear
+                for val, step, index in src._getvals(*keylist, return_defvalue=False):
+                    # update value, handling scalars vs. lists
+                    if should_append:
+                        dest.add(*keylist, val, step=step, index=index)
+                    else:
+                        dest.set(*keylist, val, step=step, index=index, clobber=clobber)
+
+                    # update other pernode fields
+                    # TODO: only update these if clobber is successful
+                    step_key = Schema.GLOBAL_KEY if not step else step
+                    idx_key = Schema.GLOBAL_KEY if not index else index
+                    for field in src.getdict(*keylist)['node'][step_key][idx_key].keys():
+                        if field == 'value':
+                            continue
+                        v = src.get(*keylist, step=step, index=index, field=field)
+                        if should_append:
+                            dest.add(*keylist, v, step=step, index=index, field=field)
+                        else:
+                            dest.set(*keylist, v, step=step, index=index, field=field)
+
+                # update other fields that a user might modify
+                for field in src.getdict(*keylist).keys():
+                    if field in ('node', 'switch', 'type', 'require', 'defvalue',
+                                 'shorthelp', 'example', 'help'):
+                        # skip these fields (node handled above, others are static)
+                        continue
+                    # TODO: should we be taking into consideration clobber for these fields?
+                    v = src.get(*keylist, field=field)
+                    dest.set(*keylist, v, field=field)
+
+    ###########################################################################
+    def _import_library(self, libname, libcfg, job=None, clobber=True):
+        '''Helper to import library with config 'libconfig' as a library
+        'libname' in current Chip object.'''
+        if job:
+            cfg = self.cfg['history'][job]['library']
+        else:
+            cfg = self.cfg['library']
+
+        if libname in cfg:
+            if clobber:
+                self.logger.warning(f'Overwriting existing library {libname}')
+            else:
+                return
+
+        cfg[libname] = copy.deepcopy(libcfg)
+        if 'pdk' in cfg:
+            del cfg[libname]['pdk']
 
 if _has_yaml:
     class YamlIndentDumper(yaml.Dumper):

--- a/siliconcompiler/tools/klayout/klayout_export.py
+++ b/siliconcompiler/tools/klayout/klayout_export.py
@@ -228,7 +228,8 @@ def gds_export(design_name, in_def, in_files, out_file, tech_file, foundry_lefs,
   write_options.gds2_write_timestamps = timestamps
   top_only_layout.write(out_file, write_options)
 
-schema = Schema(manifest='sc_manifest.json')
+schema = Schema()
+schema.read_manifest('sc_manifest.json')
 
 # Extract info from manifest
 sc_step = schema.get('arg', 'step')

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -39,13 +39,7 @@ def show(schema, input_path, output_path, screenshot=False):
 
     # Tech / library LEF files are optional.
     tech_lefs = schema.get('pdk', sc_pdk, 'aprtech', 'klayout', sc_stackup, sc_libtype, 'lef')
-
-    # Need to check validity since there are no "default" placeholders within the
-    # library schema that would allow schema.get() to get a default value.
-    if schema.valid('library', sc_mainlib, 'output', sc_stackup, 'lef'):
-        lib_lefs = schema.get('library', sc_mainlib, 'output', sc_stackup, 'lef', step=step, index=index)
-    else:
-        lib_lefs = []
+    lib_lefs = schema.get('library', sc_mainlib, 'output', sc_stackup, 'lef', step=step, index=index)
 
     # Load KLayout technology file
     tech = pya.Technology()
@@ -119,7 +113,8 @@ def main():
     sys.path.append(SC_ROOT)
     from schema import Schema
 
-    schema = Schema(manifest='sc_manifest.json')
+    schema = Schema()
+    schema.read_manifest('sc_manifest.json')
 
     flow = schema.get('option', 'flow')
     step = schema.get('arg', 'step')


### PR DESCRIPTION
Since the `Schema` object instantiated in the KL scripts was being initialized directly from a manifest, rather than having it be merged into a set of default values, some of the behavior was subtly different from using a `Chip` object instead. This is confusing and error-prone, so this PR moves `read_manifest()` and other methods used to implement it into `Schema`, so that it should behave just like a chip object. 

`Chip` still provides a `read_manifest` pass-through in the same style of get/set/etc., so its public API has not been changed.

I verified manually that this fixes the test case Aulihan reported - it runs thru successfully even if the lyp file is removed.

This PR is based on #1441, so that one should be merged first.