### PR TITLE
Improving datasheet schema

### DIFF
--- a/examples/gcd/gcd_skywater.py
+++ b/examples/gcd/gcd_skywater.py
@@ -20,7 +20,7 @@ def main():
 
     chip.load_target("skywater130_demo")
 
-    chip.set('datasheet', chip.top(), 'pin', 'vdd', 'type', 'global', 'power')
+    chip.set('datasheet', chip.top(), 'pin', 'vdd', 'type', 'global', 'supply')
     chip.set('datasheet', chip.top(), 'pin', 'vss', 'type', 'global', 'ground')
 
     # 1) RTL2GDS

--- a/examples/gcd/gcd_skywater.py
+++ b/examples/gcd/gcd_skywater.py
@@ -20,8 +20,8 @@ def main():
 
     chip.load_target("skywater130_demo")
 
-    chip.set('datasheet', chip.top(), 'pin', 'vdd', 'type', 'global', 'supply')
-    chip.set('datasheet', chip.top(), 'pin', 'vss', 'type', 'global', 'ground')
+    chip.set('datasheet', 'pin', 'vdd', 'type', 'global', 'supply')
+    chip.set('datasheet', 'pin', 'vss', 'type', 'global', 'ground')
 
     # 1) RTL2GDS
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3398,7 +3398,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
            Create a clock named 'clk' with a 1.0ns period.
         """
         design = self.top()
-        self.set('datasheet', design, 'pin', pin, 'type', 'global', 'clk')
+        self.set('datasheet', design, 'pin', pin, 'type', 'global', 'clock')
 
         period_range = (period * 1e-9, period * 1e-9, period * 1e-9)
         self.set('datasheet', design, 'pin', pin, 'tperiod', 'global', period_range)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3384,9 +3384,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         The method modifies the following schema parameters:
 
-        ['datasheet', design, 'pin', pin, 'type', mode]
-        ['datasheet', design, 'pin', pin, 'tperiod', mode]
-        ['datasheet', design, 'pin', pin, 'tjitter', mode]
+        ['datasheet', 'pin', pin, 'type', mode]
+        ['datasheet', 'pin', pin, 'tperiod', mode]
+        ['datasheet', 'pin', pin, 'tjitter', mode]
 
         Args:
             pin (str): Full hierarchical path to clk pin.
@@ -3398,14 +3398,14 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             >>> chip.clock('clk', period=1.0)
            Create a clock named 'clk' with a 1.0ns period.
         """
-        design = self.top()
-        self.set('datasheet', design, 'pin', pin, 'type', mode, 'clock')
+
+        self.set('datasheet', 'pin', pin, 'type', mode, 'clock')
 
         period_range = (period * 1e-9, period * 1e-9, period * 1e-9)
-        self.set('datasheet', design, 'pin', pin, 'tperiod', mode, period_range)
+        self.set('datasheet', 'pin', pin, 'tperiod', mode, period_range)
 
         jitter_range = (jitter * 1e-9, jitter * 1e-9, jitter * 1e-9)
-        self.set('datasheet', design, 'pin', pin, 'tjitter', mode, jitter_range)
+        self.set('datasheet', 'pin', pin, 'tjitter', mode, jitter_range)
 
     ###########################################################################
     def node(self, flow, step, task, index=0):

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3375,7 +3375,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         return allpaths
 
     ###########################################################################
-    def clock(self, pin, period, jitter=0):
+    def clock(self, pin, period, jitter=0, mode='global'):
         """
         Clock configuration helper function.
 
@@ -3384,27 +3384,28 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         The method modifies the following schema parameters:
 
-        ['datasheet', name, 'pin']
-        ['datasheet', name, 'period']
-        ['datasheet', name, 'jitter']
+        ['datasheet', design, 'pin', pin, 'type', mode]
+        ['datasheet', design, 'pin', pin, 'tperiod', mode]
+        ['datasheet', design, 'pin', pin, 'tjitter', mode]
 
         Args:
             pin (str): Full hierarchical path to clk pin.
             period (float): Clock period specified in ns.
             jitter (float): Clock jitter specified in ns.
+            mode (str): Mode of operation (from datasheet).
 
         Examples:
             >>> chip.clock('clk', period=1.0)
            Create a clock named 'clk' with a 1.0ns period.
         """
         design = self.top()
-        self.set('datasheet', design, 'pin', pin, 'type', 'global', 'clock')
+        self.set('datasheet', design, 'pin', pin, 'type', mode, 'clock')
 
         period_range = (period * 1e-9, period * 1e-9, period * 1e-9)
-        self.set('datasheet', design, 'pin', pin, 'tperiod', 'global', period_range)
+        self.set('datasheet', design, 'pin', pin, 'tperiod', mode, period_range)
 
         jitter_range = (jitter * 1e-9, jitter * 1e-9, jitter * 1e-9)
-        self.set('datasheet', design, 'pin', pin, 'tjitter', 'global', jitter_range)
+        self.set('datasheet', design, 'pin', pin, 'tjitter', mode, jitter_range)
 
     ###########################################################################
     def node(self, flow, step, task, index=0):

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -865,14 +865,14 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
 
     # Pin reset value
     scparam(cfg, ['datasheet', design, 'pin', name, 'resetvalue', mode],
-            sctype='[str]',
+            sctype='enum',
+            enum=['weak1', 'weak0', 'strong0', 'strong1', 'highz'],
             shorthelp="Datasheet: pin reset value",
             switch="-datasheet_pin_resetvalue 'design name mode <str>'",
             example=[
                 "cli: -datasheet_pin_resetvalue 'mydevice clk global weak1'",
                 "api: chip.set('datasheet','mydevice','pin','clk','resetvalue','global','weak1')"],
-            schelp="""Pin reset value specified on a per mode basis. Legal reset
-            values include weak1, weak0, strong0, strong1, highz.""")
+            schelp="""Pin reset value specified on a per mode basis.""")
 
     # Device specifications
     metrics = {'vmax': ['absolute maximum voltage', (0.2, 0.3, 0.9), 'V'],

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -769,7 +769,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
     metrics = {'storagetemp': ['storage temperature limits', (-40, 125), 'C'],
                'soldertemp': ['solder temperature limits', (-40, 125), 'C'],
                'junctiontemp': ['junction temperature limits', (-40, 125), 'C'],
-               'tid': ['total inonizing dose threshold', (3e5, 3e5), 'rad'],
+               'tid': ['total ionizing dose threshold', (3e5, 3e5), 'rad'],
                'sel': ['single event latchup threshold', (75, 75), 'MeV-cm2/mg'],
                'seb': ['single event burnout threshold', (75, 75), 'MeV-cm2/mg'],
                'segr': ['single event gate rupture threshold', (75, 75), 'MeV-cm2/mg'],
@@ -822,7 +822,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             reliability test condition is captured as key/value pairs, where
             the key is any test condition capture in the standard. Examples
             of test conditions include time, mintemp, maxtemp, cycles, vmax,
-            mostiure.""")
+            moisture.""")
 
     # Package pin map
     scparam(cfg, ['datasheet', design, 'pin', name, 'map', mode],
@@ -843,8 +843,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             example=[
                 "cli: -datasheet_pin_type 'mydevice vdd global supply'",
                 "api: chip.set('datasheet','mydevice','pin','vdd','type','global','supply')"],
-            schelp="""Pin type specified on a per mode basis. Acceptable pin types
-            include: digital, analog, clock, supply, ground""")
+            schelp="""Pin type specified on a per mode basis.""")
 
     # Pin direction
     scparam(cfg, ['datasheet', design, 'pin', name, 'dir', mode],
@@ -912,9 +911,9 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                'vnoise': ['random voltage noise', (0, 0.01, 0.1), 'V'],
                'vslew': ['slew rate', (1e-9, 2e-9, 4e-9), 'V/s'],
                # ESD
-               'vhbm': ['ESD human body model level', (200, 250, 300), 'V'],
-               'vcdm': ['ESD charge device model level', (125, 150, 175), 'V'],
-               'vmm': ['ESD machine model level', (100, 125, 150), 'V'],
+               'vhbm': ['ESD human body model voltage level', (200, 250, 300), 'V'],
+               'vcdm': ['ESD charge device model voltage level', (125, 150, 175), 'V'],
+               'vmm': ['ESD machine model voltage level', (100, 125, 150), 'V'],
                # RC
                'cap': ['capacitance', (1e-12, 1.2e-12, 1.5e-12), 'F'],
                'rdiff': ['differential pair resistance', (45, 50, 55), 'Ohm'],
@@ -1020,16 +1019,18 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             schelp="""Pin function specified on a per mode basis.
             Only applicable to output pins.""")
 
-    scparam(cfg, ['datasheet', design, 'pin', name, 'polarity', mode, name],
+    relpin = 'default'
+
+    scparam(cfg, ['datasheet', design, 'pin', name, 'polarity', mode, relpin],
             sctype='enum',
             enum=['positive', 'negative', 'none'],
             shorthelp="Datasheet: pin polarity",
-            switch="-datasheet_pin_polarity 'design name mode name <str>'",
+            switch="-datasheet_pin_polarity 'design name mode relpin <str>'",
             example=[
                 "cli: -datasheet_pin_polarity 'cpu q def clk none'",
                 "api: chip.set('datasheet','cpu','pin','q','polarity','def','clk,'none')"],
             schelp="""Pin polarity specified on a per mode basis. Only applicable to output
-            pins. Valid entries are: positive, negative, none.""")
+            pins.""")
 
     return cfg
 

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -781,10 +781,10 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 schelp=f"""Device absolute {val} not to be exceeded.""")
 
     # Thermal model
-    metrics = {'rja': 'junction to ambient thermal resistence',
-               'rjct': 'junction to case (top) thermal resistence',
-               'rjcb': 'junction to case (bottom) thermal resistence',
-               'rjb': 'junction to board thermal resistence',
+    metrics = {'rja': 'junction to ambient thermal resistance',
+               'rjct': 'junction to case (top) thermal resistance',
+               'rjcb': 'junction to case (bottom) thermal resistance',
+               'rjb': 'junction to board thermal resistance',
                'tjt': 'junction to top characterization parameter',
                'tjb': 'junction to bottom characterization parameter'}
 

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -13,7 +13,6 @@ except ImportError:
 
 SCHEMA_VERSION = '0.32.0'
 
-
 #############################################################################
 # PARAM DEFINITION
 #############################################################################
@@ -742,7 +741,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             switch="-datasheet_feature 'design name <float>'",
             example=[
                 "cli: -datasheet_feature 'mydevice ram 64e6'",
-                "api: chip.set('datasheet','mydevice','feature','ram', 1e9)"],
+                "api: chip.set('datasheet','mydevice','feature','ram',64e6)"],
             schelp="""Quantity of a specified feature. The 'unit'
             field should be used to specify the units used when unclear.""")
 
@@ -759,30 +758,39 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             standard footprint names or a custom naming methodology used in
             conjunction with 'fileset' names in the output parameter.""")
 
-    # Absolute max voltage
-    scparam(cfg, ['datasheet', design, 'limits', 'voltage', name],
-            sctype='(float,float)',
-            shorthelp="Datasheet: absolute voltage limits",
-            switch="-datasheet_limits_voltage 'design pin <(float,float)>'",
-            example=[
-                "cli: -datasheet_limits_voltage 'mydevice vdd (-0.4,1.1)'",
-                "api: chip.set('datasheet','mydevice','limits','voltage','vdd', (-0.4,1.1))"],
-            schelp="""Device absolute minimum/maximum voltage not to be
-            exceeded, specified on a per pin basis.""")
-
     # Absolute max temperatures
     metrics = {'storagetemp': 'storage temperature limits',
+               'soldertemp': 'solder temperature limits',
                'junctiontemp': 'junction temperature limits'}
 
     for item, val in metrics.items():
         scparam(cfg, ['datasheet', design, 'limits', item],
                 sctype='(float,float)',
                 shorthelp=f"Datasheet: absolute {val}",
-                switch=f"-datasheet_{item} 'design <(float,float)>'",
+                switch=f"-datasheet_limits_{item} 'design <(float,float)>'",
                 example=[
-                    f"cli: -datasheet_{item} 'mydevice (-40,125)'",
+                    f"cli: -datasheet_limits_{item} 'mydevice (-40,125)'",
                     f"api: chip.set('datasheet','mydevice','limits','{item}',(-40,125))"],
                 schelp=f"""Device absolute {val} not to be exceeded.""")
+
+    # Thermal Resistence
+    metrics = {'rja': 'junction to ambient thermal resistence',
+               'rjct': 'junction to case (top) thermal resistence',
+               'rjcb': 'junction to case (bottom)thermal resistence',
+               'rjb': 'junction to board thermal resistence',
+               'tjt': 'junction to top characterization parameter',
+               'tjb': 'junction to bottom characterization parameter'}
+
+    for item, val in metrics.items():
+        scparam(cfg, ['datasheet', design, 'thermal', item],
+                unit='C/W',
+                sctype='float',
+                shorthelp=f"Datasheet: {val}",
+                switch=f"-datasheet_thermal_{item} 'design <float>'",
+                example=[
+                    f"cli: -datasheet_thermal_{item} 'mydevice 30.4'",
+                    f"api: chip.set('datasheet','mydevice','thermal','{item}',30.4)"],
+                schelp=f"""Device {item} specified in C/W.""")
 
     # Package Pin Map
     package = 'default'
@@ -801,10 +809,23 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             shorthelp="Datasheet: pin type",
             switch="-datasheet_pin_type 'design name mode <str>'",
             example=[
-                "cli: -datasheet_pin_type 'mydevice vdd type power'",
-                "api: chip.set('datasheet','mydevice','pin','vdd','type','global','power')"],
-            schelp="""Pin type specified on a per mode basis. Acceptable pin types
+                f"cli: -datasheet_pin_type 'mydevice vdd global power'",
+                f"api: chip.set('datasheet','mydevice','pin','vdd','type','global','power')"],
+            schelp=f"""Pin type specified on a per mode basis. Acceptable pin types
             include: digital, analog, clk, power, ground""")
+
+    # Pin function
+    scparam(cfg, ['datasheet', design, 'pin', name, 'function', mode],
+            sctype='str',
+            shorthelp=f"Datasheet: pin function",
+            switch=f"-datasheet_pin_function 'design name mode <str>'",
+            example=[
+                f"cli: -datasheet_pin_function 'mydevice z global a&b'",
+                f"api: chip.set('datasheet','mydevice','pin','z','function','global','a&b')"],
+            schelp=f"""Pin function specified on a per mode basis. Only applicable to output
+            pins.""")
+
+
 
     # Pin direction
     scparam(cfg, ['datasheet', design, 'pin', name, 'dir', mode],
@@ -828,45 +849,15 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             schelp="""Pin complement specified on a per mode basis for differential
             signals.""")
 
-    # Related clock
-    scparam(cfg, ['datasheet', design, 'pin', name, 'clk', mode],
-            sctype='str',
-            shorthelp="Datasheet: pin related clock",
-            switch="-datasheet_pin_clk 'design name mode <str>'",
-            example=[
-                "cli: -datasheet_pin_clk 'mydevice ina global clka'",
-                "api: chip.set('datasheet','mydevice','pin','ina','clk','global','clka')"],
-            schelp="""Pin related clock specified on a per mode basis.""")
-
-    # Related supply
-    scparam(cfg, ['datasheet', design, 'pin', name, 'supply', mode],
-            sctype='str',
-            shorthelp="Datasheet: pin related power supply",
-            switch="-datasheet_pin_supply 'design name mode <str>'",
-            example=[
-                "cli: -datasheet_pin_supply 'mydevice ina global vdd'",
-                "api: chip.set('datasheet','mydevice','pin','ina','supply','global','vdd')"],
-            schelp="""Pin related power supply specified on a per mode basis.""")
-
-    # Related ground
-    scparam(cfg, ['datasheet', design, 'pin', name, 'ground', mode],
-            sctype='str',
-            shorthelp="Datasheet: pin related ground",
-            switch="-datasheet_pin_ground 'design name mode <str>'",
-            example=[
-                "cli: -datasheet_pin_ground 'mydevice ina ground vss'",
-                "api: chip.set('datasheet','mydevice','pin','ina','ground','global','vss')"],
-            schelp="""Pin related ground rail specified on a per mode basis.""")
-
     # Standard
     scparam(cfg, ['datasheet', design, 'pin', name, 'standard', mode],
             sctype='[str]',
             shorthelp="Datasheet: pin standard",
             switch="-datasheet_pin_standard 'design name mode <str>'",
             example=[
-                "cli: -datasheet_pin_standard 'mydevice ba0 global ddr4'",
-                "api: chip.set('datasheet','mydevice','pin','ina','standard','global','ddr4')"],
-            schelp="""Pin communication standard specified on a per mode basis.""")
+                f"cli: -datasheet_pin_standard 'mydevice clk0 ddr4 CLKN'",
+                f"api: chip.set('datasheet','mydevice','pin','clk0','standard','ddr4','CLKN')"],
+            schelp=f"""Pin mapping to standard interfaces with standarized signal names.""")
 
     # Reset value
     scparam(cfg, ['datasheet', design, 'pin', name, 'resetvalue', mode],
@@ -879,24 +870,59 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             schelp="""Pin reset value specified on a per mode basis. Legal reset
             values include weak1, weak0, strong0, strong1, highz.""")
 
-    # DC levels
-    metrics = {'vol': ['low output voltage level', (-0.2, 0, 0.2), 'V'],
+    # DC levels and Metrics
+    metrics = {# DC
+               'vsupply' : ['supply operating voltage', (0.2, 0.3, 0.9), 'V'],
+               'vmax': ['absolute maximum voltage', (0.2, 0.3, 0.9), 'V'],
+               'vol': ['low output voltage level', (-0.2, 0, 0.2), 'V'],
                'voh': ['high output voltage level', (4.6, 4.8, 5.2), 'V'],
                'vil': ['low input voltage level', (-0.2, 0, 1.0), 'V'],
                'vih': ['high input voltage level', (1.4, 1.8, 2.2), 'V'],
                'vcm': ['common mode voltage', (0.3, 1.2, 1.6), 'V'],
                'vdiff': ['differential voltage', (0.2, 0.3, 0.9), 'V'],
+               'voffset': ['offset voltage',  (0.2, 0.3, 0.9), 'V'],
                'vnoise': ['random voltage noise', (0, 0.01, 0.1), 'V'],
                'vhbm': ['HBM ESD tolerance', (200, 250, 300), 'V'],
                'vcdm': ['CDM ESD tolerance', (125, 150, 175), 'V'],
                'vmm': ['MM ESD tolerance', (100, 125, 150), 'V'],
-               'rdiff': ['differential pair resistance', (45, 50, 55), 'ohm'],
-               'rpullup': ['pullup resistance', (1000, 1200, 3000), 'ohm'],
-               'rpulldown': ['pulldown resistance', (1000, 1200, 3000), 'ohm'],
+               'rdiff': ['differential pair resistance', (45, 50, 55), 'Ohm'],
+               'rup': ['pullup resistance', (1000, 1200, 3000), 'Ohm'],
+               'rdown': ['pulldown resistance', (1000, 1200, 3000), 'Ohm'],
+               'rweakup': ['weak pullup resistance', (1000, 1200, 3000), 'Ohm'],
+               'rweakdown': ['weak pulldown resistance', (1000, 1200, 3000), 'Ohm'],
+               'rin': ['input resistance', (1000, 1200, 3000), 'Ohm'],
+               'rdrive': ['pin resistance', (1000, 1200, 3000), 'Ohm'],
+               'power': ['power consumption', (1, 2, 3), 'W'],
+               'isupply': ['supply currents', (1e-3, 12e-3, 15e-3), 'A'],
                'idrive': ['drive current', (10e-3, 12e-3, 15e-3), 'A'],
                'iinject': ['injection current', (1e-3, 1.2e-3, 1.5e-3), 'A'],
+               'ishort': ['short circuit current', (1e-3, 1.2e-3, 1.5e-3), 'A'],
+               'ioffset': ['offset current', (1e-3, 1.2e-3, 1.5e-3), 'A'],
+               'ibias': ['bias current', (1e-3, 1.2e-3, 1.5e-3), 'A'],
                'ileakage': ['leakage current', (1e-6, 1.2e-6, 1.5e-6), 'A'],
-               'capacitance': ['capacitance', (1e-12, 1.2e-12, 1.5e-12), 'F']}
+               'capacitance': ['capacitance', (1e-12, 1.2e-12, 1.5e-12), 'F'],
+               # Electrical specifications
+               'cmrr': ['common mode rejection ratio', (70, 80, 90), 'dB'],
+               'psrro': ['power suply rejection ratio (offset)', (70, 80, 90), 'mv/V'],
+               'psrrg': ['power supply rejection ratio (gain)', (70, 80, 90), '%/V'],
+               'inl': ['integral nonlinearity', (-7, 0.0, 7), 'LSB'],
+               'dnl': ['differential nonlinearity', (-1.0, 0.0, +1.0), 'LSB'],
+               'snr': ['signal to noise ratio', (70, 72, 74), 'dB'],
+               'sinad': ['signal to noise and distoartion ratio', (71, 72, 73), 'dB'],
+               'sfdr': ['spurious-free dynamic range', (82, 88, 98), 'dBc'],
+               'enob': ['effective number of bits', (8, 9, 10), 'bits'],
+               'bw': ['bandwidth', (500e6, 600e6, 700e6), 'Hz'],
+               'vofferror': ['offset error', (-1.0, 0.0, +1.0), 'mV'],
+               'vgainerror': ['gain error', (-1.0, 0.0, +1.0), 'mV'],
+               'vslew': ['slew rate', (1e-9, 2e-9, 4e-9), 'V/s'],
+               'tperiod': ['minimum period', (1e-9, 2e-9, 4e-9), 's'],
+               'tpulse': ['pulse width', (1e-9, 2e-9, 4e-9), 's'],
+               'tjitter': ['rms jitter', (1e-9, 2e-9, 4e-9), 's'],
+               'thigh': ['pulse widtdh high', (1e-9, 2e-9, 4e-9), 's'],
+               'tlow': ['pulse widtdh low', (1e-9, 2e-9, 4e-9), 's'],
+               'tduty': ['duty cycle', (45, 50, 55), '%'],
+               'duty': ['duty cycle', (45, 50, 55), '%']
+    }
 
     for item, val in metrics.items():
         scparam(cfg, ['datasheet', design, 'pin', name, item, mode],
@@ -913,27 +939,34 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
     # AC Timing
     metrics = {'tsetup': ['setup time', (1e-9, 2e-9, 4e-9), 's'],
                'thold': ['hold time', (1e-9, 2e-9, 4e-9), 's'],
+               'tdelay': ['propagation delay', (1e-9, 2e-9, 4e-9), 's'],
                'trise': ['rise transition', (1e-9, 2e-9, 4e-9), 's'],
-               'tfall': ['fall transition', (1e-9, 2e-9, 4e-9), 's'],
-               'tperiod': ['minimum period', (1e-9, 2e-9, 4e-9), 's'],
-               'tpulse': ['pulse width', (1e-9, 2e-9, 4e-9), 's'],
-               'tjitter': ['rms jitter', (1e-9, 2e-9, 4e-9), 's'],
-               'dutycycle': ['duty cycle', (45, 50, 55), '%']}
+               'tfall': ['fall transition', (1e-9, 2e-9, 4e-9), 's']}
 
     for item, val in metrics.items():
-        scparam(cfg, ['datasheet', design, 'pin', name, item, mode],
+        scparam(cfg, ['datasheet', design, 'pin', name, item, mode, 'relpin', name],
                 unit=val[2],
                 sctype='(float,float,float)',
                 shorthelp=f"Datasheet: pin {val[0]}",
-                switch=f"-datasheet_pin_{item} 'design pin mode <(float,float,float)>'",
+                switch=f"-datasheet_pin_{item} 'design pin mode relpin name <(float,float,float)>'",
                 example=[
-                    f"cli: -datasheet_pin_{item} 'mydevice sclk global {val[1]}'",
-                    f"api: chip.set('datasheet','mydevice','pin','sclk','{item}',"
-                    f"'global',{val[1]}"],
-                schelp=f"""Pin {val[0]}. Values are tuples of (min, typical, max).""")
+                    f"cli: -datasheet_pin_{item} 'mydevice sclk global relpin clk {val[1]}'",
+                    f"api: chip.set('datasheet','mydevice','pin','sclk','{item}','global','relpin','clk',{val[1]}"],
+                schelp=f"""Pin {val[0]} specified on a per pin and relpin basis.
+                Values are tuples of (min, typical, max).""")
+
+    # Pin polarity
+    scparam(cfg, ['datasheet', design, 'pin', name, 'polarity', mode, 'relpin', name],
+            sctype='str',
+            shorthelp=f"Datasheet: pin polarity",
+            switch=f"-datasheet_pin_polarity 'design name mode relpin name <str>'",
+            example=[
+                f"cli: -datasheet_pin_polarity 'cpu q global clk none'",
+                f"api: chip.set('datasheet','cpu','pin','q','polarity','global','clk,'none')"],
+            schelp=f"""Pin polarity specified on a per mode basis. Only applicable to output
+            pins. Valid values are: positive, negative, none.""")
 
     return cfg
-
 
 ###############################################################################
 # Flow Configuration

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -785,7 +785,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 switch=f"-datasheet_limit_{i} 'design <(float,float)>'",
                 example=[
                     f"cli: -datasheet_limit_{i} 'dev {v[1]}'",
-                    f"api: chip.set('datasheet','dev','{i}',{v[1]}"],
+                    f"api: chip.set('datasheet','dev','limit','{i}',{v[1]}"],
                 schelp=f"""Limit {v[0]}. Values are tuples of (min, max).
                 """)
 
@@ -805,20 +805,19 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 switch=f"-datasheet_thermal_{item} 'design <float>'",
                 example=[
                     f"cli: -datasheet_thermal_{item} 'mydevice 30.4'",
-                    f"api: chip.set('datasheet','mydevice','thermal','{item}',30.4"],
+                    f"api: chip.set('datasheet','mydevice','thermal','{item}', 30.4)"],
                 schelp=f"""Device {item}.""")
 
     # Reliability
     standard = 'default'
 
-    scparam(cfg, ['datasheet', design, 'reliability', standard, item],
+    scparam(cfg, ['datasheet', design, 'reliability', standard, name],
             sctype='float',
             shorthelp="Datasheet: reliability",
             switch="-datasheet_reliability 'design standard item <float>'",
             example=[
                 "cli: -datasheet_reliability 'dev JESD22-A104 time 1000'",
-                "api: chip.set('datasheet','dev','reliability','JESD22-A104,",
-                "'time',1000')"],
+                "api: chip.set('datasheet','dev','reliability','JESD22-A104','time',1000)"],
             schelp="""Device reliability specified on a per standard basis. The
             reliability test condition is captured as key/value pairs, where
             the key is any test condition capture in the standard. Examples

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -739,27 +739,27 @@ def schema_pdk(cfg, stackup='default'):
 ###############################################################################
 # Datasheet
 ###############################################################################
-def schema_datasheet(cfg, design='default', name='default', mode='default'):
+def schema_datasheet(cfg, name='default', mode='default'):
 
     # Device Features
-    scparam(cfg, ['datasheet', design, 'feature', name],
+    scparam(cfg, ['datasheet', 'feature', name],
             sctype='float',
             shorthelp="Datasheet: features",
-            switch="-datasheet_feature 'design name <float>'",
+            switch="-datasheet_feature 'name <float>'",
             example=[
-                "cli: -datasheet_feature 'mydevice ram 64e6'",
-                "api: chip.set('datasheet','mydevice','feature','ram',64e6)"],
+                "cli: -datasheet_feature 'ram 64e6'",
+                "api: chip.set('datasheet','feature','ram',64e6)"],
             schelp="""Quantity of a specified feature. The 'unit'
             field should be used to specify the units used when unclear.""")
 
     # Device Footprint
-    scparam(cfg, ['datasheet', design, 'footprint'],
+    scparam(cfg, ['datasheet', 'footprint'],
             sctype='[str]',
             shorthelp="Datasheet: footprint",
             switch="-datasheet_footprint 'design <str>'",
             example=[
-                "cli: -datasheet_footprint 'mydsp bga169'",
-                "api: chip.set('datasheet','mydsp', 'footprint','bga169')"],
+                "cli: -datasheet_footprint 'bga169'",
+                "api: chip.set('datasheet','footprint','bga169')"],
             schelp="""List of available physical footprints for the named
             device specified as strings. Strings can either be official
             standard footprint names or a custom naming methodology used in
@@ -778,14 +778,14 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                }
 
     for i, v in metrics.items():
-        scparam(cfg, ['datasheet', design, 'limit', i],
+        scparam(cfg, ['datasheet', 'limit', i],
                 unit=v[2],
                 sctype='(float,float)',
                 shorthelp=f"Datasheet: limit {v[0]}",
-                switch=f"-datasheet_limit_{i} 'design <(float,float)>'",
+                switch=f"-datasheet_limit_{i} '<(float,float)>'",
                 example=[
-                    f"cli: -datasheet_limit_{i} 'dev {v[1]}'",
-                    f"api: chip.set('datasheet','dev','limit','{i}',{v[1]}"],
+                    f"cli: -datasheet_limit_{i} '{v[1]}'",
+                    f"api: chip.set('datasheet', 'limit','{i}',{v[1]}"],
                 schelp=f"""Limit {v[0]}. Values are tuples of (min, max).
                 """)
 
@@ -798,26 +798,26 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                'tjb': 'thermal junction to bottom model'}
 
     for item, val in metrics.items():
-        scparam(cfg, ['datasheet', design, 'thermal', item],
+        scparam(cfg, ['datasheet', 'thermal', item],
                 unit='C/W',
                 sctype='float',
                 shorthelp=f"Datasheet: {val}",
-                switch=f"-datasheet_thermal_{item} 'design <float>'",
+                switch=f"-datasheet_thermal_{item} '<float>'",
                 example=[
-                    f"cli: -datasheet_thermal_{item} 'mydevice 30.4'",
-                    f"api: chip.set('datasheet','mydevice','thermal','{item}', 30.4)"],
+                    f"cli: -datasheet_thermal_{item} '30.4'",
+                    f"api: chip.set('datasheet','thermal','{item}', 30.4)"],
                 schelp=f"""Device {item}.""")
 
     # Reliability
     standard = 'default'
 
-    scparam(cfg, ['datasheet', design, 'reliability', standard, name],
+    scparam(cfg, ['datasheet', 'reliability', standard, name],
             sctype='float',
             shorthelp="Datasheet: reliability",
-            switch="-datasheet_reliability 'design standard item <float>'",
+            switch="-datasheet_reliability 'standard item <float>'",
             example=[
-                "cli: -datasheet_reliability 'dev JESD22-A104 time 1000'",
-                "api: chip.set('datasheet','dev','reliability','JESD22-A104','time',1000)"],
+                "cli: -datasheet_reliability 'JESD22-A104 time 1000'",
+                "api: chip.set('datasheet','reliability','JESD22-A104','time',1000)"],
             schelp="""Device reliability specified on a per standard basis. The
             reliability test condition is captured as key/value pairs, where
             the key is any test condition capture in the standard. Examples
@@ -825,77 +825,77 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             moisture.""")
 
     # Package pin map
-    scparam(cfg, ['datasheet', design, 'pin', name, 'map', mode],
+    scparam(cfg, ['datasheet', 'pin', name, 'map', mode],
             sctype='str',
             shorthelp="Datasheet: pin map",
             switch="-datasheet_pin_map 'design name package <str>'",
             example=[
-                "cli: -datasheet_pin_map 'mydevice in0 bga512 B4'",
-                "api: chip.set('datasheet','mydevice','pin','in0','map','bga512','B4')"],
+                "cli: -datasheet_pin_map 'in0 bga512 B4'",
+                "api: chip.set('datasheet','pin','in0','map','bga512','B4')"],
             schelp="""Signal to package pin mapping specified on a per package basis.""")
 
     # Pin type
-    scparam(cfg, ['datasheet', design, 'pin', name, 'type', mode],
+    scparam(cfg, ['datasheet', 'pin', name, 'type', mode],
             sctype='enum',
             enum=['digital', 'analog', 'clock', 'supply', 'ground'],
             shorthelp="Datasheet: pin type",
-            switch="-datasheet_pin_type 'design name mode <str>'",
+            switch="-datasheet_pin_type 'name mode <str>'",
             example=[
-                "cli: -datasheet_pin_type 'mydevice vdd global supply'",
-                "api: chip.set('datasheet','mydevice','pin','vdd','type','global','supply')"],
+                "cli: -datasheet_pin_type 'vdd global supply'",
+                "api: chip.set('datasheet','pin','vdd','type','global','supply')"],
             schelp="""Pin type specified on a per mode basis.""")
 
     # Pin direction
-    scparam(cfg, ['datasheet', design, 'pin', name, 'dir', mode],
+    scparam(cfg, ['datasheet', 'pin', name, 'dir', mode],
             sctype='str',
             shorthelp="Datasheet: pin direction",
-            switch="-datasheet_pin_dir 'design name mode <str>'",
+            switch="-datasheet_pin_dir 'name mode <str>'",
             example=[
-                "cli: -datasheet_pin_dir 'mydevice clk global input'",
-                "api: chip.set('datasheet','mydevice','pin','clk','dir','global','input')"],
+                "cli: -datasheet_pin_dir 'clk global input'",
+                "api: chip.set('datasheet','pin','clk','dir','global','input')"],
             schelp="""Pin direction specified on a per mode basis. Acceptable pin
             directions include: input, output, inout.""")
 
     # Pin complement (for differential pair)
-    scparam(cfg, ['datasheet', design, 'pin', name, 'complement', mode],
+    scparam(cfg, ['datasheet', 'pin', name, 'complement', mode],
             sctype='str',
             shorthelp="Datasheet: pin complement",
-            switch="-datasheet_pin_complement 'design name mode <str>'",
+            switch="-datasheet_pin_complement 'name mode <str>'",
             example=[
-                "cli: -datasheet_pin_complement 'mydevice ina global inb'",
-                "api: chip.set('datasheet','mydevice','pin','ina','complement','global','inb')"],
+                "cli: -datasheet_pin_complement 'ina global inb'",
+                "api: chip.set('datasheet','pin','ina','complement','global','inb')"],
             schelp="""Pin complement specified on a per mode basis for differential
             signals.""")
 
     # Pin standard
-    scparam(cfg, ['datasheet', design, 'pin', name, 'standard', mode],
+    scparam(cfg, ['datasheet', 'pin', name, 'standard', mode],
             sctype='[str]',
             shorthelp="Datasheet: pin standard",
-            switch="-datasheet_pin_standard 'design name mode <str>'",
+            switch="-datasheet_pin_standard 'name mode <str>'",
             example=[
-                "cli: -datasheet_pin_standard 'mydevice clk def LVCMOS'",
-                "api: chip.set('datasheet','mydevice','pin','clk','standard','def', 'LVCMOS')"],
+                "cli: -datasheet_pin_standard 'clk def LVCMOS'",
+                "api: chip.set('datasheet','pin','clk','standard','def', 'LVCMOS')"],
             schelp="""Pin electrical signaling standard (LVDS, LVCMOS, TTL,..).""")
 
     # Pin signal map
-    scparam(cfg, ['datasheet', design, 'pin', name, 'signal', mode],
+    scparam(cfg, ['datasheet', 'pin', name, 'signal', mode],
             sctype='[str]',
             shorthelp="Datasheet: pin signal map",
-            switch="-datasheet_pin_signal 'design name mode <str>'",
+            switch="-datasheet_pin_signal 'name mode <str>'",
             example=[
-                "cli: -datasheet_pin_signal 'mydevice clk0 ddr4 CLKN'",
-                "api: chip.set('datasheet','mydevice','pin','clk0','signal','ddr4','CLKN')"],
+                "cli: -datasheet_pin_signal 'clk0 ddr4 CLKN'",
+                "api: chip.set('datasheet','pin','clk0','signal','ddr4','CLKN')"],
             schelp="""Pin mapping to standardized interface signals.""")
 
     # Pin reset value
-    scparam(cfg, ['datasheet', design, 'pin', name, 'resetvalue', mode],
+    scparam(cfg, ['datasheet', 'pin', name, 'resetvalue', mode],
             sctype='enum',
             enum=['weak1', 'weak0', 'strong0', 'strong1', 'highz'],
             shorthelp="Datasheet: pin reset value",
-            switch="-datasheet_pin_resetvalue 'design name mode <str>'",
+            switch="-datasheet_pin_resetvalue 'name mode <str>'",
             example=[
-                "cli: -datasheet_pin_resetvalue 'mydevice clk global weak1'",
-                "api: chip.set('datasheet','mydevice','pin','clk','resetvalue','global','weak1')"],
+                "cli: -datasheet_pin_resetvalue 'clk global weak1'",
+                "api: chip.set('datasheet','pin','clk','resetvalue','global','weak1')"],
             schelp="""Pin reset value specified on a per mode basis.""")
 
     # Device specifications (per pin)
@@ -974,14 +974,14 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                }
 
     for item, val in metrics.items():
-        scparam(cfg, ['datasheet', design, 'pin', name, item, mode],
+        scparam(cfg, ['datasheet', 'pin', name, item, mode],
                 unit=val[2],
                 sctype='(float,float,float)',
                 shorthelp=f"Datasheet: pin {val[0]}",
-                switch=f"-datasheet_pin_{item} 'design pin mode <(float,float,float)>'",
+                switch=f"-datasheet_pin_{item} 'pin mode <(float,float,float)>'",
                 example=[
-                    f"cli: -datasheet_pin_{item} 'mydevice sclk global {val[1]}'",
-                    f"api: chip.set('datasheet','mydevice','pin','sclk','{item}',"
+                    f"cli: -datasheet_pin_{item} 'sclk global {val[1]}'",
+                    f"api: chip.set('datasheet','pin','sclk','{item}',"
                     f"'global',{val[1]}"],
                 schelp=f"""Pin {val[0]}. Values are tuples of (min, typical, max).""")
 
@@ -997,38 +997,38 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
     relpin = 'default'
 
     for i, v in metrics.items():
-        scparam(cfg, ['datasheet', design, 'pin', name, i, mode, relpin],
+        scparam(cfg, ['datasheet', 'pin', name, i, mode, relpin],
                 unit=v[2],
                 sctype='(float,float,float)',
                 shorthelp=f"Datasheet: pin {v[0]}",
-                switch=f"-datasheet_pin_{i} 'design pin mode relpin <(float,float,float)>'",
+                switch=f"-datasheet_pin_{i} 'pin mode relpin <(float,float,float)>'",
                 example=[
-                    f"cli: -datasheet_pin_{i} 'dev a glob clock {v[1]}'",
-                    f"api: chip.set('datasheet','dev','pin','a','{i}','glob','ck',{v[1]}"],
+                    f"cli: -datasheet_pin_{i} 'a glob clock {v[1]}'",
+                    f"api: chip.set('datasheet','pin','a','{i}','glob','ck',{v[1]}"],
                 schelp=f"""Pin {v[0]} specified on a per pin, mode, and relpin basis.
                 Values are tuples of (min, typical, max).""")
 
     # Low level parameters (for standard cells)
-    scparam(cfg, ['datasheet', design, 'pin', name, 'function', mode],
+    scparam(cfg, ['datasheet', 'pin', name, 'function', mode],
             sctype='str',
             shorthelp="Datasheet: pin function",
-            switch="-datasheet_pin_function 'design name mode <str>'",
+            switch="-datasheet_pin_function 'name mode <str>'",
             example=[
-                "cli: -datasheet_pin_function 'mydevice z global a&b'",
-                "api: chip.set('datasheet','mydevice','pin','z','function','global','a&b')"],
+                "cli: -datasheet_pin_function 'z global a&b'",
+                "api: chip.set('datasheet','pin','z','function','global','a&b')"],
             schelp="""Pin function specified on a per mode basis.
             Only applicable to output pins.""")
 
     relpin = 'default'
 
-    scparam(cfg, ['datasheet', design, 'pin', name, 'polarity', mode, relpin],
+    scparam(cfg, ['datasheet', 'pin', name, 'polarity', mode, relpin],
             sctype='enum',
             enum=['positive', 'negative', 'none'],
             shorthelp="Datasheet: pin polarity",
-            switch="-datasheet_pin_polarity 'design name mode relpin <str>'",
+            switch="-datasheet_pin_polarity 'name mode relpin <str>'",
             example=[
-                "cli: -datasheet_pin_polarity 'cpu q def clk none'",
-                "api: chip.set('datasheet','cpu','pin','q','polarity','def','clk,'none')"],
+                "cli: -datasheet_pin_polarity 'q def clk none'",
+                "api: chip.set('datasheet','pin','q','polarity','def','clk,'none')"],
             schelp="""Pin polarity specified on a per mode basis. Only applicable to output
             pins.""")
 

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -816,8 +816,8 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             shorthelp="Datasheet: pin type",
             switch="-datasheet_pin_type 'design name mode <str>'",
             example=[
-                "cli: -datasheet_pin_type 'mydevice vdd global power'",
-                "api: chip.set('datasheet','mydevice','pin','vdd','type','global','power')"],
+                "cli: -datasheet_pin_type 'mydevice vdd global supply'",
+                "api: chip.set('datasheet','mydevice','pin','vdd','type','global','supply')"],
             schelp="""Pin type specified on a per mode basis. Acceptable pin types
             include: digital, analog, clock, supply, ground""")
 
@@ -849,15 +849,15 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             shorthelp="Datasheet: pin standard",
             switch="-datasheet_pin_standard 'design name mode <str>'",
             example=[
-                "cli: -datasheet_pin_standard 'mydevice clk LVCMOS'",
-                "api: chip.set('datasheet','mydevice','pin','clk','standard','LVCMOS')"],
+                "cli: -datasheet_pin_standard 'mydevice clk def LVCMOS'",
+                "api: chip.set('datasheet','mydevice','pin','clk','standard','def', 'LVCMOS')"],
             schelp="""Pin electrical signaling standard (LVDS, LVCMOS, TTL,..).""")
 
     # Pin signal Map
     scparam(cfg, ['datasheet', design, 'pin', name, 'signal', name],
             sctype='[str]',
             shorthelp="Datasheet: pin signal map",
-            switch="-datasheet_pin_standard 'design name mode <str>'",
+            switch="-datasheet_pin_signal 'design name mode <str>'",
             example=[
                 "cli: -datasheet_pin_signal 'mydevice clk0 ddr4 CLKN'",
                 "api: chip.set('datasheet','mydevice','pin','clk0','signal','ddr4','CLKN')"],
@@ -970,19 +970,21 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                'trise': ['rise transition', (1e-9, 2e-9, 4e-9), 's'],
                'tfall': ['fall transition', (1e-9, 2e-9, 4e-9), 's']}
 
+    relname = 'default'
+
     for i, v in metrics.items():
-        scparam(cfg, ['datasheet', design, 'pin', name, i, mode, 'relpin', name],
+        scparam(cfg, ['datasheet', design, 'pin', name, i, mode, relname],
                 unit=v[2],
                 sctype='(float,float,float)',
                 shorthelp=f"Datasheet: pin {v[0]}",
-                switch=f"-datasheet_pin_{i} 'design pin mode relpin name <(float,float,float)>'",
+                switch=f"-datasheet_pin_{i} 'design pin mode relname <(float,float,float)>'",
                 example=[
-                    f"cli: -datasheet_pin_{i} 'dev a def relpin ck {v[1]}'",
-                    f"api: chip.set('datasheet','dev','pin','a','{i}','def','relpin','ck',{v[1]}"],
+                    f"cli: -datasheet_pin_{i} 'dev a glob clock {v[1]}'",
+                    f"api: chip.set('datasheet','dev','pin','a','{i}','glob','ck',{v[1]}"],
                 schelp=f"""Pin {v[0]} specified on a per pin, mode, and relpin basis.
                 Values are tuples of (min, typical, max).""")
 
-    # Low level paramters (for standard cells)
+    # Low level parameters (for standard cells)
 
     scparam(cfg, ['datasheet', design, 'pin', name, 'function', mode],
             sctype='str',
@@ -1000,8 +1002,8 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             shorthelp="Datasheet: pin polarity",
             switch="-datasheet_pin_polarity 'design name mode relpin name <str>'",
             example=[
-                "cli: -datasheet_pin_polarity 'cpu q global clk none'",
-                "api: chip.set('datasheet','cpu','pin','q','polarity','global','clk,'none')"],
+                "cli: -datasheet_pin_polarity 'cpu q def clk none'",
+                "api: chip.set('datasheet','cpu','pin','q','polarity','def','relpin','clk,'none')"],
             schelp="""Pin polarity specified on a per mode basis. Only applicable to output
             pins. Valid entries are: positive, negative, none.""")
 

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -774,7 +774,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                     f"api: chip.set('datasheet','mydevice','limits','{item}',(-40,125))"],
                 schelp=f"""Device absolute {val} not to be exceeded.""")
 
-    # Thermal Resistence
+    # Thermal model
     metrics = {'rja': 'junction to ambient thermal resistence',
                'rjct': 'junction to case (top) thermal resistence',
                'rjcb': 'junction to case (bottom) thermal resistence',
@@ -793,7 +793,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                     f"api: chip.set('datasheet','mydevice','thermal','{item}',30.4)"],
                 schelp=f"""Device {item}.""")
 
-    # Package Pin Map
+    # Package pin map
     scparam(cfg, ['datasheet', design, 'pin', name, 'map', name],
             sctype='str',
             shorthelp="Datasheet: pin map",
@@ -814,17 +814,6 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 "api: chip.set('datasheet','mydevice','pin','vdd','type','global','power')"],
             schelp="""Pin type specified on a per mode basis. Acceptable pin types
             include: digital, analog, clock, supply, ground""")
-
-    # Pin function
-    scparam(cfg, ['datasheet', design, 'pin', name, 'function', mode],
-            sctype='str',
-            shorthelp="Datasheet: pin function",
-            switch="-datasheet_pin_function 'design name mode <str>'",
-            example=[
-                "cli: -datasheet_pin_function 'mydevice z global a&b'",
-                "api: chip.set('datasheet','mydevice','pin','z','function','global','a&b')"],
-            schelp="""Pin function specified on a per mode basis. Only applicable to output
-            pins.""")
 
     # Pin direction
     scparam(cfg, ['datasheet', design, 'pin', name, 'dir', mode],
@@ -879,7 +868,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             schelp="""Pin reset value specified on a per mode basis. Legal reset
             values include weak1, weak0, strong0, strong1, highz.""")
 
-    # Device Specifications
+    # Device specifications
     metrics = {'vmax': ['absolute maximum voltage', (0.2, 0.3, 0.9), 'V'],
                'vnominal': ['nominal operating voltage', (1.72, 1.80, 1.92), 'V'],
                'vol': ['low output voltage level', (-0.2, 0, 0.2), 'V'],
@@ -922,22 +911,36 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                'tlow': ['pulse widtdh low', (1e-9, 2e-9, 4e-9), 's'],
                'tduty': ['duty cycle', (45, 50, 55), '%'],
                # Analog metrics
+               'bw': ['nyquist bandwidth', (500e6, 600e6, 700e6), 'Hz'],
                'inl': ['integral nonlinearity', (-7, 0.0, 7), 'LSB'],
                'dnl': ['differential nonlinearity', (-1.0, 0.0, +1.0), 'LSB'],
                'snr': ['signal to noise ratio', (70, 72, 74), 'dB'],
                'sinad': ['signal to noise and distortion ratio', (71, 72, 73), 'dB'],
                'sfdr': ['spurious-free dynamic range', (82, 88, 98), 'dBc'],
+               'imd3': ['3rd order intermodulation distortion', (82, 88, 98), 'dBc'],
+               'hd2': ['2nd order harmonic distorion', (62, 64, 66), 'dBc'],
+               'hd3': ['3rd order harmonic distorion', (62, 64, 66), 'dBc'],
+               'hd4': ['4th order harmonic distorion', (62, 64, 66), 'dBc'],
+               'nsd': ['noise spectral density', (-158, -158, -158), 'dBFS/Hz'],
+               'phasenoise': ['phase noise', (-158, -158, -158), 'dBc/Hz'],
                'enob': ['effective number of bits', (8, 9, 10), 'bits'],
-               'bw': ['bandwidth', (500e6, 600e6, 700e6), 'Hz'],
                'gain': ['gain', (11.4, 11.4, 11.4), 'dB'],
                'pout': ['output power', (12.2, 12.2, 12.2), 'dBm'],
                'pout2': ['2nd harmonic power', (-14, -14, -14), 'dBm'],
                'pout3': ['3rd harmonic power', (-28, -28, -28), 'dBm'],
-               'noisefigure': ['noise figure', (4.6, 4.6, 4.6), 'dB'],
                'vofferror': ['offset error', (-1.0, 0.0, +1.0), 'mV'],
                'vgainerror': ['gain error', (-1.0, 0.0, +1.0), 'mV'],
                'cmrr': ['common mode rejection ratio', (70, 80, 90), 'dB'],
-               'psnr': ['power supply noise rejection', (61, 61, 61), 'dB']
+               'psnr': ['power supply noise rejection', (61, 61, 61), 'dB'],
+               # RF parameters
+               's21': ['gain', (10, 11, 12), 'dB'],
+               's11': ['input return loss', (7, 7, 7), 'dB'],
+               's22': ['output return loss', (10, 10, 10), 'dB'],
+               's12': ['reverse isolation', (-20, -20, -20), 'dB'],
+               'noisefigure': ['noise figure', (4.6, 4.6, 4.6), 'dB'],
+               'ib1db': ['in band 1 dB compression point', (-1, 1, 1), 'dBm'],
+               'oob1db': ['out of band 1 dB compression point', (3, 3, 3), 'dBm'],
+               'iip3': ['3rd order input intercept point', (3, 3, 3), 'dBm']
                }
 
     for item, val in metrics.items():
@@ -956,7 +959,6 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
     metrics = {'tsetup': ['setup time', (1e-9, 2e-9, 4e-9), 's'],
                'thold': ['hold time', (1e-9, 2e-9, 4e-9), 's'],
                'tskew': ['timing skew', (1e-9, 2e-9, 4e-9), 's'],
-               'tdelay': ['propagation delay (rise/fall)', (1e-9, 2e-9, 4e-9), 's'],
                'tdelayr': ['propagation delay (rise)', (1e-9, 2e-9, 4e-9), 's'],
                'tdelayf': ['propagation delay (fall)', (1e-9, 2e-9, 4e-9), 's'],
                'trise': ['rise transition', (1e-9, 2e-9, 4e-9), 's'],
@@ -974,7 +976,18 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 schelp=f"""Pin {v[0]} specified on a per pin, mode, and relpin basis.
                 Values are tuples of (min, typical, max).""")
 
-    # Pin polarity
+    # Low level paramters (for standard cells)
+
+    scparam(cfg, ['datasheet', design, 'pin', name, 'function', mode],
+            sctype='str',
+            shorthelp="Datasheet: pin function",
+            switch="-datasheet_pin_function 'design name mode <str>'",
+            example=[
+                "cli: -datasheet_pin_function 'mydevice z global a&b'",
+                "api: chip.set('datasheet','mydevice','pin','z','function','global','a&b')"],
+            schelp="""Pin function specified on a per mode basis. Only applicable to output
+            pins.""")
+
     scparam(cfg, ['datasheet', design, 'pin', name, 'polarity', mode, 'relpin', name],
             sctype='enum',
             enum=['positive', 'negative', 'none'],

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -16,6 +16,7 @@ SCHEMA_VERSION = '0.32.0'
 #############################################################################
 # PARAM DEFINITION
 #############################################################################
+
 def scparam(cfg,
             keypath,
             sctype=None,
@@ -809,8 +810,8 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             shorthelp="Datasheet: pin type",
             switch="-datasheet_pin_type 'design name mode <str>'",
             example=[
-                f"cli: -datasheet_pin_type 'mydevice vdd global power'",
-                f"api: chip.set('datasheet','mydevice','pin','vdd','type','global','power')"],
+                "cli: -datasheet_pin_type 'mydevice vdd global power'",
+                "api: chip.set('datasheet','mydevice','pin','vdd','type','global','power')"],
             schelp=f"""Pin type specified on a per mode basis. Acceptable pin types
             include: digital, analog, clk, power, ground""")
 
@@ -820,12 +821,10 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             shorthelp=f"Datasheet: pin function",
             switch=f"-datasheet_pin_function 'design name mode <str>'",
             example=[
-                f"cli: -datasheet_pin_function 'mydevice z global a&b'",
-                f"api: chip.set('datasheet','mydevice','pin','z','function','global','a&b')"],
+                "cli: -datasheet_pin_function 'mydevice z global a&b'",
+                "api: chip.set('datasheet','mydevice','pin','z','function','global','a&b')"],
             schelp=f"""Pin function specified on a per mode basis. Only applicable to output
             pins.""")
-
-
 
     # Pin direction
     scparam(cfg, ['datasheet', design, 'pin', name, 'dir', mode],
@@ -855,8 +854,8 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             shorthelp="Datasheet: pin standard",
             switch="-datasheet_pin_standard 'design name mode <str>'",
             example=[
-                f"cli: -datasheet_pin_standard 'mydevice clk0 ddr4 CLKN'",
-                f"api: chip.set('datasheet','mydevice','pin','clk0','standard','ddr4','CLKN')"],
+                "cli: -datasheet_pin_standard 'mydevice clk0 ddr4 CLKN'",
+                "api: chip.set('datasheet','mydevice','pin','clk0','standard','ddr4','CLKN')"],
             schelp=f"""Pin mapping to standard interfaces with standarized signal names.""")
 
     # Reset value
@@ -870,9 +869,10 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             schelp="""Pin reset value specified on a per mode basis. Legal reset
             values include weak1, weak0, strong0, strong1, highz.""")
 
+    # Electrical Specifications
+
     # DC levels and Metrics
-    metrics = {# DC
-               'vsupply' : ['supply operating voltage', (0.2, 0.3, 0.9), 'V'],
+    metrics = {'vsupply' : ['supply operating voltage', (0.2, 0.3, 0.9), 'V'],
                'vmax': ['absolute maximum voltage', (0.2, 0.3, 0.9), 'V'],
                'vol': ['low output voltage level', (-0.2, 0, 0.2), 'V'],
                'voh': ['high output voltage level', (4.6, 4.8, 5.2), 'V'],
@@ -880,7 +880,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                'vih': ['high input voltage level', (1.4, 1.8, 2.2), 'V'],
                'vcm': ['common mode voltage', (0.3, 1.2, 1.6), 'V'],
                'vdiff': ['differential voltage', (0.2, 0.3, 0.9), 'V'],
-               'voffset': ['offset voltage',  (0.2, 0.3, 0.9), 'V'],
+               'voffset': ['offset voltage', (0.2, 0.3, 0.9), 'V'],
                'vnoise': ['random voltage noise', (0, 0.01, 0.1), 'V'],
                'vhbm': ['HBM ESD tolerance', (200, 250, 300), 'V'],
                'vcdm': ['CDM ESD tolerance', (125, 150, 175), 'V'],
@@ -901,7 +901,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                'ibias': ['bias current', (1e-3, 1.2e-3, 1.5e-3), 'A'],
                'ileakage': ['leakage current', (1e-6, 1.2e-6, 1.5e-6), 'A'],
                'capacitance': ['capacitance', (1e-12, 1.2e-12, 1.5e-12), 'F'],
-               # Electrical specifications
+               # Metrics
                'cmrr': ['common mode rejection ratio', (70, 80, 90), 'dB'],
                'psrro': ['power suply rejection ratio (offset)', (70, 80, 90), 'mv/V'],
                'psrrg': ['power supply rejection ratio (gain)', (70, 80, 90), '%/V'],
@@ -961,9 +961,9 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             shorthelp=f"Datasheet: pin polarity",
             switch=f"-datasheet_pin_polarity 'design name mode relpin name <str>'",
             example=[
-                f"cli: -datasheet_pin_polarity 'cpu q global clk none'",
-                f"api: chip.set('datasheet','cpu','pin','q','polarity','global','clk,'none')"],
-            schelp=f"""Pin polarity specified on a per mode basis. Only applicable to output
+                "cli: -datasheet_pin_polarity 'cpu q global clk none'",
+                "api: chip.set('datasheet','cpu','pin','q','polarity','global','clk,'none')"],
+            schelp="""Pin polarity specified on a per mode basis. Only applicable to output
             pins. Valid values are: positive, negative, none.""")
 
     return cfg

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -744,7 +744,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
     # Device Features
     scparam(cfg, ['datasheet', design, 'feature', name],
             sctype='float',
-            shorthelp="Datasheet: device features",
+            shorthelp="Datasheet: features",
             switch="-datasheet_feature 'design name <float>'",
             example=[
                 "cli: -datasheet_feature 'mydevice ram 64e6'",
@@ -755,7 +755,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
     # Device Footprint
     scparam(cfg, ['datasheet', design, 'footprint'],
             sctype='[str]',
-            shorthelp="Datasheet: device footprint",
+            shorthelp="Datasheet: footprint",
             switch="-datasheet_footprint 'design <str>'",
             example=[
                 "cli: -datasheet_footprint 'mydsp bga169'",
@@ -790,12 +790,12 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 """)
 
     # Thermal model
-    metrics = {'rja': 'junction to ambient thermal resistance',
-               'rjct': 'junction to case (top) thermal resistance',
-               'rjcb': 'junction to case (bottom) thermal resistance',
-               'rjb': 'junction to board thermal resistance',
-               'tjt': 'junction to top characterization parameter',
-               'tjb': 'junction to bottom characterization parameter'}
+    metrics = {'rja': 'thermal junction to ambient resistance',
+               'rjct': 'thermal junction to case (top) resistance',
+               'rjcb': 'thermal junction to case (bottom) resistance',
+               'rjb': 'thermal junction to board resistance',
+               'tjt': 'thermal junction to top model',
+               'tjb': 'thermal junction to bottom model'}
 
     for item, val in metrics.items():
         scparam(cfg, ['datasheet', design, 'thermal', item],
@@ -912,11 +912,11 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                'vnoise': ['random voltage noise', (0, 0.01, 0.1), 'V'],
                'vslew': ['slew rate', (1e-9, 2e-9, 4e-9), 'V/s'],
                # ESD
-               'vhbm': ['human body model ESD tolerance', (200, 250, 300), 'V'],
-               'vcdm': ['charge device model ESD tolerance', (125, 150, 175), 'V'],
-               'vmm': ['machine model ESD tolerance', (100, 125, 150), 'V'],
+               'vhbm': ['ESD human body model level', (200, 250, 300), 'V'],
+               'vcdm': ['ESD charge device model level', (125, 150, 175), 'V'],
+               'vmm': ['ESD machine model level', (100, 125, 150), 'V'],
                # RC
-               'cap': ['cap', (1e-12, 1.2e-12, 1.5e-12), 'F'],
+               'cap': ['capacitance', (1e-12, 1.2e-12, 1.5e-12), 'F'],
                'rdiff': ['differential pair resistance', (45, 50, 55), 'Ohm'],
                'rin': ['input resistance', (1000, 1200, 3000), 'Ohm'],
                'rup': ['output pullup resistance', (1000, 1200, 3000), 'Ohm'],
@@ -964,14 +964,14 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                'cmrr': ['common mode rejection ratio', (70, 80, 90), 'dB'],
                'psnr': ['power supply noise rejection', (61, 61, 61), 'dB'],
                # RF parameters
-               's21': ['gain', (10, 11, 12), 'dB'],
-               's11': ['input return loss', (7, 7, 7), 'dB'],
-               's22': ['output return loss', (10, 10, 10), 'dB'],
-               's12': ['reverse isolation', (-20, -20, -20), 'dB'],
-               'noisefigure': ['noise figure', (4.6, 4.6, 4.6), 'dB'],
-               'ib1db': ['in band 1 dB compression point', (-1, 1, 1), 'dBm'],
-               'oob1db': ['out of band 1 dB compression point', (3, 3, 3), 'dBm'],
-               'iip3': ['3rd order input intercept point', (3, 3, 3), 'dBm']
+               's21': ['rf gain', (10, 11, 12), 'dB'],
+               's11': ['rf input return loss', (7, 7, 7), 'dB'],
+               's22': ['rf output return loss', (10, 10, 10), 'dB'],
+               's12': ['rf reverse isolation', (-20, -20, -20), 'dB'],
+               'noisefigure': ['rf noise figure', (4.6, 4.6, 4.6), 'dB'],
+               'ib1db': ['rf in band 1 dB compression point', (-1, 1, 1), 'dBm'],
+               'oob1db': ['rf out of band 1 dB compression point', (3, 3, 3), 'dBm'],
+               'iip3': ['rf 3rd order input intercept point', (3, 3, 3), 'dBm']
                }
 
     for item, val in metrics.items():
@@ -1010,15 +1010,15 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 Values are tuples of (min, typical, max).""")
 
     # Low level parameters (for standard cells)
-    scparam(cfg, ['datasheet', design, 'pin', name, 'func', mode],
+    scparam(cfg, ['datasheet', design, 'pin', name, 'function', mode],
             sctype='str',
-            shorthelp="Datasheet: pin func",
-            switch="-datasheet_pin_func 'design name mode <str>'",
+            shorthelp="Datasheet: pin function",
+            switch="-datasheet_pin_function 'design name mode <str>'",
             example=[
-                "cli: -datasheet_pin_func 'mydevice z global a&b'",
-                "api: chip.set('datasheet','mydevice','pin','z','func','global','a&b')"],
-            schelp="""Pin func specified on a per mode basis. Only applicable to output
-            pins.""")
+                "cli: -datasheet_pin_function 'mydevice z global a&b'",
+                "api: chip.set('datasheet','mydevice','pin','z','function','global','a&b')"],
+            schelp="""Pin function specified on a per mode basis.
+            Only applicable to output pins.""")
 
     scparam(cfg, ['datasheet', design, 'pin', name, 'polarity', mode, name],
             sctype='enum',

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -759,7 +759,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             standard footprint names or a custom naming methodology used in
             conjunction with 'fileset' names in the output parameter.""")
 
-    # Absolute max temperatures
+    # Temperature limits
     metrics = {'storagetemp': 'storage temperature limits',
                'soldertemp': 'solder temperature limits',
                'junctiontemp': 'junction temperature limits'}
@@ -794,8 +794,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 schelp=f"""Device {item} specified in C/W.""")
 
     # Package Pin Map
-    package = 'default'
-    scparam(cfg, ['datasheet', design, 'pin', name, 'map', package],
+    scparam(cfg, ['datasheet', design, 'pin', name, 'map', name],
             sctype='str',
             shorthelp="Datasheet: pin map",
             switch="-datasheet_pin_map 'design name package <str>'",
@@ -813,7 +812,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 "cli: -datasheet_pin_type 'mydevice vdd global power'",
                 "api: chip.set('datasheet','mydevice','pin','vdd','type','global','power')"],
             schelp="""Pin type specified on a per mode basis. Acceptable pin types
-            include: digital, analog, clk, power, ground""")
+            include: digital, analog, clock, supply, ground""")
 
     # Pin function
     scparam(cfg, ['datasheet', design, 'pin', name, 'function', mode],
@@ -837,7 +836,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             schelp="""Pin direction specified on a per mode basis. Acceptable pin
             directions include: input, output, inout.""")
 
-    # Complementary pin (for differential pair)
+    # Pin complementary (for differential pair)
     scparam(cfg, ['datasheet', design, 'pin', name, 'complement', mode],
             sctype='str',
             shorthelp="Datasheet: pin complement",
@@ -848,17 +847,27 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             schelp="""Pin complement specified on a per mode basis for differential
             signals.""")
 
-    # Standard
+    # Pin standard
     scparam(cfg, ['datasheet', design, 'pin', name, 'standard', mode],
             sctype='[str]',
             shorthelp="Datasheet: pin standard",
             switch="-datasheet_pin_standard 'design name mode <str>'",
             example=[
-                "cli: -datasheet_pin_standard 'mydevice clk0 ddr4 CLKN'",
-                "api: chip.set('datasheet','mydevice','pin','clk0','standard','ddr4','CLKN')"],
-            schelp="""Pin mapping to standard interfaces with standarized signal names.""")
+                "cli: -datasheet_pin_standard 'mydevice clk LVCMOS'",
+                "api: chip.set('datasheet','mydevice','pin','clk','standard','LVCMOS')"],
+            schelp="""Pin electrical signaling standard (LVDS, LVCMOS, TTL,..).""")
 
-    # Reset value
+    # Pin signal Map
+    scparam(cfg, ['datasheet', design, 'pin', name, 'signal', name],
+            sctype='[str]',
+            shorthelp="Datasheet: pin signal map",
+            switch="-datasheet_pin_standard 'design name mode <str>'",
+            example=[
+                "cli: -datasheet_pin_signal 'mydevice clk0 ddr4 CLKN'",
+                "api: chip.set('datasheet','mydevice','pin','clk0','signal','ddr4','CLKN')"],
+            schelp="""Pin mapping to standardized interface signals.""")
+
+    # Pin reset value
     scparam(cfg, ['datasheet', design, 'pin', name, 'resetvalue', mode],
             sctype='[str]',
             shorthelp="Datasheet: pin reset value",
@@ -868,8 +877,6 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 "api: chip.set('datasheet','mydevice','pin','clk','resetvalue','global','weak1')"],
             schelp="""Pin reset value specified on a per mode basis. Legal reset
             values include weak1, weak0, strong0, strong1, highz.""")
-
-    # Electrical Specifications
 
     # DC levels and Metrics
     metrics = {'vsupply': ['supply operating voltage', (0.2, 0.3, 0.9), 'V'],

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -777,7 +777,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
     # Thermal Resistence
     metrics = {'rja': 'junction to ambient thermal resistence',
                'rjct': 'junction to case (top) thermal resistence',
-               'rjcb': 'junction to case (bottom)thermal resistence',
+               'rjcb': 'junction to case (bottom) thermal resistence',
                'rjb': 'junction to board thermal resistence',
                'tjt': 'junction to top characterization parameter',
                'tjb': 'junction to bottom characterization parameter'}
@@ -791,7 +791,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 example=[
                     f"cli: -datasheet_thermal_{item} 'mydevice 30.4'",
                     f"api: chip.set('datasheet','mydevice','thermal','{item}',30.4)"],
-                schelp=f"""Device {item} specified in C/W.""")
+                schelp=f"""Device {item}.""")
 
     # Package Pin Map
     scparam(cfg, ['datasheet', design, 'pin', name, 'map', name],
@@ -805,7 +805,8 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
 
     # Pin type
     scparam(cfg, ['datasheet', design, 'pin', name, 'type', mode],
-            sctype='str',
+            sctype='enum',
+            enum=['digital', 'analog', 'clock', 'supply', 'ground'],
             shorthelp="Datasheet: pin type",
             switch="-datasheet_pin_type 'design name mode <str>'",
             example=[
@@ -878,9 +879,9 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             schelp="""Pin reset value specified on a per mode basis. Legal reset
             values include weak1, weak0, strong0, strong1, highz.""")
 
-    # DC levels and Metrics
-    metrics = {'vsupply': ['supply operating voltage', (0.2, 0.3, 0.9), 'V'],
-               'vmax': ['absolute maximum voltage', (0.2, 0.3, 0.9), 'V'],
+    # Device Specifications
+    metrics = {'vmax': ['absolute maximum voltage', (0.2, 0.3, 0.9), 'V'],
+               'vnominal': ['nominal operating voltage', (1.72, 1.80, 1.92), 'V'],
                'vol': ['low output voltage level', (-0.2, 0, 0.2), 'V'],
                'voh': ['high output voltage level', (4.6, 4.8, 5.2), 'V'],
                'vil': ['low input voltage level', (-0.2, 0, 1.0), 'V'],
@@ -889,45 +890,54 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                'vdiff': ['differential voltage', (0.2, 0.3, 0.9), 'V'],
                'voffset': ['offset voltage', (0.2, 0.3, 0.9), 'V'],
                'vnoise': ['random voltage noise', (0, 0.01, 0.1), 'V'],
-               'vhbm': ['HBM ESD tolerance', (200, 250, 300), 'V'],
-               'vcdm': ['CDM ESD tolerance', (125, 150, 175), 'V'],
-               'vmm': ['MM ESD tolerance', (100, 125, 150), 'V'],
+               'vslew': ['slew rate', (1e-9, 2e-9, 4e-9), 'V/s'],
+               # ESD
+               'vhbm': ['human body model (HBM) ESD tolerance', (200, 250, 300), 'V'],
+               'vcdm': ['charge device model (CDM) ESD tolerance', (125, 150, 175), 'V'],
+               'vmm': ['machine model (MM) ESD tolerance', (100, 125, 150), 'V'],
+               # RC
+               'capacitance': ['capacitance', (1e-12, 1.2e-12, 1.5e-12), 'F'],
                'rdiff': ['differential pair resistance', (45, 50, 55), 'Ohm'],
-               'rup': ['pullup resistance', (1000, 1200, 3000), 'Ohm'],
-               'rdown': ['pulldown resistance', (1000, 1200, 3000), 'Ohm'],
+               'rin': ['input resistance', (1000, 1200, 3000), 'Ohm'],
+               'rup': ['output pullup resistance', (1000, 1200, 3000), 'Ohm'],
+               'rdown': ['output pulldown resistance', (1000, 1200, 3000), 'Ohm'],
                'rweakup': ['weak pullup resistance', (1000, 1200, 3000), 'Ohm'],
                'rweakdown': ['weak pulldown resistance', (1000, 1200, 3000), 'Ohm'],
-               'rin': ['input resistance', (1000, 1200, 3000), 'Ohm'],
-               'rdrive': ['pin resistance', (1000, 1200, 3000), 'Ohm'],
+               # Power
                'power': ['power consumption', (1, 2, 3), 'W'],
+               # Current
                'isupply': ['supply currents', (1e-3, 12e-3, 15e-3), 'A'],
-               'idrive': ['drive current', (10e-3, 12e-3, 15e-3), 'A'],
+               'ioh': ['output high current', (10e-3, 12e-3, 15e-3), 'A'],
+               'iol': ['output low current', (10e-3, 12e-3, 15e-3), 'A'],
                'iinject': ['injection current', (1e-3, 1.2e-3, 1.5e-3), 'A'],
                'ishort': ['short circuit current', (1e-3, 1.2e-3, 1.5e-3), 'A'],
                'ioffset': ['offset current', (1e-3, 1.2e-3, 1.5e-3), 'A'],
                'ibias': ['bias current', (1e-3, 1.2e-3, 1.5e-3), 'A'],
                'ileakage': ['leakage current', (1e-6, 1.2e-6, 1.5e-6), 'A'],
-               'capacitance': ['capacitance', (1e-12, 1.2e-12, 1.5e-12), 'F'],
-               # Metrics
-               'cmrr': ['common mode rejection ratio', (70, 80, 90), 'dB'],
-               'psrro': ['power suply rejection ratio (offset)', (70, 80, 90), 'mv/V'],
-               'psrrg': ['power supply rejection ratio (gain)', (70, 80, 90), '%/V'],
-               'inl': ['integral nonlinearity', (-7, 0.0, 7), 'LSB'],
-               'dnl': ['differential nonlinearity', (-1.0, 0.0, +1.0), 'LSB'],
-               'snr': ['signal to noise ratio', (70, 72, 74), 'dB'],
-               'sinad': ['signal to noise and distoartion ratio', (71, 72, 73), 'dB'],
-               'sfdr': ['spurious-free dynamic range', (82, 88, 98), 'dBc'],
-               'enob': ['effective number of bits', (8, 9, 10), 'bits'],
-               'bw': ['bandwidth', (500e6, 600e6, 700e6), 'Hz'],
-               'vofferror': ['offset error', (-1.0, 0.0, +1.0), 'mV'],
-               'vgainerror': ['gain error', (-1.0, 0.0, +1.0), 'mV'],
-               'vslew': ['slew rate', (1e-9, 2e-9, 4e-9), 'V/s'],
+               # Clocking
                'tperiod': ['minimum period', (1e-9, 2e-9, 4e-9), 's'],
                'tpulse': ['pulse width', (1e-9, 2e-9, 4e-9), 's'],
                'tjitter': ['rms jitter', (1e-9, 2e-9, 4e-9), 's'],
                'thigh': ['pulse widtdh high', (1e-9, 2e-9, 4e-9), 's'],
                'tlow': ['pulse widtdh low', (1e-9, 2e-9, 4e-9), 's'],
-               'tduty': ['duty cycle', (45, 50, 55), '%']
+               'tduty': ['duty cycle', (45, 50, 55), '%'],
+               # Analog metrics
+               'inl': ['integral nonlinearity', (-7, 0.0, 7), 'LSB'],
+               'dnl': ['differential nonlinearity', (-1.0, 0.0, +1.0), 'LSB'],
+               'snr': ['signal to noise ratio', (70, 72, 74), 'dB'],
+               'sinad': ['signal to noise and distortion ratio', (71, 72, 73), 'dB'],
+               'sfdr': ['spurious-free dynamic range', (82, 88, 98), 'dBc'],
+               'enob': ['effective number of bits', (8, 9, 10), 'bits'],
+               'bw': ['bandwidth', (500e6, 600e6, 700e6), 'Hz'],
+               'gain': ['gain', (11.4, 11.4, 11.4), 'dB'],
+               'pout': ['output power', (12.2, 12.2, 12.2), 'dBm'],
+               'pout2': ['2nd harmonic power', (-14, -14, -14), 'dBm'],
+               'pout3': ['3rd harmonic power', (-28, -28, -28), 'dBm'],
+               'noisefigure': ['noise figure', (4.6, 4.6, 4.6), 'dB'],
+               'vofferror': ['offset error', (-1.0, 0.0, +1.0), 'mV'],
+               'vgainerror': ['gain error', (-1.0, 0.0, +1.0), 'mV'],
+               'cmrr': ['common mode rejection ratio', (70, 80, 90), 'dB'],
+               'psnr': ['power supply noise rejection', (61, 61, 61), 'dB']
                }
 
     for item, val in metrics.items():
@@ -942,15 +952,18 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                     f"'global',{val[1]}"],
                 schelp=f"""Pin {val[0]}. Values are tuples of (min, typical, max).""")
 
-    # AC Timing
+    # Timing
     metrics = {'tsetup': ['setup time', (1e-9, 2e-9, 4e-9), 's'],
                'thold': ['hold time', (1e-9, 2e-9, 4e-9), 's'],
-               'tdelay': ['propagation delay', (1e-9, 2e-9, 4e-9), 's'],
+               'tskew': ['timing skew', (1e-9, 2e-9, 4e-9), 's'],
+               'tdelay': ['propagation delay (rise/fall)', (1e-9, 2e-9, 4e-9), 's'],
+               'tdelayr': ['propagation delay (rise)', (1e-9, 2e-9, 4e-9), 's'],
+               'tdelayf': ['propagation delay (fall)', (1e-9, 2e-9, 4e-9), 's'],
                'trise': ['rise transition', (1e-9, 2e-9, 4e-9), 's'],
                'tfall': ['fall transition', (1e-9, 2e-9, 4e-9), 's']}
 
     for i, v in metrics.items():
-        scparam(cfg, ['datasheet', design, 'pin', name, item, mode, 'relpin', name],
+        scparam(cfg, ['datasheet', design, 'pin', name, i, mode, 'relpin', name],
                 unit=v[2],
                 sctype='(float,float,float)',
                 shorthelp=f"Datasheet: pin {v[0]}",
@@ -963,14 +976,15 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
 
     # Pin polarity
     scparam(cfg, ['datasheet', design, 'pin', name, 'polarity', mode, 'relpin', name],
-            sctype='str',
+            sctype='enum',
+            enum=['positive', 'negative', 'none'],
             shorthelp="Datasheet: pin polarity",
             switch="-datasheet_pin_polarity 'design name mode relpin name <str>'",
             example=[
                 "cli: -datasheet_pin_polarity 'cpu q global clk none'",
                 "api: chip.set('datasheet','cpu','pin','q','polarity','global','clk,'none')"],
             schelp="""Pin polarity specified on a per mode basis. Only applicable to output
-            pins. Valid values are: positive, negative, none.""")
+            pins. Valid entries are: positive, negative, none.""")
 
     return cfg
 

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -800,7 +800,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                 schelp=f"""Device {item}.""")
 
     # Package pin map
-    scparam(cfg, ['datasheet', design, 'pin', name, 'map', name],
+    scparam(cfg, ['datasheet', design, 'pin', name, 'map', mode],
             sctype='str',
             shorthelp="Datasheet: pin map",
             switch="-datasheet_pin_map 'design name package <str>'",
@@ -854,7 +854,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             schelp="""Pin electrical signaling standard (LVDS, LVCMOS, TTL,..).""")
 
     # Pin signal Map
-    scparam(cfg, ['datasheet', design, 'pin', name, 'signal', name],
+    scparam(cfg, ['datasheet', design, 'pin', name, 'signal', mode],
             sctype='[str]',
             shorthelp="Datasheet: pin signal map",
             switch="-datasheet_pin_signal 'design name mode <str>'",
@@ -891,7 +891,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                'vcdm': ['charge device model (CDM) ESD tolerance', (125, 150, 175), 'V'],
                'vmm': ['machine model (MM) ESD tolerance', (100, 125, 150), 'V'],
                # RC
-               'capacitance': ['capacitance', (1e-12, 1.2e-12, 1.5e-12), 'F'],
+               'cap': ['cap', (1e-12, 1.2e-12, 1.5e-12), 'F'],
                'rdiff': ['differential pair resistance', (45, 50, 55), 'Ohm'],
                'rin': ['input resistance', (1000, 1200, 3000), 'Ohm'],
                'rup': ['output pullup resistance', (1000, 1200, 3000), 'Ohm'],
@@ -986,24 +986,24 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
 
     # Low level parameters (for standard cells)
 
-    scparam(cfg, ['datasheet', design, 'pin', name, 'function', mode],
+    scparam(cfg, ['datasheet', design, 'pin', name, 'func', mode],
             sctype='str',
-            shorthelp="Datasheet: pin function",
-            switch="-datasheet_pin_function 'design name mode <str>'",
+            shorthelp="Datasheet: pin func",
+            switch="-datasheet_pin_func 'design name mode <str>'",
             example=[
-                "cli: -datasheet_pin_function 'mydevice z global a&b'",
-                "api: chip.set('datasheet','mydevice','pin','z','function','global','a&b')"],
-            schelp="""Pin function specified on a per mode basis. Only applicable to output
+                "cli: -datasheet_pin_func 'mydevice z global a&b'",
+                "api: chip.set('datasheet','mydevice','pin','z','func','global','a&b')"],
+            schelp="""Pin func specified on a per mode basis. Only applicable to output
             pins.""")
 
-    scparam(cfg, ['datasheet', design, 'pin', name, 'polarity', mode, 'relpin', name],
+    scparam(cfg, ['datasheet', design, 'pin', name, 'polarity', mode, name],
             sctype='enum',
             enum=['positive', 'negative', 'none'],
             shorthelp="Datasheet: pin polarity",
-            switch="-datasheet_pin_polarity 'design name mode relpin name <str>'",
+            switch="-datasheet_pin_polarity 'design name mode name <str>'",
             example=[
                 "cli: -datasheet_pin_polarity 'cpu q def clk none'",
-                "api: chip.set('datasheet','cpu','pin','q','polarity','def','relpin','clk,'none')"],
+                "api: chip.set('datasheet','cpu','pin','q','polarity','def','clk,'none')"],
             schelp="""Pin polarity specified on a per mode basis. Only applicable to output
             pins. Valid entries are: positive, negative, none.""")
 

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -13,10 +13,10 @@ except ImportError:
 
 SCHEMA_VERSION = '0.32.0'
 
+
 #############################################################################
 # PARAM DEFINITION
 #############################################################################
-
 def scparam(cfg,
             keypath,
             sctype=None,
@@ -812,18 +812,18 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             example=[
                 "cli: -datasheet_pin_type 'mydevice vdd global power'",
                 "api: chip.set('datasheet','mydevice','pin','vdd','type','global','power')"],
-            schelp=f"""Pin type specified on a per mode basis. Acceptable pin types
+            schelp="""Pin type specified on a per mode basis. Acceptable pin types
             include: digital, analog, clk, power, ground""")
 
     # Pin function
     scparam(cfg, ['datasheet', design, 'pin', name, 'function', mode],
             sctype='str',
-            shorthelp=f"Datasheet: pin function",
-            switch=f"-datasheet_pin_function 'design name mode <str>'",
+            shorthelp="Datasheet: pin function",
+            switch="-datasheet_pin_function 'design name mode <str>'",
             example=[
                 "cli: -datasheet_pin_function 'mydevice z global a&b'",
                 "api: chip.set('datasheet','mydevice','pin','z','function','global','a&b')"],
-            schelp=f"""Pin function specified on a per mode basis. Only applicable to output
+            schelp="""Pin function specified on a per mode basis. Only applicable to output
             pins.""")
 
     # Pin direction
@@ -856,7 +856,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             example=[
                 "cli: -datasheet_pin_standard 'mydevice clk0 ddr4 CLKN'",
                 "api: chip.set('datasheet','mydevice','pin','clk0','standard','ddr4','CLKN')"],
-            schelp=f"""Pin mapping to standard interfaces with standarized signal names.""")
+            schelp="""Pin mapping to standard interfaces with standarized signal names.""")
 
     # Reset value
     scparam(cfg, ['datasheet', design, 'pin', name, 'resetvalue', mode],
@@ -872,7 +872,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
     # Electrical Specifications
 
     # DC levels and Metrics
-    metrics = {'vsupply' : ['supply operating voltage', (0.2, 0.3, 0.9), 'V'],
+    metrics = {'vsupply': ['supply operating voltage', (0.2, 0.3, 0.9), 'V'],
                'vmax': ['absolute maximum voltage', (0.2, 0.3, 0.9), 'V'],
                'vol': ['low output voltage level', (-0.2, 0, 0.2), 'V'],
                'voh': ['high output voltage level', (4.6, 4.8, 5.2), 'V'],
@@ -920,9 +920,8 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                'tjitter': ['rms jitter', (1e-9, 2e-9, 4e-9), 's'],
                'thigh': ['pulse widtdh high', (1e-9, 2e-9, 4e-9), 's'],
                'tlow': ['pulse widtdh low', (1e-9, 2e-9, 4e-9), 's'],
-               'tduty': ['duty cycle', (45, 50, 55), '%'],
-               'duty': ['duty cycle', (45, 50, 55), '%']
-    }
+               'tduty': ['duty cycle', (45, 50, 55), '%']
+               }
 
     for item, val in metrics.items():
         scparam(cfg, ['datasheet', design, 'pin', name, item, mode],
@@ -943,23 +942,23 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
                'trise': ['rise transition', (1e-9, 2e-9, 4e-9), 's'],
                'tfall': ['fall transition', (1e-9, 2e-9, 4e-9), 's']}
 
-    for item, val in metrics.items():
+    for i, v in metrics.items():
         scparam(cfg, ['datasheet', design, 'pin', name, item, mode, 'relpin', name],
-                unit=val[2],
+                unit=v[2],
                 sctype='(float,float,float)',
-                shorthelp=f"Datasheet: pin {val[0]}",
-                switch=f"-datasheet_pin_{item} 'design pin mode relpin name <(float,float,float)>'",
+                shorthelp=f"Datasheet: pin {v[0]}",
+                switch=f"-datasheet_pin_{i} 'design pin mode relpin name <(float,float,float)>'",
                 example=[
-                    f"cli: -datasheet_pin_{item} 'mydevice sclk global relpin clk {val[1]}'",
-                    f"api: chip.set('datasheet','mydevice','pin','sclk','{item}','global','relpin','clk',{val[1]}"],
-                schelp=f"""Pin {val[0]} specified on a per pin and relpin basis.
+                    f"cli: -datasheet_pin_{i} 'dev a def relpin ck {v[1]}'",
+                    f"api: chip.set('datasheet','dev','pin','a','{i}','def','relpin','ck',{v[1]}"],
+                schelp=f"""Pin {v[0]} specified on a per pin, mode, and relpin basis.
                 Values are tuples of (min, typical, max).""")
 
     # Pin polarity
     scparam(cfg, ['datasheet', design, 'pin', name, 'polarity', mode, 'relpin', name],
             sctype='str',
-            shorthelp=f"Datasheet: pin polarity",
-            switch=f"-datasheet_pin_polarity 'design name mode relpin name <str>'",
+            shorthelp="Datasheet: pin polarity",
+            switch="-datasheet_pin_polarity 'design name mode relpin name <str>'",
             example=[
                 "cli: -datasheet_pin_polarity 'cpu q global clk none'",
                 "api: chip.set('datasheet','cpu','pin','q','polarity','global','clk,'none')"],
@@ -967,6 +966,7 @@ def schema_datasheet(cfg, design='default', name='default', mode='default'):
             pins. Valid values are: positive, negative, none.""")
 
     return cfg
+
 
 ###############################################################################
 # Flow Configuration

--- a/siliconcompiler/tools/openroad/sc_constraints.sdc
+++ b/siliconcompiler/tools/openroad/sc_constraints.sdc
@@ -7,7 +7,7 @@ set sc_design [sc_top]
 ### Create clocks
 if {[dict exists $sc_cfg datasheet] && [dict exists $sc_cfg datasheet $sc_design]} {
     foreach pin [dict keys [dict get $sc_cfg datasheet $sc_design pin]] {
-        if {[dict get $sc_cfg datasheet $sc_design pin $pin type global] == "clk"} {
+        if {[dict get $sc_cfg datasheet $sc_design pin $pin type global] == "clock"} {
             # If clock...
 
             set periodtuple [dict get $sc_cfg datasheet $sc_design pin $pin tperiod global]

--- a/siliconcompiler/tools/openroad/sc_constraints.sdc
+++ b/siliconcompiler/tools/openroad/sc_constraints.sdc
@@ -2,17 +2,15 @@
 
 source sc_manifest.tcl
 
-set sc_design [sc_top]
-
 ### Create clocks
-if {[dict exists $sc_cfg datasheet] && [dict exists $sc_cfg datasheet $sc_design]} {
-    foreach pin [dict keys [dict get $sc_cfg datasheet $sc_design pin]] {
-        if {[dict get $sc_cfg datasheet $sc_design pin $pin type global] == "clock"} {
+if {[dict exists $sc_cfg datasheet pin]} {
+    foreach pin [dict keys [dict get $sc_cfg datasheet pin]] {
+        if {[dict get $sc_cfg datasheet pin $pin type global] == "clock"} {
             # If clock...
 
-            set periodtuple [dict get $sc_cfg datasheet $sc_design pin $pin tperiod global]
+            set periodtuple [dict get $sc_cfg datasheet pin $pin tperiod global]
             set period [sta::time_sta_ui [lindex $periodtuple 1]]
-            set jittertuple [dict get $sc_cfg datasheet $sc_design pin $pin tjitter global]
+            set jittertuple [dict get $sc_cfg datasheet pin $pin tjitter global]
             set jitter [sta::time_sta_ui [lindex $jittertuple 1]]
 
             utl::info FLW 1 "Creating clock $pin with [sta::format_time [sta::time_ui_sta $period] 3][sta::unit_scale_abreviation time]s period and [sta::format_time [sta::time_ui_sta $jitter] 3][sta::unit_scale_abreviation time]s jitter."

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1665,13 +1665,13 @@
                 ],
                 "type": "[str]"
             },
-            "limits": {
+            "limit": {
                 "junctiontemp": {
                     "example": [
-                        "cli: -datasheet_limits_junctiontemp 'mydevice (-40,125)'",
-                        "api: chip.set('datasheet','mydevice','limits','junctiontemp',(-40,125))"
+                        "cli: -datasheet_limit_junctiontemp 'dev (-40, 125)'",
+                        "api: chip.set('datasheet','dev','limit','junctiontemp',(-40, 125)"
                     ],
-                    "help": "Device absolute junction temperature limits not to be exceeded.",
+                    "help": "Limit junction temperature limits. Values are tuples of (min, max).",
                     "lock": false,
                     "node": {
                         "default": {
@@ -1685,18 +1685,149 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: absolute junction temperature limits",
+                    "shorthelp": "Datasheet: limit junction temperature limits",
                     "switch": [
-                        "-datasheet_limits_junctiontemp 'design <(float,float)>'"
+                        "-datasheet_limit_junctiontemp 'design <(float,float)>'"
                     ],
-                    "type": "(float,float)"
+                    "type": "(float,float)",
+                    "unit": "C"
+                },
+                "seb": {
+                    "example": [
+                        "cli: -datasheet_limit_seb 'dev (75, 75)'",
+                        "api: chip.set('datasheet','dev','limit','seb',(75, 75)"
+                    ],
+                    "help": "Limit single event burnout threshold. Values are tuples of (min, max).",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "never",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Datasheet: limit single event burnout threshold",
+                    "switch": [
+                        "-datasheet_limit_seb 'design <(float,float)>'"
+                    ],
+                    "type": "(float,float)",
+                    "unit": "MeV-cm2/mg"
+                },
+                "segr": {
+                    "example": [
+                        "cli: -datasheet_limit_segr 'dev (75, 75)'",
+                        "api: chip.set('datasheet','dev','limit','segr',(75, 75)"
+                    ],
+                    "help": "Limit single event gate rupture threshold. Values are tuples of (min, max).",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "never",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Datasheet: limit single event gate rupture threshold",
+                    "switch": [
+                        "-datasheet_limit_segr 'design <(float,float)>'"
+                    ],
+                    "type": "(float,float)",
+                    "unit": "MeV-cm2/mg"
+                },
+                "sel": {
+                    "example": [
+                        "cli: -datasheet_limit_sel 'dev (75, 75)'",
+                        "api: chip.set('datasheet','dev','limit','sel',(75, 75)"
+                    ],
+                    "help": "Limit single event latchup threshold. Values are tuples of (min, max).",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "never",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Datasheet: limit single event latchup threshold",
+                    "switch": [
+                        "-datasheet_limit_sel 'design <(float,float)>'"
+                    ],
+                    "type": "(float,float)",
+                    "unit": "MeV-cm2/mg"
+                },
+                "set": {
+                    "example": [
+                        "cli: -datasheet_limit_set 'dev (75, 75)'",
+                        "api: chip.set('datasheet','dev','limit','set',(75, 75)"
+                    ],
+                    "help": "Limit single event transient threshold. Values are tuples of (min, max).",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "never",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Datasheet: limit single event transient threshold",
+                    "switch": [
+                        "-datasheet_limit_set 'design <(float,float)>'"
+                    ],
+                    "type": "(float,float)",
+                    "unit": "MeV-cm2/mg"
+                },
+                "seu": {
+                    "example": [
+                        "cli: -datasheet_limit_seu 'dev (75, 75)'",
+                        "api: chip.set('datasheet','dev','limit','seu',(75, 75)"
+                    ],
+                    "help": "Limit single event upset threshold. Values are tuples of (min, max).",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "never",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Datasheet: limit single event upset threshold",
+                    "switch": [
+                        "-datasheet_limit_seu 'design <(float,float)>'"
+                    ],
+                    "type": "(float,float)",
+                    "unit": "MeV-cm2/mg"
                 },
                 "soldertemp": {
                     "example": [
-                        "cli: -datasheet_limits_soldertemp 'mydevice (-40,125)'",
-                        "api: chip.set('datasheet','mydevice','limits','soldertemp',(-40,125))"
+                        "cli: -datasheet_limit_soldertemp 'dev (-40, 125)'",
+                        "api: chip.set('datasheet','dev','limit','soldertemp',(-40, 125)"
                     ],
-                    "help": "Device absolute solder temperature limits not to be exceeded.",
+                    "help": "Limit solder temperature limits. Values are tuples of (min, max).",
                     "lock": false,
                     "node": {
                         "default": {
@@ -1710,18 +1841,19 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: absolute solder temperature limits",
+                    "shorthelp": "Datasheet: limit solder temperature limits",
                     "switch": [
-                        "-datasheet_limits_soldertemp 'design <(float,float)>'"
+                        "-datasheet_limit_soldertemp 'design <(float,float)>'"
                     ],
-                    "type": "(float,float)"
+                    "type": "(float,float)",
+                    "unit": "C"
                 },
                 "storagetemp": {
                     "example": [
-                        "cli: -datasheet_limits_storagetemp 'mydevice (-40,125)'",
-                        "api: chip.set('datasheet','mydevice','limits','storagetemp',(-40,125))"
+                        "cli: -datasheet_limit_storagetemp 'dev (-40, 125)'",
+                        "api: chip.set('datasheet','dev','limit','storagetemp',(-40, 125)"
                     ],
-                    "help": "Device absolute storage temperature limits not to be exceeded.",
+                    "help": "Limit storage temperature limits. Values are tuples of (min, max).",
                     "lock": false,
                     "node": {
                         "default": {
@@ -1735,11 +1867,38 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: absolute storage temperature limits",
+                    "shorthelp": "Datasheet: limit storage temperature limits",
                     "switch": [
-                        "-datasheet_limits_storagetemp 'design <(float,float)>'"
+                        "-datasheet_limit_storagetemp 'design <(float,float)>'"
                     ],
-                    "type": "(float,float)"
+                    "type": "(float,float)",
+                    "unit": "C"
+                },
+                "tid": {
+                    "example": [
+                        "cli: -datasheet_limit_tid 'dev (300000.0, 300000.0)'",
+                        "api: chip.set('datasheet','dev','limit','tid',(300000.0, 300000.0)"
+                    ],
+                    "help": "Limit total inonizing dose threshold. Values are tuples of (min, max).",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "never",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Datasheet: limit total inonizing dose threshold",
+                    "switch": [
+                        "-datasheet_limit_tid 'design <(float,float)>'"
+                    ],
+                    "type": "(float,float)",
+                    "unit": "rad"
                 }
             },
             "pin": {
@@ -3201,7 +3360,7 @@
                                 "scope": "job",
                                 "shorthelp": "Datasheet: pin propagation delay (fall)",
                                 "switch": [
-                                    "-datasheet_pin_tdelayf 'design pin mode relname <(float,float,float)>'"
+                                    "-datasheet_pin_tdelayf 'design pin mode relpin <(float,float,float)>'"
                                 ],
                                 "type": "(float,float,float)",
                                 "unit": "s"
@@ -3231,7 +3390,7 @@
                                 "scope": "job",
                                 "shorthelp": "Datasheet: pin propagation delay (rise)",
                                 "switch": [
-                                    "-datasheet_pin_tdelayr 'design pin mode relname <(float,float,float)>'"
+                                    "-datasheet_pin_tdelayr 'design pin mode relpin <(float,float,float)>'"
                                 ],
                                 "type": "(float,float,float)",
                                 "unit": "s"
@@ -3289,7 +3448,7 @@
                                 "scope": "job",
                                 "shorthelp": "Datasheet: pin fall transition",
                                 "switch": [
-                                    "-datasheet_pin_tfall 'design pin mode relname <(float,float,float)>'"
+                                    "-datasheet_pin_tfall 'design pin mode relpin <(float,float,float)>'"
                                 ],
                                 "type": "(float,float,float)",
                                 "unit": "s"
@@ -3302,7 +3461,7 @@
                                 "cli: -datasheet_pin_thigh 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','thigh','global',(1e-09, 2e-09, 4e-09)"
                             ],
-                            "help": "Pin pulse widtdh high. Values are tuples of (min, typical, max).",
+                            "help": "Pin pulse width high. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3316,7 +3475,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin pulse widtdh high",
+                            "shorthelp": "Datasheet: pin pulse width high",
                             "switch": [
                                 "-datasheet_pin_thigh 'design pin mode <(float,float,float)>'"
                             ],
@@ -3347,7 +3506,7 @@
                                 "scope": "job",
                                 "shorthelp": "Datasheet: pin hold time",
                                 "switch": [
-                                    "-datasheet_pin_thold 'design pin mode relname <(float,float,float)>'"
+                                    "-datasheet_pin_thold 'design pin mode relpin <(float,float,float)>'"
                                 ],
                                 "type": "(float,float,float)",
                                 "unit": "s"
@@ -3388,7 +3547,7 @@
                                 "cli: -datasheet_pin_tlow 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','tlow','global',(1e-09, 2e-09, 4e-09)"
                             ],
-                            "help": "Pin pulse widtdh low. Values are tuples of (min, typical, max).",
+                            "help": "Pin pulse width low. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3402,7 +3561,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin pulse widtdh low",
+                            "shorthelp": "Datasheet: pin pulse width low",
                             "switch": [
                                 "-datasheet_pin_tlow 'design pin mode <(float,float,float)>'"
                             ],
@@ -3489,7 +3648,7 @@
                                 "scope": "job",
                                 "shorthelp": "Datasheet: pin rise transition",
                                 "switch": [
-                                    "-datasheet_pin_trise 'design pin mode relname <(float,float,float)>'"
+                                    "-datasheet_pin_trise 'design pin mode relpin <(float,float,float)>'"
                                 ],
                                 "type": "(float,float,float)",
                                 "unit": "s"
@@ -3519,7 +3678,7 @@
                                 "scope": "job",
                                 "shorthelp": "Datasheet: pin setup time",
                                 "switch": [
-                                    "-datasheet_pin_tsetup 'design pin mode relname <(float,float,float)>'"
+                                    "-datasheet_pin_tsetup 'design pin mode relpin <(float,float,float)>'"
                                 ],
                                 "type": "(float,float,float)",
                                 "unit": "s"
@@ -3549,7 +3708,7 @@
                                 "scope": "job",
                                 "shorthelp": "Datasheet: pin timing skew",
                                 "switch": [
-                                    "-datasheet_pin_tskew 'design pin mode relname <(float,float,float)>'"
+                                    "-datasheet_pin_tskew 'design pin mode relpin <(float,float,float)>'"
                                 ],
                                 "type": "(float,float,float)",
                                 "unit": "s"
@@ -3596,7 +3755,7 @@
                                 "cli: -datasheet_pin_vcdm 'mydevice sclk global (125, 150, 175)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vcdm','global',(125, 150, 175)"
                             ],
-                            "help": "Pin charge device model (CDM) ESD tolerance. Values are tuples of (min, typical, max).",
+                            "help": "Pin charge device model ESD tolerance. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3610,7 +3769,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin charge device model (CDM) ESD tolerance",
+                            "shorthelp": "Datasheet: pin charge device model ESD tolerance",
                             "switch": [
                                 "-datasheet_pin_vcdm 'design pin mode <(float,float,float)>'"
                             ],
@@ -3708,7 +3867,7 @@
                                 "cli: -datasheet_pin_vhbm 'mydevice sclk global (200, 250, 300)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vhbm','global',(200, 250, 300)"
                             ],
-                            "help": "Pin human body model (HBM) ESD tolerance. Values are tuples of (min, typical, max).",
+                            "help": "Pin human body model ESD tolerance. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3722,7 +3881,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin human body model (HBM) ESD tolerance",
+                            "shorthelp": "Datasheet: pin human body model ESD tolerance",
                             "switch": [
                                 "-datasheet_pin_vhbm 'design pin mode <(float,float,float)>'"
                             ],
@@ -3820,7 +3979,7 @@
                                 "cli: -datasheet_pin_vmm 'mydevice sclk global (100, 125, 150)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vmm','global',(100, 125, 150)"
                             ],
-                            "help": "Pin machine model (MM) ESD tolerance. Values are tuples of (min, typical, max).",
+                            "help": "Pin machine model ESD tolerance. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3834,7 +3993,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin machine model (MM) ESD tolerance",
+                            "shorthelp": "Datasheet: pin machine model ESD tolerance",
                             "switch": [
                                 "-datasheet_pin_vmm 'design pin mode <(float,float,float)>'"
                             ],
@@ -4040,11 +4199,40 @@
                     }
                 }
             },
+            "reliability": {
+                "default": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_reliability 'dev JESD22-A104 time 1000'",
+                            "api: chip.set('datasheet','dev','reliability','JESD22-A104','time',1000)"
+                        ],
+                        "help": "Device reliability specified on a per standard basis. The\nreliability test condition is captured as key/value pairs, where\nthe key is any test condition capture in the standard. Examples\nof test conditions include time, mintemp, maxtemp, cycles, vmax,\nmostiure.",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: reliability",
+                        "switch": [
+                            "-datasheet_reliability 'design standard item <float>'"
+                        ],
+                        "type": "float"
+                    }
+                }
+            },
             "thermal": {
                 "rja": {
                     "example": [
                         "cli: -datasheet_thermal_rja 'mydevice 30.4'",
-                        "api: chip.set('datasheet','mydevice','thermal','rja',30.4)"
+                        "api: chip.set('datasheet','mydevice','thermal','rja', 30.4)"
                     ],
                     "help": "Device rja.",
                     "lock": false,
@@ -4070,7 +4258,7 @@
                 "rjb": {
                     "example": [
                         "cli: -datasheet_thermal_rjb 'mydevice 30.4'",
-                        "api: chip.set('datasheet','mydevice','thermal','rjb',30.4)"
+                        "api: chip.set('datasheet','mydevice','thermal','rjb', 30.4)"
                     ],
                     "help": "Device rjb.",
                     "lock": false,
@@ -4096,7 +4284,7 @@
                 "rjcb": {
                     "example": [
                         "cli: -datasheet_thermal_rjcb 'mydevice 30.4'",
-                        "api: chip.set('datasheet','mydevice','thermal','rjcb',30.4)"
+                        "api: chip.set('datasheet','mydevice','thermal','rjcb', 30.4)"
                     ],
                     "help": "Device rjcb.",
                     "lock": false,
@@ -4122,7 +4310,7 @@
                 "rjct": {
                     "example": [
                         "cli: -datasheet_thermal_rjct 'mydevice 30.4'",
-                        "api: chip.set('datasheet','mydevice','thermal','rjct',30.4)"
+                        "api: chip.set('datasheet','mydevice','thermal','rjct', 30.4)"
                     ],
                     "help": "Device rjct.",
                     "lock": false,
@@ -4148,7 +4336,7 @@
                 "tjb": {
                     "example": [
                         "cli: -datasheet_thermal_tjb 'mydevice 30.4'",
-                        "api: chip.set('datasheet','mydevice','thermal','tjb',30.4)"
+                        "api: chip.set('datasheet','mydevice','thermal','tjb', 30.4)"
                     ],
                     "help": "Device tjb.",
                     "lock": false,
@@ -4174,7 +4362,7 @@
                 "tjt": {
                     "example": [
                         "cli: -datasheet_thermal_tjt 'mydevice 30.4'",
-                        "api: chip.set('datasheet','mydevice','thermal','tjt',30.4)"
+                        "api: chip.set('datasheet','mydevice','thermal','tjt', 30.4)"
                     ],
                     "help": "Device tjt.",
                     "lock": false,

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -2786,17 +2786,24 @@
                     },
                     "resetvalue": {
                         "default": {
+                            "enum": [
+                                "weak1",
+                                "weak0",
+                                "strong0",
+                                "strong1",
+                                "highz"
+                            ],
                             "example": [
                                 "cli: -datasheet_pin_resetvalue 'mydevice clk global weak1'",
                                 "api: chip.set('datasheet','mydevice','pin','clk','resetvalue','global','weak1')"
                             ],
-                            "help": "Pin reset value specified on a per mode basis. Legal reset\nvalues include weak1, weak0, strong0, strong1, highz.",
+                            "help": "Pin reset value specified on a per mode basis.",
                             "lock": false,
                             "node": {
                                 "default": {
                                     "default": {
-                                        "signature": [],
-                                        "value": []
+                                        "signature": null,
+                                        "value": null
                                     }
                                 }
                             },
@@ -2808,7 +2815,7 @@
                             "switch": [
                                 "-datasheet_pin_resetvalue 'design name mode <str>'"
                             ],
-                            "type": "[str]"
+                            "type": "enum"
                         }
                     },
                     "rin": {

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1879,7 +1879,7 @@
                         "cli: -datasheet_limit_tid 'dev (300000.0, 300000.0)'",
                         "api: chip.set('datasheet','dev','limit','tid',(300000.0, 300000.0)"
                     ],
-                    "help": "Limit total inonizing dose threshold. Values are tuples of (min, max).",
+                    "help": "Limit total ionizing dose threshold. Values are tuples of (min, max).",
                     "lock": false,
                     "node": {
                         "default": {
@@ -1893,7 +1893,7 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: limit total inonizing dose threshold",
+                    "shorthelp": "Datasheet: limit total ionizing dose threshold",
                     "switch": [
                         "-datasheet_limit_tid 'design <(float,float)>'"
                     ],
@@ -2723,7 +2723,7 @@
                                     "cli: -datasheet_pin_polarity 'cpu q def clk none'",
                                     "api: chip.set('datasheet','cpu','pin','q','polarity','def','clk,'none')"
                                 ],
-                                "help": "Pin polarity specified on a per mode basis. Only applicable to output\npins. Valid entries are: positive, negative, none.",
+                                "help": "Pin polarity specified on a per mode basis. Only applicable to output\npins.",
                                 "lock": false,
                                 "node": {
                                     "default": {
@@ -2739,7 +2739,7 @@
                                 "scope": "job",
                                 "shorthelp": "Datasheet: pin polarity",
                                 "switch": [
-                                    "-datasheet_pin_polarity 'design name mode name <str>'"
+                                    "-datasheet_pin_polarity 'design name mode relpin <str>'"
                                 ],
                                 "type": "enum"
                             }
@@ -3728,7 +3728,7 @@
                                 "cli: -datasheet_pin_type 'mydevice vdd global supply'",
                                 "api: chip.set('datasheet','mydevice','pin','vdd','type','global','supply')"
                             ],
-                            "help": "Pin type specified on a per mode basis. Acceptable pin types\ninclude: digital, analog, clock, supply, ground",
+                            "help": "Pin type specified on a per mode basis.",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3755,7 +3755,7 @@
                                 "cli: -datasheet_pin_vcdm 'mydevice sclk global (125, 150, 175)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vcdm','global',(125, 150, 175)"
                             ],
-                            "help": "Pin ESD charge device model level. Values are tuples of (min, typical, max).",
+                            "help": "Pin ESD charge device model voltage level. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3769,7 +3769,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin ESD charge device model level",
+                            "shorthelp": "Datasheet: pin ESD charge device model voltage level",
                             "switch": [
                                 "-datasheet_pin_vcdm 'design pin mode <(float,float,float)>'"
                             ],
@@ -3867,7 +3867,7 @@
                                 "cli: -datasheet_pin_vhbm 'mydevice sclk global (200, 250, 300)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vhbm','global',(200, 250, 300)"
                             ],
-                            "help": "Pin ESD human body model level. Values are tuples of (min, typical, max).",
+                            "help": "Pin ESD human body model voltage level. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3881,7 +3881,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin ESD human body model level",
+                            "shorthelp": "Datasheet: pin ESD human body model voltage level",
                             "switch": [
                                 "-datasheet_pin_vhbm 'design pin mode <(float,float,float)>'"
                             ],
@@ -3979,7 +3979,7 @@
                                 "cli: -datasheet_pin_vmm 'mydevice sclk global (100, 125, 150)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vmm','global',(100, 125, 150)"
                             ],
-                            "help": "Pin ESD machine model level. Values are tuples of (min, typical, max).",
+                            "help": "Pin ESD machine model voltage level. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3993,7 +3993,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin ESD machine model level",
+                            "shorthelp": "Datasheet: pin ESD machine model voltage level",
                             "switch": [
                                 "-datasheet_pin_vmm 'design pin mode <(float,float,float)>'"
                             ],
@@ -4206,7 +4206,7 @@
                             "cli: -datasheet_reliability 'dev JESD22-A104 time 1000'",
                             "api: chip.set('datasheet','dev','reliability','JESD22-A104','time',1000)"
                         ],
-                        "help": "Device reliability specified on a per standard basis. The\nreliability test condition is captured as key/value pairs, where\nthe key is any test condition capture in the standard. Examples\nof test conditions include time, mintemp, maxtemp, cycles, vmax,\nmostiure.",
+                        "help": "Device reliability specified on a per standard basis. The\nreliability test condition is captured as key/value pairs, where\nthe key is any test condition capture in the standard. Examples\nof test conditions include time, mintemp, maxtemp, cycles, vmax,\nmoisture.",
                         "lock": false,
                         "node": {
                             "default": {

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1633,7 +1633,7 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: device features",
+                    "shorthelp": "Datasheet: features",
                     "switch": [
                         "-datasheet_feature 'design name <float>'"
                     ],
@@ -1659,7 +1659,7 @@
                 "pernode": "never",
                 "require": null,
                 "scope": "job",
-                "shorthelp": "Datasheet: device footprint",
+                "shorthelp": "Datasheet: footprint",
                 "switch": [
                     "-datasheet_footprint 'design <str>'"
                 ],
@@ -1937,7 +1937,7 @@
                                 "cli: -datasheet_pin_cap 'mydevice sclk global (1e-12, 1.2e-12, 1.5e-12)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','cap','global',(1e-12, 1.2e-12, 1.5e-12)"
                             ],
-                            "help": "Pin cap. Values are tuples of (min, typical, max).",
+                            "help": "Pin capacitance. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -1951,7 +1951,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin cap",
+                            "shorthelp": "Datasheet: pin capacitance",
                             "switch": [
                                 "-datasheet_pin_cap 'design pin mode <(float,float,float)>'"
                             ],
@@ -2097,13 +2097,13 @@
                             "unit": "bits"
                         }
                     },
-                    "func": {
+                    "function": {
                         "default": {
                             "example": [
-                                "cli: -datasheet_pin_func 'mydevice z global a&b'",
-                                "api: chip.set('datasheet','mydevice','pin','z','func','global','a&b')"
+                                "cli: -datasheet_pin_function 'mydevice z global a&b'",
+                                "api: chip.set('datasheet','mydevice','pin','z','function','global','a&b')"
                             ],
-                            "help": "Pin func specified on a per mode basis. Only applicable to output\npins.",
+                            "help": "Pin function specified on a per mode basis.\nOnly applicable to output pins.",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2117,9 +2117,9 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin func",
+                            "shorthelp": "Datasheet: pin function",
                             "switch": [
-                                "-datasheet_pin_func 'design name mode <str>'"
+                                "-datasheet_pin_function 'design name mode <str>'"
                             ],
                             "type": "str"
                         }
@@ -2242,7 +2242,7 @@
                                 "cli: -datasheet_pin_ib1db 'mydevice sclk global (-1, 1, 1)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','ib1db','global',(-1, 1, 1)"
                             ],
-                            "help": "Pin in band 1 dB compression point. Values are tuples of (min, typical, max).",
+                            "help": "Pin rf in band 1 dB compression point. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2256,7 +2256,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin in band 1 dB compression point",
+                            "shorthelp": "Datasheet: pin rf in band 1 dB compression point",
                             "switch": [
                                 "-datasheet_pin_ib1db 'design pin mode <(float,float,float)>'"
                             ],
@@ -2326,7 +2326,7 @@
                                 "cli: -datasheet_pin_iip3 'mydevice sclk global (3, 3, 3)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','iip3','global',(3, 3, 3)"
                             ],
-                            "help": "Pin 3rd order input intercept point. Values are tuples of (min, typical, max).",
+                            "help": "Pin rf 3rd order input intercept point. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2340,7 +2340,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin 3rd order input intercept point",
+                            "shorthelp": "Datasheet: pin rf 3rd order input intercept point",
                             "switch": [
                                 "-datasheet_pin_iip3 'design pin mode <(float,float,float)>'"
                             ],
@@ -2605,7 +2605,7 @@
                                 "cli: -datasheet_pin_noisefigure 'mydevice sclk global (4.6, 4.6, 4.6)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','noisefigure','global',(4.6, 4.6, 4.6)"
                             ],
-                            "help": "Pin noise figure. Values are tuples of (min, typical, max).",
+                            "help": "Pin rf noise figure. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2619,7 +2619,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin noise figure",
+                            "shorthelp": "Datasheet: pin rf noise figure",
                             "switch": [
                                 "-datasheet_pin_noisefigure 'design pin mode <(float,float,float)>'"
                             ],
@@ -2661,7 +2661,7 @@
                                 "cli: -datasheet_pin_oob1db 'mydevice sclk global (3, 3, 3)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','oob1db','global',(3, 3, 3)"
                             ],
-                            "help": "Pin out of band 1 dB compression point. Values are tuples of (min, typical, max).",
+                            "help": "Pin rf out of band 1 dB compression point. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2675,7 +2675,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin out of band 1 dB compression point",
+                            "shorthelp": "Datasheet: pin rf out of band 1 dB compression point",
                             "switch": [
                                 "-datasheet_pin_oob1db 'design pin mode <(float,float,float)>'"
                             ],
@@ -3093,7 +3093,7 @@
                                 "cli: -datasheet_pin_s11 'mydevice sclk global (7, 7, 7)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','s11','global',(7, 7, 7)"
                             ],
-                            "help": "Pin input return loss. Values are tuples of (min, typical, max).",
+                            "help": "Pin rf input return loss. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3107,7 +3107,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin input return loss",
+                            "shorthelp": "Datasheet: pin rf input return loss",
                             "switch": [
                                 "-datasheet_pin_s11 'design pin mode <(float,float,float)>'"
                             ],
@@ -3121,7 +3121,7 @@
                                 "cli: -datasheet_pin_s12 'mydevice sclk global (-20, -20, -20)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','s12','global',(-20, -20, -20)"
                             ],
-                            "help": "Pin reverse isolation. Values are tuples of (min, typical, max).",
+                            "help": "Pin rf reverse isolation. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3135,7 +3135,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin reverse isolation",
+                            "shorthelp": "Datasheet: pin rf reverse isolation",
                             "switch": [
                                 "-datasheet_pin_s12 'design pin mode <(float,float,float)>'"
                             ],
@@ -3149,7 +3149,7 @@
                                 "cli: -datasheet_pin_s21 'mydevice sclk global (10, 11, 12)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','s21','global',(10, 11, 12)"
                             ],
-                            "help": "Pin gain. Values are tuples of (min, typical, max).",
+                            "help": "Pin rf gain. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3163,7 +3163,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin gain",
+                            "shorthelp": "Datasheet: pin rf gain",
                             "switch": [
                                 "-datasheet_pin_s21 'design pin mode <(float,float,float)>'"
                             ],
@@ -3177,7 +3177,7 @@
                                 "cli: -datasheet_pin_s22 'mydevice sclk global (10, 10, 10)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','s22','global',(10, 10, 10)"
                             ],
-                            "help": "Pin output return loss. Values are tuples of (min, typical, max).",
+                            "help": "Pin rf output return loss. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3191,7 +3191,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin output return loss",
+                            "shorthelp": "Datasheet: pin rf output return loss",
                             "switch": [
                                 "-datasheet_pin_s22 'design pin mode <(float,float,float)>'"
                             ],
@@ -3755,7 +3755,7 @@
                                 "cli: -datasheet_pin_vcdm 'mydevice sclk global (125, 150, 175)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vcdm','global',(125, 150, 175)"
                             ],
-                            "help": "Pin charge device model ESD tolerance. Values are tuples of (min, typical, max).",
+                            "help": "Pin ESD charge device model level. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3769,7 +3769,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin charge device model ESD tolerance",
+                            "shorthelp": "Datasheet: pin ESD charge device model level",
                             "switch": [
                                 "-datasheet_pin_vcdm 'design pin mode <(float,float,float)>'"
                             ],
@@ -3867,7 +3867,7 @@
                                 "cli: -datasheet_pin_vhbm 'mydevice sclk global (200, 250, 300)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vhbm','global',(200, 250, 300)"
                             ],
-                            "help": "Pin human body model ESD tolerance. Values are tuples of (min, typical, max).",
+                            "help": "Pin ESD human body model level. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3881,7 +3881,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin human body model ESD tolerance",
+                            "shorthelp": "Datasheet: pin ESD human body model level",
                             "switch": [
                                 "-datasheet_pin_vhbm 'design pin mode <(float,float,float)>'"
                             ],
@@ -3979,7 +3979,7 @@
                                 "cli: -datasheet_pin_vmm 'mydevice sclk global (100, 125, 150)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vmm','global',(100, 125, 150)"
                             ],
-                            "help": "Pin machine model ESD tolerance. Values are tuples of (min, typical, max).",
+                            "help": "Pin ESD machine model level. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -3993,7 +3993,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin machine model ESD tolerance",
+                            "shorthelp": "Datasheet: pin ESD machine model level",
                             "switch": [
                                 "-datasheet_pin_vmm 'design pin mode <(float,float,float)>'"
                             ],
@@ -4248,7 +4248,7 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: junction to ambient thermal resistance",
+                    "shorthelp": "Datasheet: thermal junction to ambient resistance",
                     "switch": [
                         "-datasheet_thermal_rja 'design <float>'"
                     ],
@@ -4274,7 +4274,7 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: junction to board thermal resistance",
+                    "shorthelp": "Datasheet: thermal junction to board resistance",
                     "switch": [
                         "-datasheet_thermal_rjb 'design <float>'"
                     ],
@@ -4300,7 +4300,7 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: junction to case (bottom) thermal resistance",
+                    "shorthelp": "Datasheet: thermal junction to case (bottom) resistance",
                     "switch": [
                         "-datasheet_thermal_rjcb 'design <float>'"
                     ],
@@ -4326,7 +4326,7 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: junction to case (top) thermal resistance",
+                    "shorthelp": "Datasheet: thermal junction to case (top) resistance",
                     "switch": [
                         "-datasheet_thermal_rjct 'design <float>'"
                     ],
@@ -4352,7 +4352,7 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: junction to bottom characterization parameter",
+                    "shorthelp": "Datasheet: thermal junction to bottom model",
                     "switch": [
                         "-datasheet_thermal_tjb 'design <float>'"
                     ],
@@ -4378,7 +4378,7 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: junction to top characterization parameter",
+                    "shorthelp": "Datasheet: thermal junction to top model",
                     "switch": [
                         "-datasheet_thermal_tjt 'design <float>'"
                     ],

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -4055,7 +4055,7 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: junction to ambient thermal resistence",
+                    "shorthelp": "Datasheet: junction to ambient thermal resistance",
                     "switch": [
                         "-datasheet_thermal_rja 'design <float>'"
                     ],
@@ -4081,7 +4081,7 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: junction to board thermal resistence",
+                    "shorthelp": "Datasheet: junction to board thermal resistance",
                     "switch": [
                         "-datasheet_thermal_rjb 'design <float>'"
                     ],
@@ -4107,7 +4107,7 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: junction to case (bottom) thermal resistence",
+                    "shorthelp": "Datasheet: junction to case (bottom) thermal resistance",
                     "switch": [
                         "-datasheet_thermal_rjcb 'design <float>'"
                     ],
@@ -4133,7 +4133,7 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: junction to case (top) thermal resistence",
+                    "shorthelp": "Datasheet: junction to case (top) thermal resistance",
                     "switch": [
                         "-datasheet_thermal_rjct 'design <float>'"
                     ],

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1772,13 +1772,13 @@
                             "unit": "Hz"
                         }
                     },
-                    "capacitance": {
+                    "cap": {
                         "default": {
                             "example": [
-                                "cli: -datasheet_pin_capacitance 'mydevice sclk global (1e-12, 1.2e-12, 1.5e-12)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','capacitance','global',(1e-12, 1.2e-12, 1.5e-12)"
+                                "cli: -datasheet_pin_cap 'mydevice sclk global (1e-12, 1.2e-12, 1.5e-12)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','cap','global',(1e-12, 1.2e-12, 1.5e-12)"
                             ],
-                            "help": "Pin capacitance. Values are tuples of (min, typical, max).",
+                            "help": "Pin cap. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -1792,9 +1792,9 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin capacitance",
+                            "shorthelp": "Datasheet: pin cap",
                             "switch": [
-                                "-datasheet_pin_capacitance 'design pin mode <(float,float,float)>'"
+                                "-datasheet_pin_cap 'design pin mode <(float,float,float)>'"
                             ],
                             "type": "(float,float,float)",
                             "unit": "F"
@@ -1938,13 +1938,13 @@
                             "unit": "bits"
                         }
                     },
-                    "function": {
+                    "func": {
                         "default": {
                             "example": [
-                                "cli: -datasheet_pin_function 'mydevice z global a&b'",
-                                "api: chip.set('datasheet','mydevice','pin','z','function','global','a&b')"
+                                "cli: -datasheet_pin_func 'mydevice z global a&b'",
+                                "api: chip.set('datasheet','mydevice','pin','z','func','global','a&b')"
                             ],
-                            "help": "Pin function specified on a per mode basis. Only applicable to output\npins.",
+                            "help": "Pin func specified on a per mode basis. Only applicable to output\npins.",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -1958,9 +1958,9 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin function",
+                            "shorthelp": "Datasheet: pin func",
                             "switch": [
-                                "-datasheet_pin_function 'design name mode <str>'"
+                                "-datasheet_pin_func 'design name mode <str>'"
                             ],
                             "type": "str"
                         }
@@ -2554,37 +2554,35 @@
                     },
                     "polarity": {
                         "default": {
-                            "relpin": {
-                                "default": {
-                                    "enum": [
-                                        "positive",
-                                        "negative",
-                                        "none"
-                                    ],
-                                    "example": [
-                                        "cli: -datasheet_pin_polarity 'cpu q def clk none'",
-                                        "api: chip.set('datasheet','cpu','pin','q','polarity','def','relpin','clk,'none')"
-                                    ],
-                                    "help": "Pin polarity specified on a per mode basis. Only applicable to output\npins. Valid entries are: positive, negative, none.",
-                                    "lock": false,
-                                    "node": {
+                            "default": {
+                                "enum": [
+                                    "positive",
+                                    "negative",
+                                    "none"
+                                ],
+                                "example": [
+                                    "cli: -datasheet_pin_polarity 'cpu q def clk none'",
+                                    "api: chip.set('datasheet','cpu','pin','q','polarity','def','clk,'none')"
+                                ],
+                                "help": "Pin polarity specified on a per mode basis. Only applicable to output\npins. Valid entries are: positive, negative, none.",
+                                "lock": false,
+                                "node": {
+                                    "default": {
                                         "default": {
-                                            "default": {
-                                                "signature": null,
-                                                "value": null
-                                            }
+                                            "signature": null,
+                                            "value": null
                                         }
-                                    },
-                                    "notes": null,
-                                    "pernode": "never",
-                                    "require": null,
-                                    "scope": "job",
-                                    "shorthelp": "Datasheet: pin polarity",
-                                    "switch": [
-                                        "-datasheet_pin_polarity 'design name mode relpin name <str>'"
-                                    ],
-                                    "type": "enum"
-                                }
+                                    }
+                                },
+                                "notes": null,
+                                "pernode": "never",
+                                "require": null,
+                                "scope": "job",
+                                "shorthelp": "Datasheet: pin polarity",
+                                "switch": [
+                                    "-datasheet_pin_polarity 'design name mode name <str>'"
+                                ],
+                                "type": "enum"
                             }
                         }
                     },

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1612,46 +1612,19 @@
         }
     },
     "datasheet": {
-        "default": {
-            "feature": {
-                "default": {
-                    "example": [
-                        "cli: -datasheet_feature 'mydevice ram 64e6'",
-                        "api: chip.set('datasheet','mydevice','feature','ram',64e6)"
-                    ],
-                    "help": "Quantity of a specified feature. The 'unit'\nfield should be used to specify the units used when unclear.",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: features",
-                    "switch": [
-                        "-datasheet_feature 'design name <float>'"
-                    ],
-                    "type": "float"
-                }
-            },
-            "footprint": {
+        "feature": {
+            "default": {
                 "example": [
-                    "cli: -datasheet_footprint 'mydsp bga169'",
-                    "api: chip.set('datasheet','mydsp', 'footprint','bga169')"
+                    "cli: -datasheet_feature 'ram 64e6'",
+                    "api: chip.set('datasheet','feature','ram',64e6)"
                 ],
-                "help": "List of available physical footprints for the named\ndevice specified as strings. Strings can either be official\nstandard footprint names or a custom naming methodology used in\nconjunction with 'fileset' names in the output parameter.",
+                "help": "Quantity of a specified feature. The 'unit'\nfield should be used to specify the units used when unclear.",
                 "lock": false,
                 "node": {
                     "default": {
                         "default": {
-                            "signature": [],
-                            "value": []
+                            "signature": null,
+                            "value": null
                         }
                     }
                 },
@@ -1659,2554 +1632,283 @@
                 "pernode": "never",
                 "require": null,
                 "scope": "job",
-                "shorthelp": "Datasheet: footprint",
+                "shorthelp": "Datasheet: features",
                 "switch": [
-                    "-datasheet_footprint 'design <str>'"
+                    "-datasheet_feature 'name <float>'"
                 ],
-                "type": "[str]"
-            },
-            "limit": {
-                "junctiontemp": {
-                    "example": [
-                        "cli: -datasheet_limit_junctiontemp 'dev (-40, 125)'",
-                        "api: chip.set('datasheet','dev','limit','junctiontemp',(-40, 125)"
-                    ],
-                    "help": "Limit junction temperature limits. Values are tuples of (min, max).",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: limit junction temperature limits",
-                    "switch": [
-                        "-datasheet_limit_junctiontemp 'design <(float,float)>'"
-                    ],
-                    "type": "(float,float)",
-                    "unit": "C"
-                },
-                "seb": {
-                    "example": [
-                        "cli: -datasheet_limit_seb 'dev (75, 75)'",
-                        "api: chip.set('datasheet','dev','limit','seb',(75, 75)"
-                    ],
-                    "help": "Limit single event burnout threshold. Values are tuples of (min, max).",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: limit single event burnout threshold",
-                    "switch": [
-                        "-datasheet_limit_seb 'design <(float,float)>'"
-                    ],
-                    "type": "(float,float)",
-                    "unit": "MeV-cm2/mg"
-                },
-                "segr": {
-                    "example": [
-                        "cli: -datasheet_limit_segr 'dev (75, 75)'",
-                        "api: chip.set('datasheet','dev','limit','segr',(75, 75)"
-                    ],
-                    "help": "Limit single event gate rupture threshold. Values are tuples of (min, max).",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: limit single event gate rupture threshold",
-                    "switch": [
-                        "-datasheet_limit_segr 'design <(float,float)>'"
-                    ],
-                    "type": "(float,float)",
-                    "unit": "MeV-cm2/mg"
-                },
-                "sel": {
-                    "example": [
-                        "cli: -datasheet_limit_sel 'dev (75, 75)'",
-                        "api: chip.set('datasheet','dev','limit','sel',(75, 75)"
-                    ],
-                    "help": "Limit single event latchup threshold. Values are tuples of (min, max).",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: limit single event latchup threshold",
-                    "switch": [
-                        "-datasheet_limit_sel 'design <(float,float)>'"
-                    ],
-                    "type": "(float,float)",
-                    "unit": "MeV-cm2/mg"
-                },
-                "set": {
-                    "example": [
-                        "cli: -datasheet_limit_set 'dev (75, 75)'",
-                        "api: chip.set('datasheet','dev','limit','set',(75, 75)"
-                    ],
-                    "help": "Limit single event transient threshold. Values are tuples of (min, max).",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: limit single event transient threshold",
-                    "switch": [
-                        "-datasheet_limit_set 'design <(float,float)>'"
-                    ],
-                    "type": "(float,float)",
-                    "unit": "MeV-cm2/mg"
-                },
-                "seu": {
-                    "example": [
-                        "cli: -datasheet_limit_seu 'dev (75, 75)'",
-                        "api: chip.set('datasheet','dev','limit','seu',(75, 75)"
-                    ],
-                    "help": "Limit single event upset threshold. Values are tuples of (min, max).",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: limit single event upset threshold",
-                    "switch": [
-                        "-datasheet_limit_seu 'design <(float,float)>'"
-                    ],
-                    "type": "(float,float)",
-                    "unit": "MeV-cm2/mg"
-                },
-                "soldertemp": {
-                    "example": [
-                        "cli: -datasheet_limit_soldertemp 'dev (-40, 125)'",
-                        "api: chip.set('datasheet','dev','limit','soldertemp',(-40, 125)"
-                    ],
-                    "help": "Limit solder temperature limits. Values are tuples of (min, max).",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: limit solder temperature limits",
-                    "switch": [
-                        "-datasheet_limit_soldertemp 'design <(float,float)>'"
-                    ],
-                    "type": "(float,float)",
-                    "unit": "C"
-                },
-                "storagetemp": {
-                    "example": [
-                        "cli: -datasheet_limit_storagetemp 'dev (-40, 125)'",
-                        "api: chip.set('datasheet','dev','limit','storagetemp',(-40, 125)"
-                    ],
-                    "help": "Limit storage temperature limits. Values are tuples of (min, max).",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: limit storage temperature limits",
-                    "switch": [
-                        "-datasheet_limit_storagetemp 'design <(float,float)>'"
-                    ],
-                    "type": "(float,float)",
-                    "unit": "C"
-                },
-                "tid": {
-                    "example": [
-                        "cli: -datasheet_limit_tid 'dev (300000.0, 300000.0)'",
-                        "api: chip.set('datasheet','dev','limit','tid',(300000.0, 300000.0)"
-                    ],
-                    "help": "Limit total ionizing dose threshold. Values are tuples of (min, max).",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: limit total ionizing dose threshold",
-                    "switch": [
-                        "-datasheet_limit_tid 'design <(float,float)>'"
-                    ],
-                    "type": "(float,float)",
-                    "unit": "rad"
-                }
-            },
-            "pin": {
+                "type": "float"
+            }
+        },
+        "footprint": {
+            "example": [
+                "cli: -datasheet_footprint 'bga169'",
+                "api: chip.set('datasheet','footprint','bga169')"
+            ],
+            "help": "List of available physical footprints for the named\ndevice specified as strings. Strings can either be official\nstandard footprint names or a custom naming methodology used in\nconjunction with 'fileset' names in the output parameter.",
+            "lock": false,
+            "node": {
                 "default": {
-                    "bw": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_bw 'mydevice sclk global (500000000.0, 600000000.0, 700000000.0)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','bw','global',(500000000.0, 600000000.0, 700000000.0)"
-                            ],
-                            "help": "Pin nyquist bandwidth. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin nyquist bandwidth",
-                            "switch": [
-                                "-datasheet_pin_bw 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "Hz"
-                        }
-                    },
-                    "cap": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_cap 'mydevice sclk global (1e-12, 1.2e-12, 1.5e-12)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','cap','global',(1e-12, 1.2e-12, 1.5e-12)"
-                            ],
-                            "help": "Pin capacitance. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin capacitance",
-                            "switch": [
-                                "-datasheet_pin_cap 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "F"
-                        }
-                    },
-                    "cmrr": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_cmrr 'mydevice sclk global (70, 80, 90)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','cmrr','global',(70, 80, 90)"
-                            ],
-                            "help": "Pin common mode rejection ratio. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin common mode rejection ratio",
-                            "switch": [
-                                "-datasheet_pin_cmrr 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dB"
-                        }
-                    },
-                    "complement": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_complement 'mydevice ina global inb'",
-                                "api: chip.set('datasheet','mydevice','pin','ina','complement','global','inb')"
-                            ],
-                            "help": "Pin complement specified on a per mode basis for differential\nsignals.",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin complement",
-                            "switch": [
-                                "-datasheet_pin_complement 'design name mode <str>'"
-                            ],
-                            "type": "str"
-                        }
-                    },
-                    "dir": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_dir 'mydevice clk global input'",
-                                "api: chip.set('datasheet','mydevice','pin','clk','dir','global','input')"
-                            ],
-                            "help": "Pin direction specified on a per mode basis. Acceptable pin\ndirections include: input, output, inout.",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin direction",
-                            "switch": [
-                                "-datasheet_pin_dir 'design name mode <str>'"
-                            ],
-                            "type": "str"
-                        }
-                    },
-                    "dnl": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_dnl 'mydevice sclk global (-1.0, 0.0, 1.0)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','dnl','global',(-1.0, 0.0, 1.0)"
-                            ],
-                            "help": "Pin differential nonlinearity. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin differential nonlinearity",
-                            "switch": [
-                                "-datasheet_pin_dnl 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "LSB"
-                        }
-                    },
-                    "enob": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_enob 'mydevice sclk global (8, 9, 10)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','enob','global',(8, 9, 10)"
-                            ],
-                            "help": "Pin effective number of bits. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin effective number of bits",
-                            "switch": [
-                                "-datasheet_pin_enob 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "bits"
-                        }
-                    },
-                    "function": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_function 'mydevice z global a&b'",
-                                "api: chip.set('datasheet','mydevice','pin','z','function','global','a&b')"
-                            ],
-                            "help": "Pin function specified on a per mode basis.\nOnly applicable to output pins.",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin function",
-                            "switch": [
-                                "-datasheet_pin_function 'design name mode <str>'"
-                            ],
-                            "type": "str"
-                        }
-                    },
-                    "gain": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_gain 'mydevice sclk global (11.4, 11.4, 11.4)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','gain','global',(11.4, 11.4, 11.4)"
-                            ],
-                            "help": "Pin gain. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin gain",
-                            "switch": [
-                                "-datasheet_pin_gain 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dB"
-                        }
-                    },
-                    "hd2": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_hd2 'mydevice sclk global (62, 64, 66)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','hd2','global',(62, 64, 66)"
-                            ],
-                            "help": "Pin 2nd order harmonic distorion. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin 2nd order harmonic distorion",
-                            "switch": [
-                                "-datasheet_pin_hd2 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dBc"
-                        }
-                    },
-                    "hd3": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_hd3 'mydevice sclk global (62, 64, 66)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','hd3','global',(62, 64, 66)"
-                            ],
-                            "help": "Pin 3rd order harmonic distorion. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin 3rd order harmonic distorion",
-                            "switch": [
-                                "-datasheet_pin_hd3 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dBc"
-                        }
-                    },
-                    "hd4": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_hd4 'mydevice sclk global (62, 64, 66)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','hd4','global',(62, 64, 66)"
-                            ],
-                            "help": "Pin 4th order harmonic distorion. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin 4th order harmonic distorion",
-                            "switch": [
-                                "-datasheet_pin_hd4 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dBc"
-                        }
-                    },
-                    "ib1db": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_ib1db 'mydevice sclk global (-1, 1, 1)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','ib1db','global',(-1, 1, 1)"
-                            ],
-                            "help": "Pin rf in band 1 dB compression point. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin rf in band 1 dB compression point",
-                            "switch": [
-                                "-datasheet_pin_ib1db 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dBm"
-                        }
-                    },
-                    "ibias": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_ibias 'mydevice sclk global (0.001, 0.0012, 0.0015)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','ibias','global',(0.001, 0.0012, 0.0015)"
-                            ],
-                            "help": "Pin bias current. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin bias current",
-                            "switch": [
-                                "-datasheet_pin_ibias 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "A"
-                        }
-                    },
-                    "iinject": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_iinject 'mydevice sclk global (0.001, 0.0012, 0.0015)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','iinject','global',(0.001, 0.0012, 0.0015)"
-                            ],
-                            "help": "Pin injection current. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin injection current",
-                            "switch": [
-                                "-datasheet_pin_iinject 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "A"
-                        }
-                    },
-                    "iip3": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_iip3 'mydevice sclk global (3, 3, 3)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','iip3','global',(3, 3, 3)"
-                            ],
-                            "help": "Pin rf 3rd order input intercept point. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin rf 3rd order input intercept point",
-                            "switch": [
-                                "-datasheet_pin_iip3 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dBm"
-                        }
-                    },
-                    "ileakage": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_ileakage 'mydevice sclk global (1e-06, 1.2e-06, 1.5e-06)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','ileakage','global',(1e-06, 1.2e-06, 1.5e-06)"
-                            ],
-                            "help": "Pin leakage current. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin leakage current",
-                            "switch": [
-                                "-datasheet_pin_ileakage 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "A"
-                        }
-                    },
-                    "imd3": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_imd3 'mydevice sclk global (82, 88, 98)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','imd3','global',(82, 88, 98)"
-                            ],
-                            "help": "Pin 3rd order intermodulation distortion. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin 3rd order intermodulation distortion",
-                            "switch": [
-                                "-datasheet_pin_imd3 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dBc"
-                        }
-                    },
-                    "inl": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_inl 'mydevice sclk global (-7, 0.0, 7)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','inl','global',(-7, 0.0, 7)"
-                            ],
-                            "help": "Pin integral nonlinearity. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin integral nonlinearity",
-                            "switch": [
-                                "-datasheet_pin_inl 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "LSB"
-                        }
-                    },
-                    "ioffset": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_ioffset 'mydevice sclk global (0.001, 0.0012, 0.0015)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','ioffset','global',(0.001, 0.0012, 0.0015)"
-                            ],
-                            "help": "Pin offset current. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin offset current",
-                            "switch": [
-                                "-datasheet_pin_ioffset 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "A"
-                        }
-                    },
-                    "ioh": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_ioh 'mydevice sclk global (0.01, 0.012, 0.015)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','ioh','global',(0.01, 0.012, 0.015)"
-                            ],
-                            "help": "Pin output high current. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin output high current",
-                            "switch": [
-                                "-datasheet_pin_ioh 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "A"
-                        }
-                    },
-                    "iol": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_iol 'mydevice sclk global (0.01, 0.012, 0.015)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','iol','global',(0.01, 0.012, 0.015)"
-                            ],
-                            "help": "Pin output low current. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin output low current",
-                            "switch": [
-                                "-datasheet_pin_iol 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "A"
-                        }
-                    },
-                    "ishort": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_ishort 'mydevice sclk global (0.001, 0.0012, 0.0015)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','ishort','global',(0.001, 0.0012, 0.0015)"
-                            ],
-                            "help": "Pin short circuit current. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin short circuit current",
-                            "switch": [
-                                "-datasheet_pin_ishort 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "A"
-                        }
-                    },
-                    "isupply": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_isupply 'mydevice sclk global (0.001, 0.012, 0.015)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','isupply','global',(0.001, 0.012, 0.015)"
-                            ],
-                            "help": "Pin supply currents. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin supply currents",
-                            "switch": [
-                                "-datasheet_pin_isupply 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "A"
-                        }
-                    },
-                    "map": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_map 'mydevice in0 bga512 B4'",
-                                "api: chip.set('datasheet','mydevice','pin','in0','map','bga512','B4')"
-                            ],
-                            "help": "Signal to package pin mapping specified on a per package basis.",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin map",
-                            "switch": [
-                                "-datasheet_pin_map 'design name package <str>'"
-                            ],
-                            "type": "str"
-                        }
-                    },
-                    "noisefigure": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_noisefigure 'mydevice sclk global (4.6, 4.6, 4.6)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','noisefigure','global',(4.6, 4.6, 4.6)"
-                            ],
-                            "help": "Pin rf noise figure. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin rf noise figure",
-                            "switch": [
-                                "-datasheet_pin_noisefigure 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dB"
-                        }
-                    },
-                    "nsd": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_nsd 'mydevice sclk global (-158, -158, -158)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','nsd','global',(-158, -158, -158)"
-                            ],
-                            "help": "Pin noise spectral density. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin noise spectral density",
-                            "switch": [
-                                "-datasheet_pin_nsd 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dBFS/Hz"
-                        }
-                    },
-                    "oob1db": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_oob1db 'mydevice sclk global (3, 3, 3)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','oob1db','global',(3, 3, 3)"
-                            ],
-                            "help": "Pin rf out of band 1 dB compression point. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin rf out of band 1 dB compression point",
-                            "switch": [
-                                "-datasheet_pin_oob1db 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dBm"
-                        }
-                    },
-                    "phasenoise": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_phasenoise 'mydevice sclk global (-158, -158, -158)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','phasenoise','global',(-158, -158, -158)"
-                            ],
-                            "help": "Pin phase noise. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin phase noise",
-                            "switch": [
-                                "-datasheet_pin_phasenoise 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dBc/Hz"
-                        }
-                    },
-                    "polarity": {
-                        "default": {
-                            "default": {
-                                "enum": [
-                                    "positive",
-                                    "negative",
-                                    "none"
-                                ],
-                                "example": [
-                                    "cli: -datasheet_pin_polarity 'cpu q def clk none'",
-                                    "api: chip.set('datasheet','cpu','pin','q','polarity','def','clk,'none')"
-                                ],
-                                "help": "Pin polarity specified on a per mode basis. Only applicable to output\npins.",
-                                "lock": false,
-                                "node": {
-                                    "default": {
-                                        "default": {
-                                            "signature": null,
-                                            "value": null
-                                        }
-                                    }
-                                },
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "shorthelp": "Datasheet: pin polarity",
-                                "switch": [
-                                    "-datasheet_pin_polarity 'design name mode relpin <str>'"
-                                ],
-                                "type": "enum"
-                            }
-                        }
-                    },
-                    "pout": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_pout 'mydevice sclk global (12.2, 12.2, 12.2)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','pout','global',(12.2, 12.2, 12.2)"
-                            ],
-                            "help": "Pin output power. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin output power",
-                            "switch": [
-                                "-datasheet_pin_pout 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dBm"
-                        }
-                    },
-                    "pout2": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_pout2 'mydevice sclk global (-14, -14, -14)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','pout2','global',(-14, -14, -14)"
-                            ],
-                            "help": "Pin 2nd harmonic power. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin 2nd harmonic power",
-                            "switch": [
-                                "-datasheet_pin_pout2 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dBm"
-                        }
-                    },
-                    "pout3": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_pout3 'mydevice sclk global (-28, -28, -28)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','pout3','global',(-28, -28, -28)"
-                            ],
-                            "help": "Pin 3rd harmonic power. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin 3rd harmonic power",
-                            "switch": [
-                                "-datasheet_pin_pout3 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dBm"
-                        }
-                    },
-                    "power": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_power 'mydevice sclk global (1, 2, 3)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','power','global',(1, 2, 3)"
-                            ],
-                            "help": "Pin power consumption. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin power consumption",
-                            "switch": [
-                                "-datasheet_pin_power 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "W"
-                        }
-                    },
-                    "psnr": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_psnr 'mydevice sclk global (61, 61, 61)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','psnr','global',(61, 61, 61)"
-                            ],
-                            "help": "Pin power supply noise rejection. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin power supply noise rejection",
-                            "switch": [
-                                "-datasheet_pin_psnr 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dB"
-                        }
-                    },
-                    "rdiff": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_rdiff 'mydevice sclk global (45, 50, 55)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','rdiff','global',(45, 50, 55)"
-                            ],
-                            "help": "Pin differential pair resistance. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin differential pair resistance",
-                            "switch": [
-                                "-datasheet_pin_rdiff 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "Ohm"
-                        }
-                    },
-                    "rdown": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_rdown 'mydevice sclk global (1000, 1200, 3000)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','rdown','global',(1000, 1200, 3000)"
-                            ],
-                            "help": "Pin output pulldown resistance. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin output pulldown resistance",
-                            "switch": [
-                                "-datasheet_pin_rdown 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "Ohm"
-                        }
-                    },
-                    "resetvalue": {
-                        "default": {
-                            "enum": [
-                                "weak1",
-                                "weak0",
-                                "strong0",
-                                "strong1",
-                                "highz"
-                            ],
-                            "example": [
-                                "cli: -datasheet_pin_resetvalue 'mydevice clk global weak1'",
-                                "api: chip.set('datasheet','mydevice','pin','clk','resetvalue','global','weak1')"
-                            ],
-                            "help": "Pin reset value specified on a per mode basis.",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin reset value",
-                            "switch": [
-                                "-datasheet_pin_resetvalue 'design name mode <str>'"
-                            ],
-                            "type": "enum"
-                        }
-                    },
-                    "rin": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_rin 'mydevice sclk global (1000, 1200, 3000)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','rin','global',(1000, 1200, 3000)"
-                            ],
-                            "help": "Pin input resistance. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin input resistance",
-                            "switch": [
-                                "-datasheet_pin_rin 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "Ohm"
-                        }
-                    },
-                    "rup": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_rup 'mydevice sclk global (1000, 1200, 3000)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','rup','global',(1000, 1200, 3000)"
-                            ],
-                            "help": "Pin output pullup resistance. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin output pullup resistance",
-                            "switch": [
-                                "-datasheet_pin_rup 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "Ohm"
-                        }
-                    },
-                    "rweakdown": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_rweakdown 'mydevice sclk global (1000, 1200, 3000)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','rweakdown','global',(1000, 1200, 3000)"
-                            ],
-                            "help": "Pin weak pulldown resistance. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin weak pulldown resistance",
-                            "switch": [
-                                "-datasheet_pin_rweakdown 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "Ohm"
-                        }
-                    },
-                    "rweakup": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_rweakup 'mydevice sclk global (1000, 1200, 3000)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','rweakup','global',(1000, 1200, 3000)"
-                            ],
-                            "help": "Pin weak pullup resistance. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin weak pullup resistance",
-                            "switch": [
-                                "-datasheet_pin_rweakup 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "Ohm"
-                        }
-                    },
-                    "s11": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_s11 'mydevice sclk global (7, 7, 7)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','s11','global',(7, 7, 7)"
-                            ],
-                            "help": "Pin rf input return loss. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin rf input return loss",
-                            "switch": [
-                                "-datasheet_pin_s11 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dB"
-                        }
-                    },
-                    "s12": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_s12 'mydevice sclk global (-20, -20, -20)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','s12','global',(-20, -20, -20)"
-                            ],
-                            "help": "Pin rf reverse isolation. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin rf reverse isolation",
-                            "switch": [
-                                "-datasheet_pin_s12 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dB"
-                        }
-                    },
-                    "s21": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_s21 'mydevice sclk global (10, 11, 12)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','s21','global',(10, 11, 12)"
-                            ],
-                            "help": "Pin rf gain. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin rf gain",
-                            "switch": [
-                                "-datasheet_pin_s21 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dB"
-                        }
-                    },
-                    "s22": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_s22 'mydevice sclk global (10, 10, 10)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','s22','global',(10, 10, 10)"
-                            ],
-                            "help": "Pin rf output return loss. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin rf output return loss",
-                            "switch": [
-                                "-datasheet_pin_s22 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dB"
-                        }
-                    },
-                    "sfdr": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_sfdr 'mydevice sclk global (82, 88, 98)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','sfdr','global',(82, 88, 98)"
-                            ],
-                            "help": "Pin spurious-free dynamic range. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin spurious-free dynamic range",
-                            "switch": [
-                                "-datasheet_pin_sfdr 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dBc"
-                        }
-                    },
-                    "signal": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_signal 'mydevice clk0 ddr4 CLKN'",
-                                "api: chip.set('datasheet','mydevice','pin','clk0','signal','ddr4','CLKN')"
-                            ],
-                            "help": "Pin mapping to standardized interface signals.",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": [],
-                                        "value": []
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin signal map",
-                            "switch": [
-                                "-datasheet_pin_signal 'design name mode <str>'"
-                            ],
-                            "type": "[str]"
-                        }
-                    },
-                    "sinad": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_sinad 'mydevice sclk global (71, 72, 73)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','sinad','global',(71, 72, 73)"
-                            ],
-                            "help": "Pin signal to noise and distortion ratio. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin signal to noise and distortion ratio",
-                            "switch": [
-                                "-datasheet_pin_sinad 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dB"
-                        }
-                    },
-                    "snr": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_snr 'mydevice sclk global (70, 72, 74)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','snr','global',(70, 72, 74)"
-                            ],
-                            "help": "Pin signal to noise ratio. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin signal to noise ratio",
-                            "switch": [
-                                "-datasheet_pin_snr 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "dB"
-                        }
-                    },
-                    "standard": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_standard 'mydevice clk def LVCMOS'",
-                                "api: chip.set('datasheet','mydevice','pin','clk','standard','def', 'LVCMOS')"
-                            ],
-                            "help": "Pin electrical signaling standard (LVDS, LVCMOS, TTL,..).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": [],
-                                        "value": []
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin standard",
-                            "switch": [
-                                "-datasheet_pin_standard 'design name mode <str>'"
-                            ],
-                            "type": "[str]"
-                        }
-                    },
-                    "tdelayf": {
-                        "default": {
-                            "default": {
-                                "example": [
-                                    "cli: -datasheet_pin_tdelayf 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
-                                    "api: chip.set('datasheet','dev','pin','a','tdelayf','glob','ck',(1e-09, 2e-09, 4e-09)"
-                                ],
-                                "help": "Pin propagation delay (fall) specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
-                                "lock": false,
-                                "node": {
-                                    "default": {
-                                        "default": {
-                                            "signature": null,
-                                            "value": null
-                                        }
-                                    }
-                                },
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "shorthelp": "Datasheet: pin propagation delay (fall)",
-                                "switch": [
-                                    "-datasheet_pin_tdelayf 'design pin mode relpin <(float,float,float)>'"
-                                ],
-                                "type": "(float,float,float)",
-                                "unit": "s"
-                            }
-                        }
-                    },
-                    "tdelayr": {
-                        "default": {
-                            "default": {
-                                "example": [
-                                    "cli: -datasheet_pin_tdelayr 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
-                                    "api: chip.set('datasheet','dev','pin','a','tdelayr','glob','ck',(1e-09, 2e-09, 4e-09)"
-                                ],
-                                "help": "Pin propagation delay (rise) specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
-                                "lock": false,
-                                "node": {
-                                    "default": {
-                                        "default": {
-                                            "signature": null,
-                                            "value": null
-                                        }
-                                    }
-                                },
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "shorthelp": "Datasheet: pin propagation delay (rise)",
-                                "switch": [
-                                    "-datasheet_pin_tdelayr 'design pin mode relpin <(float,float,float)>'"
-                                ],
-                                "type": "(float,float,float)",
-                                "unit": "s"
-                            }
-                        }
-                    },
-                    "tduty": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_tduty 'mydevice sclk global (45, 50, 55)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','tduty','global',(45, 50, 55)"
-                            ],
-                            "help": "Pin duty cycle. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin duty cycle",
-                            "switch": [
-                                "-datasheet_pin_tduty 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "%"
-                        }
-                    },
-                    "tfall": {
-                        "default": {
-                            "default": {
-                                "example": [
-                                    "cli: -datasheet_pin_tfall 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
-                                    "api: chip.set('datasheet','dev','pin','a','tfall','glob','ck',(1e-09, 2e-09, 4e-09)"
-                                ],
-                                "help": "Pin fall transition specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
-                                "lock": false,
-                                "node": {
-                                    "default": {
-                                        "default": {
-                                            "signature": null,
-                                            "value": null
-                                        }
-                                    }
-                                },
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "shorthelp": "Datasheet: pin fall transition",
-                                "switch": [
-                                    "-datasheet_pin_tfall 'design pin mode relpin <(float,float,float)>'"
-                                ],
-                                "type": "(float,float,float)",
-                                "unit": "s"
-                            }
-                        }
-                    },
-                    "thigh": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_thigh 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','thigh','global',(1e-09, 2e-09, 4e-09)"
-                            ],
-                            "help": "Pin pulse width high. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin pulse width high",
-                            "switch": [
-                                "-datasheet_pin_thigh 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "s"
-                        }
-                    },
-                    "thold": {
-                        "default": {
-                            "default": {
-                                "example": [
-                                    "cli: -datasheet_pin_thold 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
-                                    "api: chip.set('datasheet','dev','pin','a','thold','glob','ck',(1e-09, 2e-09, 4e-09)"
-                                ],
-                                "help": "Pin hold time specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
-                                "lock": false,
-                                "node": {
-                                    "default": {
-                                        "default": {
-                                            "signature": null,
-                                            "value": null
-                                        }
-                                    }
-                                },
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "shorthelp": "Datasheet: pin hold time",
-                                "switch": [
-                                    "-datasheet_pin_thold 'design pin mode relpin <(float,float,float)>'"
-                                ],
-                                "type": "(float,float,float)",
-                                "unit": "s"
-                            }
-                        }
-                    },
-                    "tjitter": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_tjitter 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','tjitter','global',(1e-09, 2e-09, 4e-09)"
-                            ],
-                            "help": "Pin rms jitter. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin rms jitter",
-                            "switch": [
-                                "-datasheet_pin_tjitter 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "s"
-                        }
-                    },
-                    "tlow": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_tlow 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','tlow','global',(1e-09, 2e-09, 4e-09)"
-                            ],
-                            "help": "Pin pulse width low. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin pulse width low",
-                            "switch": [
-                                "-datasheet_pin_tlow 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "s"
-                        }
-                    },
-                    "tperiod": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_tperiod 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','tperiod','global',(1e-09, 2e-09, 4e-09)"
-                            ],
-                            "help": "Pin minimum period. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin minimum period",
-                            "switch": [
-                                "-datasheet_pin_tperiod 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "s"
-                        }
-                    },
-                    "tpulse": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_tpulse 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','tpulse','global',(1e-09, 2e-09, 4e-09)"
-                            ],
-                            "help": "Pin pulse width. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin pulse width",
-                            "switch": [
-                                "-datasheet_pin_tpulse 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "s"
-                        }
-                    },
-                    "trise": {
-                        "default": {
-                            "default": {
-                                "example": [
-                                    "cli: -datasheet_pin_trise 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
-                                    "api: chip.set('datasheet','dev','pin','a','trise','glob','ck',(1e-09, 2e-09, 4e-09)"
-                                ],
-                                "help": "Pin rise transition specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
-                                "lock": false,
-                                "node": {
-                                    "default": {
-                                        "default": {
-                                            "signature": null,
-                                            "value": null
-                                        }
-                                    }
-                                },
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "shorthelp": "Datasheet: pin rise transition",
-                                "switch": [
-                                    "-datasheet_pin_trise 'design pin mode relpin <(float,float,float)>'"
-                                ],
-                                "type": "(float,float,float)",
-                                "unit": "s"
-                            }
-                        }
-                    },
-                    "tsetup": {
-                        "default": {
-                            "default": {
-                                "example": [
-                                    "cli: -datasheet_pin_tsetup 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
-                                    "api: chip.set('datasheet','dev','pin','a','tsetup','glob','ck',(1e-09, 2e-09, 4e-09)"
-                                ],
-                                "help": "Pin setup time specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
-                                "lock": false,
-                                "node": {
-                                    "default": {
-                                        "default": {
-                                            "signature": null,
-                                            "value": null
-                                        }
-                                    }
-                                },
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "shorthelp": "Datasheet: pin setup time",
-                                "switch": [
-                                    "-datasheet_pin_tsetup 'design pin mode relpin <(float,float,float)>'"
-                                ],
-                                "type": "(float,float,float)",
-                                "unit": "s"
-                            }
-                        }
-                    },
-                    "tskew": {
-                        "default": {
-                            "default": {
-                                "example": [
-                                    "cli: -datasheet_pin_tskew 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
-                                    "api: chip.set('datasheet','dev','pin','a','tskew','glob','ck',(1e-09, 2e-09, 4e-09)"
-                                ],
-                                "help": "Pin timing skew specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
-                                "lock": false,
-                                "node": {
-                                    "default": {
-                                        "default": {
-                                            "signature": null,
-                                            "value": null
-                                        }
-                                    }
-                                },
-                                "notes": null,
-                                "pernode": "never",
-                                "require": null,
-                                "scope": "job",
-                                "shorthelp": "Datasheet: pin timing skew",
-                                "switch": [
-                                    "-datasheet_pin_tskew 'design pin mode relpin <(float,float,float)>'"
-                                ],
-                                "type": "(float,float,float)",
-                                "unit": "s"
-                            }
-                        }
-                    },
-                    "type": {
-                        "default": {
-                            "enum": [
-                                "digital",
-                                "analog",
-                                "clock",
-                                "supply",
-                                "ground"
-                            ],
-                            "example": [
-                                "cli: -datasheet_pin_type 'mydevice vdd global supply'",
-                                "api: chip.set('datasheet','mydevice','pin','vdd','type','global','supply')"
-                            ],
-                            "help": "Pin type specified on a per mode basis.",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin type",
-                            "switch": [
-                                "-datasheet_pin_type 'design name mode <str>'"
-                            ],
-                            "type": "enum"
-                        }
-                    },
-                    "vcdm": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vcdm 'mydevice sclk global (125, 150, 175)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vcdm','global',(125, 150, 175)"
-                            ],
-                            "help": "Pin ESD charge device model voltage level. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin ESD charge device model voltage level",
-                            "switch": [
-                                "-datasheet_pin_vcdm 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V"
-                        }
-                    },
-                    "vcm": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vcm 'mydevice sclk global (0.3, 1.2, 1.6)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vcm','global',(0.3, 1.2, 1.6)"
-                            ],
-                            "help": "Pin common mode voltage. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin common mode voltage",
-                            "switch": [
-                                "-datasheet_pin_vcm 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V"
-                        }
-                    },
-                    "vdiff": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vdiff 'mydevice sclk global (0.2, 0.3, 0.9)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vdiff','global',(0.2, 0.3, 0.9)"
-                            ],
-                            "help": "Pin differential voltage. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin differential voltage",
-                            "switch": [
-                                "-datasheet_pin_vdiff 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V"
-                        }
-                    },
-                    "vgainerror": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vgainerror 'mydevice sclk global (-1.0, 0.0, 1.0)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vgainerror','global',(-1.0, 0.0, 1.0)"
-                            ],
-                            "help": "Pin gain error. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin gain error",
-                            "switch": [
-                                "-datasheet_pin_vgainerror 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "mV"
-                        }
-                    },
-                    "vhbm": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vhbm 'mydevice sclk global (200, 250, 300)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vhbm','global',(200, 250, 300)"
-                            ],
-                            "help": "Pin ESD human body model voltage level. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin ESD human body model voltage level",
-                            "switch": [
-                                "-datasheet_pin_vhbm 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V"
-                        }
-                    },
-                    "vih": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vih 'mydevice sclk global (1.4, 1.8, 2.2)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vih','global',(1.4, 1.8, 2.2)"
-                            ],
-                            "help": "Pin high input voltage level. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin high input voltage level",
-                            "switch": [
-                                "-datasheet_pin_vih 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V"
-                        }
-                    },
-                    "vil": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vil 'mydevice sclk global (-0.2, 0, 1.0)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vil','global',(-0.2, 0, 1.0)"
-                            ],
-                            "help": "Pin low input voltage level. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin low input voltage level",
-                            "switch": [
-                                "-datasheet_pin_vil 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V"
-                        }
-                    },
-                    "vmax": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vmax 'mydevice sclk global (0.2, 0.3, 0.9)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vmax','global',(0.2, 0.3, 0.9)"
-                            ],
-                            "help": "Pin absolute maximum voltage. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin absolute maximum voltage",
-                            "switch": [
-                                "-datasheet_pin_vmax 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V"
-                        }
-                    },
-                    "vmm": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vmm 'mydevice sclk global (100, 125, 150)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vmm','global',(100, 125, 150)"
-                            ],
-                            "help": "Pin ESD machine model voltage level. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin ESD machine model voltage level",
-                            "switch": [
-                                "-datasheet_pin_vmm 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V"
-                        }
-                    },
-                    "vnoise": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vnoise 'mydevice sclk global (0, 0.01, 0.1)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vnoise','global',(0, 0.01, 0.1)"
-                            ],
-                            "help": "Pin random voltage noise. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin random voltage noise",
-                            "switch": [
-                                "-datasheet_pin_vnoise 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V"
-                        }
-                    },
-                    "vnominal": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vnominal 'mydevice sclk global (1.72, 1.8, 1.92)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vnominal','global',(1.72, 1.8, 1.92)"
-                            ],
-                            "help": "Pin nominal operating voltage. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin nominal operating voltage",
-                            "switch": [
-                                "-datasheet_pin_vnominal 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V"
-                        }
-                    },
-                    "vofferror": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vofferror 'mydevice sclk global (-1.0, 0.0, 1.0)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vofferror','global',(-1.0, 0.0, 1.0)"
-                            ],
-                            "help": "Pin offset error. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin offset error",
-                            "switch": [
-                                "-datasheet_pin_vofferror 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "mV"
-                        }
-                    },
-                    "voffset": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_voffset 'mydevice sclk global (0.2, 0.3, 0.9)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','voffset','global',(0.2, 0.3, 0.9)"
-                            ],
-                            "help": "Pin offset voltage. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin offset voltage",
-                            "switch": [
-                                "-datasheet_pin_voffset 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V"
-                        }
-                    },
-                    "voh": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_voh 'mydevice sclk global (4.6, 4.8, 5.2)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','voh','global',(4.6, 4.8, 5.2)"
-                            ],
-                            "help": "Pin high output voltage level. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin high output voltage level",
-                            "switch": [
-                                "-datasheet_pin_voh 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V"
-                        }
-                    },
-                    "vol": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vol 'mydevice sclk global (-0.2, 0, 0.2)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vol','global',(-0.2, 0, 0.2)"
-                            ],
-                            "help": "Pin low output voltage level. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin low output voltage level",
-                            "switch": [
-                                "-datasheet_pin_vol 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V"
-                        }
-                    },
-                    "vslew": {
-                        "default": {
-                            "example": [
-                                "cli: -datasheet_pin_vslew 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vslew','global',(1e-09, 2e-09, 4e-09)"
-                            ],
-                            "help": "Pin slew rate. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
-                                    "default": {
-                                        "signature": null,
-                                        "value": null
-                                    }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin slew rate",
-                            "switch": [
-                                "-datasheet_pin_vslew 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "V/s"
-                        }
+                    "default": {
+                        "signature": [],
+                        "value": []
                     }
                 }
             },
-            "reliability": {
-                "default": {
+            "notes": null,
+            "pernode": "never",
+            "require": null,
+            "scope": "job",
+            "shorthelp": "Datasheet: footprint",
+            "switch": [
+                "-datasheet_footprint 'design <str>'"
+            ],
+            "type": "[str]"
+        },
+        "limit": {
+            "junctiontemp": {
+                "example": [
+                    "cli: -datasheet_limit_junctiontemp '(-40, 125)'",
+                    "api: chip.set('datasheet', 'limit','junctiontemp',(-40, 125)"
+                ],
+                "help": "Limit junction temperature limits. Values are tuples of (min, max).",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: limit junction temperature limits",
+                "switch": [
+                    "-datasheet_limit_junctiontemp '<(float,float)>'"
+                ],
+                "type": "(float,float)",
+                "unit": "C"
+            },
+            "seb": {
+                "example": [
+                    "cli: -datasheet_limit_seb '(75, 75)'",
+                    "api: chip.set('datasheet', 'limit','seb',(75, 75)"
+                ],
+                "help": "Limit single event burnout threshold. Values are tuples of (min, max).",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: limit single event burnout threshold",
+                "switch": [
+                    "-datasheet_limit_seb '<(float,float)>'"
+                ],
+                "type": "(float,float)",
+                "unit": "MeV-cm2/mg"
+            },
+            "segr": {
+                "example": [
+                    "cli: -datasheet_limit_segr '(75, 75)'",
+                    "api: chip.set('datasheet', 'limit','segr',(75, 75)"
+                ],
+                "help": "Limit single event gate rupture threshold. Values are tuples of (min, max).",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: limit single event gate rupture threshold",
+                "switch": [
+                    "-datasheet_limit_segr '<(float,float)>'"
+                ],
+                "type": "(float,float)",
+                "unit": "MeV-cm2/mg"
+            },
+            "sel": {
+                "example": [
+                    "cli: -datasheet_limit_sel '(75, 75)'",
+                    "api: chip.set('datasheet', 'limit','sel',(75, 75)"
+                ],
+                "help": "Limit single event latchup threshold. Values are tuples of (min, max).",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: limit single event latchup threshold",
+                "switch": [
+                    "-datasheet_limit_sel '<(float,float)>'"
+                ],
+                "type": "(float,float)",
+                "unit": "MeV-cm2/mg"
+            },
+            "set": {
+                "example": [
+                    "cli: -datasheet_limit_set '(75, 75)'",
+                    "api: chip.set('datasheet', 'limit','set',(75, 75)"
+                ],
+                "help": "Limit single event transient threshold. Values are tuples of (min, max).",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: limit single event transient threshold",
+                "switch": [
+                    "-datasheet_limit_set '<(float,float)>'"
+                ],
+                "type": "(float,float)",
+                "unit": "MeV-cm2/mg"
+            },
+            "seu": {
+                "example": [
+                    "cli: -datasheet_limit_seu '(75, 75)'",
+                    "api: chip.set('datasheet', 'limit','seu',(75, 75)"
+                ],
+                "help": "Limit single event upset threshold. Values are tuples of (min, max).",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: limit single event upset threshold",
+                "switch": [
+                    "-datasheet_limit_seu '<(float,float)>'"
+                ],
+                "type": "(float,float)",
+                "unit": "MeV-cm2/mg"
+            },
+            "soldertemp": {
+                "example": [
+                    "cli: -datasheet_limit_soldertemp '(-40, 125)'",
+                    "api: chip.set('datasheet', 'limit','soldertemp',(-40, 125)"
+                ],
+                "help": "Limit solder temperature limits. Values are tuples of (min, max).",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: limit solder temperature limits",
+                "switch": [
+                    "-datasheet_limit_soldertemp '<(float,float)>'"
+                ],
+                "type": "(float,float)",
+                "unit": "C"
+            },
+            "storagetemp": {
+                "example": [
+                    "cli: -datasheet_limit_storagetemp '(-40, 125)'",
+                    "api: chip.set('datasheet', 'limit','storagetemp',(-40, 125)"
+                ],
+                "help": "Limit storage temperature limits. Values are tuples of (min, max).",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: limit storage temperature limits",
+                "switch": [
+                    "-datasheet_limit_storagetemp '<(float,float)>'"
+                ],
+                "type": "(float,float)",
+                "unit": "C"
+            },
+            "tid": {
+                "example": [
+                    "cli: -datasheet_limit_tid '(300000.0, 300000.0)'",
+                    "api: chip.set('datasheet', 'limit','tid',(300000.0, 300000.0)"
+                ],
+                "help": "Limit total ionizing dose threshold. Values are tuples of (min, max).",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: limit total ionizing dose threshold",
+                "switch": [
+                    "-datasheet_limit_tid '<(float,float)>'"
+                ],
+                "type": "(float,float)",
+                "unit": "rad"
+            }
+        },
+        "pin": {
+            "default": {
+                "bw": {
                     "default": {
                         "example": [
-                            "cli: -datasheet_reliability 'dev JESD22-A104 time 1000'",
-                            "api: chip.set('datasheet','dev','reliability','JESD22-A104','time',1000)"
+                            "cli: -datasheet_pin_bw 'sclk global (500000000.0, 600000000.0, 700000000.0)'",
+                            "api: chip.set('datasheet','pin','sclk','bw','global',(500000000.0, 600000000.0, 700000000.0)"
                         ],
-                        "help": "Device reliability specified on a per standard basis. The\nreliability test condition is captured as key/value pairs, where\nthe key is any test condition capture in the standard. Examples\nof test conditions include time, mintemp, maxtemp, cycles, vmax,\nmoisture.",
+                        "help": "Pin nyquist bandwidth. Values are tuples of (min, typical, max).",
                         "lock": false,
                         "node": {
                             "default": {
@@ -4220,21 +1922,2290 @@
                         "pernode": "never",
                         "require": null,
                         "scope": "job",
-                        "shorthelp": "Datasheet: reliability",
+                        "shorthelp": "Datasheet: pin nyquist bandwidth",
                         "switch": [
-                            "-datasheet_reliability 'design standard item <float>'"
+                            "-datasheet_pin_bw 'pin mode <(float,float,float)>'"
                         ],
-                        "type": "float"
+                        "type": "(float,float,float)",
+                        "unit": "Hz"
+                    }
+                },
+                "cap": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_cap 'sclk global (1e-12, 1.2e-12, 1.5e-12)'",
+                            "api: chip.set('datasheet','pin','sclk','cap','global',(1e-12, 1.2e-12, 1.5e-12)"
+                        ],
+                        "help": "Pin capacitance. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin capacitance",
+                        "switch": [
+                            "-datasheet_pin_cap 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "F"
+                    }
+                },
+                "cmrr": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_cmrr 'sclk global (70, 80, 90)'",
+                            "api: chip.set('datasheet','pin','sclk','cmrr','global',(70, 80, 90)"
+                        ],
+                        "help": "Pin common mode rejection ratio. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin common mode rejection ratio",
+                        "switch": [
+                            "-datasheet_pin_cmrr 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dB"
+                    }
+                },
+                "complement": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_complement 'ina global inb'",
+                            "api: chip.set('datasheet','pin','ina','complement','global','inb')"
+                        ],
+                        "help": "Pin complement specified on a per mode basis for differential\nsignals.",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin complement",
+                        "switch": [
+                            "-datasheet_pin_complement 'name mode <str>'"
+                        ],
+                        "type": "str"
+                    }
+                },
+                "dir": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_dir 'clk global input'",
+                            "api: chip.set('datasheet','pin','clk','dir','global','input')"
+                        ],
+                        "help": "Pin direction specified on a per mode basis. Acceptable pin\ndirections include: input, output, inout.",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin direction",
+                        "switch": [
+                            "-datasheet_pin_dir 'name mode <str>'"
+                        ],
+                        "type": "str"
+                    }
+                },
+                "dnl": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_dnl 'sclk global (-1.0, 0.0, 1.0)'",
+                            "api: chip.set('datasheet','pin','sclk','dnl','global',(-1.0, 0.0, 1.0)"
+                        ],
+                        "help": "Pin differential nonlinearity. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin differential nonlinearity",
+                        "switch": [
+                            "-datasheet_pin_dnl 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "LSB"
+                    }
+                },
+                "enob": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_enob 'sclk global (8, 9, 10)'",
+                            "api: chip.set('datasheet','pin','sclk','enob','global',(8, 9, 10)"
+                        ],
+                        "help": "Pin effective number of bits. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin effective number of bits",
+                        "switch": [
+                            "-datasheet_pin_enob 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "bits"
+                    }
+                },
+                "function": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_function 'z global a&b'",
+                            "api: chip.set('datasheet','pin','z','function','global','a&b')"
+                        ],
+                        "help": "Pin function specified on a per mode basis.\nOnly applicable to output pins.",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin function",
+                        "switch": [
+                            "-datasheet_pin_function 'name mode <str>'"
+                        ],
+                        "type": "str"
+                    }
+                },
+                "gain": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_gain 'sclk global (11.4, 11.4, 11.4)'",
+                            "api: chip.set('datasheet','pin','sclk','gain','global',(11.4, 11.4, 11.4)"
+                        ],
+                        "help": "Pin gain. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin gain",
+                        "switch": [
+                            "-datasheet_pin_gain 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dB"
+                    }
+                },
+                "hd2": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_hd2 'sclk global (62, 64, 66)'",
+                            "api: chip.set('datasheet','pin','sclk','hd2','global',(62, 64, 66)"
+                        ],
+                        "help": "Pin 2nd order harmonic distorion. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin 2nd order harmonic distorion",
+                        "switch": [
+                            "-datasheet_pin_hd2 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dBc"
+                    }
+                },
+                "hd3": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_hd3 'sclk global (62, 64, 66)'",
+                            "api: chip.set('datasheet','pin','sclk','hd3','global',(62, 64, 66)"
+                        ],
+                        "help": "Pin 3rd order harmonic distorion. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin 3rd order harmonic distorion",
+                        "switch": [
+                            "-datasheet_pin_hd3 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dBc"
+                    }
+                },
+                "hd4": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_hd4 'sclk global (62, 64, 66)'",
+                            "api: chip.set('datasheet','pin','sclk','hd4','global',(62, 64, 66)"
+                        ],
+                        "help": "Pin 4th order harmonic distorion. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin 4th order harmonic distorion",
+                        "switch": [
+                            "-datasheet_pin_hd4 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dBc"
+                    }
+                },
+                "ib1db": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_ib1db 'sclk global (-1, 1, 1)'",
+                            "api: chip.set('datasheet','pin','sclk','ib1db','global',(-1, 1, 1)"
+                        ],
+                        "help": "Pin rf in band 1 dB compression point. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin rf in band 1 dB compression point",
+                        "switch": [
+                            "-datasheet_pin_ib1db 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dBm"
+                    }
+                },
+                "ibias": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_ibias 'sclk global (0.001, 0.0012, 0.0015)'",
+                            "api: chip.set('datasheet','pin','sclk','ibias','global',(0.001, 0.0012, 0.0015)"
+                        ],
+                        "help": "Pin bias current. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin bias current",
+                        "switch": [
+                            "-datasheet_pin_ibias 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "A"
+                    }
+                },
+                "iinject": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_iinject 'sclk global (0.001, 0.0012, 0.0015)'",
+                            "api: chip.set('datasheet','pin','sclk','iinject','global',(0.001, 0.0012, 0.0015)"
+                        ],
+                        "help": "Pin injection current. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin injection current",
+                        "switch": [
+                            "-datasheet_pin_iinject 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "A"
+                    }
+                },
+                "iip3": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_iip3 'sclk global (3, 3, 3)'",
+                            "api: chip.set('datasheet','pin','sclk','iip3','global',(3, 3, 3)"
+                        ],
+                        "help": "Pin rf 3rd order input intercept point. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin rf 3rd order input intercept point",
+                        "switch": [
+                            "-datasheet_pin_iip3 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dBm"
+                    }
+                },
+                "ileakage": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_ileakage 'sclk global (1e-06, 1.2e-06, 1.5e-06)'",
+                            "api: chip.set('datasheet','pin','sclk','ileakage','global',(1e-06, 1.2e-06, 1.5e-06)"
+                        ],
+                        "help": "Pin leakage current. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin leakage current",
+                        "switch": [
+                            "-datasheet_pin_ileakage 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "A"
+                    }
+                },
+                "imd3": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_imd3 'sclk global (82, 88, 98)'",
+                            "api: chip.set('datasheet','pin','sclk','imd3','global',(82, 88, 98)"
+                        ],
+                        "help": "Pin 3rd order intermodulation distortion. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin 3rd order intermodulation distortion",
+                        "switch": [
+                            "-datasheet_pin_imd3 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dBc"
+                    }
+                },
+                "inl": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_inl 'sclk global (-7, 0.0, 7)'",
+                            "api: chip.set('datasheet','pin','sclk','inl','global',(-7, 0.0, 7)"
+                        ],
+                        "help": "Pin integral nonlinearity. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin integral nonlinearity",
+                        "switch": [
+                            "-datasheet_pin_inl 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "LSB"
+                    }
+                },
+                "ioffset": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_ioffset 'sclk global (0.001, 0.0012, 0.0015)'",
+                            "api: chip.set('datasheet','pin','sclk','ioffset','global',(0.001, 0.0012, 0.0015)"
+                        ],
+                        "help": "Pin offset current. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin offset current",
+                        "switch": [
+                            "-datasheet_pin_ioffset 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "A"
+                    }
+                },
+                "ioh": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_ioh 'sclk global (0.01, 0.012, 0.015)'",
+                            "api: chip.set('datasheet','pin','sclk','ioh','global',(0.01, 0.012, 0.015)"
+                        ],
+                        "help": "Pin output high current. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin output high current",
+                        "switch": [
+                            "-datasheet_pin_ioh 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "A"
+                    }
+                },
+                "iol": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_iol 'sclk global (0.01, 0.012, 0.015)'",
+                            "api: chip.set('datasheet','pin','sclk','iol','global',(0.01, 0.012, 0.015)"
+                        ],
+                        "help": "Pin output low current. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin output low current",
+                        "switch": [
+                            "-datasheet_pin_iol 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "A"
+                    }
+                },
+                "ishort": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_ishort 'sclk global (0.001, 0.0012, 0.0015)'",
+                            "api: chip.set('datasheet','pin','sclk','ishort','global',(0.001, 0.0012, 0.0015)"
+                        ],
+                        "help": "Pin short circuit current. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin short circuit current",
+                        "switch": [
+                            "-datasheet_pin_ishort 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "A"
+                    }
+                },
+                "isupply": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_isupply 'sclk global (0.001, 0.012, 0.015)'",
+                            "api: chip.set('datasheet','pin','sclk','isupply','global',(0.001, 0.012, 0.015)"
+                        ],
+                        "help": "Pin supply currents. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin supply currents",
+                        "switch": [
+                            "-datasheet_pin_isupply 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "A"
+                    }
+                },
+                "map": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_map 'in0 bga512 B4'",
+                            "api: chip.set('datasheet','pin','in0','map','bga512','B4')"
+                        ],
+                        "help": "Signal to package pin mapping specified on a per package basis.",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin map",
+                        "switch": [
+                            "-datasheet_pin_map 'design name package <str>'"
+                        ],
+                        "type": "str"
+                    }
+                },
+                "noisefigure": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_noisefigure 'sclk global (4.6, 4.6, 4.6)'",
+                            "api: chip.set('datasheet','pin','sclk','noisefigure','global',(4.6, 4.6, 4.6)"
+                        ],
+                        "help": "Pin rf noise figure. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin rf noise figure",
+                        "switch": [
+                            "-datasheet_pin_noisefigure 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dB"
+                    }
+                },
+                "nsd": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_nsd 'sclk global (-158, -158, -158)'",
+                            "api: chip.set('datasheet','pin','sclk','nsd','global',(-158, -158, -158)"
+                        ],
+                        "help": "Pin noise spectral density. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin noise spectral density",
+                        "switch": [
+                            "-datasheet_pin_nsd 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dBFS/Hz"
+                    }
+                },
+                "oob1db": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_oob1db 'sclk global (3, 3, 3)'",
+                            "api: chip.set('datasheet','pin','sclk','oob1db','global',(3, 3, 3)"
+                        ],
+                        "help": "Pin rf out of band 1 dB compression point. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin rf out of band 1 dB compression point",
+                        "switch": [
+                            "-datasheet_pin_oob1db 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dBm"
+                    }
+                },
+                "phasenoise": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_phasenoise 'sclk global (-158, -158, -158)'",
+                            "api: chip.set('datasheet','pin','sclk','phasenoise','global',(-158, -158, -158)"
+                        ],
+                        "help": "Pin phase noise. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin phase noise",
+                        "switch": [
+                            "-datasheet_pin_phasenoise 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dBc/Hz"
+                    }
+                },
+                "polarity": {
+                    "default": {
+                        "default": {
+                            "enum": [
+                                "positive",
+                                "negative",
+                                "none"
+                            ],
+                            "example": [
+                                "cli: -datasheet_pin_polarity 'q def clk none'",
+                                "api: chip.set('datasheet','pin','q','polarity','def','clk,'none')"
+                            ],
+                            "help": "Pin polarity specified on a per mode basis. Only applicable to output\npins.",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin polarity",
+                            "switch": [
+                                "-datasheet_pin_polarity 'name mode relpin <str>'"
+                            ],
+                            "type": "enum"
+                        }
+                    }
+                },
+                "pout": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_pout 'sclk global (12.2, 12.2, 12.2)'",
+                            "api: chip.set('datasheet','pin','sclk','pout','global',(12.2, 12.2, 12.2)"
+                        ],
+                        "help": "Pin output power. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin output power",
+                        "switch": [
+                            "-datasheet_pin_pout 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dBm"
+                    }
+                },
+                "pout2": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_pout2 'sclk global (-14, -14, -14)'",
+                            "api: chip.set('datasheet','pin','sclk','pout2','global',(-14, -14, -14)"
+                        ],
+                        "help": "Pin 2nd harmonic power. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin 2nd harmonic power",
+                        "switch": [
+                            "-datasheet_pin_pout2 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dBm"
+                    }
+                },
+                "pout3": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_pout3 'sclk global (-28, -28, -28)'",
+                            "api: chip.set('datasheet','pin','sclk','pout3','global',(-28, -28, -28)"
+                        ],
+                        "help": "Pin 3rd harmonic power. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin 3rd harmonic power",
+                        "switch": [
+                            "-datasheet_pin_pout3 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dBm"
+                    }
+                },
+                "power": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_power 'sclk global (1, 2, 3)'",
+                            "api: chip.set('datasheet','pin','sclk','power','global',(1, 2, 3)"
+                        ],
+                        "help": "Pin power consumption. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin power consumption",
+                        "switch": [
+                            "-datasheet_pin_power 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "W"
+                    }
+                },
+                "psnr": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_psnr 'sclk global (61, 61, 61)'",
+                            "api: chip.set('datasheet','pin','sclk','psnr','global',(61, 61, 61)"
+                        ],
+                        "help": "Pin power supply noise rejection. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin power supply noise rejection",
+                        "switch": [
+                            "-datasheet_pin_psnr 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dB"
+                    }
+                },
+                "rdiff": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_rdiff 'sclk global (45, 50, 55)'",
+                            "api: chip.set('datasheet','pin','sclk','rdiff','global',(45, 50, 55)"
+                        ],
+                        "help": "Pin differential pair resistance. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin differential pair resistance",
+                        "switch": [
+                            "-datasheet_pin_rdiff 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "Ohm"
+                    }
+                },
+                "rdown": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_rdown 'sclk global (1000, 1200, 3000)'",
+                            "api: chip.set('datasheet','pin','sclk','rdown','global',(1000, 1200, 3000)"
+                        ],
+                        "help": "Pin output pulldown resistance. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin output pulldown resistance",
+                        "switch": [
+                            "-datasheet_pin_rdown 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "Ohm"
+                    }
+                },
+                "resetvalue": {
+                    "default": {
+                        "enum": [
+                            "weak1",
+                            "weak0",
+                            "strong0",
+                            "strong1",
+                            "highz"
+                        ],
+                        "example": [
+                            "cli: -datasheet_pin_resetvalue 'clk global weak1'",
+                            "api: chip.set('datasheet','pin','clk','resetvalue','global','weak1')"
+                        ],
+                        "help": "Pin reset value specified on a per mode basis.",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin reset value",
+                        "switch": [
+                            "-datasheet_pin_resetvalue 'name mode <str>'"
+                        ],
+                        "type": "enum"
+                    }
+                },
+                "rin": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_rin 'sclk global (1000, 1200, 3000)'",
+                            "api: chip.set('datasheet','pin','sclk','rin','global',(1000, 1200, 3000)"
+                        ],
+                        "help": "Pin input resistance. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin input resistance",
+                        "switch": [
+                            "-datasheet_pin_rin 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "Ohm"
+                    }
+                },
+                "rup": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_rup 'sclk global (1000, 1200, 3000)'",
+                            "api: chip.set('datasheet','pin','sclk','rup','global',(1000, 1200, 3000)"
+                        ],
+                        "help": "Pin output pullup resistance. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin output pullup resistance",
+                        "switch": [
+                            "-datasheet_pin_rup 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "Ohm"
+                    }
+                },
+                "rweakdown": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_rweakdown 'sclk global (1000, 1200, 3000)'",
+                            "api: chip.set('datasheet','pin','sclk','rweakdown','global',(1000, 1200, 3000)"
+                        ],
+                        "help": "Pin weak pulldown resistance. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin weak pulldown resistance",
+                        "switch": [
+                            "-datasheet_pin_rweakdown 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "Ohm"
+                    }
+                },
+                "rweakup": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_rweakup 'sclk global (1000, 1200, 3000)'",
+                            "api: chip.set('datasheet','pin','sclk','rweakup','global',(1000, 1200, 3000)"
+                        ],
+                        "help": "Pin weak pullup resistance. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin weak pullup resistance",
+                        "switch": [
+                            "-datasheet_pin_rweakup 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "Ohm"
+                    }
+                },
+                "s11": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_s11 'sclk global (7, 7, 7)'",
+                            "api: chip.set('datasheet','pin','sclk','s11','global',(7, 7, 7)"
+                        ],
+                        "help": "Pin rf input return loss. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin rf input return loss",
+                        "switch": [
+                            "-datasheet_pin_s11 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dB"
+                    }
+                },
+                "s12": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_s12 'sclk global (-20, -20, -20)'",
+                            "api: chip.set('datasheet','pin','sclk','s12','global',(-20, -20, -20)"
+                        ],
+                        "help": "Pin rf reverse isolation. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin rf reverse isolation",
+                        "switch": [
+                            "-datasheet_pin_s12 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dB"
+                    }
+                },
+                "s21": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_s21 'sclk global (10, 11, 12)'",
+                            "api: chip.set('datasheet','pin','sclk','s21','global',(10, 11, 12)"
+                        ],
+                        "help": "Pin rf gain. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin rf gain",
+                        "switch": [
+                            "-datasheet_pin_s21 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dB"
+                    }
+                },
+                "s22": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_s22 'sclk global (10, 10, 10)'",
+                            "api: chip.set('datasheet','pin','sclk','s22','global',(10, 10, 10)"
+                        ],
+                        "help": "Pin rf output return loss. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin rf output return loss",
+                        "switch": [
+                            "-datasheet_pin_s22 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dB"
+                    }
+                },
+                "sfdr": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_sfdr 'sclk global (82, 88, 98)'",
+                            "api: chip.set('datasheet','pin','sclk','sfdr','global',(82, 88, 98)"
+                        ],
+                        "help": "Pin spurious-free dynamic range. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin spurious-free dynamic range",
+                        "switch": [
+                            "-datasheet_pin_sfdr 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dBc"
+                    }
+                },
+                "signal": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_signal 'clk0 ddr4 CLKN'",
+                            "api: chip.set('datasheet','pin','clk0','signal','ddr4','CLKN')"
+                        ],
+                        "help": "Pin mapping to standardized interface signals.",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin signal map",
+                        "switch": [
+                            "-datasheet_pin_signal 'name mode <str>'"
+                        ],
+                        "type": "[str]"
+                    }
+                },
+                "sinad": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_sinad 'sclk global (71, 72, 73)'",
+                            "api: chip.set('datasheet','pin','sclk','sinad','global',(71, 72, 73)"
+                        ],
+                        "help": "Pin signal to noise and distortion ratio. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin signal to noise and distortion ratio",
+                        "switch": [
+                            "-datasheet_pin_sinad 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dB"
+                    }
+                },
+                "snr": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_snr 'sclk global (70, 72, 74)'",
+                            "api: chip.set('datasheet','pin','sclk','snr','global',(70, 72, 74)"
+                        ],
+                        "help": "Pin signal to noise ratio. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin signal to noise ratio",
+                        "switch": [
+                            "-datasheet_pin_snr 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "dB"
+                    }
+                },
+                "standard": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_standard 'clk def LVCMOS'",
+                            "api: chip.set('datasheet','pin','clk','standard','def', 'LVCMOS')"
+                        ],
+                        "help": "Pin electrical signaling standard (LVDS, LVCMOS, TTL,..).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": [],
+                                    "value": []
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin standard",
+                        "switch": [
+                            "-datasheet_pin_standard 'name mode <str>'"
+                        ],
+                        "type": "[str]"
+                    }
+                },
+                "tdelayf": {
+                    "default": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_tdelayf 'a glob clock (1e-09, 2e-09, 4e-09)'",
+                                "api: chip.set('datasheet','pin','a','tdelayf','glob','ck',(1e-09, 2e-09, 4e-09)"
+                            ],
+                            "help": "Pin propagation delay (fall) specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin propagation delay (fall)",
+                            "switch": [
+                                "-datasheet_pin_tdelayf 'pin mode relpin <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "s"
+                        }
+                    }
+                },
+                "tdelayr": {
+                    "default": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_tdelayr 'a glob clock (1e-09, 2e-09, 4e-09)'",
+                                "api: chip.set('datasheet','pin','a','tdelayr','glob','ck',(1e-09, 2e-09, 4e-09)"
+                            ],
+                            "help": "Pin propagation delay (rise) specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin propagation delay (rise)",
+                            "switch": [
+                                "-datasheet_pin_tdelayr 'pin mode relpin <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "s"
+                        }
+                    }
+                },
+                "tduty": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_tduty 'sclk global (45, 50, 55)'",
+                            "api: chip.set('datasheet','pin','sclk','tduty','global',(45, 50, 55)"
+                        ],
+                        "help": "Pin duty cycle. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin duty cycle",
+                        "switch": [
+                            "-datasheet_pin_tduty 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "%"
+                    }
+                },
+                "tfall": {
+                    "default": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_tfall 'a glob clock (1e-09, 2e-09, 4e-09)'",
+                                "api: chip.set('datasheet','pin','a','tfall','glob','ck',(1e-09, 2e-09, 4e-09)"
+                            ],
+                            "help": "Pin fall transition specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin fall transition",
+                            "switch": [
+                                "-datasheet_pin_tfall 'pin mode relpin <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "s"
+                        }
+                    }
+                },
+                "thigh": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_thigh 'sclk global (1e-09, 2e-09, 4e-09)'",
+                            "api: chip.set('datasheet','pin','sclk','thigh','global',(1e-09, 2e-09, 4e-09)"
+                        ],
+                        "help": "Pin pulse width high. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin pulse width high",
+                        "switch": [
+                            "-datasheet_pin_thigh 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "s"
+                    }
+                },
+                "thold": {
+                    "default": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_thold 'a glob clock (1e-09, 2e-09, 4e-09)'",
+                                "api: chip.set('datasheet','pin','a','thold','glob','ck',(1e-09, 2e-09, 4e-09)"
+                            ],
+                            "help": "Pin hold time specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin hold time",
+                            "switch": [
+                                "-datasheet_pin_thold 'pin mode relpin <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "s"
+                        }
+                    }
+                },
+                "tjitter": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_tjitter 'sclk global (1e-09, 2e-09, 4e-09)'",
+                            "api: chip.set('datasheet','pin','sclk','tjitter','global',(1e-09, 2e-09, 4e-09)"
+                        ],
+                        "help": "Pin rms jitter. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin rms jitter",
+                        "switch": [
+                            "-datasheet_pin_tjitter 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "s"
+                    }
+                },
+                "tlow": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_tlow 'sclk global (1e-09, 2e-09, 4e-09)'",
+                            "api: chip.set('datasheet','pin','sclk','tlow','global',(1e-09, 2e-09, 4e-09)"
+                        ],
+                        "help": "Pin pulse width low. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin pulse width low",
+                        "switch": [
+                            "-datasheet_pin_tlow 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "s"
+                    }
+                },
+                "tperiod": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_tperiod 'sclk global (1e-09, 2e-09, 4e-09)'",
+                            "api: chip.set('datasheet','pin','sclk','tperiod','global',(1e-09, 2e-09, 4e-09)"
+                        ],
+                        "help": "Pin minimum period. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin minimum period",
+                        "switch": [
+                            "-datasheet_pin_tperiod 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "s"
+                    }
+                },
+                "tpulse": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_tpulse 'sclk global (1e-09, 2e-09, 4e-09)'",
+                            "api: chip.set('datasheet','pin','sclk','tpulse','global',(1e-09, 2e-09, 4e-09)"
+                        ],
+                        "help": "Pin pulse width. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin pulse width",
+                        "switch": [
+                            "-datasheet_pin_tpulse 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "s"
+                    }
+                },
+                "trise": {
+                    "default": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_trise 'a glob clock (1e-09, 2e-09, 4e-09)'",
+                                "api: chip.set('datasheet','pin','a','trise','glob','ck',(1e-09, 2e-09, 4e-09)"
+                            ],
+                            "help": "Pin rise transition specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin rise transition",
+                            "switch": [
+                                "-datasheet_pin_trise 'pin mode relpin <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "s"
+                        }
+                    }
+                },
+                "tsetup": {
+                    "default": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_tsetup 'a glob clock (1e-09, 2e-09, 4e-09)'",
+                                "api: chip.set('datasheet','pin','a','tsetup','glob','ck',(1e-09, 2e-09, 4e-09)"
+                            ],
+                            "help": "Pin setup time specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin setup time",
+                            "switch": [
+                                "-datasheet_pin_tsetup 'pin mode relpin <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "s"
+                        }
+                    }
+                },
+                "tskew": {
+                    "default": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_tskew 'a glob clock (1e-09, 2e-09, 4e-09)'",
+                                "api: chip.set('datasheet','pin','a','tskew','glob','ck',(1e-09, 2e-09, 4e-09)"
+                            ],
+                            "help": "Pin timing skew specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin timing skew",
+                            "switch": [
+                                "-datasheet_pin_tskew 'pin mode relpin <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "s"
+                        }
+                    }
+                },
+                "type": {
+                    "default": {
+                        "enum": [
+                            "digital",
+                            "analog",
+                            "clock",
+                            "supply",
+                            "ground"
+                        ],
+                        "example": [
+                            "cli: -datasheet_pin_type 'vdd global supply'",
+                            "api: chip.set('datasheet','pin','vdd','type','global','supply')"
+                        ],
+                        "help": "Pin type specified on a per mode basis.",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin type",
+                        "switch": [
+                            "-datasheet_pin_type 'name mode <str>'"
+                        ],
+                        "type": "enum"
+                    }
+                },
+                "vcdm": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vcdm 'sclk global (125, 150, 175)'",
+                            "api: chip.set('datasheet','pin','sclk','vcdm','global',(125, 150, 175)"
+                        ],
+                        "help": "Pin ESD charge device model voltage level. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin ESD charge device model voltage level",
+                        "switch": [
+                            "-datasheet_pin_vcdm 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V"
+                    }
+                },
+                "vcm": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vcm 'sclk global (0.3, 1.2, 1.6)'",
+                            "api: chip.set('datasheet','pin','sclk','vcm','global',(0.3, 1.2, 1.6)"
+                        ],
+                        "help": "Pin common mode voltage. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin common mode voltage",
+                        "switch": [
+                            "-datasheet_pin_vcm 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V"
+                    }
+                },
+                "vdiff": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vdiff 'sclk global (0.2, 0.3, 0.9)'",
+                            "api: chip.set('datasheet','pin','sclk','vdiff','global',(0.2, 0.3, 0.9)"
+                        ],
+                        "help": "Pin differential voltage. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin differential voltage",
+                        "switch": [
+                            "-datasheet_pin_vdiff 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V"
+                    }
+                },
+                "vgainerror": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vgainerror 'sclk global (-1.0, 0.0, 1.0)'",
+                            "api: chip.set('datasheet','pin','sclk','vgainerror','global',(-1.0, 0.0, 1.0)"
+                        ],
+                        "help": "Pin gain error. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin gain error",
+                        "switch": [
+                            "-datasheet_pin_vgainerror 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "mV"
+                    }
+                },
+                "vhbm": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vhbm 'sclk global (200, 250, 300)'",
+                            "api: chip.set('datasheet','pin','sclk','vhbm','global',(200, 250, 300)"
+                        ],
+                        "help": "Pin ESD human body model voltage level. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin ESD human body model voltage level",
+                        "switch": [
+                            "-datasheet_pin_vhbm 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V"
+                    }
+                },
+                "vih": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vih 'sclk global (1.4, 1.8, 2.2)'",
+                            "api: chip.set('datasheet','pin','sclk','vih','global',(1.4, 1.8, 2.2)"
+                        ],
+                        "help": "Pin high input voltage level. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin high input voltage level",
+                        "switch": [
+                            "-datasheet_pin_vih 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V"
+                    }
+                },
+                "vil": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vil 'sclk global (-0.2, 0, 1.0)'",
+                            "api: chip.set('datasheet','pin','sclk','vil','global',(-0.2, 0, 1.0)"
+                        ],
+                        "help": "Pin low input voltage level. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin low input voltage level",
+                        "switch": [
+                            "-datasheet_pin_vil 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V"
+                    }
+                },
+                "vmax": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vmax 'sclk global (0.2, 0.3, 0.9)'",
+                            "api: chip.set('datasheet','pin','sclk','vmax','global',(0.2, 0.3, 0.9)"
+                        ],
+                        "help": "Pin absolute maximum voltage. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin absolute maximum voltage",
+                        "switch": [
+                            "-datasheet_pin_vmax 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V"
+                    }
+                },
+                "vmm": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vmm 'sclk global (100, 125, 150)'",
+                            "api: chip.set('datasheet','pin','sclk','vmm','global',(100, 125, 150)"
+                        ],
+                        "help": "Pin ESD machine model voltage level. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin ESD machine model voltage level",
+                        "switch": [
+                            "-datasheet_pin_vmm 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V"
+                    }
+                },
+                "vnoise": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vnoise 'sclk global (0, 0.01, 0.1)'",
+                            "api: chip.set('datasheet','pin','sclk','vnoise','global',(0, 0.01, 0.1)"
+                        ],
+                        "help": "Pin random voltage noise. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin random voltage noise",
+                        "switch": [
+                            "-datasheet_pin_vnoise 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V"
+                    }
+                },
+                "vnominal": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vnominal 'sclk global (1.72, 1.8, 1.92)'",
+                            "api: chip.set('datasheet','pin','sclk','vnominal','global',(1.72, 1.8, 1.92)"
+                        ],
+                        "help": "Pin nominal operating voltage. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin nominal operating voltage",
+                        "switch": [
+                            "-datasheet_pin_vnominal 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V"
+                    }
+                },
+                "vofferror": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vofferror 'sclk global (-1.0, 0.0, 1.0)'",
+                            "api: chip.set('datasheet','pin','sclk','vofferror','global',(-1.0, 0.0, 1.0)"
+                        ],
+                        "help": "Pin offset error. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin offset error",
+                        "switch": [
+                            "-datasheet_pin_vofferror 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "mV"
+                    }
+                },
+                "voffset": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_voffset 'sclk global (0.2, 0.3, 0.9)'",
+                            "api: chip.set('datasheet','pin','sclk','voffset','global',(0.2, 0.3, 0.9)"
+                        ],
+                        "help": "Pin offset voltage. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin offset voltage",
+                        "switch": [
+                            "-datasheet_pin_voffset 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V"
+                    }
+                },
+                "voh": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_voh 'sclk global (4.6, 4.8, 5.2)'",
+                            "api: chip.set('datasheet','pin','sclk','voh','global',(4.6, 4.8, 5.2)"
+                        ],
+                        "help": "Pin high output voltage level. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin high output voltage level",
+                        "switch": [
+                            "-datasheet_pin_voh 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V"
+                    }
+                },
+                "vol": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vol 'sclk global (-0.2, 0, 0.2)'",
+                            "api: chip.set('datasheet','pin','sclk','vol','global',(-0.2, 0, 0.2)"
+                        ],
+                        "help": "Pin low output voltage level. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin low output voltage level",
+                        "switch": [
+                            "-datasheet_pin_vol 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V"
+                    }
+                },
+                "vslew": {
+                    "default": {
+                        "example": [
+                            "cli: -datasheet_pin_vslew 'sclk global (1e-09, 2e-09, 4e-09)'",
+                            "api: chip.set('datasheet','pin','sclk','vslew','global',(1e-09, 2e-09, 4e-09)"
+                        ],
+                        "help": "Pin slew rate. Values are tuples of (min, typical, max).",
+                        "lock": false,
+                        "node": {
+                            "default": {
+                                "default": {
+                                    "signature": null,
+                                    "value": null
+                                }
+                            }
+                        },
+                        "notes": null,
+                        "pernode": "never",
+                        "require": null,
+                        "scope": "job",
+                        "shorthelp": "Datasheet: pin slew rate",
+                        "switch": [
+                            "-datasheet_pin_vslew 'pin mode <(float,float,float)>'"
+                        ],
+                        "type": "(float,float,float)",
+                        "unit": "V/s"
                     }
                 }
-            },
-            "thermal": {
-                "rja": {
+            }
+        },
+        "reliability": {
+            "default": {
+                "default": {
                     "example": [
-                        "cli: -datasheet_thermal_rja 'mydevice 30.4'",
-                        "api: chip.set('datasheet','mydevice','thermal','rja', 30.4)"
+                        "cli: -datasheet_reliability 'JESD22-A104 time 1000'",
+                        "api: chip.set('datasheet','reliability','JESD22-A104','time',1000)"
                     ],
-                    "help": "Device rja.",
+                    "help": "Device reliability specified on a per standard basis. The\nreliability test condition is captured as key/value pairs, where\nthe key is any test condition capture in the standard. Examples\nof test conditions include time, mintemp, maxtemp, cycles, vmax,\nmoisture.",
                     "lock": false,
                     "node": {
                         "default": {
@@ -4248,143 +4219,170 @@
                     "pernode": "never",
                     "require": null,
                     "scope": "job",
-                    "shorthelp": "Datasheet: thermal junction to ambient resistance",
+                    "shorthelp": "Datasheet: reliability",
                     "switch": [
-                        "-datasheet_thermal_rja 'design <float>'"
+                        "-datasheet_reliability 'standard item <float>'"
                     ],
-                    "type": "float",
-                    "unit": "C/W"
-                },
-                "rjb": {
-                    "example": [
-                        "cli: -datasheet_thermal_rjb 'mydevice 30.4'",
-                        "api: chip.set('datasheet','mydevice','thermal','rjb', 30.4)"
-                    ],
-                    "help": "Device rjb.",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: thermal junction to board resistance",
-                    "switch": [
-                        "-datasheet_thermal_rjb 'design <float>'"
-                    ],
-                    "type": "float",
-                    "unit": "C/W"
-                },
-                "rjcb": {
-                    "example": [
-                        "cli: -datasheet_thermal_rjcb 'mydevice 30.4'",
-                        "api: chip.set('datasheet','mydevice','thermal','rjcb', 30.4)"
-                    ],
-                    "help": "Device rjcb.",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: thermal junction to case (bottom) resistance",
-                    "switch": [
-                        "-datasheet_thermal_rjcb 'design <float>'"
-                    ],
-                    "type": "float",
-                    "unit": "C/W"
-                },
-                "rjct": {
-                    "example": [
-                        "cli: -datasheet_thermal_rjct 'mydevice 30.4'",
-                        "api: chip.set('datasheet','mydevice','thermal','rjct', 30.4)"
-                    ],
-                    "help": "Device rjct.",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: thermal junction to case (top) resistance",
-                    "switch": [
-                        "-datasheet_thermal_rjct 'design <float>'"
-                    ],
-                    "type": "float",
-                    "unit": "C/W"
-                },
-                "tjb": {
-                    "example": [
-                        "cli: -datasheet_thermal_tjb 'mydevice 30.4'",
-                        "api: chip.set('datasheet','mydevice','thermal','tjb', 30.4)"
-                    ],
-                    "help": "Device tjb.",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: thermal junction to bottom model",
-                    "switch": [
-                        "-datasheet_thermal_tjb 'design <float>'"
-                    ],
-                    "type": "float",
-                    "unit": "C/W"
-                },
-                "tjt": {
-                    "example": [
-                        "cli: -datasheet_thermal_tjt 'mydevice 30.4'",
-                        "api: chip.set('datasheet','mydevice','thermal','tjt', 30.4)"
-                    ],
-                    "help": "Device tjt.",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": null,
-                    "scope": "job",
-                    "shorthelp": "Datasheet: thermal junction to top model",
-                    "switch": [
-                        "-datasheet_thermal_tjt 'design <float>'"
-                    ],
-                    "type": "float",
-                    "unit": "C/W"
+                    "type": "float"
                 }
+            }
+        },
+        "thermal": {
+            "rja": {
+                "example": [
+                    "cli: -datasheet_thermal_rja '30.4'",
+                    "api: chip.set('datasheet','thermal','rja', 30.4)"
+                ],
+                "help": "Device rja.",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: thermal junction to ambient resistance",
+                "switch": [
+                    "-datasheet_thermal_rja '<float>'"
+                ],
+                "type": "float",
+                "unit": "C/W"
+            },
+            "rjb": {
+                "example": [
+                    "cli: -datasheet_thermal_rjb '30.4'",
+                    "api: chip.set('datasheet','thermal','rjb', 30.4)"
+                ],
+                "help": "Device rjb.",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: thermal junction to board resistance",
+                "switch": [
+                    "-datasheet_thermal_rjb '<float>'"
+                ],
+                "type": "float",
+                "unit": "C/W"
+            },
+            "rjcb": {
+                "example": [
+                    "cli: -datasheet_thermal_rjcb '30.4'",
+                    "api: chip.set('datasheet','thermal','rjcb', 30.4)"
+                ],
+                "help": "Device rjcb.",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: thermal junction to case (bottom) resistance",
+                "switch": [
+                    "-datasheet_thermal_rjcb '<float>'"
+                ],
+                "type": "float",
+                "unit": "C/W"
+            },
+            "rjct": {
+                "example": [
+                    "cli: -datasheet_thermal_rjct '30.4'",
+                    "api: chip.set('datasheet','thermal','rjct', 30.4)"
+                ],
+                "help": "Device rjct.",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: thermal junction to case (top) resistance",
+                "switch": [
+                    "-datasheet_thermal_rjct '<float>'"
+                ],
+                "type": "float",
+                "unit": "C/W"
+            },
+            "tjb": {
+                "example": [
+                    "cli: -datasheet_thermal_tjb '30.4'",
+                    "api: chip.set('datasheet','thermal','tjb', 30.4)"
+                ],
+                "help": "Device tjb.",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: thermal junction to bottom model",
+                "switch": [
+                    "-datasheet_thermal_tjb '<float>'"
+                ],
+                "type": "float",
+                "unit": "C/W"
+            },
+            "tjt": {
+                "example": [
+                    "cli: -datasheet_thermal_tjt '30.4'",
+                    "api: chip.set('datasheet','thermal','tjt', 30.4)"
+                ],
+                "help": "Device tjt.",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Datasheet: thermal junction to top model",
+                "switch": [
+                    "-datasheet_thermal_tjt '<float>'"
+                ],
+                "type": "float",
+                "unit": "C/W"
             }
         }
     },

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1617,7 +1617,7 @@
                 "default": {
                     "example": [
                         "cli: -datasheet_feature 'mydevice ram 64e6'",
-                        "api: chip.set('datasheet','mydevice','feature','ram', 1e9)"
+                        "api: chip.set('datasheet','mydevice','feature','ram',64e6)"
                     ],
                     "help": "Quantity of a specified feature. The 'unit'\nfield should be used to specify the units used when unclear.",
                     "lock": false,
@@ -1668,7 +1668,7 @@
             "limits": {
                 "junctiontemp": {
                     "example": [
-                        "cli: -datasheet_junctiontemp 'mydevice (-40,125)'",
+                        "cli: -datasheet_limits_junctiontemp 'mydevice (-40,125)'",
                         "api: chip.set('datasheet','mydevice','limits','junctiontemp',(-40,125))"
                     ],
                     "help": "Device absolute junction temperature limits not to be exceeded.",
@@ -1687,13 +1687,38 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: absolute junction temperature limits",
                     "switch": [
-                        "-datasheet_junctiontemp 'design <(float,float)>'"
+                        "-datasheet_limits_junctiontemp 'design <(float,float)>'"
+                    ],
+                    "type": "(float,float)"
+                },
+                "soldertemp": {
+                    "example": [
+                        "cli: -datasheet_limits_soldertemp 'mydevice (-40,125)'",
+                        "api: chip.set('datasheet','mydevice','limits','soldertemp',(-40,125))"
+                    ],
+                    "help": "Device absolute solder temperature limits not to be exceeded.",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "never",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Datasheet: absolute solder temperature limits",
+                    "switch": [
+                        "-datasheet_limits_soldertemp 'design <(float,float)>'"
                     ],
                     "type": "(float,float)"
                 },
                 "storagetemp": {
                     "example": [
-                        "cli: -datasheet_storagetemp 'mydevice (-40,125)'",
+                        "cli: -datasheet_limits_storagetemp 'mydevice (-40,125)'",
                         "api: chip.set('datasheet','mydevice','limits','storagetemp',(-40,125))"
                     ],
                     "help": "Device absolute storage temperature limits not to be exceeded.",
@@ -1712,40 +1737,41 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: absolute storage temperature limits",
                     "switch": [
-                        "-datasheet_storagetemp 'design <(float,float)>'"
+                        "-datasheet_limits_storagetemp 'design <(float,float)>'"
                     ],
                     "type": "(float,float)"
-                },
-                "voltage": {
-                    "default": {
-                        "example": [
-                            "cli: -datasheet_limits_voltage 'mydevice vdd (-0.4,1.1)'",
-                            "api: chip.set('datasheet','mydevice','limits','voltage','vdd', (-0.4,1.1))"
-                        ],
-                        "help": "Device absolute minimum/maximum voltage not to be\nexceeded, specified on a per pin basis.",
-                        "lock": false,
-                        "node": {
-                            "default": {
-                                "default": {
-                                    "signature": null,
-                                    "value": null
-                                }
-                            }
-                        },
-                        "notes": null,
-                        "pernode": "never",
-                        "require": null,
-                        "scope": "job",
-                        "shorthelp": "Datasheet: absolute voltage limits",
-                        "switch": [
-                            "-datasheet_limits_voltage 'design pin <(float,float)>'"
-                        ],
-                        "type": "(float,float)"
-                    }
                 }
             },
             "pin": {
                 "default": {
+                    "bw": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_bw 'mydevice sclk global (500000000.0, 600000000.0, 700000000.0)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','bw','global',(500000000.0, 600000000.0, 700000000.0)"
+                            ],
+                            "help": "Pin nyquist bandwidth. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin nyquist bandwidth",
+                            "switch": [
+                                "-datasheet_pin_bw 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "Hz"
+                        }
+                    },
                     "capacitance": {
                         "default": {
                             "example": [
@@ -1774,13 +1800,13 @@
                             "unit": "F"
                         }
                     },
-                    "clk": {
+                    "cmrr": {
                         "default": {
                             "example": [
-                                "cli: -datasheet_pin_clk 'mydevice ina global clka'",
-                                "api: chip.set('datasheet','mydevice','pin','ina','clk','global','clka')"
+                                "cli: -datasheet_pin_cmrr 'mydevice sclk global (70, 80, 90)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','cmrr','global',(70, 80, 90)"
                             ],
-                            "help": "Pin related clock specified on a per mode basis.",
+                            "help": "Pin common mode rejection ratio. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -1794,11 +1820,12 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin related clock",
+                            "shorthelp": "Datasheet: pin common mode rejection ratio",
                             "switch": [
-                                "-datasheet_pin_clk 'design name mode <str>'"
+                                "-datasheet_pin_cmrr 'design pin mode <(float,float,float)>'"
                             ],
-                            "type": "str"
+                            "type": "(float,float,float)",
+                            "unit": "dB"
                         }
                     },
                     "complement": {
@@ -1855,13 +1882,13 @@
                             "type": "str"
                         }
                     },
-                    "dutycycle": {
+                    "dnl": {
                         "default": {
                             "example": [
-                                "cli: -datasheet_pin_dutycycle 'mydevice sclk global (45, 50, 55)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','dutycycle','global',(45, 50, 55)"
+                                "cli: -datasheet_pin_dnl 'mydevice sclk global (-1.0, 0.0, 1.0)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','dnl','global',(-1.0, 0.0, 1.0)"
                             ],
-                            "help": "Pin duty cycle. Values are tuples of (min, typical, max).",
+                            "help": "Pin differential nonlinearity. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -1875,21 +1902,21 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin duty cycle",
+                            "shorthelp": "Datasheet: pin differential nonlinearity",
                             "switch": [
-                                "-datasheet_pin_dutycycle 'design pin mode <(float,float,float)>'"
+                                "-datasheet_pin_dnl 'design pin mode <(float,float,float)>'"
                             ],
                             "type": "(float,float,float)",
-                            "unit": "%"
+                            "unit": "LSB"
                         }
                     },
-                    "ground": {
+                    "enob": {
                         "default": {
                             "example": [
-                                "cli: -datasheet_pin_ground 'mydevice ina ground vss'",
-                                "api: chip.set('datasheet','mydevice','pin','ina','ground','global','vss')"
+                                "cli: -datasheet_pin_enob 'mydevice sclk global (8, 9, 10)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','enob','global',(8, 9, 10)"
                             ],
-                            "help": "Pin related ground rail specified on a per mode basis.",
+                            "help": "Pin effective number of bits. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -1903,20 +1930,48 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin related ground",
+                            "shorthelp": "Datasheet: pin effective number of bits",
                             "switch": [
-                                "-datasheet_pin_ground 'design name mode <str>'"
+                                "-datasheet_pin_enob 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "bits"
+                        }
+                    },
+                    "function": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_function 'mydevice z global a&b'",
+                                "api: chip.set('datasheet','mydevice','pin','z','function','global','a&b')"
+                            ],
+                            "help": "Pin function specified on a per mode basis. Only applicable to output\npins.",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin function",
+                            "switch": [
+                                "-datasheet_pin_function 'design name mode <str>'"
                             ],
                             "type": "str"
                         }
                     },
-                    "idrive": {
+                    "gain": {
                         "default": {
                             "example": [
-                                "cli: -datasheet_pin_idrive 'mydevice sclk global (0.01, 0.012, 0.015)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','idrive','global',(0.01, 0.012, 0.015)"
+                                "cli: -datasheet_pin_gain 'mydevice sclk global (11.4, 11.4, 11.4)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','gain','global',(11.4, 11.4, 11.4)"
                             ],
-                            "help": "Pin drive current. Values are tuples of (min, typical, max).",
+                            "help": "Pin gain. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -1930,9 +1985,149 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin drive current",
+                            "shorthelp": "Datasheet: pin gain",
                             "switch": [
-                                "-datasheet_pin_idrive 'design pin mode <(float,float,float)>'"
+                                "-datasheet_pin_gain 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dB"
+                        }
+                    },
+                    "hd2": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_hd2 'mydevice sclk global (62, 64, 66)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','hd2','global',(62, 64, 66)"
+                            ],
+                            "help": "Pin 2nd order harmonic distorion. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin 2nd order harmonic distorion",
+                            "switch": [
+                                "-datasheet_pin_hd2 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dBc"
+                        }
+                    },
+                    "hd3": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_hd3 'mydevice sclk global (62, 64, 66)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','hd3','global',(62, 64, 66)"
+                            ],
+                            "help": "Pin 3rd order harmonic distorion. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin 3rd order harmonic distorion",
+                            "switch": [
+                                "-datasheet_pin_hd3 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dBc"
+                        }
+                    },
+                    "hd4": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_hd4 'mydevice sclk global (62, 64, 66)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','hd4','global',(62, 64, 66)"
+                            ],
+                            "help": "Pin 4th order harmonic distorion. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin 4th order harmonic distorion",
+                            "switch": [
+                                "-datasheet_pin_hd4 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dBc"
+                        }
+                    },
+                    "ib1db": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_ib1db 'mydevice sclk global (-1, 1, 1)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','ib1db','global',(-1, 1, 1)"
+                            ],
+                            "help": "Pin in band 1 dB compression point. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin in band 1 dB compression point",
+                            "switch": [
+                                "-datasheet_pin_ib1db 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dBm"
+                        }
+                    },
+                    "ibias": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_ibias 'mydevice sclk global (0.001, 0.0012, 0.0015)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','ibias','global',(0.001, 0.0012, 0.0015)"
+                            ],
+                            "help": "Pin bias current. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin bias current",
+                            "switch": [
+                                "-datasheet_pin_ibias 'design pin mode <(float,float,float)>'"
                             ],
                             "type": "(float,float,float)",
                             "unit": "A"
@@ -1966,6 +2161,34 @@
                             "unit": "A"
                         }
                     },
+                    "iip3": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_iip3 'mydevice sclk global (3, 3, 3)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','iip3','global',(3, 3, 3)"
+                            ],
+                            "help": "Pin 3rd order input intercept point. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin 3rd order input intercept point",
+                            "switch": [
+                                "-datasheet_pin_iip3 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dBm"
+                        }
+                    },
                     "ileakage": {
                         "default": {
                             "example": [
@@ -1989,6 +2212,202 @@
                             "shorthelp": "Datasheet: pin leakage current",
                             "switch": [
                                 "-datasheet_pin_ileakage 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "A"
+                        }
+                    },
+                    "imd3": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_imd3 'mydevice sclk global (82, 88, 98)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','imd3','global',(82, 88, 98)"
+                            ],
+                            "help": "Pin 3rd order intermodulation distortion. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin 3rd order intermodulation distortion",
+                            "switch": [
+                                "-datasheet_pin_imd3 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dBc"
+                        }
+                    },
+                    "inl": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_inl 'mydevice sclk global (-7, 0.0, 7)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','inl','global',(-7, 0.0, 7)"
+                            ],
+                            "help": "Pin integral nonlinearity. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin integral nonlinearity",
+                            "switch": [
+                                "-datasheet_pin_inl 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "LSB"
+                        }
+                    },
+                    "ioffset": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_ioffset 'mydevice sclk global (0.001, 0.0012, 0.0015)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','ioffset','global',(0.001, 0.0012, 0.0015)"
+                            ],
+                            "help": "Pin offset current. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin offset current",
+                            "switch": [
+                                "-datasheet_pin_ioffset 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "A"
+                        }
+                    },
+                    "ioh": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_ioh 'mydevice sclk global (0.01, 0.012, 0.015)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','ioh','global',(0.01, 0.012, 0.015)"
+                            ],
+                            "help": "Pin output high current. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin output high current",
+                            "switch": [
+                                "-datasheet_pin_ioh 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "A"
+                        }
+                    },
+                    "iol": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_iol 'mydevice sclk global (0.01, 0.012, 0.015)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','iol','global',(0.01, 0.012, 0.015)"
+                            ],
+                            "help": "Pin output low current. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin output low current",
+                            "switch": [
+                                "-datasheet_pin_iol 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "A"
+                        }
+                    },
+                    "ishort": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_ishort 'mydevice sclk global (0.001, 0.0012, 0.0015)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','ishort','global',(0.001, 0.0012, 0.0015)"
+                            ],
+                            "help": "Pin short circuit current. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin short circuit current",
+                            "switch": [
+                                "-datasheet_pin_ishort 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "A"
+                        }
+                    },
+                    "isupply": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_isupply 'mydevice sclk global (0.001, 0.012, 0.015)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','isupply','global',(0.001, 0.012, 0.015)"
+                            ],
+                            "help": "Pin supply currents. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin supply currents",
+                            "switch": [
+                                "-datasheet_pin_isupply 'design pin mode <(float,float,float)>'"
                             ],
                             "type": "(float,float,float)",
                             "unit": "A"
@@ -2021,6 +2440,294 @@
                             "type": "str"
                         }
                     },
+                    "noisefigure": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_noisefigure 'mydevice sclk global (4.6, 4.6, 4.6)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','noisefigure','global',(4.6, 4.6, 4.6)"
+                            ],
+                            "help": "Pin noise figure. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin noise figure",
+                            "switch": [
+                                "-datasheet_pin_noisefigure 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dB"
+                        }
+                    },
+                    "nsd": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_nsd 'mydevice sclk global (-158, -158, -158)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','nsd','global',(-158, -158, -158)"
+                            ],
+                            "help": "Pin noise spectral density. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin noise spectral density",
+                            "switch": [
+                                "-datasheet_pin_nsd 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dBFS/Hz"
+                        }
+                    },
+                    "oob1db": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_oob1db 'mydevice sclk global (3, 3, 3)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','oob1db','global',(3, 3, 3)"
+                            ],
+                            "help": "Pin out of band 1 dB compression point. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin out of band 1 dB compression point",
+                            "switch": [
+                                "-datasheet_pin_oob1db 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dBm"
+                        }
+                    },
+                    "phasenoise": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_phasenoise 'mydevice sclk global (-158, -158, -158)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','phasenoise','global',(-158, -158, -158)"
+                            ],
+                            "help": "Pin phase noise. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin phase noise",
+                            "switch": [
+                                "-datasheet_pin_phasenoise 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dBc/Hz"
+                        }
+                    },
+                    "polarity": {
+                        "default": {
+                            "relpin": {
+                                "default": {
+                                    "enum": [
+                                        "positive",
+                                        "negative",
+                                        "none"
+                                    ],
+                                    "example": [
+                                        "cli: -datasheet_pin_polarity 'cpu q def clk none'",
+                                        "api: chip.set('datasheet','cpu','pin','q','polarity','def','relpin','clk,'none')"
+                                    ],
+                                    "help": "Pin polarity specified on a per mode basis. Only applicable to output\npins. Valid entries are: positive, negative, none.",
+                                    "lock": false,
+                                    "node": {
+                                        "default": {
+                                            "default": {
+                                                "signature": null,
+                                                "value": null
+                                            }
+                                        }
+                                    },
+                                    "notes": null,
+                                    "pernode": "never",
+                                    "require": null,
+                                    "scope": "job",
+                                    "shorthelp": "Datasheet: pin polarity",
+                                    "switch": [
+                                        "-datasheet_pin_polarity 'design name mode relpin name <str>'"
+                                    ],
+                                    "type": "enum"
+                                }
+                            }
+                        }
+                    },
+                    "pout": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_pout 'mydevice sclk global (12.2, 12.2, 12.2)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','pout','global',(12.2, 12.2, 12.2)"
+                            ],
+                            "help": "Pin output power. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin output power",
+                            "switch": [
+                                "-datasheet_pin_pout 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dBm"
+                        }
+                    },
+                    "pout2": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_pout2 'mydevice sclk global (-14, -14, -14)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','pout2','global',(-14, -14, -14)"
+                            ],
+                            "help": "Pin 2nd harmonic power. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin 2nd harmonic power",
+                            "switch": [
+                                "-datasheet_pin_pout2 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dBm"
+                        }
+                    },
+                    "pout3": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_pout3 'mydevice sclk global (-28, -28, -28)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','pout3','global',(-28, -28, -28)"
+                            ],
+                            "help": "Pin 3rd harmonic power. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin 3rd harmonic power",
+                            "switch": [
+                                "-datasheet_pin_pout3 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dBm"
+                        }
+                    },
+                    "power": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_power 'mydevice sclk global (1, 2, 3)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','power','global',(1, 2, 3)"
+                            ],
+                            "help": "Pin power consumption. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin power consumption",
+                            "switch": [
+                                "-datasheet_pin_power 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "W"
+                        }
+                    },
+                    "psnr": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_psnr 'mydevice sclk global (61, 61, 61)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','psnr','global',(61, 61, 61)"
+                            ],
+                            "help": "Pin power supply noise rejection. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin power supply noise rejection",
+                            "switch": [
+                                "-datasheet_pin_psnr 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dB"
+                        }
+                    },
                     "rdiff": {
                         "default": {
                             "example": [
@@ -2046,7 +2753,35 @@
                                 "-datasheet_pin_rdiff 'design pin mode <(float,float,float)>'"
                             ],
                             "type": "(float,float,float)",
-                            "unit": "ohm"
+                            "unit": "Ohm"
+                        }
+                    },
+                    "rdown": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_rdown 'mydevice sclk global (1000, 1200, 3000)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','rdown','global',(1000, 1200, 3000)"
+                            ],
+                            "help": "Pin output pulldown resistance. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin output pulldown resistance",
+                            "switch": [
+                                "-datasheet_pin_rdown 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "Ohm"
                         }
                     },
                     "resetvalue": {
@@ -2076,13 +2811,13 @@
                             "type": "[str]"
                         }
                     },
-                    "rpulldown": {
+                    "rin": {
                         "default": {
                             "example": [
-                                "cli: -datasheet_pin_rpulldown 'mydevice sclk global (1000, 1200, 3000)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','rpulldown','global',(1000, 1200, 3000)"
+                                "cli: -datasheet_pin_rin 'mydevice sclk global (1000, 1200, 3000)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','rin','global',(1000, 1200, 3000)"
                             ],
-                            "help": "Pin pulldown resistance. Values are tuples of (min, typical, max).",
+                            "help": "Pin input resistance. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2096,21 +2831,21 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin pulldown resistance",
+                            "shorthelp": "Datasheet: pin input resistance",
                             "switch": [
-                                "-datasheet_pin_rpulldown 'design pin mode <(float,float,float)>'"
+                                "-datasheet_pin_rin 'design pin mode <(float,float,float)>'"
                             ],
                             "type": "(float,float,float)",
-                            "unit": "ohm"
+                            "unit": "Ohm"
                         }
                     },
-                    "rpullup": {
+                    "rup": {
                         "default": {
                             "example": [
-                                "cli: -datasheet_pin_rpullup 'mydevice sclk global (1000, 1200, 3000)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','rpullup','global',(1000, 1200, 3000)"
+                                "cli: -datasheet_pin_rup 'mydevice sclk global (1000, 1200, 3000)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','rup','global',(1000, 1200, 3000)"
                             ],
-                            "help": "Pin pullup resistance. Values are tuples of (min, typical, max).",
+                            "help": "Pin output pullup resistance. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2124,21 +2859,300 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin pullup resistance",
+                            "shorthelp": "Datasheet: pin output pullup resistance",
                             "switch": [
-                                "-datasheet_pin_rpullup 'design pin mode <(float,float,float)>'"
+                                "-datasheet_pin_rup 'design pin mode <(float,float,float)>'"
                             ],
                             "type": "(float,float,float)",
-                            "unit": "ohm"
+                            "unit": "Ohm"
+                        }
+                    },
+                    "rweakdown": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_rweakdown 'mydevice sclk global (1000, 1200, 3000)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','rweakdown','global',(1000, 1200, 3000)"
+                            ],
+                            "help": "Pin weak pulldown resistance. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin weak pulldown resistance",
+                            "switch": [
+                                "-datasheet_pin_rweakdown 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "Ohm"
+                        }
+                    },
+                    "rweakup": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_rweakup 'mydevice sclk global (1000, 1200, 3000)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','rweakup','global',(1000, 1200, 3000)"
+                            ],
+                            "help": "Pin weak pullup resistance. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin weak pullup resistance",
+                            "switch": [
+                                "-datasheet_pin_rweakup 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "Ohm"
+                        }
+                    },
+                    "s11": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_s11 'mydevice sclk global (7, 7, 7)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','s11','global',(7, 7, 7)"
+                            ],
+                            "help": "Pin input return loss. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin input return loss",
+                            "switch": [
+                                "-datasheet_pin_s11 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dB"
+                        }
+                    },
+                    "s12": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_s12 'mydevice sclk global (-20, -20, -20)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','s12','global',(-20, -20, -20)"
+                            ],
+                            "help": "Pin reverse isolation. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin reverse isolation",
+                            "switch": [
+                                "-datasheet_pin_s12 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dB"
+                        }
+                    },
+                    "s21": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_s21 'mydevice sclk global (10, 11, 12)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','s21','global',(10, 11, 12)"
+                            ],
+                            "help": "Pin gain. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin gain",
+                            "switch": [
+                                "-datasheet_pin_s21 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dB"
+                        }
+                    },
+                    "s22": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_s22 'mydevice sclk global (10, 10, 10)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','s22','global',(10, 10, 10)"
+                            ],
+                            "help": "Pin output return loss. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin output return loss",
+                            "switch": [
+                                "-datasheet_pin_s22 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dB"
+                        }
+                    },
+                    "sfdr": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_sfdr 'mydevice sclk global (82, 88, 98)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','sfdr','global',(82, 88, 98)"
+                            ],
+                            "help": "Pin spurious-free dynamic range. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin spurious-free dynamic range",
+                            "switch": [
+                                "-datasheet_pin_sfdr 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dBc"
+                        }
+                    },
+                    "signal": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_signal 'mydevice clk0 ddr4 CLKN'",
+                                "api: chip.set('datasheet','mydevice','pin','clk0','signal','ddr4','CLKN')"
+                            ],
+                            "help": "Pin mapping to standardized interface signals.",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": [],
+                                        "value": []
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin signal map",
+                            "switch": [
+                                "-datasheet_pin_signal 'design name mode <str>'"
+                            ],
+                            "type": "[str]"
+                        }
+                    },
+                    "sinad": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_sinad 'mydevice sclk global (71, 72, 73)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','sinad','global',(71, 72, 73)"
+                            ],
+                            "help": "Pin signal to noise and distortion ratio. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin signal to noise and distortion ratio",
+                            "switch": [
+                                "-datasheet_pin_sinad 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dB"
+                        }
+                    },
+                    "snr": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_snr 'mydevice sclk global (70, 72, 74)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','snr','global',(70, 72, 74)"
+                            ],
+                            "help": "Pin signal to noise ratio. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin signal to noise ratio",
+                            "switch": [
+                                "-datasheet_pin_snr 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "dB"
                         }
                     },
                     "standard": {
                         "default": {
                             "example": [
-                                "cli: -datasheet_pin_standard 'mydevice ba0 global ddr4'",
-                                "api: chip.set('datasheet','mydevice','pin','ina','standard','global','ddr4')"
+                                "cli: -datasheet_pin_standard 'mydevice clk def LVCMOS'",
+                                "api: chip.set('datasheet','mydevice','pin','clk','standard','def', 'LVCMOS')"
                             ],
-                            "help": "Pin communication standard specified on a per mode basis.",
+                            "help": "Pin electrical signaling standard (LVDS, LVCMOS, TTL,..).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2159,13 +3173,73 @@
                             "type": "[str]"
                         }
                     },
-                    "supply": {
+                    "tdelayf": {
+                        "default": {
+                            "default": {
+                                "example": [
+                                    "cli: -datasheet_pin_tdelayf 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
+                                    "api: chip.set('datasheet','dev','pin','a','tdelayf','glob','ck',(1e-09, 2e-09, 4e-09)"
+                                ],
+                                "help": "Pin propagation delay (fall) specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                                "lock": false,
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "signature": null,
+                                            "value": null
+                                        }
+                                    }
+                                },
+                                "notes": null,
+                                "pernode": "never",
+                                "require": null,
+                                "scope": "job",
+                                "shorthelp": "Datasheet: pin propagation delay (fall)",
+                                "switch": [
+                                    "-datasheet_pin_tdelayf 'design pin mode relname <(float,float,float)>'"
+                                ],
+                                "type": "(float,float,float)",
+                                "unit": "s"
+                            }
+                        }
+                    },
+                    "tdelayr": {
+                        "default": {
+                            "default": {
+                                "example": [
+                                    "cli: -datasheet_pin_tdelayr 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
+                                    "api: chip.set('datasheet','dev','pin','a','tdelayr','glob','ck',(1e-09, 2e-09, 4e-09)"
+                                ],
+                                "help": "Pin propagation delay (rise) specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                                "lock": false,
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "signature": null,
+                                            "value": null
+                                        }
+                                    }
+                                },
+                                "notes": null,
+                                "pernode": "never",
+                                "require": null,
+                                "scope": "job",
+                                "shorthelp": "Datasheet: pin propagation delay (rise)",
+                                "switch": [
+                                    "-datasheet_pin_tdelayr 'design pin mode relname <(float,float,float)>'"
+                                ],
+                                "type": "(float,float,float)",
+                                "unit": "s"
+                            }
+                        }
+                    },
+                    "tduty": {
                         "default": {
                             "example": [
-                                "cli: -datasheet_pin_supply 'mydevice ina global vdd'",
-                                "api: chip.set('datasheet','mydevice','pin','ina','supply','global','vdd')"
+                                "cli: -datasheet_pin_tduty 'mydevice sclk global (45, 50, 55)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','tduty','global',(45, 50, 55)"
                             ],
-                            "help": "Pin related power supply specified on a per mode basis.",
+                            "help": "Pin duty cycle. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2179,20 +3253,51 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin related power supply",
+                            "shorthelp": "Datasheet: pin duty cycle",
                             "switch": [
-                                "-datasheet_pin_supply 'design name mode <str>'"
+                                "-datasheet_pin_tduty 'design pin mode <(float,float,float)>'"
                             ],
-                            "type": "str"
+                            "type": "(float,float,float)",
+                            "unit": "%"
                         }
                     },
                     "tfall": {
                         "default": {
+                            "default": {
+                                "example": [
+                                    "cli: -datasheet_pin_tfall 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
+                                    "api: chip.set('datasheet','dev','pin','a','tfall','glob','ck',(1e-09, 2e-09, 4e-09)"
+                                ],
+                                "help": "Pin fall transition specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                                "lock": false,
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "signature": null,
+                                            "value": null
+                                        }
+                                    }
+                                },
+                                "notes": null,
+                                "pernode": "never",
+                                "require": null,
+                                "scope": "job",
+                                "shorthelp": "Datasheet: pin fall transition",
+                                "switch": [
+                                    "-datasheet_pin_tfall 'design pin mode relname <(float,float,float)>'"
+                                ],
+                                "type": "(float,float,float)",
+                                "unit": "s"
+                            }
+                        }
+                    },
+                    "thigh": {
+                        "default": {
                             "example": [
-                                "cli: -datasheet_pin_tfall 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','tfall','global',(1e-09, 2e-09, 4e-09)"
+                                "cli: -datasheet_pin_thigh 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','thigh','global',(1e-09, 2e-09, 4e-09)"
                             ],
-                            "help": "Pin fall transition. Values are tuples of (min, typical, max).",
+                            "help": "Pin pulse widtdh high. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2206,9 +3311,9 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin fall transition",
+                            "shorthelp": "Datasheet: pin pulse widtdh high",
                             "switch": [
-                                "-datasheet_pin_tfall 'design pin mode <(float,float,float)>'"
+                                "-datasheet_pin_thigh 'design pin mode <(float,float,float)>'"
                             ],
                             "type": "(float,float,float)",
                             "unit": "s"
@@ -2216,30 +3321,32 @@
                     },
                     "thold": {
                         "default": {
-                            "example": [
-                                "cli: -datasheet_pin_thold 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','thold','global',(1e-09, 2e-09, 4e-09)"
-                            ],
-                            "help": "Pin hold time. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
+                            "default": {
+                                "example": [
+                                    "cli: -datasheet_pin_thold 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
+                                    "api: chip.set('datasheet','dev','pin','a','thold','glob','ck',(1e-09, 2e-09, 4e-09)"
+                                ],
+                                "help": "Pin hold time specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                                "lock": false,
+                                "node": {
                                     "default": {
-                                        "signature": null,
-                                        "value": null
+                                        "default": {
+                                            "signature": null,
+                                            "value": null
+                                        }
                                     }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin hold time",
-                            "switch": [
-                                "-datasheet_pin_thold 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "s"
+                                },
+                                "notes": null,
+                                "pernode": "never",
+                                "require": null,
+                                "scope": "job",
+                                "shorthelp": "Datasheet: pin hold time",
+                                "switch": [
+                                    "-datasheet_pin_thold 'design pin mode relname <(float,float,float)>'"
+                                ],
+                                "type": "(float,float,float)",
+                                "unit": "s"
+                            }
                         }
                     },
                     "tjitter": {
@@ -2265,6 +3372,34 @@
                             "shorthelp": "Datasheet: pin rms jitter",
                             "switch": [
                                 "-datasheet_pin_tjitter 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "s"
+                        }
+                    },
+                    "tlow": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_tlow 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','tlow','global',(1e-09, 2e-09, 4e-09)"
+                            ],
+                            "help": "Pin pulse widtdh low. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin pulse widtdh low",
+                            "switch": [
+                                "-datasheet_pin_tlow 'design pin mode <(float,float,float)>'"
                             ],
                             "type": "(float,float,float)",
                             "unit": "s"
@@ -2328,67 +3463,108 @@
                     },
                     "trise": {
                         "default": {
-                            "example": [
-                                "cli: -datasheet_pin_trise 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','trise','global',(1e-09, 2e-09, 4e-09)"
-                            ],
-                            "help": "Pin rise transition. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
+                            "default": {
+                                "example": [
+                                    "cli: -datasheet_pin_trise 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
+                                    "api: chip.set('datasheet','dev','pin','a','trise','glob','ck',(1e-09, 2e-09, 4e-09)"
+                                ],
+                                "help": "Pin rise transition specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                                "lock": false,
+                                "node": {
                                     "default": {
-                                        "signature": null,
-                                        "value": null
+                                        "default": {
+                                            "signature": null,
+                                            "value": null
+                                        }
                                     }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin rise transition",
-                            "switch": [
-                                "-datasheet_pin_trise 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "s"
+                                },
+                                "notes": null,
+                                "pernode": "never",
+                                "require": null,
+                                "scope": "job",
+                                "shorthelp": "Datasheet: pin rise transition",
+                                "switch": [
+                                    "-datasheet_pin_trise 'design pin mode relname <(float,float,float)>'"
+                                ],
+                                "type": "(float,float,float)",
+                                "unit": "s"
+                            }
                         }
                     },
                     "tsetup": {
                         "default": {
-                            "example": [
-                                "cli: -datasheet_pin_tsetup 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','tsetup','global',(1e-09, 2e-09, 4e-09)"
-                            ],
-                            "help": "Pin setup time. Values are tuples of (min, typical, max).",
-                            "lock": false,
-                            "node": {
-                                "default": {
+                            "default": {
+                                "example": [
+                                    "cli: -datasheet_pin_tsetup 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
+                                    "api: chip.set('datasheet','dev','pin','a','tsetup','glob','ck',(1e-09, 2e-09, 4e-09)"
+                                ],
+                                "help": "Pin setup time specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                                "lock": false,
+                                "node": {
                                     "default": {
-                                        "signature": null,
-                                        "value": null
+                                        "default": {
+                                            "signature": null,
+                                            "value": null
+                                        }
                                     }
-                                }
-                            },
-                            "notes": null,
-                            "pernode": "never",
-                            "require": null,
-                            "scope": "job",
-                            "shorthelp": "Datasheet: pin setup time",
-                            "switch": [
-                                "-datasheet_pin_tsetup 'design pin mode <(float,float,float)>'"
-                            ],
-                            "type": "(float,float,float)",
-                            "unit": "s"
+                                },
+                                "notes": null,
+                                "pernode": "never",
+                                "require": null,
+                                "scope": "job",
+                                "shorthelp": "Datasheet: pin setup time",
+                                "switch": [
+                                    "-datasheet_pin_tsetup 'design pin mode relname <(float,float,float)>'"
+                                ],
+                                "type": "(float,float,float)",
+                                "unit": "s"
+                            }
+                        }
+                    },
+                    "tskew": {
+                        "default": {
+                            "default": {
+                                "example": [
+                                    "cli: -datasheet_pin_tskew 'dev a glob clock (1e-09, 2e-09, 4e-09)'",
+                                    "api: chip.set('datasheet','dev','pin','a','tskew','glob','ck',(1e-09, 2e-09, 4e-09)"
+                                ],
+                                "help": "Pin timing skew specified on a per pin, mode, and relpin basis.\nValues are tuples of (min, typical, max).",
+                                "lock": false,
+                                "node": {
+                                    "default": {
+                                        "default": {
+                                            "signature": null,
+                                            "value": null
+                                        }
+                                    }
+                                },
+                                "notes": null,
+                                "pernode": "never",
+                                "require": null,
+                                "scope": "job",
+                                "shorthelp": "Datasheet: pin timing skew",
+                                "switch": [
+                                    "-datasheet_pin_tskew 'design pin mode relname <(float,float,float)>'"
+                                ],
+                                "type": "(float,float,float)",
+                                "unit": "s"
+                            }
                         }
                     },
                     "type": {
                         "default": {
-                            "example": [
-                                "cli: -datasheet_pin_type 'mydevice vdd type power'",
-                                "api: chip.set('datasheet','mydevice','pin','vdd','type','global','power')"
+                            "enum": [
+                                "digital",
+                                "analog",
+                                "clock",
+                                "supply",
+                                "ground"
                             ],
-                            "help": "Pin type specified on a per mode basis. Acceptable pin types\ninclude: digital, analog, clk, power, ground",
+                            "example": [
+                                "cli: -datasheet_pin_type 'mydevice vdd global supply'",
+                                "api: chip.set('datasheet','mydevice','pin','vdd','type','global','supply')"
+                            ],
+                            "help": "Pin type specified on a per mode basis. Acceptable pin types\ninclude: digital, analog, clock, supply, ground",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2406,7 +3582,7 @@
                             "switch": [
                                 "-datasheet_pin_type 'design name mode <str>'"
                             ],
-                            "type": "str"
+                            "type": "enum"
                         }
                     },
                     "vcdm": {
@@ -2415,7 +3591,7 @@
                                 "cli: -datasheet_pin_vcdm 'mydevice sclk global (125, 150, 175)'",
                                 "api: chip.set('datasheet','mydevice','pin','sclk','vcdm','global',(125, 150, 175)"
                             ],
-                            "help": "Pin CDM ESD tolerance. Values are tuples of (min, typical, max).",
+                            "help": "Pin charge device model (CDM) ESD tolerance. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2429,7 +3605,7 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin CDM ESD tolerance",
+                            "shorthelp": "Datasheet: pin charge device model (CDM) ESD tolerance",
                             "switch": [
                                 "-datasheet_pin_vcdm 'design pin mode <(float,float,float)>'"
                             ],
@@ -2493,13 +3669,13 @@
                             "unit": "V"
                         }
                     },
-                    "vhbm": {
+                    "vgainerror": {
                         "default": {
                             "example": [
-                                "cli: -datasheet_pin_vhbm 'mydevice sclk global (200, 250, 300)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vhbm','global',(200, 250, 300)"
+                                "cli: -datasheet_pin_vgainerror 'mydevice sclk global (-1.0, 0.0, 1.0)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','vgainerror','global',(-1.0, 0.0, 1.0)"
                             ],
-                            "help": "Pin HBM ESD tolerance. Values are tuples of (min, typical, max).",
+                            "help": "Pin gain error. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2513,7 +3689,35 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin HBM ESD tolerance",
+                            "shorthelp": "Datasheet: pin gain error",
+                            "switch": [
+                                "-datasheet_pin_vgainerror 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "mV"
+                        }
+                    },
+                    "vhbm": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_vhbm 'mydevice sclk global (200, 250, 300)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','vhbm','global',(200, 250, 300)"
+                            ],
+                            "help": "Pin human body model (HBM) ESD tolerance. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin human body model (HBM) ESD tolerance",
                             "switch": [
                                 "-datasheet_pin_vhbm 'design pin mode <(float,float,float)>'"
                             ],
@@ -2577,13 +3781,13 @@
                             "unit": "V"
                         }
                     },
-                    "vmm": {
+                    "vmax": {
                         "default": {
                             "example": [
-                                "cli: -datasheet_pin_vmm 'mydevice sclk global (100, 125, 150)'",
-                                "api: chip.set('datasheet','mydevice','pin','sclk','vmm','global',(100, 125, 150)"
+                                "cli: -datasheet_pin_vmax 'mydevice sclk global (0.2, 0.3, 0.9)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','vmax','global',(0.2, 0.3, 0.9)"
                             ],
-                            "help": "Pin MM ESD tolerance. Values are tuples of (min, typical, max).",
+                            "help": "Pin absolute maximum voltage. Values are tuples of (min, typical, max).",
                             "lock": false,
                             "node": {
                                 "default": {
@@ -2597,7 +3801,35 @@
                             "pernode": "never",
                             "require": null,
                             "scope": "job",
-                            "shorthelp": "Datasheet: pin MM ESD tolerance",
+                            "shorthelp": "Datasheet: pin absolute maximum voltage",
+                            "switch": [
+                                "-datasheet_pin_vmax 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "V"
+                        }
+                    },
+                    "vmm": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_vmm 'mydevice sclk global (100, 125, 150)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','vmm','global',(100, 125, 150)"
+                            ],
+                            "help": "Pin machine model (MM) ESD tolerance. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin machine model (MM) ESD tolerance",
                             "switch": [
                                 "-datasheet_pin_vmm 'design pin mode <(float,float,float)>'"
                             ],
@@ -2628,6 +3860,90 @@
                             "shorthelp": "Datasheet: pin random voltage noise",
                             "switch": [
                                 "-datasheet_pin_vnoise 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "V"
+                        }
+                    },
+                    "vnominal": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_vnominal 'mydevice sclk global (1.72, 1.8, 1.92)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','vnominal','global',(1.72, 1.8, 1.92)"
+                            ],
+                            "help": "Pin nominal operating voltage. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin nominal operating voltage",
+                            "switch": [
+                                "-datasheet_pin_vnominal 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "V"
+                        }
+                    },
+                    "vofferror": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_vofferror 'mydevice sclk global (-1.0, 0.0, 1.0)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','vofferror','global',(-1.0, 0.0, 1.0)"
+                            ],
+                            "help": "Pin offset error. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin offset error",
+                            "switch": [
+                                "-datasheet_pin_vofferror 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "mV"
+                        }
+                    },
+                    "voffset": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_voffset 'mydevice sclk global (0.2, 0.3, 0.9)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','voffset','global',(0.2, 0.3, 0.9)"
+                            ],
+                            "help": "Pin offset voltage. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin offset voltage",
+                            "switch": [
+                                "-datasheet_pin_voffset 'design pin mode <(float,float,float)>'"
                             ],
                             "type": "(float,float,float)",
                             "unit": "V"
@@ -2688,7 +4004,193 @@
                             "type": "(float,float,float)",
                             "unit": "V"
                         }
+                    },
+                    "vslew": {
+                        "default": {
+                            "example": [
+                                "cli: -datasheet_pin_vslew 'mydevice sclk global (1e-09, 2e-09, 4e-09)'",
+                                "api: chip.set('datasheet','mydevice','pin','sclk','vslew','global',(1e-09, 2e-09, 4e-09)"
+                            ],
+                            "help": "Pin slew rate. Values are tuples of (min, typical, max).",
+                            "lock": false,
+                            "node": {
+                                "default": {
+                                    "default": {
+                                        "signature": null,
+                                        "value": null
+                                    }
+                                }
+                            },
+                            "notes": null,
+                            "pernode": "never",
+                            "require": null,
+                            "scope": "job",
+                            "shorthelp": "Datasheet: pin slew rate",
+                            "switch": [
+                                "-datasheet_pin_vslew 'design pin mode <(float,float,float)>'"
+                            ],
+                            "type": "(float,float,float)",
+                            "unit": "V/s"
+                        }
                     }
+                }
+            },
+            "thermal": {
+                "rja": {
+                    "example": [
+                        "cli: -datasheet_thermal_rja 'mydevice 30.4'",
+                        "api: chip.set('datasheet','mydevice','thermal','rja',30.4)"
+                    ],
+                    "help": "Device rja.",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "never",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Datasheet: junction to ambient thermal resistence",
+                    "switch": [
+                        "-datasheet_thermal_rja 'design <float>'"
+                    ],
+                    "type": "float",
+                    "unit": "C/W"
+                },
+                "rjb": {
+                    "example": [
+                        "cli: -datasheet_thermal_rjb 'mydevice 30.4'",
+                        "api: chip.set('datasheet','mydevice','thermal','rjb',30.4)"
+                    ],
+                    "help": "Device rjb.",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "never",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Datasheet: junction to board thermal resistence",
+                    "switch": [
+                        "-datasheet_thermal_rjb 'design <float>'"
+                    ],
+                    "type": "float",
+                    "unit": "C/W"
+                },
+                "rjcb": {
+                    "example": [
+                        "cli: -datasheet_thermal_rjcb 'mydevice 30.4'",
+                        "api: chip.set('datasheet','mydevice','thermal','rjcb',30.4)"
+                    ],
+                    "help": "Device rjcb.",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "never",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Datasheet: junction to case (bottom) thermal resistence",
+                    "switch": [
+                        "-datasheet_thermal_rjcb 'design <float>'"
+                    ],
+                    "type": "float",
+                    "unit": "C/W"
+                },
+                "rjct": {
+                    "example": [
+                        "cli: -datasheet_thermal_rjct 'mydevice 30.4'",
+                        "api: chip.set('datasheet','mydevice','thermal','rjct',30.4)"
+                    ],
+                    "help": "Device rjct.",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "never",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Datasheet: junction to case (top) thermal resistence",
+                    "switch": [
+                        "-datasheet_thermal_rjct 'design <float>'"
+                    ],
+                    "type": "float",
+                    "unit": "C/W"
+                },
+                "tjb": {
+                    "example": [
+                        "cli: -datasheet_thermal_tjb 'mydevice 30.4'",
+                        "api: chip.set('datasheet','mydevice','thermal','tjb',30.4)"
+                    ],
+                    "help": "Device tjb.",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "never",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Datasheet: junction to bottom characterization parameter",
+                    "switch": [
+                        "-datasheet_thermal_tjb 'design <float>'"
+                    ],
+                    "type": "float",
+                    "unit": "C/W"
+                },
+                "tjt": {
+                    "example": [
+                        "cli: -datasheet_thermal_tjt 'mydevice 30.4'",
+                        "api: chip.set('datasheet','mydevice','thermal','tjt',30.4)"
+                    ],
+                    "help": "Device tjt.",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "never",
+                    "require": null,
+                    "scope": "job",
+                    "shorthelp": "Datasheet: junction to top characterization parameter",
+                    "switch": [
+                        "-datasheet_thermal_tjt 'design <float>'"
+                    ],
+                    "type": "float",
+                    "unit": "C/W"
                 }
             }
         }

--- a/tests/core/test_datasheet.py
+++ b/tests/core/test_datasheet.py
@@ -1,0 +1,41 @@
+# Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
+import siliconcompiler
+
+
+def test_datasheet():
+    '''API test for help method
+    '''
+
+    chip = siliconcompiler.Chip('nand2')
+
+    mode = 'default'
+    top = chip.top()
+
+    # inputs
+    chip.set('datasheet', top, 'pin', 'a', 'dir', mode, 'input');
+    chip.set('datasheet', top, 'pin', 'b', 'dir', mode, 'input');
+    chip.set('datasheet', top, 'pin', 'a', 'cap', mode, (0.9,0.9,0.9));
+    chip.set('datasheet', top, 'pin', 'b', 'cap', mode, (0.9,0.9,0.9));
+
+    # output
+    chip.set('datasheet', top, 'pin', 'z', 'func', mode, '~(a&b)');
+    chip.set('datasheet', top, 'pin', 'z', 'dir', mode, 'output');
+    chip.set('datasheet', top, 'pin', 'z', 'trise', mode, 'a', (0.9,0.9,0.9));
+    chip.set('datasheet', top, 'pin', 'z', 'tfall', mode, 'a', (0.9,0.9,0.9));
+    chip.set('datasheet', top, 'pin', 'z', 'trise', mode, 'b', (0.9,0.9,0.9));
+    chip.set('datasheet', top, 'pin', 'z', 'tfall', mode, 'b', (0.9,0.9,0.9));
+    chip.set('datasheet', top, 'pin', 'z', 'tdelayr', mode, 'a', (0.9,0.9,0.9));
+    chip.set('datasheet', top, 'pin', 'z', 'tdelayf', mode, 'a', (0.9,0.9,0.9));
+    chip.set('datasheet', top, 'pin', 'z', 'tdelayr', mode, 'b', (0.9,0.9,0.9));
+    chip.set('datasheet', top, 'pin', 'z', 'tdelayf', mode, 'b', (0.9,0.9,0.9));
+
+    # print outputs
+    for key in chip.allkeys():
+        if key[0]=='datasheet':
+            val = chip.get(*key)
+            if val:
+                print(key, chip.get(*key))
+
+#########################
+if __name__ == "__main__":
+    test_datasheet()

--- a/tests/core/test_datasheet.py
+++ b/tests/core/test_datasheet.py
@@ -18,7 +18,7 @@ def test_datasheet():
     chip.set('datasheet', top, 'pin', 'b', 'cap', mode, (0.9, 0.9, 0.9))
 
     # output
-    chip.set('datasheet', top, 'pin', 'z', 'func', mode, '~(a&b)')
+    chip.set('datasheet', top, 'pin', 'z', 'function', mode, '~(a&b)')
     chip.set('datasheet', top, 'pin', 'z', 'dir', mode, 'output')
     chip.set('datasheet', top, 'pin', 'z', 'trise', mode, 'a', (0.9, 0.9, 0.9))
     chip.set('datasheet', top, 'pin', 'z', 'tfall', mode, 'a', (0.9, 0.9, 0.9))

--- a/tests/core/test_datasheet.py
+++ b/tests/core/test_datasheet.py
@@ -9,25 +9,24 @@ def test_datasheet():
     chip = siliconcompiler.Chip('nand2')
 
     mode = 'default'
-    top = chip.top()
 
     # inputs
-    chip.set('datasheet', top, 'pin', 'a', 'dir', mode, 'input')
-    chip.set('datasheet', top, 'pin', 'b', 'dir', mode, 'input')
-    chip.set('datasheet', top, 'pin', 'a', 'cap', mode, (0.9, 0.9, 0.9))
-    chip.set('datasheet', top, 'pin', 'b', 'cap', mode, (0.9, 0.9, 0.9))
+    chip.set('datasheet', 'pin', 'a', 'dir', mode, 'input')
+    chip.set('datasheet', 'pin', 'b', 'dir', mode, 'input')
+    chip.set('datasheet', 'pin', 'a', 'cap', mode, (0.9, 0.9, 0.9))
+    chip.set('datasheet', 'pin', 'b', 'cap', mode, (0.9, 0.9, 0.9))
 
     # output
-    chip.set('datasheet', top, 'pin', 'z', 'function', mode, '~(a&b)')
-    chip.set('datasheet', top, 'pin', 'z', 'dir', mode, 'output')
-    chip.set('datasheet', top, 'pin', 'z', 'trise', mode, 'a', (0.9, 0.9, 0.9))
-    chip.set('datasheet', top, 'pin', 'z', 'tfall', mode, 'a', (0.9, 0.9, 0.9))
-    chip.set('datasheet', top, 'pin', 'z', 'trise', mode, 'b', (0.9, 0.9, 0.9))
-    chip.set('datasheet', top, 'pin', 'z', 'tfall', mode, 'b', (0.9, 0.9, 0.9))
-    chip.set('datasheet', top, 'pin', 'z', 'tdelayr', mode, 'a', (0.9, 0.9, 0.9))
-    chip.set('datasheet', top, 'pin', 'z', 'tdelayf', mode, 'a', (0.9, 0.9, 0.9))
-    chip.set('datasheet', top, 'pin', 'z', 'tdelayr', mode, 'b', (0.9, 0.9, 0.9))
-    chip.set('datasheet', top, 'pin', 'z', 'tdelayf', mode, 'b', (0.9, 0.9, 0.9))
+    chip.set('datasheet', 'pin', 'z', 'function', mode, '~(a&b)')
+    chip.set('datasheet', 'pin', 'z', 'dir', mode, 'output')
+    chip.set('datasheet', 'pin', 'z', 'trise', mode, 'a', (0.9, 0.9, 0.9))
+    chip.set('datasheet', 'pin', 'z', 'tfall', mode, 'a', (0.9, 0.9, 0.9))
+    chip.set('datasheet', 'pin', 'z', 'trise', mode, 'b', (0.9, 0.9, 0.9))
+    chip.set('datasheet', 'pin', 'z', 'tfall', mode, 'b', (0.9, 0.9, 0.9))
+    chip.set('datasheet', 'pin', 'z', 'tdelayr', mode, 'a', (0.9, 0.9, 0.9))
+    chip.set('datasheet', 'pin', 'z', 'tdelayf', mode, 'a', (0.9, 0.9, 0.9))
+    chip.set('datasheet', 'pin', 'z', 'tdelayr', mode, 'b', (0.9, 0.9, 0.9))
+    chip.set('datasheet', 'pin', 'z', 'tdelayf', mode, 'b', (0.9, 0.9, 0.9))
 
     # print outputs
     for key in chip.allkeys():

--- a/tests/core/test_datasheet.py
+++ b/tests/core/test_datasheet.py
@@ -12,29 +12,30 @@ def test_datasheet():
     top = chip.top()
 
     # inputs
-    chip.set('datasheet', top, 'pin', 'a', 'dir', mode, 'input');
-    chip.set('datasheet', top, 'pin', 'b', 'dir', mode, 'input');
-    chip.set('datasheet', top, 'pin', 'a', 'cap', mode, (0.9,0.9,0.9));
-    chip.set('datasheet', top, 'pin', 'b', 'cap', mode, (0.9,0.9,0.9));
+    chip.set('datasheet', top, 'pin', 'a', 'dir', mode, 'input')
+    chip.set('datasheet', top, 'pin', 'b', 'dir', mode, 'input')
+    chip.set('datasheet', top, 'pin', 'a', 'cap', mode, (0.9, 0.9, 0.9))
+    chip.set('datasheet', top, 'pin', 'b', 'cap', mode, (0.9, 0.9, 0.9))
 
     # output
-    chip.set('datasheet', top, 'pin', 'z', 'func', mode, '~(a&b)');
-    chip.set('datasheet', top, 'pin', 'z', 'dir', mode, 'output');
-    chip.set('datasheet', top, 'pin', 'z', 'trise', mode, 'a', (0.9,0.9,0.9));
-    chip.set('datasheet', top, 'pin', 'z', 'tfall', mode, 'a', (0.9,0.9,0.9));
-    chip.set('datasheet', top, 'pin', 'z', 'trise', mode, 'b', (0.9,0.9,0.9));
-    chip.set('datasheet', top, 'pin', 'z', 'tfall', mode, 'b', (0.9,0.9,0.9));
-    chip.set('datasheet', top, 'pin', 'z', 'tdelayr', mode, 'a', (0.9,0.9,0.9));
-    chip.set('datasheet', top, 'pin', 'z', 'tdelayf', mode, 'a', (0.9,0.9,0.9));
-    chip.set('datasheet', top, 'pin', 'z', 'tdelayr', mode, 'b', (0.9,0.9,0.9));
-    chip.set('datasheet', top, 'pin', 'z', 'tdelayf', mode, 'b', (0.9,0.9,0.9));
+    chip.set('datasheet', top, 'pin', 'z', 'func', mode, '~(a&b)')
+    chip.set('datasheet', top, 'pin', 'z', 'dir', mode, 'output')
+    chip.set('datasheet', top, 'pin', 'z', 'trise', mode, 'a', (0.9, 0.9, 0.9))
+    chip.set('datasheet', top, 'pin', 'z', 'tfall', mode, 'a', (0.9, 0.9, 0.9))
+    chip.set('datasheet', top, 'pin', 'z', 'trise', mode, 'b', (0.9, 0.9, 0.9))
+    chip.set('datasheet', top, 'pin', 'z', 'tfall', mode, 'b', (0.9, 0.9, 0.9))
+    chip.set('datasheet', top, 'pin', 'z', 'tdelayr', mode, 'a', (0.9, 0.9, 0.9))
+    chip.set('datasheet', top, 'pin', 'z', 'tdelayf', mode, 'a', (0.9, 0.9, 0.9))
+    chip.set('datasheet', top, 'pin', 'z', 'tdelayr', mode, 'b', (0.9, 0.9, 0.9))
+    chip.set('datasheet', top, 'pin', 'z', 'tdelayf', mode, 'b', (0.9, 0.9, 0.9))
 
     # print outputs
     for key in chip.allkeys():
-        if key[0]=='datasheet':
+        if key[0] == 'datasheet':
             val = chip.get(*key)
             if val:
                 print(key, chip.get(*key))
+
 
 #########################
 if __name__ == "__main__":


### PR DESCRIPTION
This PR removes some non-useful parameters and adds a whole bunch of new parameters in preparation for using the manifests as sharable objects. A datasheet is the defacto standard abstraction for ICs today. A chip is sold to a customer using the datasheet as the contract between the company and the customer.

 - Removing related supply, pin (not useful)
 - Making absolute voltage a per pin parameter
 - Adding thermal resistance parameters
 - Adding pin function (stdcells)
 - Making standard a pin mapping feature
 - Adding pin polarity (stdcells)
 - Adding relpin for all AC parameters (mandatory, multiple clks)
 - Adding missing resistence paramters
 - Adding electrical spec parameters (adc, opamp, etc)
 - Adding reliability section