### PR TITLE
add flags to control antenna repair and checking in routing task

### DIFF
--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -286,6 +286,8 @@ def setup(chip, mode='batch'):
         ('ant_iterations', '3', 'maximum number of repair iterations to use during '
                                 'antenna repairs'),
         ('ant_margin', '0', 'adds a margin to the antenna ratios (0 - 100)'),
+        ('ant_check', 'true', 'true/false, flag to indicate whether to check for antenna violations'),
+        ('ant_repair', 'true', 'true/false, flag to indicate whether to repair antenna violations'),
         ('grt_use_pin_access', 'false', 'true/false, when true perform pin access before '
                                         'global routing'),
         ('grt_overflow_iter', '100', 'maximum number of iterations to use in flobal routing '

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -286,8 +286,10 @@ def setup(chip, mode='batch'):
         ('ant_iterations', '3', 'maximum number of repair iterations to use during '
                                 'antenna repairs'),
         ('ant_margin', '0', 'adds a margin to the antenna ratios (0 - 100)'),
-        ('ant_check', 'true', 'true/false, flag to indicate whether to check for antenna violations'),
-        ('ant_repair', 'true', 'true/false, flag to indicate whether to repair antenna violations'),
+        ('ant_check', 'true', 'true/false, flag to indicate whether to check for '
+                              'antenna violations'),
+        ('ant_repair', 'true', 'true/false, flag to indicate whether to repair antenna '
+                               'violations'),
         ('grt_use_pin_access', 'false', 'true/false, when true perform pin access before '
                                         'global routing'),
         ('grt_overflow_iter', '100', 'maximum number of iterations to use in flobal routing '

--- a/siliconcompiler/tools/openroad/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/sc_apr.tcl
@@ -237,6 +237,8 @@ set openroad_cts_balance_levels [lindex [dict get $sc_cfg tool $sc_tool task $sc
 
 set openroad_ant_iterations [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} ant_iterations] 0]
 set openroad_ant_margin [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} ant_margin] 0]
+set openroad_ant_check [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} ant_check] 0]
+set openroad_ant_repair [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} ant_repair] 0]
 
 set openroad_grt_use_pin_access [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} grt_use_pin_access] 0]
 set openroad_grt_overflow_iter [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} grt_overflow_iter] 0]

--- a/siliconcompiler/tools/openroad/sc_route.tcl
+++ b/siliconcompiler/tools/openroad/sc_route.tcl
@@ -74,8 +74,10 @@ global_route -guide_file "./route.guide" \
 ######################
 
 estimate_parasitics -global_routing
-if {[check_antennas -report_file "reports/${sc_design}_antenna.rpt"] != 0} {
-  if {[llength [dict get $sc_cfg library $sc_mainlib asic cells antenna]] != 0} {
+if {$openroad_ant_check == "true" && \
+    [check_antennas -report_file "reports/${sc_design}_antenna.rpt"] != 0} {
+  if {$openroad_ant_repair == "true" && \
+      [llength [dict get $sc_cfg library $sc_mainlib asic cells antenna]] != 0} {
     set sc_antenna [lindex [dict get $sc_cfg library $sc_mainlib asic cells antenna] 0]
 
     # Remove filler cells before attempting to repair antennas


### PR DESCRIPTION
allow for bypassing antenna repair steps when they are not needed