### PR TITLE
Fix permission child and error message in load_target

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -637,7 +637,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                     modules.append(mod)
 
             if len(modules) == 0:
-                self.error(f'Could not find target {module}', fatal=True)
+                # attempt to load just the module again with raising the actual error,
+                # this will ensure a useful error message is generated to the user
+                self._load_module(module, raise_error=True)
         else:
             modules = [module]
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3942,6 +3942,10 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                                 # Process may have already terminated or been killed.
                                 # Retain existing memory usage statistics in this case.
                                 pass
+                            except PermissionError:
+                                # OS is preventing access to this information so it cannot
+                                # be collected
+                                pass
 
                             # Loop until process terminates
                             if not quiet:


### PR DESCRIPTION
Fixes:
When the OS permissions do not allow access to the memory / child processes this ensure we still function
Adds useful error when load_target fails to get module