### PR TITLE
Configure docs build to use newer OS

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.8"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,9 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Need to specify a newer build environment for RTD due to a breaking change in a transitive dependency. 

Fix based on https://github.com/readthedocs/readthedocs.org/issues/10290#issuecomment-1535120995. 