### PR TITLE
fix handling of windows paths

### DIFF
--- a/tests/apps/test_sc.py
+++ b/tests/apps/test_sc.py
@@ -1,5 +1,8 @@
 import os
+import shutil
+import pathlib
 from siliconcompiler.apps import sc
+from siliconcompiler.schema import Schema
 
 import pytest
 
@@ -14,4 +17,25 @@ def test_design_inference(scroot, monkeypatch):
     monkeypatch.setattr('sys.argv', ['sc', source, '-steplist', 'import', '-strict'])
     assert sc.main() == 0
 
-    assert os.path.isfile('build/heartbeat/job0/heartbeat.pkg.json')
+    cfg_file = 'build/heartbeat/job0/heartbeat.pkg.json'
+    assert os.path.isfile(cfg_file)
+    assert Schema(manifest=cfg_file).get('design') == 'heartbeat'
+
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_design_inference_windows(scroot, monkeypatch):
+    '''Tests that sc CLI app can infer design name from filename.'''
+    source = os.path.join(scroot, 'tests', 'data', 'heartbeat.v')
+    # only run import, makes this quicker
+
+    os.makedirs('testdir', exist_ok=True)
+    shutil.copy(source, 'testdir')
+    source_win = str(pathlib.PureWindowsPath('testdir', os.path.basename(source)))
+
+    monkeypatch.setattr('sys.argv', ['sc', source_win, '-steplist', 'import', '-strict'])
+    assert sc.main() == 0
+
+    cfg_file = 'build/heartbeat/job0/heartbeat.pkg.json'
+    assert os.path.isfile(cfg_file)
+    assert Schema(manifest=cfg_file).get('design') == 'heartbeat'

--- a/tests/apps/test_sc.py
+++ b/tests/apps/test_sc.py
@@ -1,6 +1,4 @@
 import os
-import shutil
-import pathlib
 from siliconcompiler.apps import sc
 from siliconcompiler.schema import Schema
 
@@ -15,25 +13,6 @@ def test_design_inference(scroot, monkeypatch):
     # only run import, makes this quicker
 
     monkeypatch.setattr('sys.argv', ['sc', source, '-steplist', 'import', '-strict'])
-    assert sc.main() == 0
-
-    cfg_file = 'build/heartbeat/job0/heartbeat.pkg.json'
-    assert os.path.isfile(cfg_file)
-    assert Schema(manifest=cfg_file).get('design') == 'heartbeat'
-
-
-@pytest.mark.eda
-@pytest.mark.quick
-def test_design_inference_windows(scroot, monkeypatch):
-    '''Tests that sc CLI app can infer design name from filename.'''
-    source = os.path.join(scroot, 'tests', 'data', 'heartbeat.v')
-    # only run import, makes this quicker
-
-    os.makedirs('testdir', exist_ok=True)
-    shutil.copy(source, 'testdir')
-    source_win = str(pathlib.PureWindowsPath('testdir', os.path.basename(source)))
-
-    monkeypatch.setattr('sys.argv', ['sc', source_win, '-steplist', 'import', '-strict'])
     assert sc.main() == 0
 
     cfg_file = 'build/heartbeat/job0/heartbeat.pkg.json'

--- a/tests/core/test_collect.py
+++ b/tests/core/test_collect.py
@@ -1,5 +1,6 @@
 import siliconcompiler
 import os
+from siliconcompiler.targets import asic_demo
 
 
 def test_collect_file_update():
@@ -24,3 +25,12 @@ def test_collect_file_update():
     chip._collect()
     with open(os.path.join(chip._getcollectdir(), filename), 'r') as f:
         assert f.readline() == 'newfake'
+
+
+def test_collect_file_asic_demo():
+    chip = siliconcompiler.Chip('demo')
+    chip.load_target(asic_demo)
+    chip._collect()
+
+    for f in chip.find_files('input', 'rtl', 'verilog', step='import', index=0):
+        assert f.startswith(chip._getcollectdir())

--- a/tests/core/test_find_file.py
+++ b/tests/core/test_find_file.py
@@ -2,7 +2,6 @@
 import os
 import shutil
 import pathlib
-import sys
 from unittest import mock
 
 import pytest

--- a/tests/core/test_find_file.py
+++ b/tests/core/test_find_file.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 import os
 import shutil
+import pathlib
+import sys
 from unittest import mock
 
 import pytest
@@ -77,6 +79,92 @@ def test_invalid_script():
     with pytest.raises(SiliconCompilerError):
         chip.find_files('tool', 'yosys', 'task', 'syn_asic', 'script',
                         missing_ok=False, step='syn', index='0')
+
+
+@pytest.mark.nostrict
+def test_windows_path_relative():
+    '''
+    Test that SC can resolve a windows path on any OS
+    '''
+
+    # Create a test file using Windows file paths.
+    path = os.path.join('testpath', 'testfile.v')
+    path_as_windows = str(pathlib.PureWindowsPath(path))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w') as wf:
+        wf.write('// Test file')
+
+    # Create a Schema, and set the file path using Windows notation.
+    chip = siliconcompiler.Chip('test')
+    chip.input(path_as_windows)
+
+    # Verify that the Schema path is unmodified.
+    assert chip.get('input', 'rtl', 'verilog') == [path_as_windows]
+
+    # Verify that SC can find the file regardless of the os
+    check_files = chip.find_files('input', 'rtl', 'verilog')
+    assert check_files
+    assert os.path.isfile(check_files[0])
+
+
+@pytest.mark.nostrict
+def test_windows_path_imported_file():
+    '''
+    Test that SC can resolve a windows path on any OS
+    '''
+
+    # Create a test file using Windows file paths.
+    path = r'C:\sc-test\testpath\testfile.v'
+
+    # Create a Schema, and set the file path using Windows notation.
+    chip = siliconcompiler.Chip('test')
+    chip.input(path)
+
+    path_hash = '555973cd01971eb31ae7dee374d147d075459b4a'
+    import_path = os.path.join(chip._getcollectdir(), f'testfile_{path_hash}.v')
+
+    os.makedirs(os.path.dirname(import_path), exist_ok=True)
+    with open(import_path, 'w') as wf:
+        wf.write('// Test file')
+
+    # Verify that the Schema path is unmodified.
+    assert chip.get('input', 'rtl', 'verilog') == [path]
+
+    # Verify that SC can find the file
+    check_files = chip.find_files('input', 'rtl', 'verilog')
+    assert check_files
+    assert check_files[0] == import_path
+    assert os.path.isfile(check_files[0])
+
+
+@pytest.mark.nostrict
+def test_windows_path_imported_directory():
+    '''
+    Test that SC can resolve a windows path on any OS
+    '''
+
+    # Create a test file using Windows file paths.
+    path = r'C:\sc-test\testpath\testfile.v'
+
+    # Create a Schema, and set the file path using Windows notation.
+    chip = siliconcompiler.Chip('test')
+    chip.input(path)
+
+    path_hash = 'ed19a25d5702e8b39dcd72d51bcc8ea787cedeb1'
+    import_path = os.path.join(chip._getcollectdir(), f'testpath_{path_hash}', 'testfile.v')
+
+    os.makedirs(os.path.dirname(import_path), exist_ok=True)
+    with open(import_path, 'w') as wf:
+        wf.write('// Test file')
+
+    # Verify that the Schema path is unmodified.
+    assert chip.get('input', 'rtl', 'verilog') == [path]
+
+    # Verify that SC can find the file
+    check_files = chip.find_files('input', 'rtl', 'verilog')
+    assert check_files
+    assert check_files[0] == import_path
+    assert os.path.isfile(check_files[0])
 
 
 #########################


### PR DESCRIPTION
Fixes:
- when getting a remote submission which was started on windows, the path format wasn't handled correctly on the linux machines.
- this ensures that the path and path hashing is all handled as posix paths to avoid any compatibility issues.

Replaces: #2005 