### PR TITLE
Avoid using -r requirements for installs

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -83,6 +83,5 @@ jobs:
           source clean_env/bin/activate
           cd $GITHUB_WORKSPACE
           python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements.txt
-          python3 -m pip install -e .
+          python3 -m pip install .[test]
           pytest -n auto --import-mode=append

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Install Requirements
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install -r ./requirements.txt
+          python3 -m pip install .[test]
       - name: Lint with Flake8
         run: flake8 --statistics .

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -33,5 +33,6 @@ jobs:
           python-version: ${{ matrix.version.python }}
 
       - run: |
-          pip install $GITHUB_WORKSPACE/.[test]
+          python3 -m pip install --upgrade pip
+          python3 -m pip install .[test]
           pytest --import-mode=append -m "not eda"

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -196,6 +196,5 @@ jobs:
           source clean_env/bin/activate
           cd $GITHUB_WORKSPACE
           python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements.txt
-          python3 -m pip install -e .
+          python3 -m pip install .[test]
           pytest -n auto --import-mode=append -m "eda and quick"

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ To install the project from source (recommended for developers only).
 ```bash
 git clone https://github.com/siliconcompiler/siliconcompiler
 cd siliconcompiler
-python -m pip install -e .
-python -m pip install -e .[docs,test]  # Install dependencies for generating docs and running tests
+python -m pip install -e .             # Required install step
+python -m pip install -e .[docs,test]  # Optional install step for generating docs and running tests
 ```
 
 # Tool Installation

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ To install the project from source (recommended for developers only).
 ```bash
 git clone https://github.com/siliconcompiler/siliconcompiler
 cd siliconcompiler
-pip install -r requirements.txt
 python -m pip install -e .
+python -m pip install -e .[docs,test]  # Install dependencies for generating docs and running tests
 ```
 
 # Tool Installation

--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -192,7 +192,6 @@ Finally, to clone and install SiliconCompiler, run the following:
 
    (venv) git clone -b v\ |release| https://github.com/siliconcompiler/siliconcompiler
    (venv) cd siliconcompiler
-   (venv) pip install -r requirements.txt
    (venv) python -m pip install -e .
    (venv) export SCPATH=<the full path for your siliconcompiler/siliconcompiler directory>
 


### PR DESCRIPTION
@aulihant this solves the issue of the lint on 3.6 with the new docs build. It also makes it a little easier to install since before we asked for two install steps and now can just do one