### PR TITLE
Run server functional tests on merges to main.

### DIFF
--- a/.github/workflows/server_ci.yml
+++ b/.github/workflows/server_ci.yml
@@ -1,12 +1,14 @@
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
 
 name: 'Server Functional Tests'
 
 jobs:
   server_tests:
-    timeout-minutes: 60
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
       - name: Server action dispatch


### PR DESCRIPTION
This should reduce the test volume a bit, and we'll still be able to manually run the deploy/test action for large PRs before merging in the meantime.