### PR TITLE
Remove skipcheck from gcd test cases

### DIFF
--- a/examples/gcd/gcd.py
+++ b/examples/gcd/gcd.py
@@ -15,7 +15,6 @@ def main(root='.'):
     chip.set('option', 'quiet', True)
     chip.set('option', 'track', True)
     chip.set('option', 'hash', True)
-    chip.set('option', 'skipcheck', True)
     chip.set('option', 'novercheck', True)
     chip.set('option', 'nodisplay', True)
     chip.set('constraint', 'outline', [(0, 0), (100.13, 100.8)])

--- a/examples/gcd/gcd_multiflow.py
+++ b/examples/gcd/gcd_multiflow.py
@@ -14,7 +14,6 @@ def main():
     chip.input('gcd.sdc')
     chip.set('option', 'relax', True)
     chip.set('option', 'quiet', True)
-    chip.set('option', 'skipcheck', True)
 
     chip.load_target("skywater130_demo")
 

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -83,7 +83,6 @@ def test_py_read_manifest(scroot):
     chip.set('option', 'quiet', True)
     chip.set('option', 'track', True)
     chip.set('option', 'hash', True)
-    chip.set('option', 'skipcheck', True)
     chip.set('option', 'novercheck', True)
     chip.set('option', 'nodisplay', True)
     chip.set('constraint', 'outline', [(0, 0), (100.13, 100.8)])


### PR DESCRIPTION
I couldn't find a reason as to why this option is enabled for regular test cases.