### PR TITLE
Enable all-JSON API transition with less strict checking on check_progress responses

### DIFF
--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -298,7 +298,7 @@ def is_job_busy(chip):
 
     def success_action(resp):
         info = {
-            'busy': (resp.text != "Job has no running steps."),
+            'busy': ("Job has no running steps." not in resp.text),
             'message': resp.text
         }
         return info


### PR DESCRIPTION
This change lets the `check_progress/` API work with HTTP and JSON responses, while we make that transition.