### PR TITLE
speeds up .valid by simply checking the schema dictionary instead of requiring the allkeys()

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -850,7 +850,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         return fullstr
 
     ###########################################################################
-    def valid(self, *keypath, valid_keypaths=None, default_valid=False):
+    def valid(self, *keypath, default_valid=False):
         """
         Checks validity of a keypath.
 
@@ -858,7 +858,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         keypath is valid and False if invalid.
 
         Args:
-            keypath(list str): Variable length schema key list.
             default_valid (bool): Whether to consider "default" in valid
             keypaths as a wildcard. Defaults to False.
 
@@ -873,8 +872,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             >>> check = chip.valid('metric', 'foo', '0', 'tasktime', default_valid=True)
             Returns True, even if "foo" and "0" aren't in current configuration.
         """
-        return self.schema.valid(*keypath, valid_keypaths=valid_keypaths,
-                                 default_valid=default_valid)
+        return self.schema.valid(*keypath, default_valid=default_valid)
 
     ###########################################################################
     def get(self, *keypath, field='value', job=None, step=None, index=None):

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -421,7 +421,7 @@ class Schema:
         return copy.deepcopy(cfg)
 
     ###########################################################################
-    def valid(self, *args, valid_keypaths=None, default_valid=False):
+    def valid(self, *args, default_valid=False):
         """
         Checks validity of a keypath.
 
@@ -434,23 +434,15 @@ class Schema:
         else:
             default = None
 
-        if valid_keypaths is None:
-            valid_keypaths = self.allkeys()
-
-        # Look for a full match with default playing wild card
-        for valid_keypath in valid_keypaths:
-            if len(keylist) != len(valid_keypath):
-                continue
-
-            ok = True
-            for i in range(len(keylist)):
-                if valid_keypath[i] not in (keylist[i], default):
-                    ok = False
-                    break
-            if ok:
-                return True
-
-        return False
+        cfg = self.cfg
+        for key in keylist:
+            if key in cfg:
+                cfg = cfg[key]
+            elif default_valid and default in cfg:
+                cfg = cfg[default]
+            else:
+                return False
+        return Schema._is_leaf(cfg)
 
     ##########################################################################
     def _has_field(self, *args):


### PR DESCRIPTION
Setup node for OpenROAD is noticeably slow. This appears to be from all the calls to `valid()`
This change speeds that up by ~178x.

Before profile:
```
         3556918 function calls (3413821 primitive calls) in 3.751 seconds
```
After profile:
```
         58632 function calls (53019 primitive calls) in 0.021 seconds
```

Also removes seemingly unused `valid_keypaths` argument from `.valid`