### PR TITLE
direct all outputs through logger

### DIFF
--- a/siliconcompiler/apps/sc_remote.py
+++ b/siliconcompiler/apps/sc_remote.py
@@ -80,7 +80,7 @@ To delete a job, use:
         try:
             configure(chip, server=args['server'])
         except ValueError as e:
-            print(e)
+            chip.logger.error(e)
             return 1
         return 0
 

--- a/siliconcompiler/apps/sc_run.py
+++ b/siliconcompiler/apps/sc_run.py
@@ -22,7 +22,7 @@ def main():
 
     # Error checking
     if not chip.get('cfg'):
-        print(f"{progname} error: the following arguments are required: -cfg")
+        chip.logger.error(f"{progname}: the following arguments are required: -cfg")
         return 1
     else:
         chip.run()

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2895,7 +2895,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             elif switches[i] in options.keys():
                 options[switches[i]] = True
             elif switches[i] != '':
-                print("ERROR", switches[i])
+                self.logger.error(switches[i])
 
         # REGEX
         # TODO: add all the other optinos

--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -203,7 +203,7 @@ def prepare_synthesis_libraries(chip):
         f.write(markDontUse.processLibertyFile(
             dff_liberty_file,
             dff_dont_use,
-            chip.get('option', 'quiet', step=step, index=index),
+            logger=None if chip.get('option', 'quiet', step=step, index=index) else chip.logger
         ))
 
     # Generate synthesis_libraries and synthesis_macro_libraries for Yosys use
@@ -226,9 +226,12 @@ def prepare_synthesis_libraries(chip):
             # Mark dont use
             for lib_file in get_synthesis_libraries(lib):
                 lib_content.append(
-                    markDontUse.processLibertyFile(lib_file, dont_use,
-                                                   chip.get('option', 'quiet',
-                                                            step=step, index=index)))
+                    markDontUse.processLibertyFile(
+                        lib_file,
+                        dont_use,
+                        logger=None if chip.get('option', 'quiet',
+                                                step=step, index=index) else chip.logger
+                    ))
 
             if not lib_content:
                 continue


### PR DESCRIPTION
Changes:
- all tool outputs is directed through the logger

Motivation:
- on parallel executions outputs to the terminal ambiguous, this ensures they get the prefix for the step and index it belongs to.

Before:
```
| WARNING | job0  | import     | 0  | [WRN:PA0205] /siliconcompiler/examples/gcd/gcd.v:586:1: No timescale set for "ZeroComparator_0x422b1f52edd46a85".
| WARNING | job0  | import     | 0  | [WRN:PA0205] /siliconcompiler/examples/gcd/gcd.v:615:1: No timescale set for "Mux_0x683fa1a418b072c9".
| WARNING | job0  | import     | 0  | [WRN:PA0205] /siliconcompiler/examples/gcd/gcd.v:658:1: No timescale set for "Mux_0xdd6473406d1a99a".
| WARNING | job0  | import     | 0  | [WRN:PA0205] /siliconcompiler/examples/gcd/gcd.v:698:1: No timescale set for "Subtractor_0x422b1f52edd46a85".
| INFO    | job0  | import     | 0  | Computing hash value for [tool,surelog,task,parse,output]
| INFO    | job0  | import     | 0  | Computing hash value for [input,rtl,verilog]
| INFO    | job0  | import     | 0  | Finished task in 0.99s
Opening file for replace: /siliconcompiler/third_party/pdks/virtual/freepdk45/libs/nangate45/r1p0/lib/NangateOpenCellLibrary_typical.lib
  Marking OAI211_X1 as dont_use
Marked 1 cells as dont_use
Commented 0 lines containing "original_pin"
Replaced malformed functions 0
Replaced capacitive load 0
Opening file for replace: /siliconcompiler/third_party/pdks/virtual/freepdk45/libs/nangate45/r1p0/lib/NangateOpenCellLibrary_typical.lib
  Marking OAI211_X1 as dont_use
Marked 1 cells as dont_use
Commented 0 lines containing "original_pin"
Replaced malformed functions 0
Replaced capacitive load 0
| INFO    | job0  | syn        | 0  | Tool 'yosys' found with version '0.30+21' in directory '/.local/bin'
| INFO    | job0  | syn        | 0  | Running in /siliconcompiler/examples/gcd/build/gcd/job0/syn/0
| INFO    | job0  | syn        | 0  | yosys -c /siliconcompiler/siliconcompiler/tools/yosys/sc_syn.tcl

 /----------------------------------------------------------------------------\
 |                                                                            |
 |  yosys -- Yosys Open SYnthesis Suite                                       |
 |                                                                            |
 |  Copyright (C) 2012 - 2020  Claire Xenia Wolf <claire@yosyshq.com>         |
 |                                                                            |
 |  Permission to use, copy, modify, and/or distribute this software for any  |
 |  purpose with or without fee is hereby granted, provided that the above    |
 |  copyright notice and this permission notice appear in all copies.         |
 |                                                                            |
 |  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES  |
 |  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF          |
 |  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR   |
 |  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES    |
 |  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN     |
 |  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF   |
 |  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.            |
 |                                                                            |
 \----------------------------------------------------------------------------/

 Yosys 0.30+21 (git sha1 25954715f, clang 14.0.0-1ubuntu1 -fPIC -Os)
```

After:
```
| WARNING | job0  | import     | 0  | [WRN:PA0205] /siliconcompiler/examples/gcd/gcd.v:586:1: No timescale set for "ZeroComparator_0x422b1f52edd46a85".
| WARNING | job0  | import     | 0  | [WRN:PA0205] /siliconcompiler/examples/gcd/gcd.v:615:1: No timescale set for "Mux_0x683fa1a418b072c9".
| WARNING | job0  | import     | 0  | [WRN:PA0205] /siliconcompiler/examples/gcd/gcd.v:658:1: No timescale set for "Mux_0xdd6473406d1a99a".
| WARNING | job0  | import     | 0  | [WRN:PA0205] /siliconcompiler/examples/gcd/gcd.v:698:1: No timescale set for "Subtractor_0x422b1f52edd46a85".
| INFO    | job0  | import     | 0  | Computing hash value for [tool,surelog,task,parse,output]
| INFO    | job0  | import     | 0  | Computing hash value for [input,rtl,verilog]
| INFO    | job0  | import     | 0  | Finished task in 0.68s
| INFO    | job0  | syn        | 0  | Opening file for replace: /siliconcompiler/third_party/pdks/virtual/freepdk45/libs/nangate45/r1p0/lib/NangateOpenCellLibrary_typical.lib
| INFO    | job0  | syn        | 0  |   Marking OAI211_X1 as dont_use
| INFO    | job0  | syn        | 0  | Marked 1 cells as dont_use
| INFO    | job0  | syn        | 0  | Commented 0 lines containing "original_pin"
| INFO    | job0  | syn        | 0  | Replaced malformed functions 0
| INFO    | job0  | syn        | 0  | Replaced capacitive load 0
| INFO    | job0  | syn        | 0  | Opening file for replace: /siliconcompiler/third_party/pdks/virtual/freepdk45/libs/nangate45/r1p0/lib/NangateOpenCellLibrary_typical.lib
| INFO    | job0  | syn        | 0  |   Marking OAI211_X1 as dont_use
| INFO    | job0  | syn        | 0  | Marked 1 cells as dont_use
| INFO    | job0  | syn        | 0  | Commented 0 lines containing "original_pin"
| INFO    | job0  | syn        | 0  | Replaced malformed functions 0
| INFO    | job0  | syn        | 0  | Replaced capacitive load 0
| INFO    | job0  | syn        | 0  | Tool 'yosys' found with version '0.30+21' in directory '/.local/bin'
| INFO    | job0  | syn        | 0  | Running in /siliconcompiler/examples/gcd/build/gcd/job0/syn/0
| INFO    | job0  | syn        | 0  | yosys -c /siliconcompiler/siliconcompiler/tools/yosys/sc_syn.tcl
| INFO    | job0  | syn        | 0  | 
| INFO    | job0  | syn        | 0  |  /----------------------------------------------------------------------------\
| INFO    | job0  | syn        | 0  |  |                                                                            |
| INFO    | job0  | syn        | 0  |  |  yosys -- Yosys Open SYnthesis Suite                                       |
| INFO    | job0  | syn        | 0  |  |                                                                            |
| INFO    | job0  | syn        | 0  |  |  Copyright (C) 2012 - 2020  Claire Xenia Wolf <claire@yosyshq.com>         |
| INFO    | job0  | syn        | 0  |  |                                                                            |
| INFO    | job0  | syn        | 0  |  |  Permission to use, copy, modify, and/or distribute this software for any  |
| INFO    | job0  | syn        | 0  |  |  purpose with or without fee is hereby granted, provided that the above    |
| INFO    | job0  | syn        | 0  |  |  copyright notice and this permission notice appear in all copies.         |
| INFO    | job0  | syn        | 0  |  |                                                                            |
| INFO    | job0  | syn        | 0  |  |  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES  |
| INFO    | job0  | syn        | 0  |  |  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF          |
| INFO    | job0  | syn        | 0  |  |  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR   |
| INFO    | job0  | syn        | 0  |  |  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES    |
| INFO    | job0  | syn        | 0  |  |  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN     |
| INFO    | job0  | syn        | 0  |  |  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF   |
| INFO    | job0  | syn        | 0  |  |  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.            |
| INFO    | job0  | syn        | 0  |  |                                                                            |
| INFO    | job0  | syn        | 0  |  \----------------------------------------------------------------------------/
| INFO    | job0  | syn        | 0  | 
| INFO    | job0  | syn        | 0  |  Yosys 0.30+21 (git sha1 25954715f, clang 14.0.0-1ubuntu1 -fPIC -Os)
| INFO    | job0  | syn        | 0  | 
```