### PR TITLE
Allow selecting Verilator trace type

### DIFF
--- a/siliconcompiler/tools/verilator/compile.py
+++ b/siliconcompiler/tools/verilator/compile.py
@@ -45,6 +45,24 @@ def setup(chip):
     chip.add('tool', tool, 'task', task, 'option', f'-o ../outputs/{design}.vexe',
              step=step, index=index)
 
+    # User runtime option
+    chip.set('tool', tool, 'task', task, 'var', 'trace_type', 'vcd', clobber=False,
+             step=step, index=index)
+
+    if chip.get('option', 'trace', step=step, index=index):
+        trace_type = chip.get('tool', tool, 'task', task, 'var', 'trace_type',
+                              step=step, index=index)
+
+        if trace_type == ['vcd']:
+            trace_opt = '--trace'
+        elif trace_type == ['fst']:
+            trace_opt = '--trace-fst'
+        else:
+            chip.error(f"Invalid trace type {trace_type} provided to verilator/compile. Expected "
+                       "one of 'vcd' or 'fst'.")
+
+        chip.add('tool', tool, 'task', task, 'option', trace_opt, step=step, index=index)
+
     if chip.valid('input', 'hll', 'c'):
         chip.add('tool', tool, 'task', task, 'require',
                  ','.join(['input', 'hll', 'c']),
@@ -70,6 +88,11 @@ def setup(chip):
 
     chip.set('tool', tool, 'task', task, 'dir', 'cincludes',
              'include directories to provide to the C++ compiler invoked by Verilator',
+             field='help')
+
+    chip.set('tool', tool, 'task', task, 'var', 'trace_type',
+             "specifies type of wave file to create when [option, trace] is set. Valid options are "
+             "'vcd' or 'fst'. Defaults to 'vcd'.",
              field='help')
 
 

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -74,11 +74,6 @@ def setup(chip):
     for warning in chip.get('tool', tool, 'task', task, 'warningoff', step=step, index=index):
         chip.add('tool', tool, 'task', task, 'option', f'-Wno-{warning}', step=step, index=index)
 
-    # User runtime option
-    if chip.get('option', 'trace', step=step, index=index):
-        chip.add('tool', tool, 'task', task, 'option', '--trace',
-                 step=step, index=index)
-
     libext = chip.get('option', 'libext')
     if libext:
         libext_option = f"+libext+.{'+.'.join(libext)}"


### PR DESCRIPTION
Adds an option to Verilator letting a user select whether a VCD or FST file gets dumped when [option, trace] is True. 

This may be general enough to warrant its own schema option (or perhaps an change of option, trace from a bool to an enum) at some point. 