### PR TITLE
Add pathlib support to core API

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1109,6 +1109,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         Performs a lookup in the io map for the fileset and filetype
         and will use those if they are not provided in the arguments
         '''
+        # Normalize value to string in case we receive a pathlib.Path
+        filename = str(filename)
 
         ext = utils.get_file_ext(filename)
 

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -538,7 +538,7 @@ class Schema:
                 raise TypeError(error_msg)
 
         if sc_type in ('file', 'dir'):
-            if isinstance(value, str) or isinstance(value, pathlib.Path):
+            if isinstance(value, (str, pathlib.Path)):
                 return str(value)
             else:
                 raise TypeError(error_msg)

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import re
+import pathlib
 
 try:
     import yaml
@@ -528,9 +529,15 @@ class Schema:
         except TypeError:
             raise TypeError(error_msg) from None
 
-        if sc_type in ('str', 'file', 'dir'):
+        if sc_type == 'str':
             if isinstance(value, str):
                 return value
+            else:
+                raise TypeError(error_msg)
+
+        if sc_type in ('file', 'dir'):
+            if isinstance(value, str) or isinstance(value, pathlib.Path):
+                return str(value)
             else:
                 raise TypeError(error_msg)
 

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -56,6 +56,8 @@ class Schema:
         if cfg is not None:
             self.cfg = Schema._dict_to_schema(copy.deepcopy(cfg))
         elif manifest is not None:
+            # Normalize value to string in case we receive a pathlib.Path
+            manifest = str(manifest)
             self.cfg = Schema._read_manifest(manifest)
         else:
             self.cfg = schema_cfg()

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -114,7 +114,7 @@ def test_cli(setup_example_test):
 
 @pytest.mark.eda
 @pytest.mark.quick
-@pytest.mark.timeout(300)
+@pytest.mark.timeout(600)
 def test_py_sky130(setup_example_test):
     setup_example_test('gcd')
 

--- a/tests/schema/test_manifest.py
+++ b/tests/schema/test_manifest.py
@@ -1,0 +1,18 @@
+import pathlib
+
+from siliconcompiler.schema import Schema
+
+
+def test_manifest():
+    schema = Schema()
+
+    schema.set('input', 'rtl', 'verilog', 'foo.v')
+    with open('tmp.json', 'w') as f:
+        schema.write_json(f)
+
+    schema2 = Schema(manifest='tmp.json')
+    assert schema2.get('input', 'rtl', 'verilog') == ['foo.v']
+
+    # Ensure pathlib input works
+    schema3 = Schema(manifest=pathlib.Path('tmp.json'))
+    assert schema3.get('input', 'rtl', 'verilog') == ['foo.v']

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pytest
 
 from siliconcompiler.schema import Schema
@@ -40,3 +42,15 @@ def test_add_keypath_error():
     schema = Schema()
     with pytest.raises(ValueError):
         schema.add('input', 'verilog', 'foo.v')
+
+
+def test_pathlib():
+    schema = Schema()
+
+    file_path = pathlib.Path('path/to/file.txt')
+    schema.set('option', 'file', 'test', file_path)
+    assert schema.get('option', 'file', 'test') == [str(file_path)]
+
+    dir_path = pathlib.Path('a/directory/')
+    schema.set('option', 'dir', 'test', dir_path)
+    assert schema.get('option', 'dir', 'test') == [str(dir_path)]


### PR DESCRIPTION
This PR makes a few small updates to ensure that users can provide file paths as `pathlib.Path` objects for all our core API methods.

`set()`/`add()` are taken care of in the schema value normalization method, and then I added `str()` casts in a few places as needed. The rest of the methods that I audited expand file paths received by the user using `os.path.abspath()`, which already accepts a `pathlib.Path`.

Note that paths are always normalized to strings, so file paths read out of the schema or returned from other SC methods will remain as strings. This just makes user input more flexible. 