### PR TITLE
Fix error for add() invalid keypath

### DIFF
--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -194,15 +194,15 @@ class Schema:
 
         cfg = self._search(*keypath, insert_defaults=True)
 
+        if not Schema._is_leaf(cfg):
+            raise ValueError(f'Invalid keypath {keypath}: add() must be called on a complete keypath')
+
         err = Schema._validate_step_index(cfg['pernode'], field, step, index)
         if err:
             raise ValueError(f'Invalid args to add() of keypath {keypath}: {err}')
 
         if isinstance(index, int):
             index = str(index)
-
-        if not Schema._is_leaf(cfg):
-            raise ValueError(f'Invalid keypath {keypath}: add() must be called on a complete keypath')
 
         if not Schema._is_list(field, cfg['type']):
             if field == 'value':

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -24,3 +24,8 @@ def test_pernode_mandatory():
 
     # Should succeed
     assert schema.set('test', 'foo', step='syn', index=0)
+
+def test_add_keypath_error():
+    schema = Schema()
+    with pytest.raises(ValueError):
+        schema.add('input', 'verilog', 'foo.v')


### PR DESCRIPTION
Needed to reorder this check to ensure error messages are clear:

Before:
```
>>> chip.add('input', 'verilog', 'foo.v')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/noah/code/siliconcompiler/siliconcompiler/core.py", line 1064, in add
    if not self.schema.add(*args, field=field, step=step, index=index):
  File "/home/noah/code/siliconcompiler/siliconcompiler/schema/schema_obj.py", line 197, in add
    err = Schema._validate_step_index(cfg['pernode'], field, step, index)
KeyError: 'pernode'
```

After:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/noah/code/siliconcompiler/siliconcompiler/core.py", line 1070, in add
    self.error(str(e))
  File "/home/noah/code/siliconcompiler/siliconcompiler/core.py", line 4985, in error
    raise SiliconCompilerError(msg) from None
siliconcompiler.core.SiliconCompilerError: Invalid keypath ('input', 'verilog'): add() must be called on a complete keypath
```