### PR TITLE
Fix load target order

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -502,22 +502,11 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         print("Version:", _metadata.version, "\n")
         print("-" * 80)
 
-        # 1. set loglevel if set at command line
+        # Set loglevel if set at command line
         if 'option_loglevel' in cmdargs.keys():
             self.logger.setLevel(cmdargs['option_loglevel'])
 
-        # 2. read in target if set
-        if 'option_target' in cmdargs.keys():
-            if 'arg_pdk' in cmdargs.keys():
-                raise NotImplementedError("NOT IMPLEMENTED: ['arg', 'pdk'] parameter with target")
-            if 'arg_flow' in cmdargs.keys():
-                raise NotImplementedError("NOT IMPLEMENTED: ['arg', 'flow'] parameter with target")
-            if 'fpga_partname' in cmdargs.keys():
-                self.set('fpga', 'partname', cmdargs['fpga_partname'], clobber=True)
-            # running target command
-            self.load_target(cmdargs['option_target'])
-
-        # 4. read in all cfg files
+        # Read in all cfg files
         if 'option_cfg' in cmdargs.keys():
             for item in cmdargs['option_cfg']:
                 self.read_manifest(item, clobber=True, clear=True)
@@ -529,7 +518,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             # we don't want to handle this in the next loop
             del cmdargs['source']
 
-        # 5. Cycle through all command args and write to manifest
+        # Cycle through all command args and write to manifest
         for dest, vals in cmdargs.items():
             keypath = dest.split('_')
 
@@ -600,6 +589,11 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                         self.set(*args, val, step=step, index=index, clobber=True)
                 else:
                     self.set(*args, val, step=step, index=index, clobber=True)
+
+        # Read in target if set
+        if 'option_target' in cmdargs:
+            # running target command
+            self.load_target(cmdargs['option_target'])
 
         return extra_params
 

--- a/siliconcompiler/targets/asap7_demo.py
+++ b/siliconcompiler/targets/asap7_demo.py
@@ -32,36 +32,36 @@ def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, rou
     utils.set_common_showtools(chip)
 
     # 3. Select default flow/PDK
-    chip.set('option', 'mode', 'asic')
-    chip.set('option', 'flow', 'asicflow')
-    chip.set('option', 'pdk', 'asap7')
-    chip.set('option', 'stackup', '10M')
+    chip.set('option', 'mode', 'asic', clobber=False)
+    chip.set('option', 'flow', 'asicflow', clobber=False)
+    chip.set('option', 'pdk', 'asap7', clobber=False)
+    chip.set('option', 'stackup', '10M', clobber=False)
 
     # 4. Select libraries
-    chip.set('asic', 'logiclib', 'asap7sc7p5t_rvt')
+    chip.set('asic', 'logiclib', 'asap7sc7p5t_rvt', clobber=False)
 
     # 5. Project specific design choices
-    chip.set('asic', 'delaymodel', 'nldm')
-    chip.set('constraint', 'density', 10)
-    chip.set('constraint', 'coremargin', 0.270)
+    chip.set('asic', 'delaymodel', 'nldm', clobber=False)
+    chip.set('constraint', 'density', 10, clobber=False)
+    chip.set('constraint', 'coremargin', 0.270, clobber=False)
 
     # 6. Timing corners
     pex_corner = 'typical'
 
-    chip.set('constraint', 'timing', 'slow', 'libcorner', 'slow')
-    chip.set('constraint', 'timing', 'slow', 'pexcorner', pex_corner)
-    chip.set('constraint', 'timing', 'slow', 'mode', 'func')
-    chip.set('constraint', 'timing', 'slow', 'check', ['setup', 'hold'])
+    chip.set('constraint', 'timing', 'slow', 'libcorner', 'slow', clobber=False)
+    chip.set('constraint', 'timing', 'slow', 'pexcorner', pex_corner, clobber=False)
+    chip.set('constraint', 'timing', 'slow', 'mode', 'func', clobber=False)
+    chip.set('constraint', 'timing', 'slow', 'check', ['setup', 'hold'], clobber=False)
 
-    chip.set('constraint', 'timing', 'fast', 'libcorner', 'fast')
-    chip.set('constraint', 'timing', 'fast', 'pexcorner', pex_corner)
-    chip.set('constraint', 'timing', 'fast', 'mode', 'func')
-    chip.set('constraint', 'timing', 'fast', 'check', ['setup', 'hold'])
+    chip.set('constraint', 'timing', 'fast', 'libcorner', 'fast', clobber=False)
+    chip.set('constraint', 'timing', 'fast', 'pexcorner', pex_corner, clobber=False)
+    chip.set('constraint', 'timing', 'fast', 'mode', 'func', clobber=False)
+    chip.set('constraint', 'timing', 'fast', 'check', ['setup', 'hold'], clobber=False)
 
-    chip.set('constraint', 'timing', 'typical', 'libcorner', 'typical')
-    chip.set('constraint', 'timing', 'typical', 'pexcorner', pex_corner)
-    chip.set('constraint', 'timing', 'typical', 'mode', 'func')
-    chip.set('constraint', 'timing', 'typical', 'check', ['power'])
+    chip.set('constraint', 'timing', 'typical', 'libcorner', 'typical', clobber=False)
+    chip.set('constraint', 'timing', 'typical', 'pexcorner', pex_corner, clobber=False)
+    chip.set('constraint', 'timing', 'typical', 'mode', 'func', clobber=False)
+    chip.set('constraint', 'timing', 'typical', 'check', ['power'], clobber=False)
 
 
 #########################

--- a/siliconcompiler/targets/asic_demo.py
+++ b/siliconcompiler/targets/asic_demo.py
@@ -1,5 +1,6 @@
 import os
 import siliconcompiler
+from siliconcompiler.targets import skywater130_demo
 
 
 def setup(chip):
@@ -16,14 +17,14 @@ def setup(chip):
     chip.set('design', design)
 
     # Load the Sky130 PDK/standard cell library target.
-    chip.load_target('skywater130_demo')
+    chip.load_target(skywater130_demo)
 
     # Set quiet flag
-    chip.set('option', 'quiet', True)
+    chip.set('option', 'quiet', True, clobber=False)
 
     # Set die area and clock constraint.
-    chip.set('constraint', 'outline', [(0, 0), (55, 55)])
-    chip.set('constraint', 'corearea', [(5, 5), (50, 50)])
+    chip.set('constraint', 'outline', [(0, 0), (55, 55)], clobber=False)
+    chip.set('constraint', 'corearea', [(5, 5), (50, 50)], clobber=False)
     chip.clock('clk', period=10)
 
     # Add source files.

--- a/siliconcompiler/targets/fpgaflow_demo.py
+++ b/siliconcompiler/targets/fpgaflow_demo.py
@@ -23,8 +23,8 @@ def setup(chip):
     utils.set_common_showtools(chip)
 
     # 3. Select default flow
-    chip.set('option', 'mode', 'fpga')
-    chip.set('option', 'flow', 'fpgaflow')
+    chip.set('option', 'mode', 'fpga', clobber=False)
+    chip.set('option', 'flow', 'fpgaflow', clobber=False)
 
 
 #########################

--- a/siliconcompiler/targets/freepdk45_demo.py
+++ b/siliconcompiler/targets/freepdk45_demo.py
@@ -34,25 +34,25 @@ def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, rou
     utils.set_common_showtools(chip)
 
     # 3. Set flow and pdk
-    chip.set('option', 'mode', 'asic')
+    chip.set('option', 'mode', 'asic', clobber=False)
     chip.set('option', 'flow', 'asicflow', clobber=False)
-    chip.set('option', 'pdk', 'freepdk45')
-    chip.set('option', 'stackup', '10M')
+    chip.set('option', 'pdk', 'freepdk45', clobber=False)
+    chip.set('option', 'stackup', '10M', clobber=False)
 
     # 4. Select libraries
-    chip.set('asic', 'logiclib', 'nangate45')
+    chip.set('asic', 'logiclib', 'nangate45', clobber=False)
 
     # 5. Set project specific design choices
-    chip.set('asic', 'delaymodel', 'nldm')
-    chip.set('constraint', 'density', 10)
-    chip.set('constraint', 'coremargin', 1.9)
+    chip.set('asic', 'delaymodel', 'nldm', clobber=False)
+    chip.set('constraint', 'density', 10, clobber=False)
+    chip.set('constraint', 'coremargin', 1.9, clobber=False)
 
     # 6. Timing corners
     corner = 'typical'
-    chip.set('constraint', 'timing', 'worst', 'libcorner', corner)
-    chip.set('constraint', 'timing', 'worst', 'pexcorner', corner)
-    chip.set('constraint', 'timing', 'worst', 'mode', 'func')
-    chip.set('constraint', 'timing', 'worst', 'check', ['setup', 'hold'])
+    chip.set('constraint', 'timing', 'worst', 'libcorner', corner, clobber=False)
+    chip.set('constraint', 'timing', 'worst', 'pexcorner', corner, clobber=False)
+    chip.set('constraint', 'timing', 'worst', 'mode', 'func', clobber=False)
+    chip.set('constraint', 'timing', 'worst', 'check', ['setup', 'hold'], clobber=False)
 
 
 #########################

--- a/siliconcompiler/targets/skywater130_demo.py
+++ b/siliconcompiler/targets/skywater130_demo.py
@@ -36,34 +36,34 @@ def setup(chip, syn_np=1, floorplan_np=1, physyn_np=1, place_np=1, cts_np=1, rou
     utils.set_common_showtools(chip)
 
     # 3. Set default targets
-    chip.set('option', 'mode', 'asic')
+    chip.set('option', 'mode', 'asic', clobber=False)
     chip.set('option', 'flow', 'asicflow', clobber=False)
-    chip.set('option', 'pdk', 'skywater130')
-    chip.set('option', 'stackup', '5M1LI')
+    chip.set('option', 'pdk', 'skywater130', clobber=False)
+    chip.set('option', 'stackup', '5M1LI', clobber=False)
 
     # 4. Set project specific design choices
-    chip.set('asic', 'logiclib', 'sky130hd')
+    chip.set('asic', 'logiclib', 'sky130hd', clobber=False)
 
     # 5. get project specific design choices
-    chip.set('asic', 'delaymodel', 'nldm')
-    chip.set('constraint', 'density', 10)
-    chip.set('constraint', 'coremargin', 4.6)
+    chip.set('asic', 'delaymodel', 'nldm', clobber=False)
+    chip.set('constraint', 'density', 10, clobber=False)
+    chip.set('constraint', 'coremargin', 4.6, clobber=False)
 
     # 6. Timing corners
-    chip.set('constraint', 'timing', 'slow', 'libcorner', 'slow')
-    chip.set('constraint', 'timing', 'slow', 'pexcorner', 'maximum')
-    chip.set('constraint', 'timing', 'slow', 'mode', 'func')
-    chip.set('constraint', 'timing', 'slow', 'check', ['setup', 'hold'])
+    chip.set('constraint', 'timing', 'slow', 'libcorner', 'slow', clobber=False)
+    chip.set('constraint', 'timing', 'slow', 'pexcorner', 'maximum', clobber=False)
+    chip.set('constraint', 'timing', 'slow', 'mode', 'func', clobber=False)
+    chip.set('constraint', 'timing', 'slow', 'check', ['setup', 'hold'], clobber=False)
 
-    chip.set('constraint', 'timing', 'fast', 'libcorner', 'fast')
-    chip.set('constraint', 'timing', 'fast', 'pexcorner', 'minimum')
-    chip.set('constraint', 'timing', 'fast', 'mode', 'func')
-    chip.set('constraint', 'timing', 'fast', 'check', ['setup', 'hold'])
+    chip.set('constraint', 'timing', 'fast', 'libcorner', 'fast', clobber=False)
+    chip.set('constraint', 'timing', 'fast', 'pexcorner', 'minimum', clobber=False)
+    chip.set('constraint', 'timing', 'fast', 'mode', 'func', clobber=False)
+    chip.set('constraint', 'timing', 'fast', 'check', ['setup', 'hold'], clobber=False)
 
-    chip.set('constraint', 'timing', 'typical', 'libcorner', 'typical')
-    chip.set('constraint', 'timing', 'typical', 'pexcorner', 'typical')
-    chip.set('constraint', 'timing', 'typical', 'mode', 'func')
-    chip.set('constraint', 'timing', 'typical', 'check', ['power'])
+    chip.set('constraint', 'timing', 'typical', 'libcorner', 'typical', clobber=False)
+    chip.set('constraint', 'timing', 'typical', 'pexcorner', 'typical', clobber=False)
+    chip.set('constraint', 'timing', 'typical', 'mode', 'func', clobber=False)
+    chip.set('constraint', 'timing', 'typical', 'check', ['power'], clobber=False)
 
 
 #########################

--- a/tests/core/test_create_cmdline.py
+++ b/tests/core/test_create_cmdline.py
@@ -27,7 +27,7 @@ def test_cli_multi_source(monkeypatch):
 
     sources = chip.get('input', 'rtl', 'verilog', step='import', index=0)
     assert sources == ['examples/ibex/ibex_alu.v', 'examples/ibex/ibex_branch_predict.v']
-    assert chip.get('option', 'target') == 'freepdk45_demo'
+    assert chip.get('option', 'target') == 'siliconcompiler.targets.freepdk45_demo'
 
 
 def test_cli_include_flag(monkeypatch):
@@ -140,7 +140,7 @@ def test_additional_parameters(monkeypatch):
 
     sources = chip.get('input', 'rtl', 'verilog', step='import', index=0)
     assert sources == ['examples/ibex/ibex_alu.v', 'examples/ibex/ibex_branch_predict.v']
-    assert chip.get('option', 'target') == 'freepdk45_demo'
+    assert chip.get('option', 'target') == 'siliconcompiler.targets.freepdk45_demo'
 
 
 def test_additional_parameters_not_used(monkeypatch):
@@ -170,7 +170,7 @@ def test_additional_parameters_not_used(monkeypatch):
 
     sources = chip.get('input', 'rtl', 'verilog', step='import', index=0)
     assert sources == ['examples/ibex/ibex_alu.v', 'examples/ibex/ibex_branch_predict.v']
-    assert chip.get('option', 'target') == 'freepdk45_demo'
+    assert chip.get('option', 'target') == 'siliconcompiler.targets.freepdk45_demo'
 
 
 def test_cli_examples(monkeypatch):
@@ -224,7 +224,7 @@ def test_cli_examples(monkeypatch):
             # Handle target specially since it affects other values
             if keypath == ['option', 'target']:
                 c = do_cli_test(['sc', switch, value], monkeypatch)
-                assert c.schema.get(*replaced_keypath, step=step, index=index) == expected_val
+                assert c.schema.get(*replaced_keypath, step=step, index=index) == f'siliconcompiler.targets.{expected_val}'
                 continue
 
             args.append(switch)


### PR DESCRIPTION
Ensures the target is loaded after the options are set and makes sure the provided targets are non-clobbering