### PR TITLE
add _remove to schema object to help remove default keys

### DIFF
--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -295,6 +295,29 @@ class Schema:
         return True
 
     ###########################################################################
+    def _remove(self, *keypath):
+        '''
+        Removes a keypath from the schema.
+        '''
+        search_path = keypath[0:-1]
+        removal_key = keypath[-1]
+
+        if removal_key == 'default':
+            self.logger.error(f'Cannot remove default keypath: {keypath}')
+            return
+
+        cfg = self._search(*search_path)
+        if 'default' not in cfg:
+            self.logger.error(f'Cannot remove a non-default keypath: {keypath}')
+            return
+
+        if removal_key not in cfg:
+            self.logger.error(f'Key does not exist: {keypath}')
+            return
+
+        del cfg[removal_key]
+
+    ###########################################################################
     def unset(self, *keypath, step=None, index=None):
         '''
         Unsets a schema parameter field.

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -315,6 +315,12 @@ class Schema:
             self.logger.error(f'Key does not exist: {keypath}')
             return
 
+        for key in self.allkeys(*keypath):
+            fullpath = [*keypath, *key]
+            if self.get(*fullpath, field='lock'):
+                self.logger.error(f'Key is locked: {fullpath}')
+                return
+
         del cfg[removal_key]
 
     ###########################################################################

--- a/tests/schema/test_unset.py
+++ b/tests/schema/test_unset.py
@@ -54,3 +54,21 @@ def test_unset_optional_pernode():
 
     schema.set('asic', 'logiclib', 'syn_lib', step='syn', index=0, clobber=False)
     assert schema.get('asic', 'logiclib', step='syn', index=0) == ['default_lib']
+
+
+def test_key_removal():
+    schema = Schema()
+    schema.set('constraint', 'component', 'test_inst', 'placement', (0, 0, 0))
+
+    assert schema.valid('constraint', 'component', 'test_inst', 'placement')
+    assert schema.get('constraint', 'component', 'test_inst', 'placement') == (0, 0, 0)
+    schema._remove('constraint', 'component', 'test_inst')
+    assert not schema.valid('constraint', 'component', 'test_inst', 'placement')
+
+    # Check that non-default keys cannot be removed
+    schema._remove('option', 'idir')
+    assert schema.valid('option', 'idir')
+
+    # Check that non-default groups cannot be removed
+    schema._remove('option')
+    assert schema.valid('option', 'idir')

--- a/tests/schema/test_unset.py
+++ b/tests/schema/test_unset.py
@@ -65,6 +65,13 @@ def test_key_removal():
     schema._remove('constraint', 'component', 'test_inst')
     assert not schema.valid('constraint', 'component', 'test_inst', 'placement')
 
+    # Check if keys are locked
+    schema.set('constraint', 'component', 'test_inst', 'placement', (0, 0, 0))
+    schema.set('constraint', 'component', 'test_inst', 'placement', True, field='lock')
+    schema.set('constraint', 'component', 'test_inst', 'rotation', 0)
+    schema._remove('constraint', 'component', 'test_inst')
+    assert schema.valid('constraint', 'component', 'test_inst', 'placement')
+
     # Check that non-default keys cannot be removed
     schema._remove('option', 'idir')
     assert schema.valid('option', 'idir')


### PR DESCRIPTION
This is useful when removing previously set constraints like components or timing corners.

Only allows removal of user definable keys (ie. default keys)