### PR TITLE
fix dataframe search

### DIFF
--- a/siliconcompiler/report/streamlit_viewer.py
+++ b/siliconcompiler/report/streamlit_viewer.py
@@ -413,9 +413,11 @@ def show_dataframe_and_parameter_selection(metric_dataframe):
 
             streamlit.form_submit_button("Run")
 
-    if not options['nodes'] or not options['metrics']:
-        options = {'nodes': node_list,
-                   'metrics': metrics_list}
+    if not options['nodes']:
+        options['nodes'] = node_list
+
+    if not options['metrics']:
+        options['metrics'] = metrics_list
 
     # showing the dataframe
     # TODO By July 2024, Streamlit will let catch click events on the dataframe


### PR DESCRIPTION
There was a bit of an oversight on my part when I created the logic to search the data frame. Before, if either of the search bars were empty, the whole data frame was shown because no one wants to see no data. The oversight was that someone may want one axis filtered and one axis unfiltered.

Before:
<img width="757" alt="Data Metrics" src="https://github.com/siliconcompiler/siliconcompiler/assets/80078690/a356152c-7f48-47d7-9bed-2fe7ace63c6d">


After:
<img width="732" alt="Select Parameters" src="https://github.com/siliconcompiler/siliconcompiler/assets/80078690/0fb2576f-b3d6-4a6a-b841-60248eb25a78">
