### PR TITLE
Remove subprocess calls from non-server CI

### DIFF
--- a/siliconcompiler/apps/sc.py
+++ b/siliconcompiler/apps/sc.py
@@ -57,7 +57,7 @@ def main():
 
         if not topfile:
             chip.logger.error('Invalid arguments: either specify -design or provide sources.')
-            sys.exit(1)
+            return 1
 
         topmodule = os.path.splitext(os.path.basename(topfile))[0]
         chip.set('design', topmodule)
@@ -81,5 +81,4 @@ def main():
 
 #########################
 if __name__ == "__main__":
-
     sys.exit(main())

--- a/siliconcompiler/apps/sc.py
+++ b/siliconcompiler/apps/sc.py
@@ -78,6 +78,8 @@ def main():
     # Print Job Summary
     chip.summary(steplist=steplist)
 
+    return 0
+
 
 #########################
 if __name__ == "__main__":

--- a/siliconcompiler/apps/sc_show.py
+++ b/siliconcompiler/apps/sc_show.py
@@ -86,7 +86,7 @@ def main():
     if not (design_set or input_mode):
         chip.logger.error('Nothing to load: please define a target with '
                           '-cfg, -design, and/or inputs.')
-        sys.exit(1)
+        return 1
 
     filename = None
     if input_mode:
@@ -103,7 +103,7 @@ def main():
             design = os.path.splitext(os.path.basename(filename))[0]
             chip.logger.error(f'Unable to automatically find manifest for design {design}. '
                               'Please provide a manifest explicitly using -cfg.')
-            sys.exit(1)
+            return 1
         chip.read_manifest(manifest)
     elif not chip.get('option', 'cfg'):
         manifest = _get_manifest(chip._getworkdir())

--- a/tests/apps/test_sc.py
+++ b/tests/apps/test_sc.py
@@ -1,15 +1,17 @@
 import os
-import subprocess
+from siliconcompiler.apps import sc
 
 import pytest
 
 
 @pytest.mark.eda
 @pytest.mark.quick
-def test_design_inference(scroot):
+def test_design_inference(scroot, monkeypatch):
     '''Tests that sc CLI app can infer design name from filename.'''
     source = os.path.join(scroot, 'tests', 'data', 'heartbeat.v')
     # only run import, makes this quicker
-    subprocess.run(['sc', source, '-steplist', 'import', '-strict'])
+
+    monkeypatch.setattr('sys.argv', ['sc', source, '-steplist', 'import', '-strict'])
+    assert sc.main() == 0
 
     assert os.path.isfile('build/heartbeat/job0/heartbeat.pkg.json')

--- a/tests/flows/test_show.py
+++ b/tests/flows/test_show.py
@@ -104,9 +104,6 @@ def test_show_nopdk(datadir, display):
 
     adjust_exe_options(chip, True)
 
-    # For some reason, if we try to use monkeypath to modify the env, the
-    # subprocess call performed by chip.show() doesn't use the patched env. We
-    # use unittest.mock instead, since that behaves as desired.
     env = {'SCPATH': ''}
     with mock.patch.dict(os.environ, env):
         assert chip.show(testfile)

--- a/tests/targets/test_asic_demo.py
+++ b/tests/targets/test_asic_demo.py
@@ -1,6 +1,6 @@
 import os
 import siliconcompiler
-import subprocess
+from siliconcompiler.apps import sc
 
 import pytest
 
@@ -23,9 +23,11 @@ def test_self_test():
 @pytest.mark.eda
 @pytest.mark.quick
 @pytest.mark.timeout(300)
-def test_self_test_cli():
+def test_self_test_cli(monkeypatch):
     ''' Verify self-test functionality w/ command-line call '''
-    subprocess.run(['sc', '-target', 'asic_demo'])
+    monkeypatch.setattr('sys.argv', ['sc', '-target', 'asic_demo'])
+    assert sc.main() == 0
+
     assert os.path.isfile('build/heartbeat/job0/export/0/outputs/heartbeat.gds')
     assert os.path.isfile('build/heartbeat/job0/heartbeat.pkg.json')
 
@@ -41,7 +43,9 @@ def test_self_test_cli():
 @pytest.mark.eda
 @pytest.mark.timeout(900)
 @pytest.mark.skip(reason="Remote calls can accidentially trigger bans")
-def test_self_test_cli_remote():
+def test_self_test_cli_remote(monkeypatch):
     ''' Verify self-test functionality w/ command-line call with remote '''
-    subprocess.run(['sc', '-target', 'asic_demo', '-remote', '-nodisplay'])
-    assert os.path.isfile('build/heartbeat/job0/export/0/outputs/heartbeat.gds')
+    monkeypatch.setattr('sys.argv', ['sc', '-target', 'asic_demo', '-remote', '-nodisplay'])
+    assert sc.main() == 0
+
+    assert os.path.isfile('build/heartbeat/job0/heartbeat.png')

--- a/tests/tools/test_verilator.py
+++ b/tests/tools/test_verilator.py
@@ -58,6 +58,5 @@ def test_compile(scroot, datadir):
 
     proc = subprocess.run([exe_path], stdout=subprocess.PIPE)
     output = proc.stdout.decode('utf-8')
-    print(output)
 
     assert output == 'SUCCESS\n'


### PR DESCRIPTION
This removes the calls to the apps vias the subprocess module in favor of testing them directly from python with a monkeypatch for the sysargs