### PR TITLE
resizes the flowgraph

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ streamlit; python_version >= "3.7"
 streamlit_agraph
 streamlit_tree_select
 streamlit-toggle-switch
+streamlit_javascript
 
 # Build dependencies
 #:build

--- a/siliconcompiler/report/streamlit_viewer.py
+++ b/siliconcompiler/report/streamlit_viewer.py
@@ -2,6 +2,7 @@ import streamlit
 from streamlit_agraph import agraph, Node, Edge, Config
 from streamlit_tree_select import tree_select
 from streamlit_toggle import st_toggle_switch
+import streamlit_javascript
 from PIL import Image
 from pathlib import Path
 import os
@@ -583,6 +584,8 @@ def show_title_and_runs(title_col_width=0.7):
     return new_chip
 
 
+ui_width = streamlit_javascript.st_javascript("window.innerWidth")
+
 new_chip = show_title_and_runs()
 
 # gathering data
@@ -632,10 +635,15 @@ else:
     metrics_tab, manifest_tab, file_preview_tab = tabs
 
 with metrics_tab:
+    if ui_width <= 0:
+        # in case streamlit_javascript errors
+        ui_width = 1
     if streamlit.session_state['flowgraph']:
-        node_from_flowgraph, datafram_and_node_info_col = show_flowgraph()
+        node_from_flowgraph, datafram_and_node_info_col = \
+            show_flowgraph(flowgraph_col_width=min(520 / ui_width, 0.4))
     else:
-        node_from_flowgraph, datafram_and_node_info_col = dont_show_flowgraph()
+        node_from_flowgraph, datafram_and_node_info_col = \
+            dont_show_flowgraph(flowgraph_col_width=min(120 / ui_width, 0.1))
 
     with datafram_and_node_info_col:
         show_dataframe_header()

--- a/siliconcompiler/report/streamlit_viewer.py
+++ b/siliconcompiler/report/streamlit_viewer.py
@@ -639,11 +639,17 @@ with metrics_tab:
         # in case streamlit_javascript errors
         ui_width = 1
     if streamlit.session_state['flowgraph']:
+        flowgraph_col_width_in_pixels = 520
+        flowgraph_col_width_in_percent = \
+            min(flowgraph_col_width_in_pixels / ui_width, 0.4)
         node_from_flowgraph, datafram_and_node_info_col = \
-            show_flowgraph(flowgraph_col_width=min(520 / ui_width, 0.4))
+            show_flowgraph(flowgraph_col_width=flowgraph_col_width_in_percent)       
     else:
+        flowgraph_col_width_in_pixels = 120
+        flowgraph_col_width_in_percent = \
+            min(flowgraph_col_width_in_pixels / ui_width, 0.1)
         node_from_flowgraph, datafram_and_node_info_col = \
-            dont_show_flowgraph(flowgraph_col_width=min(120 / ui_width, 0.1))
+            dont_show_flowgraph(flowgraph_col_width=flowgraph_col_width_in_percent)
 
     with datafram_and_node_info_col:
         show_dataframe_header()

--- a/siliconcompiler/report/streamlit_viewer.py
+++ b/siliconcompiler/report/streamlit_viewer.py
@@ -584,8 +584,6 @@ def show_title_and_runs(title_col_width=0.7):
     return new_chip
 
 
-ui_width = streamlit_javascript.st_javascript("window.innerWidth")
-
 new_chip = show_title_and_runs()
 
 # gathering data
@@ -635,19 +633,26 @@ else:
     metrics_tab, manifest_tab, file_preview_tab = tabs
 
 with metrics_tab:
-    if ui_width <= 0:
-        # in case streamlit_javascript errors
-        ui_width = 1
+    ui_width = streamlit_javascript.st_javascript("window.innerWidth")
+
     if streamlit.session_state['flowgraph']:
+        default_flowgraph_width_in_percent = 0.4
         flowgraph_col_width_in_pixels = 520
+    else:
+        default_flowgraph_width_in_percent = 0.1
+        flowgraph_col_width_in_pixels = 120
+
+    if ui_width > 0:
         flowgraph_col_width_in_percent = \
-            min(flowgraph_col_width_in_pixels / ui_width, 0.4)
+            min(flowgraph_col_width_in_pixels / ui_width,
+                default_flowgraph_width_in_percent)
+    else:
+        flowgraph_col_width_in_percent = default_flowgraph_width_in_percent
+
+    if streamlit.session_state['flowgraph']:
         node_from_flowgraph, datafram_and_node_info_col = \
             show_flowgraph(flowgraph_col_width=flowgraph_col_width_in_percent)
     else:
-        flowgraph_col_width_in_pixels = 120
-        flowgraph_col_width_in_percent = \
-            min(flowgraph_col_width_in_pixels / ui_width, 0.1)
         node_from_flowgraph, datafram_and_node_info_col = \
             dont_show_flowgraph(flowgraph_col_width=flowgraph_col_width_in_percent)
 

--- a/siliconcompiler/report/streamlit_viewer.py
+++ b/siliconcompiler/report/streamlit_viewer.py
@@ -643,7 +643,7 @@ with metrics_tab:
         flowgraph_col_width_in_percent = \
             min(flowgraph_col_width_in_pixels / ui_width, 0.4)
         node_from_flowgraph, datafram_and_node_info_col = \
-            show_flowgraph(flowgraph_col_width=flowgraph_col_width_in_percent)       
+            show_flowgraph(flowgraph_col_width=flowgraph_col_width_in_percent)
     else:
         flowgraph_col_width_in_pixels = 120
         flowgraph_col_width_in_percent = \


### PR DESCRIPTION
this resizes the flowgraph to take up a maximum amount of space, or 40% if the screen is smaller than 1300 pixels
Here is a before and after:

Before:
<img width="1421" alt="Screen Shot 2023-07-11 at 12 43 41 PM" src="https://github.com/siliconcompiler/siliconcompiler/assets/80078690/892492a4-6edb-4431-92ef-223276ef2626">

After:
<img width="1349" alt="Screen Shot 2023-07-11 at 12 18 59 PM" src="https://github.com/siliconcompiler/siliconcompiler/assets/80078690/bddc5a56-0446-41ca-aa70-40f275385b37">


Limitations:
- If the user changes the screen width without refreshing, the flowgraph will not change it’s size

