### PR TITLE
Update steplist and summary logic in `sc-remote -reconnect`

### DIFF
--- a/siliconcompiler/apps/sc_remote.py
+++ b/siliconcompiler/apps/sc_remote.py
@@ -95,7 +95,16 @@ def main():
         # Also, total runtime value will be incorrect; maybe we can have the
         # server return the job's "created_at" time in the check_progress/ response.
         chip.read_manifest(chip.get('option', 'cfg')[0])
+        # Remove entry steps from the steplist, so that they are not fetched from the remote.
+        remote_steps = chip.list_steps()
+        entry_nodes = chip._get_flowgraph_entry_nodes(flow=chip.get('option', 'flow'))
+        for node in entry_nodes:
+            remote_steps.remove(node[0])
+        chip.set('option', 'steplist', remote_steps)
+        # Enter the remote run loop.
         remote_run_loop(chip)
+        # Print summary.
+        chip.summary()
 
     # If only a job ID is specified, make a 'check_progress/' request and report results:
     elif args['jobid']:

--- a/siliconcompiler/apps/sc_remote.py
+++ b/siliconcompiler/apps/sc_remote.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Silicon Compiler Authors. All Rights Reserved.
+import copy
 import json
 import os
 import sys
@@ -97,13 +98,15 @@ def main():
         chip.read_manifest(chip.get('option', 'cfg')[0])
         # Remove entry steps from the steplist, so that they are not fetched from the remote.
         remote_steps = chip.list_steps()
+        environment = copy.deepcopy(os.environ)
         entry_nodes = chip._get_flowgraph_entry_nodes(flow=chip.get('option', 'flow'))
         for node in entry_nodes:
             remote_steps.remove(node[0])
         chip.set('option', 'steplist', remote_steps)
         # Enter the remote run loop.
         remote_run_loop(chip)
-        # Print summary.
+        # Summarize the run.
+        chip._finalize_run(chip.list_steps(), environment)
         chip.summary()
 
     # If only a job ID is specified, make a 'check_progress/' request and report results:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3859,7 +3859,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         self.set('arg', 'index', None)
 
     ###########################################################################
-    def __finalize_run(self, steplist, environment, status={}):
+    def _finalize_run(self, steplist, environment, status={}):
         '''
         Helper function to finalize a job run after it completes:
         * Merge the last-completed manifests in a job's flowgraphs.
@@ -4230,7 +4230,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                         self.set('flowgraph', flow, step, index, 'status', status[stepstr])
 
         # Merge cfgs from last executed tasks, and write out a final manifest.
-        self.__finalize_run(steplist, environment, status)
+        self._finalize_run(steplist, environment, status)
 
     ###########################################################################
     def _find_showable_output(self, tool=None):

--- a/tests/apps/test_sc_remote.py
+++ b/tests/apps/test_sc_remote.py
@@ -222,6 +222,7 @@ def test_sc_remote_reconnect(monkeypatch, unused_tcp_port, scroot):
                                                           '0',
                                                           'outputs',
                                                           'gcd.pkg.json')])
+
     def mock_finalize_run(self, steplist, environment, status={}):
         final_manifest = os.path.join(chip._getworkdir(), f"{chip.get('design')}.pkg.json")
         with open(final_manifest, 'w') as wf:


### PR DESCRIPTION
After some more end-to-end testing on AWS, a couple of small improvements to the `-reconnect` flag.

* Produce a final summary manifest like a `chip.run()` call normally does.
* Omit local steps from the steplist, so the client doesn't try to fetch them from the server.
* Print a summary similar to a normal CLI run.