### PR TITLE
Clean sc_collected_files before next run

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2392,8 +2392,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         if not directory:
             directory = os.path.join(self._getcollectdir())
 
-        if not os.path.exists(directory):
-            os.makedirs(directory)
+        if os.path.exists(directory):
+            shutil.rmtree(directory)
+        os.makedirs(directory)
 
         self.logger.info('Collecting input sources')
 

--- a/tests/core/test_collect.py
+++ b/tests/core/test_collect.py
@@ -1,0 +1,26 @@
+import siliconcompiler
+import os
+
+
+def test_collect_file_update():
+    # Checks if collected files are properly updated after editing
+
+    # Create instance of Chip class
+    with open('fake.v', 'w') as f:
+        f.write('fake')
+    chip = siliconcompiler.Chip('fake')
+    chip.input('fake.v')
+    chip._collect()
+    filename = chip._get_imported_filename('fake.v')
+
+    with open(os.path.join(chip._getcollectdir(), filename), 'r') as f:
+        assert f.readline() == 'fake'
+
+    # Edit file
+    with open('fake.v', 'w') as f:
+        f.write('newfake')
+
+    # Rerun remote run
+    chip._collect()
+    with open(os.path.join(chip._getcollectdir(), filename), 'r') as f:
+        assert f.readline() == 'newfake'


### PR DESCRIPTION
*What?*
Update source files that get uploaded to remote after editing them.

*Why?*
Currently we assume that if a file is present in the `sc_collected_files` directory we don't need to refresh it.
Of course a user might edit a file between runs.

*How?*
As an intermediate solution we can clear the `sc_collected_files` directory before a run.
Long term wise we should probably hash the files content and update only the files that changed.

*Test*
Edits files before collecting them for a second run.
The test fails before the changes and passes after the changes.