### PR TITLE
Adds OpenROAD image generation to the openroad tool driver

### DIFF
--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -942,6 +942,12 @@ def _define_ord_params(chip):
                    require=['key'],
                    schelp='true/false, fill all layers when writing the abstract lef')
 
+    _set_parameter(chip, param_key='ord_enable_images',
+                   default_value='true',
+                   require=['key'],
+                   schelp='true/false, enable generating images of the design at the '
+                          'end of the task')
+
 
 def _define_pex_params(chip):
     step = chip.get('arg', 'step')

--- a/siliconcompiler/tools/openroad/scripts/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_apr.tcl
@@ -322,6 +322,8 @@ set openroad_sta_top_n_paths [lindex [dict get $sc_cfg tool $sc_tool task $sc_ta
 
 set openroad_fin_add_fill [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} fin_add_fill] 0]
 
+set openroad_ord_enable_images [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} ord_enable_images] 0]
+
 # PDK agnostic design rule translation
 set sc_minmetal [sc_get_layer_name $sc_minmetal]
 set sc_maxmetal [sc_get_layer_name $sc_maxmetal]
@@ -454,4 +456,11 @@ if { $sc_task == "show" || $sc_task == "screenshot" } {
   utl::push_metrics_stage "sc__metric__{}"
   source "$sc_refdir/sc_metrics.tcl"
   utl::pop_metrics_stage
+
+  # Images
+  if { [sc_has_gui] && $openroad_ord_enable_images == "true" } {
+    utl::push_metrics_stage "sc__image__{}"
+    gui::show "source \"$sc_refdir/sc_write_images.tcl\"" false
+    utl::pop_metrics_stage
+  }
 }

--- a/siliconcompiler/tools/openroad/scripts/sc_procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_procs.tcl
@@ -149,6 +149,19 @@ proc sc_has_routing {} {
 }
 
 ###########################
+# Check if design has global routing
+###########################
+
+proc sc_has_global_routing {} {
+  foreach net [[ord::get_db_block] getNets] {
+    if { [llength [$net getGuides]] != 0 } {
+      return true
+    }
+  }
+  return false
+}
+
+###########################
 # Design has unplaced macros
 ###########################
 

--- a/siliconcompiler/tools/openroad/scripts/sc_write_images.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_write_images.tcl
@@ -1,0 +1,314 @@
+# Adopted from https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/3f9740e6b3643835e918d78ae1d377d65af0f0fb/flow/scripts/save_images.tcl
+
+proc sc_image_resolution {} {
+  set box [[ord::get_db_block] getDieArea]
+  return [expr [ord::dbu_to_microns [$box maxDXDY]] / 3000]
+}
+
+proc sc_image_area {} {
+  set box [[ord::get_db_block] getDieArea]
+  set width [$box dx]
+  set height [$box dy]
+
+  # apply 5% margin
+  set xmargin [expr int(0.05 * $width)]
+  set ymargin [expr int(0.05 * $height)]
+
+  set area []
+  lappend area [ord::dbu_to_microns [expr [$box xMin] - $xmargin]]
+  lappend area [ord::dbu_to_microns [expr [$box yMin] - $ymargin]]
+  lappend area [ord::dbu_to_microns [expr [$box xMax] + $xmargin]]
+  lappend area [ord::dbu_to_microns [expr [$box yMax] + $ymargin]]
+  return $area
+}
+
+proc sc_image_clear_selection {} {
+  for {set i 0} {$i <= 8} {incr i} {
+    gui::clear_highlights $i
+  }
+  gui::clear_selections
+}
+
+proc sc_image_setup_default {} {
+  gui::restore_display_controls
+
+  sc_image_clear_selection
+
+  gui::fit
+
+  # Setup initial visibility to avoid any previous settings
+  gui::set_display_controls "*" visible false
+  gui::set_display_controls "Layers/*" visible true
+  gui::set_display_controls "Nets/*" visible true
+  gui::set_display_controls "Instances/*" visible true
+  gui::set_display_controls "Pin Markers" visible true
+  gui::set_display_controls "Misc/Instances/*" visible true
+  gui::set_display_controls "Misc/Instances/ITerm Labels" visible false
+  gui::set_display_controls "Misc/Scale bar" visible true
+  gui::set_display_controls "Misc/Highlight selected" visible true
+  gui::set_display_controls "Misc/Detailed view" visible true
+}
+
+proc sc_save_image { title path } {
+  utl::info FLW 1 "Saving \"$title\" to $path"
+
+  save_image -resolution [sc_image_resolution] \
+    -area [sc_image_area] \
+    $path
+}
+
+proc sc_image_heatmap { name ident image_name title } {
+  file mkdir reports/images/heatmap
+
+  gui::set_display_controls "Heat Maps/${name}" visible true
+
+  gui::set_heatmap $ident ShowLegend 1
+
+  sc_save_image "$title heatmap" reports/images/heatmap/${image_name}
+
+  gui::set_display_controls "Heat Maps/${name}" visible false
+}
+
+proc sc_image_placement {} {
+  if { ![sc_has_placed_instances] } {
+    return
+  }
+
+  global sc_design
+
+  sc_image_setup_default
+
+  # The placement view without routing
+  gui::set_display_controls "Layers/*" visible false
+  gui::set_display_controls "Instances/Physical/*" visible false
+
+  sc_save_image "placement" reports/images/${sc_design}.placement.png
+}
+
+proc sc_image_routing {} {
+  if { ![sc_has_routing] } {
+    return
+  }
+
+  global sc_design
+
+  sc_image_setup_default
+
+  gui::set_display_controls "Nets/Power" visible false
+  gui::set_display_controls "Nets/Ground" visible false
+
+  sc_save_image "routing" reports/images/${sc_design}.routing.png
+}
+
+proc sc_image_everything {} {
+  global sc_design
+
+  sc_image_setup_default
+  sc_save_image "snapshot" reports/images/${sc_design}.png
+}
+
+proc sc_image_irdrop { net corner } {
+  if { ![sc_has_placed_instances] } {
+    return
+  }
+
+  sc_image_setup_default
+
+  file mkdir reports/images/heatmap/irdrop
+
+  if { ![sc_bterm_has_placed_io $net] } {
+    return
+  }
+
+  # suppress erorr message related to failed analysis,
+  # that is okay, we just wont take a screenshot
+  suppress_message PSM 78
+  set failed [catch "analyze_power_grid -net $net -corner $corner" err]
+  unsuppress_message PSM 78
+  if { $failed } {
+    return
+  }
+
+  foreach layer [[ord::get_db_tech] getLayers] {
+    if { [$layer getRoutingLevel] == 0 } {
+      continue
+    }
+    set layer_name [$layer getName]
+
+    gui::set_heatmap IRDrop Layer $layer_name
+    gui::set_heatmap IRDrop rebuild
+
+    sc_image_heatmap "IR Drop" \
+      "IRDrop" \
+      "irdrop/${net}.${corner}.${layer_name}.png" \
+      "IR drop for $net on $layer_name for $corner"
+  }
+}
+
+proc sc_image_routing_congestion {} {
+  if { ![sc_has_global_routing] } {
+    return
+  }
+
+  sc_image_setup_default
+
+  sc_image_heatmap "Routing Congestion" \
+    "Routing" \
+    "routing_congestion.png" \
+    "routing congestion"
+}
+
+proc sc_image_power_density {} {
+  if { ![sc_has_placed_instances] } {
+    return
+  }
+
+  sc_image_setup_default
+
+  file mkdir reports/images/heatmap/power_density
+
+  foreach corner [sta::corners] {
+    set corner_name [$corner name]
+
+    gui::set_heatmap Power Corner $corner_name
+    gui::set_heatmap Power rebuild
+
+    sc_image_heatmap "Power Density" \
+        "Power" \
+        "power_density/${corner_name}.png" \
+        "power density for $corner_name"
+  }
+}
+
+proc sc_image_placement_density {} {
+  if { ![sc_has_placed_instances] } {
+    return
+  }
+
+  sc_image_setup_default
+
+  sc_image_heatmap "Placement Density" \
+    "Placement" \
+    "placement_density.png" \
+    "placement density"
+}
+
+proc sc_image_clocks {} {
+  if { ![sc_has_placed_instances] } {
+    return
+  }
+
+  global sc_design
+  sc_image_setup_default
+
+  # The clock view: all clock nets and buffers
+  gui::set_display_controls "Layers/*" visible true
+  gui::set_display_controls "Nets/*" visible false
+  gui::set_display_controls "Nets/Clock" visible true
+  gui::set_display_controls "Instances/*" visible false
+  gui::set_display_controls "Instances/StdCells/Clock tree/*" visible true
+  if { [select -name "clk*" -type Inst] == 0 } {
+    # Nothing selected
+    return
+  }
+
+  sc_save_image "clocks" reports/images/${sc_design}.clocks.png
+}
+
+proc sc_image_clocktree {} {
+  file mkdir reports/images/clocktree
+
+  gui::show_widget "Clock Tree Viewer"
+
+  foreach clock [get_clocks *] {
+    if { [sta::clock_property $clock propagated] == 0} {
+      # Dont bother with clock tree if clock is not propagated
+      continue
+    }
+    set clock_name [get_name $clock]
+    set path reports/images/clocktree/${clock_name}.png
+    utl::info FLW 1 "Saving clock tree for $clock_name in $path"
+    gui::save_clocktree_image $path $clock_name
+  }
+
+  gui::hide_widget "Clock Tree Viewer"
+}
+
+proc sc_image_optimizer {} {
+  global sc_design
+  sc_image_setup_default
+
+  # The resizer view: all instances created by the resizer grouped
+  gui::set_display_controls "Layers/*" visible false
+  gui::set_display_controls "Instances/*" visible true
+  gui::set_display_controls "Instances/Physical/*" visible false
+
+  set hold_count       [select -name "hold*" -type Inst -highlight 0]       ;# green
+  set input_count      [select -name "input*" -type Inst -highlight 1]      ;# yellow
+  set output_count     [select -name "output*" -type Inst -highlight 1]
+  set repeater_count   [select -name "repeater*" -type Inst -highlight 3]   ;# magenta
+  set fanout_count     [select -name "fanout*" -type Inst -highlight 3]
+  set load_slew_count  [select -name "load_slew*" -type Inst -highlight 3]
+  set max_cap_count    [select -name "max_cap*" -type Inst -highlight 3]
+  set max_length_count [select -name "max_length*" -type Inst -highlight 3]
+  set wire_count       [select -name "wire*" -type Inst -highlight 3]
+  set rebuffer_count   [select -name "rebuffer*" -type Inst -highlight 4]   ;# red
+  set split_count      [select -name "split*" -type Inst -highlight 5]      ;# dark green
+
+  set select_count [expr \
+    $hold_count + \
+    $input_count + \
+    $output_count + \
+    $repeater_count + \
+    $fanout_count + \
+    $load_slew_count + \
+    $max_cap_count + \
+    $max_length_count + \
+    $wire_count + \
+    $rebuffer_count + \
+    $split_count]
+
+  if { $select_count == 0} {
+    # Nothing selected
+    return
+  }
+
+  sc_save_image "optimizer" reports/images/${sc_design}.optimizer.png
+}
+
+# Setup
+file mkdir reports/images
+gui::save_display_controls
+sc_image_setup_default
+
+if { [file exists reports/${sc_design}_drc.rpt] } {
+  # Show the drc markers (if any)
+  gui::load_drc reports/${sc_design}_drc.rpt
+}
+
+# General images
+sc_image_everything
+sc_image_placement
+sc_image_routing
+
+# Heatmaps
+sc_image_placement_density
+sc_image_power_density
+sc_image_routing_congestion
+
+foreach net [sc_psm_check_nets] {
+  foreach corner $sc_corners {
+    sc_image_irdrop $net $corner
+  }
+}
+
+# Clocks
+sc_image_clocks
+sc_image_clocktree
+
+# Optimizations
+sc_image_optimizer
+
+# Restore
+sc_image_clear_selection
+gui::restore_display_controls

--- a/siliconcompiler/tools/openroad/scripts/sc_write_images.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_write_images.tcl
@@ -23,9 +23,7 @@ proc sc_image_area {} {
 }
 
 proc sc_image_clear_selection {} {
-  for {set i 0} {$i <= 8} {incr i} {
-    gui::clear_highlights $i
-  }
+  gui::clear_highlights -1
   gui::clear_selections
 }
 
@@ -111,14 +109,13 @@ proc sc_image_irdrop { net corner } {
   if { ![sc_has_placed_instances] } {
     return
   }
+  if { ![sc_bterm_has_placed_io $net] } {
+    return
+  }
 
   sc_image_setup_default
 
   file mkdir reports/images/heatmap/irdrop
-
-  if { ![sc_bterm_has_placed_io $net] } {
-    return
-  }
 
   # suppress erorr message related to failed analysis,
   # that is okay, we just wont take a screenshot
@@ -126,6 +123,7 @@ proc sc_image_irdrop { net corner } {
   set failed [catch "analyze_power_grid -net $net -corner $corner" err]
   unsuppress_message PSM 78
   if { $failed } {
+    utl::warn FLW 1 "Unable to generate IR drop heatmap for $net on $corner"
     return
   }
 
@@ -216,8 +214,6 @@ proc sc_image_clocks {} {
 }
 
 proc sc_image_clocktree {} {
-  file mkdir reports/images/clocktree
-
   gui::show_widget "Clock Tree Viewer"
 
   foreach clock [get_clocks *] {
@@ -225,6 +221,8 @@ proc sc_image_clocktree {} {
       # Dont bother with clock tree if clock is not propagated
       continue
     }
+    file mkdir reports/images/clocktree
+
     set clock_name [get_name $clock]
     set path reports/images/clocktree/${clock_name}.png
     utl::info FLW 1 "Saving clock tree for $clock_name in $path"

--- a/tests/apps/test_sc_show.py
+++ b/tests/apps/test_sc_show.py
@@ -43,6 +43,7 @@ def heartbeat_dir(tmpdir_factory):
 ])
 @pytest.mark.eda
 @pytest.mark.quick
+@pytest.mark.timeout(180)
 def test_sc_show_design_only(flags, monkeypatch, heartbeat_dir):
     '''Test sc-show app on a few sets of flags.'''
 
@@ -78,6 +79,7 @@ def test_sc_show_design_only(flags, monkeypatch, heartbeat_dir):
 ])
 @pytest.mark.eda
 @pytest.mark.quick
+@pytest.mark.timeout(180)
 def test_sc_show(flags, monkeypatch, heartbeat_dir):
     '''Test sc-show app on a few sets of flags.'''
 

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -8,9 +8,7 @@ from siliconcompiler.tools.openroad import floorplan
 from siliconcompiler.tools.builtin import nop
 
 
-@pytest.mark.eda
-@pytest.mark.quick
-def test_openroad(scroot):
+def _setup_fifo(scroot):
     datadir = os.path.join(scroot, 'tests', 'data')
     netlist = os.path.join(datadir, 'oh_fifo_sync_freepdk45.vg')
 
@@ -34,6 +32,14 @@ def test_openroad(scroot):
     chip.edge(flow, 'import', 'floorplan')
     chip.set('option', 'flow', flow)
 
+    return chip
+
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_openroad(scroot):
+    chip = _setup_fifo(scroot)
+
     chip.run()
 
     # check that compilation succeeded
@@ -43,6 +49,23 @@ def test_openroad(scroot):
     assert chip.get('metric', 'cellarea', step='floorplan', index='0') is not None
     assert chip.get('tool', 'openroad', 'task', 'floorplan', 'report', 'cellarea',
                     step='floorplan', index='0') == ['reports/metrics.json']
+
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_openroad_images(scroot):
+    chip = _setup_fifo(scroot)
+    chip.set('tool', 'openroad', 'task', 'floorplan', 'var', 'ord_enable_images', 'true')
+
+    chip.run()
+
+    # check that compilation succeeded
+    assert chip.find_result('def', step='floorplan') is not None
+    assert chip.find_result('odb', step='floorplan') is not None
+
+    assert os.path.exists(os.path.join(chip._getworkdir(step='floorplan', index='0'),
+                                       'reports',
+                                       'images'))
 
 
 #########################

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -65,7 +65,8 @@ def test_openroad_images(scroot):
 
     assert os.path.exists(os.path.join(chip._getworkdir(step='floorplan', index='0'),
                                        'reports',
-                                       'images'))
+                                       'images',
+                                       f'{chip.design}.png'))
 
 
 #########################


### PR DESCRIPTION
Adds:
- image generation at the end of each OpenROAD task: placement, routed nets, heatmaps, clock trees, etc.