### PR TITLE
read schema manifest despite missing keys

### DIFF
--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -1397,7 +1397,7 @@ class Schema:
             should_append = re.match(r'\[', typestr) and not clear
 
             if allow_missing_keys and not self.valid(*keylist, default_valid=True):
-                self.logger.warn(f'{keylist} not found in schema, skipping...')
+                self.logger.warning(f'{keylist} not found in schema, skipping...')
                 continue
 
             for val, step, index in schema._getvals(*keylist, return_defvalue=False):

--- a/tests/core/test_create_cmdline.py
+++ b/tests/core/test_create_cmdline.py
@@ -202,7 +202,7 @@ def test_additional_parameters_not_used(monkeypatch):
 def test_cli_examples(monkeypatch):
     # Need to mock this function, since our cfg CLI example will try to call it
     # on a fake manifest.
-    def _mock_read_manifest(chip, manifest, clobber=False, clear=False):
+    def _mock_read_manifest(chip, manifest, **kwargs):
         # nop
         pass
     monkeypatch.setattr(siliconcompiler.Schema, 'read_manifest', _mock_read_manifest)

--- a/tests/schema/test_manifest.py
+++ b/tests/schema/test_manifest.py
@@ -1,4 +1,5 @@
 import pathlib
+import pytest
 
 from siliconcompiler.schema import Schema
 
@@ -16,3 +17,28 @@ def test_manifest():
     # Ensure pathlib input works
     schema3 = Schema(manifest=pathlib.Path('tmp.json'))
     assert schema3.get('input', 'rtl', 'verilog') == ['foo.v']
+
+
+def test_read_manifest_with_allow_missing_keys():
+    schema = Schema()
+
+    schema.set('input', 'rtl', 'verilog', 'foo.v')
+    schema.cfg['testing'] = schema.getdict('input')
+    with open('tmp.json', 'w') as f:
+        schema.write_json(f)
+
+    schema2 = Schema()
+    schema2.read_manifest('tmp.json', allow_missing_keys=True)
+
+
+def test_read_manifest_with_disallow_missing_keys():
+    schema = Schema()
+
+    schema.set('input', 'rtl', 'verilog', 'foo.v')
+    schema.cfg['testing'] = schema.getdict('input')
+    with open('tmp.json', 'w') as f:
+        schema.write_json(f)
+
+    schema2 = Schema()
+    with pytest.raises(ValueError):
+        schema2.read_manifest('tmp.json', allow_missing_keys=False)


### PR DESCRIPTION
This change will allow us to open older schemas without failing out.
This is useful when attempting review older runs, but the schema has changed since that run and now.