### PR TITLE
ensure CLI apps use similar switches for show and dashboard to find manifests

### DIFF
--- a/siliconcompiler/apps/_common.py
+++ b/siliconcompiler/apps/_common.py
@@ -1,0 +1,70 @@
+import glob
+import os
+
+
+def manifest_find_switches():
+    return ['-design',
+            '-cfg',
+            '-arg_step',
+            '-arg_index',
+            '-jobname']
+
+
+def load_manifest(chip, src_file):
+    manifest = None
+    if (src_file is not None) and (not chip.get('option', 'cfg')):
+        # only autoload manifest if user doesn't supply manually
+        manifest = _get_manifest(os.path.dirname(src_file))
+        if not manifest:
+            design = os.path.splitext(os.path.basename(src_file))[0]
+            chip.logger.error(f'Unable to automatically find manifest for design {design}. '
+                              'Please provide a manifest explicitly using -cfg.')
+            return False
+    elif not chip.get('option', 'cfg'):
+        manifest = _get_manifest_from_design(chip)
+        if not manifest:
+            chip.logger.error(f'Could not find manifest for {chip.design}')
+            return False
+
+    if manifest:
+        chip.logger.info(f'Loading manifest: {manifest}')
+        chip.read_manifest(manifest)
+        return True
+    return False
+
+
+def _get_manifest(dirname, design='*'):
+    # pkg.json file may have a different name from the design due to the entrypoint
+    glob_paths = [os.path.join(dirname, f'{design}.pkg.json'),
+                  os.path.join(dirname, 'outputs', f'{design}.pkg.json')]
+    manifest = None
+    for path in glob_paths:
+        manifest = glob.glob(path)
+        if manifest:
+            manifest = manifest[0]
+            break
+
+    if not manifest or not os.path.isfile(manifest):
+        return None
+    return manifest
+
+
+def _get_manifest_from_design(chip):
+    for jobname, step, index in [
+            (chip.get('option', 'jobname'),
+             chip.get('arg', 'step'),
+             chip.get('arg', 'index')),
+            (chip.get('option', 'jobname'),
+             None,
+             None),
+            (chip.schema.get_default('option', 'jobname'),
+             chip.get('arg', 'step'),
+             chip.get('arg', 'index')),
+            (chip.schema.get_default('option', 'jobname'),
+             None,
+             None)]:
+        manifest = _get_manifest(chip._getworkdir(jobname=jobname, step=step, index=index))
+
+        if manifest:
+            return manifest
+    return None

--- a/siliconcompiler/apps/sc.py
+++ b/siliconcompiler/apps/sc.py
@@ -6,6 +6,7 @@ import sys
 
 import siliconcompiler
 from siliconcompiler.utils import get_default_iomap
+from siliconcompiler.targets import skywater130_demo
 
 
 ###########################
@@ -36,9 +37,13 @@ def main():
     chip = siliconcompiler.Chip(UNSET_DESIGN)
 
     # Read command-line inputs and generate Chip objects to run the flow on.
-    chip.create_cmdline(progname,
-                        description=description,
-                        input_map=get_default_iomap())
+    try:
+        chip.create_cmdline(progname,
+                            description=description,
+                            input_map=get_default_iomap())
+    except Exception as e:
+        chip.logger.error(e)
+        return 1
 
     # Set design if none specified
     if chip.get('design') == UNSET_DESIGN:
@@ -64,7 +69,7 @@ def main():
 
     # Set demo target if none specified
     if not chip.get('option', 'target'):
-        chip.load_target('skywater130_demo')
+        chip.load_target(skywater130_demo)
 
     # Storing user entered steplist/args before running
     if chip.get('arg', 'step'):

--- a/siliconcompiler/apps/sc_dashboard.py
+++ b/siliconcompiler/apps/sc_dashboard.py
@@ -4,6 +4,7 @@ import siliconcompiler
 import os
 from ._common import load_manifest, manifest_find_switches
 
+
 def main():
     progname = "sc-dashboard"
     description = """
@@ -40,12 +41,16 @@ To include another chip object to compare to:
                        'metavar': '<[manifest name, manifest path>'}
     }
 
-    switches = chip.create_cmdline(
-        progname,
-        switchlist=[*manifest_find_switches(),
-                    '-loglevel'],
-        description=description,
-        additional_args=dashboard_arguments)
+    try:
+        switches = chip.create_cmdline(
+            progname,
+            switchlist=[*manifest_find_switches(),
+                        '-loglevel'],
+            description=description,
+            additional_args=dashboard_arguments)
+    except Exception as e:
+        chip.logger.error(e)
+        return 1
 
     # Error checking
     design = chip.get('design')

--- a/siliconcompiler/apps/sc_dashboard.py
+++ b/siliconcompiler/apps/sc_dashboard.py
@@ -2,7 +2,7 @@
 import sys
 import siliconcompiler
 import os
-
+from ._common import load_manifest, manifest_find_switches
 
 def main():
     progname = "sc-dashboard"
@@ -42,8 +42,8 @@ To include another chip object to compare to:
 
     switches = chip.create_cmdline(
         progname,
-        switchlist=['-loglevel',
-                    '-cfg'],
+        switchlist=[*manifest_find_switches(),
+                    '-loglevel'],
         description=description,
         additional_args=dashboard_arguments)
 
@@ -51,6 +51,9 @@ To include another chip object to compare to:
     design = chip.get('design')
     if design == UNSET_DESIGN:
         chip.logger.error('Design not loaded')
+        return 1
+
+    if not load_manifest(chip, None):
         return 1
 
     graph_chips = []

--- a/siliconcompiler/apps/sc_issue.py
+++ b/siliconcompiler/apps/sc_issue.py
@@ -67,10 +67,14 @@ To run a testcase, use:
                   'metavar': '<file>'},
     }
 
-    switches = chip.create_cmdline(progname,
-                                   switchlist=switchlist,
-                                   description=description,
-                                   additional_args=issue_arguments)
+    try:
+        switches = chip.create_cmdline(progname,
+                                       switchlist=switchlist,
+                                       description=description,
+                                       additional_args=issue_arguments)
+    except Exception as e:
+        chip.logger.error(e)
+        return 1
 
     if switches['generate'] and switches['run']:
         raise ValueError('Only one of -generate or -run can be used')

--- a/siliconcompiler/apps/sc_remote.py
+++ b/siliconcompiler/apps/sc_remote.py
@@ -56,10 +56,15 @@ To delete a job, use:
         '-delete': {'action': 'store_true',
                     'help': 'delete a job on the remote'},
     }
-    args = chip.create_cmdline(progname,
-                               switchlist=switchlist,
-                               additional_args=extra_args,
-                               description=description)
+
+    try:
+        args = chip.create_cmdline(progname,
+                                   switchlist=switchlist,
+                                   additional_args=extra_args,
+                                   description=description)
+    except Exception as e:
+        chip.logger.error(e)
+        return 1
 
     # Sanity checks.
     exclusive = ['configure', 'reconnect', 'cancel', 'delete']

--- a/siliconcompiler/apps/sc_run.py
+++ b/siliconcompiler/apps/sc_run.py
@@ -16,9 +16,13 @@ def main():
     as inputs and executes the SC run() method.
     -----------------------------------------------------------
     """
-    chip.create_cmdline(progname,
-                        switchlist=switchlist,
-                        description=description)
+    try:
+        chip.create_cmdline(progname,
+                            switchlist=switchlist,
+                            description=description)
+    except Exception as e:
+        chip.logger.error(e)
+        return 1
 
     # Error checking
     if not chip.get('cfg'):

--- a/siliconcompiler/apps/sc_show.py
+++ b/siliconcompiler/apps/sc_show.py
@@ -82,17 +82,21 @@ def main():
         'help': '(optional) Will generate a screenshot and exit.'
     }
 
-    args = chip.create_cmdline(
-        progname,
-        switchlist=[*manifest_find_switches(),
-                    '-input',
-                    '-loglevel'],
-        description=description,
-        input_map=input_map,
-        additional_args={
-            '-ext': extension_arg,
-            '-screenshot': screenshot_arg
-        })
+    try:
+        args = chip.create_cmdline(
+            progname,
+            switchlist=[*manifest_find_switches(),
+                        '-input',
+                        '-loglevel'],
+            description=description,
+            input_map=input_map,
+            additional_args={
+                '-ext': extension_arg,
+                '-screenshot': screenshot_arg
+            })
+    except Exception as e:
+        chip.logger.error(e)
+        return 1
 
     # Error checking
     design = chip.get('design')


### PR DESCRIPTION
Closes #1990

- Allows both `sc-show` and `sc-dashboard` to use the same switches to load the initial manifest
- Wrap all CLI `create_cmdline` with try/except to provide error message to users without backtrace.