### PR TITLE
Allow latest version docker image

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -12,8 +12,9 @@ on:
         default: 'tools'
         type: string
       sc_version:
-        description: 'SC version tag'
+        description: 'SC version tag or "latest" version'
         required: false
+        default: 'main'
         type: string
     outputs:
       sc_tool:
@@ -33,11 +34,14 @@ jobs:
       sc_tool: ${{ steps.docker.outputs.sc_tool }}
 
     steps:
-      - name: Checkout repository main
-        uses: actions/checkout@v3
-        with:
-          repository: siliconcompiler/siliconcompiler
-          ref: ${{ inputs.sc_version }}
+      - name: Checkout repository
+        run: |
+          git clone https://github.com/siliconcompiler/siliconcompiler .
+          version=${{ inputs.sc_version }}
+          if [ $version == "latest" ]; then
+            version=$(git describe --abbrev=0 --tags --match="v*")
+          fi
+          git checkout $version
 
       - name: Get newest docker image for the input tool
         id: docker


### PR DESCRIPTION
For https://github.com/siliconcompiler/zerosoc/pull/32 it is useful to have the latest released version available.


**Succesful run of daily CI - targeting this branch**
https://github.com/siliconcompiler/siliconcompiler/actions/runs/6050735765