### PR TITLE
Remove subprocess from server code + minor cleanup

### DIFF
--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -191,7 +191,7 @@ def request_remote_run(chip):
         upload_file.seek(0)
         resp = requests.post(redirect_url,
                             files={'import': upload_file,
-                                    'params': json.dumps(post_params)},
+                                   'params': json.dumps(post_params)},
                             allow_redirects=False)
         if resp.status_code == 302:
             redirect_url = resp.headers['Location']

--- a/siliconcompiler/client.py
+++ b/siliconcompiler/client.py
@@ -5,13 +5,13 @@ import json
 import os
 import requests
 import shutil
-import subprocess
 import time
 import urllib.parse
 import uuid
+import tarfile
+import tempfile
 
 from siliconcompiler._metadata import default_server
-from siliconcompiler.crypto import *
 from siliconcompiler import utils
 
 ###################################
@@ -158,21 +158,18 @@ def request_remote_run(chip):
     # If '-remote_user' and '-remote_key' are not both specified,
     # no authorization is configured; proceed without crypto.
     # If they were specified, these files are now encrypted.
-    subprocess.run(['tar',
-                    '-czf',
-                    'import.tar.gz',
-                    '--exclude',
-                    'import.tar.gz',
-                    '.'],
-                   stdout=subprocess.PIPE,
-                   stderr=subprocess.STDOUT,
-                   cwd=local_build_dir)
-    upload_file = os.path.abspath(os.path.join(local_build_dir, 'import.tar.gz'))
+
+    upload_file = tempfile.TemporaryFile(prefix='sc', suffix='remote.tar.gz')
+    with tarfile.open(fileobj=upload_file, mode='w:gz') as tar:
+        tar.add(local_build_dir, arcname='')
+    # Flush file to ensure everything is written
+    upload_file.flush()
 
     # Print a reminder for public beta runs.
     default_server_name = urllib.parse.urlparse(default_server).hostname
     if default_server_name in remote_run_url:
-        chip.logger.warning("""Your job will be uploaded to a public server for processing in 5 seconds.
+        default_delay = 5
+        chip.logger.warning(f"""Your job will be uploaded to a public server for processing in {default_delay} seconds.
 ---------------------------------------------------------------------------------------------------
   DISCLAIMER:
   - The open SiliconCompiler remote server is a free service. Please don't abuse it.
@@ -183,27 +180,30 @@ def request_remote_run(chip):
   - For full TOS, see https://www.siliconcompiler.com/terms-of-service
 -------------------------------------------------------------------------------------------------""")
         chip.logger.info(f"Your job's reference ID is: {chip.status['jobhash']}")
-        time.sleep(5)
+        time.sleep(default_delay)
 
     # Make the actual request, streaming the bulk data as a multipart file.
     # Redirected POST requests are translated to GETs. This is actually
     # part of the HTTP spec, so we need to manually follow the trail.
     redirect_url = remote_run_url
     while redirect_url:
-        with open(upload_file, 'rb') as f:
-            resp = requests.post(redirect_url,
-                                 files={'import': f,
-                                        'params': json.dumps(post_params)},
-                                 allow_redirects=False)
-            if resp.status_code == 302:
-                redirect_url = resp.headers['Location']
-            elif resp.status_code >= 400:
-                chip.logger.error(resp.json()['message'])
-                chip.logger.error('Error starting remote job run; quitting.')
-                raise RuntimeError('Remote server returned unrecoverable error code.')
-            else:
-                chip.logger.info(resp.text)
-                return
+        # Return to start of file
+        upload_file.seek(0)
+        resp = requests.post(redirect_url,
+                            files={'import': upload_file,
+                                    'params': json.dumps(post_params)},
+                            allow_redirects=False)
+        if resp.status_code == 302:
+            redirect_url = resp.headers['Location']
+        elif resp.status_code >= 400:
+            chip.logger.error(resp.json()['message'])
+            chip.logger.error('Error starting remote job run; quitting.')
+            raise RuntimeError('Remote server returned unrecoverable error code.')
+        else:
+            chip.logger.info(resp.text)
+            break
+
+    upload_file.close()
 
 ###################################
 def is_job_busy(chip):
@@ -345,7 +345,8 @@ def fetch_results(chip):
 
     # Unauthenticated jobs get a gzip archive, authenticated jobs get nested archives.
     # So we need to extract and delete those.
-    subprocess.run(['tar', '-xzf', f'{job_hash}.tar.gz'])
+    with tarfile.open(f'{job_hash}.tar.gz', 'r:gz') as tar:
+        tar.extractall()
     # Remove the results archive after it is extracted.
     os.remove(f'{job_hash}.tar.gz')
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -6,7 +6,6 @@ import time
 import datetime
 import multiprocessing
 import tarfile
-from subprocess import PIPE
 import os
 import git
 import pathlib
@@ -3695,7 +3694,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             if veropt:
                 cmdlist = [exe]
                 cmdlist.extend(veropt)
-                proc = subprocess.run(cmdlist, stdout=PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
+                proc = subprocess.run(cmdlist, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
                 if proc.returncode != 0:
                     self.logger.error(f'Version check on {tool} failed with code {proc.returncode}: {proc.stdout}')
                     self._haltstep(step, index)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -6,11 +6,8 @@ import time
 import datetime
 import multiprocessing
 import tarfile
-import traceback
-import asyncio
-from subprocess import run, PIPE
+from subprocess import PIPE
 import os
-import glob
 import git
 import pathlib
 import sys
@@ -51,6 +48,7 @@ from siliconcompiler import utils
 from siliconcompiler import units
 from siliconcompiler import _metadata
 import psutil
+import subprocess
 
 class TaskStatus():
     # Could use Python 'enum' class here, but that doesn't work nicely with


### PR DESCRIPTION
Changes:
- Removes subprocess calls to tar infavor of using tarfile
- Plus minor code formatting
- Adding nfs_mount to Server object  (real solution is probably to cleanup its schema accesses)