### PR TITLE
Log job IDs for remote jobs to a file

### DIFF
--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -386,6 +386,8 @@ def request_remote_run(chip):
         chip.logger.info(resp.text)
         chip.status['jobhash'] = json.loads(resp.text)['job_hash']
         chip.logger.info(f"Your job's reference ID is: {chip.status['jobhash']}")
+        with open(os.path.join(chip._getworkdir(), 'jobid.txt'), 'w') as wf:
+            wf.write(chip.status['jobhash'])
 
     __post(chip, '/remote_run/', post_action, success_action)
     upload_file.close()


### PR DESCRIPTION
It probably isn't reasonable to expect that people will remember or write down the UUID which gets printed at a start of a job run.

Previously, the ID wasn't something that the user needed to worry about. Now that we're adding a way to interact with remote jobs asynchronously though, it seems like it would be a good idea to store the ID somewhere that users can find it later.

For a longer-term solution, maybe in the next release, we could also consider stashing the ID somewhere in the schema, and using `-cfg` instead of `-jobid` as an argument to the `sc-remote` CLI app.