### PR TITLE
Remove install from linter job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,33 +10,14 @@ on:
 jobs:
   lint_python:
     name: Lint Python Code
-
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - {python: "3.6", os: "ubuntu-20.04"}
-          - {python: "3.7", os: "ubuntu-latest"}
-          - {python: "3.8", os: "ubuntu-latest"}
-          - {python: "3.9", os: "ubuntu-latest"}
-          - {python: "3.10", os: "ubuntu-latest"}
-          - {python: "3.11", os: "ubuntu-latest"}
-
-    runs-on: ${{ matrix.version.os }}
-
+    runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.version.python }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.version.python }}
-      - name: Install Requirements
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install .[test]
       - name: Lint with Flake8
-        run: flake8 --statistics .
+        run: |
+          python -m pip install flake8
+          flake8 --statistics .
 
   lint_verilog:
     name: Lint Verilog Code


### PR DESCRIPTION
Removing install here speeds up linting a lot.
Also the feedback will be more useful feedback to the user.
The install gets executed in the `python_ci.yml` anyways for every push.

Tested that it still lints by adding violation:
https://github.com/siliconcompiler/siliconcompiler/actions/runs/5521649690/jobs/10070070190
```
./setup.py:7:1: F401 'streamlit' imported but unused
1     F401 'streamlit' imported but unused
Error: Process completed with exit code 1.
```