### PR TITLE
Round down demo die area to fix platform-dependent replace divergence

### DIFF
--- a/siliconcompiler/targets/asic_demo.py
+++ b/siliconcompiler/targets/asic_demo.py
@@ -23,8 +23,8 @@ def setup(chip):
     chip.set('option', 'quiet', True, clobber=False)
 
     # Set die area and clock constraint.
-    chip.set('constraint', 'outline', [(0, 0), (55, 55)], clobber=False)
-    chip.set('constraint', 'corearea', [(5, 5), (50, 50)], clobber=False)
+    chip.set('constraint', 'outline', [(0, 0), (50, 50)], clobber=False)
+    chip.set('constraint', 'corearea', [(5, 5), (45, 45)], clobber=False)
     chip.clock('clk', period=10)
 
     # Add source files.


### PR DESCRIPTION
It looks like the current heartbeat example die area causes divergence in the placement step with very recent versions of OpenROAD on some platforms (Ubuntu 22?)

50um is a nice, round number which works with the newer version, and IIRC this sort of fuzziness in placement convergence is a known issue with very small designs on the order of ~10s of standard cells.