### PR TITLE
deprecate support for python3.6 and python3.7 as they are EOL

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Checkout SiliconCompiler
         uses: actions/checkout@v3

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -13,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - {python: "3.6", os: "ubuntu-20.04"}
-          - {python: "3.7", os: "ubuntu-latest"}
           - {python: "3.8", os: "ubuntu-latest"}
           - {python: "3.9", os: "ubuntu-latest"}
           - {python: "3.10", os: "ubuntu-latest"}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -227,7 +227,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [cp36-cp36m, cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310, cp311-cp311]
+        python: [cp38-cp38, cp39-cp39, cp310-cp310, cp311-cp311]
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ A. Olofsson, W. Ransohoff, N. Moroze, "[Invited: A Distributed Approach to Silic
 # Getting Started
 
 SiliconCompiler is available as wheel packages on PyPI for macOS, Windows and
-Linux platforms. For working Python 3.6-3.11 environment, just use pip.
+Linux platforms. For working Python 3.8-3.11 environment, just use pip.
 
 ```sh
 python -m pip install --upgrade siliconcompiler

--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -41,8 +41,8 @@ Open up a terminal and enter the following command sequence.
 .. code-block:: bash
 
    sudo subscription-manager repos --enable rhel-server-rhscl-7-rpms  # enable Red Hat Software Collections repository
-   sudo yum -y install rh-python36                                    # install Python 3.6
-   scl enable rh-python36 bash                                        # enable Python in current environment
+   sudo yum -y install rh-python38                                    # install Python 3.8
+   scl enable rh-python38 bash                                        # enable Python in current environment
    python3 --version                                                  # check for Python 3
    python3 -m venv ./venv                                             # create a virtual env
    source ./venv/bin/activate                                         # active virtual env (bash/zsh)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,11 +22,11 @@ Pillow >= 8.4.0
 GitPython >= 3.1.0
 
 # Report
-streamlit; python_version >= "3.7"
-streamlit_agraph; python_version >= "3.7"
-streamlit_tree_select; python_version >= "3.7"
-streamlit_javascript; python_version >= "3.7"
-altair==4; python_version >= "3.7"
+streamlit
+streamlit_agraph
+streamlit_tree_select
+streamlit_javascript
+altair==4
 
 # Build dependencies
 #:build

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ setup(
         'siliconcompiler.checklists': get_package_data('.', 'siliconcompiler/checklists'),
     },
 
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     install_requires=install_reqs,
     extras_require=extras_req,
     entry_points={"console_scripts": entry_points_apps},

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4580,7 +4580,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             if self.__relative_path:
                 work_dir = os.path.relpath(work_dir, self.__relative_path)
             print(f'cd {work_dir}', file=f)
-            print(' '.join(f'"{arg}"' if ' ' in arg else arg for arg in replay_cmdlist), file=f)
+            print(shlex.join(replay_cmdlist), file=f)
 
         os.chmod(script_name, 0o755)
 

--- a/siliconcompiler/report/streamlit_report.py
+++ b/siliconcompiler/report/streamlit_report.py
@@ -2,11 +2,9 @@ import os
 import time
 import tempfile
 import json
-import sys
 
-if sys.version_info >= (3, 7, 0):
-    from streamlit.web import bootstrap
-    from streamlit import config as _config
+from streamlit.web import bootstrap
+from streamlit import config as _config
 
 import multiprocessing
 import subprocess
@@ -18,9 +16,6 @@ class Dashboard():
     __port = 8501
 
     def __init__(self, chip, port=None, graph_chips=None):
-        if sys.version_info < (3, 7, 0):
-            raise RuntimeError("Dashboard is not available for Python <3.7")
-
         if not port:
             port = Dashboard.__port
 

--- a/tests/core/test_dashboard.py
+++ b/tests/core/test_dashboard.py
@@ -1,12 +1,8 @@
 import siliconcompiler
 from siliconcompiler.targets import freepdk45_demo
 import time
-import sys
-import pytest
 
 
-@pytest.mark.skipif(sys.version_info.major == 3 and sys.version_info.minor == 6,
-                    reason="Dashboard not available in 3.6")
 def test_dashboard():
     chip = siliconcompiler.Chip('dashboard')
     chip.load_target(freepdk45_demo)


### PR DESCRIPTION
This removes support for 3.6 and 3.7.
Changes:
- removes wheels builds for those versions
- updates docs to use minimum version of 3.8
