### PR TITLE
add extension to sc-show to allow users to pick the file type easily when multiple displayble files are generated

### DIFF
--- a/siliconcompiler/apps/sc_show.py
+++ b/siliconcompiler/apps/sc_show.py
@@ -55,10 +55,19 @@ def main():
         if ext in default_input_map:
             input_map[ext] = default_input_map[ext]
 
-    chip.create_cmdline(progname,
-                        switchlist=['-design', '-input', '-loglevel', '-cfg'],
-                        description=description,
-                        input_map=input_map)
+    extension_arg = {
+        'metavar': '<ext>',
+        'help': 'Specify the extention of the file to show'
+    }
+
+    args = chip.create_cmdline(
+        progname,
+        switchlist=['-design', '-input', '-loglevel', '-cfg'],
+        description=description,
+        input_map=input_map,
+        additional_args={
+            '-ext': extension_arg
+        })
 
     # Error checking
     design = chip.get('design')
@@ -107,7 +116,7 @@ def main():
     # Set supported showtools incase custom flow was used and didn't get set
     set_common_showtools(chip)
 
-    success = chip.show(filename)
+    success = chip.show(filename, extension=args['ext'])
 
     return 0 if success else 1
 

--- a/siliconcompiler/apps/sc_show.py
+++ b/siliconcompiler/apps/sc_show.py
@@ -34,6 +34,9 @@ def main():
     sc-show -design adder
     (displays build/job0/adder/export/0/outputs/adder.gds)
 
+    sc-show -design adder -ext odb
+    (displays build/job0/adder/export/1/outputs/adder.odb)
+
     sc-show build/job0/adder/route/1/outputs/adder.def
     (displays build/job0/adder/route/1/outputs/adder.def)
 
@@ -57,7 +60,7 @@ def main():
 
     extension_arg = {
         'metavar': '<ext>',
-        'help': 'Specify the extention of the file to show'
+        'help': '(optional) Specify the extension of the file to show.'
     }
 
     args = chip.create_cmdline(

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4506,7 +4506,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         return None
 
     ###########################################################################
-    def show(self, filename=None, screenshot=False):
+    def show(self, filename=None, screenshot=False, extension=None):
         '''
         Opens a graphical viewer for the filename provided.
 
@@ -4519,7 +4519,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         saved in the <build_dir>/_show_<jobname> directory.
 
         Args:
-            filename: Name of file to display
+            filename (path): Name of file to display
+            screenshot (bool): Flag to indicate if this is a screenshot or show
+            extension (str): extension of file to show
 
         Examples:
             >>> show('build/oh_add/job0/export/0/outputs/oh_add.gds')
@@ -4539,6 +4541,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 search_nodes.append((sc_step, sc_index))
             search_nodes.extend(self._get_flowgraph_exit_nodes())
             for ext in self.getkeys('option', 'showtool'):
+                if extension and extension != ext:
+                    continue
                 for step, index in search_nodes:
                     filename = self.find_result(ext, step=step, index=index, jobname=sc_job)
                     if filename:
@@ -4588,6 +4592,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         # Override enviroment
         self.set('option', 'flow', 'showflow', clobber=True)
         self.set('option', 'track', False, clobber=True)
+        self.set('option', 'hash', False, clobber=True)
+        self.set('option', 'nodisplay', False, clobber=True)
         self.set('option', 'flowcontinue', True, clobber=True)
         self.set('arg', 'step', None, clobber=True)
         self.set('arg', 'index', None, clobber=True)

--- a/tests/apps/test_sc_show.py
+++ b/tests/apps/test_sc_show.py
@@ -43,7 +43,7 @@ def test_sc_show_design_only(flags, monkeypatch, heartbeat_dir):
     # We have separate tests in test/core/test_show.py that handle these
     # complications and test this function itself, so there's no need to
     # run it here.
-    def fake_show(chip, filename):
+    def fake_show(chip, filename, extension=None):
         # when only -design is provided the filename will not be available
         assert not filename
 
@@ -78,7 +78,7 @@ def test_sc_show(flags, monkeypatch, heartbeat_dir):
     # We have separate tests in test/core/test_show.py that handle these
     # complications and test this function itself, so there's no need to
     # run it here.
-    def fake_show(chip, filename):
+    def fake_show(chip, filename, extension=None):
         # Test basic conditions required for chip.show() to work, to make sure
         # that the sc-show app set up the chip object correctly.
         assert os.path.exists(filename)


### PR DESCRIPTION
Adds: `-ext` option to sc-show to allow users to select the filetype to display. This is useful when multiple filetypes are available and you need a particular one, like def or odb.