### PR TITLE
Dependency caching

### DIFF
--- a/siliconcompiler/__init__.py
+++ b/siliconcompiler/__init__.py
@@ -7,6 +7,8 @@ from siliconcompiler._metadata import version as __version__
 
 from siliconcompiler.use import PDK, Library, Flow, Checklist
 
+import siliconcompiler.dependency as dep
+
 __all__ = [
     "__version__",
     "Chip",
@@ -16,5 +18,6 @@ __all__ = [
     "Library",
     "Flow",
     "Checklist",
-    "Schema"
+    "Schema",
+    "dep"
 ]

--- a/siliconcompiler/dependency.py
+++ b/siliconcompiler/dependency.py
@@ -1,0 +1,80 @@
+import os
+import requests
+import tarfile
+
+
+def path(chip, package):
+    """
+    Compute dependency data path
+
+    Additionally cache dependency data if possible
+
+    Parameters:
+    arg1 (package): Package with dependency source info
+        package.dependency (dict):
+            Mandatory keys:
+            'path': '/path/on/network/drive',
+            or
+            'archive_url': e.g. 'https://github.com/xyz/xyz/archive/'
+            'commit_id': e.g. '3b94aa80506d25d5388131e9f2ecfcf4025ca866',
+            'project_name': e.g. 'freepdk',
+            or
+            'full_url': e.g. 'https://zeroasic.com/xyz.tar.gz',
+            'project_id': e.g. 'your-project-id-123',
+
+            Additional keys:
+            'rel_data_path': 'data/path/inside/archive/or/directory',
+            'type': e.g. 'pdk'
+
+    Returns:
+    string: Location of dependency data
+
+    """
+
+    dependency = package.dependency
+    dependency_type = dependency.get('type', 'dependency')
+    # check network drive for dependency data
+    if dependency.get('path') and os.path.exists(dependency['path']):
+        chip.logger.info(f'Found network {dependency_type} data at {dependency["path"]}')
+        return dependency['path']
+
+    # location of the python package
+    package_path = os.path.dirname(os.path.realpath(package.__file__))
+    dependency_url = dependency.get('full_url')
+    if not dependency_url:
+        if dependency.get('archive_url') and dependency.get('commit_id'):
+            dependency_url = dependency['archive_url'] + dependency['commit_id'] + '.tar.gz'
+    project_id = dependency.get('project_id')
+    if not project_id:
+        if dependency.get('project_name') and dependency.get('commit_id'):
+            project_id = dependency['project_name'] + '-' + dependency['commit_id']
+    if not dependency_url or not project_id:
+        chip.error(f'Could not find {dependency_type} data in package {package.__name__}')
+    cache_path = os.path.join(package_path, project_id, dependency.get('rel_data_path', ''))
+
+    # check cached dependency data
+    if os.path.exists(cache_path):
+        chip.logger.info(f'Found cached {dependency_type} data at {cache_path}')
+        return cache_path
+    # download dependency data
+    chip.logger.info(f'Downloading {dependency_type} data from {dependency_url}')
+    response = requests.get(dependency_url, stream=True)
+    if not response.ok:
+        chip.error(f'Failed to download {dependency_type}')
+    file = tarfile.open(fileobj=response.raw, mode='r|gz')
+    # extract only the data files of the dependency commit
+    try:
+        dependency_filter = (
+            lambda member, path: member
+            if member.name.startswith(os.path.join(project_id, dependency.get('rel_data_path', '')))
+            else None
+        )
+        file.extractall(path=package_path, filter=dependency_filter)
+    except TypeError:
+        chip.logger.info(f'Filtering {dependency_type}.tar.gz not supported on Python <3.11.4')
+        chip.logger.info(f'Extracting full {dependency_type} repository instead')
+        file.extractall(path=package_path)
+    if os.path.exists(cache_path):
+        chip.logger.info(f'Saved {dependency_type} data to {cache_path}')
+        return cache_path
+    chip.error(f'Extracting {dependency_type} data to {cache_path} failed')

--- a/siliconcompiler/dependency.py
+++ b/siliconcompiler/dependency.py
@@ -41,6 +41,9 @@ def path(chip, package):
     # location of the python package
     package_path = os.path.dirname(os.path.realpath(package.__file__))
     dependency_url = dependency.get('full_url')
+    headers = {}
+    if dependency.get('token'):
+        headers['Authorization'] = f'token {dependency["token"]}'
     if not dependency_url:
         if dependency.get('archive_url') and dependency.get('commit_id'):
             dependency_url = dependency['archive_url'] + dependency['commit_id'] + '.tar.gz'
@@ -58,7 +61,7 @@ def path(chip, package):
         return cache_path
     # download dependency data
     chip.logger.info(f'Downloading {dependency_type} data from {dependency_url}')
-    response = requests.get(dependency_url, stream=True)
+    response = requests.get(dependency_url, stream=True, headers=headers)
     if not response.ok:
         chip.error(f'Failed to download {dependency_type}')
     file = tarfile.open(fileobj=response.raw, mode='r|gz')

--- a/siliconcompiler/libs/nangate45.py
+++ b/siliconcompiler/libs/nangate45.py
@@ -1,5 +1,7 @@
 import os
 import siliconcompiler
+import freepdk45_data
+from siliconcompiler import dep
 
 
 def setup(chip):
@@ -7,7 +9,6 @@ def setup(chip):
     Nangate open standard cell library for FreePDK45.
     '''
     libname = 'nangate45'
-    foundry = 'virtual'
     process = 'freepdk45'
     stackup = '10M'
     libtype = '10t'
@@ -16,14 +17,7 @@ def setup(chip):
 
     lib = siliconcompiler.Library(chip, libname)
 
-    libdir = os.path.join('..',
-                          'third_party',
-                          'pdks',
-                          foundry,
-                          process,
-                          'libs',
-                          libname,
-                          version)
+    libdir = os.path.join(dep.path(chip, freepdk45_data), 'libs', libname, version)
 
     # version
     lib.set('package', 'version', version)

--- a/siliconcompiler/pdks/freepdk45.py
+++ b/siliconcompiler/pdks/freepdk45.py
@@ -1,6 +1,8 @@
 
 import os
 import siliconcompiler
+import freepdk45_data
+from siliconcompiler import dependency
 
 
 ####################################################
@@ -42,7 +44,7 @@ def setup(chip):
     edgemargin = 2
     d0 = 1.25
 
-    pdkdir = os.path.join('..', 'third_party', 'pdks', foundry, process, 'pdk', rev)
+    pdkdir = os.path.join(dependency.path(chip, freepdk45_data), 'pdk', rev)
 
     pdk = siliconcompiler.PDK(chip, process)
 


### PR DESCRIPTION
Utilize pip to organize dependencies e.g. for PDKs.
The installed package needs to provide a `dependency.py` file which contains a `dependency` dict with all the source information.
Siliconcompiler reads this information and if possible downloads+caches the information to the location of the freepdk45 package.
Alternatively a path in the network drive can be specified.

Currently only the final path path of the pdk will be stored in the pdk information of the schema as before.
This path contains the unique id (project_name+commit_id or a custom unique_id).
We could also store this information in a more prominent place in the schema.

Depends on the [dependency-caching branch of freepdk45](https://github.com/siliconcompiler/freepdk45/tree/dependency-caching).