### PR TITLE
Fix use of find_files in setup()

### DIFF
--- a/siliconcompiler/tools/openroad/cts.py
+++ b/siliconcompiler/tools/openroad/cts.py
@@ -2,6 +2,7 @@
 from siliconcompiler.tools.openroad.openroad import setup as setup_tool
 from siliconcompiler.tools.openroad.openroad import build_pex_corners
 from siliconcompiler.tools.openroad.openroad import post_process as or_post_process
+from siliconcompiler.tools.openroad.openroad import pre_process as or_pre_process
 
 
 def setup(chip):
@@ -22,6 +23,7 @@ def setup(chip):
 
 
 def pre_process(chip):
+    or_pre_process(chip)
     build_pex_corners(chip)
 
 

--- a/siliconcompiler/tools/openroad/dfm.py
+++ b/siliconcompiler/tools/openroad/dfm.py
@@ -2,6 +2,7 @@
 from siliconcompiler.tools.openroad.openroad import setup as setup_tool
 from siliconcompiler.tools.openroad.openroad import build_pex_corners
 from siliconcompiler.tools.openroad.openroad import post_process as or_post_process
+from siliconcompiler.tools.openroad.openroad import pre_process as or_pre_process
 
 
 def setup(chip):
@@ -22,6 +23,7 @@ def setup(chip):
 
 
 def pre_process(chip):
+    or_pre_process(chip)
     build_pex_corners(chip)
 
 

--- a/siliconcompiler/tools/openroad/export.py
+++ b/siliconcompiler/tools/openroad/export.py
@@ -2,6 +2,7 @@
 from siliconcompiler.tools.openroad.openroad import setup as setup_tool
 from siliconcompiler.tools.openroad.openroad import build_pex_corners
 from siliconcompiler.tools.openroad.openroad import post_process as or_post_process
+from siliconcompiler.tools.openroad.openroad import pre_process as or_pre_process
 
 
 def setup(chip):
@@ -67,6 +68,7 @@ def setup(chip):
 
 
 def pre_process(chip):
+    or_pre_process(chip)
     build_pex_corners(chip)
 
 

--- a/siliconcompiler/tools/openroad/floorplan.py
+++ b/siliconcompiler/tools/openroad/floorplan.py
@@ -2,6 +2,7 @@
 from siliconcompiler.tools.openroad.openroad import setup as setup_tool
 from siliconcompiler.tools.openroad.openroad import build_pex_corners
 from siliconcompiler.tools.openroad.openroad import post_process as or_post_process
+from siliconcompiler.tools.openroad.openroad import pre_process as or_pre_process
 
 
 def setup(chip):
@@ -42,6 +43,7 @@ def setup(chip):
 
 
 def pre_process(chip):
+    or_pre_process(chip)
     build_pex_corners(chip)
 
 

--- a/siliconcompiler/tools/openroad/physyn.py
+++ b/siliconcompiler/tools/openroad/physyn.py
@@ -2,6 +2,7 @@
 from siliconcompiler.tools.openroad.openroad import setup as setup_tool
 from siliconcompiler.tools.openroad.openroad import build_pex_corners
 from siliconcompiler.tools.openroad.openroad import post_process as or_post_process
+from siliconcompiler.tools.openroad.openroad import pre_process as or_pre_process
 
 
 def setup(chip):
@@ -22,6 +23,7 @@ def setup(chip):
 
 
 def pre_process(chip):
+    or_pre_process(chip)
     build_pex_corners(chip)
 
 

--- a/siliconcompiler/tools/openroad/place.py
+++ b/siliconcompiler/tools/openroad/place.py
@@ -2,6 +2,7 @@
 from siliconcompiler.tools.openroad.openroad import setup as setup_tool
 from siliconcompiler.tools.openroad.openroad import build_pex_corners
 from siliconcompiler.tools.openroad.openroad import post_process as or_post_process
+from siliconcompiler.tools.openroad.openroad import pre_process as or_pre_process
 
 
 def setup(chip):
@@ -24,6 +25,7 @@ def setup(chip):
 
 
 def pre_process(chip):
+    or_pre_process(chip)
     build_pex_corners(chip)
 
 

--- a/siliconcompiler/tools/openroad/route.py
+++ b/siliconcompiler/tools/openroad/route.py
@@ -2,6 +2,7 @@
 from siliconcompiler.tools.openroad.openroad import setup as setup_tool
 from siliconcompiler.tools.openroad.openroad import build_pex_corners
 from siliconcompiler.tools.openroad.openroad import post_process as or_post_process
+from siliconcompiler.tools.openroad.openroad import pre_process as or_pre_process
 
 
 def setup(chip):
@@ -22,6 +23,7 @@ def setup(chip):
 
 
 def pre_process(chip):
+    or_pre_process(chip)
     build_pex_corners(chip)
 
 

--- a/siliconcompiler/tools/openroad/screenshot.py
+++ b/siliconcompiler/tools/openroad/screenshot.py
@@ -2,6 +2,7 @@ from siliconcompiler.tools.openroad import openroad
 from siliconcompiler.tools.openroad.openroad import setup as setup_tool
 from siliconcompiler.tools.openroad.openroad import build_pex_corners
 from siliconcompiler.tools.openroad.show import copy_show_files, generic_show_setup
+from siliconcompiler.tools.openroad.openroad import pre_process as or_pre_process
 
 
 ####################################################################
@@ -35,5 +36,6 @@ def setup(chip):
 
 
 def pre_process(chip):
+    or_pre_process(chip)
     copy_show_files(chip)
     build_pex_corners(chip)

--- a/siliconcompiler/tools/openroad/show.py
+++ b/siliconcompiler/tools/openroad/show.py
@@ -4,6 +4,7 @@ import os
 from siliconcompiler.tools.openroad import openroad
 from siliconcompiler.tools.openroad.openroad import setup as setup_tool
 from siliconcompiler.tools.openroad.openroad import build_pex_corners
+from siliconcompiler.tools.openroad.openroad import pre_process as or_pre_process
 
 
 ####################################################################
@@ -54,6 +55,7 @@ def generic_show_setup(chip, task, exit):
 
 
 def pre_process(chip):
+    or_pre_process(chip)
     copy_show_files(chip)
     build_pex_corners(chip)
 

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -56,7 +56,8 @@ def setup(chip):
     # system path, set the path to the bundled copy in the schema.
     if shutil.which('surelog') is None:
         surelog_path = os.path.join(os.path.dirname(__file__), 'bin')
-        chip.set('tool', tool, 'path', surelog_path, clobber=False)
+        if os.path.exists(os.path.join(surelog_path, 'surelog')):
+            chip.set('tool', tool, 'path', surelog_path, clobber=False)
 
     # Log file parsing
     chip.set('tool', tool, 'task', task, 'regex', 'warnings', r'^\[WRN:',

--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -54,9 +54,9 @@ def setup(chip):
     # We package SC wheels with a precompiled copy of Surelog installed to
     # tools/surelog/bin. If the user doesn't have Surelog installed on their
     # system path, set the path to the bundled copy in the schema.
-    if shutil.which('surelog') is None:
+    if shutil.which(exe) is None:
         surelog_path = os.path.join(os.path.dirname(__file__), 'bin')
-        if os.path.exists(os.path.join(surelog_path, 'surelog')):
+        if os.path.exists(os.path.join(surelog_path, exe)):
             chip.set('tool', tool, 'path', surelog_path, clobber=False)
 
     # Log file parsing

--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -41,10 +41,6 @@ def setup_asic(chip):
         chip.add('tool', tool, 'task', task, 'require',
                  ",".join(['tool', tool, 'task', task, 'var', 'synthesis_corner']),
                  step=step, index=index)
-    if get_dff_liberty_file(chip) is None:
-        chip.add('tool', tool, 'task', task, 'require',
-                 ",".join(['tool', tool, 'task', task, 'file', 'dff_liberty']),
-                 step=step, index=index)
 
     if syn_corner is not None:
         # add timing library requirements
@@ -65,7 +61,6 @@ def setup_asic(chip):
 
     # set default control knobs
     logiclibs = chip.get('asic', 'logiclib', step=step, index=index)
-    macrolibs = chip.get('asic', 'macrolib', step=step, index=index)
     mainlib = logiclibs[0]
     for option, value, additional_require in [
             ('flatten', "True", None),
@@ -82,15 +77,6 @@ def setup_asic(chip):
             chip.add('tool', tool, 'task', task, 'require',
                      ",".join(additional_require),
                      step=step, index=index)
-
-    # copy techmapping from libraries
-    for lib in logiclibs + macrolibs:
-        if not chip.valid('library', lib, 'option', 'file', 'yosys_techmap'):
-            continue
-        for techmap in chip.find_files('library', lib, 'option', 'file', 'yosys_techmap'):
-            if techmap is None:
-                continue
-            chip.add('tool', tool, 'task', task, 'file', 'techmap', techmap, step=step, index=index)
 
     # Add conditionally required mainlib variables
     if chip.valid('library', mainlib, 'option', 'var', 'yosys_buffer_cell'):
@@ -112,24 +98,9 @@ def setup_asic(chip):
 
     chip.set('tool', tool, 'task', task, 'var', 'synthesis_corner', get_synthesis_corner(chip),
              step=step, index=index, clobber=False)
-    dff_liberty_file = get_dff_liberty_file(chip)
-    if dff_liberty_file:
-        chip.set('tool', tool, 'task', task, 'file', 'dff_liberty', dff_liberty_file,
-                 step=step, index=index, clobber=False)
     chip.add('tool', tool, 'task', task, 'require',
              ",".join(['tool', tool, 'task', task, 'var', 'synthesis_corner']),
              step=step, index=index)
-    chip.add('tool', tool, 'task', task, 'require',
-             ",".join(['tool', tool, 'task', task, 'file', 'dff_liberty']),
-             step=step, index=index)
-
-    # Constants needed by yosys, do not allow overriding of values so force clobbering
-    chip.set('tool', tool, 'task', task, 'file', 'dff_liberty_file',
-             f"{chip._getworkdir(step=step, index=index)}/inputs/sc_dff_library.lib",
-             step=step, index=index, clobber=True)
-    chip.set('tool', tool, 'task', task, 'file', 'abc_constraint_file',
-             f"{chip._getworkdir(step=step, index=index)}/inputs/sc_abc.constraints",
-             step=step, index=index, clobber=True)
 
     abc_driver = get_abc_driver(chip)
     if abc_driver:
@@ -447,6 +418,30 @@ def pre_process(chip):
     step = chip.get('arg', 'step')
     index = chip.get('arg', 'index')
     tool, task = chip._get_tool_task(step, index)
+
+    # copy techmapping from libraries
+    logiclibs = chip.get('asic', 'logiclib', step=step, index=index)
+    macrolibs = chip.get('asic', 'macrolib', step=step, index=index)
+    for lib in logiclibs + macrolibs:
+        if not chip.valid('library', lib, 'option', 'file', 'yosys_techmap'):
+            continue
+        for techmap in chip.find_files('library', lib, 'option', 'file', 'yosys_techmap'):
+            if techmap is None:
+                continue
+            chip.add('tool', tool, 'task', task, 'file', 'techmap', techmap, step=step, index=index)
+
+    # Constants needed by yosys, do not allow overriding of values so force clobbering
+    chip.set('tool', tool, 'task', task, 'file', 'dff_liberty_file',
+             f"{chip._getworkdir(step=step, index=index)}/inputs/sc_dff_library.lib",
+             step=step, index=index, clobber=True)
+    chip.set('tool', tool, 'task', task, 'file', 'abc_constraint_file',
+             f"{chip._getworkdir(step=step, index=index)}/inputs/sc_abc.constraints",
+             step=step, index=index, clobber=True)
+
+    dff_liberty_file = get_dff_liberty_file(chip)
+    if dff_liberty_file:
+        chip.set('tool', tool, 'task', task, 'file', 'dff_liberty', dff_liberty_file,
+                 step=step, index=index, clobber=False)
 
     abc_clock_period = get_abc_period(chip)
     if abc_clock_period:

--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -135,13 +135,6 @@ def setup_asic(chip):
     if abc_driver:
         chip.set('tool', tool, 'task', task, 'var', 'abc_constraint_driver', abc_driver,
                  step=step, index=index, clobber=False)
-    abc_clock_period = get_abc_period(chip)
-    if abc_clock_period:
-        chip.set('tool', tool, 'task', task, 'var', 'abc_clock_period', str(abc_clock_period),
-                 step=step, index=index, clobber=False)
-        chip.add('tool', tool, 'task', task, 'require',
-                 ",".join(['tool', tool, 'task', task, 'var', 'abc_clock_period']),
-                 step=step, index=index)
 
     # document parameters
     chip.set('tool', tool, 'task', task, 'var', 'preserve_modules',
@@ -450,6 +443,15 @@ def get_abc_driver(chip):
 def pre_process(chip):
     ''' Tool specific function to run before step execution
     '''
+
+    step = chip.get('arg', 'step')
+    index = chip.get('arg', 'index')
+    tool, task = chip._get_tool_task(step, index)
+
+    abc_clock_period = get_abc_period(chip)
+    if abc_clock_period:
+        chip.set('tool', tool, 'task', task, 'var', 'abc_clock_period', str(abc_clock_period),
+                 step=step, index=index, clobber=False)
 
     prepare_synthesis_libraries(chip)
     create_abc_synthesis_constraints(chip)


### PR DESCRIPTION
This fixes the use of `find_files()` in `setup()` for the tools and moves it to the `pre_process()` where it belongs.
