### PR TITLE
fix failure tests to pass based on new exit logic

### DIFF
--- a/tests/flows/test_failure.py
+++ b/tests/flows/test_failure.py
@@ -23,6 +23,7 @@ def chip(datadir):
 
 
 @pytest.mark.eda
+@pytest.mark.quick
 def test_failure_notquiet(chip):
     '''Test that SC exits early on errors without -quiet switch.
 
@@ -39,15 +40,14 @@ def test_failure_notquiet(chip):
 
     # Check we made it past initial setup
     assert os.path.isdir('build/bad/job0/import')
-    assert os.path.isdir('build/bad/job0/syn')
+    assert not os.path.isdir('build/bad/job0/syn')
 
     # Expect that there is no import output
     assert chip.find_result('v', step='import') is None
-    # Expect that synthesis doesn't run
-    assert not os.path.isdir('build/bad/job0/syn/0/syn.log')
 
 
 @pytest.mark.eda
+@pytest.mark.quick
 def test_failure_quiet(chip):
     '''Test that SC exits early on errors with -quiet switch.
     '''
@@ -60,12 +60,10 @@ def test_failure_quiet(chip):
 
     # Check we made it past initial setup
     assert os.path.isdir('build/bad/job0/import')
-    assert os.path.isdir('build/bad/job0/syn')
+    assert not os.path.isdir('build/bad/job0/syn')
 
     # Expect that there is no import output
     assert chip.find_result('v', step='import') is None
-    # Expect that synthesis doesn't run
-    assert not os.path.isdir('build/bad/job0/syn/0/syn.log')
 
 
 @pytest.mark.quick


### PR DESCRIPTION
fixes two failing CI tests based on the new exit quickly logic
also adds them to the quick list since they take almost no time to run.