### PR TITLE
Set 'QT_QPA_PLATFORM' env var in KLayout if nodisplay option is set

### DIFF
--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -80,6 +80,10 @@ def setup(chip, mode="batch"):
 
     chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=clobber)
 
+    if chip.get('option', 'nodisplay'):
+        # Tells QT to use the offscreen platform if nodisplay is used
+        chip.set('tool', tool, 'task', task, 'env', 'QT_QPA_PLATFORM', 'offscreen', step=step, index=index)
+
     # Log file parsing
     chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'(WARNING|warning)', step=step, index=index, clobber=False)
     chip.set('tool', tool, 'task', task, 'regex', 'errors', r'ERROR', step=step, index=index, clobber=False)


### PR DESCRIPTION
Our KLayout tool driver should not try to open GUI windows on a headless machine. Like OpenROAD, KLayout uses QT for its user interface, and we should be able to ask it to render graphical components to a virtual framebuffer by setting `$QT_QPA_PLATFORM = "offscreen"`.

The OpenROAD tool driver already contains this logic, and adding it to the KLayout driver will let us remove some logic which ensures that this environment variable is set elsewhere.