### PR TITLE
Fix yosys pre-process method to allow macro libs which lack ('asic', 'cells') configs

### DIFF
--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -162,19 +162,22 @@ def prepare_synthesis_libraries(chip):
                                        step=step, index=index)[0]
     dff_dont_use = []
     for lib in chip.get('asic', 'logiclib', step=step, index=index):
-        dontuse = chip.get('library', lib, 'asic', 'cells', 'dontuse', step=step, index=index)
-        if dff_liberty_file in chip.find_files('library', lib, 'output', corner, delaymodel,
-                                               step=step, index=index):
-            # if we have the exact library, use those dontuses,
-            # otherwise continue to build full list
-            dff_dont_use = dontuse
-            break
+        # Only process dontuse cells if they are defined in the Schema.
+        if chip.valid('library', lib, 'asic', 'cells', 'dontuse'):
+            dontuse = chip.get('library', lib, 'asic', 'cells', 'dontuse', step=step, index=index)
+            if dff_liberty_file in chip.find_files('library', lib, 'output', corner, delaymodel,
+                                                   step=step, index=index):
+                # if we have the exact library, use those dontuses,
+                # otherwise continue to build full list
+                dff_dont_use = dontuse
+                break
 
-        dff_dont_use.extend(dontuse)
+            dff_dont_use.extend(dontuse)
 
     markDontUse.processLibertyFile(
         dff_liberty_file,
-        chip.get('tool', tool, 'task', task, 'file', 'dff_liberty_file', step=step, index=index)[0],
+        chip.get('tool', tool, 'task', task, 'file', 'dff_liberty_file',
+                 step=step, index=index)[0],
         dff_dont_use,
         chip.get('option', 'quiet', step=step, index=index),
     )
@@ -214,7 +217,11 @@ def prepare_synthesis_libraries(chip):
 
     for libtype in ('logiclib', 'macrolib'):
         for lib in chip.get('asic', libtype, step=step, index=index):
-            dont_use = chip.get('library', lib, 'asic', 'cells', 'dontuse', step=step, index=index)
+            # Only process dontuse cells if they are defined in the Schema.
+            dont_use = []
+            if chip.valid('library', lib, 'asic', 'cells', 'dontuse'):
+                dont_use = chip.get('library', lib, 'asic', 'cells', 'dontuse',
+                                    step=step, index=index)
 
             for lib_file in get_synthesis_libraries(lib):
                 process_lib_file(libtype, lib, lib_file, dont_use)

--- a/tests/flows/test_lib_min_config.py
+++ b/tests/flows/test_lib_min_config.py
@@ -1,6 +1,4 @@
 import os
-import subprocess
-
 import pytest
 
 

--- a/tests/flows/test_lib_min_config.py
+++ b/tests/flows/test_lib_min_config.py
@@ -1,0 +1,21 @@
+import os
+import subprocess
+
+import pytest
+
+
+@pytest.mark.eda
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_yosys_lib_preproc(gcd_chip):
+    # Remove "cells" configs from the standard cell lib,
+    # to simulate a minimal library configuration.
+    gcd_chip.schema.cfg['library']['nangate45']['asic'].pop('cells')
+
+    # Run the design's Yosys task; it should succeed.
+    gcd_chip.set('option', 'steplist', ['import', 'syn'])
+    gcd_chip.run()
+
+    # Verify that synthesis output is generated.
+    assert os.path.isfile('build/gcd/job0/syn/0/outputs/gcd.vg')
+    assert os.path.isfile('build/gcd/job0/syn/0/outputs/gcd.pkg.json')


### PR DESCRIPTION
This PR addresses an issue which came up in a parallel investigation, and adds a test to catch it in the future.

Some macro libraries may not set values such as `('asic', 'cells', 'dontuse')`, `('asic', 'cells', 'clkbuf')`, etc.

If no value under the top-level `('asic', 'cells')` keypath is set, then the Yosys pre_process method will crash when it tries to call `chip.get('library', [...], 'asic', 'cells', 'dontuse')`, because the `'cells'` key will not exist in the Schema.