### PR TITLE
Add prune

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4234,7 +4234,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 # If node is builtin and not all input nodes were pruned, mark visited
                 if self._is_builtin(tool, task) \
                         and self._get_pruned_node_inputs(flow, current_node):
-                    print(self._get_pruned_node_inputs(flow, current_node))
                     nodes_sorted.append(current_node)
                     visited_nodes.add(current_node)
                     current_nodes.remove(current_node)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4230,9 +4230,10 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             if current_nodes == current_nodes_copy:
                 # Only fail if step was not visited
                 if not any(filter(lambda node: node[0] == current_node[0], visited_nodes)):
-                    raise Exception(
-                        f'Input paths coming from {inputs.difference(visited_nodes)} '
-                        f'to {current_node} are missing.')
+                    raise SiliconCompilerError(
+                        f'Flowgraph connection from {inputs.difference(visited_nodes)} '
+                        f'to {current_node} are missing. '
+                        f'Double check your flowgraph and from/to/prune options.')
                 current_nodes.remove(current_node)
         return nodes_sorted
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4216,7 +4216,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         while current_nodes and not to_nodes.issubset(visited_nodes):
             current_nodes_copy = current_nodes.copy()
             for current_node in current_nodes_copy:
-                if f'{current_node[0]}{current_node[1]}' in prune_nodes:
+                if current_node in prune_nodes:
                     current_nodes.remove(current_node)
                     continue
                 inputs = set(self._get_flowgraph_node_inputs(flow, current_node))
@@ -4277,7 +4277,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         while current_nodes:
             current_nodes_copy = current_nodes.copy()
             for current_node in current_nodes_copy:
-                if f'{current_node[0]}{current_node[1]}' in prune_nodes:
+                if current_node in prune_nodes:
                     current_nodes.remove(current_node)
                     continue
                 if cond(current_node):

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4228,11 +4228,13 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                     outputs = self._get_flowgraph_node_outputs(flow, current_node)
                     current_nodes.update(outputs)
 
-            # The graph traversal has locked up
+            # Handle missing input connections
             if current_nodes == current_nodes_copy:
                 tool, task = self._get_tool_task(current_node[0], current_node[1], flow=flow)
-                # If node is min/max and some input nodes were pruned, mark visited, continue
-                if self._is_builtin(tool, task) and (task == 'minimum' or task == 'maximum'):
+                # If node is builtin and not all input nodes were pruned, mark visited
+                if self._is_builtin(tool, task) \
+                        and self._get_pruned_node_inputs(flow, current_node):
+                    print(self._get_pruned_node_inputs(flow, current_node))
                     nodes_sorted.append(current_node)
                     visited_nodes.add(current_node)
                     current_nodes.remove(current_node)

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -2485,6 +2485,18 @@ def schema_option(cfg):
             Inclusive list of steps to end execution with. The default is to go
             to all exit steps in the flow graph.""")
 
+    scparam(cfg, ['option', 'prune'],
+            sctype='[str]',
+            scope='job',
+            shorthelp="Prune branches starting with",
+            switch="-prune <node>",
+            example=[
+                "cli: -prune 'syn0'",
+                "api: chip.set('option', 'prune', 'syn0')"],
+            schelp="""
+            List of starting nodes for branches to be pruned.
+            The default is to not prune any nodes/branches.""")
+
     scparam(cfg, ['option', 'breakpoint'],
             sctype='bool',
             scope='job',

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -2486,13 +2486,13 @@ def schema_option(cfg):
             to all exit steps in the flow graph.""")
 
     scparam(cfg, ['option', 'prune'],
-            sctype='[str]',
+            sctype='[(str,str)]',
             scope='job',
-            shorthelp="Prune branches starting with",
-            switch="-prune <node>",
+            shorthelp="Prune flowgraph branches starting with",
+            switch="-prune 'node <(str,str)>'",
             example=[
-                "cli: -prune 'syn0'",
-                "api: chip.set('option', 'prune', 'syn0')"],
+                "cli: -prune (syn,0)",
+                "api: chip.set('option', 'prune', ('syn', '0'))"],
             schelp="""
             List of starting nodes for branches to be pruned.
             The default is to not prune any nodes/branches.""")

--- a/siliconcompiler/tools/builtin/maximum.py
+++ b/siliconcompiler/tools/builtin/maximum.py
@@ -25,7 +25,7 @@ def _select_inputs(chip, step, index):
     chip.logger.info("Running builtin task 'maximum'")
 
     flow = chip.get('option', 'flow')
-    inputs = chip.get('flowgraph', flow, step, index, 'input')
+    inputs = chip._get_pruned_node_inputs(flow, (step, index))
 
     score, sel_inputs = _common._minmax(chip, *inputs, op='maximum')
 

--- a/siliconcompiler/tools/builtin/minimum.py
+++ b/siliconcompiler/tools/builtin/minimum.py
@@ -24,7 +24,7 @@ def _select_inputs(chip, step, index):
     chip.logger.info("Running builtin task 'minimum'")
 
     flow = chip.get('option', 'flow')
-    inputs = chip.get('flowgraph', flow, step, index, 'input')
+    inputs = chip._get_pruned_node_inputs(flow, (step, index))
 
     score, sel_inputs = _common._minmax(chip, *inputs, op='minimum')
 

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -7578,8 +7578,8 @@
         },
         "prune": {
             "example": [
-                "cli: -prune 'syn0'",
-                "api: chip.set('option', 'prune', 'syn0')"
+                "cli: -prune (syn,0)",
+                "api: chip.set('option', 'prune', ('syn', '0'))"
             ],
             "help": "List of starting nodes for branches to be pruned.\nThe default is to not prune any nodes/branches.",
             "lock": false,
@@ -7595,11 +7595,11 @@
             "pernode": "never",
             "require": null,
             "scope": "job",
-            "shorthelp": "Prune branches starting with",
+            "shorthelp": "Prune flowgraph branches starting with",
             "switch": [
-                "-prune <node>"
+                "-prune 'node <(str,str)>'"
             ],
-            "type": "[str]"
+            "type": "[(str,str)]"
         },
         "strict": {
             "example": [

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -7576,6 +7576,31 @@
             ],
             "type": "[str]"
         },
+        "prune": {
+            "example": [
+                "cli: -prune 'syn0'",
+                "api: chip.set('option', 'prune', 'syn0')"
+            ],
+            "help": "List of starting nodes for branches to be pruned.\nThe default is to not prune any nodes/branches.",
+            "lock": false,
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
+            "notes": null,
+            "pernode": "never",
+            "require": null,
+            "scope": "job",
+            "shorthelp": "Prune branches starting with",
+            "switch": [
+                "-prune <node>"
+            ],
+            "type": "[str]"
+        },
         "strict": {
             "example": [
                 "cli: -strict true",

--- a/tests/core/data/last_major.json
+++ b/tests/core/data/last_major.json
@@ -7578,8 +7578,8 @@
         },
         "prune": {
             "example": [
-                "cli: -prune 'syn0'",
-                "api: chip.set('option', 'prune', 'syn0')"
+                "cli: -prune (syn,0)",
+                "api: chip.set('option', 'prune', ('syn', '0'))"
             ],
             "help": "List of starting nodes for branches to be pruned.\nThe default is to not prune any nodes/branches.",
             "lock": false,
@@ -7595,11 +7595,11 @@
             "pernode": "never",
             "require": null,
             "scope": "job",
-            "shorthelp": "Prune branches starting with",
+            "shorthelp": "Prune flowgraph branches starting with",
             "switch": [
-                "-prune <node>"
+                "-prune 'node <(str,str)>'"
             ],
-            "type": "[str]"
+            "type": "[(str,str)]"
         },
         "strict": {
             "example": [

--- a/tests/core/data/last_major.json
+++ b/tests/core/data/last_major.json
@@ -7576,6 +7576,31 @@
             ],
             "type": "[str]"
         },
+        "prune": {
+            "example": [
+                "cli: -prune 'syn0'",
+                "api: chip.set('option', 'prune', 'syn0')"
+            ],
+            "help": "List of starting nodes for branches to be pruned.\nThe default is to not prune any nodes/branches.",
+            "lock": false,
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": [],
+                        "value": []
+                    }
+                }
+            },
+            "notes": null,
+            "pernode": "never",
+            "require": null,
+            "scope": "job",
+            "shorthelp": "Prune branches starting with",
+            "switch": [
+                "-prune <node>"
+            ],
+            "type": "[str]"
+        },
         "strict": {
             "example": [
                 "cli: -strict true",

--- a/tests/flows/test_flowstatus.py
+++ b/tests/flows/test_flowstatus.py
@@ -5,7 +5,6 @@ import json
 import os
 import subprocess
 import time
-import re
 
 import pytest
 
@@ -14,7 +13,6 @@ from siliconcompiler.tools.openroad import cts
 
 from siliconcompiler.tools.builtin import nop
 from siliconcompiler.tools.builtin import minimum
-from siliconcompiler import SiliconCompilerError
 
 
 @pytest.mark.eda
@@ -120,9 +118,10 @@ def test_long_branch(scroot):
 
     chip.set('option', 'flow', flow)
 
-    with pytest.raises(SiliconCompilerError,
-                       match=re.escape("These final nodes could not be reached: ['cts0']")):
-        chip.run()
+    chip.run()
+
+    assert chip.get('flowgraph', flow, 'cts', '0', 'status') == NodeStatus.ERROR
+    assert chip.get('flowgraph', flow, 'cts', '1', 'status') == NodeStatus.SUCCESS
 
 
 @pytest.mark.eda

--- a/tests/flows/test_prune.py
+++ b/tests/flows/test_prune.py
@@ -1,6 +1,7 @@
 import siliconcompiler
 
 from siliconcompiler.tools.builtin import nop, minimum, maximum
+from tests.core.tools.dummy import dummy
 from siliconcompiler._common import SiliconCompilerError
 
 import pytest
@@ -75,7 +76,7 @@ def test_prune_split_join():
     chip.node(flow, 'import', nop)
     chip.node(flow, 'syn', nop, index=0)
     chip.node(flow, 'syn', nop, index=1)
-    chip.node(flow, 'place', nop)
+    chip.node(flow, 'place', dummy)
     chip.edge(flow, 'import', 'syn', head_index=0)
     chip.edge(flow, 'import', 'syn', head_index=1)
     chip.edge(flow, 'syn', 'place', tail_index=0)
@@ -125,3 +126,26 @@ def test_prune_max():
     chip.set('option', 'prune', ('syn', '0'))
 
     chip.run()
+
+
+def test_prune_max_all_inputs_pruned(caplog):
+    chip = siliconcompiler.Chip('foo')
+    chip.logger = logging.getLogger()
+    chip.load_target('freepdk45_demo')
+
+    flow = 'test'
+    chip.set('option', 'flow', flow)
+    chip.node(flow, 'import', nop)
+    chip.node(flow, 'syn', nop, index=0)
+    chip.node(flow, 'syn', nop, index=1)
+    chip.node(flow, 'place', maximum)
+    chip.edge(flow, 'import', 'syn', head_index=0)
+    chip.edge(flow, 'import', 'syn', head_index=1)
+    chip.edge(flow, 'syn', 'place', tail_index=0)
+    chip.edge(flow, 'syn', 'place', tail_index=1)
+    chip.set('option', 'prune', [('syn', '0'), ('syn', '1')])
+
+    with pytest.raises(SiliconCompilerError,
+                       match=f"{flow} flowgraph contains errors and cannot be run."):
+        chip.run()
+    assert f"These final steps in {flow} can not be reached: ['place']" in caplog.text

--- a/tests/flows/test_prune.py
+++ b/tests/flows/test_prune.py
@@ -1,0 +1,87 @@
+import siliconcompiler
+
+from siliconcompiler.tools.builtin import nop
+from siliconcompiler._common import SiliconCompilerError
+
+import pytest
+
+
+def test_prune_end(capfd):
+    chip = siliconcompiler.Chip('foo')
+    chip.load_target('freepdk45_demo')
+
+    flow = 'test'
+    chip.set('option', 'flow', flow)
+    chip.node(flow, 'import', nop)
+    chip.node(flow, 'syn', nop)
+    chip.edge(flow, 'import', 'syn')
+    chip.set('option', 'prune', 'syn0')
+
+    with pytest.raises(SiliconCompilerError,
+                       match=f"{flow} flowgraph contains errors and cannot be run."):
+        chip.run()
+    stdout, _ = capfd.readouterr()
+    assert f"These final steps in {flow} can not be reached: ['syn']" in stdout
+
+
+def test_prune_middle(capfd):
+    chip = siliconcompiler.Chip('foo')
+    chip.load_target('freepdk45_demo')
+
+    flow = 'test'
+    chip.set('option', 'flow', flow)
+    chip.node(flow, 'import', nop)
+    chip.node(flow, 'syn', nop)
+    chip.node(flow, 'place', nop)
+    chip.edge(flow, 'import', 'syn')
+    chip.edge(flow, 'syn', 'place')
+    chip.set('option', 'prune', 'syn0')
+
+    with pytest.raises(SiliconCompilerError,
+                       match=f"{flow} flowgraph contains errors and cannot be run."):
+        chip.run()
+    stdout, _ = capfd.readouterr()
+    assert f"These final steps in {flow} can not be reached: ['place']" in stdout
+
+
+def test_prune_split():
+    chip = siliconcompiler.Chip('foo')
+    chip.load_target('freepdk45_demo')
+
+    flow = 'test'
+    chip.set('option', 'flow', flow)
+    chip.node(flow, 'import', nop)
+    chip.node(flow, 'syn', nop, index=0)
+    chip.node(flow, 'syn', nop, index=1)
+    chip.node(flow, 'place', nop, index=0)
+    chip.node(flow, 'place', nop, index=1)
+    chip.edge(flow, 'import', 'syn', head_index=1)
+    chip.edge(flow, 'import', 'syn', head_index=1)
+    chip.edge(flow, 'syn', 'place', head_index=0, tail_index=0)
+    chip.edge(flow, 'syn', 'place', head_index=1, tail_index=1)
+    chip.set('option', 'prune', 'syn0')
+
+    chip.run()
+
+
+def test_prune_split_join(capfd):
+    chip = siliconcompiler.Chip('foo')
+    chip.load_target('freepdk45_demo')
+
+    flow = 'test'
+    chip.set('option', 'flow', flow)
+    chip.node(flow, 'import', nop)
+    chip.node(flow, 'syn', nop, index=0)
+    chip.node(flow, 'syn', nop, index=1)
+    chip.node(flow, 'place', nop)
+    chip.edge(flow, 'import', 'syn', tail_index=0)
+    chip.edge(flow, 'import', 'syn', tail_index=1)
+    chip.edge(flow, 'syn', 'place', head_index=0)
+    chip.edge(flow, 'syn', 'place', head_index=1)
+    chip.set('option', 'prune', 'syn0')
+
+    with pytest.raises(SiliconCompilerError,
+                       match=f"{flow} flowgraph contains errors and cannot be run."):
+        chip.run()
+    stdout, _ = capfd.readouterr()
+    assert f"These final steps in {flow} can not be reached: ['place']" in stdout

--- a/tests/flows/test_prune.py
+++ b/tests/flows/test_prune.py
@@ -5,10 +5,12 @@ from siliconcompiler._common import SiliconCompilerError
 
 import pytest
 import re
+import logging
 
 
-def test_prune_end(capfd):
+def test_prune_end(caplog):
     chip = siliconcompiler.Chip('foo')
+    chip.logger = logging.getLogger()
     chip.load_target('freepdk45_demo')
 
     flow = 'test'
@@ -21,12 +23,12 @@ def test_prune_end(capfd):
     with pytest.raises(SiliconCompilerError,
                        match=f"{flow} flowgraph contains errors and cannot be run."):
         chip.run()
-    stdout, _ = capfd.readouterr()
-    assert f"These final steps in {flow} can not be reached: ['syn']" in stdout
+    assert f"These final steps in {flow} can not be reached: ['syn']" in caplog.text
 
 
-def test_prune_middle(capfd):
+def test_prune_middle(caplog):
     chip = siliconcompiler.Chip('foo')
+    chip.logger = logging.getLogger()
     chip.load_target('freepdk45_demo')
 
     flow = 'test'
@@ -41,8 +43,7 @@ def test_prune_middle(capfd):
     with pytest.raises(SiliconCompilerError,
                        match=f"{flow} flowgraph contains errors and cannot be run."):
         chip.run()
-    stdout, _ = capfd.readouterr()
-    assert f"These final steps in {flow} can not be reached: ['place']" in stdout
+    assert f"These final steps in {flow} can not be reached: ['place']" in caplog.text
 
 
 def test_prune_split():

--- a/tests/flows/test_prune.py
+++ b/tests/flows/test_prune.py
@@ -15,7 +15,7 @@ def test_prune_end(capfd):
     chip.node(flow, 'import', nop)
     chip.node(flow, 'syn', nop)
     chip.edge(flow, 'import', 'syn')
-    chip.set('option', 'prune', 'syn0')
+    chip.set('option', 'prune', ('syn', '0'))
 
     with pytest.raises(SiliconCompilerError,
                        match=f"{flow} flowgraph contains errors and cannot be run."):
@@ -35,7 +35,7 @@ def test_prune_middle(capfd):
     chip.node(flow, 'place', nop)
     chip.edge(flow, 'import', 'syn')
     chip.edge(flow, 'syn', 'place')
-    chip.set('option', 'prune', 'syn0')
+    chip.set('option', 'prune', ('syn', '0'))
 
     with pytest.raises(SiliconCompilerError,
                        match=f"{flow} flowgraph contains errors and cannot be run."):
@@ -59,7 +59,7 @@ def test_prune_split():
     chip.edge(flow, 'import', 'syn', head_index=1)
     chip.edge(flow, 'syn', 'place', head_index=0, tail_index=0)
     chip.edge(flow, 'syn', 'place', head_index=1, tail_index=1)
-    chip.set('option', 'prune', 'syn0')
+    chip.set('option', 'prune', ('syn', '0'))
 
     chip.run()
 
@@ -78,7 +78,7 @@ def test_prune_split_join(capfd):
     chip.edge(flow, 'import', 'syn', tail_index=1)
     chip.edge(flow, 'syn', 'place', head_index=0)
     chip.edge(flow, 'syn', 'place', head_index=1)
-    chip.set('option', 'prune', 'syn0')
+    chip.set('option', 'prune', ('syn', '0'))
 
     with pytest.raises(SiliconCompilerError,
                        match=f"{flow} flowgraph contains errors and cannot be run."):

--- a/tests/flows/test_prune.py
+++ b/tests/flows/test_prune.py
@@ -1,6 +1,6 @@
 import siliconcompiler
 
-from siliconcompiler.tools.builtin import nop
+from siliconcompiler.tools.builtin import nop, minimum, maximum
 from siliconcompiler._common import SiliconCompilerError
 
 import pytest
@@ -83,7 +83,45 @@ def test_prune_split_join():
     chip.set('option', 'prune', ('syn', '0'))
 
     message = re.escape("Flowgraph connection from {('syn', '0')} "
-                        "to ('place', '0') are missing. "
+                        "to ('place', '0') is missing. "
                         "Double check your flowgraph and from/to/prune options.")
     with pytest.raises(SiliconCompilerError, match=message):
         chip.run()
+
+
+def test_prune_min():
+    chip = siliconcompiler.Chip('foo')
+    chip.load_target('freepdk45_demo')
+
+    flow = 'test'
+    chip.set('option', 'flow', flow)
+    chip.node(flow, 'import', nop)
+    chip.node(flow, 'syn', nop, index=0)
+    chip.node(flow, 'syn', nop, index=1)
+    chip.node(flow, 'place', minimum)
+    chip.edge(flow, 'import', 'syn', head_index=0)
+    chip.edge(flow, 'import', 'syn', head_index=1)
+    chip.edge(flow, 'syn', 'place', tail_index=0)
+    chip.edge(flow, 'syn', 'place', tail_index=1)
+    chip.set('option', 'prune', ('syn', '0'))
+
+    chip.run()
+
+
+def test_prune_max():
+    chip = siliconcompiler.Chip('foo')
+    chip.load_target('freepdk45_demo')
+
+    flow = 'test'
+    chip.set('option', 'flow', flow)
+    chip.node(flow, 'import', nop)
+    chip.node(flow, 'syn', nop, index=0)
+    chip.node(flow, 'syn', nop, index=1)
+    chip.node(flow, 'place', maximum)
+    chip.edge(flow, 'import', 'syn', head_index=0)
+    chip.edge(flow, 'import', 'syn', head_index=1)
+    chip.edge(flow, 'syn', 'place', tail_index=0)
+    chip.edge(flow, 'syn', 'place', tail_index=1)
+    chip.set('option', 'prune', ('syn', '0'))
+
+    chip.run()


### PR DESCRIPTION
**What?**
Extends the functionality in: https://github.com/siliconcompiler/siliconcompiler/pull/1976
The naming is `prune` instead of `exclude` as that is what was the outcome of the siliconcompiler meeting two weeks ago.

**Testing:**
I implemented the specification as best as I could understand it.
The most important part to me and what required changes is that the correctness of the paths in the flowgraph is based on reaching all final steps but within those final steps it doesn't matter how many nodes (at least one) was reached.