### PR TITLE
add slurm to ci container and enable ci for slurm

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Run tests with Python ${{ matrix.python-version }}
         run: |
+          /start_slurm.sh
           export PYENV_ROOT="$HOME/.pyenv"
           export PATH="$PYENV_ROOT/bin:$PATH"
           eval "$(pyenv init -)"

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -191,6 +191,7 @@ jobs:
 
       - name: Run tests
         run: |
+          /start_slurm.sh
           python3 -m venv clean_env
           source clean_env/bin/activate
           cd $GITHUB_WORKSPACE

--- a/setup/_tools.json
+++ b/setup/_tools.json
@@ -82,5 +82,10 @@
     "git-url": "https://github.com/YosysHQ/yosys.git",
     "git-commit": "51dd0290241c521f5498f71f4fd4fb0598d83a76",
     "auto-update": true
+  },
+  "slurm": {
+    "version": "22.05.7",
+    "git-url": "https://github.com/SchedMD/slurm.git",
+    "auto-update": false
   }
 }

--- a/setup/docker/sc_tools.docker
+++ b/setup/docker/sc_tools.docker
@@ -19,7 +19,8 @@ RUN apt-get update
 RUN apt-get install -y curl wget \
                        git \
                        python3 python3-pip \
-                       xvfb && \
+                       xvfb \
+                       munge libmunge-dev build-essential libmariadb-dev lbzip2 libjson-c-dev && \
     apt-get clean
 
 {% for tool in tools %}
@@ -51,6 +52,37 @@ RUN chmod +x $SC_BUILD/install-{{ tool }}.sh && \
     apt-get clean && \
     rm -rf $SC_BUILD/deps
 {% endfor %}
+
+######################
+# Install slurm
+######################
+
+# Create slurm user
+RUN useradd slurm
+
+# Build and install Slurm
+RUN mkdir slurm && \
+    cd slurm && \
+    wget -O slurm.tar.bz2 https://download.schedmd.com/slurm/slurm-{{ slurm_version }}.tar.bz2 && \
+    tar xf slurm.tar.bz2 --strip-components=1 && \
+    ./configure --prefix=/usr/local --sysconfdir=/etc/slurm && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf slurm
+
+# Configure Slurm
+RUN mkdir -p /etc/slurm/
+COPY slurm.conf /etc/slurm/slurm.conf.in
+COPY cgroup.conf /etc/slurm/cgroup.conf
+RUN mkdir -p /var/log/slurm /var/spool/slurm /var/spool/slurmd /etc/slurm
+RUN chown -R slurm:slurm /var/log/slurm /var/spool/slurm /var/spool/slurmd /etc/slurm
+
+COPY start_slurm.sh /start_slurm.sh
+RUN chmod +x /start_slurm.sh
+
+######################
+# Finish slurm install
+######################
 
 # Cleanup builds
 WORKDIR /

--- a/setup/docker/slurm/cgroup.conf
+++ b/setup/docker/slurm/cgroup.conf
@@ -1,0 +1,1 @@
+CgroupPlugin=cgroup/v1

--- a/setup/docker/slurm/slurm.conf
+++ b/setup/docker/slurm/slurm.conf
@@ -1,0 +1,38 @@
+# Slurm configuration file.
+SlurmctldHost={{ hostname }}
+
+# CORE CONFIG
+MpiDefault=none
+ProctrackType=proctrack/linuxproc
+
+SlurmctldPidFile=/run/slurmctld.pid
+SlurmdPidFile=/run/slurmd.pid
+SlurmdSpoolDir=/var/spool/slurmd
+StateSaveLocation=/var/spool/slurm
+
+SlurmUser=slurm
+
+SwitchType=switch/none
+TaskPlugin=task/none
+SrunPortRange=50001-52000
+
+# SCHEDULING
+MinJobAge=30
+MessageTimeout=30
+SchedulerType=sched/builtin
+SchedulerParameters=batch_sched_delay=20,step_retry_time=10,sched_interval=10,sched_min_interval=200000
+SelectType=select/linear
+
+ClusterName=I10
+
+JobAcctGatherType=jobacct_gather/none
+
+SlurmCtldLogFile=/var/log/slurm/slurmctld.log
+SlurmdLogFile=/var/log/slurm/slurmd.log
+
+# COMPUTE NODES
+# (Set RealMemory to a bit below the reported value to account for possible consumption at boot)
+NodeName={{ hostname }} State=IDLE CPUs=2 Boards=1 SocketsPerBoard=1 CoresPerSocket=1 ThreadsPerCore=2 RealMemory=4000
+
+# PARTITIONS
+PartitionName=ctldpart Nodes={{ hostname }} Default=yes

--- a/setup/docker/slurm/start_slurm.sh
+++ b/setup/docker/slurm/start_slurm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Set the container's hostname in slurm.conf
+sed "s^{{ hostname }}^`hostname`^g" /etc/slurm/slurm.conf.in >  /etc/slurm/slurm.conf
+
+# Start munge and slurm daemons
+/etc/init.d/munge start
+slurmctld
+slurmd

--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -1,72 +1,74 @@
-import base64
 import os
 import shlex
 import subprocess
 import stat
 import time
+import uuid
+import json
 
 ###########################################################################
 def _deferstep(chip, step, index, status):
     '''
     Helper method to run an individual step on a slurm cluster.
-    If a base64-encoded 'decrypt_key' is set in the Chip's status
-    dictionary, the job's data is assumed to be encrypted,
-    and a more complex command is assembled to ensure that the data
-    is only decrypted temporarily in the compute node's local storage.
     '''
 
     # Determine which HPC job scheduler being used.
     scheduler_type = chip.get('option', 'scheduler', 'name', step=step, index=index)
 
+    if scheduler_type != 'slurm':
+        raise ValueError(f'{scheduler_type} is not a supported scheduler')
+
     # Determine which cluster parititon to use. (Default value can be overridden on per-step basis)
     partition = chip.get('option', 'scheduler', 'queue', step=step, index=index)
-    # Get the temporary UID associated with this job run.
-    job_hash = chip.status['jobhash']
+    if not partition:
+        partition = _get_slurm_partitions()
 
-    # Job data is not encrypted, so it can be run in shared storage.
+    # Get the temporary UID associated with this job run.
+    if 'jobhash' in chip.status:
+        job_hash = chip.status['jobhash']
+    else:
+        # Generate a new uuid since it was not set
+        job_hash = uuid.uuid4().hex
+
+    job_name = f'{job_hash}_{step}{index}'
+
     # Write out the current schema for the compute node to pick up.
     job_dir = chip._getworkdir()
     cfg_dir = f'{job_dir}/configs'
     cfg_file = f'{cfg_dir}/{step}{index}.json'
     if not os.path.isdir(cfg_dir):
         os.mkdir(cfg_dir)
-    chip.unset('option', 'scheduler', 'name', step=step, index=index)
+    chip.set('option', 'scheduler', 'name', None, step=step, index=index)
     chip.write_manifest(cfg_file)
 
-    if scheduler_type == 'slurm':
-        # The script defining this Chip object may specify feature(s) to
-        # ensure that the job runs on a specific subset of available nodes.
-        # TODO: Maybe we should add a Schema parameter for these values.
-        if 'slurm_constraint' in chip.status:
-            slurm_constraint = chip.status['slurm_constraint']
-        else:
-            slurm_constraint = 'SHARED'
+    # Set the log file location.
+    # TODO: May need to prepend ('option', 'builddir') and remove the '--chdir' arg if
+    # running on a locally-managed cluster control node instead of submitting to a server app.
+    #output_file = os.path.join(chip.get('option', 'builddir'),
+    output_file = os.path.join(chip._getworkdir(),
+                               f'sc_remote-{step}-{index}.log')
+    schedule_cmd = ['sbatch',
+                    '--exclusive',
+                    '--partition', partition,
+                    '--chdir', chip.cwd,
+                    '--job-name', job_name,
+                    '--output', output_file
+                    ]
 
-        # Set the log file location.
-        # TODO: May need to prepend ('option', 'builddir') and remove the '--chdir' arg if
-        # running on a locally-managed cluster control node instead of submitting to a server app.
-        #output_file = os.path.join(chip.get('option', 'builddir'),
-        output_file = os.path.join(chip.get('design'),
-                                   chip.get('option', 'jobname'),
-                                   f'sc_remote-{step}-{index}.log')
-        schedule_cmd = ['sbatch', '--exclusive',
-                       '--constraint', slurm_constraint,
-                       '--partition', partition,
-                       '--chdir', chip.get('option', 'builddir'),
-                       '--job-name', f'{job_hash}_{step}{index}',
-                       '--output', output_file,
-                       ]
-        # Only specify an account if accounting is required for this cluster/run.
-        if 'slurm_account' in chip.status:
-            username = chip.status['slurm_account']
-            schedule_cmd.extend(['--account', username])
-        # Only delay the starting time if the 'defer' Schema option is specified.
-        defer_time = chip.get('option', 'scheduler', 'defer', step=step, index=index)
-        if defer_time:
-            schedule_cmd.extend(['--begin', defer_time])
-    elif scheduler_type == 'lsf':
-        # TODO: LSF support is untested and currently unsupported.
-        schedule_cmd = ['lsrun']
+    # The script defining this Chip object may specify feature(s) to
+    # ensure that the job runs on a specific subset of available nodes.
+    # TODO: Maybe we should add a Schema parameter for these values.
+    if 'slurm_constraint' in chip.status:
+        schedule_cmd.extend(['--constraint', chip.status['slurm_constraint']])
+
+    # Only specify an account if accounting is required for this cluster/run.
+    if 'slurm_account' in chip.status:
+        schedule_cmd.extend(['--account', chip.status['slurm_account']])
+
+    # Only delay the starting time if the 'defer' Schema option is specified.
+    defer_time = chip.get('option', 'scheduler', 'defer', step=step, index=index)
+    if defer_time:
+        schedule_cmd.extend(['--begin', defer_time])
 
     # Allow user-defined compute node execution script if it already exists on the filesystem.
     # Otherwise, create a minimal script to run the task using the SiliconCompiler CLI.
@@ -119,8 +121,8 @@ def _deferstep(chip, step, index, status):
                 # File size overrun; cancel the current task, and mark an error.
                 retcode = 1
                 sq_out = subprocess.run(['squeue',
-                                         '--partition', 'debug',
-                                         '--name', f'{job_hash}_{step}{index}',
+                                         '--partition', partition,
+                                         '--name', job_name,
                                          '--noheader'],
                                         stdout=subprocess.PIPE)
                 for line in sq_out.stdout.splitlines():
@@ -150,3 +152,16 @@ def _deferstep(chip, step, index, status):
 
     if retcode > 0:
         chip.logger.error(f'srun command for {step} failed.')
+
+def _get_slurm_partitions():
+    partitions = subprocess.run(['sinfo', '--json'],
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT)
+    #partitions.wait()
+    if partitions.returncode != 0:
+        raise RuntimeError('Unable to determine partitions in slurm')
+
+    sinfo = json.loads(partitions.stdout.decode())
+
+    # Return the first listed partition
+    return sinfo['nodes'][0]['partitions'][0]

--- a/tests/flows/test_slurm_local.py
+++ b/tests/flows/test_slurm_local.py
@@ -2,7 +2,8 @@ import os
 import pytest
 
 @pytest.mark.eda
-@pytest.mark.skip(reason='Skipped until CI container is updated to include a local Slurm controller.')
+@pytest.mark.quick
+@pytest.mark.timeout(300)
 def test_slurm_local_py(gcd_chip):
     '''Basic Python API test: build the GCD example using only Python code.
        Note: Requires that the test runner be connected to a cluster, or configured
@@ -10,7 +11,7 @@ def test_slurm_local_py(gcd_chip):
     '''
 
     # Inserting value into configuration
-    gcd_chip.set('option', 'scheduler', 'slurm')
+    gcd_chip.set('option', 'scheduler', 'name', 'slurm')
 
     # Run the chip's build process synchronously.
     gcd_chip.run()
@@ -19,7 +20,9 @@ def test_slurm_local_py(gcd_chip):
     assert os.path.isfile('build/gcd/job0/export/0/outputs/gcd.gds')
 
 @pytest.mark.eda
-@pytest.mark.skip(reason='Skipped until CI container is updated to include a local Slurm controller.')
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+@pytest.mark.skip(reason='Skipped until test can be fixed')
 def test_slurm_local_py_script_override(gcd_chip):
     '''Basic Python API test: build the GCD example using only Python code.
        Note: Requires that the test runner be connected to a cluster, or configured
@@ -27,7 +30,7 @@ def test_slurm_local_py_script_override(gcd_chip):
     '''
 
     # Inserting value into configuration
-    gcd_chip.set('option', 'scheduler', 'slurm')
+    gcd_chip.set('option', 'scheduler', 'name', 'slurm')
     os.makedirs('build/configs')
     gcd_chip.write_manifest('build/configs/import0.json')
     with open('build/configs/import0.sh', 'w') as slurm_script:


### PR DESCRIPTION
This adds back the slurm CI for one test for now.
To enable that test, several changes in the scheduler.py were needed.
1. job_hash may not be set for local runs
2. queue may not be set, so just picking the first queue in those cases
3. removing hard coded values