### PR TITLE
`archive()` enhancements SC-25

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2449,24 +2449,21 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
     ###########################################################################
     def _archive_node(self, tar, step=None, index=None, all_files=False):
-        design = self.get('design')
-        jobname = self.get('option', 'jobname')
-        buildpath = self.get('option', 'builddir')
+        basedir = self._getworkdir(step=step, index=index)
 
-        # Don't use _getworkdir() since we want a relative path for arcname
-        jobdir = os.path.join(buildpath, design, jobname)
+        def arcname(path):
+            return pathlib.Path(path).relative_to(self.cwd)
 
-        basedir = os.path.join(jobdir, step, index)
         if all_files:
-            tar.add(os.path.abspath(basedir), arcname=basedir)
+            tar.add(basedir, arcname=arcname(basedir))
         else:
             for folder in ('reports', 'outputs'):
                 path = os.path.join(basedir, folder)
-                tar.add(os.path.abspath(path), arcname=path)
+                tar.add(path, arcname=arcname(path))
 
             logfile = os.path.join(basedir, f'{step}.log')
             if os.path.isfile(logfile):
-                tar.add(os.path.abspath(logfile), arcname=logfile)
+                tar.add(logfile, arcname=arcname(logfile))
 
     ###########################################################################
     def archive(self, step=None, index=None, all_files=False, archive_name=None):
@@ -2489,7 +2486,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         design = self.get('design')
         jobname = self.get('option', 'jobname')
-        buildpath = self.get('option', 'builddir')
         flow = self.get('option', 'flow')
 
         if step:
@@ -2510,12 +2506,11 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 archive_name = f"{design}_{jobname}.tgz"
 
         with tarfile.open(archive_name, "w:gz") as tar:
-            # Don't use _getworkdir() since we want a relative path for arcname
-            jobdir = os.path.join(buildpath, design, jobname)
-
+            jobdir = self._getworkdir()
             manifest = os.path.join(jobdir, f'{design}.pkg.json')
             if os.path.isfile(manifest):
-                tar.add(os.path.abspath(manifest), arcname=manifest)
+                arcname = pathlib.Path(manifest).relative_to(self.cwd)
+                tar.add(manifest, arcname=arcname)
             else:
                 self.logger.warning('Archiving job with failed or incomplete run.')
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -46,7 +46,6 @@ from siliconcompiler import _metadata
 import psutil
 import subprocess
 import glob
-import itertools
 
 
 class TaskStatus():

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2472,7 +2472,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 tar.add(logfile, arcname=arcname(logfile))
 
     ###########################################################################
-    def archive(self, step=None, index=None, include=None, archive_name=None):
+    def archive(self, step=None, index=None, include=None, archive_name=None, quiet=True):
         '''Archive a job directory.
 
         Creates a single compressed archive (.tgz) based on the design,
@@ -2489,8 +2489,13 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 patterns that are matched from the root of individual step/index directories. To
                 capture all files, supply "*".
             archive_name (str): Path to the archive
-
+            quiet (bool): Which stream to use for logging progress. If True, log to debug stream,
+                otherwise info.
         '''
+        if quiet:
+            log_level = logging.DEBUG
+        else:
+            log_level = logging.INFO
 
         design = self.get('design')
         jobname = self.get('option', 'jobname')
@@ -2513,6 +2518,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             else:
                 archive_name = f"{design}_{jobname}.tgz"
 
+        self.logger.log(log_level, f'Creating archive {archive_name}...')
+
         with tarfile.open(archive_name, "w:gz") as tar:
             jobdir = self._getworkdir()
             manifest = os.path.join(jobdir, f'{design}.pkg.json')
@@ -2528,6 +2535,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 else:
                     indexlist = self.getkeys('flowgraph', flow, step)
                 for idx in indexlist:
+                    self.logger.log(log_level, f'Archiving {step}{idx}...')
                     self._archive_node(tar, step, idx, include=include)
 
         return archive_name

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2470,7 +2470,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 tar.add(logfile, arcname=arcname(logfile))
 
     ###########################################################################
-    def __archive_job(self, tar, job, steplist, index=None, include=None, log_level=logging.DEBUG):
+    def __archive_job(self, tar, job, steplist, index=None, include=None):
         design = self.get('design')
         flow = self.get('option', 'flow')
 
@@ -2488,12 +2488,11 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             else:
                 indexlist = self.getkeys('flowgraph', flow, step)
             for idx in indexlist:
-                self.logger.log(log_level, f'Archiving {step}{idx}...')
+                self.logger.info(f'Archiving {step}{idx}...')
                 self._archive_node(tar, step, idx, include=include)
 
     ###########################################################################
-    def archive(self, jobs=None, step=None, index=None, include=None, archive_name=None,
-                quiet=True):
+    def archive(self, jobs=None, step=None, index=None, include=None, archive_name=None):
         '''Archive a job directory.
 
         Creates a single compressed archive (.tgz) based on the design,
@@ -2511,14 +2510,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 patterns that are matched from the root of individual step/index directories. To
                 capture all files, supply "*".
             archive_name (str): Path to the archive
-            quiet (bool): Which stream to use for logging progress. If True, log to debug stream,
-                otherwise info.
         '''
-        if quiet:
-            log_level = logging.DEBUG
-        else:
-            log_level = logging.INFO
-
         design = self.get('design')
         if not jobs:
             jobname = self.get('option', 'jobname')
@@ -2543,14 +2535,13 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             else:
                 archive_name = f"{design}_{jobname}.tgz"
 
-        self.logger.log(log_level, f'Creating archive {archive_name}...')
+        self.logger.info(f'Creating archive {archive_name}...')
 
         with tarfile.open(archive_name, "w:gz") as tar:
             for job in jobs:
                 if len(jobs) > 0:
-                    self.logger.log(log_level, f'Archiving job {job}...')
-                self.__archive_job(tar, job, steplist, index=index, include=include,
-                                   log_level=log_level)
+                    self.logger.info(f'Archiving job {job}...')
+                self.__archive_job(tar, job, steplist, index=index, include=include)
         return archive_name
 
     ###########################################################################

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2454,14 +2454,12 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         basedir = self._getworkdir(step=step, index=index)
 
         def arcname(path):
-            return pathlib.Path(path).relative_to(self.cwd)
+            return os.path.relpath(path, self.cwd)
 
         if include:
-            itr = itertools.chain.from_iterable([
-                glob.iglob(os.path.join(basedir, i)) for i in include
-            ])
-            for path in itr:
-                tar.add(path, arcname=arcname(path))
+            for pattern in include:
+                for path in glob.iglob(os.path.join(basedir, pattern)):
+                    tar.add(path, arcname=arcname(path))
         else:
             for folder in ('reports', 'outputs'):
                 path = os.path.join(basedir, folder)
@@ -2479,7 +2477,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         jobdir = self._getworkdir(jobname=job)
         manifest = os.path.join(jobdir, f'{design}.pkg.json')
         if os.path.isfile(manifest):
-            arcname = pathlib.Path(manifest).relative_to(self.cwd)
+            arcname = os.path.relpath(manifest, self.cwd)
             tar.add(manifest, arcname=arcname)
         else:
             self.logger.warning('Archiving job with failed or incomplete run.')

--- a/tests/core/test_archive.py
+++ b/tests/core/test_archive.py
@@ -1,24 +1,77 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 import siliconcompiler
 import os
+import tarfile
 import pytest
 
 
-@pytest.mark.eda
-@pytest.mark.quick
-def test_archive(oh_dir):
+@pytest.fixture(scope='module')
+def chip(oh_dir, tmp_path_factory):
+    tmpdir = tmp_path_factory.mktemp('archive_run')
+    os.chdir(tmpdir)
+
     srcdir = os.path.join(oh_dir, 'stdlib', 'hdl')
 
     chip = siliconcompiler.Chip('oh_parity')
     chip.input(os.path.join(srcdir, 'oh_parity.v'))
-    chip.set('option', 'steplist', 'import')
+    chip.set('option', 'steplist', ['import', 'syn'])
     chip.load_target('freepdk45_demo')
     chip.run()
+
+    return chip
+
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_archive(chip):
     chip.archive()
 
     assert os.path.isfile('oh_parity_job0.tgz')
 
+    with tarfile.open('oh_parity_job0.tgz', 'r:gz') as f:
+        contents = f.getnames()
 
-#########################
-if __name__ == "__main__":
-    test_archive()
+    for item in ('build/oh_parity/job0/oh_parity.pkg.json',
+                 'build/oh_parity/job0/import/0/reports',
+                 'build/oh_parity/job0/import/0/outputs',
+                 'build/oh_parity/job0/import/0/import.log',
+                 'build/oh_parity/job0/syn/0/reports',
+                 'build/oh_parity/job0/syn/0/outputs',
+                 'build/oh_parity/job0/syn/0/syn.log'):
+        assert item in contents
+
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_archive_step_index(chip):
+    chip.archive(step='import', index='0')
+
+    assert os.path.isfile('oh_parity_job0_import0.tgz')
+
+    with tarfile.open('oh_parity_job0_import0.tgz', 'r:gz') as f:
+        contents = f.getnames()
+
+    for item in ('build/oh_parity/job0/oh_parity.pkg.json',
+                 'build/oh_parity/job0/import/0/reports',
+                 'build/oh_parity/job0/import/0/outputs',
+                 'build/oh_parity/job0/import/0/import.log'):
+        assert item in contents
+
+    for item in contents:
+        assert not item.startswith('build/oh_parity/job0/syn')
+
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_archive_all(chip):
+    chip.archive(all_files=True, archive_name='all.tgz')
+
+    assert os.path.isfile('all.tgz')
+
+    with tarfile.open('all.tgz', 'r:gz') as f:
+        contents = f.getnames()
+
+    for item in ('build/oh_parity/job0/oh_parity.pkg.json',
+                 'build/oh_parity/job0/import/0',
+                 'build/oh_parity/job0/syn/0'):
+        assert item in contents

--- a/tests/core/test_archive.py
+++ b/tests/core/test_archive.py
@@ -97,3 +97,23 @@ def test_archive_include(chip):
     for item in contents:
         if not item.endswith('oh_parity.pkg.json'):
             assert 'outputs/' not in item
+
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_archive_jobs(chip, monkeypatch):
+    monkeypatch.chdir(chip.cwd)
+    chip.set('option', 'jobname', 'job1')
+    chip.run()
+    monkeypatch.undo()
+
+    chip.archive(jobs=['job0', 'job1'])
+
+    assert os.path.isfile('oh_parity_job0_job1.tgz')
+
+    with tarfile.open('oh_parity_job0_job1.tgz') as f:
+        contents = f.getnames()
+
+    for item in ('build/oh_parity/job0/oh_parity.pkg.json',
+                 'build/oh_parity/job1/oh_parity.pkg.json'):
+        assert item in contents


### PR DESCRIPTION
- Improve `archive()` tests
  - To facilitate running multiple tests on a single build directory, I also refactored `archive()` so it's not required to run it from the build working directory
- Add `include` kwarg for selecting files to include
  - Provides more flexibility for tuning what goes in the archive
  - Replaces `all_files` to ensure that we have orthogonal arguments
- Add configurable logging 
  - Helpful for watching progress on large directories, but is disabled by default
- Support archiving multiple jobs
  - Helpful for including e.g. PNR and signoff in one tarball