### PR TITLE
Fix leflib clang extraneous parantheses

### DIFF
--- a/siliconcompiler/leflib/_leflib.pyx
+++ b/siliconcompiler/leflib/_leflib.pyx
@@ -217,7 +217,7 @@ cdef int clearance_measure_cb(lefrCallbackType_e cb_type, const char* val, lefiU
 cdef int fixed_mask_cb(lefrCallbackType_e cb_type, int val, lefiUserData data):
     try:
         # I think val should always be 1.
-        _state.data['fixedmask'] = True if val == 1 else False
+        _state.data['fixedmask'] = val == 1
     except Exception:
         traceback.print_exc()
         return 1


### PR DESCRIPTION
The ternary operator was confusing Cython and let to double parantheses being generated e.g. `if ((expr))`. Clang seems to be more sensitive than gcc and issued an extraneous parantheses warning. Because for the leflib we currently treat all warnings as errors the [build was failing](https://github.com/siliconcompiler/siliconcompiler/actions/runs/5605379609/jobs/10256600902).

```
/Users/runner/work/siliconcompiler/siliconcompiler/_skbuild/macosx-10.15-x86_64-3.6/cmake-build/_leflib.cxx:5372:24: error: equality comparison with extraneous parentheses [-Werror,-Wparentheses-equality]
          if ((__pyx_v_val == 1)) {
               ~~~~~~~~~~~~^~~~
```
This simplification fixes the issue.
[Successful build.](https://github.com/siliconcompiler/siliconcompiler/actions/runs/5611131909/jobs/10267090958)