### PR TITLE
add windows and macos to python ci tests

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -7,28 +7,44 @@ on:
 jobs:
   python_test_job:
     timeout-minutes: 15
-    runs-on: ${{ matrix.version.os }}
+    runs-on: ${{ matrix.os }}
     name: 'Pure Python tests'
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - {python: "3.8", os: "ubuntu-latest"}
-          - {python: "3.9", os: "ubuntu-latest"}
-          - {python: "3.10", os: "ubuntu-latest"}
-          - {python: "3.11", os: "ubuntu-latest"}
+        python: ["3.8", "3.9", "3.10", "3.11"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Dependencies
+      - name: Install Dependencies (linux)
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install graphviz
 
-      - name: Set up Python ${{ matrix.version.python }}
+      - name: Install Dependencies (windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install -y graphviz
+          choco install -y winflexbison3
+          vcpkg install zlib zlib:x64-windows
+
+      - name: Install Dependencies (macos)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install graphviz
+          brew install bison
+          # https://github.com/The-OpenROAD-Project/OpenROAD/issues/1688
+          echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
+          brew install flex
+          echo "/usr/local/opt/flex/bin" >> $GITHUB_PATH
+
+      - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.version.python }}
+          python-version: ${{ matrix.python }}
           cache: pip
 
       - name: Run Python tests
@@ -42,5 +58,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-          name: codecov-${{ matrix.version.python }}
+          name: codecov-${{ matrix.python }}-${{ matrix.os }}
           verbose: true

--- a/tests/apps/test_sc_remote.py
+++ b/tests/apps/test_sc_remote.py
@@ -75,6 +75,7 @@ def mock_post(url, data={}, files={}, stream=True, timeout=0):
 
 ###########################
 @pytest.mark.quick
+@pytest.mark.skipif(sys.platform == 'win32', reason='Breaks on Windows')
 def test_sc_remote_noauth(monkeypatch, unused_tcp_port):
     '''Basic sc-remote test: Call with no user credentials and no arguments.
     '''
@@ -105,6 +106,7 @@ def test_sc_remote_noauth(monkeypatch, unused_tcp_port):
 
 ###########################
 @pytest.mark.quick
+@pytest.mark.skipif(sys.platform == 'win32', reason='Breaks on Windows')
 def test_sc_remote_auth(monkeypatch, unused_tcp_port):
     '''Basic sc-remote test: Call with an authenticated user and no arguments.
     '''

--- a/tests/leflib/test_leflib.py
+++ b/tests/leflib/test_leflib.py
@@ -1,8 +1,11 @@
 from siliconcompiler import leflib
 
 import os
+import sys
+import pytest
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='Breaks on Windows')
 def test_leflib(scroot):
     path = os.path.join(scroot,
                         'third_party',
@@ -18,10 +21,12 @@ def test_leflib(scroot):
     assert data['version'] == 5.7
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='Breaks on Windows')
 def test_leflib_garbage():
     assert leflib.parse('asdf') is None
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='Breaks on Windows')
 def test_leflib_complete(datadir):
     # This file contains nonsense and some things that are technically illegal,
     # but good coverage of what you might see in a LEF. I've left comments where


### PR DESCRIPTION
Once leflib is fully ported the only thing needed for each os is the graphviz install.