### PR TITLE
ensure calls to _runtask are spawned

### DIFF
--- a/siliconcompiler/apps/sc_issue.py
+++ b/siliconcompiler/apps/sc_issue.py
@@ -155,7 +155,8 @@ To run a testcase, use:
                     chip.logger.error(f"Unable to use '{use}' module")
 
         # Run task
-        # Rerun setup task
+        # Rerun setup task, assumed to be running in its own thread so
+        # multiprocess is not needed
         chip._runtask(step, index, {}, replay=True)
 
         return 0

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -10,6 +10,7 @@ import urllib.parse
 import uuid
 import tarfile
 import tempfile
+import multiprocessing
 
 from siliconcompiler._metadata import default_server
 from siliconcompiler import utils
@@ -127,6 +128,7 @@ def remote_preprocess(chip, steplist):
                    f'Full steplist: {remote_steplist}\nStarting steps: {entry_steps}',
                    fatal=True)
     # Setup up tools for all local functions
+    multiprocessor = multiprocessing.get_context('spawn')
     for local_step, index in entry_steps:
         tool = chip.get('flowgraph', flow, local_step, index, 'tool')
         task = chip._get_task(local_step, index)
@@ -141,11 +143,15 @@ def remote_preprocess(chip, steplist):
         # check steps that haven't been setup.
         chip.set('option', 'steplist', local_step)
 
-        # Run the actual import step locally.
+        # Run the actual import step locally with multiprocess as _runtask must
+        # be run in a seperate thread.
         # We can pass in an empty 'status' dictionary, since _runtask() will
         # only look up a step's depedencies in this dictionary, and the first
         # step should have none.
-        chip._runtask(local_step, index, {})
+        run_task = multiprocessor.Process(target=chip._runtask,
+                                          args=(local_step, index, {}))
+        run_task.start()
+        run_task.join()
 
     # Collect inputs into a collection directory only for remote runs, since
     # we need to send inputs up to the server.


### PR DESCRIPTION
When using threading and the remote, that was causing the os.chdir to interfere with eachother, this avoids this by ensure all calls to _runtask are done through a multiprocessing call.