### PR TITLE
Enable assertion support in verilator

### DIFF
--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -64,6 +64,12 @@ def setup(chip):
              'Verilator configuration file',
              field='help')
 
+    chip.set('tool', tool, 'task', task, 'var', 'enable_assert',
+             'true/false, when true assertions are enabled in Verilator.',
+             field='help')
+    chip.set('tool', tool, 'task', task, 'var', 'enable_assert', 'false',
+             step=step, index=index, clobber=False)
+
 
 def runtime_options(chip):
     cmdlist = []
@@ -80,6 +86,11 @@ def runtime_options(chip):
 
     cmdlist.append('-sv')
     cmdlist.extend(['--top-module', design])
+
+    assertions = chip.get('tool', tool, 'task', task, 'var',
+                          'enable_assert', step=step, index=index)
+    if assertions == ['true']:
+        cmdlist.append('--assert')
 
     # Make warnings non-fatal in relaxed mode
     if chip.get('option', 'relax'):

--- a/tests/data/assert.v
+++ b/tests/data/assert.v
@@ -1,0 +1,13 @@
+module heartbeat (
+    //inputs
+    input      clk,     // clock
+    input      nreset,  //async active low reset
+    //outputs
+    output reg out      //heartbeat
+);
+
+    always @(posedge clk) begin
+        assert (0);
+    end
+
+endmodule

--- a/tests/tools/test_verilator.py
+++ b/tests/tools/test_verilator.py
@@ -60,3 +60,37 @@ def test_compile(scroot, datadir):
     output = proc.stdout.decode('utf-8')
 
     assert output == 'SUCCESS\n'
+
+
+@pytest.mark.quick
+@pytest.mark.eda
+def test_assert(scroot, datadir):
+    chip = siliconcompiler.Chip('heartbeat')
+    chip.set('tool', 'verilator', 'task', 'compile', 'var', 'enable_assert', ['true'])
+
+    v_src = os.path.join(scroot, 'tests', 'data', 'assert.v')
+    chip.input(v_src)
+    c_src = os.path.join(datadir, 'verilator', 'heartbeat_tb.cpp')
+    chip.input(c_src)
+
+    chip.set('option', 'mode', 'sim')
+
+    chip.add('tool', 'verilator', 'task', 'compile', 'var', 'cflags', '-DREQUIRED_FROM_USER')
+    c_inc = os.path.join(datadir, 'verilator', 'include')
+    chip.add('tool', 'verilator', 'task', 'compile', 'dir', 'cincludes', c_inc)
+
+    # Basic Verilator compilation flow
+    flow = 'verilator_compile'
+    chip.node(flow, 'import', parse)
+    chip.node(flow, 'compile', compile)
+    chip.edge(flow, 'import', 'compile')
+    chip.set('option', 'flow', flow)
+
+    chip.run()
+
+    exe_path = chip.find_result('vexe', step='compile')
+
+    proc = subprocess.run([exe_path], stdout=subprocess.PIPE)
+    output = proc.stdout.decode('utf-8')
+    print(output)
+    assert "Assertion failed in TOP.heartbeat: 'assert' failed." in output


### PR DESCRIPTION
This makes it possible to use assertions in Verilator to help with verification.
**Usage:**
```
sc ... \
-tool_task_var 'verilator compile enable_assert true' 
```

**Before:**
I.e. `assert(0)` was ignored.

**After:**
```
[0] %Error: heartbeat.v:10: Assertion failed in TOP.heartbeat: 'assert' failed.
%Error: inputs/heartbeat.v:10: Verilog $stop
Aborting...
```