### PR TITLE
Fix Schema._is_empty() [SC-330]

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3725,8 +3725,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         # Write manifest (tool interface) (Don't move this!)
         suffix = self.get('tool', tool, 'format')
         if suffix:
-            pruneopt = (suffix != 'tcl')
-            self.write_manifest(f"sc_manifest.{suffix}", prune=pruneopt, abspath=True)
+            self.write_manifest(f"sc_manifest.{suffix}", prune=False, abspath=True)
 
         ##################
         # Start CPU Timer

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1708,7 +1708,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                     keypath = item.split(',')
                     if self.schema._is_empty(*keypath):
                         error = True
-                        self.logger.error(f"Value empty for [{keypath}] for {tool}.")
+                        self.logger.error(f"Value empty for {keypath} for {tool}.")
 
                 task_run = getattr(self._get_task_module(step, index, flow=flow), 'run', None)
                 if self.schema._is_empty('tool', tool, 'exe') and not task_run:
@@ -2596,7 +2596,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         Args:
             step (str): name of the step to calculate the area from
             index (str): name of the step to calculate the area from
-        
+
         Returns:
             Design area (float).
 

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -824,9 +824,8 @@ class Schema:
         defvalue = self.get(*keypath, field='defvalue')
         value_empty = (
             (defvalue in empty) and
-            all([value in empty for value in values])
+            all([value in empty for value, _, _ in values])
         )
-
         return value_empty
 
     ###########################################################################

--- a/tests/core/tools/fake/bar.py
+++ b/tests/core/tools/fake/bar.py
@@ -1,0 +1,2 @@
+def run():
+    return 0

--- a/tests/core/tools/fake/baz.py
+++ b/tests/core/tools/fake/baz.py
@@ -1,0 +1,2 @@
+def run():
+    return 0

--- a/tests/core/tools/fake/foo.py
+++ b/tests/core/tools/fake/foo.py
@@ -1,0 +1,2 @@
+def run():
+    return 0

--- a/tests/flows/test_multiple_tools.py
+++ b/tests/flows/test_multiple_tools.py
@@ -29,6 +29,8 @@ def test_multiple_tools():
     chip = siliconcompiler.Chip('test')
     chip.load_target('freepdk45_demo')
 
+    chip.input('foo.v')
+
     flow = 'test'
     chip.set('option', 'flow', flow)
     chip.node(flow, 'import', nop)
@@ -49,7 +51,7 @@ def test_multiple_tools():
     # Set fake license server for slog1
     chip.set('tool', 'surelog', 'licenseserver', 'ACME_LICENSE', '1700@server', step='slog', index=1)
 
-    # Don't run tools, just vesion check
+    # Don't run tools, just version check
     chip.set('option', 'skipall', True)
     chip.run()
 

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -24,3 +24,10 @@ def test_pernode_mandatory():
 
     # Should succeed
     assert schema.set('test', 'foo', step='syn', index=0)
+
+def test_empty():
+    schema = Schema()
+    assert schema._is_empty('package', 'version')
+
+    schema.set('package', 'version', '1.0')
+    assert not schema._is_empty('package', 'version')


### PR DESCRIPTION
This PR fixes a bug in the Schema._is_empty() function that caused it to always return False. It also includes a few other fixes of issues that were masked by this bug:

- Need to add a `run()` function to the fake tools - each tool needs either a `run()` or the exe param defined, but the check wasn't working previously
- No more pruning of manifests dumped for tools - with is_empty fixed the pruning becomes a lot more aggressive, which makes a lot of keypaths no longer exist in the Schema in the KL driver