### PR TITLE
ignore .pkg.json files in inputs for execute

### DIFF
--- a/siliconcompiler/tools/execute/exec_input.py
+++ b/siliconcompiler/tools/execute/exec_input.py
@@ -19,6 +19,8 @@ def pre_process(chip):
 
     exec = None
     for fin in glob.glob('inputs/*'):
+        if fin.endswith('.pkg.json'):
+            continue
         exec = os.path.abspath(fin)
         break
 


### PR DESCRIPTION
Fixes issue found from: https://github.com/siliconcompiler/siliconcompiler/pull/1725