### PR TITLE
Split up run()

### DIFF
--- a/siliconcompiler/__init__.py
+++ b/siliconcompiler/__init__.py
@@ -1,4 +1,4 @@
-from siliconcompiler._common import TaskStatus, SiliconCompilerError
+from siliconcompiler._common import NodeStatus, SiliconCompilerError
 
 from siliconcompiler.core import Chip
 from siliconcompiler.schema import Schema
@@ -11,7 +11,7 @@ __all__ = [
     "__version__",
     "Chip",
     "SiliconCompilerError",
-    "TaskStatus",
+    "NodeStatus",
     "PDK",
     "FPGA",
     "Library",

--- a/siliconcompiler/_common.py
+++ b/siliconcompiler/_common.py
@@ -1,4 +1,4 @@
-class TaskStatus():
+class NodeStatus():
     # Could use Python 'enum' class here, but that doesn't work nicely with
     # schema.
     PENDING = 'pending'

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4053,11 +4053,10 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                         for record in self.getkeys('record'):
                             self.unset('record', record, step=step, index=index)
 
-    def _remote_process(self, steplist):
+    def _load_remote_config(self):
         '''
-        Dispatch the Chip to a remote server for processing.
+        Load the remote storage config into the status dictionary.
         '''
-        # Load the remote storage config into the status dictionary.
         if self.get('option', 'credentials'):
             # Use the provided remote credentials file.
             cfg_file = os.path.abspath(self.get('option', 'credentials'))
@@ -4084,6 +4083,12 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             self.error('Improperly formatted remote server configuration - '
                        'please run "sc-configure" and enter your server address and '
                        'credentials.', fatal=True)
+
+    def _remote_process(self, steplist):
+        '''
+        Dispatch the Chip to a remote server for processing.
+        '''
+        self._load_remote_config()
 
         # Pre-process: Run an starting nodes locally, and upload the
         # in-progress build directory to the remote server.

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4013,7 +4013,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 indexlist[step] = self.getkeys('flowgraph', flow, step)
         return indexlist
 
-    def _resume_steps(self, flow, steplist, indexlist):
+    def _reset_flow_nodes(self, flow, steplist, indexlist):
         # Reset flowgraph/records/metrics by probing build directory. We need
         # to set values to None for steps we may re-run so that merging
         # manifests from _runtask() actually updates values.
@@ -4256,7 +4256,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         steplist = self._get_flow_steplist(flow)
         indexlist = self._get_flow_indexlist(flow)
-        self._resume_steps(flow, steplist, indexlist)
+        self._reset_flow_nodes(flow, steplist, indexlist)
 
         # Save current environment
         environment = copy.deepcopy(os.environ)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4305,10 +4305,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         indexlist = self._precompute_indexlist(steplist, flow)
         self._resume_steps(flow, steplist, indexlist)
 
-        # Set env variables
         # Save current environment
         environment = copy.deepcopy(os.environ)
-
+        # Set env variables
         for envvar in self.getkeys('option', 'env'):
             val = self.get('option', 'env', envvar)
             os.environ[envvar] = val

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3960,7 +3960,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             self.logger.warning("Setting ['option', 'nodisplay'] to True")
             self.set('option', 'nodisplay', True)
 
-    def _increment_jobs(self):
+    def _increment_job_name(self):
         '''
         Auto-update jobname if ['option', 'jobincr'] is True
         Do this before initializing logger so that it picks up correct jobname
@@ -4243,7 +4243,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 self.error(f"{key} must be set before calling run()",
                            fatal=True)
 
-        self._increment_jobs()
+        self._increment_job_name()
 
         # Re-init logger to include run info after setting up flowgraph.
         self._init_logger(in_run=True)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3979,14 +3979,14 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                         jobid = max(jobid, int(m.group(1)))
                 self.set('option', 'jobname', f'{stem}{jobid + 1}')
 
-    def _filter_steplist(self):
+    def _get_flow_steplist(self, flow):
         # Run steps if set, otherwise run whole graph
         if self.get('arg', 'step'):
             return [self.get('arg', 'step')]
         elif self.get('option', 'steplist'):
             return self.get('option', 'steplist')
         else:
-            steplist = self.list_steps()
+            steplist = self.list_steps(flow)
 
             if not self.get('option', 'resume'):
                 # If no step(list) was specified, the whole flow is being run
@@ -3997,14 +3997,14 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
             return steplist
 
-    def _precompute_indexlist(self, steplist, flow):
+    def _get_flow_indexlist(self, flow):
         '''
         List of indices to run per step. Precomputing this ensures we won't
         have any problems if [arg, index] gets clobbered, and reduces logic
         repetition.
         '''
         indexlist = {}
-        for step in steplist:
+        for step in self._get_flow_steplist(flow):
             if self.get('arg', 'index'):
                 indexlist[step] = [self.get('arg', 'index')]
             elif self.get('option', 'indexlist'):
@@ -4254,8 +4254,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             self.error(f"{flow} flowgraph contains errors and cannot be run.",
                        fatal=True)
 
-        steplist = self._filter_steplist()
-        indexlist = self._precompute_indexlist(steplist, flow)
+        steplist = self._get_flow_steplist(flow)
+        indexlist = self._get_flow_indexlist(flow)
         self._resume_steps(flow, steplist, indexlist)
 
         # Save current environment

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4053,37 +4053,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                         for record in self.getkeys('record'):
                             self.unset('record', record, step=step, index=index)
 
-    def _load_remote_config(self):
-        '''
-        Load the remote storage config into the status dictionary.
-        '''
-        if self.get('option', 'credentials'):
-            # Use the provided remote credentials file.
-            cfg_file = os.path.abspath(self.get('option', 'credentials'))
-
-            if not os.path.isfile(cfg_file):
-                # Check if it's a file since its been requested by the user
-                self.error(f'Unable to find the credentials file: {cfg_file}', fatal=True)
-        else:
-            # Use the default config file path.
-            cfg_file = utils.default_credentials_file()
-
-        cfg_dir = os.path.dirname(cfg_file)
-        if os.path.isdir(cfg_dir) and os.path.isfile(cfg_file):
-            self.logger.info(f'Using credentials: {cfg_file}')
-            with open(cfg_file, 'r') as cfgf:
-                self.status['remote_cfg'] = json.loads(cfgf.read())
-        else:
-            self.logger.warning('Could not find remote server configuration: '
-                                f'defaulting to {_metadata.default_server}')
-            self.status['remote_cfg'] = {
-                "address": _metadata.default_server
-            }
-        if ('address' not in self.status['remote_cfg']):
-            self.error('Improperly formatted remote server configuration - '
-                       'please run "sc-configure" and enter your server address and '
-                       'credentials.', fatal=True)
-
     def _prepare_tasks(self, tasks_to_run, processes, flow, status, steplist, indexlist):
         '''
         For each task to run, prepare a process and store its dependencies

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4054,6 +4054,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                             self.unset('record', record, step=step, index=index)
 
     def _remote_process(self, steplist):
+        '''
+        Dispatch the Chip to a remote server for processing.
+        '''
         # Load the remote storage config into the status dictionary.
         if self.get('option', 'credentials'):
             # Use the provided remote credentials file.
@@ -4310,7 +4313,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             val = self.get('option', 'env', envvar)
             os.environ[envvar] = val
 
-        # Remote workflow: Dispatch the Chip to a remote server for processing.
         status = {}
         if self.get('option', 'remote'):
             self._remote_process(steplist)

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -132,7 +132,7 @@ def _remote_preprocess(chip, steplist):
         task = chip._get_task(local_step, index)
         # Setting up tool is optional (step may be a builtin function)
         if not chip._is_builtin(tool, task):
-            chip._setup_task(local_step, index)
+            chip._setup_node(local_step, index)
 
         # Remove each local step from the list of steps to run on the server side.
         remote_steplist.remove(local_step)

--- a/siliconcompiler/report/streamlit_viewer.py
+++ b/siliconcompiler/report/streamlit_viewer.py
@@ -12,7 +12,7 @@ import altair
 import gzip
 import base64
 from siliconcompiler.report import report
-from siliconcompiler import Chip, TaskStatus, utils
+from siliconcompiler import Chip, NodeStatus, utils
 from siliconcompiler import __version__ as sc_version
 
 '''
@@ -176,10 +176,10 @@ def get_nodes_and_edges(chip, node_dependencies, successful_path,
                (step, index) in chip._get_flowgraph_entry_nodes():
                 node_border_width = successful_path_node_width
         flow = chip.get("option", "flow")
-        task_status = chip.get('flowgraph', flow, step, index, 'status')
-        if task_status == TaskStatus.SUCCESS:
+        node_status = chip.get('flowgraph', flow, step, index, 'status')
+        if node_status == NodeStatus.SUCCESS:
             node_color = SUCCESS_COLOR
-        elif task_status == TaskStatus.ERROR:
+        elif node_status == NodeStatus.ERROR:
             node_color = FAILURE_COLOR
         else:
             node_color = PENDING_COLOR

--- a/siliconcompiler/report/utils.py
+++ b/siliconcompiler/report/utils.py
@@ -1,4 +1,4 @@
-from siliconcompiler import TaskStatus
+from siliconcompiler import NodeStatus
 from siliconcompiler import units
 
 
@@ -68,7 +68,7 @@ def _collect_data(chip, flow=None, steplist=None, format_as_string=True):
 
             errors[step, index] = chip.get('flowgraph', flow,
                                            step, index, 'status') == \
-                TaskStatus.ERROR
+                NodeStatus.ERROR
 
             if value is not None:
                 value = _format_value(metric, value, metric_unit, metric_type, format_as_string)
@@ -109,7 +109,7 @@ def _get_flowgraph_path(chip, flow, steplist, only_include_successful=False):
     for node in end_nodes:
         if only_include_successful:
             if chip.get('flowgraph', flow, *node, 'status') == \
-               TaskStatus.SUCCESS:
+               NodeStatus.SUCCESS:
                 selected_nodes.add(node)
                 to_search.append(node)
         else:

--- a/siliconcompiler/tools/builtin/_common.py
+++ b/siliconcompiler/tools/builtin/_common.py
@@ -1,5 +1,5 @@
 
-from siliconcompiler import TaskStatus
+from siliconcompiler import NodeStatus
 from siliconcompiler import utils
 
 
@@ -19,7 +19,7 @@ def _mux(chip, *steps, operations=None):
             failed[step] = {}
         failed[step][index] = False
 
-        if chip.get('flowgraph', flow, step, index, 'status') == TaskStatus.ERROR:
+        if chip.get('flowgraph', flow, step, index, 'status') == NodeStatus.ERROR:
             failed[step][index] = True
         else:
             failed[step][index] = False
@@ -72,7 +72,7 @@ def _minmax(chip, *steps, op=None):
             failed[step] = {}
         failed[step][index] = False
 
-        if chip.get('flowgraph', flow, step, index, 'status') == TaskStatus.ERROR:
+        if chip.get('flowgraph', flow, step, index, 'status') == NodeStatus.ERROR:
             failed[step][index] = True
         else:
             for metric in chip.getkeys('metric'):

--- a/tests/apps/test_sc_remote.py
+++ b/tests/apps/test_sc_remote.py
@@ -168,8 +168,8 @@ def test_sc_remote_check_progress(monkeypatch, unused_tcp_port, scroot):
     chip.load_target('freepdk45_demo')
     chip.status['remote_cfg'] = remote_cfg
     # Start the run, but don't wait for it to finish.
-    client.remote_preprocess(chip, chip.list_steps())
-    client.request_remote_run(chip)
+    client._remote_preprocess(chip, chip.list_steps())
+    client._request_remote_run(chip)
 
     # Check job progress.
     monkeypatch.setattr("sys.argv", ['sc-remote',
@@ -208,8 +208,8 @@ def test_sc_remote_reconnect(monkeypatch, unused_tcp_port, scroot):
     chip.load_target('freepdk45_demo')
     chip.status['remote_cfg'] = remote_cfg
     # Start the run, but don't wait for it to finish.
-    client.remote_preprocess(chip, chip.list_steps())
-    client.request_remote_run(chip)
+    client._remote_preprocess(chip, chip.list_steps())
+    client._request_remote_run(chip)
 
     # Mock CLI parameters, and the '_finalize_run' call
     # which expects a non-mocked build directory.

--- a/tests/builtin/test_minmax.py
+++ b/tests/builtin/test_minmax.py
@@ -87,7 +87,7 @@ def test_all_failed(chip):
     N = len(chip.getkeys('flowgraph', flow, 'syn'))
 
     for index in range(N):
-        chip.set('flowgraph', flow, 'syn', str(index), 'status', siliconcompiler.TaskStatus.ERROR)
+        chip.set('flowgraph', flow, 'syn', str(index), 'status', siliconcompiler.NodeStatus.ERROR)
 
     task = chip._get_task_module('teststep', '0')
     winner = task._select_inputs(chip, 'teststep', '0')
@@ -99,7 +99,7 @@ def test_winner_failed(chip):
     flow = chip.get('option', 'flow')
 
     # set error bit on what would otherwise be winner
-    chip.set('flowgraph', flow, 'syn', '9', 'status', siliconcompiler.TaskStatus.ERROR)
+    chip.set('flowgraph', flow, 'syn', '9', 'status', siliconcompiler.NodeStatus.ERROR)
 
     task = chip._get_task_module('teststep', '0')
     winner = task._select_inputs(chip, 'teststep', '0')

--- a/tests/core/test_check_flowgraph_io.py
+++ b/tests/core/test_check_flowgraph_io.py
@@ -25,7 +25,7 @@ def test_check_flowgraph():
             tool = chip.get('flowgraph', flow, step, index, 'tool')
             task = chip.get('flowgraph', flow, step, index, 'task')
             if not chip._is_builtin(tool, task):
-                chip._setup_task(step, index)
+                chip._setup_node(step, index)
 
     assert chip._check_flowgraph_io()
 

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -107,7 +107,7 @@ def test_check_missing_file_param():
     chip = siliconcompiler.Chip('gcd')
     chip.load_target("freepdk45_demo")
 
-    chip._setup_task('syn', '0')
+    chip._setup_node('syn', '0')
 
     chip.set('arg', 'step', 'syn')
     chip.set('arg', 'index', '0')

--- a/tests/core/test_summary.py
+++ b/tests/core/test_summary.py
@@ -1,6 +1,6 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 import siliconcompiler
-from siliconcompiler import TaskStatus
+from siliconcompiler import NodeStatus
 
 import pytest
 
@@ -21,7 +21,7 @@ def gcd_with_metrics(gcd_chip):
         dummy_data += 1
         for index in gcd_chip.getkeys('flowgraph', flow, step):
             for metric in gcd_chip.getkeys('flowgraph', flow, step, index, 'weight'):
-                gcd_chip.set('flowgraph', flow, step, index, 'status', TaskStatus.SUCCESS)
+                gcd_chip.set('flowgraph', flow, step, index, 'status', NodeStatus.SUCCESS)
                 gcd_chip.set('metric', metric, str(dummy_data), step=step, index=index)
                 prev_step = steps.index(step) - 1
                 if prev_step >= 0:
@@ -57,16 +57,16 @@ def test_parallel_path(capfd):
         chip.node(flow, 'import', nop)
         chip.node(flow, 'ctsmin', minimum)
 
-        chip.set('flowgraph', flow, 'import', '0', 'status', siliconcompiler.TaskStatus.SUCCESS)
-        chip.set('flowgraph', flow, 'ctsmin', '0', 'status', siliconcompiler.TaskStatus.SUCCESS)
+        chip.set('flowgraph', flow, 'import', '0', 'status', siliconcompiler.NodeStatus.SUCCESS)
+        chip.set('flowgraph', flow, 'ctsmin', '0', 'status', siliconcompiler.NodeStatus.SUCCESS)
         chip.set('flowgraph', flow, 'ctsmin', '0', 'select', ('cts', '1'))
 
         for i in ('0', '1', '2'):
             chip.node(flow, 'place', place, index=i)
             chip.node(flow, 'cts', cts, index=i)
 
-            chip.set('flowgraph', flow, 'place', i, 'status', siliconcompiler.TaskStatus.SUCCESS)
-            chip.set('flowgraph', flow, 'cts', i, 'status', siliconcompiler.TaskStatus.SUCCESS)
+            chip.set('flowgraph', flow, 'place', i, 'status', siliconcompiler.NodeStatus.SUCCESS)
+            chip.set('flowgraph', flow, 'cts', i, 'status', siliconcompiler.NodeStatus.SUCCESS)
 
             chip.edge(flow, 'place', 'cts', tail_index=i, head_index=i)
             chip.edge(flow, 'cts', 'ctsmin', tail_index=i)

--- a/tests/flows/test_flowstatus.py
+++ b/tests/flows/test_flowstatus.py
@@ -1,5 +1,5 @@
 import siliconcompiler
-from siliconcompiler import TaskStatus
+from siliconcompiler import NodeStatus
 
 import json
 import os
@@ -70,8 +70,8 @@ def test_flowstatus(scroot, steplist):
 
     chip.summary()
 
-    assert chip.get('flowgraph', flow, 'place', '0', 'status') == TaskStatus.ERROR
-    assert chip.get('flowgraph', flow, 'place', '1', 'status') == TaskStatus.SUCCESS
+    assert chip.get('flowgraph', flow, 'place', '0', 'status') == NodeStatus.ERROR
+    assert chip.get('flowgraph', flow, 'place', '1', 'status') == NodeStatus.SUCCESS
 
 
 @pytest.mark.eda
@@ -124,8 +124,8 @@ def test_long_branch(scroot):
 
     chip.run()
 
-    assert chip.get('flowgraph', flow, 'place', '0', 'status') == TaskStatus.ERROR
-    assert chip.get('flowgraph', flow, 'place', '1', 'status') == TaskStatus.SUCCESS
+    assert chip.get('flowgraph', flow, 'place', '0', 'status') == NodeStatus.ERROR
+    assert chip.get('flowgraph', flow, 'place', '1', 'status') == NodeStatus.SUCCESS
 
 
 @pytest.mark.eda
@@ -168,7 +168,7 @@ def test_remote(scroot):
     # Kill the server process.
     srv_proc.kill()
 
-    assert chip.get('flowgraph', flow, 'place', '0', 'status') == TaskStatus.ERROR
-    assert chip.get('flowgraph', flow, 'place', '1', 'status') == TaskStatus.SUCCESS
+    assert chip.get('flowgraph', flow, 'place', '0', 'status') == NodeStatus.ERROR
+    assert chip.get('flowgraph', flow, 'place', '1', 'status') == NodeStatus.SUCCESS
 
     chip.summary()

--- a/tests/flows/test_multiple_tools.py
+++ b/tests/flows/test_multiple_tools.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 import siliconcompiler
-from siliconcompiler import TaskStatus
+from siliconcompiler import NodeStatus
 
 from siliconcompiler.tools.surelog import parse
 
@@ -59,5 +59,5 @@ def test_multiple_tools():
     chip.set('option', 'skipall', True)
     chip.run()
 
-    assert chip.get('flowgraph', flow, 'slog', '0', 'status') == TaskStatus.SUCCESS
-    assert chip.get('flowgraph', flow, 'slog', '1', 'status') == TaskStatus.SUCCESS
+    assert chip.get('flowgraph', flow, 'slog', '0', 'status') == NodeStatus.SUCCESS
+    assert chip.get('flowgraph', flow, 'slog', '1', 'status') == NodeStatus.SUCCESS

--- a/tests/flows/test_steplist.py
+++ b/tests/flows/test_steplist.py
@@ -4,7 +4,7 @@ import siliconcompiler
 
 import pytest
 
-from siliconcompiler import TaskStatus
+from siliconcompiler import NodeStatus
 
 
 @pytest.mark.eda
@@ -18,8 +18,8 @@ def test_steplist(gcd_chip):
     # Make sure we ran syn
     assert gcd_chip.find_result('vg', step='syn')
     flow = gcd_chip.get('option', 'flow')
-    assert gcd_chip.get('flowgraph', flow, 'import', '0', 'status') == TaskStatus.SUCCESS
-    assert gcd_chip.get('flowgraph', flow, 'syn', '0', 'status') == TaskStatus.SUCCESS
+    assert gcd_chip.get('flowgraph', flow, 'import', '0', 'status') == NodeStatus.SUCCESS
+    assert gcd_chip.get('flowgraph', flow, 'syn', '0', 'status') == NodeStatus.SUCCESS
 
     # Re-run
     gcd_chip.set('option', 'steplist', ['syn'])

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -8,7 +8,7 @@ from siliconcompiler.tools.builtin import nop
 from siliconcompiler.tools.builtin import join
 from siliconcompiler.tools.builtin import minimum
 
-from siliconcompiler import TaskStatus
+from siliconcompiler import NodeStatus
 
 
 @pytest.mark.eda
@@ -113,9 +113,9 @@ def test_failed_branch_min(chip):
     chip.run()
 
     assert chip.get('history', 'job0', 'flowgraph', flow, 'place', '0', 'status') == \
-        TaskStatus.ERROR
+        NodeStatus.ERROR
     assert chip.get('history', 'job0', 'flowgraph', flow, 'place', '1', 'status') == \
-        TaskStatus.SUCCESS
+        NodeStatus.SUCCESS
 
     # check that compilation succeeded
     assert chip.find_result('def', step='placemin') is not None


### PR DESCRIPTION
**What?**
Refactor of `run()` no functionality changes.
Also solves SC-586

**Why?**
SC-557, SC-562 and others are difficult to do since `_runtask()` and `run()` are huge function in which changes could easy break something important.

**How?**
We split up `run()` to make editing and testing the steps of the flow easier.

**Test**
So far just the existing test cases.
I could add further ones if necessary.
[Successful run on remote server](https://github.com/zeroasiccorp/scserver/actions/runs/6023567892/job/16340572454)