### PR TITLE
Move job IDs into the core Schema

### DIFF
--- a/siliconcompiler/apps/sc_remote.py
+++ b/siliconcompiler/apps/sc_remote.py
@@ -49,10 +49,6 @@ def main():
     elif ((args['reconnect'] or args['cancel'] or args['delete']) and not chip_cfg):
         chip.logger.error('Error: -cfg is required for -reconnect, -cancel, and -delete')
         return 1
-    elif (args['reconnect'] and not chip_cfg):
-        chip.logger.error("Error: -cfg is required for -reconnect. Recommended value is "
-                          "the post-import manifest in the job's original build directory.")
-        return 1
 
     # Read in credentials from file, if specified and available.
     # Otherwise, use the default server address.

--- a/siliconcompiler/apps/sc_remote.py
+++ b/siliconcompiler/apps/sc_remote.py
@@ -39,16 +39,17 @@ def main():
                                description=description)
 
     # Sanity checks.
+    chip_cfg = chip.get('option', 'cfg')
     if (args['reconnect'] and (args['cancel'] or args['delete'])):
         chip.logger.error('Error: -reconnect is mutually exclusive to -cancel and -delete')
         return 1
     elif (args['cancel'] and (args['reconnect'] or args['delete'])):
         chip.logger.error('Error: -cancel is mutually exclusive to -reconnect and -delete')
         return 1
-    elif ((args['reconnect'] or args['cancel'] or args['delete']) and not chip.get('option', 'cfg')):
+    elif ((args['reconnect'] or args['cancel'] or args['delete']) and not chip_cfg):
         chip.logger.error('Error: -cfg is required for -reconnect, -cancel, and -delete')
         return 1
-    elif (args['reconnect'] and not chip.get('option', 'cfg')):
+    elif (args['reconnect'] and not chip_cfg):
         chip.logger.error("Error: -cfg is required for -reconnect. Recommended value is "
                           "the post-import manifest in the job's original build directory.")
         return 1
@@ -92,7 +93,7 @@ def main():
         # and node names from a call to 'check_progress/'.
         # Also, total runtime value will be incorrect; maybe we can have the
         # server return the job's "created_at" time in the check_progress/ response.
-        chip.read_manifest(chip.get('option', 'cfg')[0])
+        chip.read_manifest(chip_cfg[0])
         # Remove entry steps from the steplist, so that they are not fetched from the remote.
         remote_steps = chip.list_steps()
         environment = copy.deepcopy(os.environ)
@@ -108,7 +109,7 @@ def main():
         chip.summary()
 
     # If only a manifest is specified, make a 'check_progress/' request and report results:
-    elif chip.get('option', 'cfg'):
+    elif chip_cfg:
         check_progress(chip)
 
     # Done

--- a/siliconcompiler/apps/sc_remote.py
+++ b/siliconcompiler/apps/sc_remote.py
@@ -82,14 +82,6 @@ def main():
     # If the -reconnect flag is specified, re-enter the client flow
     # in its "check_progress/ until job is done" loop.
     elif args['reconnect']:
-        # TODO: Will require optional '-cfg' argument, we can't reconnect
-        # without the job's manifest. If we update the server to return the
-        # design name in the 'check_progress/' response, we could instead accept
-        # optional '-builddir' and '-jobname' arguments, then get the design
-        # and node names from a call to 'check_progress/'.
-        # Also, total runtime value will be incorrect; maybe we can have the
-        # server return the job's "created_at" time in the check_progress/ response.
-        chip.read_manifest(chip_cfg[0])
         # Remove entry steps from the steplist, so that they are not fetched from the remote.
         remote_steps = chip.list_steps()
         environment = copy.deepcopy(os.environ)

--- a/siliconcompiler/apps/sc_remote.py
+++ b/siliconcompiler/apps/sc_remote.py
@@ -18,9 +18,9 @@ def main():
     SC app that provides an entry point to common remote / server
     interactions. Can be used to:
     * Check software versions on the server (no flags)
-    * Check an ongoing job's progress (-jobid)
-    * Cancel an ongoing job (-jobid + -cancel)
-    * Re-attach SC client to an ongoing job (-jobid + -attach)
+    * Check an ongoing job's progress (-cfg)
+    * Cancel an ongoing job (-cfg + -cancel)
+    * Re-attach SC client to an ongoing job (-cfg + -attach)
     -----------------------------------------------------------
     """
 
@@ -29,7 +29,6 @@ def main():
     chip = Chip(progname)
     switchlist = ['-cfg', '-credentials']
     extra_args = {
-        '-jobid': {'required': False},
         '-reconnect': {'action': 'store_true', 'required': False},
         '-cancel': {'action': 'store_true', 'required': False},
         '-delete': {'action': 'store_true', 'required': False},
@@ -46,8 +45,8 @@ def main():
     elif (args['cancel'] and (args['reconnect'] or args['delete'])):
         chip.logger.error('Error: -cancel is mutually exclusive to -reconnect and -delete')
         return 1
-    elif ((args['reconnect'] or args['cancel'] or args['delete']) and not args['jobid']):
-        chip.logger.error('Error: -jobid is required for -reconnect, -cancel, and -delete')
+    elif ((args['reconnect'] or args['cancel'] or args['delete']) and not chip.get('option', 'cfg')):
+        chip.logger.error('Error: -cfg is required for -reconnect, -cancel, and -delete')
         return 1
     elif (args['reconnect'] and not chip.get('option', 'cfg')):
         chip.logger.error("Error: -cfg is required for -reconnect. Recommended value is "
@@ -73,7 +72,6 @@ def main():
     # If no job-related options are specified, fetch and report basic info.
     # Create temporary Chip object and check on the server.
     chip.status['remote_cfg'] = remote_cfg
-    chip.status['jobhash'] = args['jobid']
     remote_ping(chip)
 
     # If the -cancel flag is specified, cancel the job.
@@ -109,8 +107,8 @@ def main():
         chip._finalize_run(chip.list_steps(), environment)
         chip.summary()
 
-    # If only a job ID is specified, make a 'check_progress/' request and report results:
-    elif args['jobid']:
+    # If only a manifest is specified, make a 'check_progress/' request and report results:
+    elif chip.get('option', 'cfg'):
         check_progress(chip)
 
     # Done

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -84,7 +84,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         # The 'status' dictionary can be used to store ephemeral config values.
         # Its contents will not be saved, and can be set by parent scripts
         # such as a web server or supervisor process. Currently supported keys:
-        # * 'jobhash': A hash or UUID which can identify jobs in a larger system.
         # * 'remote_cfg': Dictionary containing remote server configurations
         #                 (address, credentials, etc.)
         # * 'slurm_account': User account ID in a connected slurm HPC cluster.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4059,7 +4059,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                     for metric in self.getkeys('metric'):
                         self._clear_metric(step, index, metric)
                     for record in self.getkeys('record'):
-                        self.unset('record', record, step=step, index=index)
+                        self._clear_record(step, index, record)
                 elif os.path.isfile(cfg):
                     self.set('flowgraph', flow, step, index, 'status', TaskStatus.SUCCESS)
                     all_indices_failed = False
@@ -4075,7 +4075,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                         for metric in self.getkeys('metric'):
                             self._clear_metric(step, index, metric)
                         for record in self.getkeys('record'):
-                            self.unset('record', record, step=step, index=index)
+                            self._clear_record(step, index, record)
 
         # Set env variables
         # Save current environment
@@ -4982,6 +4982,17 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         self.unset('metric', metric, step=step, index=index)
         self.unset('tool', tool, 'task', task, 'report', metric, step=step, index=index)
+
+    #######################################
+    def _clear_record(self, step, index, record):
+        '''
+        Helper function to clear record parameters
+        '''
+
+        if self.get('record', record, field='pernode') == 'never':
+            self.unset('record', record)
+        else:
+            self.unset('record', record, step=step, index=index)
 
     #######################################
     def __getstate__(self):

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -361,7 +361,7 @@ def update_entry_manifests(chip):
     '''
 
     flow = chip.get('option', 'flow')
-    jobid = chip.get('record', 'jobid')
+    jobid = chip.get('option', 'jobid')
     design = chip.get('design')
 
     entry_nodes = chip._get_flowgraph_entry_nodes(flow=flow)
@@ -370,7 +370,7 @@ def update_entry_manifests(chip):
                                      'outputs',
                                      f'{design}.pkg.json')
         tmp_schema = Schema(manifest=manifest_path)
-        tmp_schema.set('record', 'jobid', jobid)
+        tmp_schema.set('option', 'jobid', jobid)
         with open(manifest_path, 'w') as new_manifest:
             tmp_schema.write_json(new_manifest)
 
@@ -429,7 +429,7 @@ def request_remote_run(chip):
 
     if 'message' in resp and resp['message']:
         chip.logger.info(resp['message'])
-    chip.set('record', 'jobid', resp['job_hash'])
+    chip.set('option', 'jobid', resp['job_hash'])
     update_entry_manifests(chip)
     chip.logger.info(f"Your job's reference ID is: {resp['job_hash']}")
 
@@ -445,7 +445,7 @@ def is_job_busy(chip):
     # Make the request and print its response.
     def post_action(url):
         params = __build_post_params(chip,
-                                     job_hash=chip.get('record', 'jobid'),
+                                     job_hash=chip.get('option', 'jobid'),
                                      job_name=chip.get('option', 'jobname'))
         return requests.post(url,
                              data=json.dumps(params),
@@ -501,7 +501,7 @@ def cancel_job(chip):
         return requests.post(url,
                              data=json.dumps(__build_post_params(
                                  chip,
-                                 job_hash=chip.get('record', 'jobid'))),
+                                 job_hash=chip.get('option', 'jobid'))),
                              timeout=__timeout)
 
     def success_action(resp):
@@ -520,7 +520,7 @@ def delete_job(chip):
         return requests.post(url,
                              data=json.dumps(__build_post_params(
                                  chip,
-                                 job_hash=chip.get('record', 'jobid'))),
+                                 job_hash=chip.get('option', 'jobid'))),
                              timeout=__timeout)
 
     def success_action(resp):
@@ -542,7 +542,7 @@ def fetch_results_request(chip, node, results_path):
     '''
 
     # Set the request URL.
-    job_hash = chip.get('record', 'jobid')
+    job_hash = chip.get('option', 'jobid')
 
     # Fetch results archive.
     with open(results_path, 'wb') as zipf:
@@ -582,7 +582,7 @@ def fetch_results(chip, node, results_path=None):
 
     # Collect local values.
     top_design = chip.get('design')
-    job_hash = chip.get('record', 'jobid')
+    job_hash = chip.get('option', 'jobid')
     local_dir = chip.get('option', 'builddir')
 
     # Set default results archive path if necessary, and fetch it.

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -355,13 +355,13 @@ def check_progress(chip):
 
 
 ###################################
-def update_entry_manifests(chip):
+def _update_entry_manifests(chip):
     '''
     Helper method to update locally-run manifests to include remote job ID.
     '''
 
     flow = chip.get('option', 'flow')
-    jobid = chip.get('record', 'jobid')
+    jobid = chip.get('record', 'remoteid')
     design = chip.get('design')
 
     entry_nodes = chip._get_flowgraph_entry_nodes(flow=flow)
@@ -370,7 +370,7 @@ def update_entry_manifests(chip):
                                      'outputs',
                                      f'{design}.pkg.json')
         tmp_schema = Schema(manifest=manifest_path)
-        tmp_schema.set('record', 'jobid', jobid)
+        tmp_schema.set('record', 'remoteid', jobid)
         with open(manifest_path, 'w') as new_manifest:
             tmp_schema.write_json(new_manifest)
 
@@ -429,8 +429,8 @@ def request_remote_run(chip):
 
     if 'message' in resp and resp['message']:
         chip.logger.info(resp['message'])
-    chip.set('record', 'jobid', resp['job_hash'])
-    update_entry_manifests(chip)
+    chip.set('record', 'remoteid', resp['job_hash'])
+    _update_entry_manifests(chip)
     chip.logger.info(f"Your job's reference ID is: {resp['job_hash']}")
 
 
@@ -445,7 +445,7 @@ def is_job_busy(chip):
     # Make the request and print its response.
     def post_action(url):
         params = __build_post_params(chip,
-                                     job_hash=chip.get('record', 'jobid'),
+                                     job_hash=chip.get('record', 'remoteid'),
                                      job_name=chip.get('option', 'jobname'))
         return requests.post(url,
                              data=json.dumps(params),
@@ -501,7 +501,7 @@ def cancel_job(chip):
         return requests.post(url,
                              data=json.dumps(__build_post_params(
                                  chip,
-                                 job_hash=chip.get('record', 'jobid'))),
+                                 job_hash=chip.get('record', 'remoteid'))),
                              timeout=__timeout)
 
     def success_action(resp):
@@ -520,7 +520,7 @@ def delete_job(chip):
         return requests.post(url,
                              data=json.dumps(__build_post_params(
                                  chip,
-                                 job_hash=chip.get('record', 'jobid'))),
+                                 job_hash=chip.get('record', 'remoteid'))),
                              timeout=__timeout)
 
     def success_action(resp):
@@ -542,7 +542,7 @@ def fetch_results_request(chip, node, results_path):
     '''
 
     # Set the request URL.
-    job_hash = chip.get('record', 'jobid')
+    job_hash = chip.get('record', 'remoteid')
 
     # Fetch results archive.
     with open(results_path, 'wb') as zipf:
@@ -582,7 +582,7 @@ def fetch_results(chip, node, results_path=None):
 
     # Collect local values.
     top_design = chip.get('design')
-    job_hash = chip.get('record', 'jobid')
+    job_hash = chip.get('record', 'remoteid')
     local_dir = chip.get('option', 'builddir')
 
     # Set default results archive path if necessary, and fetch it.

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -499,8 +499,9 @@ def cancel_job(chip):
 
     def post_action(url):
         return requests.post(url,
-                             data=json.dumps(__build_post_params(chip,
-                                                                 job_hash=chip.get('record', 'jobid'))),
+                             data=json.dumps(__build_post_params(
+                                 chip,
+                                 job_hash=chip.get('record', 'jobid'))),
                              timeout=__timeout)
 
     def success_action(resp):
@@ -517,8 +518,9 @@ def delete_job(chip):
 
     def post_action(url):
         return requests.post(url,
-                             data=json.dumps(__build_post_params(chip,
-                                                                 job_hash=chip.get('record', 'jobid'))),
+                             data=json.dumps(__build_post_params(
+                                 chip,
+                                 job_hash=chip.get('record', 'jobid'))),
                              timeout=__timeout)
 
     def success_action(resp):

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -279,7 +279,7 @@ def remote_run_loop(chip):
     try:
         __remote_run_loop(chip)
     except KeyboardInterrupt:
-        jobid = chip.status['jobhash']
+        jobid = chip.get('record', 'jobid')
         entry_step, entry_index = \
             chip._get_flowgraph_entry_nodes(flow=chip.get('option', 'flow'))[0]
         entry_manifest = os.path.join(chip._getworkdir(step=entry_step, index=entry_index),
@@ -409,8 +409,8 @@ def request_remote_run(chip):
 
     if 'message' in resp and resp['message']:
         chip.logger.info(resp['message'])
-    chip.status['jobhash'] = resp['job_hash']
-    chip.logger.info(f"Your job's reference ID is: {chip.status['jobhash']}")
+    chip.set('record', 'jobid', resp['job_hash'])
+    chip.logger.info(f"Your job's reference ID is: {resp['job_hash']}")
 
 
 ###################################
@@ -424,7 +424,7 @@ def is_job_busy(chip):
     # Make the request and print its response.
     def post_action(url):
         params = __build_post_params(chip,
-                                     job_hash=chip.status['jobhash'],
+                                     job_hash=chip.get('record', 'jobid'),
                                      job_name=chip.get('option', 'jobname'))
         return requests.post(url,
                              data=json.dumps(params),
@@ -479,7 +479,7 @@ def cancel_job(chip):
     def post_action(url):
         return requests.post(url,
                              data=json.dumps(__build_post_params(chip,
-                                                                 job_hash=chip.status['jobhash'])),
+                                                                 job_hash=chip.get('record', 'jobid'))),
                              timeout=__timeout)
 
     def success_action(resp):
@@ -497,7 +497,7 @@ def delete_job(chip):
     def post_action(url):
         return requests.post(url,
                              data=json.dumps(__build_post_params(chip,
-                                                                 job_hash=chip.status['jobhash'])),
+                                                                 job_hash=chip.get('record', 'jobid'))),
                              timeout=__timeout)
 
     def success_action(resp):
@@ -519,7 +519,7 @@ def fetch_results_request(chip, node, results_path):
     '''
 
     # Set the request URL.
-    job_hash = chip.status['jobhash']
+    job_hash = chip.get('record', 'jobid')
 
     # Fetch results archive.
     with open(results_path, 'wb') as zipf:
@@ -559,7 +559,7 @@ def fetch_results(chip, node, results_path=None):
 
     # Collect local values.
     top_design = chip.get('design')
-    job_hash = chip.status['jobhash']
+    job_hash = chip.get('record', 'jobid')
     local_dir = chip.get('option', 'builddir')
 
     # Set default results archive path if necessary, and fetch it.

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -361,7 +361,7 @@ def update_entry_manifests(chip):
     '''
 
     flow = chip.get('option', 'flow')
-    jobid = chip.get('option', 'jobid')
+    jobid = chip.get('record', 'jobid')
     design = chip.get('design')
 
     entry_nodes = chip._get_flowgraph_entry_nodes(flow=flow)
@@ -370,7 +370,7 @@ def update_entry_manifests(chip):
                                      'outputs',
                                      f'{design}.pkg.json')
         tmp_schema = Schema(manifest=manifest_path)
-        tmp_schema.set('option', 'jobid', jobid)
+        tmp_schema.set('record', 'jobid', jobid)
         with open(manifest_path, 'w') as new_manifest:
             tmp_schema.write_json(new_manifest)
 
@@ -429,7 +429,7 @@ def request_remote_run(chip):
 
     if 'message' in resp and resp['message']:
         chip.logger.info(resp['message'])
-    chip.set('option', 'jobid', resp['job_hash'])
+    chip.set('record', 'jobid', resp['job_hash'])
     update_entry_manifests(chip)
     chip.logger.info(f"Your job's reference ID is: {resp['job_hash']}")
 
@@ -445,7 +445,7 @@ def is_job_busy(chip):
     # Make the request and print its response.
     def post_action(url):
         params = __build_post_params(chip,
-                                     job_hash=chip.get('option', 'jobid'),
+                                     job_hash=chip.get('record', 'jobid'),
                                      job_name=chip.get('option', 'jobname'))
         return requests.post(url,
                              data=json.dumps(params),
@@ -501,7 +501,7 @@ def cancel_job(chip):
         return requests.post(url,
                              data=json.dumps(__build_post_params(
                                  chip,
-                                 job_hash=chip.get('option', 'jobid'))),
+                                 job_hash=chip.get('record', 'jobid'))),
                              timeout=__timeout)
 
     def success_action(resp):
@@ -520,7 +520,7 @@ def delete_job(chip):
         return requests.post(url,
                              data=json.dumps(__build_post_params(
                                  chip,
-                                 job_hash=chip.get('option', 'jobid'))),
+                                 job_hash=chip.get('record', 'jobid'))),
                              timeout=__timeout)
 
     def success_action(resp):
@@ -542,7 +542,7 @@ def fetch_results_request(chip, node, results_path):
     '''
 
     # Set the request URL.
-    job_hash = chip.get('option', 'jobid')
+    job_hash = chip.get('record', 'jobid')
 
     # Fetch results archive.
     with open(results_path, 'wb') as zipf:
@@ -582,7 +582,7 @@ def fetch_results(chip, node, results_path=None):
 
     # Collect local values.
     top_design = chip.get('design')
-    job_hash = chip.get('option', 'jobid')
+    job_hash = chip.get('record', 'jobid')
     local_dir = chip.get('option', 'builddir')
 
     # Set default results archive path if necessary, and fetch it.

--- a/siliconcompiler/remote/server.py
+++ b/siliconcompiler/remote/server.py
@@ -152,7 +152,7 @@ class Server:
         design = chip.design
         job_name = chip.get('option', 'jobname')
         job_hash = uuid.uuid4().hex
-        chip.set('record', 'jobid', job_hash)
+        chip.set('option', 'jobid', job_hash)
 
         # Ensure that the job's root directory exists.
         job_root = os.path.join(self.nfs_mount, job_hash)
@@ -322,7 +322,7 @@ class Server:
         '''
 
         # Assemble core job parameters.
-        job_hash = chip.get('record', 'jobid')
+        job_hash = chip.get('option', 'jobid')
         job_nameid = chip.get('option', 'jobname')
 
         # Mark the job run as busy.

--- a/siliconcompiler/remote/server.py
+++ b/siliconcompiler/remote/server.py
@@ -152,7 +152,7 @@ class Server:
         design = chip.design
         job_name = chip.get('option', 'jobname')
         job_hash = uuid.uuid4().hex
-        chip.status['jobhash'] = job_hash
+        chip.set('record', 'jobid', job_hash)
 
         # Ensure that the job's root directory exists.
         job_root = os.path.join(self.nfs_mount, job_hash)
@@ -322,7 +322,7 @@ class Server:
         '''
 
         # Assemble core job parameters.
-        job_hash = chip.status['jobhash']
+        job_hash = chip.get('record', 'jobid')
         job_nameid = chip.get('option', 'jobname')
 
         # Mark the job run as busy.

--- a/siliconcompiler/remote/server.py
+++ b/siliconcompiler/remote/server.py
@@ -152,7 +152,7 @@ class Server:
         design = chip.design
         job_name = chip.get('option', 'jobname')
         job_hash = uuid.uuid4().hex
-        chip.set('option', 'jobid', job_hash)
+        chip.set('record', 'jobid', job_hash)
 
         # Ensure that the job's root directory exists.
         job_root = os.path.join(self.nfs_mount, job_hash)
@@ -322,7 +322,7 @@ class Server:
         '''
 
         # Assemble core job parameters.
-        job_hash = chip.get('option', 'jobid')
+        job_hash = chip.get('record', 'jobid')
         job_nameid = chip.get('option', 'jobname')
 
         # Mark the job run as busy.

--- a/siliconcompiler/remote/server.py
+++ b/siliconcompiler/remote/server.py
@@ -152,7 +152,7 @@ class Server:
         design = chip.design
         job_name = chip.get('option', 'jobname')
         job_hash = uuid.uuid4().hex
-        chip.set('record', 'jobid', job_hash)
+        chip.set('record', 'remoteid', job_hash)
 
         # Ensure that the job's root directory exists.
         job_root = os.path.join(self.nfs_mount, job_hash)
@@ -322,7 +322,7 @@ class Server:
         '''
 
         # Assemble core job parameters.
-        job_hash = chip.get('record', 'jobid')
+        job_hash = chip.get('record', 'remoteid')
         job_nameid = chip.get('option', 'jobname')
 
         # Mark the job run as busy.

--- a/siliconcompiler/report/report.py
+++ b/siliconcompiler/report/report.py
@@ -50,7 +50,10 @@ def get_flowgraph_nodes(chip, step, index):
     if task is not None:
         nodes['task'] = task
     for key in chip.getkeys('record'):
-        value = chip.get('record', key, step=step, index=index)
+        if chip.get('record', key, field='pernode') == 'never':
+            value = chip.get('record', key)
+        else:
+            value = chip.get('record', key, step=step, index=index)
         if value is not None:
             nodes[key] = value
     return nodes

--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -57,7 +57,7 @@ def _deferstep(chip, step, index, status):
         partition = _get_slurm_partition()
 
     # Get the temporary UID associated with this job run.
-    job_hash = chip.get('record', 'jobid')
+    job_hash = chip.get('option', 'jobid')
     if not job_hash:
         # Generate a new uuid since it was not set
         job_hash = uuid.uuid4().hex

--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -57,9 +57,8 @@ def _deferstep(chip, step, index, status):
         partition = _get_slurm_partition()
 
     # Get the temporary UID associated with this job run.
-    if 'jobhash' in chip.status:
-        job_hash = chip.status['jobhash']
-    else:
+    job_hash = chip.get('record', 'jobid')
+    if not job_hash:
         # Generate a new uuid since it was not set
         job_hash = uuid.uuid4().hex
 

--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -60,7 +60,7 @@ def _deferstep(chip, step, index, status):
         partition = _get_slurm_partition()
 
     # Get the temporary UID associated with this job run.
-    job_hash = chip.get('record', 'jobid')
+    job_hash = chip.get('record', 'remoteid')
     if not job_hash:
         # Generate a new uuid since it was not set
         job_hash = uuid.uuid4().hex

--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -57,7 +57,7 @@ def _deferstep(chip, step, index, status):
         partition = _get_slurm_partition()
 
     # Get the temporary UID associated with this job run.
-    job_hash = chip.get('option', 'jobid')
+    job_hash = chip.get('record', 'jobid')
     if not job_hash:
         # Generate a new uuid since it was not set
         job_hash = uuid.uuid4().hex

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -2112,7 +2112,6 @@ def schema_record(cfg, step='default', index='default'):
             example=[
                 "cli: -record_jobid '0123456789abcdeffedcba9876543210'",
                 "api: chip.set('record', 'jobid', '0123456789abcdeffedcba9876543210')"],
-            pernode='optional',
             schelp='Record tracking the job ID for a remote run.')
 
     return cfg

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -2104,16 +2104,6 @@ def schema_record(cfg, step='default', index='default'):
                 pernode='required',
                 schelp=f'Record tracking the {val[0]} per step and index basis. {helpext}')
 
-    # Unlike most other 'record' fields, job ID is not set per-node.
-    scparam(cfg, ['record', 'jobid'],
-            sctype='str',
-            shorthelp="Record: remote job ID",
-            switch="-record_jobid 'step index <str>'",
-            example=[
-                "cli: -record_jobid '0123456789abcdeffedcba9876543210'",
-                "api: chip.set('record', 'jobid', '0123456789abcdeffedcba9876543210')"],
-            schelp='Record tracking the job ID for a remote run.')
-
     return cfg
 
 
@@ -2197,6 +2187,15 @@ def schema_option(cfg):
             username=<user id> (optional)
 
             password=<password / key used for authentication> (optional)""")
+
+    scparam(cfg, ['option', 'jobid'],
+            sctype='str',
+            shorthelp="Remote job ID",
+            switch="-option_jobid 'step index <str>'",
+            example=[
+                "cli: -option_jobid '0123456789abcdeffedcba9876543210'",
+                "api: chip.set('option', 'jobid', '0123456789abcdeffedcba9876543210')"],
+            schelp='Serverside UID for a remote job run.')
 
     scparam(cfg, ['option', 'nice'],
             sctype='int',

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from siliconcompiler.schema.utils import trim
 
-SCHEMA_VERSION = '0.35.0'
+SCHEMA_VERSION = '0.36.0'
 
 
 #############################################################################
@@ -2103,6 +2103,17 @@ def schema_record(cfg, step='default', index='default'):
                     f"api: chip.set('record', '{item}', '{val[1]}', step='dfm', index=0)"],
                 pernode='required',
                 schelp=f'Record tracking the {val[0]} per step and index basis. {helpext}')
+
+    # Unlike most other 'record' fields, job ID is not set per-node.
+    scparam(cfg, ['record', 'jobid'],
+            sctype='str',
+            shorthelp=f"Record: remote job ID",
+            switch=f"-record_jobid 'step index <str>'",
+            example=[
+                f"cli: -record_jobid '0123456789abcdeffedcba9876543210'",
+                f"api: chip.set('record', 'jobid', '0123456789abcdeffedcba9876543210')"],
+            pernode='optional',
+            schelp=f'Record tracking the job ID for a remote run.')
 
     return cfg
 

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -2104,6 +2104,16 @@ def schema_record(cfg, step='default', index='default'):
                 pernode='required',
                 schelp=f'Record tracking the {val[0]} per step and index basis. {helpext}')
 
+    # Unlike most other 'record' fields, job ID is not set per-node.
+    scparam(cfg, ['record', 'jobid'],
+            sctype='str',
+            shorthelp="Record: remote job ID",
+            switch="-record_jobid 'step index <str>'",
+            example=[
+                "cli: -record_jobid '0123456789abcdeffedcba9876543210'",
+                "api: chip.set('record', 'jobid', '0123456789abcdeffedcba9876543210')"],
+            schelp='Record tracking the job ID for a remote run.')
+
     return cfg
 
 
@@ -2187,15 +2197,6 @@ def schema_option(cfg):
             username=<user id> (optional)
 
             password=<password / key used for authentication> (optional)""")
-
-    scparam(cfg, ['option', 'jobid'],
-            sctype='str',
-            shorthelp="Remote job ID",
-            switch="-option_jobid 'step index <str>'",
-            example=[
-                "cli: -option_jobid '0123456789abcdeffedcba9876543210'",
-                "api: chip.set('option', 'jobid', '0123456789abcdeffedcba9876543210')"],
-            schelp='Serverside UID for a remote job run.')
 
     scparam(cfg, ['option', 'nice'],
             sctype='int',

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -2107,13 +2107,13 @@ def schema_record(cfg, step='default', index='default'):
     # Unlike most other 'record' fields, job ID is not set per-node.
     scparam(cfg, ['record', 'jobid'],
             sctype='str',
-            shorthelp=f"Record: remote job ID",
-            switch=f"-record_jobid 'step index <str>'",
+            shorthelp="Record: remote job ID",
+            switch="-record_jobid 'step index <str>'",
             example=[
-                f"cli: -record_jobid '0123456789abcdeffedcba9876543210'",
-                f"api: chip.set('record', 'jobid', '0123456789abcdeffedcba9876543210')"],
+                "cli: -record_jobid '0123456789abcdeffedcba9876543210'",
+                "api: chip.set('record', 'jobid', '0123456789abcdeffedcba9876543210')"],
             pernode='optional',
-            schelp=f'Record tracking the job ID for a remote run.')
+            schelp='Record tracking the job ID for a remote run.')
 
     return cfg
 

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -2105,13 +2105,13 @@ def schema_record(cfg, step='default', index='default'):
                 schelp=f'Record tracking the {val[0]} per step and index basis. {helpext}')
 
     # Unlike most other 'record' fields, job ID is not set per-node.
-    scparam(cfg, ['record', 'jobid'],
+    scparam(cfg, ['record', 'remoteid'],
             sctype='str',
             shorthelp="Record: remote job ID",
-            switch="-record_jobid 'step index <str>'",
+            switch="-record_remoteid 'step index <str>'",
             example=[
-                "cli: -record_jobid '0123456789abcdeffedcba9876543210'",
-                "api: chip.set('record', 'jobid', '0123456789abcdeffedcba9876543210')"],
+                "cli: -record_remoteid '0123456789abcdeffedcba9876543210'",
+                "api: chip.set('record', 'remoteid', '0123456789abcdeffedcba9876543210')"],
             schelp='Record tracking the job ID for a remote run.')
 
     return cfg

--- a/tests/apps/test_sc_remote.py
+++ b/tests/apps/test_sc_remote.py
@@ -173,8 +173,7 @@ def test_sc_remote_check_progress(monkeypatch, unused_tcp_port, scroot):
 
     # Check job progress.
     monkeypatch.setattr("sys.argv", ['sc-remote',
-                                     '-credentials', '.test_remote_cfg',
-                                     '-jobid', chip.status['jobhash']])
+                                     '-credentials', '.test_remote_cfg'])
     retcode = sc_remote.main()
 
     assert retcode == 0
@@ -215,7 +214,6 @@ def test_sc_remote_reconnect(monkeypatch, unused_tcp_port, scroot):
     # which expects a non-mocked build directory.
     monkeypatch.setattr("sys.argv", ['sc-remote',
                                      '-credentials', '.test_remote_cfg',
-                                     '-jobid', chip.status['jobhash'],
                                      '-reconnect',
                                      '-cfg', os.path.join(chip._getworkdir(),
                                                           'import',

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -9989,6 +9989,31 @@
             ],
             "type": "str"
         },
+        "jobid": {
+            "example": [
+                "cli: -record_jobid '0123456789abcdeffedcba9876543210'",
+                "api: chip.set('record', 'jobid', '0123456789abcdeffedcba9876543210')"
+            ],
+            "help": "Record tracking the job ID for a remote run.",
+            "lock": false,
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
+            "notes": null,
+            "pernode": "optional",
+            "require": null,
+            "scope": "job",
+            "shorthelp": "Record: remote job ID",
+            "switch": [
+                "-record_jobid 'step index <str>'"
+            ],
+            "type": "str"
+        },
         "kernelversion": {
             "example": [
                 "cli: -record_kernelversion 'dfm 0 5.11.0-34-generic'",
@@ -10325,7 +10350,7 @@
             "default": {
                 "default": {
                     "signature": null,
-                    "value": "0.35.0"
+                    "value": "0.36.0"
                 }
             }
         },

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -10005,7 +10005,7 @@
                 }
             },
             "notes": null,
-            "pernode": "optional",
+            "pernode": "never",
             "require": null,
             "scope": "job",
             "shorthelp": "Record: remote job ID",

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -6720,6 +6720,31 @@
             ],
             "type": "[str]"
         },
+        "jobid": {
+            "example": [
+                "cli: -option_jobid '0123456789abcdeffedcba9876543210'",
+                "api: chip.set('option', 'jobid', '0123456789abcdeffedcba9876543210')"
+            ],
+            "help": "Serverside UID for a remote job run.",
+            "lock": false,
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
+            "notes": null,
+            "pernode": "never",
+            "require": null,
+            "scope": "job",
+            "shorthelp": "Remote job ID",
+            "switch": [
+                "-option_jobid 'step index <str>'"
+            ],
+            "type": "str"
+        },
         "jobincr": {
             "example": [
                 "cli: -jobincr",
@@ -9986,31 +10011,6 @@
             "shorthelp": "Record: IP address",
             "switch": [
                 "-record_ipaddr 'step index <str>'"
-            ],
-            "type": "str"
-        },
-        "jobid": {
-            "example": [
-                "cli: -record_jobid '0123456789abcdeffedcba9876543210'",
-                "api: chip.set('record', 'jobid', '0123456789abcdeffedcba9876543210')"
-            ],
-            "help": "Record tracking the job ID for a remote run.",
-            "lock": false,
-            "node": {
-                "default": {
-                    "default": {
-                        "signature": null,
-                        "value": null
-                    }
-                }
-            },
-            "notes": null,
-            "pernode": "never",
-            "require": null,
-            "scope": "job",
-            "shorthelp": "Record: remote job ID",
-            "switch": [
-                "-record_jobid 'step index <str>'"
             ],
             "type": "str"
         },

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -9989,10 +9989,10 @@
             ],
             "type": "str"
         },
-        "jobid": {
+        "remoteid": {
             "example": [
-                "cli: -record_jobid '0123456789abcdeffedcba9876543210'",
-                "api: chip.set('record', 'jobid', '0123456789abcdeffedcba9876543210')"
+                "cli: -record_remoteid '0123456789abcdeffedcba9876543210'",
+                "api: chip.set('record', 'remoteid', '0123456789abcdeffedcba9876543210')"
             ],
             "help": "Record tracking the job ID for a remote run.",
             "lock": false,
@@ -10010,7 +10010,7 @@
             "scope": "job",
             "shorthelp": "Record: remote job ID",
             "switch": [
-                "-record_jobid 'step index <str>'"
+                "-record_remoteid 'step index <str>'"
             ],
             "type": "str"
         },

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -6720,31 +6720,6 @@
             ],
             "type": "[str]"
         },
-        "jobid": {
-            "example": [
-                "cli: -option_jobid '0123456789abcdeffedcba9876543210'",
-                "api: chip.set('option', 'jobid', '0123456789abcdeffedcba9876543210')"
-            ],
-            "help": "Serverside UID for a remote job run.",
-            "lock": false,
-            "node": {
-                "default": {
-                    "default": {
-                        "signature": null,
-                        "value": null
-                    }
-                }
-            },
-            "notes": null,
-            "pernode": "never",
-            "require": null,
-            "scope": "job",
-            "shorthelp": "Remote job ID",
-            "switch": [
-                "-option_jobid 'step index <str>'"
-            ],
-            "type": "str"
-        },
         "jobincr": {
             "example": [
                 "cli: -jobincr",
@@ -10011,6 +9986,31 @@
             "shorthelp": "Record: IP address",
             "switch": [
                 "-record_ipaddr 'step index <str>'"
+            ],
+            "type": "str"
+        },
+        "jobid": {
+            "example": [
+                "cli: -record_jobid '0123456789abcdeffedcba9876543210'",
+                "api: chip.set('record', 'jobid', '0123456789abcdeffedcba9876543210')"
+            ],
+            "help": "Record tracking the job ID for a remote run.",
+            "lock": false,
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
+            "notes": null,
+            "pernode": "never",
+            "require": null,
+            "scope": "job",
+            "shorthelp": "Record: remote job ID",
+            "switch": [
+                "-record_jobid 'step index <str>'"
             ],
             "type": "str"
         },


### PR DESCRIPTION
Like we've discussed offline, the job ID values could easily be moved into the core schema, instead of using the ephemeral `chip.status` dictionary, which we would like to get rid of eventually.

This PR implements the client-side changes required to do that. I bumped the schema's minor version number instead of its patch number, because v0.35.0 manifests will not work with servers that are using the new version for remote runs.

I also updated the `sc-remote` CLI app to replace its `-jobid` CLI parameter with `-cfg`, which was already required for reconnecting to a running job. That required a little bit of extra logic to insert the job ID values into the manifests produced by the locally-run entry steps, because the client doesn't know what its job ID will be until it submits a job and receives a response from the server.