### PR TITLE
Flowgraph nodes remaining instances

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -269,10 +269,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             # Figure out how wide to make step and index fields
             max_step_len = 2
             max_index_len = 2
-            for future_step in self.getkeys('flowgraph', flow):
+            for (future_step, future_index) in self._get_flowgraph_nodes(flow):
                 max_step_len = max(len(future_step) + 1, max_step_len)
-                for future_index in self.getkeys('flowgraph', flow, future_step):
-                    max_index_len = max(len(future_index) + 1, max_index_len)
+                max_index_len = max(len(future_index) + 1, max_index_len)
 
             jobname = self.get('option', 'jobname')
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4420,24 +4420,23 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         self.set('option', 'jobname', f'_{taskname}_{sc_job}_{sc_step}{sc_index}', clobber=True)
 
         # Setup in step/index variables
-        for step in self.getkeys('flowgraph', 'showflow'):
+        for (step, index) in self._get_flowgraph_nodes('showflow',):
             if step != taskname:
                 continue
-            for index in self.getkeys('flowgraph', 'showflow', step):
-                show_tool, _ = self._get_tool_task(step, index, flow='showflow')
-                self.set('tool', show_tool, 'task', taskname, 'var', 'show_filetype', filetype,
+            show_tool, _ = self._get_tool_task(step, index, flow='showflow')
+            self.set('tool', show_tool, 'task', taskname, 'var', 'show_filetype', filetype,
+                     step=step, index=index)
+            self.set('tool', show_tool, 'task', taskname, 'var', 'show_filepath', filepath,
+                     step=step, index=index)
+            if sc_step:
+                self.set('tool', show_tool, 'task', taskname, 'var', 'show_step', sc_step,
                          step=step, index=index)
-                self.set('tool', show_tool, 'task', taskname, 'var', 'show_filepath', filepath,
+            if sc_index:
+                self.set('tool', show_tool, 'task', taskname, 'var', 'show_index', sc_index,
                          step=step, index=index)
-                if sc_step:
-                    self.set('tool', show_tool, 'task', taskname, 'var', 'show_step', sc_step,
-                             step=step, index=index)
-                if sc_index:
-                    self.set('tool', show_tool, 'task', taskname, 'var', 'show_index', sc_index,
-                             step=step, index=index)
-                if sc_job:
-                    self.set('tool', show_tool, 'task', taskname, 'var', 'show_job', sc_job,
-                             step=step, index=index)
+            if sc_job:
+                self.set('tool', show_tool, 'task', taskname, 'var', 'show_job', sc_job,
+                         step=step, index=index)
 
         # run show flow
         try:


### PR DESCRIPTION
Cleanup from https://github.com/siliconcompiler/siliconcompiler/pull/1937
Replace any remaining uses of `self.getkeys('flowgraph',)` with `self._get_flowgraph_nodes()`.
Any now remaining instances of `self.getkeys('flowgraph',)` require the rewrite with `from/to`.