### PR TITLE
Allow no username and password in cmd

### DIFF
--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -827,14 +827,14 @@ def configure(chip, server=None, port=None, username=None, password=None):
         config['port'] = server.port
 
     if not public_server:
-        if not username:
+        if username is None:
             username = server.username
-            if not username:
+            if username is None:
                 username = input('Remote username (leave blank for no username):\n')
                 username = username.replace(" ", "")
-        if not password:
+        if password is None:
             password = server.password
-            if not password:
+            if password is None:
                 password = input('Remote password (leave blank for no password):\n')
                 password = password.replace(" ", "")
 

--- a/tests/apps/test_sc_remote.py
+++ b/tests/apps/test_sc_remote.py
@@ -391,6 +391,25 @@ def test_configure_cmdarg_with_username(monkeypatch):
 
 
 @pytest.mark.quick
+def test_configure_cmdarg_no_username_password(monkeypatch):
+    monkeypatch.setattr('sys.argv', ['sc-remote',
+                                     '-configure',
+                                     '-server',
+                                     ':@example.com'])
+
+    sc_remote.main()
+
+    # Check that generated credentials match the expected values.
+    generated_creds = {}
+    with open(default_credentials_file(), 'r') as cf:
+        generated_creds = json.loads(cf.read())
+
+    assert generated_creds['address'] == 'example.com'
+    assert 'username' not in generated_creds
+    assert 'password' not in generated_creds
+
+
+@pytest.mark.quick
 def test_configure_interactive(monkeypatch):
     server_name = 'https://example.com'
     username = 'ci_test_user'


### PR DESCRIPTION
Leaving username and password empty is currently not allowed but would be very helpful to connect to a test instance of scserver.