### PR TITLE
[sc-issue] update to make testcases self-contained

### DIFF
--- a/siliconcompiler/apps/sc_issue.py
+++ b/siliconcompiler/apps/sc_issue.py
@@ -105,9 +105,9 @@ To run a testcase, use:
 
         test_dir = os.path.basename(switches['file']).split('.')[0]
         with tarfile.open(switches['file'], 'r:gz') as f:
-            f.extractall(path=test_dir)
+            f.extractall(path='.')
 
-        chip.read_manifest(f'{test_dir}/manifest.json')
+        chip.read_manifest(f'{test_dir}/orig_manifest.json')
 
         with open(f'{test_dir}/issue.json', 'r') as f:
             issue_info = json.load(f)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1311,7 +1311,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         elif len(keypath) >= 5 and keypath[0] == 'tool' and keypath[4] == 'script':
             tool = keypath[1]
             task = keypath[3]
-            refdirs = self._find_files('tool', tool, 'task', task, 'refdir', step=step, index=index, abs_path_only=True)
+            refdirs = self._find_files('tool', tool, 'task', task, 'refdir',
+                                       step=step, index=index,
+                                       abs_path_only=True)
             search_paths = refdirs
 
         for path in paths:
@@ -5301,12 +5303,14 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 try:
                     # Rerun pre_process
                     func(self)
-                except Exception as e:
+                except Exception:
                     pass
         except SiliconCompilerError:
             pass
 
-        self._makecmd(tool, task, step, index, script_name=f'{self._getworkdir(step=step, index=index)}/replay.sh', include_path=False)
+        self._makecmd(tool, task, step, index,
+                      script_name=f'{self._getworkdir(step=step, index=index)}/replay.sh',
+                      include_path=False)
 
         # Restore normal path behavior
         self.__relative_path = None
@@ -5368,7 +5372,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         with open(issue_path, 'w') as fd:
             json.dump(issue_information, fd, indent=4, sort_keys=True)
 
-        jinja_env = Environment(loader=FileSystemLoader(os.path.join(self.scroot, 'templates', 'issue')))
+        jinja_env = Environment(loader=FileSystemLoader(os.path.join(self.scroot,
+                                                                     'templates',
+                                                                     'issue')))
         readme_path = os.path.join(issue_dir.name, 'README.txt')
         with open(readme_path, 'w') as f:
             f.write(jinja_env.get_template('README.txt').render(
@@ -5393,9 +5399,14 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                          issue_path,
                          readme_path,
                          run_path]:
-                tar.add(os.path.abspath(path), arcname=os.path.join(arch_base_dir, os.path.basename(path)))
+                tar.add(os.path.abspath(path),
+                        arcname=os.path.join(arch_base_dir,
+                                             os.path.basename(path)))
 
-            tar.add(job_dir, arcname=os.path.join(arch_base_dir, os.path.relpath(job_dir, issue_dir.name)))
+            tar.add(job_dir,
+                    arcname=os.path.join(arch_base_dir,
+                                         os.path.relpath(job_dir,
+                                                         issue_dir.name)))
 
         issue_dir.cleanup()
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -5356,6 +5356,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                                     'libraries_included': include_libraries,
                                     'pdks_included': include_pdks,
                                     'tool': tool,
+                                    'toolversion': self.get('record', 'toolversion',
+                                                            step=step, index=index),
                                     'task': task}
         issue_information['version'] = {'schema': self.schemaversion,
                                         'sc': self.scversion,

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -5224,15 +5224,13 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 else:
                     copy = include_libraries
 
-                copy &= determine_copy(*keypath[2:])
+                copy = copy and determine_copy(*keypath[2:])
             elif keypath[0] == 'pdk':
                 # only copy pdks if selected
                 if include_specific_pdks and keypath[1] in include_specific_pdks:
                     copy = True
                 else:
                     copy = include_pdks
-
-                copy &= determine_copy(*keypath[2:])
             elif keypath[0] == 'history':
                 # Skip history
                 copy = False

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4650,7 +4650,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         return fullexe
 
     #######################################
-    def _makecmd(self, tool, task, step, index, extra_options=None):
+    def _makecmd(self, tool, task, step, index, script_name='replay.sh'):
         '''
         Constructs a subprocess run command based on eda tool setup.
         Creates a replay script in current directory.
@@ -4674,8 +4674,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         scripts = self.find_files('tool', tool, 'task', task, 'script', step=step, index=index)
 
         cmdlist = [fullexe]
-        if extra_options:
-            cmdlist.extend(extra_options)
         cmdlist.extend(options)
         cmdlist.extend(scripts)
 
@@ -4724,15 +4722,17 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         cmdlist = [*nice_cmdlist, *cmdlist]
 
         # create replay file
-        script_name = 'replay.sh'
         with open(script_name, 'w') as f:
-            print('#!/bin/bash', file=f)
+            print('#!/usr/bin/env bash', file=f)
 
             envvar_cmd = 'export'
             for key, val in envvars.items():
                 print(f'{envvar_cmd} {key}="{val}"', file=f)
 
+            # Ensure execution runs from the same directory
+            print(f'cd {self._getworkdir(step=step, index=index)}', file=f)
             print(' '.join(f'"{arg}"' if ' ' in arg else arg for arg in replay_cmdlist), file=f)
+
         os.chmod(script_name, 0o755)
 
         return cmdlist, ' '.join(replay_cmdlist), cmd, cmd_args

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3568,6 +3568,19 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             prevstep = step
 
     ###########################################################################
+    def __write_task_manifest(self, tool, path=None, backup=True):
+        suffix = self.get('tool', tool, 'format')
+        if suffix:
+            manifest_path = f"sc_manifest.{suffix}"
+            if path:
+                manifest_path = os.path.join(path, manifest_path)
+
+            if backup and os.path.exists(manifest_path):
+                shutil.copyfile(manifest_path, f'{manifest_path}.bak')
+
+            self.write_manifest(manifest_path, prune=False, abspath=True)
+
+    ###########################################################################
     def _runtask(self, step, index, status, replay=False):
         '''
         Private per step run method called by run().
@@ -3802,9 +3815,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         ##################
         # Write manifest (tool interface) (Don't move this!)
-        suffix = self.get('tool', tool, 'format')
-        if suffix:
-            self.write_manifest(f"sc_manifest.{suffix}", prune=False, abspath=True)
+        self.__write_task_manifest(tool)
 
         ##################
         # Start CPU Timer

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4676,7 +4676,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         return fullexe
 
     #######################################
-    def _makecmd(self, tool, task, step, index, script_name='replay.sh'):
+    def _makecmd(self, tool, task, step, index, script_name='replay.sh', include_path=True):
         '''
         Constructs a subprocess run command based on eda tool setup.
         Creates a replay script in current directory.
@@ -4723,11 +4723,12 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             if license_file:
                 envvars[item] = ':'.join(license_file)
 
-        path = self.get('tool', tool, 'path', step=step, index=index)
-        if path:
-            envvars['PATH'] = path + os.pathsep + os.environ['PATH']
-        else:
-            envvars['PATH'] = os.environ['PATH']
+        if include_path:
+            path = self.get('tool', tool, 'path', step=step, index=index)
+            if path:
+                envvars['PATH'] = path + os.pathsep + os.environ['PATH']
+            else:
+                envvars['PATH'] = os.environ['PATH']
 
         for key in self.getkeys('tool', tool, 'task', task, 'env'):
             val = self.get('tool', tool, 'task', task, 'env', key, step=step, index=index)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4757,7 +4757,10 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 print(f'{envvar_cmd} {key}="{val}"', file=f)
 
             # Ensure execution runs from the same directory
-            print(f'cd {self._getworkdir(step=step, index=index)}', file=f)
+            work_dir = self._getworkdir(step=step, index=index)
+            if self.__relative_path:
+                work_dir = os.path.relpath(work_dir, self.__relative_path)
+            print(f'cd {work_dir}', file=f)
             print(' '.join(f'"{arg}"' if ' ' in arg else arg for arg in replay_cmdlist), file=f)
 
         os.chmod(script_name, 0o755)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3670,8 +3670,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         ##################
         # Write manifest prior to step running into inputs
 
-        self.set('arg', 'step', None, clobber=True)
-        self.set('arg', 'index', None, clobber=True)
         self.write_manifest(f'inputs/{design}.pkg.json')
 
         ##################

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -5213,6 +5213,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         tool, task = self._get_tool_task(step, index, flow=flow)
 
         # Set copy flags for _collect
+        self.set('option', 'copyall', False)
         for keypath in self.allkeys():
             if 'default' in keypath:
                 continue

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -5203,7 +5203,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 for _, key_step, key_index in self.schema._getvals(*key):
                     self.hash_files(*key, step=key_step, index=key_index)
 
-        manifest_path = os.path.join(issue_dir.name, 'manifest.json')
+        manifest_path = os.path.join(issue_dir.name, 'orig_manifest.json')
         self.write_manifest(manifest_path)
 
         flow = self.get('option', 'flow')
@@ -5254,6 +5254,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 copy = False
             if keypath[-2:] == ['option', 'scpath']:
                 # Avoid all of scpath
+                copy = False
+            if keypath[-2:] == ['option', 'cfg']:
+                # Avoid all of cfg, since we are getting the manifest seperately
                 copy = False
             elif keypath[-2:] == ['option', 'credentials']:
                 # Exclude credentials file

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -5282,19 +5282,25 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         original_cwd = self.cwd
         self.cwd = issue_dir.name
 
+        # Get new directories
         job_dir = self._getworkdir()
+        new_work_dir = self._getworkdir(step=step, index=index)
+        collection_dir = self._getcollectdir()
 
-        # Copy in issue run
-        utils.copytree(work_dir, self._getworkdir(step=step, index=index), dirs_exist_ok=True)
+        # Restore current directory
+        self.cwd = original_cwd
 
-        # Copy in files
-        self._collect(directory=self._getcollectdir())
+        # Copy in issue run files
+        utils.copytree(work_dir, new_work_dir, dirs_exist_ok=True)
+        # Copy in source files
+        self._collect(directory=collection_dir)
 
         # Set relative path to generate runnable files
-        self.__relative_path = self._getworkdir(step=step, index=index)
+        self.__relative_path = new_work_dir
+        self.cwd = issue_dir.name
 
         # Rewrite tool manifest
-        self.__write_task_manifest(tool, path=self._getworkdir(step=step, index=index))
+        self.__write_task_manifest(tool, path=new_work_dir)
 
         # Rewrite replay.sh
         try:

--- a/siliconcompiler/templates/issue/README.txt
+++ b/siliconcompiler/templates/issue/README.txt
@@ -1,0 +1,26 @@
+SiliconCompiler test case
+
+To run this testcase:
+./run.sh
+-- or --
+sc-issue -run -file {{ archive_name }}
+
+** SiliconCompiler information **
+Version: {{ version['sc'] }}
+Schema: {{ version['schema'] }}
+
+** Run **
+Testcase built: {{ date }}
+Tool: {{ run['tool'] }}
+Task: {{ run['task'] }}
+Node: {{ run['step'] }}{{ run['index'] }}
+
+** Python **
+Version: {{ python['version'] }}
+
+** Machine **
+System: {{ machine['system'] }}
+Distribution: {{ machine['distro'] }}
+Version: {{ machine['osversion'] }}
+Kernel version: {{ machine['kernelversion'] }}
+Architecture: {{ machine['arch'] }}

--- a/siliconcompiler/templates/issue/README.txt
+++ b/siliconcompiler/templates/issue/README.txt
@@ -11,7 +11,7 @@ Schema: {{ version['schema'] }}
 
 ** Run **
 Testcase built: {{ date }}
-Tool: {{ run['tool'] }}
+Tool: {{ run['tool'] }} {% if run['toolversion'] %}{{ run['toolversion'] }}{% endif %}
 Task: {{ run['task'] }}
 Node: {{ run['step'] }}{{ run['index'] }}
 

--- a/siliconcompiler/templates/issue/run.sh
+++ b/siliconcompiler/templates/issue/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+echo "{{ title }}"
+echo "see README.txt for more information"
+echo "executing {{ exec_path }}"
+{{ exec_path }}

--- a/siliconcompiler/templates/issue/run.sh
+++ b/siliconcompiler/templates/issue/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 echo "{{ title }}"
 echo "see README.txt for more information"
-echo "executing {{ exec_path }}"
-{{ exec_path }}
+echo "executing in {{ exec_dir }}"
+cd {{ exec_dir }}
+./replay.sh


### PR DESCRIPTION
Changes:
- `_find_files` can now return relative paths if the private variable `__relative_path` is set. This allows the testcase generator to build testcases with complete tests.
- Fixes incorrect libraries key path
- Rework the testcase generator to include a README.txt and a run.sh file to allow for standalone tests.
