### PR TITLE
Test cases for to from

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -4545,12 +4545,14 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         return nodes
 
     #######################################
-    def _get_execution_entry_nodes(self, flow=None):
+    def _get_execution_entry_nodes(self, flow):
         if self.get('arg', 'step') and self.get('arg', 'index'):
             return [(self.get('arg', 'step'), self.get('arg', 'index'))]
         if self.get('arg', 'step'):
             return self._get_flowgraph_nodes(flow, steps=[self.get('arg', 'step')])
-        if self.get('option', 'from'):
+        # If we explicitely get the nodes for a flow other than the current one,
+        # Ignore the 'option' 'from'
+        if self.get('option', 'flow') == flow and self.get('option', 'from'):
             return self._get_flowgraph_nodes(flow, steps=self.get('option', 'from'))
         return self._get_flowgraph_entry_nodes(flow)
 
@@ -4565,12 +4567,14 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 nodes.append((step, index))
         return nodes
 
-    def _get_execution_exit_nodes(self, flow=None):
+    def _get_execution_exit_nodes(self, flow):
         if self.get('arg', 'step') and self.get('arg', 'index'):
             return [(self.get('arg', 'step'), self.get('arg', 'index'))]
         if self.get('arg', 'step'):
             return self._get_flowgraph_nodes(flow, steps=[self.get('arg', 'step')])
-        if self.get('option', 'to'):
+        # If we explicitely get the nodes for a flow other than the current one,
+        # Ignore the 'option' 'to'
+        if self.get('option', 'flow') == flow and self.get('option', 'to'):
             return self._get_flowgraph_nodes(flow, steps=self.get('option', 'to'))
         return self._get_flowgraph_exit_nodes(flow)
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1624,6 +1624,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 self.logger.error(f'{step} is not defined in the {flow} flowgraph')
                 error = True
 
+        if not self._check_execution_nodes_inputs(flow):
+            error = True
+
         unreachable_steps = self._unreachable_steps_to_execute(flow)
         if unreachable_steps:
             self.logger.error(f'These final steps in {flow} can not be reached: '
@@ -3993,56 +3996,62 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         # Merge cfgs from last executed tasks, and write out a final manifest.
         self._finalize_run(set(self._get_execution_exit_nodes(flow)), environment, status)
 
-    def _nodes_to_execute(self, flow, from_nodes, to_nodes, prune_nodes):
-        visited_nodes = set()
-        nodes_sorted = []
-        current_nodes = from_nodes.copy()
-        while current_nodes and not to_nodes.issubset(visited_nodes):
-            current_nodes_copy = current_nodes.copy()
-            for current_node in current_nodes_copy:
-                if current_node in prune_nodes:
-                    current_nodes.remove(current_node)
-                    continue
-                inputs = set(self._get_flowgraph_node_inputs(flow, current_node))
-                if current_node in from_nodes or \
-                        inputs.issubset(visited_nodes):
-                    nodes_sorted.append(current_node)
-                    visited_nodes.add(current_node)
-                    current_nodes.remove(current_node)
-                    outputs = self._get_flowgraph_node_outputs(flow, current_node)
-                    current_nodes.update(outputs)
-
-            # Handle missing input connections
-            if current_nodes == current_nodes_copy:
-                tool, task = self._get_tool_task(current_node[0], current_node[1], flow=flow)
-                # If node is builtin and not all input nodes were pruned, mark visited
-                if self._is_builtin(tool, task) \
-                        and self._get_pruned_node_inputs(flow, current_node):
-                    nodes_sorted.append(current_node)
-                    visited_nodes.add(current_node)
-                    current_nodes.remove(current_node)
-                    outputs = self._get_flowgraph_node_outputs(flow, current_node)
-                    current_nodes.update(outputs)
-                    continue
-                # If this step was reached but the current node is pruned, continue
-                if any(filter(lambda node: node[0] == current_node[0], visited_nodes)):
-                    current_nodes.remove(current_node)
-                    continue
-                raise SiliconCompilerError(
-                    f'Flowgraph connection from {inputs.difference(visited_nodes)} '
-                    f'to {current_node} is missing. '
+    def _check_execution_nodes_inputs(self, flow):
+        for node in self.nodes_to_execute(flow):
+            if node in self._get_execution_entry_nodes(flow):
+                continue
+            pruned_node_inputs = set(self._get_pruned_node_inputs(flow, node))
+            node_inputs = set(self._get_flowgraph_node_inputs(flow, node))
+            tool, task = self._get_tool_task(node[0], node[1], flow=flow)
+            if self._is_builtin(tool, task) and not pruned_node_inputs or \
+                    not self._is_builtin(tool, task) and pruned_node_inputs != node_inputs:
+                self.logger.warning(
+                    f'Flowgraph connection from {node_inputs.difference(pruned_node_inputs)} '
+                    f'to {node} is missing. '
                     f'Double check your flowgraph and from/to/prune options.')
+                return False
+        return True
 
-        return nodes_sorted
+    def _nodes_to_execute(self, flow, from_nodes, to_nodes, prune_nodes):
+        '''
+        Assumes a flowgraph with valid edges for the inputs
+        '''
+        nodes_to_execute = []
+        for from_node in from_nodes:
+            for node in self._nodes_to_execute_recursive(flow, from_node, to_nodes, prune_nodes):
+                if node not in nodes_to_execute:
+                    nodes_to_execute.append(node)
+        return nodes_to_execute
+
+    def _nodes_to_execute_recursive(self, flow, from_node, to_nodes, prune_nodes, path=[]):
+        path = path.copy()
+        nodes_to_execute = []
+
+        if from_node in prune_nodes:
+            return []
+        if from_node in path:
+            raise SiliconCompilerError(f'Path {path} would form a circle with {from_node}')
+        path.append(from_node)
+
+        if from_node in to_nodes:
+            for node in path:
+                nodes_to_execute.append(node)
+        for output_node in self._get_flowgraph_node_outputs(flow, from_node):
+            for node in self._nodes_to_execute_recursive(flow, output_node, to_nodes,
+                                                         prune_nodes, path=path):
+                if node not in nodes_to_execute:
+                    nodes_to_execute.append(node)
+
+        return nodes_to_execute
 
     ###########################################################################
     def nodes_to_execute(self, flow=None):
         '''
         Returns an ordered list of flowgraph nodes which will be executed.
-        This takes the from/to options into account.
+        This takes the from/to options into account if flow is the current flow or None.
 
         Returns:
-            A list of nodes that will get executed during run().
+            A list of nodes that will get executed during run() (or a specific flow).
 
         Example:
             >>> nodes = chip.nodes_to_execute()

--- a/tests/core/test_nodes_to_execute.py
+++ b/tests/core/test_nodes_to_execute.py
@@ -160,6 +160,117 @@ def test_nodes_to_execute_from_to():
     ]
 
 
+def test_nodes_to_execute_disjoint_graph_from():
+    '''
+    Check to ensure nodes_to_execute properly handles disjoint flowgraphs
+    A --{B}-- C -- D
+
+    E -- F -- G -- H
+    '''
+    chip = siliconcompiler.Chip('test')
+    flow = 'test'
+
+    prev = None
+    for n in ('A', 'B', 'C', 'D'):
+        chip.node(flow, n, nop)
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    prev = None
+    for n in ('E', 'F', 'G', 'H'):
+        chip.node(flow, n, nop)
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    chip.set('option', 'flow', flow)
+    chip.set('option', 'from', 'B')
+    assert chip.nodes_to_execute() == [
+        ('B', '0'),
+        ('C', '0'),
+        ('D', '0')
+    ]
+
+
+def test_nodes_to_execute_disjoint_graph_to():
+    '''
+    Check to ensure nodes_to_execute properly handles disjoint flowgraphs
+    A -- B --[C]-- D
+
+    E -- F -- G -- H
+    '''
+    chip = siliconcompiler.Chip('test')
+    flow = 'test'
+
+    prev = None
+    for n in ('A', 'B', 'C', 'D'):
+        chip.node(flow, n, nop)
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    prev = None
+    for n in ('E', 'F', 'G', 'H'):
+        chip.node(flow, n, nop)
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    chip.set('option', 'flow', flow)
+    chip.set('option', 'to', 'C')
+    assert chip.nodes_to_execute() == [
+        ('A', '0'),
+        ('B', '0'),
+        ('C', '0')
+    ]
+
+
+def test_nodes_to_execute_disjoint_graph_from_to():
+    '''
+    Check to ensure nodes_to_execute properly handles disjoint flowgraphs
+    A --{B}--[C]-- D
+
+    E -- F -- G -- H
+    '''
+    chip = siliconcompiler.Chip('test')
+    flow = 'test'
+
+    prev = None
+    for n in ('A', 'B', 'C', 'D'):
+        chip.node(flow, n, nop)
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    prev = None
+    for n in ('E', 'F', 'G', 'H'):
+        chip.node(flow, n, nop)
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    chip.set('option', 'flow', flow)
+    chip.set('option', 'from', 'B')
+    chip.set('option', 'to', 'C')
+    assert chip.nodes_to_execute() == [
+        ('B', '0'),
+        ('C', '0')
+    ]
+
+
 def test_nodes_to_execute_different_flow():
     '''
     Check to ensure nodes_to_execute properly handles multiple flows

--- a/tests/core/test_nodes_to_execute.py
+++ b/tests/core/test_nodes_to_execute.py
@@ -5,6 +5,11 @@ from siliconcompiler.tools.builtin import nop
 
 
 def test_nodes_to_execute():
+    '''
+    A -- B -- C -- D
+    |              |
+    ----------------
+    '''
     chip = siliconcompiler.Chip('test')
     flow = 'test'
     chip.node(flow, 'A', join)
@@ -27,6 +32,9 @@ def test_nodes_to_execute():
 def test_nodes_to_execute_to():
     '''
     Check to ensure forked graph is handled properly with to
+    A -- B -- C -- D
+    |    |    |    |
+    Aa  [Ba]  Ca   Da
     '''
     chip = siliconcompiler.Chip('test')
     flow = 'test'
@@ -55,6 +63,9 @@ def test_nodes_to_execute_to():
 def test_nodes_to_execute_to_multiple():
     '''
     Check to ensure forked graph is handled properly with to and multiple ends
+    A -- B -- C -- D
+    |    |    |    |
+    Aa  [Ba]  Ca  [Da]
     '''
     chip = siliconcompiler.Chip('test')
     flow = 'test'
@@ -86,6 +97,9 @@ def test_nodes_to_execute_to_multiple():
 def test_nodes_to_execute_from():
     '''
     Check to ensure forked graph is handled properly with from
+    A --{B}-- C -- D
+    |    |    |    |
+    Aa   Ba   Ca   Da
     '''
     chip = siliconcompiler.Chip('test')
     flow = 'test'
@@ -117,6 +131,9 @@ def test_nodes_to_execute_from():
 def test_nodes_to_execute_from_to():
     '''
     Check to ensure forked graph is handled properly with from/to
+    A --{B}-- C -- D
+    |    |    |    |
+    Aa   Ba  [Ca]  Da
     '''
     chip = siliconcompiler.Chip('test')
     flow = 'test'
@@ -146,6 +163,9 @@ def test_nodes_to_execute_from_to():
 def test_nodes_to_execute_different_flow():
     '''
     Check to ensure nodes_to_execute properly handles multiple flows
+    A -- B -- C -- D (flow: test)
+
+    E -- F -- G -- H (flow: test2)
     '''
     chip = siliconcompiler.Chip('test')
     flow = 'test'
@@ -189,6 +209,9 @@ def test_nodes_to_execute_different_flow_from_to():
     '''
     Check to ensure nodes_to_execute only applies from/to/prune
     to the correct flow
+    {A}--[B]-- C -- D (flow: test)
+
+     E -- F -- G -- H (flow: test2)
     '''
     chip = siliconcompiler.Chip('test')
     flow = 'test'

--- a/tests/core/test_nodes_to_execute.py
+++ b/tests/core/test_nodes_to_execute.py
@@ -1,6 +1,7 @@
 import siliconcompiler
 
 from siliconcompiler.tools.builtin import join
+from siliconcompiler.tools.builtin import nop
 
 
 def test_nodes_to_execute():
@@ -20,6 +21,208 @@ def test_nodes_to_execute():
 
     chip.set('option', 'flow', flow)
 
-    chip.write_flowgraph('test_list_steps.png')
-
     assert chip.nodes_to_execute() == [('A', '0'), ('B', '0'), ('C', '0'), ('D', '0')]
+
+
+def test_nodes_to_execute_to():
+    '''
+    Check to ensure forked graph is handled properly with to
+    '''
+    chip = siliconcompiler.Chip('test')
+    flow = 'test'
+
+    prev = None
+    for n in ('A', 'B', 'C', 'D'):
+        chip.node(flow, n, nop)
+        chip.node(flow, n + 'a', nop)
+        chip.edge(flow, n, n + 'a')
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    chip.set('option', 'flow', flow)
+    chip.set('option', 'to', 'Ba')
+
+    assert chip.nodes_to_execute() == [
+        ('A', '0'),
+        ('B', '0'),
+        ('Ba', '0')
+    ]
+
+
+def test_nodes_to_execute_to_multiple():
+    '''
+    Check to ensure forked graph is handled properly with to and multiple ends
+    '''
+    chip = siliconcompiler.Chip('test')
+    flow = 'test'
+
+    prev = None
+    for n in ('A', 'B', 'C', 'D'):
+        chip.node(flow, n, nop)
+        chip.node(flow, n + 'a', nop)
+        chip.edge(flow, n, n + 'a')
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    chip.set('option', 'flow', flow)
+    chip.set('option', 'to', ['Ba', 'Da'])
+
+    assert chip.nodes_to_execute() == [
+        ('A', '0'),
+        ('B', '0'),
+        ('Ba', '0'),
+        ('C', '0'),
+        ('D', '0'),
+        ('Da', '0')
+    ]
+
+
+def test_nodes_to_execute_from():
+    '''
+    Check to ensure forked graph is handled properly with from
+    '''
+    chip = siliconcompiler.Chip('test')
+    flow = 'test'
+
+    prev = None
+    for n in ('A', 'B', 'C', 'D'):
+        chip.node(flow, n, nop)
+        chip.node(flow, n + 'a', nop)
+        chip.edge(flow, n, n + 'a')
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    chip.set('option', 'flow', flow)
+    chip.set('option', 'from', 'B')
+
+    assert chip.nodes_to_execute() == [
+        ('B', '0'),
+        ('Ba', '0'),
+        ('C', '0'),
+        ('Ca', '0'),
+        ('D', '0'),
+        ('Da', '0')
+    ]
+
+
+def test_nodes_to_execute_from_to():
+    '''
+    Check to ensure forked graph is handled properly with from/to
+    '''
+    chip = siliconcompiler.Chip('test')
+    flow = 'test'
+
+    prev = None
+    for n in ('A', 'B', 'C', 'D'):
+        chip.node(flow, n, nop)
+        chip.node(flow, n + 'a', nop)
+        chip.edge(flow, n, n + 'a')
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    chip.set('option', 'flow', flow)
+    chip.set('option', 'from', 'B')
+    chip.set('option', 'to', 'Ca')
+
+    assert chip.nodes_to_execute() == [
+        ('B', '0'),
+        ('C', '0'),
+        ('Ca', '0')
+    ]
+
+
+def test_nodes_to_execute_different_flow():
+    '''
+    Check to ensure nodes_to_execute properly handles multiple flows
+    '''
+    chip = siliconcompiler.Chip('test')
+    flow = 'test'
+
+    prev = None
+    for n in ('A', 'B', 'C', 'D'):
+        chip.node(flow, n, nop)
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    flow = 'test2'
+
+    prev = None
+    for n in ('E', 'F', 'G', 'H'):
+        chip.node(flow, n, nop)
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    chip.set('option', 'flow', flow)
+    assert chip.nodes_to_execute(flow='test') == [
+        ('A', '0'),
+        ('B', '0'),
+        ('C', '0'),
+        ('D', '0')
+    ]
+    assert chip.nodes_to_execute(flow='test2') == [
+        ('E', '0'),
+        ('F', '0'),
+        ('G', '0'),
+        ('H', '0')
+    ]
+
+
+def test_nodes_to_execute_different_flow_from_to():
+    '''
+    Check to ensure nodes_to_execute only applies from/to/prune
+    to the correct flow
+    '''
+    chip = siliconcompiler.Chip('test')
+    flow = 'test'
+
+    prev = None
+    for n in ('A', 'B', 'C', 'D'):
+        chip.node(flow, n, nop)
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    flow = 'test2'
+
+    prev = None
+    for n in ('E', 'F', 'G', 'H'):
+        chip.node(flow, n, nop)
+
+        if prev:
+            chip.edge(flow, prev, n)
+
+        prev = n
+
+    chip.set('option', 'flow', 'test')
+    chip.set('option', 'from', 'A')
+    chip.set('option', 'to', 'B')
+    assert chip.nodes_to_execute(flow='test') == [
+        ('A', '0'),
+        ('B', '0')
+    ]
+    assert chip.nodes_to_execute(flow='test2') == [
+        ('E', '0'),
+        ('F', '0'),
+        ('G', '0'),
+        ('H', '0')
+    ]

--- a/tests/flows/test_prune.py
+++ b/tests/flows/test_prune.py
@@ -5,7 +5,6 @@ from tests.core.tools.dummy import dummy
 from siliconcompiler._common import SiliconCompilerError
 
 import pytest
-import re
 import logging
 
 
@@ -67,8 +66,9 @@ def test_prune_split():
     chip.run()
 
 
-def test_prune_split_join():
+def test_prune_split_join(caplog):
     chip = siliconcompiler.Chip('foo')
+    chip.logger = logging.getLogger()
     chip.load_target('freepdk45_demo')
 
     flow = 'test'
@@ -83,11 +83,12 @@ def test_prune_split_join():
     chip.edge(flow, 'syn', 'place', tail_index=1)
     chip.set('option', 'prune', ('syn', '0'))
 
-    message = re.escape("Flowgraph connection from {('syn', '0')} "
-                        "to ('place', '0') is missing. "
-                        "Double check your flowgraph and from/to/prune options.")
-    with pytest.raises(SiliconCompilerError, match=message):
+    message = str("Flowgraph connection from {('syn', '0')} to ('place', '0') is missing. "
+                  "Double check your flowgraph and from/to/prune options.")
+    with pytest.raises(SiliconCompilerError,
+                       match=f'{flow} flowgraph contains errors and cannot be run.'):
         chip.run()
+    assert message in caplog.text
 
 
 def test_prune_min():


### PR DESCRIPTION
**What?**
Changes the approach used when determinig which nodes to execute from a breadth first approach with to as a border to a path based approach with to as the final node(s).
Additionally change behavior to ignore from/to when using a different flow than the currently set flow.

**Why?**
Extra test cases mimic the behavior of usage did not align with the currently used algorithms