### PR TITLE
fix sc-show to find gz'd files and load tools when setting up common show tools

### DIFF
--- a/siliconcompiler/flows/showflow.py
+++ b/siliconcompiler/flows/showflow.py
@@ -58,6 +58,11 @@ def setup(chip, flowname='showflow', filetype=None, screenshot=False, np=1):
                     tools.add(tool_module.__name__)
                 except SiliconCompilerError:
                     pass
+    # If no tools found in flowgraph, check the loaded modules
+    if not tools:
+        for module_name in chip._get_loaded_modules().keys():
+            if module_name.endswith(f".{show_tool}"):
+                tools.add(module_name)
 
     show_task_module = None
     for tool in tools:

--- a/siliconcompiler/targets/utils.py
+++ b/siliconcompiler/targets/utils.py
@@ -1,11 +1,27 @@
 # Copyright 2023 Silicon Compiler Authors. All Rights Reserved.
 
+from siliconcompiler.tools.klayout import (
+    klayout,
+    show as klayout_show,
+    screenshot as klayout_screenshot)
+from siliconcompiler.tools.openroad import (
+    openroad,
+    show as openroad_show,
+    screenshot as openroad_screenshot)
+
+
 def set_common_showtools(chip):
 
     # Physical only
     chip.set('option', 'showtool', 'gds', 'klayout', clobber=False)
     chip.set('option', 'showtool', 'lef', 'klayout', clobber=False)
+    chip._load_module(klayout.__name__)
+    chip._load_module(klayout_show.__name__)
+    chip._load_module(klayout_screenshot.__name__)
 
     # Design
     chip.set('option', 'showtool', 'def', 'openroad', clobber=False)
     chip.set('option', 'showtool', 'odb', 'openroad', clobber=False)
+    chip._load_module(openroad.__name__)
+    chip._load_module(openroad_show.__name__)
+    chip._load_module(openroad_screenshot.__name__)


### PR DESCRIPTION
allow show to find gz'd files and preload the modules for show into Chip to ensure they are present if flowgraph does not contain them