### PR TITLE
Save cfg on error at input merge and final merge

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3368,8 +3368,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 in_node_status = status[in_step + in_index]
                 self.set('flowgraph', flow, in_step, in_index, 'status', in_node_status)
                 cfgfile = f"../../../{in_job}/{in_step}/{in_index}/outputs/{design}.pkg.json"
-                if os.path.isfile(cfgfile):
-                    self._read_manifest(cfgfile, clobber=False, partial=True)
+                self._read_manifest(cfgfile, clobber=False, partial=True)
 
     def _select_inputs(self, step, index):
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3367,8 +3367,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             for in_step, in_index in self.get('flowgraph', flow, step, index, 'input'):
                 in_node_status = status[in_step + in_index]
                 self.set('flowgraph', flow, in_step, in_index, 'status', in_node_status)
-                if in_node_status != NodeStatus.ERROR:
-                    cfgfile = f"../../../{in_job}/{in_step}/{in_index}/outputs/{design}.pkg.json"
+                cfgfile = f"../../../{in_job}/{in_step}/{in_index}/outputs/{design}.pkg.json"
+                if os.path.isfile(cfgfile):
                     self._read_manifest(cfgfile, clobber=False, partial=True)
 
     def _select_inputs(self, step, index):
@@ -3946,10 +3946,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 schema = Schema(manifest=lastcfg)
                 if schema.get('flowgraph', flow, step, index, 'status') == NodeStatus.SUCCESS:
                     stat_success = True
-            # Merge in manifest if the task was successful.
+            self._read_manifest(lastcfg, clobber=False, partial=True)
+            # (Status doesn't get propagated w/ "clobber=False")
             if stat_success:
-                self._read_manifest(lastcfg, clobber=False, partial=True)
-                # (Status doesn't get propagated w/ "clobber=False")
                 self.set('flowgraph', flow, step, index, 'status', NodeStatus.SUCCESS)
             else:
                 self.set('flowgraph', flow, step, index, 'status', NodeStatus.ERROR)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3852,6 +3852,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
     def _haltstep(self, step, index, log=True):
         if log:
             self.logger.error(f"Halting step '{step}' index '{index}' due to errors.")
+        self.write_manifest(os.path.join("outputs", f"{self.get('design')}.pkg.json"))
         sys.exit(1)
 
     ###########################################################################

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -156,7 +156,7 @@ def _remote_preprocess(chip, steplist):
         # only look up a step's dependencies in this dictionary, and the first
         # step should have none.
         run_task = multiprocessor.Process(target=chip._runtask,
-                                          args=(local_step, index, {}))
+                                          args=(flow, local_step, index, {}))
         run_task.start()
         run_task.join()
         if run_task.exitcode != 0:


### PR DESCRIPTION
Currently the only places where the manifest gets merged is when collecting the inputs on the start of a node or at the and of a run. In both these cases the manifest gets only merged on success this merges it regardless of success or failure.
This pull request saves the manifest regardless of whether the steps have failed.
@gadfort Are you sure we want to change the behaviour in this way?