### PR TITLE
checkout client_payload.ref to ensure correct version of SC is tested

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -27,7 +27,14 @@ jobs:
       sc_tools: ${{ steps.docker.outputs.sc_tools }}
 
     steps:
-      - name: Checkout repository
+      - name: Checkout repository ref
+        if: ${{ github.event_name == 'repository_dispatch' }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.client_payload.ref }}
+
+      - name: Checkout repository main
+        if: ${{ github.event_name != 'repository_dispatch' }}
         uses: actions/checkout@v3
 
       - name: Get image name


### PR DESCRIPTION
This ensures we checkout the correct ref when triggering the daily run otherwise we keep testing main, instead of testing the actual branch