### PR TITLE
add additional timeout to some tests to allow for variations in runtime

### DIFF
--- a/tests/apps/test_sc_issue.py
+++ b/tests/apps/test_sc_issue.py
@@ -51,6 +51,7 @@ def heartbeat_dir(tmpdir_factory):
 ])
 @pytest.mark.eda
 @pytest.mark.quick
+@pytest.mark.timeout(300)
 def test_sc_issue_generate_success(flags, outputfileglob, monkeypatch, heartbeat_dir):
     '''Test sc-issue app on a few sets of flags.'''
 
@@ -66,6 +67,7 @@ def test_sc_issue_generate_success(flags, outputfileglob, monkeypatch, heartbeat
 ])
 @pytest.mark.eda
 @pytest.mark.quick
+@pytest.mark.timeout(300)
 def test_sc_issue_generate_fail(flags, monkeypatch, heartbeat_dir):
     '''Test sc-issue app on a few sets of flags.'''
 

--- a/tests/apps/test_sc_show.py
+++ b/tests/apps/test_sc_show.py
@@ -36,6 +36,7 @@ def heartbeat_dir(tmpdir_factory):
 ])
 @pytest.mark.eda
 @pytest.mark.quick
+@pytest.mark.timeout(120)
 def test_sc_show_design_only(flags, monkeypatch, heartbeat_dir):
     '''Test sc-show app on a few sets of flags.'''
 
@@ -71,6 +72,7 @@ def test_sc_show_design_only(flags, monkeypatch, heartbeat_dir):
 ])
 @pytest.mark.eda
 @pytest.mark.quick
+@pytest.mark.timeout(120)
 def test_sc_show(flags, monkeypatch, heartbeat_dir):
     '''Test sc-show app on a few sets of flags.'''
 

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -159,6 +159,7 @@ def test_merged_graph_good(merge_flow_chip):
     assert merge_flow_chip.check_manifest()
 
 
+@pytest.mark.timeout(120)
 def test_merged_graph_good_steplist():
     chip = siliconcompiler.Chip('test')
     flow = 'test'


### PR DESCRIPTION
Some of the CI tests are taking slightly longer than 60 seconds to complete, this adds some guardband around those that appear in last nights failures.