### PR TITLE
dashboard: ensure pictures are recognized and avoid indexing into empty array

### DIFF
--- a/siliconcompiler/report/streamlit_viewer.py
+++ b/siliconcompiler/report/streamlit_viewer.py
@@ -255,15 +255,17 @@ def show_files(chip, step, index):
     selected['checked'] = [x for x in selected['checked'] if os.path.isfile(x)]
     if len(selected['checked']) == 0:
         streamlit.session_state['selected'] = []
-    if len(selected["checked"]) == 1:
-        streamlit.session_state['selected'] = selected["checked"]
-    if len(selected["checked"]) > 1:
-        for x in selected["checked"]:
-            if x != streamlit.session_state['selected'][0]:
-                newly_selected = x
-                break
+    elif len(selected["checked"]) == 1:
+        streamlit.session_state['selected'] = [*selected["checked"]]
+    elif len(selected["checked"]) > 1:
+        newly_selected = selected["checked"][0]
+        if len(streamlit.session_state['selected']) != 0:
+            for x in selected["checked"]:
+                if x != streamlit.session_state['selected'][0]:
+                    newly_selected = x
+                    break
         streamlit.session_state['selected'] = [newly_selected]
-        streamlit.session_state['expanded'] = selected["expanded"]
+        streamlit.session_state['expanded'] = [*selected["expanded"]]
         streamlit.session_state['right after rerun'] = True
         streamlit.experimental_rerun()
     if streamlit.session_state.selected != []:

--- a/siliconcompiler/report/streamlit_viewer.py
+++ b/siliconcompiler/report/streamlit_viewer.py
@@ -191,7 +191,7 @@ def file_viewer_module(display_file_content, chip, step, index, header_col_width
         return
     path = streamlit.session_state['selected'][0]
     # This file extension may be '.gz', if it is, it is compressed.
-    file_name, compressed_file_extension = os.path.splitext(path)
+    _, compressed_file_extension = os.path.splitext(path)
     # This is the true file_extension of the file, regardless of if it is
     # compressed or not.
     file_extension = utils.get_file_ext(path)
@@ -205,7 +205,8 @@ def file_viewer_module(display_file_content, chip, step, index, header_col_width
         streamlit.download_button(label="Download file",
                                   data=path,
                                   file_name=relative_path)
-    if file_extension.lower() in {".png", ".jpg"}:
+
+    if file_extension.lower() in ("png", "jpg"):
         streamlit.image(path)
     else:
         try:
@@ -215,7 +216,7 @@ def file_viewer_module(display_file_content, chip, step, index, header_col_width
                 fid = open(path, 'r')
             content = fid.read()
             fid.close()
-            if file_extension.lower() == ".json":
+            if file_extension.lower() == "json":
                 streamlit.json(content)
             else:
                 streamlit.code(content, language='markdown', line_numbers=True)


### PR DESCRIPTION
Fixes:
- pictures and json files not getting loaded correctly
- sometimes a [0] was getting accessed in an empty array.