### PR TITLE
Set -nodisplay for ssh

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3924,14 +3924,14 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         self.write_manifest(filepath)
 
     ###########################################################################
-    def _ssh_nodisplay(self):
+    def _check_display(self):
         '''
-        Automatically disable display on ssh for Linux systems
+        Automatically disable display for Linux systems without desktop environment
         '''
         if not self.get('option', 'nodisplay') and sys.platform == 'linux' \
                 and 'DISPLAY' not in os.environ and 'WAYLAND_DISPLAY' not in os.environ:
             self.logger.warning('Environment variable $DISPLAY or $WAYLAND_DISPLAY not set')
-            self.logger.warning('Running with option -nodisplay enabled')
+            self.logger.warning("Setting ['option', 'nodisplay'] to True")
             self.set('option', 'nodisplay', True)
 
     ###########################################################################
@@ -3964,7 +3964,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             Runs the execution flow defined by the flowgraph dictionary.
         '''
 
-        self._ssh_nodisplay()
+        self._check_display()
 
         # Check required settings before attempting run()
         for key in (['option', 'flow'],

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3924,6 +3924,17 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         self.write_manifest(filepath)
 
     ###########################################################################
+    def _ssh_nodisplay(self):
+        '''
+        Automatically disable display on ssh for Linux systems
+        '''
+        if not self.get('option', 'nodisplay') and sys.platform == 'linux' \
+                and 'DISPLAY' not in os.environ and 'WAYLAND_DISPLAY' not in os.environ:
+            self.logger.warning('Environment variable $DISPLAY or $WAYLAND_DISPLAY not set')
+            self.logger.warning('Running with option -nodisplay enabled')
+            self.set('option', 'nodisplay', True)
+
+    ###########################################################################
     def run(self):
         '''
         Executes tasks in a flowgraph.
@@ -3952,6 +3963,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             >>> run()
             Runs the execution flow defined by the flowgraph dictionary.
         '''
+
+        self._ssh_nodisplay()
 
         # Check required settings before attempting run()
         for key in (['option', 'flow'],

--- a/tests/core/test_check_display.py
+++ b/tests/core/test_check_display.py
@@ -9,8 +9,8 @@ modified_environ = {k: v for k, v in os.environ.items() if k not in names_to_rem
 
 
 @patch('sys.platform', 'linux')
-def test_ssh_nodisplay_run():
-    # Checks if _ssh_nodisplay() is called during run()
+def test_check_display_run():
+    # Checks if _check_display() is called during run()
     chip = siliconcompiler.Chip('test')
 
     flow = 'test'
@@ -23,50 +23,50 @@ def test_ssh_nodisplay_run():
 
 
 @patch('sys.platform', 'linux')
-def test_ssh_nodisplay():
+def test_check_display_nodisplay():
     # Checks if the nodisplay option is set
     # On linux system without display
     with patch.dict(os.environ, modified_environ, clear=True):
         chip = siliconcompiler.Chip('test')
-        chip._ssh_nodisplay()
+        chip._check_display()
         assert chip.get('option', 'nodisplay')
 
 
 @patch('sys.platform', 'linux')
 @patch.dict(os.environ, {'DISPLAY': ':0'})
-def test_with_display_x11():
+def test_check_display_with_display_x11():
     # Checks that the nodisplay option is not set
     # On linux system with X11 disp
     chip = siliconcompiler.Chip('test')
-    chip._ssh_nodisplay()
+    chip._check_display()
     assert not chip.get('option', 'nodisplay')
 
 
 @patch('sys.platform', 'linux')
 @patch.dict(os.environ, {'WAYLAND_DISPLAY': 'wayland-0'})
-def test_with_display_wayland():
+def test_check_display_with_display_wayland():
     # Checks that the nodisplay option is not set
     # On linux system with Wayland display
     chip = siliconcompiler.Chip('test')
-    chip._ssh_nodisplay()
+    chip._check_display()
     assert not chip.get('option', 'nodisplay')
 
 
 @patch('sys.platform', 'darwin')
-def test_with_display_macos():
+def test_check_display_with_display_macos():
     # Checks that the nodisplay option is not set
     # On macos system
     with patch.dict(os.environ, modified_environ, clear=True):
         chip = siliconcompiler.Chip('test')
-        chip._ssh_nodisplay()
+        chip._check_display()
         assert not chip.get('option', 'nodisplay')
 
 
 @patch('sys.platform', 'win32')
-def test_with_display_windows():
+def test_check_display_with_display_windows():
     # Checks that the nodisplay option is not set
     # On windows system
     with patch.dict(os.environ, modified_environ, clear=True):
         chip = siliconcompiler.Chip('test')
-        chip._ssh_nodisplay()
+        chip._check_display()
         assert not chip.get('option', 'nodisplay')

--- a/tests/core/test_ssh_nodisplay.py
+++ b/tests/core/test_ssh_nodisplay.py
@@ -1,0 +1,72 @@
+import siliconcompiler
+import os
+from siliconcompiler.tools.builtin import nop
+from unittest.mock import patch
+
+
+names_to_remove = {'DISPLAY', 'WAYLAND_DISPLAY'}
+modified_environ = {k: v for k, v in os.environ.items() if k not in names_to_remove}
+
+
+@patch('sys.platform', 'linux')
+def test_ssh_nodisplay_run():
+    # Checks if _ssh_nodisplay() is called during run()
+    chip = siliconcompiler.Chip('test')
+
+    flow = 'test'
+    chip.set('option', 'flow', flow)
+    chip.node(flow, 'import', nop)
+    chip.set('option', 'mode', 'asic')
+    with patch.dict(os.environ, modified_environ, clear=True):
+        chip.run()
+        assert chip.get('option', 'nodisplay')
+
+
+@patch('sys.platform', 'linux')
+def test_ssh_nodisplay():
+    # Checks if the nodisplay option is set
+    # On linux system without display
+    with patch.dict(os.environ, modified_environ, clear=True):
+        chip = siliconcompiler.Chip('test')
+        chip._ssh_nodisplay()
+        assert chip.get('option', 'nodisplay')
+
+
+@patch('sys.platform', 'linux')
+@patch.dict(os.environ, {'DISPLAY': ':0'})
+def test_with_display_x11():
+    # Checks that the nodisplay option is not set
+    # On linux system with X11 disp
+    chip = siliconcompiler.Chip('test')
+    chip._ssh_nodisplay()
+    assert not chip.get('option', 'nodisplay')
+
+
+@patch('sys.platform', 'linux')
+@patch.dict(os.environ, {'WAYLAND_DISPLAY': 'wayland-0'})
+def test_with_display_wayland():
+    # Checks that the nodisplay option is not set
+    # On linux system with Wayland display
+    chip = siliconcompiler.Chip('test')
+    chip._ssh_nodisplay()
+    assert not chip.get('option', 'nodisplay')
+
+
+@patch('sys.platform', 'darwin')
+def test_with_display_macos():
+    # Checks that the nodisplay option is not set
+    # On macos system
+    with patch.dict(os.environ, modified_environ, clear=True):
+        chip = siliconcompiler.Chip('test')
+        chip._ssh_nodisplay()
+        assert not chip.get('option', 'nodisplay')
+
+
+@patch('sys.platform', 'win32')
+def test_with_display_windows():
+    # Checks that the nodisplay option is not set
+    # On windows system
+    with patch.dict(os.environ, modified_environ, clear=True):
+        chip = siliconcompiler.Chip('test')
+        chip._ssh_nodisplay()
+        assert not chip.get('option', 'nodisplay')


### PR DESCRIPTION
**What?**
Automatically enable `-nodisplay` for ssh or other configurations without display on linux.

**Why?**
On ssh it's one extra step to enable the nodisplay option. So this improves usability.

**How?**
We check the the `$DISPLAY` and `$WAYLAND_DISPLAY` variables on linux.

**Test:**
Checks that nodisplay is set on linux with x11 or wayland.
Additionally checks there are no regressions on other platforms.