### PR TITLE
add abstract_lef controls to OpenROAD

### DIFF
--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -912,6 +912,16 @@ def _define_ord_params(chip):
              'list of files to use for specifying global connections',
              field='help')
 
+    _set_parameter(chip, param_key='ord_abstract_lef_bloat_factor',
+                   default_value='10',
+                   require=['key'],
+                   schelp='Factor to apply when writing the abstract lef')
+
+    _set_parameter(chip, param_key='ord_abstract_lef_bloat_layers',
+                   default_value='false',
+                   require=['key'],
+                   schelp='Fill all layers when writing the abstract lef')
+
 
 def _define_pex_params(chip):
     step = chip.get('arg', 'step')

--- a/siliconcompiler/tools/openroad/scripts/sc_export.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_export.tcl
@@ -1,5 +1,11 @@
 # Write LEF
-write_abstract_lef "outputs/${sc_design}.lef"
+set lef_args []
+if { [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} ord_abstract_lef_bloat_layers] 0] == "true" } {
+  lappend lef_args "-bloat_occupied_layers"
+} else {
+  lappend lef_args "-bloat_factor" [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} ord_abstract_lef_bloat_factor] 0]
+}
+write_abstract_lef {*}$lef_args "outputs/${sc_design}.lef"
 
 if { [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} write_cdl] 0] == "true" } {
   # Write CDL


### PR DESCRIPTION
adds the flags needed to be able to control the abstract lef writing to the OpenROAD driver