### PR TITLE
Fix wheels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Packages we rely on
-find_package(PythonExtensions REQUIRED)
+find_package(PythonExtensions)
 find_package(Cython REQUIRED)
 
 execute_process(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Packages we rely on
+find_package(PythonInterp)
+find_package(PythonLibs)
 find_package(PythonExtensions)
 find_package(Cython REQUIRED)
 


### PR DESCRIPTION
Looks like the failing wheels build was due to a recent update in scikit-build that affects how the location of Python libraries are reported to CMake. I based the fix on notes from https://github.com/scikit-build/scikit-build/issues/963 and https://github.com/Qiskit/qiskit-aer/pull/1786

Fix verified in https://github.com/siliconcompiler/siliconcompiler/actions/runs/4854034031. I did notice that one of the KL show tests timed out for macOS, but is fine after re-running. Might be something to keep an eye on, not sure if we need to bump the timeout or if it's just a weird transient thing...