### PR TITLE
Fix server CI failures caused by a failure to detect failures in the local import task.

### DIFF
--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -13,7 +13,7 @@ import tempfile
 import multiprocessing
 
 from siliconcompiler._metadata import default_server
-from siliconcompiler import utils, SiliconCompilerError
+from siliconcompiler import utils
 
 
 # Client / server timeout
@@ -154,7 +154,9 @@ def remote_preprocess(chip, steplist):
         run_task.join()
         if run_task.exitcode != 0:
             # A 'None' or nonzero value indicates that the Process target failed.
-            raise SiliconCompilerError("Could not start remote job: local setup task failed.")
+            ftask = f'{local_step}{index}'
+            chip.error(f"Could not start remote job: local setup task {ftask} failed.",
+                       fatal=True)
 
     # Collect inputs into a collection directory only for remote runs, since
     # we need to send inputs up to the server.

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -13,7 +13,7 @@ import tempfile
 import multiprocessing
 
 from siliconcompiler._metadata import default_server
-from siliconcompiler import utils
+from siliconcompiler import utils, SiliconCompilerError
 
 
 # Client / server timeout
@@ -152,6 +152,9 @@ def remote_preprocess(chip, steplist):
                                           args=(local_step, index, {}))
         run_task.start()
         run_task.join()
+        if run_task.exitcode != 0:
+            # A 'None' or nonzero value indicates that the Process target failed.
+            raise SiliconCompilerError("Could not start remote job: local setup task failed.")
 
     # Collect inputs into a collection directory only for remote runs, since
     # we need to send inputs up to the server.


### PR DESCRIPTION
Moving the local import nodes into spawned processes makes them parallelizable, but it also means that failures are silently ignored.

This change detects failed local tasks, and prevents a remote run from being submitted when they don't succeed, which was the behavior before #1755 got merged.