### PR TITLE
add : cntrl+c capturing to remote run 

### DIFF
--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -10,10 +10,10 @@ import urllib.parse
 import tarfile
 import tempfile
 import multiprocessing
-import sys
 
 from siliconcompiler._metadata import default_server
 from siliconcompiler import utils
+from siliconcompiler import SiliconCompilerError
 
 
 # Client / server timeout
@@ -290,7 +290,7 @@ def remote_run_loop(chip):
         chip.logger.info('Disconnecting from remote job')
         chip.logger.info(f'To reconnect to this job use: {reconnect_cmd}')
         chip.logger.info(f'To cancel this job use: {cancel_cmd}')
-        sys.exit(0)
+        raise SiliconCompilerError('Job canceled by user keyboard interrupt')
 
 
 ###################################

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -280,8 +280,14 @@ def remote_run_loop(chip):
         __remote_run_loop(chip)
     except KeyboardInterrupt:
         jobid = chip.status['jobhash']
-        reconnect_cmd = f'sc-remote -jobid {jobid} -reconnect'
+        entry_step, entry_index = \
+            chip._get_flowgraph_entry_nodes(flow=chip.get('option', 'flow'))[0]
+        entry_manifest = os.path.join(chip._getworkdir(step=entry_step, index=entry_index),
+                                      'outputs',
+                                      f'{chip.design}.pkg.json')
+        reconnect_cmd = f'sc-remote -jobid {jobid} -cfg {entry_manifest} -reconnect'
         cancel_cmd = f'sc-remote -jobid {jobid} -cancel'
+        chip.logger.info('Disconnecting from remote job')
         chip.logger.info(f'To reconnect to this job use: {reconnect_cmd}')
         chip.logger.info(f'To cancel this job use: {cancel_cmd}')
         sys.exit(0)


### PR DESCRIPTION
Allows a user to do Control+C to exit out of SC and gives the required information to resume the connection