### PR TITLE
Update yosys to make use of new -dont_use flag to ABC

### DIFF
--- a/setup/_tools.json
+++ b/setup/_tools.json
@@ -85,7 +85,7 @@
   },
   "yosys": {
     "git-url": "https://github.com/YosysHQ/yosys.git",
-    "git-commit": "41b34a19353dbbe00aa08f3561e25e0bfa4c84d2",
+    "git-commit": "9ed38bf9b662b36852271671f2a73ed659b00331",
     "auto-update": true
   },
   "slurm": {

--- a/siliconcompiler/tools/yosys/prepareLib.py
+++ b/siliconcompiler/tools/yosys/prepareLib.py
@@ -7,7 +7,7 @@ import argparse  # argument parsing
 import fnmatch
 
 
-def processLibertyFile(input_file, dont_use, logger=None):
+def processLibertyFile(input_file, dont_use=None, logger=None):
     # Read input file
     if logger:
         logger.info(f"Opening file for replace: {input_file}")
@@ -18,26 +18,27 @@ def processLibertyFile(input_file, dont_use, logger=None):
     content = f.read().encode("ascii", "ignore").decode("ascii")
     f.close()
 
-    # Pattern to match a cell header
-    patternList = [re.compile(fnmatch.translate(du)) for du in dont_use]
+    if dont_use:
+        # Pattern to match a cell header
+        patternList = [re.compile(fnmatch.translate(du)) for du in dont_use]
 
-    content_dont_use = ""
-    re_cell_line = re.compile(r"^\s*cell\s*\(\s*[\"]?(\w+)[\"]?\)\s*\{")
-    count = 0
-    for line in content.splitlines():
-        content_dont_use += line + "\n"
-        cell_match = re_cell_line.match(line)
-        if cell_match:
-            for du in patternList:
-                if du.match(cell_match.group(1)):
-                    if logger:
-                        logger.info(f'  Marking {cell_match.group(1)} as dont_use')
-                    content_dont_use += "    dont_use : true;\n"
-                    count += 1
-                    break
-    content = content_dont_use
-    if logger:
-        logger.info(f"Marked {count} cells as dont_use")
+        content_dont_use = ""
+        re_cell_line = re.compile(r"^\s*cell\s*\(\s*[\"]?(\w+)[\"]?\)\s*\{")
+        count = 0
+        for line in content.splitlines():
+            content_dont_use += line + "\n"
+            cell_match = re_cell_line.match(line)
+            if cell_match:
+                for du in patternList:
+                    if du.match(cell_match.group(1)):
+                        if logger:
+                            logger.info(f'  Marking {cell_match.group(1)} as dont_use')
+                        content_dont_use += "    dont_use : true;\n"
+                        count += 1
+                        break
+        content = content_dont_use
+        if logger:
+            logger.info(f"Marked {count} cells as dont_use")
 
     # Yosys-abc throws an error if original_pin is found within the liberty file.
     # removing

--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -2,7 +2,7 @@
 from siliconcompiler.tools.yosys.yosys import syn_setup, syn_post_process
 import os
 import re
-import siliconcompiler.tools.yosys.markDontUse as markDontUse
+import siliconcompiler.tools.yosys.prepareLib as prepareLib
 import siliconcompiler.tools.yosys.mergeLib as mergeLib
 
 
@@ -200,9 +200,9 @@ def prepare_synthesis_libraries(chip):
 
     with open(chip.get('tool', tool, 'task', task, 'file', 'dff_liberty_file',
                        step=step, index=index)[0], 'w') as f:
-        f.write(markDontUse.processLibertyFile(
+        f.write(prepareLib.processLibertyFile(
             dff_liberty_file,
-            dff_dont_use,
+            dont_use=dff_dont_use,
             logger=None if chip.get('option', 'quiet', step=step, index=index) else chip.logger
         ))
 
@@ -219,16 +219,12 @@ def prepare_synthesis_libraries(chip):
 
     for libtype in ('logiclib', 'macrolib'):
         for lib in chip.get('asic', libtype, step=step, index=index):
-            dont_use = chip.get('library', lib, 'asic', 'cells', 'dontuse',
-                                step=step, index=index)
-
             lib_content = []
             # Mark dont use
             for lib_file in get_synthesis_libraries(lib):
                 lib_content.append(
-                    markDontUse.processLibertyFile(
+                    prepareLib.processLibertyFile(
                         lib_file,
-                        dont_use,
                         logger=None if chip.get('option', 'quiet',
                                                 step=step, index=index) else chip.logger
                     ))

--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -275,7 +275,7 @@ foreach lib "$sc_logiclibs $sc_macrolibs" {
     }
 }
 
-yosys abc -liberty $sc_dff_library {*}$abc_args {*}$abc_dont_use
+yosys abc {*}$abc_args {*}$abc_dont_use
 
 ########################################################
 # Cleanup

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -41,7 +41,7 @@ def setup(chip):
     # Standard Setup
     chip.set('tool', tool, 'exe', 'yosys')
     chip.set('tool', tool, 'vswitch', '--version')
-    chip.set('tool', tool, 'version', '>=0.27', clobber=False)
+    chip.set('tool', tool, 'version', '>=0.33+21', clobber=False)
     chip.set('tool', tool, 'format', 'tcl', clobber=False)
 
     # Task Setup

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -41,11 +41,11 @@ def __check_gcd(chip):
 
     # Warning: *. (x3)
     # Missing route to pin (x70)
-    assert chip.get('metric', 'warnings', step='route', index='0') == 73
+    assert chip.get('metric', 'warnings', step='route', index='0') == 69
 
     # Warning: *. (x3)
     # Missing route to pin (x185)
-    assert chip.get('metric', 'warnings', step='dfm', index='0') == 186
+    assert chip.get('metric', 'warnings', step='dfm', index='0') == 238
 
     # "no fill config specified"
     assert chip.get('metric', 'warnings', step='export', index='0') == 1

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -24,8 +24,8 @@ def __check_gcd(chip):
     # "No timescale set..."
     assert chip.get('metric', 'warnings', step='import', index='0') == 10
 
-    # "Found unsupported expression..." (x72) + 3 ABC Warnings
-    assert chip.get('metric', 'warnings', step='syn', index='0') == 75
+    # "Found unsupported expression..." (x71) + 3 ABC Warnings
+    assert chip.get('metric', 'warnings', step='syn', index='0') == 74
 
     # Warning: *. (x3)
     # [WARNING PSM*] (x12)
@@ -40,11 +40,11 @@ def __check_gcd(chip):
     assert chip.get('metric', 'warnings', step='cts', index='0') == 5
 
     # Warning: *. (x3)
-    # Missing route to pin (x70)
+    # Missing route to pin (x66)
     assert chip.get('metric', 'warnings', step='route', index='0') == 69
 
     # Warning: *. (x3)
-    # Missing route to pin (x185)
+    # Missing route to pin (x235)
     assert chip.get('metric', 'warnings', step='dfm', index='0') == 238
 
     # "no fill config specified"


### PR DESCRIPTION
This removes the need to modify the libraries for ABC to mark cells as dont_use, but instead use the new -dont_use.