### PR TITLE
Enable parallel heartbeat

### DIFF
--- a/examples/heartbeat/parallel.py
+++ b/examples/heartbeat/parallel.py
@@ -26,7 +26,7 @@ def run_design(design, M, job):
     chip.run()
 
 
-def all_serial(design='heatbeat', N=2, M=2):
+def all_serial(design='heartbeat', N=2, M=2):
     serial_start = time.time()
     for i in range(N):
         for j in range(M):
@@ -37,7 +37,7 @@ def all_serial(design='heatbeat', N=2, M=2):
     return serial_start, serial_end
 
 
-def parallel_steps(design='heatbeat', N=2, M=2):
+def parallel_steps(design='heartbeat', N=2, M=2):
     parastep_start = time.time()
     for i in range(M):
         job = f"parasteps_{i}"
@@ -47,7 +47,7 @@ def parallel_steps(design='heatbeat', N=2, M=2):
     return parastep_start, parastep_end
 
 
-def parallel_flows(design='heatbeat', N=2, M=2):
+def parallel_flows(design='heartbeat', N=2, M=2):
     paraflow_start = time.time()
 
     processes = []

--- a/tests/examples/test_heartbeat.py
+++ b/tests/examples/test_heartbeat.py
@@ -16,7 +16,6 @@ def test_py(setup_example_test):
 
 @pytest.mark.eda
 @pytest.mark.quick
-@pytest.mark.timeout(300)
 def test_sim(setup_example_test):
     setup_example_test('heartbeat')
 
@@ -36,7 +35,6 @@ def test_cli(setup_example_test):
 
 @pytest.mark.eda
 @pytest.mark.timeout(600)
-@pytest.mark.skip(reason='periodic timeouts in Daily CI')
 def test_parallel_all_serial(setup_example_test):
     setup_example_test('heartbeat')
 
@@ -46,7 +44,6 @@ def test_parallel_all_serial(setup_example_test):
 
 @pytest.mark.eda
 @pytest.mark.timeout(600)
-@pytest.mark.skip(reason='periodic timeouts in Daily CI')
 def test_parallel_steps(setup_example_test):
     setup_example_test('heartbeat')
 
@@ -55,8 +52,7 @@ def test_parallel_steps(setup_example_test):
 
 
 @pytest.mark.eda
-@pytest.mark.timeout(600)
-@pytest.mark.skip(reason='periodic timeouts in Daily CI')
+@pytest.mark.timeout(300)
 def test_parallel_flows(setup_example_test):
     setup_example_test('heartbeat')
 


### PR DESCRIPTION
- Fixed typo
- To enable the tests again I ran them locally and recorded the time it took:
  - test_py 72s
  - test_sim 3s
  - test_cli 40s
  - test_parallel_all_serial 140s
  - test_parallel_steps 122s
  - test_parallel_flows 72s

Then I adjusted the timeouts.
Let's see if the CI is now happy:
[Daily CI run](https://github.com/siliconcompiler/siliconcompiler/actions/runs/5534007110)