### PR TITLE
Show "node" subfields for unset schema params

### DIFF
--- a/docs/_ext/schemagen.py
+++ b/docs/_ext/schemagen.py
@@ -43,7 +43,8 @@ class SchemaGen(SphinxDirective):
             if 'unit' in schema:
                 entries.append([strong('Unit'), para(schema['unit'])])
 
-            entries.extend([[strong('Default Value'), para(schema['defvalue'])],
+            defvalue = schema['node']['default']['default']['value']
+            entries.extend([[strong('Default Value'), para(defvalue)],
                             [strong('CLI Switch'), code(schema['switch'])]])
 
             for example in schema['example']:

--- a/docs/reference_manual/schema.rst
+++ b/docs/reference_manual/schema.rst
@@ -62,7 +62,7 @@ Parameter Fields
         Implied unit for parameter value.
 
 
-Per-node Parameter fields
+Per-node Parameter Fields
 ---------------------------
 
 The following fields are specified inside the ``node`` dictionary on a per-step/index basis. Default values for each field are stored under the special keys ``"default", "default"``, and global values are specified under the special keys ``"global", "global"``.

--- a/docs/reference_manual/schema.rst
+++ b/docs/reference_manual/schema.rst
@@ -16,17 +16,8 @@ Parameter Fields
 
 .. glossary::
 
-    author
-        File author. The author string records the person/entity that authored/created each item in the list of files within 'value' parameter field. The 'author' field can be used to validate the provenance of the data used for compilation.
-
     copy
         Whether to copy files into build directory, applies to files only
-
-    date
-        String containing the data stamp of each item in the list of files within 'value' parameter field. The 'date' field can be used to validate the provenance of the data used for compilation.
-
-    defvalue
-        Default value for the parameter. The default value must agree with the parameter 'type'. To specify that a parameter has no default value, set the defvalue to [] (ie empty list) for a list type and to 'null' or None for a non-list/scalar type.
 
     enum
         List of strings containing the set of legal values for this parameter.
@@ -37,14 +28,14 @@ Parameter Fields
     hashalgo
         Hasing algorithm useed to calculate filehash value.
 
-    filehash
-        Calculated file hash value for each file in the 'value' field of the parameter.
-
     help
         Complete parameter help doc string. The help string serves as ground truth for describing the parameter functionality and should be used for long help descriptions in command line interface programs and for automated schema document generation. The long help can be pruned/filtered before the schema is dumped into a JSON file.
 
     lock
         Boolean value dictating whether the parameter can be modified by the set/get/add core API methods. A value of True specifiers that the parameter is locked and cannot be modified. Attempts to write to to a locked parameter shall result in an exception/error that blocks compilation progress.
+
+    node
+        Dictionary containing fields whose values may vary on a per-step/index basis. Sub-fields are described in :ref:`Per-node Parameter Fields`
 
     notes
         User entered 'notes'/'disclaimers' about value being set.
@@ -58,9 +49,6 @@ Parameter Fields
     scope
         Scope of parameter in schema
 
-    signature
-        String recording a unique machine calculated string for each item in the list of files within 'value' parameter field. The 'signature' field can be used to validate the provenance of the data used for compilation.
-
     switch
         String that specifies the equivalent switch to use in command line interfaces. The switch string must start with a '-' and cannot contain spaces.
 
@@ -72,6 +60,25 @@ Parameter Fields
 
     unit
         Implied unit for parameter value.
+
+
+Per-node Parameter fields
+---------------------------
+
+The following fields are specified inside the ``node`` dictionary on a per-step/index basis. Default values for each field are stored under the special keys ``"default", "default"``, and global values are specified under the special keys ``"global", "global"``.
+
+.. glossary::
+    author
+        File author. The author string records the person/entity that authored/created each item in the list of files within 'value' parameter field. The 'author' field can be used to validate the provenance of the data used for compilation.
+
+    date
+        String containing the data stamp of each item in the list of files within 'value' parameter field. The 'date' field can be used to validate the provenance of the data used for compilation.
+
+    filehash
+        Calculated file hash value for each file in the 'value' field of the parameter.
+
+    signature
+        String recording a unique machine calculated string for each item in the list of files within 'value' parameter field. The 'signature' field can be used to validate the provenance of the data used for compilation.
 
     value
         Parameter value

--- a/docs/user_guide/data_model.rst
+++ b/docs/user_guide/data_model.rst
@@ -118,7 +118,7 @@ If you further go one step further down, you'll see that ``verilog`` is a leaf p
 .. code-block:: python
 
    >>> chip.getkeys('input', 'rtl', 'verilog')
-   ['defvalue', 'type', 'scope', 'require', 'lock', 'switch', 'shorthelp', 'example', 'help', 'notes', 'pernode', 'node', 'hashalgo', 'copy']
+   ['type', 'scope', 'require', 'lock', 'switch', 'shorthelp', 'example', 'help', 'notes', 'pernode', 'node', 'hashalgo', 'copy']
 
 
 Parameter fields are standardized variables which help to define the parameter. In the case below, you can see that :meth:`.get()` can also be used to query parameter fields to provide more information about the parameters:
@@ -153,11 +153,17 @@ The :meth:`.write_manifest()` method above writes out the JSON file below, showi
 .. code-block:: json
 
     "design": {
-        "defvalue": null,
         "lock": false,
         "node": {
+            "default": {
+               "default": {
+                    "signature": null,
+                    "value": null
+               }
+            },
             "global": {
                 "global": {
+                    "signature": null,
                     "value": "hello_world"
                 }
             }
@@ -167,8 +173,9 @@ The :meth:`.write_manifest()` method above writes out the JSON file below, showi
         "require": "all",
         "scope": "global",
         "shorthelp": "Design top module name",
-        "signature": null,
-        "switch": "-design <str>",
+        "switch": [
+            "-design <str>"
+        ],
         "type": "str"
     },
   

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -765,7 +765,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         description = self.get(*keypath, field='shorthelp')
         typestr = self.get(*keypath, field='type')
         switchstr = str(self.get(*keypath, field='switch'))
-        defstr = str(self.get(*keypath, field='defvalue'))
+        defstr = str(self.schema.get_default(*keypath))
         requirement = str(self.get(*keypath, field='require'))
         helpstr = self.get(*keypath, field='help')
         example = self.get(*keypath, field='example')
@@ -1492,7 +1492,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
                 # update other fields that a user might modify
                 for field in src.getdict(*keylist).keys():
-                    if field in ('node', 'switch', 'type', 'require', 'defvalue',
+                    if field in ('node', 'switch', 'type', 'require',
                                  'shorthelp', 'example', 'help'):
                         # skip these fields (node handled above, others are static)
                         continue

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from siliconcompiler.schema.utils import trim
 
-SCHEMA_VERSION = '0.33.0'
+SCHEMA_VERSION = '0.34.0'
 
 
 #############################################################################

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -94,6 +94,10 @@ def scparam(cfg,
         # never, optional, required
         cfg['pernode'] = pernode
         cfg['node'] = {}
+        cfg['node']['default'] = {}
+        cfg['node']['default']['default'] = {}
+        cfg['node']['default']['default']['value'] = defvalue
+        cfg['node']['default']['default']['signature'] = signature
 
         if enum is not None:
             cfg['enum'] = enum
@@ -106,6 +110,9 @@ def scparam(cfg,
         if re.search(r'file', sctype):
             cfg['hashalgo'] = hashalgo
             cfg['copy'] = copy
+            cfg['node']['default']['default']['date'] = []
+            cfg['node']['default']['default']['author'] = []
+            cfg['node']['default']['default']['filehash'] = []
 
         if re.search(r'dir', sctype):
             cfg['copy'] = copy

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -79,7 +79,6 @@ def scparam(cfg,
             defvalue = []
 
         # mandatory for all
-        cfg['defvalue'] = defvalue
         cfg['type'] = sctype
         cfg['scope'] = scope
         cfg['require'] = require

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -948,7 +948,7 @@ class Schema:
         # Reinitialize logger on restore
         self._init_logger()
 
-
+    #######################################
     def get_default(self, *keypath):
         '''Returns default value of a parameter.
 

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -66,6 +66,8 @@ class Schema:
             for field, value in cfg.items():
                 if field == 'node':
                     for step in value:
+                        if step == 'default':
+                            continue
                         for index in value[step]:
                             if step == Schema.GLOBAL_KEY:
                                 sstep = None
@@ -240,7 +242,7 @@ class Schema:
             if step not in cfg['node']:
                 cfg['node'][step] = {}
             if index not in cfg['node'][step]:
-                cfg['node'][step][index] = {}
+                cfg['node'][step][index] = copy.deepcopy(cfg['node']['default']['default'])
             cfg['node'][step][index][field] = value
         else:
             cfg[field] = value
@@ -292,9 +294,7 @@ class Schema:
             if step not in cfg['node']:
                 cfg['node'][step] = {}
             if index not in cfg['node'][step]:
-                cfg['node'][step][index] = {}
-            if field not in cfg['node'][step][index]:
-                cfg['node'][step][index][field] = []
+                cfg['node'][step][index] = copy.deepcopy(cfg['node']['default']['default'])
             cfg['node'][step][index][field].extend(value)
         else:
             cfg[field].extend(value)
@@ -356,6 +356,9 @@ class Schema:
         vals = []
         has_global = False
         for step in cfg['node']:
+            if step == 'default':
+                continue
+
             for index in cfg['node'][step]:
                 step_arg = None if step == self.GLOBAL_KEY else step
                 index_arg = None if index == self.GLOBAL_KEY else index

--- a/siliconcompiler/sphinx_ext/utils.py
+++ b/siliconcompiler/sphinx_ext/utils.py
@@ -123,15 +123,6 @@ def build_list(items, enumerated=False):
     return list
 
 
-# SC schema helpers
-def is_leaf(schema):
-    if 'defvalue' in schema:
-        return True
-    elif len(schema.keys()) == 1 and 'default' in schema:
-        return is_leaf(schema['default'])
-    return False
-
-
 def keypath(key_path, refdoc, key_text=None):
     '''Helper function for displaying Schema keypaths.'''
     text_parts = []

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -8,7 +8,14 @@
             ],
             "help": "Dynamic parameter passed in by the sc runtime as an argument to\na runtime task. The parameter enables configuration code\n(usually TCL) to use control flow that depend on the current\n'index'. The parameter is used the run() function and\nis not intended for external use.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -27,7 +34,14 @@
             ],
             "help": "Dynamic parameter passed in by the sc runtime as an argument to\na runtime task. The parameter enables configuration code\n(usually TCL) to use control flow that depend on the current\n'step'. The parameter is used the run() function and\nis not intended for external use.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -49,7 +63,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -68,7 +89,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -87,7 +115,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -106,7 +141,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -125,7 +167,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -144,7 +193,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -163,7 +219,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -182,7 +245,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -201,7 +271,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -220,7 +297,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -239,7 +323,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -258,7 +349,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -277,7 +375,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -296,7 +401,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -315,7 +427,14 @@
                 ],
                 "help": "List of cells grouped by a property that can be accessed\ndirectly by the designer and tools. The example below shows how\nall cells containing the string 'eco' could be marked as dont use\nfor the tool.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -335,7 +454,14 @@
             ],
             "help": "Delay model to use for the target libs. Supported values\nare nldm and ccs.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": null,
@@ -354,7 +480,14 @@
             ],
             "help": "The library architecture (e.g. library height) used to build the\ndesign. For example a PDK with support for 9 and 12 track libraries\nmight have 'libarchs' called 9t and 12t.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": null,
@@ -373,7 +506,14 @@
             ],
             "help": "List of all selected logic libraries libraries\nto use for optimization for a given library architecture\n(9T, 11T, etc).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": null,
@@ -392,7 +532,14 @@
             ],
             "help": "List of macro libraries to be linked in during synthesis and place\nand route. Macro libraries are used for resolving instances but are\nnot used as targets for logic synthesis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": null,
@@ -412,7 +559,14 @@
                 ],
                 "help": "Site names for a given library architecture.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -436,7 +590,14 @@
                     ],
                     "help": "Simple list of signoff criteria for checklist item which\nmust all be met for signoff. Each signoff criteria consists of\na metric, a relational operator, and a value in the form.\n'metric op value'.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -455,7 +616,14 @@
                     ],
                     "help": "Free text description of the type of data files acceptable as\nchecklist signoff validation.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -474,7 +642,14 @@
                     ],
                     "help": "A short one line description of the checklist item.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -493,7 +668,14 @@
                     ],
                     "help": "Boolean check mark for the checklist item. A value of\nTrue indicates a human has inspected the all item dictionary\nparameters check out.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": false
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": "all",
@@ -512,7 +694,14 @@
                     ],
                     "help": "Rationale for the the checklist item. Rationale should be a\nunique alphanumeric code used by the standard or a short one line\nor single word description.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -533,7 +722,17 @@
                     "hashalgo": "sha256",
                     "help": "Filepath to report(s) of specified type documenting the successful\nvalidation of the checklist item.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "author": [],
+                                "date": [],
+                                "filehash": [],
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -552,7 +751,14 @@
                     ],
                     "help": "A complete requirement description of the checklist item\nentered as a multi-line string.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -571,7 +777,14 @@
                     ],
                     "help": "Flowgraph job and task used to verify the checklist item.\nThe parameter should be left empty for manual and for tool\nflows that bypass the SC infrastructure.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -593,7 +806,17 @@
                         "hashalgo": "sha256",
                         "help": "Filepath to report(s) documenting waivers for the checklist\nitem specified on a per metric basis.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "author": [],
+                                    "date": [],
+                                    "filehash": [],
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "never",
                         "require": null,
@@ -617,7 +840,14 @@
             ],
             "help": "Height to width ratio of the block for automated floorplanning.\nValues below 0.1 and above 10 should be avoided as they will likely fail\nto converge during placement and routing. The ideal aspect ratio for\nmost designs is 1. This value is only used when no diearea or floorplan\nis supplied.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "1.0"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": null,
@@ -638,7 +868,14 @@
                     ],
                     "help": "Boolean parameter specifying that the instanced library component should be flipped\naround the vertical axis before being placed on the substrate. The need to\nflip a component depends on the component footprint. Most dies have pads\nfacing up and so must be flipped when assembled face down (eg. flip-chip,\nWCSP).",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": false
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": "all",
@@ -657,7 +894,14 @@
                     ],
                     "help": "Placement keepout halo around the named component, specified as a\n(horizontal, vertical) tuple represented in microns or lambda units.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -677,7 +921,14 @@
                     ],
                     "help": "Part name of a named instance. The parameter is required for instances\nthat are not contained within the design netlist (ie. physical only cells).",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -696,7 +947,14 @@
                     ],
                     "help": "Placement location of a named instance, specified as a (x,y,z) tuple of\nfloats. The location refers to the placement of the center/centroid of the\ncomponent. The 'placement' parameter is a goal/intent, not an exact specification.\nThe compiler and layout system may adjust coordinates to meet competing\ngoals such as manufacturing design  rules and grid placement\nguidelines. The 'z' coordinate shall be set to 0 for planar systems\nwith only (x,y) coordinates. Discretized systems like PCB stacks,\npackage stacks, and breadboards only allow a reduced\nset of floating point values (0,1,2,3). The user specifying the\nplacement will need to have some understanding of the type of\nlayout system the component is being placed in (ASIC, SIP, PCB) but\nshould not need to know exact manufacturing specifications.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -716,7 +974,14 @@
                     ],
                     "help": "Placement rotation of the component specified in degrees. Rotation\ngoes counter-clockwise for all parts on top and clock-wise for parts\non the bottom. In both cases, this is from the perspective of looking\nat the top of the board. Rotation is specified in degrees. Most gridded\nlayout systems (like ASICs) only allow a finite number of rotation\nvalues (0,90,180,270).",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -737,7 +1002,14 @@
             ],
             "help": "List of (x,y) points that define the outline of the core area for the\nphysical design. Simple rectangle areas can be defined with two points,\none for the lower left corner and one for the upper right corner. All\nvalues are specified in microns or lambda units.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": null,
@@ -757,7 +1029,14 @@
             ],
             "help": "Halo/margin between the outline and core area for fully\nautomated layout sizing and floorplanning, specified in\nmicrons or lambda units.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": null,
@@ -777,7 +1056,14 @@
             ],
             "help": "Target density based on the total design cells area reported\nafter synthesis/elaboration. This number is used when no outline\nor floorplan is supplied. Any number between 1 and 100 is legal,\nbut values above 50 may fail due to area/congestion issues during\nautomated place and route.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": null,
@@ -798,7 +1084,14 @@
                     ],
                     "help": "Differential pair signal of the named net (only used for actual\ndifferential paris).",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -817,7 +1110,14 @@
                     ],
                     "help": "List of nets whose routing should closely matched the named\nnet in terms of length, layer, width, etc. Wildcards ('*') can\nbe used for net names.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -836,7 +1136,14 @@
                     ],
                     "help": "Maximum metal layer to be used for automated place and route\nspecified on a per net basis. Metal names should either be the PDK\nspecific metal stack name or an integer with '1' being the lowest\nrouting layer. Wildcards ('*') can be used for net names.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -855,7 +1162,14 @@
                     ],
                     "help": "Maximum total length of a net, specified in microns or lambda units.\nWildcards ('*') can be used for net names.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -875,7 +1189,14 @@
                     ],
                     "help": "Maximum resistance of named net between driver and receiver\nspecified in ohms. Wildcards ('*') can be used for net names.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -895,7 +1216,14 @@
                     ],
                     "help": "Minimum metal layer to be used for automated place and route\nspecified on a per net basis. Metal names should either be the PDK\nspecific metal stack name or an integer with '1' being the lowest\nrouting layer. Wildcards ('*') can be used for net names.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -914,7 +1242,14 @@
                     ],
                     "help": "Definitions of non-default routing rule specified on a per\nnet basis. Constraints are entered as a (width,space) tuples\nspecified in microns or lambda units. Wildcards ('*') can be used\nfor net names.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -934,7 +1269,14 @@
                     ],
                     "help": "Specifies that the named net should be shielded by the given\nsignal on both sides of the net.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -953,7 +1295,14 @@
                     ],
                     "help": "Symmetrical pair signal to the named net. The two nets should be routed\nas reflections around the vertical or horizontal axis to minimize on-chip\nvariability.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -974,7 +1323,14 @@
             ],
             "help": "List of (x,y) points that define the outline physical layout\nphysical design. Simple rectangle areas can be defined with two points,\none for the lower left corner and one for the upper right corner. All\nvalues are specified in microns or lambda units.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": null,
@@ -996,7 +1352,14 @@
                     ],
                     "help": "Pin metal layer specified based on the SC standard layer stack\nstarting with m1 as the lowest routing layer and ending\nwith m<n> as the highest routing layer.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -1015,7 +1378,14 @@
                     ],
                     "help": "The relative position of the named pin in a vector of pins\non the side specified by the 'side' option. Pin order counting\nis done clockwise. If multiple pins on the same side have the\nsame order number, the actual order is at the discretion of the\ntool.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -1034,7 +1404,14 @@
                     ],
                     "help": "Placement location of a named pin, specified as a (x,y,z) tuple of\nfloats. The location refers to the placement of the center of the\npin. The 'placement' parameter is a goal/intent, not an exact specification.\nThe compiler and layout system may adjust sizes to meet competing\ngoals such as manufacturing design  rules and grid placement\nguidelines. The 'z' coordinate shall be set to 0 for planar components\nwith only (x,y) coordinates. Discretized systems like 3D chips with\npins on top and bottom may choose to discretize the top and bottom\nlayer as 0,1 or use absolute coordinates. Values are specified\nin microns or lambda units.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -1054,7 +1431,14 @@
                     ],
                     "help": "Side of block where the named pin should be placed. Sides are\nenumerated as integers with '1' being the lower left side,\nwith the side index incremented on right turn in a clock wise\nfashion. In case of conflict between 'lower' and 'left',\n'left' has precedence. The side option and order option are\northogonal to the placement option.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -1077,7 +1461,14 @@
                     ],
                     "help": "List of checks for to perform for the scenario. The checks must\nalign with the capabilities of the EDA tools and flow being used.\nChecks generally include objectives like meeting setup and hold goals\nand minimize power. Standard check names include setup, hold, power,\nnoise, reliability.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -1098,7 +1489,17 @@
                     "hashalgo": "sha256",
                     "help": "List of timing constraint files to use for the scenario. The\nvalues are combined with any constraints specified by the design\n'constraint' parameter. If no constraints are found, a default\nconstraint file is used based on the clock definitions.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "author": [],
+                                "date": [],
+                                "filehash": [],
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -1117,7 +1518,14 @@
                     ],
                     "help": "List of characterization corners used to select\ntiming files for all logiclibs and macrolibs.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -1136,7 +1544,14 @@
                     ],
                     "help": "Operating mode for the scenario. Operating mode strings\ncan be values such as test, functional, standby.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -1155,7 +1570,14 @@
                     ],
                     "help": "Operating condition applied to the scenario. The value\ncan be used to access specific conditions within the library\ntiming models from the 'logiclib' timing models.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -1174,7 +1596,14 @@
                     ],
                     "help": "Parasitic corner applied to the scenario. The\n'pexcorner' string must match a corner found in the pdk\npexmodel setup.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -1193,7 +1622,14 @@
                     ],
                     "help": "Chip temperature applied to the scenario specified in degrees C.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -1214,7 +1650,14 @@
                         ],
                         "help": "Operating voltage applied to a specific pin in the scenario.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "optional",
                         "require": null,
@@ -1241,7 +1684,14 @@
                     ],
                     "help": "Quantity of a specified feature. The 'unit'\nfield should be used to specify the units used when unclear.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -1261,7 +1711,14 @@
                 ],
                 "help": "List of available physical footprints for the named\ndevice specified as strings. Strings can either be official\nstandard footprint names or a custom naming methodology used in\nconjunction with 'fileset' names in the output parameter.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -1281,7 +1738,14 @@
                     ],
                     "help": "Device absolute junction temperature limits not to be exceeded.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -1300,7 +1764,14 @@
                     ],
                     "help": "Device absolute storage temperature limits not to be exceeded.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -1320,7 +1791,14 @@
                         ],
                         "help": "Device absolute minimum/maximum voltage not to be\nexceeded, specified on a per pin basis.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "never",
                         "require": null,
@@ -1344,7 +1822,14 @@
                             ],
                             "help": "Pin capacitance. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1366,7 +1851,14 @@
                             ],
                             "help": "Pin related clock specified on a per mode basis.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1387,7 +1879,14 @@
                             ],
                             "help": "Pin complement specified on a per mode basis for differential\nsignals.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1408,7 +1907,14 @@
                             ],
                             "help": "Pin direction specified on a per mode basis. Acceptable pin\ndirections include: input, output, inout.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1429,7 +1935,14 @@
                             ],
                             "help": "Pin duty cycle. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1451,7 +1964,14 @@
                             ],
                             "help": "Pin related ground rail specified on a per mode basis.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1472,7 +1992,14 @@
                             ],
                             "help": "Pin drive current. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1494,7 +2021,14 @@
                             ],
                             "help": "Pin injection current. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1516,7 +2050,14 @@
                             ],
                             "help": "Pin leakage current. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1538,7 +2079,14 @@
                             ],
                             "help": "Signal to package pin mapping specified on a per package basis.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1559,7 +2107,14 @@
                             ],
                             "help": "Pin differential pair resistance. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1581,7 +2136,14 @@
                             ],
                             "help": "Pin reset value specified on a per mode basis. Legal reset\nvalues include weak1, weak0, strong0, strong1, highz.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": [],
+                                        "value": []
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1602,7 +2164,14 @@
                             ],
                             "help": "Pin pulldown resistance. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1624,7 +2193,14 @@
                             ],
                             "help": "Pin pullup resistance. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1646,7 +2222,14 @@
                             ],
                             "help": "Pin communication standard specified on a per mode basis.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": [],
+                                        "value": []
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1667,7 +2250,14 @@
                             ],
                             "help": "Pin related power supply specified on a per mode basis.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1688,7 +2278,14 @@
                             ],
                             "help": "Pin fall transition. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1710,7 +2307,14 @@
                             ],
                             "help": "Pin hold time. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1732,7 +2336,14 @@
                             ],
                             "help": "Pin rms jitter. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1754,7 +2365,14 @@
                             ],
                             "help": "Pin minimum period. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1776,7 +2394,14 @@
                             ],
                             "help": "Pin pulse width. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1798,7 +2423,14 @@
                             ],
                             "help": "Pin rise transition. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1820,7 +2452,14 @@
                             ],
                             "help": "Pin setup time. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1842,7 +2481,14 @@
                             ],
                             "help": "Pin type specified on a per mode basis. Acceptable pin types\ninclude: digital, analog, clk, power, ground",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1863,7 +2509,14 @@
                             ],
                             "help": "Pin CDM ESD tolerance. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1885,7 +2538,14 @@
                             ],
                             "help": "Pin common mode voltage. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1907,7 +2567,14 @@
                             ],
                             "help": "Pin differential voltage. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1929,7 +2596,14 @@
                             ],
                             "help": "Pin HBM ESD tolerance. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1951,7 +2625,14 @@
                             ],
                             "help": "Pin high input voltage level. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1973,7 +2654,14 @@
                             ],
                             "help": "Pin low input voltage level. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -1995,7 +2683,14 @@
                             ],
                             "help": "Pin MM ESD tolerance. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -2017,7 +2712,14 @@
                             ],
                             "help": "Pin random voltage noise. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -2039,7 +2741,14 @@
                             ],
                             "help": "Pin high output voltage level. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -2061,7 +2770,14 @@
                             ],
                             "help": "Pin low output voltage level. Values are tuples of (min, typical, max).",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -2086,7 +2802,14 @@
         ],
         "help": "Name of the top level module or library. Required for all\nchip objects.",
         "lock": false,
-        "node": {},
+        "node": {
+            "default": {
+                "default": {
+                    "signature": null,
+                    "value": null
+                }
+            }
+        },
         "notes": null,
         "pernode": "never",
         "require": "all",
@@ -2109,7 +2832,14 @@
                         ],
                         "help": "User specified flowgraph string arguments specified on a per\nstep and per index basis.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "never",
                         "require": null,
@@ -2129,7 +2859,14 @@
                             ],
                             "help": "Goals specified on a per step and per metric basis used to\ndetermine whether a certain task can be considered when merging\nmultiple tasks at a minimum or maximum node. A task is considered\nfailing if the absolute value of any of its metrics are larger than\nthe goal for that metric, if set.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -2149,7 +2886,14 @@
                         ],
                         "help": "A list of inputs for the current step and index, specified as a\n(step,index) tuple.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "never",
                         "require": null,
@@ -2168,7 +2912,14 @@
                         ],
                         "help": "List of selected inputs for the current step/index specified as\n(in_step,in_index) tuple.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "never",
                         "require": null,
@@ -2192,7 +2943,14 @@
                         ],
                         "help": "Parameter that tracks the status of a task. Valid values are:\n\n* \"success\": task ran successfully\n* \"error\": task failed with an error\n\nAn empty value indicates the task has not yet been completed.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "never",
                         "require": null,
@@ -2211,7 +2969,14 @@
                         ],
                         "help": "Name of the tool associated task used for step execution. Builtin\ntask names include: minimum, maximum, join, verify, mux.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "never",
                         "require": null,
@@ -2230,7 +2995,14 @@
                         ],
                         "help": "Full python module name of the task module used for task setup and execution.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "never",
                         "require": null,
@@ -2249,7 +3021,14 @@
                         ],
                         "help": "Timeout value in seconds specified on a per step and per index\nbasis. The flowgraph timeout value is compared against the\nwall time tracked by the SC runtime to determine if an\noperation should continue. Timeout values help in situations\nwhere 1.) an operation is stuck and may never finish. 2.) the\noperation progress has saturated and continued execution has\na negative return on investment.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "never",
                         "require": null,
@@ -2269,7 +3048,14 @@
                         ],
                         "help": "Name of the tool name used for task execution. The 'tool' parameter\nis ignored for builtin tasks.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "never",
                         "require": null,
@@ -2288,7 +3074,14 @@
                         ],
                         "help": "Flowgraph valid bit specified on a per step and per index basis.\nThe parameter can be used to control flow execution. If the bit\nis cleared (0), then the step/index combination is invalid and\nshould not be run.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": false
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "never",
                         "require": "all",
@@ -2308,7 +3101,14 @@
                             ],
                             "help": "Weights specified on a per step and per metric basis used to give\neffective \"goodness\" score for a step by calculating the sum all step\nreal metrics results by the corresponding per step weights.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -2335,7 +3135,17 @@
             "hashalgo": "sha256",
             "help": "Architecture definition file for FPGA place and route\ntool. For the VPR tool, the file is a required XML based description,\nallowing targeting a large number of virtual and commercial\narchitectures. For most commercial tools, the fpga part name provides\nenough information to enable compilation and the 'arch' parameter is\noptional.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "author": [],
+                        "date": [],
+                        "filehash": [],
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -2354,7 +3164,14 @@
             ],
             "help": "Complete board name used as a device target by the FPGA compilation\ntool. The board name must be an exact string match to the partname\nhard coded within the FPGA eda tool. The parameter is optional and can\nbe used in place of a partname and pin constraints for some tools.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -2373,7 +3190,14 @@
             ],
             "help": "Specifies that the bitstream should be flashed in the board/device.\nThe default is to load the bitstream into volatile memory (SRAM).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -2392,7 +3216,14 @@
             ],
             "help": "Complete part name used as a device target by the FPGA compilation\ntool. The part name must be an exact string match to the partname\nhard coded within the FPGA eda tool.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "fpga",
@@ -2411,7 +3242,14 @@
             ],
             "help": "Specifies that the bitstream should be loaded into an FPGA.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -2430,7 +3268,14 @@
             ],
             "help": "Name of the FPGA vendor. The parameter is used to check part\nname and to select the eda tool flow in case 'edaflow' is\nunspecified.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -2455,7 +3300,17 @@
                 "hashalgo": "sha256",
                 "help": "List of files of type ('filetype') grouped as a named set ('fileset').\nThe exact names of filetypes and filesets must match the string names\nused by the tasks called during flowgraph execution. By convention,\nthe fileset names should match the the name of the flowgraph being\nexecuted.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "author": [],
+                            "date": [],
+                            "filehash": [],
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -2478,7 +3333,14 @@
             ],
             "help": "Metric tracking the average workload power of the design specified on a per step\nand index basis. Power metric depend heavily on the method\nbeing used for extraction: dynamic vs static, workload\nspecification (vcd vs saif), power models, process/voltage/temperature.\nThe power averagepower metric tries to capture the data that would\nusually be reflected inside a datasheet given the approprate\nfootnote conditions.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2498,7 +3360,14 @@
             ],
             "help": "Metric tracking the total FPGA BRAM tiles used by the design as reported\nby the implementation tool. There is no standardized definition\nfor this metric across vendors, so metric comparisons can\ngenerally only be done between runs on identical tools and\ndevice families.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2517,7 +3386,14 @@
             ],
             "help": "Metric tracking the total number of buffer and inverter instances in the design\non a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2536,7 +3412,14 @@
             ],
             "help": "Metric tracking the total cell area (ignoring fillers) occupied by the design.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2556,7 +3439,14 @@
             ],
             "help": "Metric tracking the total number of cell instances in the design\non a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2575,7 +3465,14 @@
             ],
             "help": "Metric tracking the test coverage in the design expressed as a percentage\nwith 100 meaning full coverage. The meaning of the metric depends on the\ntask being executed. It can refer to code coverage, feature coverage,\nstuck at fault coverage.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2595,7 +3492,14 @@
             ],
             "help": "Metric tracking the power consumed while in low frequency operating mode of the design specified on a per step\nand index basis. Power metric depend heavily on the method\nbeing used for extraction: dynamic vs static, workload\nspecification (vcd vs saif), power models, process/voltage/temperature.\nThe power dozepower metric tries to capture the data that would\nusually be reflected inside a datasheet given the approprate\nfootnote conditions.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2615,7 +3519,14 @@
             ],
             "help": "Metric tracking the total number of design rule violations on a\nper step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2634,7 +3545,14 @@
             ],
             "help": "Metric tracking the total FPGA DSP slices used by the design as reported\nby the implementation tool. There is no standardized definition\nfor this metric across vendors, so metric comparisons can\ngenerally only be done between runs on identical tools and\ndevice families.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2653,7 +3571,14 @@
             ],
             "help": "Metric tracking the total number of errors on a\nper step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2672,7 +3597,14 @@
             ],
             "help": "Metric tracking time spent by the eda executable 'exe' on a\nper step and index basis. It does not include the siliconcompiler\nruntime overhead or time waiting for I/O operations and\ninter-processor communication to complete.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2692,7 +3624,14 @@
             ],
             "help": "Metric tracking the maximum clock frequency on a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2712,7 +3651,14 @@
             ],
             "help": "Metric tracking the total number of timing paths violating hold\nconstraints.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2731,7 +3677,14 @@
             ],
             "help": "Metric tracking the worst hold slack (positive or negative) on a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2751,7 +3704,14 @@
             ],
             "help": "Metric tracking the total negative hold slack (TNS) on a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2771,7 +3731,14 @@
             ],
             "help": "Metric tracking the worst negative hold slack (positive values truncated to zero) on a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2791,7 +3758,14 @@
             ],
             "help": "Metric tracking the power while not performing useful work of the design specified on a per step\nand index basis. Power metric depend heavily on the method\nbeing used for extraction: dynamic vs static, workload\nspecification (vcd vs saif), power models, process/voltage/temperature.\nThe power idlepower metric tries to capture the data that would\nusually be reflected inside a datasheet given the approprate\nfootnote conditions.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2811,7 +3785,14 @@
             ],
             "help": "Metric tracking the peak IR drop in the design based on extracted\npower and ground rail parasitics, library power models, and\nswitching activity. The switching activity calculated on a per\nnode basis is taken from one of three possible sources, in order\nof priority: VCD file, SAIF file, 'activityfactor' parameter.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2831,7 +3812,14 @@
             ],
             "help": "Metric tracking the leakage power with rails active but without any dynamic switching activity of the design specified on a per step\nand index basis. Power metric depend heavily on the method\nbeing used for extraction: dynamic vs static, workload\nspecification (vcd vs saif), power models, process/voltage/temperature.\nThe power leakagepower metric tries to capture the data that would\nusually be reflected inside a datasheet given the approprate\nfootnote conditions.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2851,7 +3839,14 @@
             ],
             "help": "Metric tracking the total FPGA LUTs used by the design as reported\nby the implementation tool. There is no standardized definition\nfor this metric across vendors, so metric comparisons can\ngenerally only be done between runs on identical tools and\ndevice families.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2870,7 +3865,14 @@
             ],
             "help": "Metric tracking the total number of macros in the design\non a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2889,7 +3891,14 @@
             ],
             "help": "Metric tracking total peak program memory footprint on a per\nstep and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2909,7 +3918,14 @@
             ],
             "help": "Metric tracking the total number of nets in the design\non a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2928,7 +3944,14 @@
             ],
             "help": "Metric tracking the total number of overflow tracks for the routing\non per step and index basis. Any non-zero number suggests an over\ncongested design. To analyze where the congestion is occurring\ninspect the router log files for detailed per metal overflow\nreporting and open up the design to find routing hotspots.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2947,7 +3970,14 @@
             ],
             "help": "Metric tracking the worst case total peak power of the design specified on a per step\nand index basis. Power metric depend heavily on the method\nbeing used for extraction: dynamic vs static, workload\nspecification (vcd vs saif), power models, process/voltage/temperature.\nThe power peakpower metric tries to capture the data that would\nusually be reflected inside a datasheet given the approprate\nfootnote conditions.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2967,7 +3997,14 @@
             ],
             "help": "Metric tracking the total number of pins in the design\non a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -2986,7 +4023,14 @@
             ],
             "help": "Metric tracking the total number of register instances in the design\non a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3005,7 +4049,14 @@
             ],
             "help": "Metric tracking the level of security (1/vulnerability) of the design.\nA completely secure design would have a score of 100. There is no\nabsolute scale for the security metrics (like with power, area, etc)\nso the metric will be task and tool dependent.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3025,7 +4076,14 @@
             ],
             "help": "Metric tracking the total number of timing paths violating setup\nconstraints.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3044,7 +4102,14 @@
             ],
             "help": "Metric tracking the worst setup slack (positive or negative) on a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3064,7 +4129,14 @@
             ],
             "help": "Metric tracking the total negative setup slack (TNS) on a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3084,7 +4156,14 @@
             ],
             "help": "Metric tracking the worst negative setup slack (positive values truncated to zero) on a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3104,7 +4183,14 @@
             ],
             "help": "Metric tracking the power consumed with some or all power rails gated off of the design specified on a per step\nand index basis. Power metric depend heavily on the method\nbeing used for extraction: dynamic vs static, workload\nspecification (vcd vs saif), power models, process/voltage/temperature.\nThe power sleeppower metric tries to capture the data that would\nusually be reflected inside a datasheet given the approprate\nfootnote conditions.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3124,7 +4210,14 @@
             ],
             "help": "Metric tracking the total amount of time spent on a task from\nbeginning to end, including data transfers and pre/post\nprocessing.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3144,7 +4237,14 @@
             ],
             "help": "Metric tracking the total physical die area occupied by the design.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3164,7 +4264,14 @@
             ],
             "help": "Metric tracking the total amount of time spent from the beginning\nof the run up to and including the current step and index.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3184,7 +4291,14 @@
             ],
             "help": "Metric tracking the total number of transistors in the design\non a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3203,7 +4317,14 @@
             ],
             "help": "Metric tracking the total number of unconstrained timing paths on a\nper step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3222,7 +4343,14 @@
             ],
             "help": "Metric tracking the area utilization of the design calculated as\n100 * (cellarea/totalarea).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3242,7 +4370,14 @@
             ],
             "help": "Metric tracking the total number of vias in the design\non a per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3261,7 +4396,14 @@
             ],
             "help": "Metric tracking the total number of warnings on a\nper step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3280,7 +4422,14 @@
             ],
             "help": "Metric tracking the total wirelength of the design on a per step\nand index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -3302,7 +4451,14 @@
             ],
             "help": "Enables automatic installation of missing dependencies from\nthe registry.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -3321,7 +4477,14 @@
             ],
             "help": "Set a breakpoint on specific steps. If the step is a TCL\nbased tool, then the breakpoints stops the flow inside the\nEDA tool. If the step is a command line tool, then the flow\ndrops into a Python interpreter.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": "all",
@@ -3341,7 +4504,14 @@
             ],
             "help": "The default build directory is in the local './build' where SC was\nexecuted. The 'builddir' parameter can be used to set an alternate\ncompilation directory path.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "build"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3362,7 +4532,17 @@
             "hashalgo": "sha256",
             "help": "List of filepaths to JSON formatted schema configuration\nmanifests. The files are read in automatically when using the\n'sc' command line application. In Python programs, JSON manifests\ncan be merged into the current working manifest using the\nread_manifest() method.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "author": [],
+                        "date": [],
+                        "filehash": [],
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3381,7 +4561,14 @@
             ],
             "help": "Clean up all intermediate and non essential files at the end\nof a task, leaving the following:\n\n* log file\n* replay.sh\n* inputs/\n* outputs/\n* reports/\n* autogenerated manifests\n* any files generated by schema-specified regexes\n* files specified by :keypath:`tool, <tool>, task, <task>, keep`",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -3402,7 +4589,17 @@
             "hashalgo": "sha256",
             "help": "Read the specified file, and act as if all text inside it was specified\nas command line parameters. Supported by most verilog simulators\nincluding Icarus and Verilator. The format of the file is not strongly\nstandardized. Support for comments and environment variables within\nthe file varies and depends on the tool used. SC simply passes on\nthe filepath toe the tool executable.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "author": [],
+                        "date": [],
+                        "filehash": [],
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3421,7 +4618,14 @@
             ],
             "help": "Attempt to continue even when errors are encountered in the SC\nimplementation. If errors are encountered, execution will halt\nbefore a run.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": "all",
@@ -3440,7 +4644,14 @@
             ],
             "help": "Specifies that all used files should be copied into the\nbuild directory, overriding the per schema entry copy\nsettings.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -3461,7 +4672,17 @@
             "hashalgo": "sha256",
             "help": "Filepath to credentials used for remote processing. If the\ncredentials parameter is empty, the remote processing client program\ntries to access the \".sc/credentials\" file in the user's home\ndirectory. The file supports the following fields:\n\nuserid=<user id>\nsecret_key=<secret key used for authentication>\nserver=<ipaddr or url>",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "author": [],
+                        "date": [],
+                        "filehash": [],
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3480,7 +4701,14 @@
             ],
             "help": "Symbol definition for source preprocessor.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3501,7 +4729,14 @@
                 ],
                 "help": "List of named directories specified. Certain tools and\nreference flows require special parameters, this\nparameter should only be used for specifying directories that are\nnot directly supported by the schema.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -3521,7 +4756,14 @@
             ],
             "help": "Alternative entrypoint for compilation and\nsimulation. The default entry point is 'design'.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3541,7 +4783,14 @@
                 ],
                 "help": "Certain tools and reference flows require global environment\nvariables to be set. These variables can be managed externally or\nspecified through the env variable.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -3564,7 +4813,17 @@
                 "hashalgo": "sha256",
                 "help": "List of named files specified. Certain tools and\nreference flows require special parameters, this\nparameter should only be used for specifying files that are\nnot directly supported by the schema.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "author": [],
+                            "date": [],
+                            "filehash": [],
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -3584,7 +4843,14 @@
             ],
             "help": "Sets the flow for the current run. The flow name\nmust match up with a 'flow' in the flowgraph",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3603,7 +4869,14 @@
             ],
             "help": "Continue executing flow after a tool logs errors. The default\nbehavior is to quit executing the flow if a task ends and the errors\nmetric is greater than 0. Note that the flow will always cease\nexecuting if the tool returns a nonzero status code.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": "all",
@@ -3622,7 +4895,14 @@
             ],
             "help": "Specifies the frontend that flows should use for importing and\nprocessing source files. Default option is 'verilog', also supports\n'systemverilog' and 'chisel'. When using the Python API, this parameter\nmust be configured before calling load_target().",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "verilog"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3641,7 +4921,14 @@
             ],
             "help": "Enables hashing of all inputs and outputs during\ncompilation. The hash values are stored in the hashvalue\nfield of the individual parameters.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -3661,7 +4948,14 @@
             ],
             "help": "Search paths to look for files included in the design using\nthe ```include`` statement.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3681,7 +4975,14 @@
             ],
             "help": "List of indices to execute. The default is to execute all\nindices for each step of a run.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3700,7 +5001,14 @@
             ],
             "help": "Forces an auto-update of the jobname parameter if a directory\nmatching the jobname is found in the build directory. If the\njobname does not include a trailing digit, then the number\n'1' is added to the jobname before updating the jobname\nparameter.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -3721,7 +5029,14 @@
                     ],
                     "help": "Specifies jobname inputs for the current run() on a per step\nand per index basis. During execution, the default behavior is to\ncopy inputs from the current job.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -3742,7 +5057,14 @@
             ],
             "help": "Jobname during invocation of run(). The jobname combined with a\ndefined director structure (<dir>/<design>/<jobname>/<step>/<index>)\nenables multiple levels of transparent job, step, and index\nintrospection.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "job0"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3761,7 +5083,14 @@
             ],
             "help": "List of file extensions that should be used for finding modules.\nFor example, if -y is specified as ./lib\", and '.v' is specified as\nlibext then the files ./lib/\\*.v \", will be searched for\nmodule matches.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3788,7 +5117,14 @@
             ],
             "help": "Provides explicit control over the level of debug logging printed.\nValid entries include INFO, DEBUG, WARNING, ERROR.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "INFO"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": null,
@@ -3807,7 +5143,14 @@
             ],
             "help": "List of metrics to suppress when printing out the run\nsummary.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3831,7 +5174,14 @@
             ],
             "help": "Sets the operating mode of the compiler. Valid modes are:\nasic: RTL to GDS ASIC compilation\nfpga: RTL to bitstream FPGA compilation\nsim: simulation to verify design and compilation",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3850,7 +5200,14 @@
             ],
             "help": "Sets the type of execution priority of each individual flowgraph steps.\nIf the parameter is undefined, nice will not be used. For more information see\n`Unix 'nice' <https://en.wikipedia.org/wiki/Nice_(Unix)>`_.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": null,
@@ -3869,7 +5226,14 @@
             ],
             "help": "The '-nodisplay' flag prevents SiliconCompiler from\nopening GUI windows such as the final metrics report.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -3888,7 +5252,14 @@
             ],
             "help": "Disables strict version checking on all invoked tools if True.\nThe list of supported version numbers is defined in the\n'version' parameter in the 'eda' dictionary for each tool.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": "all",
@@ -3907,7 +5278,14 @@
             ],
             "help": "The compiler has modes to prioritize run time and ppa. Modes\ninclude.\n\n(O0) = Exploration mode for debugging setup\n(O1) = Higher effort and better PPA than O0\n(O2) = Higher effort and better PPA than O1\n(O3) = Signoff quality. Better PPA and higher run times than O2\n(O4-O98) = Reserved (compiler/target dependent)\n(O99) = Experimental highest possible effort, may be unstable",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "O0"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": "all",
@@ -3927,7 +5305,14 @@
                 ],
                 "help": "Sets a top verilog level design module parameter. The value\nis limited to basic data literals. The parameter override is\npassed into tools such as Verilator and Yosys. The parameters\nsupport Verilog integer literals (64'h4, 2'b0, 4) and strings.\nName of the top level module to compile.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -3947,7 +5332,14 @@
             ],
             "help": "Target PDK used during compilation.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -3966,7 +5358,14 @@
             ],
             "help": "The -quiet option forces all steps to print to a log file.\nThis can be useful with Modern EDA tools which print\nsignificant content to the screen.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": "all",
@@ -3986,7 +5385,14 @@
             ],
             "help": "List of Silicon Unified Packager (SUP) registry directories.\nDirectories can be local file system folders or\npublicly available registries served up over http. The naming\nconvention for registry packages is:\n<name>/<name>-<version>.json(.<gz>)?",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -4005,7 +5411,14 @@
             ],
             "help": "Global option specifying that tools should be lenient and\nsuppress warnings that may or may not indicate real design\nissues. Extent of leniency is tool/task specific.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -4024,7 +5437,14 @@
             ],
             "help": "Sends job for remote processing if set to true. The remote\noption requires a credentials file to be placed in the home\ndirectory. Fore more information, see the credentials\nparameter.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -4043,7 +5463,14 @@
             ],
             "help": "If results exist for current job, then don't re-run any steps that\nhad at least one index run successfully. Useful for debugging a\nflow that failed partway through.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -4063,7 +5490,14 @@
                 ],
                 "help": "Specifies the number cpu cores required to run the job.\nFor the slurm scheduler, this translates to the '-c'\nswitch. For more information, see the job scheduler\ndocumentation",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -4082,7 +5516,14 @@
                 ],
                 "help": "Defer initiation of job until the specified time. The parameter\nis pass through string for remote job scheduler such as slurm.\nFor more information abotut the exact format specification, see\nthe job scheduler documentation. Examples of valid slurm specific\nvalues include: now+1hour, 16:00, 010-01-20T12:34:00. For more\ninformation, see the job scheduler documentation.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -4101,7 +5542,14 @@
                 ],
                 "help": "Specifies the amount of memory required to run the job,\nspecified in MB. For the slurm scheduler, this translates to\nthe '--mem' switch. For more information, see the job\nscheduler documentation",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -4121,7 +5569,14 @@
                 ],
                 "help": "List of email addresses to message on a 'msgevent'. Support for\nemail messages relies on job scheduler daemon support.\nFor more information, see the job scheduler documentation.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -4140,7 +5595,14 @@
                 ],
                 "help": "Directs job scheduler to send a message to the user when\ncertain events occur during a task. Supported data types for\nSLURM include NONE, BEGIN, END, FAIL, ALL, TIME_LIMIT. For a\nlist of supported event types, see the job scheduler\ndocumentation. For more information, see the job scheduler\ndocumentation.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": "NONE"
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -4164,7 +5626,14 @@
                 ],
                 "help": "Sets the type of job scheduler to be used for each individual\nflowgraph steps. If the parameter is undefined, the steps are executed\non the same machine that the SC was launched on. If 'slurm' is used,\nthe host running the 'sc' command must be running a 'slurmctld' daemon\nmanaging a Slurm cluster. Additionally, the build directory ('-dir')\nmust be located in shared storage which can be accessed by all hosts\nin the cluster.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -4183,7 +5652,14 @@
                 ],
                 "help": "Advanced/export options passed through unchanged to the job\nscheduler as-is. (The user specified options must be compatible\nwith the rest of the scheduler parameters entered.(memory etc).\nFor more information, see the job scheduler documentation.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -4202,7 +5678,14 @@
                 ],
                 "help": "Send the job to the specified queue. With slurm, this\ntranslates to 'partition'. The queue name must match\nthe name of an existing job schemduler queue. For more information,\nsee the job scheduler documentation",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -4223,7 +5706,14 @@
             ],
             "help": "Specifies python modules paths for target import.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -4242,7 +5732,14 @@
             ],
             "help": "Specifies that the final hardware layout should be\nshown after the compilation has been completed. The\nfinal layout and tool used to display the layout is\nflow dependent.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -4262,7 +5759,14 @@
                 ],
                 "help": "Selects the tool to use by the show function for displaying\nthe specified filetype.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -4282,7 +5786,14 @@
             ],
             "help": "Skips the execution of all tools in run(), enabling a quick\ncheck of tool and setup without having to run through each\nstep of a flow to completion.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -4301,7 +5812,14 @@
             ],
             "help": "Bypasses the strict runtime manifest check. Can be used for\naccelerating initial bringup of tool/flow/pdk/libs targets.\nThe flag should not be used for production compilation.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -4320,7 +5838,14 @@
             ],
             "help": "List of steps to skip during execution.The default is to\nexecute all steps  defined in the flow graph.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -4339,7 +5864,14 @@
             ],
             "help": "Target stackup used during compilation. The stackup is required\nparameter for PDKs with multiple metal stackups.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -4358,7 +5890,14 @@
             ],
             "help": "List of steps to execute. The default is to execute all steps\ndefined in the flow graph.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -4377,7 +5916,14 @@
             ],
             "help": "Enable additional strict checking in the SC Python API. When this\nparameter is set to True, users must provide step and index keyword\narguments when reading from parameters with the pernode field set to\n'optional'.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -4396,7 +5942,14 @@
             ],
             "help": "Sets a target module to be used for compilation. The target\nmodule must set up all parameters needed. The target module\nmay load multiple flows and libraries.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -4415,7 +5968,14 @@
             ],
             "help": "Timeout value in seconds. The timeout value is compared\nagainst the wall time tracked by the SC runtime to determine\nif an operation should continue. The timeout value is also\nuseed by the jobscheduler to automatically kill jobs.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -4435,7 +5995,14 @@
             ],
             "help": "Enables debug tracing during compilation and/or runtime.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": "all",
@@ -4454,7 +6021,14 @@
             ],
             "help": "Turns on tracking of all 'record' parameters during each\ntask. Tracking will result in potentially sensitive data\nbeing recorded in the manifest so only turn on this feature\nif you have control of the final manifest.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "optional",
             "require": "all",
@@ -4473,7 +6047,14 @@
             ],
             "help": "Turns on lambda scaling of all dimensionsional constraints.\n(new value = value * ['pdk', 'lambda']).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": false
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": "all",
@@ -4493,7 +6074,14 @@
                 ],
                 "help": "List of key/value strings specified. Certain tools and\nreference flows require special parameters, this\nshould only be used for specifying variables that are\nnot directly supported by the SiliconCompiler schema.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -4515,7 +6103,17 @@
             "hashalgo": "sha256",
             "help": "List of library files to be read in. Modules found in the\nlibraries are not interpreted as root modules.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "author": [],
+                        "date": [],
+                        "filehash": [],
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -4535,7 +6133,14 @@
             ],
             "help": "Search paths to look for verilog modules found in the the\nsource list. The import engine will look for modules inside\nfiles with the specified +libext+ param suffix.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -4559,7 +6164,17 @@
                 "hashalgo": "sha256",
                 "help": "List of files of type ('filetype') grouped as a named set ('fileset').\nThe exact names of filetypes and filesets must match the string names\nused by the tasks called during flowgraph execution. By convention,\nthe fileset names should match the the name of the flowgraph being\nexecuted.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "author": [],
+                            "date": [],
+                            "filehash": [],
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -4583,7 +6198,14 @@
                     ],
                     "help": "Package author email provided with full name as key and\nemail as value.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -4602,7 +6224,14 @@
                     ],
                     "help": "Package author location provided with full name as key and\nlocation as value.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -4621,7 +6250,14 @@
                     ],
                     "help": "Package author name provided with full name as key and\nname as value.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -4640,7 +6276,14 @@
                     ],
                     "help": "Package author organization provided with full name as key and\norganization as value.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -4659,7 +6302,14 @@
                     ],
                     "help": "Package author publickey provided with full name as key and\npublickey as value.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -4678,7 +6328,14 @@
                     ],
                     "help": "Package author username provided with full name as key and\nusername as value.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -4700,7 +6357,14 @@
                 ],
                 "help": "Package dependencies specified as a key value pair.\nVersions shall follow the semver standard.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -4721,7 +6385,14 @@
                 ],
                 "help": "List of Silicon Unified Packager (SUP) dependencies\nused by the design specified on a per module basis a\nlist of string tuples ('name','version').",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -4741,7 +6412,14 @@
             ],
             "help": "Package short one line description for package\nmanagers and summary reports.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -4763,7 +6441,17 @@
                 "hashalgo": "sha256",
                 "help": "Package list of datasheet documents.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "author": [],
+                            "date": [],
+                            "filehash": [],
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -4782,7 +6470,14 @@
                 ],
                 "help": "Package documentation homepage. Filepath to design docs homepage.\nComplex designs can can include a long non standard list of\ndocuments dependent.  A single html entry point can be used to\npresent an organized documentation dashboard to the designer.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -4803,7 +6498,17 @@
                 "hashalgo": "sha256",
                 "help": "Package list of quickstart documents.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "author": [],
+                            "date": [],
+                            "filehash": [],
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -4824,7 +6529,17 @@
                 "hashalgo": "sha256",
                 "help": "Package list of reference documents.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "author": [],
+                            "date": [],
+                            "filehash": [],
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -4845,7 +6560,17 @@
                 "hashalgo": "sha256",
                 "help": "Package list of releasenotes documents.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "author": [],
+                            "date": [],
+                            "filehash": [],
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -4866,7 +6591,17 @@
                 "hashalgo": "sha256",
                 "help": "Package list of signoff documents.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "author": [],
+                            "date": [],
+                            "filehash": [],
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -4887,7 +6622,17 @@
                 "hashalgo": "sha256",
                 "help": "Package list of testplan documents.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "author": [],
+                            "date": [],
+                            "filehash": [],
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -4908,7 +6653,17 @@
                 "hashalgo": "sha256",
                 "help": "Package list of tutorial documents.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "author": [],
+                            "date": [],
+                            "filehash": [],
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -4929,7 +6684,17 @@
                 "hashalgo": "sha256",
                 "help": "Package list of userguide documents.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "author": [],
+                            "date": [],
+                            "filehash": [],
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -4949,7 +6714,14 @@
             ],
             "help": "Package homepage.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -4968,7 +6740,14 @@
             ],
             "help": "Package keyword(s) used to characterize package.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -4987,7 +6766,14 @@
             ],
             "help": "Package list of SPDX license identifiers.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -5008,7 +6794,17 @@
             "hashalgo": "sha256",
             "help": "Package list of license files for to be\napplied in cases when a SPDX identifier is not available.\n(eg. proprietary licenses).list of SPDX license identifiers.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "author": [],
+                        "date": [],
+                        "filehash": [],
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -5027,7 +6823,14 @@
             ],
             "help": "Package country of origin specified as standardized\ninternational country codes. The field can be left blank\nif the location is unknown or global.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -5046,7 +6849,14 @@
             ],
             "help": "Package name.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -5065,7 +6875,14 @@
             ],
             "help": "Package sponsoring organization. The field can be left\nblank if not applicable.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -5084,7 +6901,14 @@
             ],
             "help": "Package public project key.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -5103,7 +6927,14 @@
             ],
             "help": "Package IP address to source code repository.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -5122,7 +6953,14 @@
             ],
             "help": "Package list of qualified compilation targets.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -5141,7 +6979,14 @@
             ],
             "help": "Package version. Can be a branch, tag, commit hash,\nor a semver compatible version.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -5169,7 +7014,17 @@
                                 "hashalgo": "sha256",
                                 "help": "Technology file containing setup information needed to enable DRC clean APR\nfor the specified stackup, libarch, and format. The 'libarch' specifies the\nlibrary architecture (e.g. library height). For example a PDK with support\nfor 9 and 12 track libraries might have 'libarchs' called 9t and 12t.\nThe standard filetype for specifying place and route design rules for a\nprocess node is through a 'lef' format technology file. The\n'filetype' used in the aprtech is used by the tool specific APR TCL scripts\nto set up the technology parameters. Some tools may require additional\nfiles beyond the tech.lef file. Examples of extra file types include\nantenna, tracks, tapcell, viarules, em.",
                                 "lock": false,
-                                "node": {},
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "author": [],
+                                            "date": [],
+                                            "filehash": [],
+                                            "signature": [],
+                                            "value": []
+                                        }
+                                    }
+                                },
                                 "notes": null,
                                 "pernode": "never",
                                 "require": null,
@@ -5192,7 +7047,14 @@
                 ],
                 "help": "Process defect density (d0) expressed as random defects per cm^2. The\nvalue is used to calculate yield losses as a function of area, which in\nturn affects the chip full factory costs. Two yield models are\nsupported: Poisson (default), and Murphy. The Poisson based yield is\ncalculated as dy = exp(-area * d0/100). The Murphy based yield is\ncalculated as dy = ((1-exp(-area * d0/100))/(area * d0/100))^2.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -5211,7 +7073,14 @@
                 ],
                 "help": "Approximate logic density expressed as # transistors / mm^2\ncalculated as:\n0.6 * (Nand2 Transistor Count) / (Nand2 Cell Area) +\n0.4 * (Register Transistor Count) / (Register Cell Area)\nThe value is specified for a fixed standard cell library within a node\nand will differ depending on the library vendor, library track height\nand library type. The value can be used to to normalize the effective\ndensity reported for the design across different process nodes. The\nvalue can be derived from a variety of sources, including the PDK DRM,\nlibrary LEFs, conference presentations, and public analysis.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -5235,7 +7104,17 @@
                             "hashalgo": "sha256",
                             "help": "List of filepaths to PDK device models for different simulation\npurposes and for different tools. Examples of device model types\ninclude spice, aging, electromigration, radiation. An example of a\n'spice' tool is xyce. Device models are specified on a per metal stack\nbasis. Process nodes with a single device model across all stacks will\nhave a unique parameter record per metal stack pointing to the same\ndevice model file.  Device types and tools are dynamic entries\nthat depend on the tool setup and device technology. Pseudo-standardized\ndevice types include spice, em (electromigration), and aging.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "author": [],
+                                        "date": [],
+                                        "filehash": [],
+                                        "signature": [],
+                                        "value": []
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -5261,7 +7140,14 @@
                             ],
                             "help": "List of named directories specified on a per tool and per stackup basis.\nThe parameter should only be used for specifying files that are\nnot directly  supported by the SiliconCompiler PDK schema.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": [],
+                                        "value": []
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -5287,7 +7173,17 @@
                         "hashalgo": "sha256",
                         "help": "Display configuration files describing colors and pattern schemes for\nall layers in the PDK. The display configuration file is entered on a\nstackup and tool basis.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "author": [],
+                                    "date": [],
+                                    "filehash": [],
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "never",
                         "require": null,
@@ -5311,7 +7207,17 @@
                     "hashalgo": "sha256",
                     "help": "Filepath to datasheet document.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "author": [],
+                                "date": [],
+                                "filehash": [],
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -5332,7 +7238,17 @@
                     "hashalgo": "sha256",
                     "help": "Filepath to PDK docs homepage. Modern PDKs can include tens or\nhundreds of individual documents. A single html entry point can\nbe used to present an organized documentation dashboard to the\ndesigner.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "author": [],
+                                "date": [],
+                                "filehash": [],
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -5353,7 +7269,17 @@
                     "hashalgo": "sha256",
                     "help": "Filepath to install document.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "author": [],
+                                "date": [],
+                                "filehash": [],
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -5374,7 +7300,17 @@
                     "hashalgo": "sha256",
                     "help": "Filepath to quickstart document.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "author": [],
+                                "date": [],
+                                "filehash": [],
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -5395,7 +7331,17 @@
                     "hashalgo": "sha256",
                     "help": "Filepath to reference document.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "author": [],
+                                "date": [],
+                                "filehash": [],
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -5416,7 +7362,17 @@
                     "hashalgo": "sha256",
                     "help": "Filepath to releasenotes document.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "author": [],
+                                "date": [],
+                                "filehash": [],
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -5437,7 +7393,17 @@
                     "hashalgo": "sha256",
                     "help": "Filepath to tutorial document.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "author": [],
+                                "date": [],
+                                "filehash": [],
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -5458,7 +7424,17 @@
                     "hashalgo": "sha256",
                     "help": "Filepath to userguide document.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "author": [],
+                                "date": [],
+                                "filehash": [],
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -5484,7 +7460,17 @@
                                 "hashalgo": "sha256",
                                 "help": "Runset files for DRC task.",
                                 "lock": false,
-                                "node": {},
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "author": [],
+                                            "date": [],
+                                            "filehash": [],
+                                            "signature": [],
+                                            "value": []
+                                        }
+                                    }
+                                },
                                 "notes": null,
                                 "pernode": "never",
                                 "require": null,
@@ -5511,7 +7497,17 @@
                                 "hashalgo": "sha256",
                                 "help": "Waiver files for DRC task.",
                                 "lock": false,
-                                "node": {},
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "author": [],
+                                            "date": [],
+                                            "filehash": [],
+                                            "signature": [],
+                                            "value": []
+                                        }
+                                    }
+                                },
                                 "notes": null,
                                 "pernode": "never",
                                 "require": null,
@@ -5534,7 +7530,14 @@
                 ],
                 "help": "Keep-out distance/margin from the edge inwards. The edge\nis prone to chipping and need special treatment that preclude\nplacement of designs in this area. The edge value is used to\ncalculate effective units per wafer/panel and full factory cost.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -5560,7 +7563,17 @@
                                 "hashalgo": "sha256",
                                 "help": "Runset files for ERC task.",
                                 "lock": false,
-                                "node": {},
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "author": [],
+                                            "date": [],
+                                            "filehash": [],
+                                            "signature": [],
+                                            "value": []
+                                        }
+                                    }
+                                },
                                 "notes": null,
                                 "pernode": "never",
                                 "require": null,
@@ -5587,7 +7600,17 @@
                                 "hashalgo": "sha256",
                                 "help": "Waiver files for ERC task.",
                                 "lock": false,
-                                "node": {},
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "author": [],
+                                            "date": [],
+                                            "filehash": [],
+                                            "signature": [],
+                                            "value": []
+                                        }
+                                    }
+                                },
                                 "notes": null,
                                 "pernode": "never",
                                 "require": null,
@@ -5615,7 +7638,17 @@
                             "hashalgo": "sha256",
                             "help": "List of named files specified on a per tool and per stackup basis.\nThe parameter should only be used for specifying files that are\nnot directly  supported by the SiliconCompiler PDK schema.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "author": [],
+                                        "date": [],
+                                        "filehash": [],
+                                        "signature": [],
+                                        "value": []
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -5643,7 +7676,17 @@
                                 "hashalgo": "sha256",
                                 "help": "Runset files for FILL task.",
                                 "lock": false,
-                                "node": {},
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "author": [],
+                                            "date": [],
+                                            "filehash": [],
+                                            "signature": [],
+                                            "value": []
+                                        }
+                                    }
+                                },
                                 "notes": null,
                                 "pernode": "never",
                                 "require": null,
@@ -5670,7 +7713,17 @@
                                 "hashalgo": "sha256",
                                 "help": "Waiver files for FILL task.",
                                 "lock": false,
-                                "node": {},
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "author": [],
+                                            "date": [],
+                                            "filehash": [],
+                                            "signature": [],
+                                            "value": []
+                                        }
+                                    }
+                                },
                                 "notes": null,
                                 "pernode": "never",
                                 "require": null,
@@ -5693,7 +7746,14 @@
                 ],
                 "help": "Name of foundry corporation. Examples include intel, gf, tsmc,\nsamsung, skywater, virtual. The 'virtual' keyword is reserved for\nsimulated non-manufacturable processes.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": "asic",
@@ -5712,7 +7772,14 @@
                 ],
                 "help": "Width of the horizontal scribe line used during die separation.\nThe process is generally completed using a mechanical saw, but can be\ndone through combinations of mechanical saws, lasers, wafer thinning,\nand chemical etching in more advanced technologies. The value is used\nto calculate effective dies per wafer and full factory cost.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -5732,7 +7799,14 @@
                 ],
                 "help": "Elementary distance unit used for scaling user\nspecified physical schema parameters such as layout\nconstraints.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": "1e-06"
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": "asic",
@@ -5757,7 +7831,17 @@
                                 "hashalgo": "sha256",
                                 "help": "Files describing input/output mapping for streaming layout data from\none format to another. A foundry PDK will include an official layer\nlist for all user entered and generated layers supported in the GDS\naccepted by the foundry for processing, but there is no standardized\nlayer definition format that can be read and written by all EDA tools.\nTo ensure mask layer matching, key/value type mapping files are needed\nto convert EDA databases to/from GDS and to convert between different\ntypes of EDA databases. Layer maps are specified on a per metal\nstackup basis. The 'src' and 'dst' can be names of SC supported tools\nor file formats (like 'gds').",
                                 "lock": false,
-                                "node": {},
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "author": [],
+                                            "date": [],
+                                            "filehash": [],
+                                            "signature": [],
+                                            "value": []
+                                        }
+                                    }
+                                },
                                 "notes": null,
                                 "pernode": "never",
                                 "require": null,
@@ -5786,7 +7870,17 @@
                                 "hashalgo": "sha256",
                                 "help": "Runset files for LVS task.",
                                 "lock": false,
-                                "node": {},
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "author": [],
+                                            "date": [],
+                                            "filehash": [],
+                                            "signature": [],
+                                            "value": []
+                                        }
+                                    }
+                                },
                                 "notes": null,
                                 "pernode": "never",
                                 "require": null,
@@ -5813,7 +7907,17 @@
                                 "hashalgo": "sha256",
                                 "help": "Waiver files for LVS task.",
                                 "lock": false,
-                                "node": {},
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "author": [],
+                                            "date": [],
+                                            "filehash": [],
+                                            "signature": [],
+                                            "value": []
+                                        }
+                                    }
+                                },
                                 "notes": null,
                                 "pernode": "never",
                                 "require": null,
@@ -5837,7 +7941,14 @@
                     ],
                     "help": "Maximum metal layer to be used for automated place and route\nspecified on a per stackup basis.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": "asic",
@@ -5858,7 +7969,14 @@
                     ],
                     "help": "Minimum metal layer to be used for automated place and route\nspecified on a per stackup basis.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": "asic",
@@ -5878,7 +7996,14 @@
                 ],
                 "help": "Approximate relative minimum dimension of the process target specified\nin nanometers. The parameter is required for flows and tools that\nleverage the value to drive technology dependent synthesis and APR\noptimization. Node examples include 180, 130, 90, 65, 45, 32, 22 14,\n10, 7, 5, 3.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": "asic",
@@ -5897,7 +8022,14 @@
                 ],
                 "help": "List of panel sizes supported in the manufacturing process.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -5922,7 +8054,17 @@
                             "hashalgo": "sha256",
                             "help": "List of filepaths to PDK wire TCAD models used during automated\nsynthesis, APR, and signoff verification. Pexmodels are specified on\na per metal stack basis. Corner values depend on the process being\nused, but typically include nomenclature such as min, max, nominal.\nFor exact names, refer to the DRM. Pexmodels are generally not\nstandardized and specified on a per tool basis. An example of pexmodel\ntype is 'fastcap'.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "author": [],
+                                        "date": [],
+                                        "filehash": [],
+                                        "signature": [],
+                                        "value": []
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -5944,7 +8086,14 @@
                 ],
                 "help": "List of all metal stackups offered in the process node. Older process\nnodes may only offer a single metal stackup, while advanced nodes\noffer a large but finite list of metal stacks with varying combinations\nof metal line pitches and thicknesses. Stackup naming is unique to a\nfoundry, but is generally a long string or code. For example, a 10\nmetal stackup with two 1x wide, four 2x wide, and 4x wide metals,\nmight be identified as 2MA4MB2MC, where MA, MB, and MC denote wiring\nlayers with different properties (thickness, width, space). Each\nstackup will come with its own set of routing technology files and\nparasitic models specified in the pdk_pexmodel and pdk_aprtech\nparameters.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": "asic",
@@ -5964,7 +8113,14 @@
                     ],
                     "help": "Thickness of a manufactured unit specified on a per stackup.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "never",
                     "require": null,
@@ -5985,7 +8141,14 @@
                 ],
                 "help": "Raw cost per unit shipped by the factory, not accounting for yield\nloss.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -6008,7 +8171,14 @@
                             ],
                             "help": "List of key/value strings specified on a per tool and per stackup basis.\nThe parameter should only be used for specifying variables that are\nnot directly  supported by the SiliconCompiler PDK schema.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": [],
+                                        "value": []
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "never",
                             "require": null,
@@ -6030,7 +8200,14 @@
                 ],
                 "help": "Alphanumeric string specifying the version of the PDK. Verification of\ncorrect PDK and IP versions is a hard ASIC tapeout require in all\ncommercial foundries. The version number can be used for design manifest\ntracking and tapeout checklists.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -6049,7 +8226,14 @@
                 ],
                 "help": " Width of the vertical scribe line used during die separation.\nThe process is generally completed using a mechanical saw, but can be\ndone through combinations of mechanical saws, lasers, wafer thinning,\nand chemical etching in more advanced technologies. The value is used\nto calculate effective dies per wafer and full factory cost.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -6069,7 +8253,14 @@
                 ],
                 "help": "Wafer diameter used in wafer based manufacturing process.\nThe standard diameter for leading edge manufacturing is 300mm. For\nolder process technologies and specialty fabs, smaller diameters\nsuch as 200, 100, 125, 100 are common. The value is used to\ncalculate dies per wafer and full factory chip costs.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": "asic",
@@ -6092,7 +8283,14 @@
             ],
             "help": "Record tracking the hardware architecture per step and index basis. (x86_64, rv64imafdc)",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6111,7 +8309,14 @@
             ],
             "help": "Record tracking the distro name per step and index basis. (ubuntu, redhat, centos)",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6130,7 +8335,14 @@
             ],
             "help": "Record tracking the end time per step and index basis. Time is reported in the ISO 8601 format YYYY-MM-DD HR:MIN:SEC",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6149,7 +8361,14 @@
             ],
             "help": "Record tracking the IP address per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6168,7 +8387,14 @@
             ],
             "help": "Record tracking the O/S kernel version per step and index basis. Used for platforms that support a distinction\nbetween os kernels and os distributions.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6187,7 +8413,14 @@
             ],
             "help": "Record tracking the MAC address per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6206,7 +8439,14 @@
             ],
             "help": "Record tracking the machine name per step and index basis. (myhost, localhost, ...",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6225,7 +8465,14 @@
             ],
             "help": "Record tracking the O/S version per step and index basis. Since there is not standard version system for operating\nsystems, extracting information from is platform dependent.\nFor Linux based operating systems, the 'osversion' is the\nversion of the distro.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6244,7 +8491,14 @@
             ],
             "help": "Record tracking the platform name per step and index basis. (linux, windows, freebsd)",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6263,7 +8517,14 @@
             ],
             "help": "Record tracking the public key per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6282,7 +8543,14 @@
             ],
             "help": "Record tracking the cloud region per step and index basis. Recommended naming methodology:\n\n* local: node is the local machine\n* onprem: node in on-premises IT infrastructure\n* public: generic public cloud\n* govcloud: generic US government cloud\n* <region>: cloud and entity specific region string name",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6301,7 +8569,14 @@
             ],
             "help": "Record tracking the software version per step and index basis. Version number for the SiliconCompiler software.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6320,7 +8595,14 @@
             ],
             "help": "Record tracking the start time per step and index basis. Time is reported in the ISO 8601 format YYYY-MM-DD HR:MIN:SEC",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6339,7 +8621,14 @@
             ],
             "help": "Record tracking the tool CLI arguments per step and index basis. Arguments passed to tool via CLI.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6358,7 +8647,14 @@
             ],
             "help": "Record tracking the tool path per step and index basis. Full path to tool executable used to run this\ntask.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6377,7 +8673,14 @@
             ],
             "help": "Record tracking the tool version per step and index basis. The tool version captured corresponds to the 'tool'\nparameter within the 'eda' dictionary.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6396,7 +8699,14 @@
             ],
             "help": "Record tracking the userid per step and index basis.",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
             "notes": null,
             "pernode": "required",
             "require": null,
@@ -6415,7 +8725,14 @@
         ],
         "help": "SiliconCompiler schema version number.",
         "lock": true,
-        "node": {},
+        "node": {
+            "default": {
+                "default": {
+                    "signature": null,
+                    "value": "0.33.0"
+                }
+            }
+        },
         "notes": null,
         "pernode": "never",
         "require": "all",
@@ -6436,7 +8753,14 @@
                 ],
                 "help": "Tool executable name.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -6455,7 +8779,14 @@
                 ],
                 "help": "File format for tool manifest handoff. Supported formats are tcl,\nyaml, and json.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -6475,7 +8806,14 @@
                     ],
                     "help": "Defines a set of tool specific environment variables used by the executables\nthat depend on license key servers to control access. For multiple servers,\nseparate each server by a 'colon'. The named license variable are read at\nruntime (run()) and the environment variables are set.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -6496,7 +8834,14 @@
                 ],
                 "help": "File system path to tool executable. The path is prepended to the\nsystem PATH environment variable for batch and interactive runs. The\npath parameter can be left blank if the 'exe' is already in the\nenvironment search path.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -6518,7 +8863,17 @@
                     "hashalgo": "sha256",
                     "help": "Paths to software bill of material (SBOM) document file of the tool\nspecified on a per version basis. The SBOM includes critical\npackage information about the tool including the list of included\ncomponents, licenses, and copyright. The SBOM file is generally\nprovided as in a a standardized open data format such as SPDX.",
                     "lock": false,
-                    "node": {},
+                    "node": {
+                        "default": {
+                            "default": {
+                                "author": [],
+                                "date": [],
+                                "filehash": [],
+                                "signature": [],
+                                "value": []
+                            }
+                        }
+                    },
                     "notes": null,
                     "pernode": "optional",
                     "require": null,
@@ -6540,7 +8895,14 @@
                         ],
                         "help": "Directs flow to continue even if errors are encountered during task. The default\nbehavior is for SC to exit on error.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": false
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "optional",
                         "require": "all",
@@ -6561,7 +8923,14 @@
                             ],
                             "help": "Paths to user supplied directories mapped to keys. Keys must match\nwhat's expected by the task/reference script consuming the\ndirectory.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": [],
+                                        "value": []
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "optional",
                             "require": null,
@@ -6582,7 +8951,14 @@
                             ],
                             "help": "Environment variables to set for individual tasks. Keys and values\nshould be set in accordance with the task's documentation. Most\ntasks do not require extra environment variables to function.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "optional",
                             "require": null,
@@ -6605,7 +8981,17 @@
                             "hashalgo": "sha256",
                             "help": "Paths to user supplied files mapped to keys. Keys and filetypes must\nmatch what's expected by the task/reference script consuming the\nfile.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "author": [],
+                                        "date": [],
+                                        "filehash": [],
+                                        "signature": [],
+                                        "value": []
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "optional",
                             "require": null,
@@ -6627,7 +9013,17 @@
                         "hashalgo": "sha256",
                         "help": "List of data files to be copied from previous flowgraph steps 'output'\ndirectory. The list of steps to copy files from is defined by the\nlist defined by the dictionary key ['flowgraph', step, index, 'input'].\nAll files must be available for flow to continue. If a file\nis missing, the program exists on an error.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "author": [],
+                                    "date": [],
+                                    "filehash": [],
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "required",
                         "require": null,
@@ -6646,7 +9042,14 @@
                         ],
                         "help": "Names of additional files and directories in the work directory that\nshould be kept when :keypath:`option, clean` is true.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "optional",
                         "require": null,
@@ -6665,7 +9068,14 @@
                         ],
                         "help": "List of command line options for the task executable, specified on\na per task and per step basis. Options must not include spaces.\nFor multiple argument options, each option is a separate list element.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "optional",
                         "require": null,
@@ -6686,7 +9096,17 @@
                         "hashalgo": "sha256",
                         "help": "List of data files to be copied from previous flowgraph steps 'output'\ndirectory. The list of steps to copy files from is defined by the\nlist defined by the dictionary key ['flowgraph', step, index, 'output'].\nAll files must be available for flow to continue. If a file\nis missing, the program exists on an error.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "author": [],
+                                    "date": [],
+                                    "filehash": [],
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "required",
                         "require": null,
@@ -6707,7 +9127,17 @@
                         "hashalgo": "sha256",
                         "help": "Path to a user supplied script to execute after the main execution\nstage of the step but before the design is saved.\nExact entry point depends on the step and main script being\nexecuted. An example of a postscript entry point would be immediately\nafter global placement.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "author": [],
+                                    "date": [],
+                                    "filehash": [],
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "optional",
                         "require": null,
@@ -6728,7 +9158,17 @@
                         "hashalgo": "sha256",
                         "help": "Path to a user supplied script to execute after reading in the design\nbut before the main execution stage of the step. Exact entry point\ndepends on the step and main script being executed. An example\nof a prescript entry point would be immediately before global\nplacement.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "author": [],
+                                    "date": [],
+                                    "filehash": [],
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "optional",
                         "require": null,
@@ -6748,7 +9188,14 @@
                         ],
                         "help": "Path to directories containing reference flow scripts, specified\non a per step and index basis.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "optional",
                         "require": null,
@@ -6768,7 +9215,14 @@
                             ],
                             "help": "A list of piped together grep commands. Each entry represents a set\nof command line arguments for grep including the regex pattern to\nmatch. Starting with the first list entry, each grep output is piped\ninto the following grep command in the list. Supported grep options\ninclude ``-v`` and ``-e``. Patterns starting with \"-\" should be\ndirectly preceded by the ``-e`` option. The following example\nillustrates the concept.\n\nUNIX grep:\n\n.. code-block:: bash\n\n    $ grep WARNING place.log | grep -v \"bbox\" > place.warnings\n\nSiliconCompiler::\n\n    chip.set('task', 'openroad', 'regex', 'place', '0', 'warnings',\n             [\"WARNING\", \"-v bbox\"])\n\nThe \"errors\" and \"warnings\" suffixes are special cases. When set,\nthe number of matches found for these regexes will be added to the\nerrors and warnings metrics for the task, respectively. This will\nalso cause the logfile to be added to the :keypath:`tool, <tool>,\ntask, <task>, report` parameter for those metrics, if not already present.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": [],
+                                        "value": []
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "optional",
                             "require": null,
@@ -6791,7 +9245,17 @@
                             "hashalgo": "sha256",
                             "help": "List of report files associated with a specific 'metric'. The file path\nspecified is relative to the run directory of the current task.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "author": [],
+                                        "date": [],
+                                        "filehash": [],
+                                        "signature": [],
+                                        "value": []
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "required",
                             "require": null,
@@ -6811,7 +9275,14 @@
                         ],
                         "help": "List of keypaths to required task parameters. The list is used\nby check_manifest() to verify that all parameters have been set up before\nstep execution begins.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "optional",
                         "require": null,
@@ -6832,7 +9303,17 @@
                         "hashalgo": "sha256",
                         "help": "Path to the entry script called by the executable specified\non a per task and per step basis.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "author": [],
+                                    "date": [],
+                                    "filehash": [],
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "optional",
                         "require": null,
@@ -6852,7 +9333,14 @@
                             ],
                             "help": "Defines where to direct the output generated over stderr.\nSupported options are:\nnone: the stream generated to STDERR is ignored\nlog: the generated stream is stored in <step>.<suffix>; if not in quiet mode,\nit is additionally dumped to the display output: the generated stream is\nstored in outputs/<design>.<suffix>",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": "log"
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "optional",
                             "require": null,
@@ -6871,7 +9359,14 @@
                             ],
                             "help": "Specifies the file extension for the content redirected from stderr.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": "log"
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "optional",
                             "require": null,
@@ -6892,7 +9387,14 @@
                             ],
                             "help": "Defines where to direct the output generated over stdout.\nSupported options are:\nnone: the stream generated to STDOUT is ignored\nlog: the generated stream is stored in <step>.<suffix>; if not in quiet mode,\nit is additionally dumped to the display output: the generated stream is stored\nin outputs/<design>.<suffix>",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": "log"
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "optional",
                             "require": null,
@@ -6911,7 +9413,14 @@
                             ],
                             "help": "Specifies the file extension for the content redirected from stdout.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": "log"
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "optional",
                             "require": null,
@@ -6931,7 +9440,14 @@
                         ],
                         "help": "Thread parallelism to use for execution specified on a per task and per\nstep basis. If not specified, SC queries the operating system and sets\nthe threads based on the maximum thread count supported by the\nhardware.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "optional",
                         "require": null,
@@ -6951,7 +9467,14 @@
                             ],
                             "help": "Task script variables specified as key value pairs. Variable\nnames and value types must match the name and type of task and reference\nscript consuming the variable.",
                             "lock": false,
-                            "node": {},
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": [],
+                                        "value": []
+                                    }
+                                }
+                            },
                             "notes": null,
                             "pernode": "optional",
                             "require": null,
@@ -6971,7 +9494,14 @@
                         ],
                         "help": "A list of tool warnings for which printing should be suppressed.\nGenerally this is done on a per design basis after review has\ndetermined that warning can be safely ignored The code for turning\noff warnings can be found in the specific task reference manual.",
                         "lock": false,
-                        "node": {},
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
                         "notes": null,
                         "pernode": "optional",
                         "require": null,
@@ -6992,7 +9522,14 @@
                 ],
                 "help": "Name of the tool vendor. Parameter can be used to set vendor\nspecific technology variables in the PDK and libraries. For\nopen source projects, the project name should be used in\nplace of vendor.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -7011,7 +9548,14 @@
                 ],
                 "help": "List of acceptable versions of the tool executable to be used. Each\nentry in this list must be a version specifier as described by Python\n`PEP-440 <https://peps.python.org/pep-0440/#version-specifiers>`_.\nDuring task execution, the tool is called with the 'vswitch' to\ncheck the runtime executable version. If the version of the system\nexecutable is not allowed by any of the specifiers in 'version',\nthen the job is halted pre-execution. For backwards compatibility,\nentries that do not conform to the standard will be interpreted as a\nversion with an '==' specifier. This check can be disabled by\nsetting 'novercheck' to True.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "optional",
                 "require": null,
@@ -7030,7 +9574,14 @@
                 ],
                 "help": "Command line switch to use with executable used to print out\nthe version number. Common switches include -v, -version,\n--version. Some tools may require extra flags to run in batch mode.",
                 "lock": false,
-                "node": {},
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": [],
+                            "value": []
+                        }
+                    }
+                },
                 "notes": null,
                 "pernode": "never",
                 "require": null,
@@ -7052,7 +9603,14 @@
             ],
             "help": "Units used for capacitance when not explicitly specified. Units\nare case insensitive (ie. pF == pf).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "pf"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -7071,7 +9629,14 @@
             ],
             "help": "Units used for current when not explicitly specified. Units\nare case insensitive (ie. pF == pf).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "mA"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -7090,7 +9655,14 @@
             ],
             "help": "Units used for energy when not explicitly specified. Units\nare case insensitive (ie. pF == pf).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "pj"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -7109,7 +9681,14 @@
             ],
             "help": "Units used for inductance when not explicitly specified. Units\nare case insensitive (ie. pF == pf).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "nh"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -7128,7 +9707,14 @@
             ],
             "help": "Units used for length when not explicitly specified. Units\nare case insensitive (ie. pF == pf).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "um"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -7147,7 +9733,14 @@
             ],
             "help": "Units used for mass when not explicitly specified. Units\nare case insensitive (ie. pF == pf).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "g"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -7166,7 +9759,14 @@
             ],
             "help": "Units used for power when not explicitly specified. Units\nare case insensitive (ie. pF == pf).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "mw"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -7185,7 +9785,14 @@
             ],
             "help": "Units used for resistance when not explicitly specified. Units\nare case insensitive (ie. pF == pf).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "ohm"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -7204,7 +9811,14 @@
             ],
             "help": "Units used for temperature when not explicitly specified. Units\nare case insensitive (ie. pF == pf).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "C"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -7223,7 +9837,14 @@
             ],
             "help": "Units used for time when not explicitly specified. Units\nare case insensitive (ie. pF == pf).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "ns"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,
@@ -7242,7 +9863,14 @@
             ],
             "help": "Units used for voltage when not explicitly specified. Units\nare case insensitive (ie. pF == pf).",
             "lock": false,
-            "node": {},
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": "mv"
+                    }
+                }
+            },
             "notes": null,
             "pernode": "never",
             "require": null,

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1,7 +1,6 @@
 {
     "arg": {
         "index": {
-            "defvalue": null,
             "example": [
                 "cli: -arg_index 0",
                 "api: chip.set('arg','index','0')"
@@ -27,7 +26,6 @@
             "type": "str"
         },
         "step": {
-            "defvalue": null,
             "example": [
                 "cli: -arg_step 'route'",
                 "api: chip.set('arg', 'step', 'route')"
@@ -56,7 +54,6 @@
     "asic": {
         "cells": {
             "antenna": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_antenna '*eco*'",
                     "api: chip.set('asic','cells',antenna,'*eco*')"
@@ -82,7 +79,6 @@
                 "type": "[str]"
             },
             "clkbuf": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_clkbuf '*eco*'",
                     "api: chip.set('asic','cells',clkbuf,'*eco*')"
@@ -108,7 +104,6 @@
                 "type": "[str]"
             },
             "clkdelay": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_clkdelay '*eco*'",
                     "api: chip.set('asic','cells',clkdelay,'*eco*')"
@@ -134,7 +129,6 @@
                 "type": "[str]"
             },
             "clkgate": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_clkgate '*eco*'",
                     "api: chip.set('asic','cells',clkgate,'*eco*')"
@@ -160,7 +154,6 @@
                 "type": "[str]"
             },
             "clkicg": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_clkicg '*eco*'",
                     "api: chip.set('asic','cells',clkicg,'*eco*')"
@@ -186,7 +179,6 @@
                 "type": "[str]"
             },
             "clkinv": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_clkinv '*eco*'",
                     "api: chip.set('asic','cells',clkinv,'*eco*')"
@@ -212,7 +204,6 @@
                 "type": "[str]"
             },
             "clklogic": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_clklogic '*eco*'",
                     "api: chip.set('asic','cells',clklogic,'*eco*')"
@@ -238,7 +229,6 @@
                 "type": "[str]"
             },
             "decap": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_decap '*eco*'",
                     "api: chip.set('asic','cells',decap,'*eco*')"
@@ -264,7 +254,6 @@
                 "type": "[str]"
             },
             "delay": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_delay '*eco*'",
                     "api: chip.set('asic','cells',delay,'*eco*')"
@@ -290,7 +279,6 @@
                 "type": "[str]"
             },
             "dontuse": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_dontuse '*eco*'",
                     "api: chip.set('asic','cells',dontuse,'*eco*')"
@@ -316,7 +304,6 @@
                 "type": "[str]"
             },
             "endcap": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_endcap '*eco*'",
                     "api: chip.set('asic','cells',endcap,'*eco*')"
@@ -342,7 +329,6 @@
                 "type": "[str]"
             },
             "filler": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_filler '*eco*'",
                     "api: chip.set('asic','cells',filler,'*eco*')"
@@ -368,7 +354,6 @@
                 "type": "[str]"
             },
             "hold": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_hold '*eco*'",
                     "api: chip.set('asic','cells',hold,'*eco*')"
@@ -394,7 +379,6 @@
                 "type": "[str]"
             },
             "tap": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_tap '*eco*'",
                     "api: chip.set('asic','cells',tap,'*eco*')"
@@ -420,7 +404,6 @@
                 "type": "[str]"
             },
             "tie": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_cells_tie '*eco*'",
                     "api: chip.set('asic','cells',tie,'*eco*')"
@@ -447,7 +430,6 @@
             }
         },
         "delaymodel": {
-            "defvalue": null,
             "example": [
                 "cli: -asic_delaymodel ccs",
                 "api: chip.set('asic', 'delaymodel', 'ccs')"
@@ -473,7 +455,6 @@
             "type": "str"
         },
         "libarch": {
-            "defvalue": null,
             "example": [
                 "cli: -asic_libarch '12track'",
                 "api: chip.set('asic','libarch','12track')"
@@ -499,7 +480,6 @@
             "type": "str"
         },
         "logiclib": {
-            "defvalue": [],
             "example": [
                 "cli: -asic_logiclib nangate45",
                 "api: chip.set('asic', 'logiclib','nangate45')"
@@ -525,7 +505,6 @@
             "type": "[str]"
         },
         "macrolib": {
-            "defvalue": [],
             "example": [
                 "cli: -asic_macrolib sram64x1024",
                 "api: chip.set('asic', 'macrolib','sram64x1024')"
@@ -552,7 +531,6 @@
         },
         "site": {
             "default": {
-                "defvalue": [],
                 "example": [
                     "cli: -asic_site '12track Site_12T'",
                     "api: chip.set('asic','site','12track','Site_12T')"
@@ -583,7 +561,6 @@
         "default": {
             "default": {
                 "criteria": {
-                    "defvalue": [],
                     "example": [
                         "cli: -checklist_criteria 'ISO D000 errors==0'",
                         "api: chip.set('checklist','ISO','D000','criteria','errors==0')"
@@ -609,7 +586,6 @@
                     "type": "[str]"
                 },
                 "dataformat": {
-                    "defvalue": null,
                     "example": [
                         "cli: -checklist_dataformat 'ISO D000 dataformat README'",
                         "api: chip.set('checklist','ISO','D000','dataformat','README')"
@@ -635,7 +611,6 @@
                     "type": "str"
                 },
                 "description": {
-                    "defvalue": null,
                     "example": [
                         "cli: -checklist_description 'ISO D000 A-DESCRIPTION'",
                         "api: chip.set('checklist','ISO','D000','description','A-DESCRIPTION')"
@@ -661,7 +636,6 @@
                     "type": "str"
                 },
                 "ok": {
-                    "defvalue": false,
                     "example": [
                         "cli: -checklist_ok 'ISO D000 true'",
                         "api: chip.set('checklist','ISO','D000','ok', True)"
@@ -687,7 +661,6 @@
                     "type": "bool"
                 },
                 "rationale": {
-                    "defvalue": [],
                     "example": [
                         "cli: -checklist_rational 'ISO D000 reliability'",
                         "api: chip.set('checklist','ISO','D000','rationale','reliability')"
@@ -714,7 +687,6 @@
                 },
                 "report": {
                     "copy": false,
-                    "defvalue": [],
                     "example": [
                         "cli: -checklist_report 'ISO D000 my.rpt'",
                         "api: chip.set('checklist','ISO','D000','report','my.rpt')"
@@ -744,7 +716,6 @@
                     "type": "[file]"
                 },
                 "requirement": {
-                    "defvalue": null,
                     "example": [
                         "cli: -checklist_requirement 'ISO D000 DOCSTRING'",
                         "api: chip.set('checklist','ISO','D000','requirement','DOCSTRING')"
@@ -770,7 +741,6 @@
                     "type": "str"
                 },
                 "task": {
-                    "defvalue": [],
                     "example": [
                         "cli: -checklist_task 'ISO D000 (job0,place,0)'",
                         "api: chip.set('checklist','ISO','D000','task',('job0','place','0'))"
@@ -798,7 +768,6 @@
                 "waiver": {
                     "default": {
                         "copy": false,
-                        "defvalue": [],
                         "example": [
                             "cli: -checklist_waiver 'ISO D000 bold my.txt'",
                             "api: chip.set('checklist','ISO','D000','waiver','hold', 'my.txt')"
@@ -833,7 +802,6 @@
     },
     "constraint": {
         "aspectratio": {
-            "defvalue": "1.0",
             "example": [
                 "cli: -constraint_aspectratio 2.0",
                 "api: chip.set('constraint', 'aspectratio', '2.0')"
@@ -861,7 +829,6 @@
         "component": {
             "default": {
                 "flip": {
-                    "defvalue": false,
                     "example": [
                         "cli: -constraint_component_flip 'i0 true'",
                         "api: chip.set('constraint', 'component', 'i0', 'flip', True)"
@@ -887,7 +854,6 @@
                     "type": "bool"
                 },
                 "halo": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_component_halo 'i0 (1,1)'",
                         "api: chip.set('constraint', 'component', 'i0', 'halo', (1,1))"
@@ -914,7 +880,6 @@
                     "unit": "um"
                 },
                 "partname": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_component_partname 'i0 filler_x1'",
                         "api: chip.set('constraint', 'component', 'i0', 'partname', 'filler_x1')"
@@ -940,7 +905,6 @@
                     "type": "str"
                 },
                 "placement": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_component_placement 'i0 (2.0,3.0,0.0)'",
                         "api: chip.set('constraint', 'component', 'i0', 'placement', (2.0,3.0,0.0))"
@@ -967,7 +931,6 @@
                     "unit": "um"
                 },
                 "rotation": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_component_rotation 'i0 90'",
                         "api: chip.set('constraint', 'component', 'i0', 'rotation', '90')"
@@ -995,7 +958,6 @@
             }
         },
         "corearea": {
-            "defvalue": [],
             "example": [
                 "cli: -constraint_corearea '(0,0)'",
                 "api: chip.set('constraint', 'corearea', (0,0))"
@@ -1022,7 +984,6 @@
             "unit": "um"
         },
         "coremargin": {
-            "defvalue": null,
             "example": [
                 "cli: -constraint_coremargin 1",
                 "api: chip.set('constraint', 'coremargin', '1')"
@@ -1049,7 +1010,6 @@
             "unit": "um"
         },
         "density": {
-            "defvalue": null,
             "example": [
                 "cli: -constraint_density 30",
                 "api: chip.set('constraint', 'density', '30')"
@@ -1077,7 +1037,6 @@
         "net": {
             "default": {
                 "diffpair": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_net_diffpair 'clkn clkp'",
                         "api: chip.set('constraint', 'net', 'clkn', 'diffpair', 'clkp')"
@@ -1103,7 +1062,6 @@
                     "type": "str"
                 },
                 "match": {
-                    "defvalue": [],
                     "example": [
                         "cli: -constraint_net_match 'clk1 clk2'",
                         "api: chip.set('constraint', 'net', 'clk1', 'match', 'clk2')"
@@ -1129,7 +1087,6 @@
                     "type": "[str]"
                 },
                 "maxlayer": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_net_maxlayer 'nreset m1'",
                         "api: chip.set('constraint', 'net', 'nreset', 'maxlayer', 'm1')"
@@ -1155,7 +1112,6 @@
                     "type": "str"
                 },
                 "maxlength": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_net_maxlength 'nreset 1000'",
                         "api: chip.set('constraint', 'net', 'nreset', 'maxlength', '1000')"
@@ -1182,7 +1138,6 @@
                     "unit": "um"
                 },
                 "maxresistance": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_net_maxresistance 'nreset 1'",
                         "api: chip.set('constraint', 'net', 'nreset', 'maxresistance', '1')"
@@ -1209,7 +1164,6 @@
                     "unit": "ohm"
                 },
                 "minlayer": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_net_minlayer 'nreset m1'",
                         "api: chip.set('constraint', 'net', 'nreset', 'minlayer', 'm1')"
@@ -1235,7 +1189,6 @@
                     "type": "str"
                 },
                 "ndr": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_net_ndr 'nreset (0.4,0.4)'",
                         "api: chip.set('constraint', 'net', 'nreset', 'ndr', (0.4,0.4))"
@@ -1262,7 +1215,6 @@
                     "unit": "um"
                 },
                 "shield": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_net_shield 'clk vss'",
                         "api: chip.set('constraint', 'net', 'clk', 'shield', 'vss')"
@@ -1288,7 +1240,6 @@
                     "type": "str"
                 },
                 "sympair": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_net_sympair 'netA netB'",
                         "api: chip.set('constraint', 'net', 'netA', 'sympair', 'netB')"
@@ -1316,7 +1267,6 @@
             }
         },
         "outline": {
-            "defvalue": [],
             "example": [
                 "cli: -constraint_outline '(0,0)'",
                 "api: chip.set('constraint', 'outline', (0,0))"
@@ -1345,7 +1295,6 @@
         "pin": {
             "default": {
                 "layer": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_pin_layer 'nreset m4'",
                         "api: chip.set('constraint', 'pin', 'nreset', 'layer', 'm4')"
@@ -1371,7 +1320,6 @@
                     "type": "str"
                 },
                 "order": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_pin_order 'nreset 1'",
                         "api: chip.set('constraint', 'pin', 'nreset', 'order', 1)"
@@ -1397,7 +1345,6 @@
                     "type": "int"
                 },
                 "placement": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_pin_placement 'nreset (2.0,3.0,0.0)'",
                         "api: chip.set('constraint', 'pin', 'nreset', 'placement', (2.0,3.0,0.0))"
@@ -1424,7 +1371,6 @@
                     "unit": "um"
                 },
                 "side": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_pin_side 'nreset 1'",
                         "api: chip.set('constraint', 'pin', 'nreset', 'side', 1)"
@@ -1454,7 +1400,6 @@
         "timing": {
             "default": {
                 "check": {
-                    "defvalue": [],
                     "example": [
                         "cli: -constraint_timing_check 'worst setup'",
                         "api: chip.add('constraint', 'timing', 'worst','check','setup')"
@@ -1481,7 +1426,6 @@
                 },
                 "file": {
                     "copy": true,
-                    "defvalue": [],
                     "example": [
                         "cli: -constraint_timing_file 'worst hello.sdc'",
                         "api: chip.set('constraint', 'timing', 'worst','file', 'hello.sdc')"
@@ -1511,7 +1455,6 @@
                     "type": "[file]"
                 },
                 "libcorner": {
-                    "defvalue": [],
                     "example": [
                         "cli: -constraint_timing_libcorner 'worst ttt'",
                         "api: chip.set('constraint', 'timing', 'worst', 'libcorner', 'ttt')"
@@ -1537,7 +1480,6 @@
                     "type": "[str]"
                 },
                 "mode": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_timing_mode 'worst test'",
                         "api: chip.set('constraint', 'timing', 'worst','mode', 'test')"
@@ -1563,7 +1505,6 @@
                     "type": "str"
                 },
                 "opcond": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_timing_opcond 'worst typical_1.0'",
                         "api: chip.set('constraint', 'timing', 'worst', 'opcond',  'typical_1.0')"
@@ -1589,7 +1530,6 @@
                     "type": "str"
                 },
                 "pexcorner": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_timing_pexcorner 'worst max'",
                         "api: chip.set('constraint', 'timing', 'worst', 'pexcorner', 'max')"
@@ -1615,7 +1555,6 @@
                     "type": "str"
                 },
                 "temperature": {
-                    "defvalue": null,
                     "example": [
                         "cli: -constraint_timing_temperature 'worst 125'",
                         "api: chip.set('constraint', 'timing', 'worst', 'temperature','125')"
@@ -1643,7 +1582,6 @@
                 },
                 "voltage": {
                     "default": {
-                        "defvalue": null,
                         "example": [
                             "cli: -constraint_timing_voltage 'worst VDD 0.9'",
                             "api: chip.set('constraint', 'timing', 'worst', 'voltage', 'VDD', '0.9')"
@@ -1677,7 +1615,6 @@
         "default": {
             "feature": {
                 "default": {
-                    "defvalue": null,
                     "example": [
                         "cli: -datasheet_feature 'mydevice ram 64e6'",
                         "api: chip.set('datasheet','mydevice','feature','ram', 1e9)"
@@ -1704,7 +1641,6 @@
                 }
             },
             "footprint": {
-                "defvalue": [],
                 "example": [
                     "cli: -datasheet_footprint 'mydsp bga169'",
                     "api: chip.set('datasheet','mydsp', 'footprint','bga169')"
@@ -1731,7 +1667,6 @@
             },
             "limits": {
                 "junctiontemp": {
-                    "defvalue": null,
                     "example": [
                         "cli: -datasheet_junctiontemp 'mydevice (-40,125)'",
                         "api: chip.set('datasheet','mydevice','limits','junctiontemp',(-40,125))"
@@ -1757,7 +1692,6 @@
                     "type": "(float,float)"
                 },
                 "storagetemp": {
-                    "defvalue": null,
                     "example": [
                         "cli: -datasheet_storagetemp 'mydevice (-40,125)'",
                         "api: chip.set('datasheet','mydevice','limits','storagetemp',(-40,125))"
@@ -1784,7 +1718,6 @@
                 },
                 "voltage": {
                     "default": {
-                        "defvalue": null,
                         "example": [
                             "cli: -datasheet_limits_voltage 'mydevice vdd (-0.4,1.1)'",
                             "api: chip.set('datasheet','mydevice','limits','voltage','vdd', (-0.4,1.1))"
@@ -1815,7 +1748,6 @@
                 "default": {
                     "capacitance": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_capacitance 'mydevice sclk global (1e-12, 1.2e-12, 1.5e-12)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','capacitance','global',(1e-12, 1.2e-12, 1.5e-12)"
@@ -1844,7 +1776,6 @@
                     },
                     "clk": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_clk 'mydevice ina global clka'",
                                 "api: chip.set('datasheet','mydevice','pin','ina','clk','global','clka')"
@@ -1872,7 +1803,6 @@
                     },
                     "complement": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_complement 'mydevice ina global inb'",
                                 "api: chip.set('datasheet','mydevice','pin','ina','complement','global','inb')"
@@ -1900,7 +1830,6 @@
                     },
                     "dir": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_dir 'mydevice clk global input'",
                                 "api: chip.set('datasheet','mydevice','pin','clk','dir','global','input')"
@@ -1928,7 +1857,6 @@
                     },
                     "dutycycle": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_dutycycle 'mydevice sclk global (45, 50, 55)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','dutycycle','global',(45, 50, 55)"
@@ -1957,7 +1885,6 @@
                     },
                     "ground": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_ground 'mydevice ina ground vss'",
                                 "api: chip.set('datasheet','mydevice','pin','ina','ground','global','vss')"
@@ -1985,7 +1912,6 @@
                     },
                     "idrive": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_idrive 'mydevice sclk global (0.01, 0.012, 0.015)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','idrive','global',(0.01, 0.012, 0.015)"
@@ -2014,7 +1940,6 @@
                     },
                     "iinject": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_iinject 'mydevice sclk global (0.001, 0.0012, 0.0015)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','iinject','global',(0.001, 0.0012, 0.0015)"
@@ -2043,7 +1968,6 @@
                     },
                     "ileakage": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_ileakage 'mydevice sclk global (1e-06, 1.2e-06, 1.5e-06)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','ileakage','global',(1e-06, 1.2e-06, 1.5e-06)"
@@ -2072,7 +1996,6 @@
                     },
                     "map": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_map 'mydevice in0 bga512 B4'",
                                 "api: chip.set('datasheet','mydevice','pin','in0','map','bga512','B4')"
@@ -2100,7 +2023,6 @@
                     },
                     "rdiff": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_rdiff 'mydevice sclk global (45, 50, 55)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','rdiff','global',(45, 50, 55)"
@@ -2129,7 +2051,6 @@
                     },
                     "resetvalue": {
                         "default": {
-                            "defvalue": [],
                             "example": [
                                 "cli: -datasheet_pin_resetvalue 'mydevice clk global weak1'",
                                 "api: chip.set('datasheet','mydevice','pin','clk','resetvalue','global','weak1')"
@@ -2157,7 +2078,6 @@
                     },
                     "rpulldown": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_rpulldown 'mydevice sclk global (1000, 1200, 3000)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','rpulldown','global',(1000, 1200, 3000)"
@@ -2186,7 +2106,6 @@
                     },
                     "rpullup": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_rpullup 'mydevice sclk global (1000, 1200, 3000)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','rpullup','global',(1000, 1200, 3000)"
@@ -2215,7 +2134,6 @@
                     },
                     "standard": {
                         "default": {
-                            "defvalue": [],
                             "example": [
                                 "cli: -datasheet_pin_standard 'mydevice ba0 global ddr4'",
                                 "api: chip.set('datasheet','mydevice','pin','ina','standard','global','ddr4')"
@@ -2243,7 +2161,6 @@
                     },
                     "supply": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_supply 'mydevice ina global vdd'",
                                 "api: chip.set('datasheet','mydevice','pin','ina','supply','global','vdd')"
@@ -2271,7 +2188,6 @@
                     },
                     "tfall": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_tfall 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','tfall','global',(1e-09, 2e-09, 4e-09)"
@@ -2300,7 +2216,6 @@
                     },
                     "thold": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_thold 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','thold','global',(1e-09, 2e-09, 4e-09)"
@@ -2329,7 +2244,6 @@
                     },
                     "tjitter": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_tjitter 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','tjitter','global',(1e-09, 2e-09, 4e-09)"
@@ -2358,7 +2272,6 @@
                     },
                     "tperiod": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_tperiod 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','tperiod','global',(1e-09, 2e-09, 4e-09)"
@@ -2387,7 +2300,6 @@
                     },
                     "tpulse": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_tpulse 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','tpulse','global',(1e-09, 2e-09, 4e-09)"
@@ -2416,7 +2328,6 @@
                     },
                     "trise": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_trise 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','trise','global',(1e-09, 2e-09, 4e-09)"
@@ -2445,7 +2356,6 @@
                     },
                     "tsetup": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_tsetup 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','tsetup','global',(1e-09, 2e-09, 4e-09)"
@@ -2474,7 +2384,6 @@
                     },
                     "type": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_type 'mydevice vdd type power'",
                                 "api: chip.set('datasheet','mydevice','pin','vdd','type','global','power')"
@@ -2502,7 +2411,6 @@
                     },
                     "vcdm": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_vcdm 'mydevice sclk global (125, 150, 175)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vcdm','global',(125, 150, 175)"
@@ -2531,7 +2439,6 @@
                     },
                     "vcm": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_vcm 'mydevice sclk global (0.3, 1.2, 1.6)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vcm','global',(0.3, 1.2, 1.6)"
@@ -2560,7 +2467,6 @@
                     },
                     "vdiff": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_vdiff 'mydevice sclk global (0.2, 0.3, 0.9)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vdiff','global',(0.2, 0.3, 0.9)"
@@ -2589,7 +2495,6 @@
                     },
                     "vhbm": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_vhbm 'mydevice sclk global (200, 250, 300)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vhbm','global',(200, 250, 300)"
@@ -2618,7 +2523,6 @@
                     },
                     "vih": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_vih 'mydevice sclk global (1.4, 1.8, 2.2)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vih','global',(1.4, 1.8, 2.2)"
@@ -2647,7 +2551,6 @@
                     },
                     "vil": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_vil 'mydevice sclk global (-0.2, 0, 1.0)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vil','global',(-0.2, 0, 1.0)"
@@ -2676,7 +2579,6 @@
                     },
                     "vmm": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_vmm 'mydevice sclk global (100, 125, 150)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vmm','global',(100, 125, 150)"
@@ -2705,7 +2607,6 @@
                     },
                     "vnoise": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_vnoise 'mydevice sclk global (0, 0.01, 0.1)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vnoise','global',(0, 0.01, 0.1)"
@@ -2734,7 +2635,6 @@
                     },
                     "voh": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_voh 'mydevice sclk global (4.6, 4.8, 5.2)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','voh','global',(4.6, 4.8, 5.2)"
@@ -2763,7 +2663,6 @@
                     },
                     "vol": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -datasheet_pin_vol 'mydevice sclk global (-0.2, 0, 0.2)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vol','global',(-0.2, 0, 0.2)"
@@ -2795,7 +2694,6 @@
         }
     },
     "design": {
-        "defvalue": null,
         "example": [
             "cli: -design hello_world",
             "api: chip.set('design', 'hello_world')"
@@ -2825,7 +2723,6 @@
             "default": {
                 "default": {
                     "args": {
-                        "defvalue": [],
                         "example": [
                             "cli: -flowgraph_args 'asicflow cts 0 0'",
                             "api:  chip.add('flowgraph','asicflow','cts','0','args','0')"
@@ -2852,7 +2749,6 @@
                     },
                     "goal": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -flowgraph_goal 'asicflow cts 0 area_cells 1.0'",
                                 "api:  chip.set('flowgraph','asicflow','cts','0','goal','errors', 0)"
@@ -2879,7 +2775,6 @@
                         }
                     },
                     "input": {
-                        "defvalue": [],
                         "example": [
                             "cli: -flowgraph_input 'asicflow cts 0 (place,0)'",
                             "api:  chip.set('flowgraph','asicflow','cts','0','input',('place','0'))"
@@ -2905,7 +2800,6 @@
                         "type": "[(str,str)]"
                     },
                     "select": {
-                        "defvalue": [],
                         "example": [
                             "cli: -flowgraph_select 'asicflow cts 0 (place,42)'",
                             "api:  chip.set('flowgraph','asicflow', 'cts','0','select',('place','42'))"
@@ -2931,7 +2825,6 @@
                         "type": "[(str,str)]"
                     },
                     "status": {
-                        "defvalue": null,
                         "enum": [
                             "pending",
                             "success",
@@ -2962,7 +2855,6 @@
                         "type": "enum"
                     },
                     "task": {
-                        "defvalue": null,
                         "example": [
                             "cli: -flowgraph_task 'asicflow myplace 0 place'",
                             "api: chip.set('flowgraph','asicflow','myplace','0','task','place')"
@@ -2988,7 +2880,6 @@
                         "type": "str"
                     },
                     "taskmodule": {
-                        "defvalue": null,
                         "example": [
                             "cli: -flowgraph_taskmodule 'asicflow place 0 siliconcompiler.tools.openroad.place'",
                             "api: chip.set('flowgraph','asicflow','place','0','taskmodule','siliconcompiler.tools.openroad.place')"
@@ -3014,7 +2905,6 @@
                         "type": "str"
                     },
                     "timeout": {
-                        "defvalue": null,
                         "example": [
                             "cli: -flowgraph_timeout 'asicflow cts 0 3600'",
                             "api:  chip.set('flowgraph','asicflow','cts','0','timeout', 3600)"
@@ -3041,7 +2931,6 @@
                         "unit": "s"
                     },
                     "tool": {
-                        "defvalue": null,
                         "example": [
                             "cli: -flowgraph_tool 'asicflow place 0 openroad'",
                             "api: chip.set('flowgraph','asicflow','place','0','tool','openroad')"
@@ -3067,7 +2956,6 @@
                         "type": "str"
                     },
                     "valid": {
-                        "defvalue": false,
                         "example": [
                             "cli: -flowgraph_valid 'asicflow cts 0 true'",
                             "api:  chip.set('flowgraph','asicflow','cts','0','valid',True)"
@@ -3094,7 +2982,6 @@
                     },
                     "weight": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -flowgraph_weight 'asicflow cts 0 area_cells 1.0'",
                                 "api:  chip.set('flowgraph','asicflow','cts','0','weight','area_cells',1.0)"
@@ -3127,7 +3014,6 @@
     "fpga": {
         "arch": {
             "copy": true,
-            "defvalue": [],
             "example": [
                 "cli: -fpga_arch myfpga.xml",
                 "api:  chip.set('fpga', 'arch', 'myfpga.xml')"
@@ -3157,7 +3043,6 @@
             "type": "[file]"
         },
         "board": {
-            "defvalue": null,
             "example": [
                 "cli: -fpga_board parallella",
                 "api:  chip.set('fpga', 'board', 'parallella')"
@@ -3183,7 +3068,6 @@
             "type": "str"
         },
         "flash": {
-            "defvalue": false,
             "example": [
                 "cli: -fpga_flash",
                 "api:  chip.set('fpga', 'flash', True)"
@@ -3209,7 +3093,6 @@
             "type": "bool"
         },
         "partname": {
-            "defvalue": null,
             "example": [
                 "cli: -fpga_partname fpga64k",
                 "api:  chip.set('fpga', 'partname', 'fpga64k')"
@@ -3235,7 +3118,6 @@
             "type": "str"
         },
         "program": {
-            "defvalue": false,
             "example": [
                 "cli: -fpga_program",
                 "api:  chip.set('fpga', 'program', True)"
@@ -3261,7 +3143,6 @@
             "type": "bool"
         },
         "vendor": {
-            "defvalue": null,
             "example": [
                 "cli: -fpga_vendor acme",
                 "api:  chip.set('fpga', 'vendor', 'acme')"
@@ -3292,7 +3173,6 @@
         "default": {
             "default": {
                 "copy": true,
-                "defvalue": [],
                 "example": [
                     "cli: -input 'rtl verilog hello_world.v'",
                     "api: chip.set(input, 'rtl','verilog','hello_world.v')"
@@ -3326,7 +3206,6 @@
     "library": {},
     "metric": {
         "averagepower": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_averagepower 'place 0 0.01'",
                 "api: chip.set('metric', 'averagepower', 0.01, step='place', index=0)"
@@ -3353,7 +3232,6 @@
             "unit": "mw"
         },
         "brams": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_brams 'place 0 100'",
                 "api: chip.set('metric', 'brams', 100, step='place', index=0)"
@@ -3379,7 +3257,6 @@
             "type": "int"
         },
         "buffers": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_buffers 'place 0 100'",
                 "api: chip.set('metric', 'buffers', 50, step='place', index=0)"
@@ -3405,7 +3282,6 @@
             "type": "int"
         },
         "cellarea": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_cellarea 'place 0 100.00'",
                 "api: chip.set('metric', 'cellarea', 100.00, step='place', index=0)"
@@ -3432,7 +3308,6 @@
             "unit": "um^2"
         },
         "cells": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_cells 'place 0 100'",
                 "api: chip.set('metric', 'cells', 50, step='place', index=0)"
@@ -3458,7 +3333,6 @@
             "type": "int"
         },
         "coverage": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_coverage 'place 0 99.9'",
                 "api: chip.set('metric', 'coverage', 99.9, step='place', index=0)"
@@ -3485,7 +3359,6 @@
             "unit": "%"
         },
         "dozepower": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_dozepower 'place 0 0.01'",
                 "api: chip.set('metric', 'dozepower', 0.01, step='place', index=0)"
@@ -3512,7 +3385,6 @@
             "unit": "mw"
         },
         "drvs": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_drvs 'dfm 0 0'",
                 "api: chip.set('metric', 'drvs', 0, step='dfm', index=0)"
@@ -3538,7 +3410,6 @@
             "type": "int"
         },
         "dsps": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_dsps 'place 0 100'",
                 "api: chip.set('metric', 'dsps', 100, step='place', index=0)"
@@ -3564,7 +3435,6 @@
             "type": "int"
         },
         "errors": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_errors 'dfm 0 0'",
                 "api: chip.set('metric', 'errors', 0, step='dfm', index=0)"
@@ -3590,7 +3460,6 @@
             "type": "int"
         },
         "exetime": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_exetime 'dfm 0 10.0'",
                 "api: chip.set('metric', 'exetime', 10.0, step='dfm', index=0)"
@@ -3617,7 +3486,6 @@
             "unit": "s"
         },
         "fmax": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_fmax 'place 0 100e6'",
                 "api: chip.set('metric', 'fmax', 100e6, step='place', index=0)"
@@ -3644,7 +3512,6 @@
             "unit": "Hz"
         },
         "holdpaths": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_holdpaths 'place 0 10'",
                 "api: chip.set('metric', 'holdpaths', 10, step='place', index=0)"
@@ -3670,7 +3537,6 @@
             "type": "int"
         },
         "holdslack": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_holdslack 'place 0 0.01'",
                 "api: chip.set('metric', 'holdslack', 0.01, step='place', index=0)"
@@ -3697,7 +3563,6 @@
             "unit": "ns"
         },
         "holdtns": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_holdtns 'place 0 0.01'",
                 "api: chip.set('metric', 'holdtns', 0.01, step='place', index=0)"
@@ -3724,7 +3589,6 @@
             "unit": "ns"
         },
         "holdwns": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_holdwns 'place 0 0.01'",
                 "api: chip.set('metric', 'holdwns', 0.01, step='place', index=0)"
@@ -3751,7 +3615,6 @@
             "unit": "ns"
         },
         "idlepower": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_idlepower 'place 0 0.01'",
                 "api: chip.set('metric', 'idlepower', 0.01, step='place', index=0)"
@@ -3778,7 +3641,6 @@
             "unit": "mw"
         },
         "irdrop": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_irdrop 'place 0 0.05'",
                 "api: chip.set('metric', 'irdrop', 0.05, step='place', index=0)"
@@ -3805,7 +3667,6 @@
             "unit": "mv"
         },
         "leakagepower": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_leakagepower 'place 0 0.01'",
                 "api: chip.set('metric', 'leakagepower', 0.01, step='place', index=0)"
@@ -3832,7 +3693,6 @@
             "unit": "mw"
         },
         "luts": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_luts 'place 0 100'",
                 "api: chip.set('metric', 'luts', 100, step='place', index=0)"
@@ -3858,7 +3718,6 @@
             "type": "int"
         },
         "macros": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_macros 'place 0 100'",
                 "api: chip.set('metric', 'macros', 50, step='place', index=0)"
@@ -3884,7 +3743,6 @@
             "type": "int"
         },
         "memory": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_memory 'dfm 0 10e9'",
                 "api: chip.set('metric', 'memory', 10e9, step='dfm', index=0)"
@@ -3911,7 +3769,6 @@
             "unit": "B"
         },
         "nets": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_nets 'place 0 100'",
                 "api: chip.set('metric', 'nets', 50, step='place', index=0)"
@@ -3937,7 +3794,6 @@
             "type": "int"
         },
         "overflow": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_overflow 'place 0 0'",
                 "api: chip.set('metric', 'overflow', 50, step='place', index=0)"
@@ -3963,7 +3819,6 @@
             "type": "int"
         },
         "peakpower": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_peakpower 'place 0 0.01'",
                 "api: chip.set('metric', 'peakpower', 0.01, step='place', index=0)"
@@ -3990,7 +3845,6 @@
             "unit": "mw"
         },
         "pins": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_pins 'place 0 100'",
                 "api: chip.set('metric', 'pins', 50, step='place', index=0)"
@@ -4016,7 +3870,6 @@
             "type": "int"
         },
         "registers": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_registers 'place 0 100'",
                 "api: chip.set('metric', 'registers', 50, step='place', index=0)"
@@ -4042,7 +3895,6 @@
             "type": "int"
         },
         "security": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_security 'place 0 100'",
                 "api: chip.set('metric', 'security', 100, step='place', index=0)"
@@ -4069,7 +3921,6 @@
             "unit": "%"
         },
         "setuppaths": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_setuppaths 'place 0 10'",
                 "api: chip.set('metric', 'setuppaths', 10, step='place', index=0)"
@@ -4095,7 +3946,6 @@
             "type": "int"
         },
         "setupslack": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_setupslack 'place 0 0.01'",
                 "api: chip.set('metric', 'setupslack', 0.01, step='place', index=0)"
@@ -4122,7 +3972,6 @@
             "unit": "ns"
         },
         "setuptns": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_setuptns 'place 0 0.01'",
                 "api: chip.set('metric', 'setuptns', 0.01, step='place', index=0)"
@@ -4149,7 +3998,6 @@
             "unit": "ns"
         },
         "setupwns": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_setupwns 'place 0 0.01'",
                 "api: chip.set('metric', 'setupwns', 0.01, step='place', index=0)"
@@ -4176,7 +4024,6 @@
             "unit": "ns"
         },
         "sleeppower": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_sleeppower 'place 0 0.01'",
                 "api: chip.set('metric', 'sleeppower', 0.01, step='place', index=0)"
@@ -4203,7 +4050,6 @@
             "unit": "mw"
         },
         "tasktime": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_tasktime 'dfm 0 10.0'",
                 "api: chip.set('metric', 'tasktime', 10.0, step='dfm', index=0)"
@@ -4230,7 +4076,6 @@
             "unit": "s"
         },
         "totalarea": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_totalarea 'place 0 100.00'",
                 "api: chip.set('metric', 'totalarea', 100.00, step='place', index=0)"
@@ -4257,7 +4102,6 @@
             "unit": "um^2"
         },
         "totaltime": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_totaltime 'dfm 0 10.0'",
                 "api: chip.set('metric', 'totaltime', 10.0, step='dfm', index=0)"
@@ -4284,7 +4128,6 @@
             "unit": "s"
         },
         "transistors": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_transistors 'place 0 100'",
                 "api: chip.set('metric', 'transistors', 50, step='place', index=0)"
@@ -4310,7 +4153,6 @@
             "type": "int"
         },
         "unconstrained": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_unconstrained 'dfm 0 0'",
                 "api: chip.set('metric', 'unconstrained', 0, step='dfm', index=0)"
@@ -4336,7 +4178,6 @@
             "type": "int"
         },
         "utilization": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_utilization 'place 0 50.00'",
                 "api: chip.set('metric', 'utilization', 50.00, step='place', index=0)"
@@ -4363,7 +4204,6 @@
             "unit": "%"
         },
         "vias": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_vias 'place 0 100'",
                 "api: chip.set('metric', 'vias', 50, step='place', index=0)"
@@ -4389,7 +4229,6 @@
             "type": "int"
         },
         "warnings": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_warnings 'dfm 0 0'",
                 "api: chip.set('metric', 'warnings', 0, step='dfm', index=0)"
@@ -4415,7 +4254,6 @@
             "type": "int"
         },
         "wirelength": {
-            "defvalue": null,
             "example": [
                 "cli: -metric_wirelength 'place 0 100.0'",
                 "api: chip.set('metric', 'wirelength', 50.0, step='place', index=0)"
@@ -4444,7 +4282,6 @@
     },
     "option": {
         "autoinstall": {
-            "defvalue": false,
             "example": [
                 "cli: -autoinstall true'",
                 "api: chip.set('option', 'autoinstall', True)"
@@ -4470,7 +4307,6 @@
             "type": "bool"
         },
         "breakpoint": {
-            "defvalue": false,
             "example": [
                 "cli: -breakpoint true",
                 "api: chip.set('option, 'breakpoint', True)"
@@ -4497,7 +4333,6 @@
         },
         "builddir": {
             "copy": false,
-            "defvalue": "build",
             "example": [
                 "cli: -builddir ./build_the_future",
                 "api: chip.set('option', 'builddir','./build_the_future')"
@@ -4524,7 +4359,6 @@
         },
         "cfg": {
             "copy": false,
-            "defvalue": [],
             "example": [
                 "cli: -cfg mypdk.json",
                 "api: chip.set('option','cfg','mypdk.json')"
@@ -4554,7 +4388,6 @@
             "type": "[file]"
         },
         "clean": {
-            "defvalue": false,
             "example": [
                 "cli: -clean",
                 "api: chip.set('option','clean',True)"
@@ -4581,7 +4414,6 @@
         },
         "cmdfile": {
             "copy": false,
-            "defvalue": [],
             "example": [
                 "cli: -f design.f",
                 "api: chip.set('option', 'cmdfile','design.f')"
@@ -4611,7 +4443,6 @@
             "type": "[file]"
         },
         "continue": {
-            "defvalue": false,
             "example": [
                 "cli: -continue",
                 "api: chip.set('option', 'continue', True)"
@@ -4637,7 +4468,6 @@
             "type": "bool"
         },
         "copyall": {
-            "defvalue": false,
             "example": [
                 "cli: -copyall",
                 "api: chip.set('option','copyall',True)"
@@ -4664,7 +4494,6 @@
         },
         "credentials": {
             "copy": false,
-            "defvalue": null,
             "example": [
                 "cli: -credentials /home/user/.sc/credentials",
                 "api: chip.set('option', 'credentials','/home/user/.sc/credentials')"
@@ -4694,7 +4523,6 @@
             "type": "file"
         },
         "define": {
-            "defvalue": [],
             "example": [
                 "cli: -DCFG_ASIC=1",
                 "api: chip.set('option','define','CFG_ASIC=1')"
@@ -4722,7 +4550,6 @@
         "dir": {
             "default": {
                 "copy": false,
-                "defvalue": [],
                 "example": [
                     "cli: -dir 'openroad_tapcell ./tapcell.tcl'",
                     "api: chip.set('option', 'dir', 'openroad_files', './openroad_support/')"
@@ -4749,7 +4576,6 @@
             }
         },
         "entrypoint": {
-            "defvalue": null,
             "example": [
                 "cli: -entrypoint top",
                 "api: chip.set('option', 'entrypoint', 'top')"
@@ -4776,7 +4602,6 @@
         },
         "env": {
             "default": {
-                "defvalue": null,
                 "example": [
                     "cli: -env 'PDK_HOME /disk/mypdk'",
                     "api: chip.set('option', 'env', 'PDK_HOME', '/disk/mypdk')"
@@ -4805,7 +4630,6 @@
         "file": {
             "default": {
                 "copy": false,
-                "defvalue": [],
                 "example": [
                     "cli: -file 'openroad_tapcell ./tapcell.tcl'",
                     "api: chip.set('option', 'file', 'openroad_tapcell', './tapcell.tcl')"
@@ -4836,7 +4660,6 @@
             }
         },
         "flow": {
-            "defvalue": null,
             "example": [
                 "cli: -flow asicflow",
                 "api: chip.set('option','flow','asicflow')"
@@ -4862,7 +4685,6 @@
             "type": "str"
         },
         "flowcontinue": {
-            "defvalue": false,
             "example": [
                 "cli: -flowcontinue",
                 "api: chip.set('option', 'flowcontinue', True)"
@@ -4888,7 +4710,6 @@
             "type": "bool"
         },
         "frontend": {
-            "defvalue": "verilog",
             "example": [
                 "cli: -frontend systemverilog",
                 "api: chip.set('option','frontend', 'systemverilog')"
@@ -4914,7 +4735,6 @@
             "type": "str"
         },
         "hash": {
-            "defvalue": false,
             "example": [
                 "cli: -hash",
                 "api: chip.set('option','hash',True)"
@@ -4941,7 +4761,6 @@
         },
         "idir": {
             "copy": false,
-            "defvalue": [],
             "example": [
                 "cli: +incdir+./mylib",
                 "api: chip.set('option','idir','./mylib')"
@@ -4968,7 +4787,6 @@
             "type": "[dir]"
         },
         "indexlist": {
-            "defvalue": [],
             "example": [
                 "cli: -indexlist 0",
                 "api: chip.set('option','indexlist','0')"
@@ -4994,7 +4812,6 @@
             "type": "[str]"
         },
         "jobincr": {
-            "defvalue": false,
             "example": [
                 "cli: -jobincr",
                 "api: chip.set('option','jobincr',True)"
@@ -5022,7 +4839,6 @@
         "jobinput": {
             "default": {
                 "default": {
-                    "defvalue": null,
                     "example": [
                         "cli: -jobinput 'cts 0 job0'",
                         "api:  chip.set('option','jobinput','cts,'0','job0')"
@@ -5050,7 +4866,6 @@
             }
         },
         "jobname": {
-            "defvalue": "job0",
             "example": [
                 "cli: -jobname may1",
                 "api: chip.set('option','jobname','may1')"
@@ -5076,7 +4891,6 @@
             "type": "str"
         },
         "libext": {
-            "defvalue": [],
             "example": [
                 "cli: +libext+sv",
                 "api: chip.set('option','libext','sv')"
@@ -5102,7 +4916,6 @@
             "type": "[str]"
         },
         "loglevel": {
-            "defvalue": "INFO",
             "enum": [
                 "NOTSET",
                 "INFO",
@@ -5136,7 +4949,6 @@
             "type": "enum"
         },
         "metricoff": {
-            "defvalue": [],
             "example": [
                 "cli: -metricoff 'wirelength'",
                 "api: chip.set('option','metricoff','wirelength')"
@@ -5162,7 +4974,6 @@
             "type": "[str]"
         },
         "mode": {
-            "defvalue": null,
             "enum": [
                 "asic",
                 "fpga",
@@ -5193,7 +5004,6 @@
             "type": "enum"
         },
         "nice": {
-            "defvalue": null,
             "example": [
                 "cli: -nice 5",
                 "api: chip.set('option','nice',5)"
@@ -5219,7 +5029,6 @@
             "type": "int"
         },
         "nodisplay": {
-            "defvalue": false,
             "example": [
                 "cli: -nodisplay",
                 "api: chip.set('option','nodisplay',True)"
@@ -5245,7 +5054,6 @@
             "type": "bool"
         },
         "novercheck": {
-            "defvalue": false,
             "example": [
                 "cli: -novercheck",
                 "api: chip.set('option','novercheck',True)"
@@ -5271,7 +5079,6 @@
             "type": "bool"
         },
         "optmode": {
-            "defvalue": "O0",
             "example": [
                 "cli: -O3",
                 "api: chip.set('option','optmode','O3')"
@@ -5298,7 +5105,6 @@
         },
         "param": {
             "default": {
-                "defvalue": null,
                 "example": [
                     "cli: -param 'N 64'",
                     "api: chip.set('option','param','N','64')"
@@ -5325,7 +5131,6 @@
             }
         },
         "pdk": {
-            "defvalue": null,
             "example": [
                 "cli: -pdk freepdk45",
                 "api: chip.set('option','pdk','freepdk45')"
@@ -5351,7 +5156,6 @@
             "type": "str"
         },
         "quiet": {
-            "defvalue": false,
             "example": [
                 "cli: -quiet",
                 "api: chip.set('option','quiet',True)"
@@ -5378,7 +5182,6 @@
         },
         "registry": {
             "copy": false,
-            "defvalue": [],
             "example": [
                 "cli: -registry '~/myregistry'",
                 "api: chip.set('option','registry','~/myregistry')"
@@ -5404,7 +5207,6 @@
             "type": "[dir]"
         },
         "relax": {
-            "defvalue": false,
             "example": [
                 "cli: -relax",
                 "api: chip.set('option','relax',True)"
@@ -5430,7 +5232,6 @@
             "type": "bool"
         },
         "remote": {
-            "defvalue": false,
             "example": [
                 "cli: -remote",
                 "api: chip.set('option','remote', True)"
@@ -5456,7 +5257,6 @@
             "type": "bool"
         },
         "resume": {
-            "defvalue": false,
             "example": [
                 "cli: -resume",
                 "api: chip.set('option','resume',True)"
@@ -5483,7 +5283,6 @@
         },
         "scheduler": {
             "cores": {
-                "defvalue": null,
                 "example": [
                     "cli: -cores 48",
                     "api: chip.set('option', 'scheduler', 'cores', '48')"
@@ -5509,7 +5308,6 @@
                 "type": "int"
             },
             "defer": {
-                "defvalue": null,
                 "example": [
                     "cli: -defer 16:00",
                     "api: chip.set('option', 'scheduler', 'defer', '16:00')"
@@ -5535,7 +5333,6 @@
                 "type": "str"
             },
             "memory": {
-                "defvalue": null,
                 "example": [
                     "cli: -memory 8000",
                     "api: chip.set('option', 'scheduler', 'memory', '8000')"
@@ -5562,7 +5359,6 @@
                 "unit": "MB"
             },
             "msgcontact": {
-                "defvalue": [],
                 "example": [
                     "cli: -msgcontact 'wile.e.coyote@acme.com'",
                     "api: chip.set('option', 'scheduler', 'msgcontact', 'wiley@acme.com')"
@@ -5588,7 +5384,6 @@
                 "type": "[str]"
             },
             "msgevent": {
-                "defvalue": "NONE",
                 "example": [
                     "cli: -msgevent ALL",
                     "api: chip.set('option', 'scheduler', 'msgevent', 'ALL')"
@@ -5614,7 +5409,6 @@
                 "type": "str"
             },
             "name": {
-                "defvalue": null,
                 "enum": [
                     "slurm",
                     "lsf",
@@ -5645,7 +5439,6 @@
                 "type": "enum"
             },
             "options": {
-                "defvalue": [],
                 "example": [
                     "cli: -scheduler_options \"--pty\"",
                     "api: chip.set('option', 'scheduler', 'options', \"--pty\")"
@@ -5671,7 +5464,6 @@
                 "type": "[str]"
             },
             "queue": {
-                "defvalue": null,
                 "example": [
                     "cli: -queue nightrun",
                     "api: chip.set('option', 'scheduler', 'queue', 'nightrun')"
@@ -5699,7 +5491,6 @@
         },
         "scpath": {
             "copy": false,
-            "defvalue": [],
             "example": [
                 "cli: -scpath '/home/$USER/sclib'",
                 "api: chip.set('option', 'scpath','/home/$USER/sclib')"
@@ -5725,7 +5516,6 @@
             "type": "[dir]"
         },
         "show": {
-            "defvalue": false,
             "example": [
                 "cli: -show",
                 "api: chip.set('option','show',True)"
@@ -5752,7 +5542,6 @@
         },
         "showtool": {
             "default": {
-                "defvalue": null,
                 "example": [
                     "cli: -showtool 'gds klayout'",
                     "api: chip.set('option','showtool','gds','klayout')"
@@ -5779,7 +5568,6 @@
             }
         },
         "skipall": {
-            "defvalue": false,
             "example": [
                 "cli: -skipall",
                 "api: chip.set('option','skipall',True)"
@@ -5805,7 +5593,6 @@
             "type": "bool"
         },
         "skipcheck": {
-            "defvalue": false,
             "example": [
                 "cli: -skipcheck",
                 "api: chip.set('option','skipcheck',True)"
@@ -5831,7 +5618,6 @@
             "type": "bool"
         },
         "skipstep": {
-            "defvalue": [],
             "example": [
                 "cli: -skipstep lvs",
                 "api: chip.set('option','skipstep','lvs')"
@@ -5857,7 +5643,6 @@
             "type": "[str]"
         },
         "stackup": {
-            "defvalue": null,
             "example": [
                 "cli: -stackup 2MA4MB2MC",
                 "api: chip.set('option','stackup','2MA4MB2MC')"
@@ -5883,7 +5668,6 @@
             "type": "str"
         },
         "steplist": {
-            "defvalue": [],
             "example": [
                 "cli: -steplist 'import'",
                 "api: chip.set('option','steplist','import')"
@@ -5909,7 +5693,6 @@
             "type": "[str]"
         },
         "strict": {
-            "defvalue": false,
             "example": [
                 "cli: -strict true",
                 "api: chip.set('option', 'strict', True)"
@@ -5935,7 +5718,6 @@
             "type": "bool"
         },
         "target": {
-            "defvalue": null,
             "example": [
                 "cli: -target freepdk45_demo",
                 "api: chip.set('option','target','freepdk45_demo')"
@@ -5961,7 +5743,6 @@
             "type": "str"
         },
         "timeout": {
-            "defvalue": null,
             "example": [
                 "cli: -timeout 3600",
                 "api: chip.set('option', 'timeout', 3600)"
@@ -5988,7 +5769,6 @@
             "unit": "s"
         },
         "trace": {
-            "defvalue": false,
             "example": [
                 "cli: -trace",
                 "api: chip.set('option','trace',True)"
@@ -6014,7 +5794,6 @@
             "type": "bool"
         },
         "track": {
-            "defvalue": false,
             "example": [
                 "cli: -track",
                 "api: chip.set('option','track',True)"
@@ -6040,7 +5819,6 @@
             "type": "bool"
         },
         "uselambda": {
-            "defvalue": false,
             "example": [
                 "cli: -uselambda true",
                 "api: chip.set('option','uselambda', True)"
@@ -6067,7 +5845,6 @@
         },
         "var": {
             "default": {
-                "defvalue": [],
                 "example": [
                     "cli: -var 'openroad_place_density 0.4'",
                     "api: chip.set('option', 'var', 'openroad_place_density', '0.4')"
@@ -6095,7 +5872,6 @@
         },
         "vlib": {
             "copy": false,
-            "defvalue": [],
             "example": [
                 "cli: -v './mylib.v'",
                 "api: chip.set('option', 'vlib','./mylib.v')"
@@ -6126,7 +5902,6 @@
         },
         "ydir": {
             "copy": false,
-            "defvalue": [],
             "example": [
                 "cli: -y './mylib'",
                 "api: chip.set('option','ydir','./mylib')"
@@ -6156,7 +5931,6 @@
         "default": {
             "default": {
                 "copy": false,
-                "defvalue": [],
                 "example": [
                     "cli: -output 'rtl verilog hello_world.v'",
                     "api: chip.set(output, 'rtl','verilog','hello_world.v')"
@@ -6191,7 +5965,6 @@
         "author": {
             "default": {
                 "email": {
-                    "defvalue": null,
                     "example": [
                         "cli: -package_author_email 'wiley wiley@acme.com'",
                         "api: chip.set('package','author','wiley','email','wiley@acme.com')"
@@ -6217,7 +5990,6 @@
                     "type": "str"
                 },
                 "location": {
-                    "defvalue": null,
                     "example": [
                         "cli: -package_author_location 'wiley wiley@acme.com'",
                         "api: chip.set('package','author','wiley','location','wiley@acme.com')"
@@ -6243,7 +6015,6 @@
                     "type": "str"
                 },
                 "name": {
-                    "defvalue": null,
                     "example": [
                         "cli: -package_author_name 'wiley wiley@acme.com'",
                         "api: chip.set('package','author','wiley','name','wiley@acme.com')"
@@ -6269,7 +6040,6 @@
                     "type": "str"
                 },
                 "organization": {
-                    "defvalue": null,
                     "example": [
                         "cli: -package_author_organization 'wiley wiley@acme.com'",
                         "api: chip.set('package','author','wiley','organization','wiley@acme.com')"
@@ -6295,7 +6065,6 @@
                     "type": "str"
                 },
                 "publickey": {
-                    "defvalue": null,
                     "example": [
                         "cli: -package_author_publickey 'wiley wiley@acme.com'",
                         "api: chip.set('package','author','wiley','publickey','wiley@acme.com')"
@@ -6321,7 +6090,6 @@
                     "type": "str"
                 },
                 "username": {
-                    "defvalue": null,
                     "example": [
                         "cli: -package_author_username 'wiley wiley@acme.com'",
                         "api: chip.set('package','author','wiley','username','wiley@acme.com')"
@@ -6350,7 +6118,6 @@
         },
         "dependency": {
             "default": {
-                "defvalue": [],
                 "example": [
                     "cli: -package_dependency 'hello 1.0'",
                     "api: chip.set('package','dependency','hello','1.0')"
@@ -6378,7 +6145,6 @@
         },
         "depgraph": {
             "default": {
-                "defvalue": [],
                 "example": [
                     "cli: -package_depgraph 'top (cpu,1.0.1)'",
                     "api: chip.set('package','depgraph','top',('cpu','1.0.1'))"
@@ -6405,7 +6171,6 @@
             }
         },
         "description": {
-            "defvalue": null,
             "example": [
                 "cli: -package_description 'Yet another cpu'",
                 "api: chip.set('package','description','Yet another cpu')"
@@ -6433,7 +6198,6 @@
         "doc": {
             "datasheet": {
                 "copy": false,
-                "defvalue": [],
                 "example": [
                     "cli: -package_doc_datasheet datasheet.pdf",
                     "api: chip.set('package','doc',datasheet,'datasheet.pdf')"
@@ -6463,7 +6227,6 @@
                 "type": "[file]"
             },
             "homepage": {
-                "defvalue": null,
                 "example": [
                     "cli: -package_doc_homepage index.html",
                     "api: chip.set('package','doc', 'homepage','index.html')"
@@ -6490,7 +6253,6 @@
             },
             "quickstart": {
                 "copy": false,
-                "defvalue": [],
                 "example": [
                     "cli: -package_doc_quickstart quickstart.pdf",
                     "api: chip.set('package','doc',quickstart,'quickstart.pdf')"
@@ -6521,7 +6283,6 @@
             },
             "reference": {
                 "copy": false,
-                "defvalue": [],
                 "example": [
                     "cli: -package_doc_reference reference.pdf",
                     "api: chip.set('package','doc',reference,'reference.pdf')"
@@ -6552,7 +6313,6 @@
             },
             "releasenotes": {
                 "copy": false,
-                "defvalue": [],
                 "example": [
                     "cli: -package_doc_releasenotes releasenotes.pdf",
                     "api: chip.set('package','doc',releasenotes,'releasenotes.pdf')"
@@ -6583,7 +6343,6 @@
             },
             "signoff": {
                 "copy": false,
-                "defvalue": [],
                 "example": [
                     "cli: -package_doc_signoff signoff.pdf",
                     "api: chip.set('package','doc',signoff,'signoff.pdf')"
@@ -6614,7 +6373,6 @@
             },
             "testplan": {
                 "copy": false,
-                "defvalue": [],
                 "example": [
                     "cli: -package_doc_testplan testplan.pdf",
                     "api: chip.set('package','doc',testplan,'testplan.pdf')"
@@ -6645,7 +6403,6 @@
             },
             "tutorial": {
                 "copy": false,
-                "defvalue": [],
                 "example": [
                     "cli: -package_doc_tutorial tutorial.pdf",
                     "api: chip.set('package','doc',tutorial,'tutorial.pdf')"
@@ -6676,7 +6433,6 @@
             },
             "userguide": {
                 "copy": false,
-                "defvalue": [],
                 "example": [
                     "cli: -package_doc_userguide userguide.pdf",
                     "api: chip.set('package','doc',userguide,'userguide.pdf')"
@@ -6707,7 +6463,6 @@
             }
         },
         "homepage": {
-            "defvalue": null,
             "example": [
                 "cli: -package_homepage index.html",
                 "api: chip.set('package','homepage','index.html')"
@@ -6733,7 +6488,6 @@
             "type": "str"
         },
         "keyword": {
-            "defvalue": null,
             "example": [
                 "cli: -package_keyword cpu",
                 "api: chip.set('package','keyword','cpu')"
@@ -6759,7 +6513,6 @@
             "type": "str"
         },
         "license": {
-            "defvalue": [],
             "example": [
                 "cli: -package_license 'Apache-2.0'",
                 "api: chip.set('package','license','Apache-2.0')"
@@ -6786,7 +6539,6 @@
         },
         "licensefile": {
             "copy": false,
-            "defvalue": [],
             "example": [
                 "cli: -package_licensefile './LICENSE'",
                 "api: chip.set('package','licensefile','./LICENSE')"
@@ -6816,7 +6568,6 @@
             "type": "[file]"
         },
         "location": {
-            "defvalue": [],
             "example": [
                 "cli: -package_location 'mars'",
                 "api: chip.set('package','location','mars')"
@@ -6842,7 +6593,6 @@
             "type": "[str]"
         },
         "name": {
-            "defvalue": null,
             "example": [
                 "cli: -package_name yac",
                 "api: chip.set('package','name','yac')"
@@ -6868,7 +6618,6 @@
             "type": "str"
         },
         "organization": {
-            "defvalue": [],
             "example": [
                 "cli: -package_organization 'humanity'",
                 "api: chip.set('package','organization','humanity')"
@@ -6894,7 +6643,6 @@
             "type": "[str]"
         },
         "publickey": {
-            "defvalue": null,
             "example": [
                 "cli: -package_publickey '6EB695706EB69570'",
                 "api: chip.set('package','publickey','6EB695706EB69570')"
@@ -6920,7 +6668,6 @@
             "type": "str"
         },
         "repo": {
-            "defvalue": [],
             "example": [
                 "cli: -package_repo 'git@github.com:aolofsson/oh.git'",
                 "api: chip.set('package','repo','git@github.com:aolofsson/oh.git')"
@@ -6946,7 +6693,6 @@
             "type": "[str]"
         },
         "target": {
-            "defvalue": [],
             "example": [
                 "cli: -package_target 'asicflow_freepdk45'",
                 "api: chip.set('package','target','asicflow_freepdk45')"
@@ -6972,7 +6718,6 @@
             "type": "[str]"
         },
         "version": {
-            "defvalue": null,
             "example": [
                 "cli: -package_version 1.0",
                 "api: chip.set('package','version','1.0')"
@@ -7006,7 +6751,6 @@
                         "default": {
                             "default": {
                                 "copy": false,
-                                "defvalue": [],
                                 "example": [
                                     "cli: -pdk_aprtech 'asap7 openroad M10 12t lef tech.lef'",
                                     "api: chip.set('pdk','asap7','aprtech','openroad','M10','12t','lef','tech.lef')"
@@ -7040,7 +6784,6 @@
                 }
             },
             "d0": {
-                "defvalue": null,
                 "example": [
                     "cli: -pdk_d0 'asap7 0.1'",
                     "api:  chip.set('pdk', 'asap7', 'd0', 0.1)"
@@ -7066,7 +6809,6 @@
                 "type": "float"
             },
             "density": {
-                "defvalue": null,
                 "example": [
                     "cli: -pdk_density 'asap7 100e6'",
                     "api:  chip.set('pdk', 'asap7', 'density', 10e6)"
@@ -7096,7 +6838,6 @@
                     "default": {
                         "default": {
                             "copy": false,
-                            "defvalue": [],
                             "example": [
                                 "cli: -pdk_devmodel 'asap7 xyce spice M10 asap7.sp'",
                                 "api: chip.set('pdk','asap7','devmodel','xyce','spice','M10','asap7.sp')"
@@ -7133,7 +6874,6 @@
                     "default": {
                         "default": {
                             "copy": false,
-                            "defvalue": [],
                             "example": [
                                 "cli: -pdk_directory 'asap7 xyce rfmodel M10 rftechdir'",
                                 "api: chip.set('pdk','asap7','directory','xyce','rfmodel','M10','rftechdir')"
@@ -7165,7 +6905,6 @@
                 "default": {
                     "default": {
                         "copy": false,
-                        "defvalue": [],
                         "example": [
                             "cli: -pdk_display 'asap7 klayout M10 display.lyt'",
                             "api: chip.set('pdk','asap7','display','klayout','M10','display.cfg')"
@@ -7199,7 +6938,6 @@
             "doc": {
                 "datasheet": {
                     "copy": false,
-                    "defvalue": [],
                     "example": [
                         "cli: -pdk_doc_datasheet 'asap7 datasheet.pdf'",
                         "api: chip.set('pdk','asap7','doc',datasheet,'datasheet.pdf')"
@@ -7230,7 +6968,6 @@
                 },
                 "homepage": {
                     "copy": false,
-                    "defvalue": [],
                     "example": [
                         "cli: -pdk_doc_homepage 'asap7 index.html'",
                         "api: chip.set('pdk','asap7','doc','homepage','index.html')"
@@ -7261,7 +6998,6 @@
                 },
                 "install": {
                     "copy": false,
-                    "defvalue": [],
                     "example": [
                         "cli: -pdk_doc_install 'asap7 install.pdf'",
                         "api: chip.set('pdk','asap7','doc',install,'install.pdf')"
@@ -7292,7 +7028,6 @@
                 },
                 "quickstart": {
                     "copy": false,
-                    "defvalue": [],
                     "example": [
                         "cli: -pdk_doc_quickstart 'asap7 quickstart.pdf'",
                         "api: chip.set('pdk','asap7','doc',quickstart,'quickstart.pdf')"
@@ -7323,7 +7058,6 @@
                 },
                 "reference": {
                     "copy": false,
-                    "defvalue": [],
                     "example": [
                         "cli: -pdk_doc_reference 'asap7 reference.pdf'",
                         "api: chip.set('pdk','asap7','doc',reference,'reference.pdf')"
@@ -7354,7 +7088,6 @@
                 },
                 "releasenotes": {
                     "copy": false,
-                    "defvalue": [],
                     "example": [
                         "cli: -pdk_doc_releasenotes 'asap7 releasenotes.pdf'",
                         "api: chip.set('pdk','asap7','doc',releasenotes,'releasenotes.pdf')"
@@ -7385,7 +7118,6 @@
                 },
                 "tutorial": {
                     "copy": false,
-                    "defvalue": [],
                     "example": [
                         "cli: -pdk_doc_tutorial 'asap7 tutorial.pdf'",
                         "api: chip.set('pdk','asap7','doc',tutorial,'tutorial.pdf')"
@@ -7416,7 +7148,6 @@
                 },
                 "userguide": {
                     "copy": false,
-                    "defvalue": [],
                     "example": [
                         "cli: -pdk_doc_userguide 'asap7 userguide.pdf'",
                         "api: chip.set('pdk','asap7','doc',userguide,'userguide.pdf')"
@@ -7452,7 +7183,6 @@
                         "default": {
                             "default": {
                                 "copy": false,
-                                "defvalue": [],
                                 "example": [
                                     "cli: -pdk_drc_runset 'asap7 magic M10 basic $PDK/drc.rs'",
                                     "api: chip.set('pdk', 'asap7','drc','runset','magic','M10','basic','$PDK/drc.rs')"
@@ -7489,7 +7219,6 @@
                         "default": {
                             "default": {
                                 "copy": false,
-                                "defvalue": [],
                                 "example": [
                                     "cli: -pdk_drc_waiver 'asap7 magic M10 basic $PDK/drc.txt'",
                                     "api: chip.set('pdk', 'asap7','drc','waiver','magic','M10','basic','$PDK/drc.txt')"
@@ -7523,7 +7252,6 @@
                 }
             },
             "edgemargin": {
-                "defvalue": null,
                 "example": [
                     "cli: -pdk_edgemargin 'asap7 1'",
                     "api:  chip.set('pdk', 'asap7', 'edgemargin', 1)"
@@ -7555,7 +7283,6 @@
                         "default": {
                             "default": {
                                 "copy": false,
-                                "defvalue": [],
                                 "example": [
                                     "cli: -pdk_erc_runset 'asap7 magic M10 basic $PDK/erc.rs'",
                                     "api: chip.set('pdk', 'asap7','erc','runset','magic','M10','basic','$PDK/erc.rs')"
@@ -7592,7 +7319,6 @@
                         "default": {
                             "default": {
                                 "copy": false,
-                                "defvalue": [],
                                 "example": [
                                     "cli: -pdk_erc_waiver 'asap7 magic M10 basic $PDK/erc.txt'",
                                     "api: chip.set('pdk', 'asap7','erc','waiver','magic','M10','basic','$PDK/erc.txt')"
@@ -7630,7 +7356,6 @@
                     "default": {
                         "default": {
                             "copy": false,
-                            "defvalue": [],
                             "example": [
                                 "cli: -pdk_file 'asap7 xyce spice M10 asap7.sp'",
                                 "api: chip.set('pdk','asap7','file','xyce','spice','M10','asap7.sp')"
@@ -7668,7 +7393,6 @@
                         "default": {
                             "default": {
                                 "copy": false,
-                                "defvalue": [],
                                 "example": [
                                     "cli: -pdk_fill_runset 'asap7 magic M10 basic $PDK/fill.rs'",
                                     "api: chip.set('pdk', 'asap7','fill','runset','magic','M10','basic','$PDK/fill.rs')"
@@ -7705,7 +7429,6 @@
                         "default": {
                             "default": {
                                 "copy": false,
-                                "defvalue": [],
                                 "example": [
                                     "cli: -pdk_fill_waiver 'asap7 magic M10 basic $PDK/fill.txt'",
                                     "api: chip.set('pdk', 'asap7','fill','waiver','magic','M10','basic','$PDK/fill.txt')"
@@ -7739,7 +7462,6 @@
                 }
             },
             "foundry": {
-                "defvalue": null,
                 "example": [
                     "cli: -pdk_foundry 'asap7 virtual'",
                     "api:  chip.set('pdk', 'asap7', 'foundry', 'virtual')"
@@ -7765,7 +7487,6 @@
                 "type": "str"
             },
             "hscribe": {
-                "defvalue": null,
                 "example": [
                     "cli: -pdk_hscribe 'asap7 0.1'",
                     "api:  chip.set('pdk', 'asap7', 'hscribe', 0.1)"
@@ -7792,7 +7513,6 @@
                 "unit": "mm"
             },
             "lambda": {
-                "defvalue": "1e-06",
                 "example": [
                     "cli: -pdk_lambda 'asap7 1e-06'",
                     "api: chip.set('pdk', 'asap7', 'lambda', 1e-06)"
@@ -7823,7 +7543,6 @@
                         "default": {
                             "default": {
                                 "copy": false,
-                                "defvalue": [],
                                 "example": [
                                     "cli: -pdk_layermap 'asap7 klayout db gds M10 asap7.map'",
                                     "api: chip.set('pdk','asap7','layermap','klayout','db','gds','M10','asap7.map')"
@@ -7862,7 +7581,6 @@
                         "default": {
                             "default": {
                                 "copy": false,
-                                "defvalue": [],
                                 "example": [
                                     "cli: -pdk_lvs_runset 'asap7 magic M10 basic $PDK/lvs.rs'",
                                     "api: chip.set('pdk', 'asap7','lvs','runset','magic','M10','basic','$PDK/lvs.rs')"
@@ -7899,7 +7617,6 @@
                         "default": {
                             "default": {
                                 "copy": false,
-                                "defvalue": [],
                                 "example": [
                                     "cli: -pdk_lvs_waiver 'asap7 magic M10 basic $PDK/lvs.txt'",
                                     "api: chip.set('pdk', 'asap7','lvs','waiver','magic','M10','basic','$PDK/lvs.txt')"
@@ -7934,7 +7651,6 @@
             },
             "maxlayer": {
                 "default": {
-                    "defvalue": null,
                     "example": [
                         "cli: -pdk_maxlayer 'asap7 2MA4MB2MC M8'",
                         "api: chip.set('pdk', 'asap7', 'maxlayer', 'MA4MB2MC', 'M8')"
@@ -7962,7 +7678,6 @@
             },
             "minlayer": {
                 "default": {
-                    "defvalue": null,
                     "example": [
                         "cli: -pdk_minlayer 'asap7 2MA4MB2MC M2'",
                         "api: chip.set('pdk', 'asap7', 'minlayer', '2MA4MB2MC', 'M2')"
@@ -7989,7 +7704,6 @@
                 }
             },
             "node": {
-                "defvalue": null,
                 "example": [
                     "cli: -pdk_node 'asap7 130'",
                     "api:  chip.set('pdk', 'asap7', 'node', 130)"
@@ -8015,7 +7729,6 @@
                 "type": "float"
             },
             "panelsize": {
-                "defvalue": [],
                 "example": [
                     "cli: -pdk_panelsize 'asap7 (45.72,60.96)'",
                     "api:  chip.set('pdk', 'asap7', 'panelsize', (45.72,60.96))"
@@ -8046,7 +7759,6 @@
                     "default": {
                         "default": {
                             "copy": false,
-                            "defvalue": [],
                             "example": [
                                 "cli: -pdk_pexmodel 'asap7 fastcap M10 max wire.mod'",
                                 "api: chip.set('pdk','asap7','pexmodel','fastcap','M10','max','wire.mod')"
@@ -8079,7 +7791,6 @@
                 }
             },
             "stackup": {
-                "defvalue": [],
                 "example": [
                     "cli: -pdk_stackup 'asap7 2MA4MB2MC'",
                     "api: chip.add('pdk', 'asap7','stackup','2MA4MB2MC')"
@@ -8106,7 +7817,6 @@
             },
             "thickness": {
                 "default": {
-                    "defvalue": null,
                     "example": [
                         "cli: -pdk_thickness 'asap7 2MA4MB2MC 1.57'",
                         "api:  chip.set('pdk', 'asap7', 'thickness', '2MA4MB2MC', 1.57)"
@@ -8134,7 +7844,6 @@
                 }
             },
             "unitcost": {
-                "defvalue": null,
                 "example": [
                     "cli: -pdk_unitcost 'asap7 10000'",
                     "api:  chip.set('pdk', 'asap7', 'unitcost', 10000)"
@@ -8164,7 +7873,6 @@
                 "default": {
                     "default": {
                         "default": {
-                            "defvalue": [],
                             "example": [
                                 "cli: -pdk_var 'asap7 xyce modeltype M10 bsim4'",
                                 "api: chip.set('pdk','asap7','var','xyce','modeltype','M10','bsim4')"
@@ -8193,7 +7901,6 @@
                 }
             },
             "version": {
-                "defvalue": null,
                 "example": [
                     "cli: -pdk_version 'asap7 1.0'",
                     "api:  chip.set('pdk', 'asap7', 'version', '1.0')"
@@ -8219,7 +7926,6 @@
                 "type": "str"
             },
             "vscribe": {
-                "defvalue": null,
                 "example": [
                     "cli: -pdk_vscribe 'asap7 0.1'",
                     "api:  chip.set('pdk', 'asap7', 'vscribe', 0.1)"
@@ -8246,7 +7952,6 @@
                 "unit": "mm"
             },
             "wafersize": {
-                "defvalue": null,
                 "example": [
                     "cli: -pdk_wafersize 'asap7 300'",
                     "api:  chip.set('pdk', 'asap7', 'wafersize', 300)"
@@ -8276,7 +7981,6 @@
     },
     "record": {
         "arch": {
-            "defvalue": null,
             "example": [
                 "cli: -record_arch 'dfm 0 <x86_64>'",
                 "api: chip.set('record', 'arch', <x86_64>, step='dfm', index=0)"
@@ -8302,7 +8006,6 @@
             "type": "str"
         },
         "distro": {
-            "defvalue": null,
             "example": [
                 "cli: -record_distro 'dfm 0 <ubuntu>'",
                 "api: chip.set('record', 'distro', <ubuntu>, step='dfm', index=0)"
@@ -8328,7 +8031,6 @@
             "type": "str"
         },
         "endtime": {
-            "defvalue": null,
             "example": [
                 "cli: -record_endtime 'dfm 0 <2021-09-06 12:20:20>'",
                 "api: chip.set('record', 'endtime', <2021-09-06 12:20:20>, step='dfm', index=0)"
@@ -8354,7 +8056,6 @@
             "type": "str"
         },
         "ipaddr": {
-            "defvalue": null,
             "example": [
                 "cli: -record_ipaddr 'dfm 0 <<addr>>'",
                 "api: chip.set('record', 'ipaddr', <<addr>>, step='dfm', index=0)"
@@ -8380,7 +8081,6 @@
             "type": "str"
         },
         "kernelversion": {
-            "defvalue": null,
             "example": [
                 "cli: -record_kernelversion 'dfm 0 <5.11.0-34-generic>'",
                 "api: chip.set('record', 'kernelversion', <5.11.0-34-generic>, step='dfm', index=0)"
@@ -8406,7 +8106,6 @@
             "type": "str"
         },
         "macaddr": {
-            "defvalue": null,
             "example": [
                 "cli: -record_macaddr 'dfm 0 <<addr>>'",
                 "api: chip.set('record', 'macaddr', <<addr>>, step='dfm', index=0)"
@@ -8432,7 +8131,6 @@
             "type": "str"
         },
         "machine": {
-            "defvalue": null,
             "example": [
                 "cli: -record_machine 'dfm 0 <carbon>'",
                 "api: chip.set('record', 'machine', <carbon>, step='dfm', index=0)"
@@ -8458,7 +8156,6 @@
             "type": "str"
         },
         "osversion": {
-            "defvalue": null,
             "example": [
                 "cli: -record_osversion 'dfm 0 <20.04.1-Ubuntu>'",
                 "api: chip.set('record', 'osversion', <20.04.1-Ubuntu>, step='dfm', index=0)"
@@ -8484,7 +8181,6 @@
             "type": "str"
         },
         "platform": {
-            "defvalue": null,
             "example": [
                 "cli: -record_platform 'dfm 0 <linux>'",
                 "api: chip.set('record', 'platform', <linux>, step='dfm', index=0)"
@@ -8510,7 +8206,6 @@
             "type": "str"
         },
         "publickey": {
-            "defvalue": null,
             "example": [
                 "cli: -record_publickey 'dfm 0 <<key>>'",
                 "api: chip.set('record', 'publickey', <<key>>, step='dfm', index=0)"
@@ -8536,7 +8231,6 @@
             "type": "str"
         },
         "region": {
-            "defvalue": null,
             "example": [
                 "cli: -record_region 'dfm 0 <US Gov Boston>'",
                 "api: chip.set('record', 'region', <US Gov Boston>, step='dfm', index=0)"
@@ -8562,7 +8256,6 @@
             "type": "str"
         },
         "scversion": {
-            "defvalue": null,
             "example": [
                 "cli: -record_scversion 'dfm 0 <1.0>'",
                 "api: chip.set('record', 'scversion', <1.0>, step='dfm', index=0)"
@@ -8588,7 +8281,6 @@
             "type": "str"
         },
         "starttime": {
-            "defvalue": null,
             "example": [
                 "cli: -record_starttime 'dfm 0 <2021-09-06 12:20:20>'",
                 "api: chip.set('record', 'starttime', <2021-09-06 12:20:20>, step='dfm', index=0)"
@@ -8614,7 +8306,6 @@
             "type": "str"
         },
         "toolargs": {
-            "defvalue": null,
             "example": [
                 "cli: -record_toolargs 'dfm 0 <-I include/ foo.v>'",
                 "api: chip.set('record', 'toolargs', <-I include/ foo.v>, step='dfm', index=0)"
@@ -8640,7 +8331,6 @@
             "type": "str"
         },
         "toolpath": {
-            "defvalue": null,
             "example": [
                 "cli: -record_toolpath 'dfm 0 </usr/bin/openroad>'",
                 "api: chip.set('record', 'toolpath', </usr/bin/openroad>, step='dfm', index=0)"
@@ -8666,7 +8356,6 @@
             "type": "str"
         },
         "toolversion": {
-            "defvalue": null,
             "example": [
                 "cli: -record_toolversion 'dfm 0 <1.0>'",
                 "api: chip.set('record', 'toolversion', <1.0>, step='dfm', index=0)"
@@ -8692,7 +8381,6 @@
             "type": "str"
         },
         "userid": {
-            "defvalue": null,
             "example": [
                 "cli: -record_userid 'dfm 0 <wiley>'",
                 "api: chip.set('record', 'userid', <wiley>, step='dfm', index=0)"
@@ -8719,7 +8407,6 @@
         }
     },
     "schemaversion": {
-        "defvalue": "0.33.0",
         "example": [
             "api: chip.get('schemaversion')"
         ],
@@ -8746,7 +8433,6 @@
     "tool": {
         "default": {
             "exe": {
-                "defvalue": null,
                 "example": [
                     "cli: -tool_exe 'openroad openroad'",
                     "api:  chip.set('tool','openroad','exe','openroad')"
@@ -8772,7 +8458,6 @@
                 "type": "str"
             },
             "format": {
-                "defvalue": null,
                 "example": [
                     "cli: -tool_format 'yosys tcl'",
                     "api: chip.set('tool','yosys','format','tcl')"
@@ -8799,7 +8484,6 @@
             },
             "licenseserver": {
                 "default": {
-                    "defvalue": [],
                     "example": [
                         "cli: -tool_licenseserver 'atask ACME_LICENSE 1700@server'",
                         "api: chip.set('tool','acme','licenseserver','ACME_LICENSE','1700@server')"
@@ -8827,7 +8511,6 @@
             },
             "path": {
                 "copy": false,
-                "defvalue": null,
                 "example": [
                     "cli: -tool_path 'openroad /usr/local/bin'",
                     "api: chip.set('tool','openroad','path','/usr/local/bin')"
@@ -8855,7 +8538,6 @@
             "sbom": {
                 "default": {
                     "copy": false,
-                    "defvalue": [],
                     "example": [
                         "cli: -tool_sbom 'yosys 1.0.1 ys_sbom.json'",
                         "api:  chip.set('tool','yosys','sbom','1.0','ys_sbom.json')"
@@ -8888,7 +8570,6 @@
             "task": {
                 "default": {
                     "continue": {
-                        "defvalue": false,
                         "example": [
                             "cli: -tool_task_continue 'verilator lint true'",
                             "api: chip.set('tool','verilator','task','lint','continue',True)"
@@ -8916,7 +8597,6 @@
                     "dir": {
                         "default": {
                             "copy": false,
-                            "defvalue": [],
                             "example": [
                                 "cli: -tool_task_dir 'verilator compile cincludes include'",
                                 "api: chip.set('tool','verilator','task','compile','dir','cincludes', 'include')"
@@ -8944,7 +8624,6 @@
                     },
                     "env": {
                         "default": {
-                            "defvalue": null,
                             "example": [
                                 "cli: -tool_task_env 'openroad cts MYVAR 42'",
                                 "api: chip.set('tool','openroad','task','cts','env','MYVAR','42')"
@@ -8973,7 +8652,6 @@
                     "file": {
                         "default": {
                             "copy": false,
-                            "defvalue": [],
                             "example": [
                                 "cli: -tool_task_file 'openroad floorplan macroplace macroplace.tcl'",
                                 "api: chip.set('tool','openroad','task','floorplan','file','macroplace', 'macroplace.tcl')"
@@ -9005,7 +8683,6 @@
                     },
                     "input": {
                         "copy": false,
-                        "defvalue": [],
                         "example": [
                             "cli: -tool_task_input 'openroad place place 0 oh_add.def'",
                             "api: chip.set('tool','openroad','task','place','input','oh_add.def', step='place', index='0')"
@@ -9035,7 +8712,6 @@
                         "type": "[file]"
                     },
                     "keep": {
-                        "defvalue": [],
                         "example": [
                             "cli: -tool_task_keep 'surelog import slp_all'",
                             "api: chip.set('tool','surelog','task','import','script','slpp_all')"
@@ -9061,7 +8737,6 @@
                         "type": "[str]"
                     },
                     "option": {
-                        "defvalue": [],
                         "example": [
                             "cli: -tool_task_option 'openroad cts -no_init'",
                             "api: chip.set('tool','openroad','task','cts','option','-no_init')"
@@ -9088,7 +8763,6 @@
                     },
                     "output": {
                         "copy": false,
-                        "defvalue": [],
                         "example": [
                             "cli: -tool_task_output 'openroad place place 0 oh_add.def'",
                             "api: chip.set('tool','openroad','task','place','output','oh_add.def', step='place', index='0')"
@@ -9119,7 +8793,6 @@
                     },
                     "postscript": {
                         "copy": false,
-                        "defvalue": [],
                         "example": [
                             "cli: -tool_task_postscript 'yosys syn syn_post.tcl'",
                             "api: chip.set('tool','yosys','task','syn_asic','postscript','syn_post.tcl')"
@@ -9150,7 +8823,6 @@
                     },
                     "prescript": {
                         "copy": false,
-                        "defvalue": [],
                         "example": [
                             "cli: -tool_task_prescript 'yosys syn syn_pre.tcl'",
                             "api: chip.set('tool','yosys','task','syn_asic','prescript','syn_pre.tcl')"
@@ -9181,7 +8853,6 @@
                     },
                     "refdir": {
                         "copy": false,
-                        "defvalue": [],
                         "example": [
                             "cli: -tool_task_refdir 'yosys syn ./myref'",
                             "api:  chip.set('tool','yosys','task','syn_asic','refdir','./myref')"
@@ -9208,7 +8879,6 @@
                     },
                     "regex": {
                         "default": {
-                            "defvalue": [],
                             "example": [
                                 "cli: -tool_task_regex 'openroad place errors \"-v ERROR\"'",
                                 "api: chip.set('tool','openroad','task','place','regex','errors','-v ERROR')"
@@ -9237,7 +8907,6 @@
                     "report": {
                         "default": {
                             "copy": false,
-                            "defvalue": [],
                             "example": [
                                 "cli: -tool_task_report 'openroad place holdtns place 0 place.log'",
                                 "api: chip.set('tool','openroad','task','place','report','holdtns','place.log', step='place', index='0')"
@@ -9268,7 +8937,6 @@
                         }
                     },
                     "require": {
-                        "defvalue": [],
                         "example": [
                             "cli: -tool_task_require 'openroad cts design'",
                             "api: chip.set('tool','openroad', 'task','cts','require','design')"
@@ -9295,7 +8963,6 @@
                     },
                     "script": {
                         "copy": false,
-                        "defvalue": [],
                         "example": [
                             "cli: -tool_task_script 'yosys syn syn.tcl'",
                             "api: chip.set('tool','yosys','task','syn_asic','script','syn.tcl')"
@@ -9326,7 +8993,6 @@
                     },
                     "stderr": {
                         "destination": {
-                            "defvalue": "log",
                             "example": [
                                 "cli: -tool_task_stderr_destination 'ghdl import log'",
                                 "api: chip.set('tool',ghdl','task','import','stderr','destination','log')"
@@ -9352,7 +9018,6 @@
                             "type": "str"
                         },
                         "suffix": {
-                            "defvalue": "log",
                             "example": [
                                 "cli: -tool_task_stderr_suffix 'ghdl import log'",
                                 "api: chip.set('tool','ghdl','task','import','stderr','suffix','log')"
@@ -9380,7 +9045,6 @@
                     },
                     "stdout": {
                         "destination": {
-                            "defvalue": "log",
                             "example": [
                                 "cli: -tool_task_stdout_destination 'ghdl import log'",
                                 "api: chip.set('tool','ghdl','task','import','stdout','destination','log')"
@@ -9406,7 +9070,6 @@
                             "type": "str"
                         },
                         "suffix": {
-                            "defvalue": "log",
                             "example": [
                                 "cli: -tool_task_stdout_suffix 'ghdl import log'",
                                 "api: chip.set('tool',ghdl','task','import','stdout','suffix','log')"
@@ -9433,7 +9096,6 @@
                         }
                     },
                     "threads": {
-                        "defvalue": null,
                         "example": [
                             "cli: -tool_task_threads 'magic drc 64'",
                             "api: chip.set('tool','magic','task', 'drc','threads','64')"
@@ -9460,7 +9122,6 @@
                     },
                     "var": {
                         "default": {
-                            "defvalue": [],
                             "example": [
                                 "cli: -tool_task_var 'openroad cts myvar 42'",
                                 "api: chip.set('tool','openroad','task','cts','var','myvar','42')"
@@ -9487,7 +9148,6 @@
                         }
                     },
                     "warningoff": {
-                        "defvalue": [],
                         "example": [
                             "cli: -tool_task_warningoff 'verilator lint COMBDLY'",
                             "api: chip.set('tool','verilator','task','lint','warningoff','COMBDLY')"
@@ -9515,7 +9175,6 @@
                 }
             },
             "vendor": {
-                "defvalue": null,
                 "example": [
                     "cli: -tool_vendor 'yosys yosys'",
                     "api: chip.set('tool','yosys','vendor','yosys')"
@@ -9541,7 +9200,6 @@
                 "type": "str"
             },
             "version": {
-                "defvalue": [],
                 "example": [
                     "cli: -tool_version 'openroad >=v2.0'",
                     "api:  chip.set('tool','openroad','version','>=v2.0')"
@@ -9567,7 +9225,6 @@
                 "type": "[str]"
             },
             "vswitch": {
-                "defvalue": [],
                 "example": [
                     "cli: -tool_vswitch 'openroad -version'",
                     "api:  chip.set('tool','openroad','vswitch','-version')"
@@ -9596,7 +9253,6 @@
     },
     "unit": {
         "capacitance": {
-            "defvalue": "pf",
             "example": [
                 "cli: -unit_capacitance 'pf'",
                 "api: chip.set('unit','capacitance',pf)"
@@ -9622,7 +9278,6 @@
             "type": "str"
         },
         "current": {
-            "defvalue": "mA",
             "example": [
                 "cli: -unit_current 'mA'",
                 "api: chip.set('unit','current',mA)"
@@ -9648,7 +9303,6 @@
             "type": "str"
         },
         "energy": {
-            "defvalue": "pj",
             "example": [
                 "cli: -unit_energy 'pj'",
                 "api: chip.set('unit','energy',pj)"
@@ -9674,7 +9328,6 @@
             "type": "str"
         },
         "inductance": {
-            "defvalue": "nh",
             "example": [
                 "cli: -unit_inductance 'nh'",
                 "api: chip.set('unit','inductance',nh)"
@@ -9700,7 +9353,6 @@
             "type": "str"
         },
         "length": {
-            "defvalue": "um",
             "example": [
                 "cli: -unit_length 'um'",
                 "api: chip.set('unit','length',um)"
@@ -9726,7 +9378,6 @@
             "type": "str"
         },
         "mass": {
-            "defvalue": "g",
             "example": [
                 "cli: -unit_mass 'g'",
                 "api: chip.set('unit','mass',g)"
@@ -9752,7 +9403,6 @@
             "type": "str"
         },
         "power": {
-            "defvalue": "mw",
             "example": [
                 "cli: -unit_power 'mw'",
                 "api: chip.set('unit','power',mw)"
@@ -9778,7 +9428,6 @@
             "type": "str"
         },
         "resistance": {
-            "defvalue": "ohm",
             "example": [
                 "cli: -unit_resistance 'ohm'",
                 "api: chip.set('unit','resistance',ohm)"
@@ -9804,7 +9453,6 @@
             "type": "str"
         },
         "temperature": {
-            "defvalue": "C",
             "example": [
                 "cli: -unit_temperature 'C'",
                 "api: chip.set('unit','temperature',C)"
@@ -9830,7 +9478,6 @@
             "type": "str"
         },
         "time": {
-            "defvalue": "ns",
             "example": [
                 "cli: -unit_time 'ns'",
                 "api: chip.set('unit','time',ns)"
@@ -9856,7 +9503,6 @@
             "type": "str"
         },
         "voltage": {
-            "defvalue": "mv",
             "example": [
                 "cli: -unit_voltage 'mv'",
                 "api: chip.set('unit','voltage',mv)"

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -8416,7 +8416,7 @@
             "default": {
                 "default": {
                     "signature": null,
-                    "value": "0.33.0"
+                    "value": "0.34.0"
                 }
             }
         },

--- a/tests/core/test_read_manifest.py
+++ b/tests/core/test_read_manifest.py
@@ -46,12 +46,10 @@ def test_modified_schema(datadir):
 
     # special case (initialized in constructor)
     glbl_key = siliconcompiler.Schema.GLOBAL_KEY
-    expected['design']['node'] = {
-        glbl_key: {
-            glbl_key: {
-                'value': 'test'
-            }
-        }
+    expected['design']['node'][glbl_key] = {}
+    expected['design']['node'][glbl_key][glbl_key] = {
+        'value': 'test',
+        'signature': None
     }
 
     assert chip.schema.cfg == expected

--- a/tests/core/test_scparam.py
+++ b/tests/core/test_scparam.py
@@ -53,7 +53,6 @@ def test_scparam():
         'lock': False,
         'scope': 'job',
         'require': 'all',
-        'defvalue': None,
         'notes': None,
         'pernode': 'never',
         'node': {
@@ -79,7 +78,6 @@ def test_scparam():
         'lock': False,
         'scope': 'job',
         'require': 'asic',
-        'defvalue': None,
         'notes': None,
         'pernode': 'never',
         'node': {
@@ -106,9 +104,9 @@ def test_defvalue():
     '''Regression test that changing list-type value doesn't change defvalue.'''
 
     schema = Schema()
-    assert schema.cfg['asic']['logiclib']['defvalue'] == []
+    assert schema.get_default('asic', 'logiclib') == []
     schema.add('asic', 'logiclib', 'mylib')
-    assert schema.cfg['asic']['logiclib']['defvalue'] == []
+    assert schema.get_default('asic', 'logiclib') == []
 
 
 #########################

--- a/tests/core/test_scparam.py
+++ b/tests/core/test_scparam.py
@@ -56,7 +56,14 @@ def test_scparam():
         'defvalue': None,
         'notes': None,
         'pernode': 'never',
-        'node': {},
+        'node': {
+            'default': {
+                'default': {
+                    'value': None,
+                    'signature': None
+                }
+            }
+        },
         'shorthelp': 'Metric total warnings',
         'example': [
             "cli: -metric_warnings 'dfm 0 goal 0'",
@@ -75,7 +82,14 @@ def test_scparam():
         'defvalue': None,
         'notes': None,
         'pernode': 'never',
-        'node': {},
+        'node': {
+            'default': {
+                'default': {
+                    'value': None,
+                    'signature': None
+                }
+            }
+        },
         'shorthelp': 'Metric instance count',
         'example': [
             "cli: -metric_cells 'place 0 goal 100'",


### PR DESCRIPTION
This PR addresses the fact that our change to storing all value-specific data underneath the "node" dict makes the subfields not appear for unset parameters in a manifest. I fixed this by adding a `'default', 'default'` entry that is always empty and is used to initialize the node dict whenever it gets populated, mimicking the pattern that gets used for schema parameter keypaths themselves.

I was originally planning to have `'global', 'global'` be always filled in by default, but I realized this mucks with some of the logic as it loses the distinction between required and optional pernode parameters (required ones should not have a `'global', 'global'` entry). 