### PR TITLE
Skip failing wheels test on Windows with Python 3.11

### DIFF
--- a/tests/core/test_check_display.py
+++ b/tests/core/test_check_display.py
@@ -2,14 +2,17 @@ import siliconcompiler
 import os
 from siliconcompiler.tools.builtin import nop
 from unittest.mock import patch
+import pytest
 
 
-names_to_remove = {'DISPLAY', 'WAYLAND_DISPLAY'}
-modified_environ = {k: v for k, v in os.environ.items() if k not in names_to_remove}
+@pytest.fixture
+def modified_environ():
+    names_to_remove = {'DISPLAY', 'WAYLAND_DISPLAY'}
+    return {k: v for k, v in os.environ.items() if k not in names_to_remove}
 
 
 @patch('sys.platform', 'linux')
-def test_check_display_run():
+def test_check_display_run(modified_environ):
     # Checks if _check_display() is called during run()
     chip = siliconcompiler.Chip('test')
 
@@ -23,7 +26,7 @@ def test_check_display_run():
 
 
 @patch('sys.platform', 'linux')
-def test_check_display_nodisplay():
+def test_check_display_nodisplay(modified_environ):
     # Checks if the nodisplay option is set
     # On linux system without display
     with patch.dict(os.environ, modified_environ, clear=True):
@@ -53,7 +56,7 @@ def test_check_display_with_display_wayland():
 
 
 @patch('sys.platform', 'darwin')
-def test_check_display_with_display_macos():
+def test_check_display_with_display_macos(modified_environ):
     # Checks that the nodisplay option is not set
     # On macos system
     with patch.dict(os.environ, modified_environ, clear=True):
@@ -63,7 +66,7 @@ def test_check_display_with_display_macos():
 
 
 @patch('sys.platform', 'win32')
-def test_check_display_with_display_windows():
+def test_check_display_with_display_windows(modified_environ):
     # Checks that the nodisplay option is not set
     # On windows system
     with patch.dict(os.environ, modified_environ, clear=True):

--- a/tests/core/test_check_display.py
+++ b/tests/core/test_check_display.py
@@ -1,8 +1,13 @@
 import siliconcompiler
 import os
+import sys
 from siliconcompiler.tools.builtin import nop
 from unittest.mock import patch
 import pytest
+
+
+if sys.platform == 'win32' and sys.version_info >= (3, 11):
+    pytest.skip("Skipping test on Windows with Python >3.11", allow_module_level=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
**What?**
The wheels test on Windows with Python 3.11 fails with no apparent reason.
https://github.com/siliconcompiler/siliconcompiler/actions/runs/5873062166/job/15927788456

**Why?**
There seems to be some weird changes going on related to the environment variables on Windows + Python 3.11.


**How?**
Write a proper fixture so variables are not shared between tests.
Don't run the failing test cases on the platform

**Test**
Wheels passes again:
https://github.com/siliconcompiler/siliconcompiler/actions/runs/5883403874/job/15956049276

**Original failing test for documentation purposes**
```
___________________________ test_check_display_run ____________________________
  
      @patch('sys.platform', 'linux')
      def test_check_display_run():
          # Checks if _check_display() is called during run()
          chip = siliconcompiler.Chip('test')
      
          flow = 'test'
          chip.set('option', 'flow', flow)
          chip.node(flow, 'import', nop)
          chip.set('option', 'mode', 'asic')
          with patch.dict(os.environ, modified_environ, clear=True):
  >           chip.run()
  
  D:\a\siliconcompiler\siliconcompiler\tests\core\test_check_display.py:21: 
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  C:\Users\runneradmin\AppData\Local\Temp\cibw-run-ww4nohk4\cp311-win_amd64\venv-test\Lib\site-packages\siliconcompiler\core.py:4224: in run
      processes[node].start()
  C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.11.2\tools\Lib\multiprocessing\process.py:121: in start
      self._popen = self._Popen(self)
  C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.11.2\tools\Lib\multiprocessing\context.py:336: in _Popen
      return Popen(process_obj)
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  
  self = <multiprocessing.popen_spawn_win32.Popen object at 0x000001F3AADD7F90>
  process_obj = <SpawnProcess name='SpawnProcess-1' parent=2052 initial>
  
      def __init__(self, process_obj):
          prep_data = spawn.get_preparation_data(process_obj._name)
      
          # read end of pipe will be duplicated by the child process
          # -- see spawn_main() in spawn.py.
          #
          # bpo-33929: Previously, the read end of pipe was "stolen" by the child
          # process, but it leaked a handle if the child process had been
          # terminated before it could steal the handle from the parent process.
          rhandle, whandle = _winapi.CreatePipe(None, 0)
          wfd = msvcrt.open_osfhandle(whandle, 0)
          cmd = spawn.get_command_line(parent_pid=os.getpid(),
                                       pipe_handle=rhandle)
      
          python_exe = spawn.get_executable()
      
          # bpo-35797: When running in a venv, we bypass the redirect
          # executor and launch our base Python.
          if WINENV and _path_eq(python_exe, sys.executable):
              cmd[0] = python_exe = sys._base_executable
              env = os.environ.copy()
              env["__PYVENV_LAUNCHER__"] = sys.executable
          else:
              env = None
      
          cmd = ' '.join('"%s"' % x for x in cmd)
      
          with open(wfd, 'wb', closefd=True) as to_child:
              # start process
              try:
  >               hp, ht, pid, tid = _winapi.CreateProcess(
                      python_exe, cmd,
                      None, None, False, 0, env, None, None)
  E                   TypeError: argument must be str or None, not bytes
  
  C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.11.2\tools\Lib\multiprocessing\popen_spawn_win32.py:74: TypeError
  ---------------------------- Captured stdout call -----------------------------
  | WARNING | Environment variable $DISPLAY or $WAYLAND_DISPLAY not set
  | WARNING | Setting ['option', 'nodisplay'] to True
  | INFO    | job0  | -       | -  | Checking manifest before running.
```