### PR TITLE
Fix error_action signature in get_results call

### DIFF
--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -492,7 +492,7 @@ def fetch_results_request(chip, node, results_path):
             shutil.copyfileobj(resp.raw, zipf)
             return 0
 
-        def error_action(resp):
+        def error_action(code, msg):
             chip.logger.warning(f'Error fetching results for node: {node}')
             return 1
 


### PR DESCRIPTION
This fixes the recently-added `error_action` on the `get_results` call - the function signature expects two arguments.