### PR TITLE
trigger daily run if _tools.json changes

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -2,6 +2,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 8 * * *'
+  repository_dispatch:
+    types: [trigger-daily-workflow]
 
 name: 'Daily CI Tests'
 

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -198,3 +198,29 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install .[test]
           pytest -n auto --import-mode=append -m "eda and quick"
+
+  trigger_daily:
+    if: always()
+    needs: build_sc_tools
+    runs-on: ubuntu-latest
+    name: Trigger daily, if tools changed
+    steps:
+      - name: Checkout current SiliconCompiler
+        uses: actions/checkout@v3
+
+      - name: Check tool updates
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            tools:
+              - 'setup/_tools.json'
+
+      - name: Trigger
+        if: steps.changes.outputs.tools == 'true'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          repository: ${{ github.repository }}
+          event-type: trigger-daily-workflow
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
When tools change it would be nice to auto trigger the daily tests so we can see any failures.

Tested on: https://github.com/siliconcompiler/sc_private/actions/runs/4959488716 and https://github.com/siliconcompiler/sc_private/actions/runs/4959691379