### PR TITLE
Fix docs build

### DIFF
--- a/siliconcompiler/flows/showflow.py
+++ b/siliconcompiler/flows/showflow.py
@@ -6,6 +6,7 @@ import importlib
 # DOCS
 ############################################################################
 def make_docs(chip):
+    chip.load_target('freepdk45_demo')
     return setup(chip, filetype='gds', np=3)
 
 ###########################################################################

--- a/siliconcompiler/sphinx_ext/dynamicgen.py
+++ b/siliconcompiler/sphinx_ext/dynamicgen.py
@@ -481,6 +481,7 @@ class ToolGen(DynamicGen):
         flow = chip.get('option', 'flow')
         if not flow:
             flow = '<flow>'
+        chip.set('option', 'flow', flow)
         chip.set('flowgraph', flow, step, index, 'tool', tool_name)
         chip.set('flowgraph', flow, step, index, 'task', task_name)
 


### PR DESCRIPTION
Fixes:
- during the tool/task merges the docs started to fail in to build some tools. This corrects it by ensuring the right setting are available. 