### PR TITLE
add hierarchical synthesis in yosys 

### DIFF
--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -63,7 +63,7 @@ def setup_asic(chip):
     logiclibs = chip.get('asic', 'logiclib', step=step, index=index)
     mainlib = logiclibs[0]
     for option, value, additional_require in [
-            ('flatten', "False", None),
+            ('flatten', "True", None),
             ('hier_iterations', "10", None),
             ('hier_threshold', "1000", None),
             ('autoname', "True", None),

--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -63,7 +63,9 @@ def setup_asic(chip):
     logiclibs = chip.get('asic', 'logiclib', step=step, index=index)
     mainlib = logiclibs[0]
     for option, value, additional_require in [
-            ('flatten', "True", None),
+            ('flatten', "False", None),
+            ('hier_iterations', "10", None),
+            ('hier_threshold', "1000", None),
             ('autoname', "True", None),
             ('add_buffers', "True", None),
             ('map_adders', "False", ['library', mainlib, 'option', 'file', 'yosys_addermap'])]:
@@ -145,6 +147,13 @@ def setup_asic(chip):
              'File to use for the DFF mapping stage of Yosys', field='help')
     chip.set('tool', tool, 'task', task, 'var', 'add_buffers',
              'True/False, flag to indicate whether to add buffers or not.', field='help')
+
+    chip.set('tool', tool, 'task', task, 'var', 'hier_iterations',
+             'Number of iterations to attempt to determine the hierarchy to flatten',
+             field='help')
+    chip.set('tool', tool, 'task', task, 'var', 'hier_threshold',
+             'Instance limit for the number of cells in a module to preserve.',
+             field='help')
 
 
 ################################

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -43,12 +43,12 @@ def __check_gcd(chip):
     assert chip.get('metric', 'warnings', step='cts', index='0') == 5
 
     # Warning: *. (x3)
-    # Missing route to pin (x69)
-    assert chip.get('metric', 'warnings', step='route', index='0') == 72
+    # Missing route to pin (x63)
+    assert chip.get('metric', 'warnings', step='route', index='0') == 66
 
     # Warning: *. (x3)
-    # Missing route to pin (x235)
-    assert chip.get('metric', 'warnings', step='dfm', index='0') == 238
+    # Missing route to pin (x224)
+    assert chip.get('metric', 'warnings', step='dfm', index='0') == 227
 
     # "no fill config specified"
     assert chip.get('metric', 'warnings', step='export', index='0') == 1

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -43,12 +43,12 @@ def __check_gcd(chip):
     assert chip.get('metric', 'warnings', step='cts', index='0') == 5
 
     # Warning: *. (x3)
-    # Missing route to pin (x85)
-    assert chip.get('metric', 'warnings', step='route', index='0') == 88
+    # Missing route to pin (x48)
+    assert chip.get('metric', 'warnings', step='route', index='0') == 51
 
     # Warning: *. (x3)
-    # Missing route to pin (x224)
-    assert chip.get('metric', 'warnings', step='dfm', index='0') == 227
+    # Missing route to pin (x202)
+    assert chip.get('metric', 'warnings', step='dfm', index='0') == 205
 
     # "no fill config specified"
     assert chip.get('metric', 'warnings', step='export', index='0') == 1


### PR DESCRIPTION
Adds:
- this is an initial implementation of hierarchical synthesis for yosys.

Idea:
- break the synthesis step and look for modules below a specific size, those can be flattened and the rest kept and then try again.