### PR TITLE
Add sc-issue to generate runnable testcases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ distro >= 1.6.0
 packaging >= 21.3
 psutil >= 5.8.0
 Pillow >= 8.4.0
+GitPython >= 3.1.0
 
 # Build dependencies
 #:build

--- a/siliconcompiler/apps/sc_issue.py
+++ b/siliconcompiler/apps/sc_issue.py
@@ -22,11 +22,11 @@ def main():
     failed flow or runs an issue generated with this program.
 
     To generate a testcase, use:
-        sc-issue -generate -cfg <cfg_file>
+        sc-issue -generate -cfg <stepdir>/outputs/<design>.pkg.json
       or include a different step/index than what the cfg_file is pointing to:
-        sc-issue -generate -cfg <cfg_file> -arg_step <step> -arg_index <index>
+        sc-issue -generate -cfg <otherdir>/outputs/<design>.pkg.json -arg_step <step> -arg_index <index>
       or include specific libraries while excluding others:
-        sc-issue -generate -cfg <cfg_file> -exclude_libraries -add_library sram -add_library gpio
+        sc-issue -generate -cfg <stepdir>/outputs/<design>.pkg.json -exclude_libraries -add_library sram -add_library gpio
 
     To run a testcase, use:
         sc-issue -run -file sc_issue_<...>.tar.gz
@@ -73,6 +73,15 @@ def main():
     if switches['generate']:
         step = chip.get('arg', 'step')
         index = chip.get('arg', 'index')
+
+        if not step:
+            chip.logger.error('Unable to determine step from manifest')
+        if not index:
+            chip.logger.error('Unable to determine index from manifest')
+        if not step or not index:
+            # Exit out
+            sys.exit(1)
+
         chip._generate_testcase(step,
                                 index,
                                 switches['file'],

--- a/siliconcompiler/apps/sc_issue.py
+++ b/siliconcompiler/apps/sc_issue.py
@@ -80,7 +80,7 @@ def main():
             chip.logger.error('Unable to determine index from manifest')
         if not step or not index:
             # Exit out
-            sys.exit(1)
+            return 1
 
         chip._generate_testcase(step,
                                 index,
@@ -90,11 +90,14 @@ def main():
                                 include_libraries=not switches['exclude_libraries'],
                                 include_specific_libraries=switches['add_library'],
                                 hash_files=switches['hash_files'])
+
+        return 0
+
     if switches['run']:
         if not switches['file']:
             raise ValueError('-file must be provided')
 
-        test_dir = os.path.splitext(os.path.basename(switches['file']))[0]
+        test_dir = os.path.basename(switches['file']).split('.')[0]
         with tarfile.open(switches['file'], 'r:gz') as f:
             f.extractall(path=test_dir)
 
@@ -157,6 +160,8 @@ def main():
         # Rerun setup task
         chip._setup_task(step, index)
         chip._runtask(step, index, {}, replay=True)
+
+        return 0
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/apps/sc_issue.py
+++ b/siliconcompiler/apps/sc_issue.py
@@ -1,0 +1,134 @@
+# Copyright 2023 Silicon Compiler Authors. All Rights Reserved.
+import sys
+import os
+import siliconcompiler
+import tarfile
+import json
+import importlib
+
+def main():
+    progname = "sc-issue"
+    chip = siliconcompiler.Chip(progname)
+    switchlist = ['-cfg',
+                  '-version',
+                  '-arg_step',
+                  '-arg_index',
+                  '-tool_task_variable',
+                  '-tool_task_option',
+                  '-loglevel']
+    description = """
+    -----------------------------------------------------------
+    Restricted SC app that generates a sharable testcase from a 
+    failed flow or runs an issue generated with this program.
+    -----------------------------------------------------------
+    """
+
+    default_file = 'sc_issue.tgz'
+
+    issue_arguments = {
+        '-generate': {'action': 'store_true',
+                      'help': 'generate a testcase'},
+
+        '-exclude_libraries': {'action': 'store_true',
+                               'help': 'flag to ensure libraries are excluded in the testcase'},
+        '-exclude_pdks': {'action': 'store_true',
+                          'help': 'flag to ensure pdks are excluded in the testcase'},
+        '-hash_files': {'action': 'store_true',
+                        'help': 'flag to hash the files in the schema before generating the manifest'},
+
+        '-run': {'action': 'store_true',
+                 'help': 'run a provided testcase'},
+
+        '-use': {'action': 'append',
+                 'help': 'list of modules to load into test run'},
+
+        '-file': {'default': default_file,
+                  'help': f'filename for the generated testcase, defaults to {default_file}',
+                  'metavar': '<file>'},
+    }
+
+    switches = chip.create_cmdline(progname,
+                                   switchlist=switchlist,
+                                   description=description,
+                                   additional_args=issue_arguments)
+
+    if switches['generate'] and switches['run']:
+        raise ValueError('Only one of -generate or -run can be used')
+
+    if switches['generate']:
+        step = chip.get('arg', 'step')
+        index = chip.get('arg', 'index')
+        chip._generate_testcase(step,
+                                index,
+                                switches['file'],
+                                include_pdks=not switches['exclude_pdks'],
+                                include_libraries=not switches['exclude_libraries'],
+                                hash_files=switches['hash_files'])
+    if switches['run']:
+        test_dir = os.path.splitext(os.path.basename(switches['file']))[0]
+        with tarfile.open(switches['file'], 'r:gz') as f:
+            f.extractall(path=test_dir)
+
+        chip.read_manifest(f'{test_dir}/manifest.json')
+
+        with open(f'{test_dir}/issue.json', 'r') as f:
+            issue_info = json.load(f)
+
+        # Report major information
+        sc_version = issue_info['version']['sc']
+        if 'commit' in issue_info['version']['git']:
+            sc_source = issue_info['version']['git']['commit']
+        else:
+            sc_source = 'installed'
+
+        chip.logger.info(f"Design: {chip.design}")
+        chip.logger.info(f"SiliconCompiler version: {sc_version} / {sc_source}")
+        chip.logger.info(f"Schema version: {issue_info['version']['schema']}")
+        chip.logger.info(f"Python version: {issue_info['python']['version']}")
+
+        sc_os = issue_info['machine']['system']
+        if 'distro' in issue_info['machine']:
+            sc_os += f" {issue_info['machine']['distro']}"
+        sc_os += f" {issue_info['machine']['osversion']} {issue_info['machine']['arch']} {issue_info['machine']['kernelversion']}"
+        chip.logger.info(f"Machine: {sc_os}")
+        chip.logger.info(f"Date: {issue_info['date']}")
+
+        step = issue_info['run']['step']
+        index = issue_info['run']['index']
+
+        chip.set('arg', 'step', step)
+        chip.set('arg', 'index', index)
+        tool, task = chip._get_tool_task(step, index)
+        chip.logger.info(f'Preparing run for {step}{index} - {tool}/{task}')
+
+        # Modify run environment to point to extracted files
+        builddir_key = ['option', 'builddir']
+        new_builddir = f"{test_dir}/{chip.get(*builddir_key)}"
+        chip.logger.info(f"Changing {builddir_key} to '{new_builddir}'")
+        chip.set(*builddir_key, new_builddir)
+
+        option_key = ['tool', tool, 'task', task, 'option']
+        chip.logger.info(f"Removing previous settings of {option_key}: {chip.get(*option_key, step=step, index=index)}")
+        chip.unset(*option_key, step=step, index=index)
+
+        breakpoint_key = ['option', 'breakpoint']
+        chip.logger.info(f"Setting {breakpoint_key} to True")
+        chip.set(*breakpoint_key, True, step=step, index=index)
+
+        if switches['use']:
+            for use in switches['use']:
+                try:
+                    module = importlib.import_module(use)
+                    chip.logger.info(f"Loading '{use}' module")
+                    chip.use(module)
+                except ModuleNotFoundError:
+                    chip.logger.error(f"Unable to use '{use}' module")
+
+        # Run task
+        # Rerun setup task
+        chip._setup_task(step, index)
+        chip._runtask(step, index, {}, replay=True)
+
+#########################
+if __name__ == "__main__":
+    sys.exit(main())

--- a/siliconcompiler/apps/sc_issue.py
+++ b/siliconcompiler/apps/sc_issue.py
@@ -23,8 +23,6 @@ def main():
     -----------------------------------------------------------
     """
 
-    default_file = 'sc_issue.tgz'
-
     issue_arguments = {
         '-generate': {'action': 'store_true',
                       'help': 'generate a testcase'},
@@ -42,8 +40,7 @@ def main():
         '-use': {'action': 'append',
                  'help': 'list of modules to load into test run'},
 
-        '-file': {'default': default_file,
-                  'help': f'filename for the generated testcase, defaults to {default_file}',
+        '-file': {'help': f'filename for the generated testcase',
                   'metavar': '<file>'},
     }
 
@@ -65,6 +62,9 @@ def main():
                                 include_libraries=not switches['exclude_libraries'],
                                 hash_files=switches['hash_files'])
     if switches['run']:
+        if not switches['file']:
+            raise ValueError('-file must be provided')
+
         test_dir = os.path.splitext(os.path.basename(switches['file']))[0]
         with tarfile.open(switches['file'], 'r:gz') as f:
             f.extractall(path=test_dir)

--- a/siliconcompiler/apps/sc_issue.py
+++ b/siliconcompiler/apps/sc_issue.py
@@ -20,6 +20,16 @@ def main():
     -----------------------------------------------------------
     Restricted SC app that generates a sharable testcase from a 
     failed flow or runs an issue generated with this program.
+
+    To generate a testcase, use:
+        sc-issue -generate -cfg <cfg_file>
+      or include a different step/index than what the cfg_file is pointing to:
+        sc-issue -generate -cfg <cfg_file> -arg_step <step> -arg_index <index>
+      or include specific libraries while excluding others:
+        sc-issue -generate -cfg <cfg_file> -exclude_libraries -add_library sram -add_library gpio
+
+    To run a testcase, use:
+        sc-issue -run -file sc_issue_<...>.tar.gz
     -----------------------------------------------------------
     """
 
@@ -38,7 +48,15 @@ def main():
                  'help': 'run a provided testcase'},
 
         '-use': {'action': 'append',
-                 'help': 'list of modules to load into test run'},
+                 'help': 'modules to load into test run',
+                 'metavar': '<module>'},
+
+        '-add_library': {'action': 'append',
+                         'help': 'library to include in the testcase, if not provided all libraries will be added according to the -exclude_libraries flag',
+                         'metavar': '<library>'},
+        '-add_pdk': {'action': 'append',
+                     'help':  'pdk to include in the testcase, if not provided all libraries will be added according to the -exclude_pdks flag',
+                     'metavar': '<pdk>'},
 
         '-file': {'help': f'filename for the generated testcase',
                   'metavar': '<file>'},
@@ -59,7 +77,9 @@ def main():
                                 index,
                                 switches['file'],
                                 include_pdks=not switches['exclude_pdks'],
+                                include_specific_pdks=switches['add_pdk'],
                                 include_libraries=not switches['exclude_libraries'],
+                                include_specific_libraries=switches['add_library'],
                                 hash_files=switches['hash_files'])
     if switches['run']:
         if not switches['file']:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3499,7 +3499,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             prevstep = step
 
     ###########################################################################
-    def _runtask(self, step, index, status):
+    def _runtask(self, step, index, status, replay=False):
         '''
         Private per step run method called by run().
 
@@ -3562,7 +3562,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         workdir = self._getworkdir(step=step,index=index)
         cwd = os.getcwd()
-        if os.path.isdir(workdir):
+        if os.path.isdir(workdir) and not replay:
             shutil.rmtree(workdir)
         os.makedirs(workdir, exist_ok=True)
 
@@ -3575,7 +3575,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         # Merge manifests from all input dependancies
 
         all_inputs = []
-        if not self.get('option', 'remote'):
+        if not self.get('option', 'remote') and not replay:
             for in_step, in_index in self.get('flowgraph', flow, step, index, 'input'):
                 in_task_status = status[in_step + in_index]
                 self.set('flowgraph', flow, in_step, in_index, 'status', in_task_status)
@@ -3623,8 +3623,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
             # Skip copying pkg.json files here, since we write the current chip
             # configuration into inputs/{design}.pkg.json earlier in _runstep.
-            utils.copytree(f"../../../{in_job}/{in_step}/{in_index}/outputs", 'inputs/', dirs_exist_ok=True,
-                ignore=[f'{design}.pkg.json'], link=True)
+            if not replay:
+                utils.copytree(f"../../../{in_job}/{in_step}/{in_index}/outputs", 'inputs/', dirs_exist_ok=True,
+                    ignore=[f'{design}.pkg.json'], link=True)
 
         ##################
         # Check manifest

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -5112,19 +5112,23 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         try:
             # Check git information
             repo = git.Repo(path=os.path.join(self.scroot, '..'))
-            git_data['commit'] = repo.head.commit.hexsha
-            git_data['date'] = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(repo.head.commit.committed_date))
-            git_data['author'] = f'{repo.head.commit.author.name} <{repo.head.commit.author.email}>'
-            git_data['msg'] = repo.head.commit.message
+            commit = repo.head.commit
+            git_data['commit'] = commit.hexsha
+            git_data['date'] = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(commit.committed_date))
+            git_data['author'] = f'{commit.author.name} <{commit.author.email}>'
+            git_data['msg'] = commit.message
             # Count number of commits ahead of version
             version_tag = repo.tag(f'v{self.scversion}')
             count = 0
-            for c in repo.head.commit.iter_parents():
+            for c in commit.iter_parents():
                 count += 1
                 if c == version_tag.commit:
                     break
             git_data['count'] = count
         except git.InvalidGitRepositoryError:
+            pass
+        except Exception as e:
+            git_data['failed'] = str(e)
             pass
 
         issue_time = time.time()

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -5033,7 +5033,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         return attributes
 
     #######################################
-    def _generate_testcase(self, step, index, archive_name=None, include_pdks=True, include_libraries=True, hash_files=False):
+    def _generate_testcase(self, step, index, archive_name=None, include_pdks=True, include_specific_pdks=None, include_libraries=True, include_specific_libraries=None, hash_files=False):
         # Save original schema since it will be modified
         schema_copy = self.schema.copy()
 
@@ -5067,10 +5067,16 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             copy = True
             if keypath[0] == 'libraries':
                 # only copy libraries if selected
-                copy = include_libraries
+                if include_specific_libraries and keypath[1] in include_specific_libraries:
+                    copy = True
+                else:
+                    copy = include_libraries
             elif keypath[0] == 'pdk':
                 # only copy pdks if selected
-                copy = include_pdks
+                if include_specific_pdks and keypath[1] in include_specific_pdks:
+                    copy = True
+                else:
+                    copy = include_pdks
             elif keypath[0] == 'history':
                 # Skip history
                 continue

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1165,6 +1165,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         """
 
+        if not filename:
+            return None
+
         # Replacing environment variables
         filename = self._resolve_env_vars(filename)
 
@@ -1285,14 +1288,14 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         # cases.
 
         search_paths = None
-        if len(keypath) >= 4 and keypath[0] == 'tool' and keypath[4] in ('input', 'output', 'report'):
+        if len(keypath) >= 5 and keypath[0] == 'tool' and keypath[4] in ('input', 'output', 'report'):
             if keypath[4] == 'report':
                 io = ""
             else:
                 io = keypath[4] + 's'
             iodir = os.path.join(self._getworkdir(jobname=job, step=step, index=index), io)
             search_paths = [iodir]
-        elif len(keypath) >= 4 and keypath[0] == 'tool' and keypath[4] == 'script':
+        elif len(keypath) >= 5 and keypath[0] == 'tool' and keypath[4] == 'script':
             tool = keypath[1]
             task = keypath[3]
             refdirs = self._find_files('tool', tool, 'task', task, 'refdir', step=step, index=index)
@@ -4813,6 +4816,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
     #######################################
     def _resolve_env_vars(self, filepath):
+        if not filepath:
+            return None
+
         resolved_path = os.path.expandvars(filepath)
 
         # variables that don't exist in environment get ignored by `expandvars`,

--- a/tests/apps/test_sc_issue.py
+++ b/tests/apps/test_sc_issue.py
@@ -1,0 +1,74 @@
+import os
+import shutil
+import glob
+
+import pytest
+import siliconcompiler
+
+from siliconcompiler.apps import sc_issue
+
+# TODO: I think moving back to something like a tarfile would be nice here to
+# remove the dependency on EDA tools. Maybe make that tarfile the single source
+# of truth rather than gcd.pkg.json.
+@pytest.fixture(scope='module')
+def heartbeat_dir(tmpdir_factory):
+    '''Fixture that creates a heartbeat build directory by running a build.
+    '''
+    scroot = os.path.join(os.path.dirname(__file__), '..', '..')
+    datadir = os.path.join(scroot, 'tests', 'data')
+
+    cwd = str(tmpdir_factory.mktemp("heartbeat"))
+
+    os.chdir(cwd)
+    chip = siliconcompiler.Chip('heartbeat')
+    chip.set('option', 'loglevel', 'ERROR')
+    chip.set('option', 'quiet', True)
+    chip.input(os.path.join(datadir, 'heartbeat.v'))
+    chip.input(os.path.join(datadir, 'heartbeat.sdc'))
+    chip.load_target('freepdk45_demo')
+    chip.run()
+
+    return cwd
+
+@pytest.mark.parametrize('flags,outputfileglob', [
+    (['-generate', '-cfg', 'build/heartbeat/job0/syn/0/outputs/heartbeat.pkg.json'], 'sc_issue_heartbeat_job0_syn0_*.tar.gz'),
+    (['-generate', '-cfg', 'build/heartbeat/job0/place/0/outputs/heartbeat.pkg.json', '-arg_step', 'syn', '-arg_index', '0'], 'sc_issue_heartbeat_job0_syn0_*.tar.gz'),
+    (['-generate', '-cfg', 'build/heartbeat/job0/place/0/outputs/heartbeat.pkg.json', '-arg_step', 'place', '-arg_index', '0'], 'sc_issue_heartbeat_job0_place0_*.tar.gz'),
+    (['-generate', '-cfg', 'build/heartbeat/job0/heartbeat.pkg.json', '-arg_step', 'place', '-arg_index', '0'], 'sc_issue_heartbeat_job0_place0_*.tar.gz')
+    ])
+@pytest.mark.eda
+@pytest.mark.quick
+def test_sc_issue_generate_success(flags, outputfileglob, monkeypatch, heartbeat_dir):
+    '''Test sc-issue app on a few sets of flags.'''
+
+    shutil.copytree(heartbeat_dir, './', dirs_exist_ok=True)
+
+    monkeypatch.setattr('sys.argv', ['sc-issue'] + flags)
+    assert sc_issue.main() == 0
+    assert os.path.exists(glob.glob(outputfileglob)[0])
+
+@pytest.mark.parametrize('flags', [
+    ['-generate', '-cfg', 'build/heartbeat/job0/heartbeat.pkg.json']
+    ])
+@pytest.mark.eda
+@pytest.mark.quick
+def test_sc_issue_generate_fail(flags, monkeypatch, heartbeat_dir):
+    '''Test sc-issue app on a few sets of flags.'''
+
+    shutil.copytree(heartbeat_dir, './', dirs_exist_ok=True)
+
+    monkeypatch.setattr('sys.argv', ['sc-issue'] + flags)
+    assert sc_issue.main() == 1
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_sc_issue_run(monkeypatch, heartbeat_dir):
+    '''Test sc-issue app on a few sets of flags.'''
+
+    shutil.copytree(heartbeat_dir, './', dirs_exist_ok=True)
+
+    monkeypatch.setattr('sys.argv', ['sc-issue', '-generate', '-cfg', 'build/heartbeat/job0/syn/0/outputs/heartbeat.pkg.json', '-file', 'sc_issue.tar.gz'])
+    assert sc_issue.main() == 0
+
+    monkeypatch.setattr('sys.argv', ['sc-issue', '-run', '-file', 'sc_issue.tar.gz'])
+    assert sc_issue.main() == 0


### PR DESCRIPTION
Adds:
- sc-issue as a cli app to be able to generate and run testcases

Fixes:
- keypaths and file handling when files are sometimes not Found

`sc-issue -generate -cfg ...` will make a `sc_issue.tar.gz` which can be shared and run using `sc-issue -run`

Closes: #1466

This is an initial version, which can be improved upon, @maliberty FYI