### PR TITLE
Remove the 'delete_job' call from the client

### DIFF
--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -302,8 +302,6 @@ def remote_process(chip, steplist):
     chip._init_logger(step='remote', index='0', in_run=True)
     _remote_run(chip)
 
-    # Delete the job's data from the server.
-    delete_job(chip)
     # Restore logger
     chip._init_logger(in_run=True)
     # Restore steplist


### PR DESCRIPTION
This will make it easier to allow remote jobs to be resumed, and aid debugging. Splitting this self-contained change off from #1934 at Peter's request.

After this change, jobs will either be automatically deleted after a period of inactivity, or when the user manually runs `sc-remote -cfg [...] -delete`.