### PR TITLE
Allow integer index for unset()

### DIFF
--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -310,6 +310,9 @@ class Schema:
         if err:
             raise ValueError(f'Invalid args to unset() of keypath {keypath}: {err}')
 
+        if isinstance(index, int):
+            index = str(index)
+
         if cfg['lock']:
             # TODO: log here
             return False

--- a/tests/core/test_setget.py
+++ b/tests/core/test_setget.py
@@ -188,29 +188,6 @@ def test_get_no_side_effect():
     assert chip.getkeys('tool', 'surelog', 'task') == []
 
 
-def test_unset():
-    chip = siliconcompiler.Chip('test')
-    chip.set('option', 'remote', True)
-    assert chip.get('option', 'remote') is True
-
-    # Clearing a keypath resets it to default value
-    chip.unset('option', 'remote')
-    assert chip.get('option', 'remote') is False
-
-    # Able to set a keypath after it's been cleared even if clobber=False
-    chip.set('option', 'remote', True, clobber=False)
-    assert chip.get('option', 'remote') is True
-
-    # Make sure unset() clears values and pernode field
-    chip.set('input', 'doc', 'txt', 'foo.txt')
-    chip.set('input', 'doc', 'txt', 'abc123', field='filehash')
-    chip.unset('input', 'doc', 'txt')
-
-    # arbitrary step/index to avoid error
-    assert chip.get('input', 'doc', 'txt', step='syn', index=0) == []
-    assert chip.get('input', 'doc', 'txt', step='syn', index=0, field='filehash') == []
-
-
 def test_set_enum_success():
     chip = siliconcompiler.Chip('test')
     chip.add('option', 'mode', 'asic_new', field='enum')

--- a/tests/schema/test_unset.py
+++ b/tests/schema/test_unset.py
@@ -28,7 +28,6 @@ def test_unset_clear_fields():
     assert schema.get('input', 'doc', 'txt', step='syn', index=0, field='filehash') == []
 
 
-
 def test_unset_required_pernode():
     schema = Schema()
     schema.set('metric', 'errors', 5, step='syn', index=0)
@@ -42,7 +41,6 @@ def test_unset_required_pernode():
 
 
 def test_unset_optional_pernode():
-    # Note: this behavior may change once we close on SC-351
     schema = Schema()
     schema.set('asic', 'logiclib', 'default_lib')
     assert schema.get('asic', 'logiclib', step='syn', index=0) == ['default_lib']

--- a/tests/schema/test_unset.py
+++ b/tests/schema/test_unset.py
@@ -33,7 +33,7 @@ def test_unset_required_pernode():
     schema.set('metric', 'errors', 5, step='syn', index=0)
     schema.unset('metric', 'errors', step='syn', index=0)
 
-    assert schema.get('metric', 'errors', step='syn', index=0) == None
+    assert schema.get('metric', 'errors', step='syn', index=0) is None
 
     schema.set('metric', 'errors', 6, step='syn', index=0, clobber=False)
 

--- a/tests/schema/test_unset.py
+++ b/tests/schema/test_unset.py
@@ -1,0 +1,58 @@
+from siliconcompiler.schema import Schema
+
+
+def test_unset():
+    schema = Schema()
+    schema.set('option', 'remote', True)
+    assert schema.get('option', 'remote') is True
+
+    # Clearing a keypath resets it to default value
+    schema.unset('option', 'remote')
+    assert schema.get('option', 'remote') is False
+
+    # Able to set a keypath after it's been cleared even if clobber=False
+    schema.set('option', 'remote', True, clobber=False)
+    assert schema.get('option', 'remote') is True
+
+
+def test_unset_clear_fields():
+    '''Ensure unset() clears pernode-fields other than value'''
+    schema = Schema()
+
+    schema.set('input', 'doc', 'txt', 'foo.txt')
+    schema.set('input', 'doc', 'txt', 'abc123', field='filehash')
+    schema.unset('input', 'doc', 'txt')
+
+    # arbitrary step/index to avoid error
+    assert schema.get('input', 'doc', 'txt', step='syn', index=0) == []
+    assert schema.get('input', 'doc', 'txt', step='syn', index=0, field='filehash') == []
+
+
+
+def test_unset_required_pernode():
+    schema = Schema()
+    schema.set('metric', 'errors', 5, step='syn', index=0)
+    schema.unset('metric', 'errors', step='syn', index=0)
+
+    assert schema.get('metric', 'errors', step='syn', index=0) == None
+
+    schema.set('metric', 'errors', 6, step='syn', index=0, clobber=False)
+
+    assert schema.get('metric', 'errors', step='syn', index=0) == 6
+
+
+def test_unset_optional_pernode():
+    # Note: this behavior may change once we close on SC-351
+    schema = Schema()
+    schema.set('asic', 'logiclib', 'default_lib')
+    assert schema.get('asic', 'logiclib', step='syn', index=0) == ['default_lib']
+
+    schema.set('asic', 'logiclib', 'syn_lib', step='syn', index=0)
+    assert schema.get('asic', 'logiclib', step='syn', index=0) == ['syn_lib']
+
+    schema.unset('asic', 'logiclib', step='syn', index=0)
+    assert schema.get('asic', 'logiclib', step='syn', index=0) == ['default_lib']
+    assert schema.get('asic', 'logiclib') == ['default_lib']
+
+    schema.set('asic', 'logiclib', 'syn_lib', step='syn', index=0, clobber=False)
+    assert schema.get('asic', 'logiclib', step='syn', index=0) == ['default_lib']


### PR DESCRIPTION
This PR fixes a bug where `unset()` would act as a silent no-op if an integer index was provided, which is inconsistent with how the `get/set/add` functions behave.

I also added additional unit tests for `unset()`, and moved the existing test from the core tests to the schema tests, since I think moving towards testing base `Schema` functionality within the schema tests will help with organization.