### PR TITLE
Add [option, softlib]

### DIFF
--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -3003,6 +3003,16 @@ def schema_option(cfg):
             email messages relies on job scheduler daemon support.
             For more information, see the job scheduler documentation. """)
 
+    scparam(cfg, ['option', 'softlib'],
+            sctype='[str]',
+            scope='job',
+            pernode='optional',
+            shorthelp="Option: Soft libraries",
+            switch="-softlib <str>",
+            example=["cli: -softlib sram64x1024",
+                     "api: chip.set('option', 'softlib', 'sram64x1024_generic')"],
+            schelp="""List of soft libraries to be linked in for processing by frontends.""")
+
     return cfg
 
 

--- a/siliconcompiler/tools/surelog/parse.py
+++ b/siliconcompiler/tools/surelog/parse.py
@@ -154,9 +154,8 @@ def runtime_options(chip):
 
     src_files = chip.find_files('input', 'rtl', 'verilog', step=step, index=index)
 
-    # TODO: add back later
-    # for item in libs:
-    #    src_files.extend(chip.find_files('library', item, 'input', 'verilog'))
+    for item in libs:
+        src_files.extend(chip.find_files('library', item, 'input', 'rtl', 'verilog'))
 
     for value in _remove_dups(chip, 'source', src_files):
         cmdlist.append(value)

--- a/siliconcompiler/tools/surelog/parse.py
+++ b/siliconcompiler/tools/surelog/parse.py
@@ -42,8 +42,7 @@ def setup(chip):
              step=step, index=index)
 
     libs = []
-    libs.extend(chip.get('asic', 'logiclib', step=step, index=index))
-    libs.extend(chip.get('asic', 'macrolib', step=step, index=index))
+    libs.extend(chip.get('option', 'softlib', step=step, index=index))
 
     def add_require_if_set(*key):
         if not chip.valid(*key):
@@ -85,8 +84,7 @@ def runtime_options(chip):
     cmdlist = []
 
     libs = []
-    libs.extend(chip.get('asic', 'logiclib', step=step, index=index))
-    libs.extend(chip.get('asic', 'macrolib', step=step, index=index))
+    libs.extend(chip.get('option', 'softlib', step=step, index=index))
 
     #####################
     # Library directories

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -7526,6 +7526,31 @@
             ],
             "type": "bool"
         },
+        "softlib": {
+            "example": [
+                "cli: -softlib sram64x1024",
+                "api: chip.set('option', 'softlib', 'sram64x1024_generic')"
+            ],
+            "help": "List of soft libraries to be linked in for processing by frontends.",
+            "lock": false,
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
+            "notes": null,
+            "pernode": "optional",
+            "require": null,
+            "scope": "job",
+            "shorthelp": "Option: Soft libraries",
+            "switch": [
+                "-softlib <str>"
+            ],
+            "type": "[str]"
+        },
         "stackup": {
             "example": [
                 "cli: -stackup 2MA4MB2MC",
@@ -9964,31 +9989,6 @@
             ],
             "type": "str"
         },
-        "remoteid": {
-            "example": [
-                "cli: -record_remoteid '0123456789abcdeffedcba9876543210'",
-                "api: chip.set('record', 'remoteid', '0123456789abcdeffedcba9876543210')"
-            ],
-            "help": "Record tracking the job ID for a remote run.",
-            "lock": false,
-            "node": {
-                "default": {
-                    "default": {
-                        "signature": null,
-                        "value": null
-                    }
-                }
-            },
-            "notes": null,
-            "pernode": "never",
-            "require": null,
-            "scope": "job",
-            "shorthelp": "Record: remote job ID",
-            "switch": [
-                "-record_remoteid 'step index <str>'"
-            ],
-            "type": "str"
-        },
         "kernelversion": {
             "example": [
                 "cli: -record_kernelversion 'dfm 0 5.11.0-34-generic'",
@@ -10161,6 +10161,31 @@
             "shorthelp": "Record: cloud region",
             "switch": [
                 "-record_region 'step index <str>'"
+            ],
+            "type": "str"
+        },
+        "remoteid": {
+            "example": [
+                "cli: -record_remoteid '0123456789abcdeffedcba9876543210'",
+                "api: chip.set('record', 'remoteid', '0123456789abcdeffedcba9876543210')"
+            ],
+            "help": "Record tracking the job ID for a remote run.",
+            "lock": false,
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
+            "notes": null,
+            "pernode": "never",
+            "require": null,
+            "scope": "job",
+            "shorthelp": "Record: remote job ID",
+            "switch": [
+                "-record_remoteid 'step index <str>'"
             ],
             "type": "str"
         },


### PR DESCRIPTION
Adds support for soft libraries instead of using macrolib/logiclib for pulling in Verilog sources, ydirs, etc. 

@gadfort do you have a strong opinion about adding support to all frontends before merge?