### PR TITLE
implement x/y location snapping to OpenROAD driver to ensure ongrid placement of macros

### DIFF
--- a/siliconcompiler/tools/openroad/floorplan.py
+++ b/siliconcompiler/tools/openroad/floorplan.py
@@ -27,5 +27,10 @@ def setup(chip):
         chip.add('tool', tool, 'task', task, 'require', ','.join(['tool', tool, 'task', task, 'file', 'padring']))
     chip.set('tool', tool, 'task', task, 'file', 'padring', 'script to insert the padring', field='help')
 
+    snap = chip.get('tool', tool, 'task', task, 'var', 'ifp_snap_strategy', step=step, index=index)[0]
+    snaps_allowed =  ('none', 'site', 'manufacturing_grid')
+    if snap not in snaps_allowed:
+        chip.error(f'{snap} is not a supported snapping strategy. Allowed values: {snaps_allowed}')
+
 def pre_process(chip):
     build_pex_corners(chip)

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -196,6 +196,7 @@ def setup(chip, mode='batch'):
     # set default values for openroad
     for variable, value, helptext in [
         ('ifp_tie_separation', '0', 'maximum distance between tie high/low cells in microns'),
+        ('ifp_snap_strategy', 'site', 'Snapping strategy to use when placing macros. Allowed values: none, site, manufacturing_grid'),
         ('pdn_enable', 'true', 'true/false, when true enables power grid generation'),
         ('gpl_routability_driven', 'true', 'true/false, when true global placement will consider the routability of the design'),
         ('gpl_timing_driven', 'true', 'true/false, when true global placement will consider the timing performance of the design'),


### PR DESCRIPTION
Changes:
- implements missing functionality in OpenROAD driver to place macros on grid
