### PR TITLE
Add version check back in to examples and tests

### DIFF
--- a/examples/gcd/gcd.py
+++ b/examples/gcd/gcd.py
@@ -15,7 +15,6 @@ def main(root='.'):
     chip.set('option', 'quiet', True)
     chip.set('option', 'track', True)
     chip.set('option', 'hash', True)
-    chip.set('option', 'novercheck', True)
     chip.set('option', 'nodisplay', True)
     chip.set('constraint', 'outline', [(0, 0), (100.13, 100.8)])
     chip.set('constraint', 'corearea', [(10.07, 11.2), (90.25, 91)])

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -83,7 +83,6 @@ def test_py_read_manifest(scroot):
     chip.set('option', 'quiet', True)
     chip.set('option', 'track', True)
     chip.set('option', 'hash', True)
-    chip.set('option', 'novercheck', True)
     chip.set('option', 'nodisplay', True)
     chip.set('constraint', 'outline', [(0, 0), (100.13, 100.8)])
     chip.set('constraint', 'corearea', [(10.07, 11.2), (90.25, 91)])

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -11,7 +11,6 @@ def gcd_chip():
     chip.input(os.path.join(gcd_ex_dir, 'gcd.sdc'))
     chip.set('constraint', 'outline', [(0, 0), (100.13, 100.8)])
     chip.set('constraint', 'corearea', [(10.07, 11.2), (90.25, 91)])
-    chip.set('option', 'novercheck', 'true')
     chip.set('option', 'nodisplay', 'true')
     chip.set('option', 'quiet', 'true')
     chip.set('option', 'relax', 'true')

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -29,7 +29,6 @@ def test_tool_option(scroot):
     chip.set('constraint', 'corearea', [(10.07, 11.2), (90.25, 91)])
     chip.set('option', 'quiet', 'true')
     chip.set('option', 'relax', 'true')
-    chip.set('option', 'novercheck', 'true')
     chip.load_target('freepdk45_demo', place_np=2)
 
     chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', '0.4',
@@ -72,7 +71,6 @@ def chip(scroot):
     chip = siliconcompiler.Chip(design)
     chip.input(def_file)
     chip.set('option', 'quiet', True)
-    chip.set('option', 'novercheck', 'true')
     chip.load_target('freepdk45_demo')
 
     # Important: set up our own flow instead of using asicflow.

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -18,7 +18,6 @@ def _setup_fifo(scroot):
 
     chip.input(netlist)
     chip.set('option', 'quiet', True)
-    chip.set('option', 'novercheck', True)
     chip.set('constraint', 'outline', [(0, 0), (100.13, 100.8)])
     chip.set('constraint', 'corearea', [(10.07, 11.2), (90.25, 91)])
 


### PR DESCRIPTION
Ran into this while working on https://github.com/siliconcompiler/siliconcompiler/pull/2000
I'm not quite sure why it got removed in the first place.