### PR TITLE
Check tool versions at beginning of run

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4211,6 +4211,18 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         for (step, index) in flowgraph_nodes:
             # Setting up tool is optional
             self._setup_node(step, index)
+            # Env vars are necessary as test_multiple_tools.py requires it for its version check
+            self._set_env_vars(step, index)
+            tool, task = self._get_tool_task(step, index, flow)
+            # Icarus compiles its executable during the run so we can't check its version
+            if (tool, task) != ('execute', 'exec_input'):
+                run_func = getattr(self._get_task_module(step, index, flow=flow), 'run', None)
+                try:
+                    self._check_tool_version(step, index, run_func)
+                # Convert sys.exit(1) from haltstep() in version check to SilicoCompilerError
+                except SystemExit:
+                    self.error('Pre-run version check failed. Please update your tools.',
+                               fatal=True)
 
         # Check validity of setup
         self.logger.info("Checking manifest before running.")

--- a/siliconcompiler/tools/execute/execute.py
+++ b/siliconcompiler/tools/execute/execute.py
@@ -11,5 +11,6 @@ def setup(chip):
 
     tool, task = chip._get_tool_task(step, index)
 
-    chip.set('tool', tool, 'exe', ":exe:", clobber=False)
+    # Use dummy bash executable 'true' to pass pre-run version check
+    chip.set('tool', tool, 'exe', 'true', clobber=False)
     chip.set('tool', tool, 'task', task, 'option', [], step=step, index=index, clobber=False)

--- a/tests/core/test_error_manifest.py
+++ b/tests/core/test_error_manifest.py
@@ -1,9 +1,12 @@
 import siliconcompiler
 from siliconcompiler.tools.surelog import parse
-from siliconcompiler._common import SiliconCompilerError
 import os
 
+import pytest
 
+
+@pytest.mark.quick
+@pytest.mark.eda
 def test_error_manifest():
     '''
     Executing a node with errors should still produce an output manifest
@@ -18,9 +21,8 @@ def test_error_manifest():
     index = '0'
     chip.node(flow, step, parse, index=index)
 
-    try:
+    with pytest.raises(siliconcompiler.SiliconCompilerError):
         chip.run()
-    except SiliconCompilerError:
-        workdir = chip._getworkdir(jobname=chip._get_in_job(step, index), step=step, index=index)
-        cfg = os.path.join(workdir, 'outputs', f'{chip.top()}.pkg.json')
-        assert os.path.isfile(cfg)
+    workdir = chip._getworkdir(jobname=chip._get_in_job(step, index), step=step, index=index)
+    cfg = os.path.join(workdir, 'outputs', f'{chip.top()}.pkg.json')
+    assert os.path.isfile(cfg)

--- a/tests/core/test_version_early.py
+++ b/tests/core/test_version_early.py
@@ -1,13 +1,10 @@
 import siliconcompiler
-from siliconcompiler.tools.yosys import syn_asic
 from siliconcompiler.tools.surelog import parse
 
 import pytest
 
 
-@pytest.mark.quick
-@pytest.mark.eda
-def test_fail_early(capfd):
+def test_version_early(capfd):
     chip = siliconcompiler.Chip('test')
     chip.set('input', 'rtl', 'verilog', 'fake.v')
     chip.load_target('freepdk45_demo')
@@ -15,12 +12,12 @@ def test_fail_early(capfd):
     flow = 'test'
     chip.set('option', 'flow', flow)
     chip.node(flow, 'import', parse)
-    chip.node(flow, 'syn', syn_asic)
-    chip.edge(flow, 'import', 'syn')
+    chip.set('tool', 'surelog', 'version', '==100.0')
 
-    with pytest.raises(siliconcompiler.SiliconCompilerError):
+    with pytest.raises(siliconcompiler.SiliconCompilerError,
+                       match='Pre-run version check failed. Please update your tools.'):
         chip.run()
-    # Fail if 'syn' step is run
+    # Fail if any task is run
     out, _ = capfd.readouterr()
     assert "Halting step 'import'" in out
-    assert "Halting step 'syn'" not in out
+    assert "Finished task in" not in out

--- a/tests/core/test_version_early.py
+++ b/tests/core/test_version_early.py
@@ -4,6 +4,8 @@ from siliconcompiler.tools.surelog import parse
 import pytest
 
 
+@pytest.mark.eda
+@pytest.mark.quick
 def test_version_early(capfd):
     chip = siliconcompiler.Chip('test')
     chip.set('input', 'rtl', 'verilog', 'fake.v')
@@ -14,10 +16,9 @@ def test_version_early(capfd):
     chip.node(flow, 'import', parse)
     chip.set('tool', 'surelog', 'version', '==100.0')
 
-    with pytest.raises(siliconcompiler.SiliconCompilerError,
-                       match='Pre-run version check failed. Please update your tools.'):
+    with pytest.raises(SystemExit):
         chip.run()
     # Fail if any task is run
     out, _ = capfd.readouterr()
-    assert "Halting step 'import'" in out
+    assert "Version check failed" in out
     assert "Finished task in" not in out

--- a/tests/flows/test_multiple_tools.py
+++ b/tests/flows/test_multiple_tools.py
@@ -55,6 +55,9 @@ def test_multiple_tools():
     chip.set('tool', 'surelog', 'licenseserver', 'ACME_LICENSE', '1700@server',
              step='slog', index=1)
 
+    # Set env vars for slog1 for pre-run version check
+    chip._set_env_vars('slog', '1')
+
     # Don't run tools, just version check
     chip.set('option', 'skipall', True)
     chip.run()


### PR DESCRIPTION
**Why?**
Currently even on a local run we only check if the tool version is correct and the tool exists when executing a node.
This leads to failures in the middle of the run and is annoying to the user.

**What?**
If the nodes are executed locally then we check at the beginning of the run if all tools are present and have right version.

**How?**
We use the same tool version check that we use when executing a node but run it also at the start of the run.

**Issues:**
Some tools like `iverilog` produce their binary while executing the flow.
These binaries can't be version checked in the beginning of the run.

**Before:**
```-------------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------------
| INFO    | /home/martin-zeroasic/coding/siliconcompiler/examples/gcd/gcd.v inferred as rtl/verilog
| INFO    | /home/martin-zeroasic/coding/siliconcompiler/examples/gcd/gcd.sdc inferred as constraint/sdc
| INFO    | job0 | --        | - | Setting up node import0 with surelog/parse
| INFO    | job0 | --        | - | Setting up node syn0 with yosys/syn_asic
| INFO    | job0 | --        | - | Setting up node floorplan0 with openroad/floorplan
| INFO    | job0 | --        | - | Setting up node place0 with openroad/place
| INFO    | job0 | --        | - | Setting up node cts0 with openroad/cts
| INFO    | job0 | --        | - | Setting up node route0 with openroad/route
| INFO    | job0 | --        | - | Setting up node dfm0 with openroad/dfm
| INFO    | job0 | --        | - | Setting up node export0 with klayout/export
| INFO    | job0 | --        | - | Setting up node export1 with openroad/export
| INFO    | job0 | --        | - | Checking manifest before running.
| INFO    | job0 | import    | 0 | Tool 'surelog' found with version '1.71' in directory '/usr/local/bin'
| INFO    | job0 | import    | 0 | Running in /tmp/pytest-of-martin-zeroasic/pytest-24/test_py_read_manifest0/build/gcd/job0/import/0
| INFO    | job0 | import    | 0 | surelog -nocache +libext+.sv+.v -parse -nouhdm /home/martin-zeroasic/coding/siliconcompiler/examples/gcd/gcd.v -top gcd
| INFO    | job0 | import    | 0 | Computing hash value for [tool,surelog,task,parse,output]
| INFO    | job0 | import    | 0 | Computing hash value for [input,rtl,verilog]
| INFO    | job0 | import    | 0 | Finished task in 0.59s
| INFO    | job0 | syn       | 0 | Tool 'yosys' found with version '0.31+16' in directory '/usr/local/bin'
| INFO    | job0 | syn       | 0 | Running in /tmp/pytest-of-martin-zeroasic/pytest-24/test_py_read_manifest0/build/gcd/job0/syn/0
| INFO    | job0 | syn       | 0 | yosys -c /home/martin-zeroasic/coding/siliconcompiler/siliconcompiler/tools/yosys/sc_syn.tcl
| INFO    | job0 | syn       | 0 | Computing hash value for [tool,yosys,task,syn_asic,output]
| INFO    | job0 | syn       | 0 | Computing hash value for [library,nangate45,output,typical,nldm]
| INFO    | job0 | syn       | 0 | Computing hash value for [library,nangate45,option,file,yosys_addermap]
| INFO    | job0 | syn       | 0 | Finished task in 2.4s
| INFO    | job0 | floorplan | 0 | Tool 'openroad' found with version 'v2.0-9907' in directory '/usr/local/bin'
| ERROR   | job0 | floorplan | 0 | Version check failed for openroad. Check installation.
| ERROR   | job0 | floorplan | 0 | Found version v2.0-9907, did not satisfy any version specifier set >=v2.0-10370.
| ERROR   | job0 | floorplan | 0 | Halting step 'floorplan' index '0' due to errors.
```

**After:**
```

-------------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------------
| INFO    | gcd.v inferred as rtl/verilog
| INFO    | rtl2gds | --        | - | Setting up node import0 with surelog/parse
| INFO    | rtl2gds | --        | - | Tool 'surelog' found with version '1.71' in directory '/usr/local/bin'
| INFO    | rtl2gds | --        | - | Setting up node syn0 with yosys/syn_asic
| INFO    | rtl2gds | --        | - | Tool 'yosys' found with version '0.31+16' in directory '/usr/local/bin'
| INFO    | rtl2gds | --        | - | Setting up node floorplan0 with openroad/floorplan
| INFO    | rtl2gds | --        | - | Tool 'openroad' found with version 'v2.0-9907' in directory '/usr/local/bin'
| ERROR   | rtl2gds | --        | - | Version check failed for openroad. Check installation.
| ERROR   | rtl2gds | --        | - | Found version v2.0-9907, did not satisfy any version specifier set >=v2.0-10370.
| ERROR   | rtl2gds | --        | - | Halting step 'floorplan' index '0' due to errors.
```

**Testing:**
- `tests/core/test_error_manifest.py` and `tests/core/test_fail_early.py` needed to be added to the eda tests since we are now checking earlier if their executable is present
- `tests/core/test_version_early.py`