### PR TITLE
Enforce mode setting

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4031,10 +4031,12 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             Runs the execution flow defined by the flowgraph dictionary.
         '''
 
-        flow = self.get('option', 'flow')
-        if flow is None:
-            self.error("['option', 'flow'] must be set before calling run()",
-                       fatal=True)
+        # Check required settings before attempting run()
+        for key in (['option', 'flow'],
+                    ['option', 'mode']):
+            if self.get(*key) is None:
+                self.error(f"{key} must be set before calling run()",
+                           fatal=True)
 
         # Auto-update jobname if ['option', 'jobincr'] is True
         # Do this before initializing logger so that it picks up correct jobname
@@ -4056,6 +4058,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         self._init_logger(in_run=True)
 
         # Check if flowgraph is complete and valid
+        flow = self.get('option', 'flow')
         if not self._check_flowgraph(flow=flow):
             self.error(f"{flow} flowgraph contains errors and cannot be run.",
                        fatal=True)

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -163,6 +163,7 @@ def test_merged_graph_good_steplist():
     chip.edge(flow, 'parallel2', 'merge')
     chip.edge(flow, 'merge', 'export')
     chip.set('option', 'flow', flow)
+    chip.set('option', 'mode', 'asic')
 
     chip.run()
 

--- a/tests/core/test_jobincr.py
+++ b/tests/core/test_jobincr.py
@@ -8,6 +8,7 @@ def test_jobincr():
     chip = siliconcompiler.Chip('test')
     flow = 'test'
     chip.set('option', 'flow', flow)
+    chip.set('option', 'mode', 'asic')
     chip.node(flow, 'import', nop)
 
     chip.set('option', 'jobincr', True)


### PR DESCRIPTION
This ensures the option,mode is set correctly before running as this avoid ambiguity about the run type, show the summary table is checked, and when checking mode specific requirements.