### PR TITLE
Verilator SystemC support, fix trace

### DIFF
--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -76,7 +76,7 @@ def setup(chip):
 
     # User runtime option
     if chip.get('option', 'trace', step=step, index=index):
-        chip.add('tool', tool, 'task', task, 'task', task, 'option', '--trace',
+        chip.add('tool', tool, 'task', task, 'option', '--trace',
                  step=step, index=index)
 
     chip.set('tool', tool, 'task', task, 'file', 'config',


### PR DESCRIPTION
- Add options for selecting C++ vs SystemC compilation mode, add [pins-bv](https://veripool.org/guide/latest/exe_verilator.html#cmdoption-pins-bv) option that's used by SystemC mode
- Fix trace support