### PR TITLE
Remove '-design' parameter from scheduler.py

### DIFF
--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -78,8 +78,7 @@ def _deferstep(chip, step, index, status):
         with open(script_path, 'w') as sf:
             sf.write('#!/bin/bash\n')
             sf.write(f'sc -cfg {shlex.quote(cfg_file)} -builddir {shlex.quote(buildir)} '
-                     f'-arg_step {shlex.quote(step)} -arg_index {shlex.quote(index)} '
-                     f"-design {shlex.quote(chip.top())}\n")
+                     f'-arg_step {shlex.quote(step)} -arg_index {shlex.quote(index)}\n')
             # In case of error(s) which prevents the SC build script from completing, ensure the
             # file mutex for job completion is set in shared storage. This lockfile signals the
             # server to mark the job done, without putting load on the cluster reporting/accounting


### PR DESCRIPTION
The design value is already in the Schema, and `chip.top()` points to the entrypoint parameter.