### PR TITLE
gate pin placement refinement if there are unplaced instances

### DIFF
--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -709,7 +709,7 @@ def _define_gpl_params(chip):
                    schelp='percent of remaining area density to apply above '
                           'uniform density (0.00 - 0.99)')
     _set_parameter(chip, param_key='gpl_enable_skip_io',
-                   default_value='false',
+                   default_value='true',
                    schelp='true/false, when enabled a global placement is performed without '
                           'considering the impact of the pin placements')
 

--- a/siliconcompiler/tools/openroad/scripts/sc_place.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_place.tcl
@@ -16,7 +16,11 @@ if { [sc_design_has_placeable_ios] } {
   # Refine Automatic Pin Placement
   ###########################
 
-  sc_pin_placement
+  if { ![sc_has_unplaced_instances] } {
+    sc_pin_placement
+  } else {
+    utl::info FLW 1 "Skipping pin placements refinement due to unplaced instances"
+  }
 }
 
 #######################

--- a/siliconcompiler/tools/openroad/scripts/sc_procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_procs.tcl
@@ -136,6 +136,19 @@ proc sc_has_placed_instances {} {
 }
 
 ###########################
+# Check if design has unplaced instances
+###########################
+
+proc sc_has_unplaced_instances {} {
+  foreach inst [[ord::get_db_block] getInsts] {
+    if {![$inst isPlaced]} {
+      return true
+    }
+  }
+  return false
+}
+
+###########################
 # Check if design has routing
 ###########################
 

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -43,12 +43,12 @@ def __check_gcd(chip):
     assert chip.get('metric', 'warnings', step='cts', index='0') == 5
 
     # Warning: *. (x3)
-    # Missing route to pin (x61)
-    assert chip.get('metric', 'warnings', step='route', index='0') == 64
+    # Missing route to pin (x60)
+    assert chip.get('metric', 'warnings', step='route', index='0') == 63
 
     # Warning: *. (x3)
-    # Missing route to pin (x182)
-    assert chip.get('metric', 'warnings', step='dfm', index='0') == 185
+    # Missing route to pin (x184)
+    assert chip.get('metric', 'warnings', step='dfm', index='0') == 187
 
     # "no fill config specified"
     assert chip.get('metric', 'warnings', step='export', index='0') == 1

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -34,8 +34,8 @@ def __check_gcd(chip):
     # Warning: *. (x3)
     assert chip.get('metric', 'warnings', step='physyn', index='0') == 3
 
-    # Warning: *. (x3)
-    assert chip.get('metric', 'warnings', step='place', index='0') == 3
+    # Warning: *. (x5)
+    assert chip.get('metric', 'warnings', step='place', index='0') == 5
 
     # Warning: *. (x3)
     # "1632 wires are pure wire and no slew degradation"
@@ -43,12 +43,12 @@ def __check_gcd(chip):
     assert chip.get('metric', 'warnings', step='cts', index='0') == 5
 
     # Warning: *. (x3)
-    # Missing route to pin (x60)
-    assert chip.get('metric', 'warnings', step='route', index='0') == 63
+    # Missing route to pin (x70)
+    assert chip.get('metric', 'warnings', step='route', index='0') == 73
 
     # Warning: *. (x3)
-    # Missing route to pin (x184)
-    assert chip.get('metric', 'warnings', step='dfm', index='0') == 187
+    # Missing route to pin (x185)
+    assert chip.get('metric', 'warnings', step='dfm', index='0') == 186
 
     # "no fill config specified"
     assert chip.get('metric', 'warnings', step='export', index='0') == 1


### PR DESCRIPTION
Fixes:
- pin placement generates very dense pin placement when the design is not placed, this avoids this when there are unplaced instances in the design.