### PR TITLE
Fix race condition when running parallel flowgraphs on a Slurm cluster

### DIFF
--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -37,8 +37,7 @@ def _deferstep(chip, step, index, status):
     job_dir = chip._getworkdir()
     cfg_dir = f'{job_dir}/configs'
     cfg_file = f'{cfg_dir}/{step}{index}.json'
-    if not os.path.isdir(cfg_dir):
-        os.mkdir(cfg_dir)
+    os.makedirs(cfg_dir, exist_ok=True)
 
     chip.set('option', 'scheduler', 'name', None, step=step, index=index)
     chip.write_manifest(cfg_file)


### PR DESCRIPTION
When there are many parallel tasks in a flowgraph, and the server kicks them all off at exactly the same time, it can trigger a race condition in the scheduler logic which causes a `FileExistsError`.

Using `os.makedirs` with `exist_ok=True` makes the operation atomic-ish, and prevents that kind of failure.