### PR TITLE
fix server credentials finding

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4159,8 +4159,12 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             # Load the remote storage config into the status dictionary.
             if self.get('option','credentials'):
                 # Use the provided remote credentials file.
-                cfg_file = self.find_files('option', 'credentials')[-1]
+                cfg_file = os.path.abspath(self.get('option', 'credentials')[-1])
                 cfg_dir = os.path.dirname(cfg_file)
+
+                if not os.path.isfile(cfg_file):
+                    # Check if it's a file since its been requested by the user
+                    self.error(f'Unable to find the credentials file: {cfg_file}', fatal=True)
             else:
                 # Use the default config file path.
                 cfg_dir = os.path.join(Path.home(), '.sc')

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4159,7 +4159,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             # Load the remote storage config into the status dictionary.
             if self.get('option','credentials'):
                 # Use the provided remote credentials file.
-                cfg_file = self.get('option','credentials')[-1]
+                cfg_file = self.find_files('option', 'credentials')[-1]
                 cfg_dir = os.path.dirname(cfg_file)
             else:
                 # Use the default config file path.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4166,6 +4166,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 cfg_dir = os.path.join(Path.home(), '.sc')
                 cfg_file = os.path.join(cfg_dir, 'credentials')
             if os.path.isdir(cfg_dir) and os.path.isfile(cfg_file):
+                self.logger.info(f'Using credentials: {cfg_file}')
                 with open(cfg_file, 'r') as cfgf:
                     self.status['remote_cfg'] = json.loads(cfgf.read())
             else:


### PR DESCRIPTION
When a relative path is provided to the credentials, which contains no directory, the isdir returns false. This ensures the path used is an abs path do the directory component will have something and can fail out correctly.