### PR TITLE
Ensure compiled Surelog is backwards compatible with older macOS versions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,6 +8,10 @@ on:
     types:
       - published
 
+# Ensures Surelog/wheels are compatible with macOS 10.15+
+env:
+  MACOSX_DEPLOYMENT_TARGET: "10.15"
+
 jobs:
   build_surelog:
     name: Build Surelog for ${{ matrix.platform.os }} ${{ matrix.platform.arch}}
@@ -174,7 +178,6 @@ jobs:
         CIBW_ENVIRONMENT_WINDOWS: SC_CMAKEARGS="-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake."
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_SKIP: "pp* *win32 *i686 *-musllinux_*"
-        MACOSX_DEPLOYMENT_TARGET: "10.15"
         CIBW_ARCHS_MACOS: x86_64 arm64
         CIBW_TEST_SKIP: "*_arm64"
         CIBW_TEST_EXTRAS: test


### PR DESCRIPTION
This PR fixes the bug that our compiled Surelog binary reports a missing system library on macOS Big Sur, even though the wheels are marked as compatible with this version. We need to define a special env variable `MACOSX_DEPLOYMENT_TARGET` that the macOS compiler uses to determine backwards compatibility requirements. This variable was previously set in the context where our leflib C-extension was built, but not for Surelog.

@mayagokhale tested out a binary built with this env var set, I'm re-running a wheels build from scratch with the macOS Surelog cache invalidated: https://github.com/siliconcompiler/siliconcompiler/actions/runs/5616770044. 

Closes #1732. 