### PR TITLE
Add 'resume' functionality to remote runs

### DIFF
--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -131,9 +131,10 @@ def remote_preprocess(chip, steplist):
     # If 'resume' is set, and the entry steps have completed, no action is needed.
     # Otherwise, proceed to run entry steps and set the flowgraph to run the whole job.
     if not (chip.get('option', 'resume') and entry_success):
-        if any([step not in remote_steplist for step, _ in entry_steps]) or (len(remote_steplist) == 1):
-            chip.error('Remote flows must be organized such that the starting task(s) are run before '
-                       'all other steps, and at least one other task is included.\n'
+        if any([step not in remote_steplist for step, _ in entry_steps]) \
+           or (len(remote_steplist) == 1):
+            chip.error('Remote flows must be organized such that the starting task(s) are '
+                       'run before all other steps, and at least one other task is included.\n'
                        f'Full steplist: {remote_steplist}\nStarting steps: {entry_steps}',
                        fatal=True)
         # Setup up tools for all local functions


### PR DESCRIPTION
Since the server runs remote jobs using the core `chip.run()` call, we only need some minor client-side changes to make the remote flow work with `('option', 'resume')`.

This change will let us resume partially-completed jobs on a server, functionality which has been helpful with large local jobs in the past. It also cleans up some logging when the server returns empty task archives, which it will do for any completed tasks that get uploaded in order to resume a job.

The feature works by re-submitting completed tasks from a local build directory, so users will only be able to resume jobs on servers which return the full `outputs/` directory for each flowgraph node. Otherwise, the local build directories won't contain the processed design files which are needed by steps that come later in the flowgraph.

Most of the changes are just indentation. The main `remote_preprocess` modifications are in lines 123-133.