### PR TITLE
Gracefully handle duplicate edges

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3429,13 +3429,12 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 self.error(f'Illegal step name: {step} is reserved')
                 return
 
-        # Adding
         tail_node = (tail, str(tail_index))
         if tail_node in self.get('flowgraph', flow, head, str(head_index), 'input'):
-            self.logger.warning(f'Edge from {tail}{tail_index} -> {head}{head_index} already exists, skipping')
+            self.logger.warning(f'Edge from {tail}{tail_index} to {head}{head_index} already exists, skipping')
             return
 
-        self.add('flowgraph', flow, head, str(head_index), 'input', (tail, str(tail_index)))
+        self.add('flowgraph', flow, head, str(head_index), 'input', tail_node)
 
     ###########################################################################
     def graph(self, flow, subflow, name=None):

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3424,17 +3424,20 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             >>> chip.edge('place', 'cts')
             Creates a directed edge from place to cts.
         '''
+        head_index = str(head_index)
+        tail_index = str(tail_index)
+
         for step in (head, tail):
             if step in (Schema.GLOBAL_KEY, 'default'):
                 self.error(f'Illegal step name: {step} is reserved')
                 return
 
-        tail_node = (tail, str(tail_index))
-        if tail_node in self.get('flowgraph', flow, head, str(head_index), 'input'):
+        tail_node = (tail, tail_index)
+        if tail_node in self.get('flowgraph', flow, head, head_index, 'input'):
             self.logger.warning(f'Edge from {tail}{tail_index} to {head}{head_index} already exists, skipping')
             return
 
-        self.add('flowgraph', flow, head, str(head_index), 'input', tail_node)
+        self.add('flowgraph', flow, head, head_index, 'input', tail_node)
 
     ###########################################################################
     def graph(self, flow, subflow, name=None):

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -204,6 +204,28 @@ def test_check_missing_task_module():
     assert not chip.check_manifest()
 
 
+@pytest.mark.quick
+def test_check_graph_duplicate_edge():
+    chip = siliconcompiler.Chip('test')
+
+    flow = 'test'
+    chip.set('option', 'flow', flow)
+
+    chip.node(flow, 'import', foo)
+    chip.node(flow, 'export', baz)
+
+    chip.edge(flow, 'import', 'export')
+
+    # edge() should not allow duplicates
+    chip.edge(flow, 'import', 'export')
+    assert len(chip.get('flowgraph', flow, 'export', '0', 'input')) == 1
+
+    # check_manifest() should catch it if forced
+    chip.add('flowgraph', flow, 'export', '0', 'input', ('import', '0'))
+
+    assert not chip._check_flowgraph()
+
+
 #########################
 if __name__ == "__main__":
     test_check_manifest()


### PR DESCRIPTION
If a user accidentally adds duplicate edges to a flowgraph, they'll get a confusing error mid run: 

```
| INFO    | job0  | mystep    | 0  | Finished task in 60s
Process Process-4:
Traceback (most recent call last):
  File "/opt/rh/rh-python38/root/usr/lib64/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/opt/rh/rh-python38/root/usr/lib64/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/centos/venv/lib64/python3.8/site-packages/siliconcompiler/core.py", line 3608, in _runtask
    utils.copytree(f"../../../{in_job}/{in_step}/{in_index}/outputs", 'inputs/',
  File "/home/centos/venv/lib64/python3.8/site-packages/siliconcompiler/utils.py", line 30, in copytree
    os.link(srcfile, dstfile)
FileExistsError: [Errno 17] File exists: '../../../job0/mystep/0/outputs/design.out' -> 'inputs/design.out'
```

This PR fixes the problem in a couple places: it performs validation in `edge()` with a warning message, and adds a manifest check as a fallback (in case a user is manipulating the `flowgraph` schema directly). 