### PR TITLE
Refactor Verilator driver to allow user options

### DIFF
--- a/siliconcompiler/tools/verilator/lint.py
+++ b/siliconcompiler/tools/verilator/lint.py
@@ -11,14 +11,8 @@ def setup(chip):
     # Generic tool setup.
     setup_tool(chip)
 
-    tool = 'verilator'
-    step = chip.get('arg', 'step')
-    index = chip.get('arg', 'index')
-    task = chip._get_task(step, index)
-
-    chip.add('tool', tool, 'task', task, 'option', ['--lint-only'],
-             step=step, index=index)
-
 
 def runtime_options(chip):
-    return runtime_options_tool(chip)
+    cmdlist = runtime_options_tool(chip)
+    cmdlist.append('--lint-only')
+    return cmdlist


### PR DESCRIPTION
This PR moves Verilator driver command line options to `runtime_options()`. This makes it so a user can supply custom CLI options using the tool/task parameter. 

cc @petergrossmann21 