### PR TITLE
Fix missing requests JSONDecodeError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 
 numpy >= 1.19
 aiohttp >= 3.7.4.post0
-requests >= 2.22.0
+requests >= 2.27.0
 PyYAML >= 5.4.1
 defusedxml >= 0.7.1
 pandas >= 1.1.5


### PR DESCRIPTION
When running the client for the scserver on my CI I encountered this issue in case of an internal server error.
The required exception was only added in version 2.27 of the requests library so upgrading fixes this issue.
```
Traceback (most recent call last):
  File "/usr/local/bin/sc", line 33, in <module>
    sys.exit(load_entry_point('siliconcompiler', 'console_scripts', 'sc')())
  File "/code/siliconcompiler/siliconcompiler/apps/sc.py", line 76, in main
    chip.run()
  File "/code/siliconcompiler/siliconcompiler/core.py", line 4149, in run
    remote_run(self)
  File "/code/siliconcompiler/siliconcompiler/remote/client.py", line 264, in remote_run
    request_remote_run(chip)
  File "/code/siliconcompiler/siliconcompiler/remote/client.py", line 407, in request_remote_run
    resp = __post(chip, '/remote_run/', post_action, success_action)
  File "/code/siliconcompiler/siliconcompiler/remote/client.py", line 75, in __post
    except requests.JSONDecodeError:
AttributeError: module 'requests' has no attribute 'JSONDecodeError'
```