### PR TITLE
fix default setting for macro extensions and add helper messages to global router setup

### DIFF
--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -777,7 +777,7 @@ def _define_grt_params(chip):
                    schelp='maximum number of iterations to use in global routing when '
                           'attempting to solve overflow')
     _set_parameter(chip, param_key='grt_macro_extension',
-                   default_value='2',
+                   default_value='0',
                    schelp='macro extension distance in number of gcells, this can be useful '
                           'when the detailed router needs additional space to avoid DRCs')
     _set_parameter(chip, param_key='grt_allow_congestion',

--- a/siliconcompiler/tools/openroad/scripts/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_apr.tcl
@@ -384,8 +384,13 @@ if {$sc_task != "floorplan"} {
     }
   }
 
-  set_macro_extension $openroad_grt_macro_extension
+  if { $openroad_grt_macro_extension > 0 } {
+    utl::info FLW 1 "Setting global routing macro extension to $openroad_grt_macro_extension gcells"
+    set_macro_extension $openroad_grt_macro_extension
+  }
+  utl::info FLW 1 "Setting global routing signal routing layers to: ${openroad_grt_signal_min_layer}-${openroad_grt_signal_max_layer}"
   set_routing_layers -signal "${openroad_grt_signal_min_layer}-${openroad_grt_signal_max_layer}"
+  utl::info FLW 1 "Setting global routing clock routing layers to: ${openroad_grt_signal_min_layer}-${openroad_grt_signal_max_layer}"
   set_routing_layers -clock "${openroad_grt_clock_min_layer}-${openroad_grt_clock_max_layer}"
 }
 


### PR DESCRIPTION
Changing macro_extension in openroad to 0 by default as this makes routing easier in almost all cases.