### PR TITLE
Fix normalization of list to tuples for list-of-tuples

### DIFF
--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -79,3 +79,20 @@ def test_allkeys():
 
     complete = schema.allkeys('option', 'autoinstall')
     assert complete == []
+
+
+def test_list_of_tuples():
+    schema = Schema()
+    keypath = ['flowgraph', 'asicflow', 'syn', '0', 'input']
+    expected = [('import', '0')]
+
+    schema.set(*keypath, ('import', '0'))
+    assert schema.get(*keypath) == expected
+
+    schema.set(*keypath, [['import', '0']])
+    assert schema.get(*keypath) == expected
+
+    # should be legal, since the list can be normalized to a tuple, and it's legal to set a scalar
+    # for a list type
+    schema.set(*keypath, ['import', '0'])
+    assert schema.get(*keypath) == expected


### PR DESCRIPTION
This PR fixes a bug where setting a single "scalar" value for a list-of-tuples field using a list rather than a tuple is considered invalid. There's a bit of ambiguity here when parsing the type/value from the "outside-in", so I think the easiest solution without restructuring this code is to speculatively consider the value in each possible way and see which works. 