### PR TITLE
Update get_results error to allow single nodes to fail without interrupting the whole job

### DIFF
--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -515,8 +515,10 @@ def fetch_results_request(chip, node, results_path):
             return 0
 
         def error_action(code, msg):
-            chip.logger.warning(f'Error fetching results for node: {node}')
-            return 1
+            # Results are fetched in parallel, and a failure in one node
+            # does not necessarily mean that the whole job failed.
+            chip.logger.warning(f'Could not fetch results for node: {node}')
+            return 0
 
         return __post(chip,
                       f'/get_results/{job_hash}.tar.gz',


### PR DESCRIPTION
We should treat failures to fetch remote results for individual flowgraph nodes as warnings, so that they don't prematurely fail out of the job run.

Individual nodes could fail in a way that is not fatal for the entire job, for example in a branching flowgraph. Interrupting the job when a result cannot be fetched could also interfere with ongoing downloads for other nodes which did complete. Finally, SC is already set up to report build failures after the client attempts to fetch all of its results.