### PR TITLE
fix incorrect detection of invalid url

### DIFF
--- a/siliconcompiler/apps/sc_configure.py
+++ b/siliconcompiler/apps/sc_configure.py
@@ -70,7 +70,7 @@ def main():
 
     server = urlparse(srv_addr)
     has_scheme = True
-    if not server.scheme:
+    if not server.hostname:
         # fake add a scheme to the url
         has_scheme = False
         server = urlparse('https://' + srv_addr)

--- a/siliconcompiler/apps/sc_configure.py
+++ b/siliconcompiler/apps/sc_configure.py
@@ -74,7 +74,6 @@ def main():
         # fake add a scheme to the url
         has_scheme = False
         server = urlparse('https://' + srv_addr)
-        config['address'] = server.hostname
     if not server.hostname:
         print(f'Invalid address provided: {srv_addr}')
         return


### PR DESCRIPTION
Fixes:
- when running sc-configure localhost:8080 it should detect that this is missing the scheme and therefore needs a dummy one pre-pended to parse the hostname correctly.
