### PR TITLE
provide siliconcompiler cli app as alias for sc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,10 @@ for app in os.listdir('siliconcompiler/apps'):
         entry = f'{cli_name}=siliconcompiler.apps.{name}:main'
         entry_points_apps.append(entry)
 
+        if cli_name == 'sc':
+            entry = f'siliconcompiler=siliconcompiler.apps.{name}:main'
+            entry_points_apps.append(entry)
+
 # Remove the _skbuild/ directory before running install procedure. This helps
 # fix very opaque bugs we've run into where the install fails due to some bad
 # state being cached in this directory. This means we won't get caching of build


### PR DESCRIPTION
because `sc` is a system alias in Windows powershell, this provides a full name `siliconcompiler` cli app which is an alias to `sc` to allow for easier use on Windows.