### PR TITLE
Reuse docker image

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   docker_image:
-    uses: siliconcompiler/siliconcompiler/.github/workflows/docker_image.yml@reuse-docker-image
+    uses: siliconcompiler/siliconcompiler/.github/workflows/docker_image.yml@main
     with:
       tool: 'tools'
 

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -12,13 +12,15 @@ defaults:
 jobs:
   docker_image:
     uses: siliconcompiler/siliconcompiler/.github/workflows/docker_image.yml@reuse-docker-image
+    with:
+      tool: 'tools'
 
   daily_tests_job:
     needs: docker_image
     timeout-minutes: 60
     runs-on: ubuntu-20.04 # Match ubuntu version with container
     container:
-      image: ${{ needs.docker_image.outputs.sc_tools }}
+      image: ${{ needs.docker_image.outputs.sc_tool }}
       credentials:
         username: ${{ secrets.PACKAGES_ACTOR }}
         password: ${{ secrets.PACKAGES_TOKEN }}
@@ -70,7 +72,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-latest
     container:
-      image: ${{ needs.docker_image.outputs.sc_tools }}
+      image: ${{ needs.docker_image.outputs.sc_tool }}
       credentials:
         username: ${{ secrets.PACKAGES_ACTOR }}
         password: ${{ secrets.PACKAGES_TOKEN }}

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -9,31 +9,9 @@ defaults:
   run:
     shell: bash
 
-env:
-  REGISTRY: ghcr.io
-
 jobs:
   docker_image:
-    name: 'Get docker sc_tools image'
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-      packages: read
-
-    outputs:
-      sc_tools: ${{ steps.docker.outputs.sc_tools }}
-
-    steps:
-      - name: Checkout repository main
-        uses: actions/checkout@v3
-
-      - name: Get image name
-        id: docker
-        run: |
-          pip install -r setup/docker/requirements.txt
-          sc_tools_name=$(python3 setup/docker/builder.py --tool tools --registry ${{ env.REGISTRY }})
-          echo "sc_tools=${sc_tools_name}" >> $GITHUB_OUTPUT
+    uses: siliconcompiler/siliconcompiler/.github/workflows/docker_image.yml@reuse-docker-image
 
   daily_tests_job:
     needs: docker_image

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -12,7 +12,7 @@ on:
         default: 'tools'
         type: string
       sc_version:
-        description: 'SC Version tag'
+        description: 'SC version tag'
         required: false
         type: string
     outputs:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: 'tools'
         type: string
+      sc_version:
+        description: 'SC Version tag'
+        required: false
+        type: string
     outputs:
       sc_tool:
         description: 'Name and newest digest for the docker image of the input tool'
@@ -33,6 +37,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: siliconcompiler/siliconcompiler
+          ref: ${{ inputs.sc_version }}
 
       - name: Get newest docker image for the input tool
         id: docker

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository main
         uses: actions/checkout@v3
+        with:
+          repository: siliconcompiler/siliconcompiler
 
       - name: Get newest sc_tools docker image
         id: docker

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,0 +1,34 @@
+name: 'Get name and newest digest for docker image'
+
+env:
+  REGISTRY: ghcr.io
+
+on:
+  workflow_call:
+    outputs:
+      sc_tools:
+        description: "Name and newest digest for sc_tools docker image"
+        value: ${{ jobs.docker_image.outputs.sc_tools }}
+
+jobs:
+  docker_image:
+    name: 'Get newest docker image'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      packages: read
+
+    outputs:
+      sc_tools: ${{ steps.docker.outputs.sc_tools }}
+
+    steps:
+      - name: Checkout repository main
+        uses: actions/checkout@v3
+
+      - name: Get newest sc_tools docker image
+        id: docker
+        run: |
+          pip install -r setup/docker/requirements.txt
+          sc_tools_name=$(python3 setup/docker/builder.py --tool tools --registry ${{ env.REGISTRY }})
+          echo "sc_tools=${sc_tools_name}" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -7,8 +7,9 @@ on:
   workflow_call:
     inputs:
       tool:
-        description: 'Name of the tool or "tools" for all tools'
-        required: true
+        description: 'Name of the tool'
+        required: false
+        default: 'tools'
         type: string
     outputs:
       sc_tool:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -5,10 +5,15 @@ env:
 
 on:
   workflow_call:
+    inputs:
+      tool:
+        description: 'Name of the tool or "tools" for all tools'
+        required: true
+        type: string
     outputs:
-      sc_tools:
-        description: "Name and newest digest for sc_tools docker image"
-        value: ${{ jobs.docker_image.outputs.sc_tools }}
+      sc_tool:
+        description: 'Name and newest digest for the docker image of the input tool'
+        value: ${{ jobs.docker_image.outputs.sc_tool }}
 
 jobs:
   docker_image:
@@ -20,7 +25,7 @@ jobs:
       packages: read
 
     outputs:
-      sc_tools: ${{ steps.docker.outputs.sc_tools }}
+      sc_tool: ${{ steps.docker.outputs.sc_tool }}
 
     steps:
       - name: Checkout repository main
@@ -28,9 +33,9 @@ jobs:
         with:
           repository: siliconcompiler/siliconcompiler
 
-      - name: Get newest sc_tools docker image
+      - name: Get newest docker image for the input tool
         id: docker
         run: |
           pip install -r setup/docker/requirements.txt
-          sc_tools_name=$(python3 setup/docker/builder.py --tool tools --registry ${{ env.REGISTRY }})
-          echo "sc_tools=${sc_tools_name}" >> $GITHUB_OUTPUT
+          sc_tool_name=$(python3 setup/docker/builder.py --tool ${{ inputs.tool }} --registry ${{ env.REGISTRY }})
+          echo "sc_tool=${sc_tool_name}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**What?**
This commit introduces a github action that takes the tool as an input and returns the latest version of its docker image.

**Why?**
We currently copy and paste the code to retrieve the latest version of the `sc_tools` images.
This is also the case for sclib, zerosoc and scscerver.

**Successful run:**
https://github.com/siliconcompiler/siliconcompiler/actions/runs/6039399625