### PR TITLE
Return copy instead of reference for chip.get()

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -923,12 +923,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                     )
                     return None
 
-            # Prevent accidental modifications of the schema content by not passing a reference
-            result = self.schema.get(*keypath, field=field, job=job, step=step, index=index)
-            try:
-                return result.copy()
-            except AttributeError:
-                return result
+            return self.schema.get(*keypath, field=field, job=job, step=step, index=index)
         except (ValueError, TypeError) as e:
             self.error(str(e))
             return None

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -923,7 +923,12 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                     )
                     return None
 
-            return self.schema.get(*keypath, field=field, job=job, step=step, index=index)
+            # Prevent accidental modifications of the schema content by not passing a reference
+            result = self.schema.get(*keypath, field=field, job=job, step=step, index=index)
+            try:
+                return result.copy()
+            except AttributeError:
+                return result
         except (ValueError, TypeError) as e:
             self.error(str(e))
             return None
@@ -4102,7 +4107,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 # we assume we are good to run it.
                 nodes_to_run[node] = []
             else:
-                nodes_to_run[node] = self.get('flowgraph', flow, step, index, 'input').copy()
+                nodes_to_run[node] = self.get('flowgraph', flow, step, index, 'input')
 
             processes[node] = multiprocessor.Process(target=self._runtask,
                                                      args=(flow, step, index, status))

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -141,11 +141,7 @@ class Schema:
         See :meth:`~siliconcompiler.core.Chip.get` for detailed documentation.
         """
         # Prevent accidental modifications of the schema content by not passing a reference
-        result = self.__get(*keypath, field=field, job=job, step=step, index=index)
-        try:
-            return result.copy()
-        except AttributeError:
-            return result
+        return copy.copy(self.__get(*keypath, field=field, job=job, step=step, index=index))
 
     ###########################################################################
     def __get(self, *keypath, field='value', job=None, step=None, index=None):

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -134,13 +134,21 @@ class Schema:
 
         return localcfg
 
-    ###########################################################################
     def get(self, *keypath, field='value', job=None, step=None, index=None):
         """
         Returns a schema parameter field.
 
         See :meth:`~siliconcompiler.core.Chip.get` for detailed documentation.
         """
+        # Prevent accidental modifications of the schema content by not passing a reference
+        result = self.__get(*keypath, field=field, job=job, step=step, index=index)
+        try:
+            return result.copy()
+        except AttributeError:
+            return result
+
+    ###########################################################################
+    def __get(self, *keypath, field='value', job=None, step=None, index=None):
         cfg = self._search(*keypath, job=job)
 
         if not Schema._is_leaf(cfg):

--- a/tests/core/test_get_copy.py
+++ b/tests/core/test_get_copy.py
@@ -1,0 +1,8 @@
+import siliconcompiler
+
+
+def test_get_copy():
+    chip = siliconcompiler.Chip('test')
+    cfg = chip.get('option', 'cfg')
+    cfg.append('manifest.json')
+    assert chip.get('option', 'cfg') != cfg


### PR DESCRIPTION
**What?**
Always copy the list or other objects that would otherwise returned by reference from the schema.

**Why?**
Benazeer was most recently running into accidental edits of lists in the schema.
I have personally noticed this in the past.

**Issues:**
I'm not sure if this is "deep" enough.
Maybe this should even be on the `schema.get()` level.

**Testing:**
tests/core/test_get_copy.py