### PR TITLE
linking fails when link is to a symbolic link

### DIFF
--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -35,8 +35,13 @@ def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
                      dirs_exist_ok=dirs_exist_ok,
                      link=link)
         elif link:
-            # create link
-            os.link(srcfile, dstfile)
+            for method in [os.link, os.symlink, shutil.copy2]:
+                try:
+                    # create link
+                    method(srcfile, dstfile)
+                    # success, no need to continue trying
+                except OSError:
+                    pass
         else:
             # copy file
             shutil.copy2(srcfile, dstfile)

--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -35,6 +35,8 @@ def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
                      dirs_exist_ok=dirs_exist_ok,
                      link=link)
         elif link:
+            # first try hard linking, then symbolic linking,
+            # and finally just copy the file
             for method in [os.link, os.symlink, shutil.copy2]:
                 try:
                     # create link

--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -24,11 +24,21 @@ def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
         srcfile = os.path.join(src, name)
         dstfile = os.path.join(dst, name)
 
+        if os.path.islink(srcfile):
+            # Get the true filepath if its a link
+            srcfile = os.path.realpath(srcfile)
+
         if os.path.isdir(srcfile):
-            copytree(srcfile, dstfile, ignore=ignore, dirs_exist_ok=dirs_exist_ok)
+            # Continue to copy the hierarchy
+            copytree(srcfile, dstfile,
+                     ignore=ignore,
+                     dirs_exist_ok=dirs_exist_ok,
+                     link=link)
         elif link:
+            # create link
             os.link(srcfile, dstfile)
         else:
+            # copy file
             shutil.copy2(srcfile, dstfile)
 
 


### PR DESCRIPTION
When the output of a task contains a symbolic link, the `copytree` method fails.
This converts the link to a full path, attempts to make it a symbolic link or copy the file if the initial hard link failed.