### PR TITLE
pin streamlit to 1.9.0 for Python3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,8 @@ GitPython >= 3.1.0
 # Report
 # pin transitive dependency of streamlit to ensure Windows 3.6 works
 pywinpty <= 2.0.2; platform_system == 'Windows'
-streamlit
+streamlit == 1.9.0; python_version == "3.6"
+streamlit; python_version >= "3.7"
 streamlit_agraph
 streamlit_tree_select
 streamlit-toggle-switch


### PR DESCRIPTION
This fixes the path error in python 3.6 for the daily CI