### PR TITLE
Windows pathlib fix

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -118,3 +118,22 @@ jobs:
           cd $GITHUB_WORKSPACE/zerosoc
           ./build.py --core-only
           ./build.py --top-only
+
+  windows_unit_tests:
+    name: Windows Unit Tests
+    runs-on: windows-latest
+    steps:
+      - name: Checkout SiliconCompiler
+        uses: actions/checkout@v3
+
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          architecture: x64
+
+      - name: Install SC Without Surelog
+        run: READTHEDOCS=True pip3 install -r requirements.txt .
+
+      - name: Run Windows Unit Tests
+        run: pytest tests/schema/test_windows_paths.py

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1284,7 +1284,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             entry, depending on whether it is found.
 
         Examples:
-            >>> chip.find_files('input', 'verilog')
+            >>> chip.find_files('input', 'rtl', 'verilog')
             Returns a list of absolute paths to source files, as specified in
             the schema.
 

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -488,7 +488,7 @@ def _request_remote_run(chip):
     proprietary IP that may be uploaded.
   - Only send one run at a time (or you may be temporarily blocked).
   - Do not send large designs (machines have limited resources).
-  - We are currently only returning metrics, renderings of the results, and the final GDS-II.
+  - Nontrivial designs may take some time to run. (machines have limited resources).
   - For full TOS, see https://www.siliconcompiler.com/terms-of-service
 -----------------------------------------------------------------------------------------------""")
         time.sleep(upload_delay)

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -570,7 +570,7 @@ class Schema:
 
         if sc_type in ('file', 'dir'):
             if isinstance(value, (str, pathlib.Path)):
-                return str(value)
+                return pathlib.Path(value).as_posix()
             else:
                 raise TypeError(error_msg)
 

--- a/tests/core/test_create_cmdline.py
+++ b/tests/core/test_create_cmdline.py
@@ -1,4 +1,5 @@
 import re
+import pathlib
 import pytest
 
 import siliconcompiler
@@ -272,7 +273,15 @@ def test_cli_examples(monkeypatch):
 
     for kp, step, index, val in expected_data:
         print("Check", kp, c.schema.get(*kp, step=step, index=index), val)
-        assert c.schema.get(*kp, step=step, index=index) == val
+        stype = c.schema.get(*kp, field='type')
+        if stype in ('file', 'dir'):
+            assert pathlib.Path(c.schema.get(*kp, step=step, index=index)) == pathlib.Path(val)
+        elif stype in ('[file]', '[dir]'):
+            actual_paths = c.schema.get(*kp, step=step, index=index)
+            for i in range(len(val)):
+                assert pathlib.Path(actual_paths[i]) == pathlib.Path(val[i])
+        else:
+            assert c.schema.get(*kp, step=step, index=index) == val
 
 
 def test_invalid_switch():

--- a/tests/core/test_setget.py
+++ b/tests/core/test_setget.py
@@ -86,12 +86,11 @@ def test_setget():
             # arbitrary step/index to avoid error
             step, index = 'syn', '0'
         result = chip.get(*keypath, step=step, index=index)
-        stype = chip.schema.get(*keypath, field='type')
+        stype = chip.get(*keypath, field='type')
         if stype in ('file', 'dir'):
             assert pathlib.Path(result) == pathlib.Path(value), \
                 f'Expected value {value} from keypath {keypath}. Got {result}.'
         elif stype in ('[file]', '[dir]'):
-            actual_paths = chip.schema.get(*keypath, step=step, index=index)
             for i in range(len(value)):
                 assert pathlib.Path(result[i]) == pathlib.Path(value[i]), \
                     f'Expected value {value} from keypath {keypath}. Got {result}.'

--- a/tests/core/test_setget.py
+++ b/tests/core/test_setget.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
+import pathlib
 import pytest
 import re
 import siliconcompiler
@@ -85,7 +86,17 @@ def test_setget():
             # arbitrary step/index to avoid error
             step, index = 'syn', '0'
         result = chip.get(*keypath, step=step, index=index)
-        assert result == value, f'Expected value {value} from keypath {keypath}. Got {result}.'
+        stype = chip.schema.get(*keypath, field='type')
+        if stype in ('file', 'dir'):
+            assert pathlib.Path(result) == pathlib.Path(value), \
+                f'Expected value {value} from keypath {keypath}. Got {result}.'
+        elif stype in ('[file]', '[dir]'):
+            actual_paths = chip.schema.get(*keypath, step=step, index=index)
+            for i in range(len(value)):
+                assert pathlib.Path(result[i]) == pathlib.Path(value[i]), \
+                    f'Expected value {value} from keypath {keypath}. Got {result}.'
+        else:
+            assert result == value, f'Expected value {value} from keypath {keypath}. Got {result}.'
 
     chip.write_manifest('allvals.json')
 

--- a/tests/schema/test_windows_paths.py
+++ b/tests/schema/test_windows_paths.py
@@ -21,6 +21,7 @@ def test_windows_path_compat():
 
     # Create a Schema, and set the file path using Windows notation.
     chip = Chip('path_test')
+    chip.set('option', 'strict', False)
     chip.input(windows_path)
 
     # Verify that the Schema path is POSIX-style.

--- a/tests/schema/test_windows_paths.py
+++ b/tests/schema/test_windows_paths.py
@@ -1,6 +1,9 @@
 import os
+import pathlib
+import pytest
 
 from siliconcompiler import Chip
+
 
 @pytest.mark.win32
 def test_windows_path_compat():

--- a/tests/schema/test_windows_paths.py
+++ b/tests/schema/test_windows_paths.py
@@ -24,11 +24,11 @@ def test_windows_path_compat():
     chip.input(windows_path)
 
     # Verify that the Schema path is POSIX-style.
-    path = chip.get('input', 'verilog')[0]
+    path = chip.get('input', 'rtl', 'verilog')[0]
     assert path == pathlib.Path(windows_path).as_posix()
 
     # Verify that SC still uses the Windows path on a Windows system.
-    win_path = chip.find_files('input', 'verilog')[0]
+    win_path = chip.find_files('input', 'rtl', 'verilog')[0]
     assert os.path.isfile(win_path)
     with open(win_path, 'r') as rf:
         assert rf.read() == windows_content

--- a/tests/schema/test_windows_paths.py
+++ b/tests/schema/test_windows_paths.py
@@ -1,0 +1,31 @@
+import os
+
+from siliconcompiler import Chip
+
+@pytest.mark.win32
+def test_windows_path_compat():
+    '''
+    Test that SC stores POSIX-style paths internally, while still
+    providing Windows-style paths when necessary on a Windows system.
+    '''
+
+    # Create a test file using Windows file paths.
+    os.makedirs('d:\\\\windows_dir', exist_ok=True)
+    windows_path = 'd:\\\\windows_dir\\windows_file.v'
+    windows_content = '// Test file'
+    with open(windows_path, 'w') as wf:
+        wf.write(windows_content)
+
+    # Create a Schema, and set the file path using Windows notation.
+    chip = Chip('path_test')
+    chip.input(windows_path)
+
+    # Verify that the Schema path is POSIX-style.
+    path = chip.get('input', 'verilog')[0]
+    assert path == pathlib.Path(windows_path).as_posix()
+
+    # Verify that SC still uses the Windows path on a Windows system.
+    win_path = chip.find_files('input', 'verilog')[0]
+    assert os.path.isfile(win_path)
+    with open(win_path, 'r') as rf:
+        assert rf.read() == windows_content

--- a/tests/schema/test_windows_paths.py
+++ b/tests/schema/test_windows_paths.py
@@ -1,11 +1,9 @@
 import os
 import pathlib
-import pytest
 
 from siliconcompiler import Chip
 
 
-@pytest.mark.win32
 def test_windows_path_compat():
     '''
     Test that SC stores POSIX-style paths internally, while still


### PR DESCRIPTION
This change updates the Schema's normalization logic to always store paths in a POSIX format.

Windows machines will still be able to find files using the Schema's POSIX paths, even with absolute paths, thanks to the `pathlib.Path` parsing in `core.py`. I added [a daily CI test](https://github.com/siliconcompiler/siliconcompiler/actions/runs/6343604134/job/17231856210) to verify that.

While this logic won't change the path's meaning, it will strip leading `./` characters for relative paths; I had to adjust a couple of CI tests to account for that, but they still use the `==` operator on `Path` objects.