### PR TITLE
Lint - Fix unknown proc openroad_pin_access_args

### DIFF
--- a/siliconcompiler/tools/openroad/scripts/sc_route.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_route.tcl
@@ -45,7 +45,7 @@ if {[dict exists $sc_cfg tool $sc_tool task $sc_task var drt_unidirectional_laye
 
 # Pin access
 if {$openroad_grt_use_pin_access == "true"} {
-  openroad_pin_access_args []
+  set openroad_pin_access_args []
   if {$openroad_drt_process_node != "false"} {
     lappend openroad_pin_access_args "-db_process_node" $openroad_drt_process_node
   }


### PR DESCRIPTION
Just did an initial run of the [`ttclcheck` linter](https://wiki.tcl-lang.org/page/ttclcheck).
It's the linter used in Vivado.
Still haven't figured out completly how to set up openroad and other dependencies but I found my first real error within seconds.
Hopefully we can set it up properly and integrate it soon...