### PR TITLE
Support libext option for Surelog and Verilator

### DIFF
--- a/siliconcompiler/tools/surelog/surelog.py
+++ b/siliconcompiler/tools/surelog/surelog.py
@@ -52,6 +52,14 @@ def setup(chip):
     if lowmem == ['true']:
         options.append('-lowmem')
 
+    libext = chip.get('option', 'libext')
+    if libext:
+        libext_option = f"+libext+.{'+.'.join(libext)}"
+    else:
+        # default value for backwards compatibility
+        libext_option = '+libext+.sv+.v'
+    options.append(libext_option)
+
     # Wite back options to cfg
     chip.add('tool', tool, 'task', task, 'option', options, step=step, index=index)
 
@@ -190,14 +198,6 @@ def runtime_options(chip):
     #######################
 
     cmdlist.append('-top ' + chip.top())
-
-    #######################
-    # Lib extensions
-    #######################
-
-    # make sure we can find .sv files in ydirs
-    # TODO: need to add libext
-    cmdlist.append('+libext+.sv+.v')
 
     ###############################
     # Parameters (top module only)

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -79,6 +79,12 @@ def setup(chip):
         chip.add('tool', tool, 'task', task, 'option', '--trace',
                  step=step, index=index)
 
+    libext = chip.get('option', 'libext')
+    if libext:
+        libext_option = f"+libext+.{'+.'.join(libext)}"
+        chip.add('tool', tool, 'task', task, 'option', libext_option,
+                 step=step, index=index)
+
     chip.set('tool', tool, 'task', task, 'file', 'config',
              'Verilator configuration file',
              field='help')

--- a/tests/flows/data/test_libext/lib.verilog
+++ b/tests/flows/data/test_libext/lib.verilog
@@ -1,0 +1,2 @@
+module lib();
+endmodule

--- a/tests/flows/data/test_libext/top.v
+++ b/tests/flows/data/test_libext/top.v
@@ -1,0 +1,3 @@
+module top ();
+    lib lib_i ();
+endmodule

--- a/tests/flows/test_libext.py
+++ b/tests/flows/test_libext.py
@@ -1,0 +1,25 @@
+import os
+
+import pytest
+
+import siliconcompiler
+from siliconcompiler.tools.surelog import parse
+from siliconcompiler.tools.verilator import lint
+
+
+@pytest.mark.quick
+@pytest.mark.eda
+@pytest.mark.parametrize('task', [parse, lint])
+def test_libext(task, datadir):
+    chip = siliconcompiler.Chip('top')
+
+    test_dir = os.path.join(datadir, 'test_libext')
+    chip.input(os.path.join(test_dir, 'top.v'))
+    chip.set('option', 'ydir', test_dir)
+    chip.set('option', 'libext', 'verilog')
+
+    chip.set('option', 'mode', 'sim')
+    chip.set('option', 'flow', 'test')
+    chip.node('test', 'import', task)
+
+    chip.run()


### PR DESCRIPTION
This PR implements libext for Surelog and Verilator, implementing a TODO in Surelog and ensuring consistency with Icarus (being added by PR #1736). Also adds a test of this feature, although I'm not a huge fan of adding yet another test that has to execute tools... 