### PR TITLE
Allow debugging failed slurm jobs on "small" server

### DIFF
--- a/siliconcompiler/scheduler.py
+++ b/siliconcompiler/scheduler.py
@@ -112,11 +112,6 @@ def _deferstep(chip, step, index, status):
             sf.write('#!/bin/bash\n')
             sf.write(f'sc -cfg {shlex.quote(cfg_file)} -builddir {shlex.quote(buildir)} '
                      f'-arg_step {shlex.quote(step)} -arg_index {shlex.quote(index)}\n')
-            # In case of error(s) which prevents the SC build script from completing, ensure the
-            # file mutex for job completion is set in shared storage. This lockfile signals the
-            # server to mark the job done, without putting load on the cluster reporting/accounting
-            # system.
-            sf.write(f'touch {os.path.dirname(output_file)}/done')
 
     # This is Python for: `chmod +x [script_path]`
     fst = os.stat(script_path)
@@ -189,6 +184,7 @@ def _deferstep(chip, step, index, status):
 
     if retcode > 0:
         chip.logger.error(f'srun command for {step} failed.')
+        chip.logger.error(f'srun output for {step}:\n{jobout}')
 
 
 def _get_slurm_partition():


### PR DESCRIPTION
**What?**
Pass through errors from slurm jobs on "small" server.

**Why?**
Currently on the local slurm setup (used by the `siliconcompiler/remote/server.py` and `test_slurm_local.py`) it is not possible to debug a failed node as the returncode of `touch` overshadows that one of `sc`.
Additionally in case of a failed run no information about the failure is printed.
As far as I can tell this does not affect "real" scserver because scserver has different `stepindex.sh` scripts.

**How?**
Remove last `touch` to create success file (on failure).
Add slurm output to error log which contains the exit code, run script location and run log location.

**Before:**
```
--------------------------------------------------------------------------------- Captured stdout setup ----------------------------------------------------------------------------------
| INFO    | /home/martin-zeroasic/coding/siliconcompiler/examples/gcd/gcd.v inferred as rtl/verilog
| INFO    | /home/martin-zeroasic/coding/siliconcompiler/examples/gcd/gcd.sdc inferred as constraint/sdc
---------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------
| INFO    | job0  | --         | -  | Checking manifest before running.
| INFO    | job0  | import     | 0  | Tool 'surelog' found with version '1.71' in directory '/usr/local/bin'
| INFO    | job0  | import     | 0  | Running in /tmp/pytest-of-martin-zeroasic/pytest-92/test_slurm_local_py0/build/gcd/job0/import/0
| INFO    | job0  | import     | 0  | surelog -nocache +libext+.sv+.v -parse -nouhdm /home/martin-zeroasic/coding/siliconcompiler/examples/gcd/gcd.v -top gcd
| INFO    | job0  | import     | 0  | Finished task in 0.79s
---------------------------------------------------------------------------------- Captured stderr call ----------------------------------------------------------------------------------
Process SpawnProcess-3:
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
..........................................................
  File "/home/martin-zeroasic/coding/siliconcompiler/siliconcompiler/schema/schema_obj.py", line 110, in _read_manifest
    raise ValueError(f'Manifest file not found {filepath}')
ValueError: Manifest file not found ../../../job0/syn/0/outputs/gcd.pkg.json
================================================================================ short test summary info =================================================================================
FAILED tests/flows/test_slurm_local.py::test_slurm_local_py - siliconcompiler._common.SiliconCompilerError: Run() failed, see previous errors.
```

**After:**
```
--------------------------------------------------------------------------------- Captured stdout setup ----------------------------------------------------------------------------------
| INFO    | /home/martin-zeroasic/coding/siliconcompiler/examples/gcd/gcd.v inferred as rtl/verilog
| INFO    | /home/martin-zeroasic/coding/siliconcompiler/examples/gcd/gcd.sdc inferred as constraint/sdc
---------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------
| INFO    | job0  | --         | -  | Checking manifest before running.
| INFO    | job0  | import     | 0  | Tool 'surelog' found with version '1.71' in directory '/usr/local/bin'
| INFO    | job0  | import     | 0  | Running in /tmp/pytest-of-martin-zeroasic/pytest-93/test_slurm_local_py0/build/gcd/job0/import/0
| INFO    | job0  | import     | 0  | surelog -nocache +libext+.sv+.v -parse -nouhdm /home/martin-zeroasic/coding/siliconcompiler/examples/gcd/gcd.v -top gcd
| INFO    | job0  | import     | 0  | Finished task in 0.8s
| ERROR   | job0  | syn        | 0  | srun command for syn failed.
| ERROR   | job0  | syn        | 0  | srun output for syn:
JobId=161 JobName=6f88ef50f1e2430da1beb45c0cf3582d_syn0
   UserId=martin-zeroasic(1001) GroupId=martin-zeroasic(1001) MCS_label=N/A
   Priority=4294901599 Nice=0 Account=(null) QOS=(null)
   JobState=FAILED Reason=NonZeroExitCode Dependency=(null)
   Requeue=1 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=1:0
   RunTime=00:00:02 TimeLimit=UNLIMITED TimeMin=N/A
   SubmitTime=2023-09-09T19:57:27 EligibleTime=2023-09-09T19:57:27
   AccrueTime=2023-09-09T19:57:27
   StartTime=2023-09-09T19:57:33 EndTime=2023-09-09T19:57:35 Deadline=N/A
   SuspendTime=None SecsPreSuspend=0 LastSchedEval=2023-09-09T19:57:33 Scheduler=Main
   Partition=ctldpart AllocNode:Sid=martin-ThinkPad-T14-Gen-1:112086
   ReqNodeList=(null) ExcNodeList=(null)
   NodeList=martin-ThinkPad-T14-Gen-1
   BatchHost=martin-ThinkPad-T14-Gen-1
   NumNodes=1 NumCPUs=16 NumTasks=1 CPUs/Task=1 ReqB:S:C:T=0:0:*:*
   TRES=cpu=16,node=1,billing=16
   Socks/Node=* NtasksPerN:B:S:C=0:0:*:* CoreSpec=*
   MinCPUsNode=1 MinMemoryNode=0 MinTmpDiskNode=0
   Features=(null) DelayBoot=00:00:00
   OverSubscribe=NO Contiguous=0 Licenses=(null) Network=(null)
   Command=/tmp/pytest-of-martin-zeroasic/pytest-93/test_slurm_local_py0/build/gcd/job0/configs/syn0.sh
   WorkDir=/tmp/pytest-of-martin-zeroasic/pytest-93/test_slurm_local_py0
   StdErr=/tmp/pytest-of-martin-zeroasic/pytest-93/test_slurm_local_py0/build/gcd/job0/sc_remote-syn-0.log
   StdIn=/dev/null
   StdOut=/tmp/pytest-of-martin-zeroasic/pytest-93/test_slurm_local_py0/build/gcd/job0/sc_remote-syn-0.log
   Power=
   


---------------------------------------------------------------------------------- Captured stderr call ----------------------------------------------------------------------------------
Process SpawnProcess-3:
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
...........................................................
  File "/home/martin-zeroasic/coding/siliconcompiler/siliconcompiler/schema/schema_obj.py", line 110, in _read_manifest
    raise ValueError(f'Manifest file not found {filepath}')
ValueError: Manifest file not found ../../../job0/syn/0/outputs/gcd.pkg.json
================================================================================ short test summary info =================================================================================
FAILED tests/flows/test_slurm_local.py::test_slurm_local_py - siliconcompiler._common.SiliconCompilerError: Run() failed, see previous errors.
```