### PR TITLE
Cleanup sc-server round 1

### DIFF
--- a/siliconcompiler/apps/sc_server.py
+++ b/siliconcompiler/apps/sc_server.py
@@ -14,12 +14,9 @@ def server_cmdline():
     '''
     Command-line parsing for sc-server variables.
     TODO: It may be a good idea to merge with 'cmdline()' to reduce code duplication.
-
     '''
 
     def_cfg = server_schema()
-
-    os.environ["COLUMNS"] = '100'
 
     #Argument Parser
     parser = argparse.ArgumentParser(prog='sc-server',
@@ -87,13 +84,7 @@ def main():
     cmdlinecfg = server_cmdline()
 
     #Create the Server class instance.
-    server = Server(cmdlinecfg)
-
-    #Save the given server configuration in JSON format (not yet implemented)
-    server.writecfg("sc_server_setup.json")
-
-    # Start processing incoming requests.
-    server.run()
+    Server(cmdlinecfg)
 
 if __name__ == '__main__':
     main()

--- a/siliconcompiler/server.py
+++ b/siliconcompiler/server.py
@@ -159,8 +159,10 @@ class Server:
         # Create a dummy Chip object to make schema traversal easier.
         # TODO: if this is a dummy Chip we should be able to use Schema class,
         # but looks like it relies on chip.status.
-        chip = Chip('server')  # start with a dummy name, as this will be overwritten
-        chip.schema = Schema(cfg=cfg) # Add provided schema
+        # start with a dummy name, as this will be overwritten
+        chip = Chip('server')
+        # Add provided schema
+        chip.schema = Schema(cfg=cfg)
 
         # Fetch some common values.
         design = chip.get('design')
@@ -438,7 +440,6 @@ class Server:
 
             utils.copytree(from_dir, build_dir, dirs_exist_ok=True)
 
-            utils.copytree(from_dir, build_dir, dirs_exist_ok=True)
             run_cmd += f"sc-crypt -mode decrypt -target {job_dir} -key_file {keypath} ; "
             run_cmd += f"sc -cfg {build_dir}/configs/chip{chip.get('option', 'jobname')}.json -dir {build_dir} -remote_addr '' ; "
             run_cmd += f"sc-crypt -mode encrypt -target {job_dir} -key_file {keypath} ; "

--- a/siliconcompiler/server.py
+++ b/siliconcompiler/server.py
@@ -10,13 +10,16 @@ import re
 import subprocess
 import shutil
 import uuid
+import tempfile
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives import hashes, serialization
 from siliconcompiler import Chip
-from siliconcompiler.crypto import decrypt_job, gen_cipher_key
+from siliconcompiler import Schema
+from siliconcompiler import utils
+from siliconcompiler.crypto import gen_cipher_key
 
 class Server:
     """
@@ -36,12 +39,12 @@ class Server:
         '''
 
         # Initialize logger
-        self.logger = log.getLogger()
+        self.logger = log.getLogger(uuid.uuid4().hex)
         self.handler = log.StreamHandler()
         self.formatter = log.Formatter('%(asctime)s %(levelname)-8s %(message)s')
         self.handler.setFormatter(self.formatter)
         self.logger.addHandler(self.handler)
-        self.logger.setLevel(str(loglevel))
+        self.logger.setLevel(loglevel)
 
         # Use the config that was passed in.
         self.cfg = cmdlinecfg
@@ -156,8 +159,8 @@ class Server:
         # Create a dummy Chip object to make schema traversal easier.
         # TODO: if this is a dummy Chip we should be able to use Schema class,
         # but looks like it relies on chip.status.
-        chip = Chip(cfg['design']['value'])
-        chip.schema.cfg = cfg
+        chip = Chip('server')  # start with a dummy name, as this will be overwritten
+        chip.schema = Schema(cfg=cfg) # Add provided schema
 
         # Fetch some common values.
         design = chip.get('design')
@@ -168,7 +171,7 @@ class Server:
         # Ensure that the job's root directory exists.
         job_root = f"{self.cfg['nfsmount']['value'][-1]}/{job_hash}"
         job_dir  = f"{job_root}/{design}/{job_name}"
-        subprocess.run(['mkdir', '-p', job_dir])
+        os.makedirs(job_dir, exist_ok=True)
 
         if use_auth:
             # Create a new AES block cipher key, and an IV for the import step.
@@ -214,10 +217,10 @@ class Server:
         job_nameid = f"{chip.get('option', 'jobname')}"
 
         # Create the working directory for the given 'job hash' if necessary.
-        subprocess.run(['mkdir', '-p', jobs_dir])
+        os.makedirs(jobs_dir, exist_ok=True)
         chip.set('option', 'builddir', build_dir, clobber=True)
         # Link to the 'import' directory if necessary.
-        subprocess.run(['mkdir', '-p', '%s/%s'%(jobs_dir, job_nameid)])
+        os.makedirs(os.path.join(jobs_dir, job_nameid), exist_ok=True)
         #subprocess.run(['ln', '-s', '%s/import0'%build_dir, '%s/%s/import0'%(jobs_dir, job_nameid)])
 
         # Remove 'remote' JSON config value to run locally on compute node.
@@ -225,7 +228,7 @@ class Server:
         chip.set('option', 'credentials', '', clobber=True)
 
         # Write JSON config to shared compute storage.
-        subprocess.run(['mkdir', '-p', '%s/configs'%build_dir])
+        os.makedirs(os.path.join(build_dir, 'configs'), exist_ok=True)
 
         # Run the job with the configured clustering option. (Non-blocking)
         if use_auth:
@@ -397,17 +400,12 @@ class Server:
 
         # Assemble core job parameters.
         job_hash = chip.status['jobhash']
-        design = chip.get('design')
         top_module = chip.top()
-        job_nameid = f"{chip.get('option', 'jobname')}"
+        job_nameid = chip.get('option', 'jobname')
         nfs_mount = self.cfg['nfsmount']['value'][-1]
 
         # Mark the job run as busy.
         self.sc_jobs[f'{username}{job_hash}_{job_nameid}'] = 'busy'
-
-        # Reset 'build' directory in NFS storage.
-        build_dir = '/tmp/%s_%s'%(job_hash, job_nameid)
-        os.mkdir(build_dir)
 
         run_cmd = ''
         if self.cfg['cluster']['value'][-1] == 'slurm':
@@ -419,34 +417,39 @@ class Server:
             chip.status['decrypt_key'] = base64.urlsafe_b64encode(pk)
             chip.run()
         else:
+            # Reset 'build' directory in NFS storage.
+            _, build_dir = tempfile.mkstemp(prefix=job_hash, suffix=job_nameid)
+
             chip.set('option', 'builddir', build_dir, clobber=True)
             # Run the build command locally.
             from_dir = '%s/%s'%(nfs_mount, job_hash)
-            to_dir   = '/tmp/%s_%s'%(job_hash, job_nameid)
             job_dir  = os.path.join(build_dir, top_module, job_nameid)
             # Write plaintext JSON config to the build directory.
-            subprocess.run(['mkdir', '-p', to_dir])
-            subprocess.run(['mkdir', '-p', '%s/configs'%build_dir])
+            os.makedirs(os.path.join(build_dir, 'configs'), exist_ok=True)
             # Write private key to a file.
             # This should be okay, because we are already trusting the local
             # "compute node" disk to store the decrypted data. Further, the
             # file will be deleted immediately after the run.
             # Even so, use the usual 400 permissions for key files.
-            keypath = f'{to_dir}/pk'
+            keypath = f'{build_dir}/pk'
             with open(os.open(keypath, os.O_CREAT | os.O_WRONLY, 0o400), 'w+') as keyfile:
                 keyfile.write(pk)
             chip.write_manifest(f"{build_dir}/configs/chip{chip.get('option', 'jobname')}.json")
-            # Create the command to run.
-            run_cmd  = f"cp -R {from_dir}/* {to_dir}/ ; "
+
+            utils.copytree(from_dir, build_dir, dirs_exist_ok=True)
+
+            utils.copytree(from_dir, build_dir, dirs_exist_ok=True)
             run_cmd += f"sc-crypt -mode decrypt -target {job_dir} -key_file {keypath} ; "
-            run_cmd += f"sc -cfg {build_dir}/configs/chip{chip.get('option', 'jobname')}.json -dir {to_dir} -remote_addr '' ; "
+            run_cmd += f"sc -cfg {build_dir}/configs/chip{chip.get('option', 'jobname')}.json -dir {build_dir} -remote_addr '' ; "
             run_cmd += f"sc-crypt -mode encrypt -target {job_dir} -key_file {keypath} ; "
-            run_cmd += f"cp -R {to_dir}/{top_module}/* {from_dir}/{top_module}/ ; "
-            run_cmd += f"rm -rf {to_dir}"
 
             # Run the generated command.
             proc = await asyncio.create_subprocess_shell(run_cmd)
             await proc.wait()
+
+            utils.copytree(os.path.join(build_dir, top_module),
+                           os.path.join(from_dir, top_module), dirs_exist_ok=True)
+            os.removedirs(build_dir)
 
             # Ensure that the private key file was deleted.
             # (The whole directory should already be gone,


### PR DESCRIPTION
Changes:
- fix sc-configure to allow for port to be entered
- removed calls to mkdir via subprocess and instead use builtin makedirs
- removed unused code from sc-server
- added local server tests to CI and updated to sc-server to function again.

This is a step towards getting all server tests with slurm enabled as well.