### PR TITLE
rework prune to avoid removing information

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1930,7 +1930,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         Args:
             filename (filepath): Output filepath
-            prune (bool): If True, only essential parameters from the
+            prune (bool): If True, only essential fields from the
                  the Chip object schema are written to the output file.
             abspath (bool): If set to True, then all schema filepaths
                  are resolved to absolute filepaths.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1930,7 +1930,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         Args:
             filename (filepath): Output filepath
-            prune (bool): If True, essential non-empty parameters from the
+            prune (bool): If True, only essential parameters from the
                  the Chip object schema are written to the output file.
             abspath (bool): If set to True, then all schema filepaths
                  are resolved to absolute filepaths.
@@ -1954,12 +1954,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         if prune:
             self.logger.debug('Pruning dictionary before writing file %s', filepath)
-            # Keep empty lists to simplify TCL coding
-            if filepath.endswith('.tcl'):
-                keeplists = True
-            else:
-                keeplists = False
-            schema.prune(keeplists=keeplists)
+            schema.prune()
 
         is_csv = re.search(r'(\.csv)(\.gz)*$', filepath)
 
@@ -3584,7 +3579,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             if backup and os.path.exists(manifest_path):
                 shutil.copyfile(manifest_path, f'{manifest_path}.bak')
 
-            self.write_manifest(manifest_path, prune=False, abspath=True)
+            self.write_manifest(manifest_path, abspath=True)
 
     ###########################################################################
     def _runtask(self, step, index, status, replay=False):

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -875,8 +875,7 @@ class Schema:
             elif 'example' in cfg[k].keys():
                 del cfg[k]['example']
             elif Schema._is_leaf(cfg[k]):
-                if self._is_empty(*keypath, k, keeplists=keeplists):
-                    del cfg[k]
+                pass
             # removing stale branches
             elif not cfg[k]:
                 cfg.pop(k)

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -838,7 +838,7 @@ class Schema:
         return Schema(cfg=self.cfg)
 
     ###########################################################################
-    def prune(self, keeplists=False):
+    def prune(self):
         '''Remove all empty parameters from configuration dictionary.
 
         Also deletes 'help' and 'example' keys.
@@ -851,10 +851,10 @@ class Schema:
         maxdepth = 10
 
         for _ in range(maxdepth):
-            self._prune(keeplists=keeplists)
+            self._prune()
 
     ###########################################################################
-    def _prune(self, *keypath, keeplists=False):
+    def _prune(self, *keypath):
         '''
         Internal recursive function that creates a local copy of the Chip
         schema (cfg) with only essential non-empty parameters retained.
@@ -881,19 +881,14 @@ class Schema:
                 cfg.pop(k)
             # keep traversing tree
             else:
-                self._prune(*keypath, k, keeplists=keeplists)
+                self._prune(*keypath, k)
 
     ###########################################################################
-    def _is_empty(self, *keypath, keeplists=False):
+    def _is_empty(self, *keypath):
         '''
         Utility function to check key for an empty value.
-
-        If keeplists is True, don't consider length 0 lists as empty.
         '''
-        if keeplists:
-            empty = (None,)
-        else:
-            empty = (None, [])
+        empty = (None, [])
 
         values = self._getvals(*keypath)
         defvalue = self.get_default(*keypath)

--- a/tests/core/test_write_manifest.py
+++ b/tests/core/test_write_manifest.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 import csv
+import os
 
 import pytest
 
@@ -15,10 +16,11 @@ def test_write_manifest():
     chip.input('b.v')
     chip.input('c.v')
 
-    chip.write_manifest('top.pkg.json')
-    chip.write_manifest('top.csv')
-    chip.write_manifest('top.tcl', prune=False)
-    chip.write_manifest('top.yaml')
+    for ext in ('pkg.json', 'tcl', 'csv', 'yaml',
+                'pkg.json.gz', 'tcl.gz', 'csv.gz', 'yaml.gz'):
+        manifest_path = f'top.{ext}'
+        chip.write_manifest(manifest_path)
+        assert os.path.exists(manifest_path)
 
 
 def test_advanced_tcl(monkeypatch):

--- a/tests/core/test_write_manifest.py
+++ b/tests/core/test_write_manifest.py
@@ -23,6 +23,23 @@ def test_write_manifest():
         assert os.path.exists(manifest_path)
 
 
+def test_write_manifest_prune():
+
+    chip = siliconcompiler.Chip('top')
+    chip.input('top.sdc')
+    chip.input('top.v')
+    chip.input('a.v')
+    chip.input('b.v')
+    chip.input('c.v')
+
+    chip.write_manifest('top.json', prune=True)
+    assert os.path.exists('top.json')
+
+    assert 'example' in chip.schema.cfg['schemaversion']
+    schema = siliconcompiler.Schema(manifest='top.json')
+    assert 'example' not in schema.cfg['schemaversion']
+
+
 def test_advanced_tcl(monkeypatch):
     # Tkinter module is part of Python standard library, but may not be
     # available depending on if the system has the python3-tk package installed.


### PR DESCRIPTION
Reworks prune()
Adds loopback test for gcd to ensure python run and manifest based run both work the same