### PR TITLE
revert OpenROAD to last known functional state

### DIFF
--- a/setup/_tools.json
+++ b/setup/_tools.json
@@ -1,7 +1,7 @@
 {
   "openroad": {
     "git-url": "https://github.com/The-OpenROAD-Project/OpenROAD.git",
-    "git-commit": "ffa127cb22da12c0fd1fe787e2119651cad06806",
+    "git-commit": "3ec606c02c6ec8fb332891e0107eb17eaa939653",
     "docker-cmds": [
       "RUN cp $SC_BUILD/DependencyInstaller.sh $SC_PREFIX/openroad_runtime.sh"
     ],


### PR DESCRIPTION
OpenROAD has slowed down a good deal on placement and estimation of parasitics, this reverts us to a commit that predates this issue until they are able to fix it.