### PR TITLE
Multithread Verilator builds

### DIFF
--- a/siliconcompiler/tools/verilator/compile.py
+++ b/siliconcompiler/tools/verilator/compile.py
@@ -1,5 +1,3 @@
-import subprocess
-
 from siliconcompiler.tools.verilator.verilator import setup as setup_tool
 from siliconcompiler.tools.verilator.verilator import runtime_options as runtime_options_tool
 
@@ -23,7 +21,7 @@ def setup(chip):
     task = chip._get_task(step, index)
     design = chip.top()
 
-    chip.add('tool', tool, 'task', task, 'option', '--exe',
+    chip.add('tool', tool, 'task', task, 'option', ['--exe', '--build'],
              step=step, index=index)
 
     chip.set('tool', tool, 'task', task, 'var', 'mode', 'cc', clobber=False, step=step, index=index)
@@ -100,20 +98,3 @@ def runtime_options(chip):
         cmdlist.append(value)
 
     return cmdlist
-
-
-def post_process(chip):
-    ''' Tool specific function to run after step execution
-    '''
-
-    design = chip.top()
-
-    # Run make to compile Verilated design into executable.
-    # If we upgrade our minimum supported Verilog, we can remove this and
-    # use the --build flag instead.
-    proc = subprocess.run(['make', '-C', 'obj_dir', '-f', f'V{design}.mk'])
-    if proc.returncode > 0:
-        chip.error(
-            f'Make returned error code {proc.returncode} when compiling '
-            'Verilated design', fatal=True
-        )

--- a/siliconcompiler/tools/verilator/compile.py
+++ b/siliconcompiler/tools/verilator/compile.py
@@ -24,6 +24,9 @@ def setup(chip):
     chip.add('tool', tool, 'task', task, 'option', ['--exe', '--build'],
              step=step, index=index)
 
+    threads = chip.get('tool', tool, 'task', task, 'threads', step=step, index=index)
+    chip.add('tool', tool, 'task', task, 'option', ['-j', str(threads)], step=step, index=index)
+
     chip.set('tool', tool, 'task', task, 'var', 'mode', 'cc', clobber=False, step=step, index=index)
     mode = chip.get('tool', tool, 'task', task, 'var', 'mode', step=step, index=index)
     if mode == ['cc']:

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -48,7 +48,7 @@ def setup(chip):
     # Basic Tool Setup
     chip.set('tool', tool, 'exe', 'verilator')
     chip.set('tool', tool, 'vswitch', '--version')
-    chip.set('tool', tool, 'version', '>=4.028', clobber=False)
+    chip.set('tool', tool, 'version', '>=4.034', clobber=False)
 
     # Common to all tasks
     # Max threads


### PR DESCRIPTION
This PR updates our Verilator driver to multithread builds according to the SC threads parameter. It uses Verilator's `-j` flag, which should enable multi-threading both in the "Verilation" (RTL->C++) phase and in the C++ compile phase. 

In addition, I decided to bump the minimum required Verilator in order to make use of Verilator's `--build` flag and simplify the driver a bit. 4.028 was the version available in apt for Ubuntu 20.04, but I think newer versions of Verilator are more widespread now (22.04 includes 4.038). 