### PR TITLE
Explicitely set -from for public server

### DIFF
--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -169,6 +169,13 @@ def _remote_preprocess(chip, remote_nodelist):
     # we need to send inputs up to the server.
     chip._collect()
 
+    # This is necessary because the public version of the server somehow loses the information
+    # that the entry nodes were already executed
+    entry_nodes_successors = set()
+    for node in entry_nodes:
+        entry_nodes_successors.update(chip._get_flowgraph_node_outputs(flow, node))
+    entry_steps_successors = list(map(lambda node: node[0], entry_nodes_successors))
+    chip.set('option', 'from', entry_steps_successors)
     # Recover step/index
     chip.set('arg', 'step', preset_step)
     chip.set('arg', 'index', preset_index)


### PR DESCRIPTION
**What?**
Fix for https://github.com/siliconcompiler/siliconcompiler/issues/2036

**Why?**
The public version of the server somehow loses the information that the entry nodes were already executed.
The issue is not reproducible on the server CI which receives the import node status information as expected.

**How?**
Set the starting point on server explicitely with `-from` in the client.

**Successful Test**
```
sc -target asic_demo -remote

 ____  _ _ _                    ____                      _ _
/ ___|(_) (_) ___ ___  _ __    / ___|___  _ __ ___  _ __ (_) | ___ _ __
\___ \| | | |/ __/ _ \| '_ \  | |   / _ \| '_ ` _ \| '_ \| | |/ _ \ '__|
 ___) | | | | (_| (_) | | | | | |__| (_) | | | | | | |_) | | |  __/ |
|____/|_|_|_|\___\___/|_| |_|  \____\___/|_| |_| |_| .__/|_|_|\___|_|
                                                   |_|

Authors: Andreas Olofsson, William Ransohoff, Noah Moroze, Zachary Yedidia, Massimiliano Giacometti, Kimia Talaei, Peter Gadfort, Aulihan Teng, Peter Grossmann, Gabriel Aguirre, Martin Troiber
Version: 0.16.0 

--------------------------------------------------------------------------------
| INFO    | Command line argument entered: ['option', 'target'] Value: asic_demo
| INFO    | Command line argument entered: ['option', 'remote'] Value: true
| INFO    | /home/martin-zeroasic/coding/siliconcompiler/siliconcompiler/targets/../data/heartbeat.v inferred as rtl/verilog
| WARNING | job0 | --        | - | Could not find remote server configuration: defaulting to https://server.siliconcompiler.com
| INFO    | job0 | --        | - | Setting up node import0 with surelog/parse
| INFO    | job0 | import | 0 | Tool 'surelog' found with version '1.71' in directory '/usr/local/bin'
| INFO    | job0 | import | 0 | Running in /home/martin-zeroasic/coding/siliconcompiler/build/heartbeat/job0/import/0
| INFO    | job0 | import | 0 | surelog -nocache +libext+.sv+.v -parse -nouhdm /home/martin-zeroasic/coding/siliconcompiler/siliconcompiler/targets/../data/heartbeat.v -top heartbeat
| INFO    | job0 | import | 0 | Finished task in 0.43s
| INFO    | job0 | --        | - | Collecting input sources
| INFO    | job0 | --        | - | Copying /home/martin-zeroasic/coding/siliconcompiler/siliconcompiler/targets/../data/heartbeat.v to '/home/martin-zeroasic/coding/siliconcompiler/build/heartbeat/job0/sc_collected_files' directory
| INFO    | job0 | remote    | 0 | Your job will be uploaded to a public server in 5 seconds.
| WARNING | job0 | remote    | 0 | 
-----------------------------------------------------------------------------------------------
  DISCLAIMER:
  - The open SiliconCompiler remote server is a free service. Please don't abuse it.
  - Submitted designs must be open source. SiliconCompiler is not responsible for any
    proprietary IP that may be uploaded.
  - Only send one run at a time (or you may be temporarily blocked).
  - Do not send large designs (machines have limited resources).
  - Nontrivial designs may take some time to run. (machines have limited resources).
  - For full TOS, see https://www.siliconcompiler.com/terms-of-service
-----------------------------------------------------------------------------------------------
| INFO    | job0 | remote    | 0 | Job started. Progress will be checked and reported every 30 seconds.
| INFO    | job0 | remote    | 0 | Your job's reference ID is: 17b162e0ed104905b60be01c30db530e
| INFO    | job0 | remote    | 0 | Job is still running. Status:
| INFO    | job0 | remote    | 0 |   Completed (1): syn0
| INFO    | job0 | remote    | 0 |   Pending (7): floorplan0, place0, cts0, ...
| INFO    | job0 | remote    | 0 |   Fetching completed results:
| INFO    | job0 | remote    | 0 |     syn0
| INFO    | job0 | remote    | 0 | Job is still running. Status:
| INFO    | job0 | remote    | 0 |   Completed (2): syn0, floorplan0
| INFO    | job0 | remote    | 0 |   Running (1):
| INFO    | job0 | remote    | 0 |     place0 (00:00:05)
| INFO    | job0 | remote    | 0 |   Pending (5): cts0, route0, dfm0, ...
| INFO    | job0 | remote    | 0 |   Fetching completed results:
| INFO    | job0 | remote    | 0 |     floorplan0
| INFO    | job0 | remote    | 0 | Job is still running. Status:
| INFO    | job0 | remote    | 0 |   Completed (4): syn0, floorplan0, place0, ...
| INFO    | job0 | remote    | 0 |   Pending (4): route0, dfm0, export0, ...
| INFO    | job0 | remote    | 0 |   Fetching completed results:
| INFO    | job0 | remote    | 0 |     place0
| INFO    | job0 | remote    | 0 |     cts0
| INFO    | job0 | remote    | 0 | Job is still running. Status:
| INFO    | job0 | remote    | 0 |   Completed (5): syn0, floorplan0, place0, ...
| INFO    | job0 | remote    | 0 |   Pending (3): dfm0, export0, export1
| INFO    | job0 | remote    | 0 |   Fetching completed results:
| INFO    | job0 | remote    | 0 |     route0
| INFO    | job0 | remote    | 0 | Job is still running. Status:
| INFO    | job0 | remote    | 0 |   Completed (6): syn0, floorplan0, place0, ...
| INFO    | job0 | remote    | 0 |   Pending (2): export0, export1
| INFO    | job0 | remote    | 0 |   Fetching completed results:
| INFO    | job0 | remote    | 0 |     dfm0
| INFO    | job0 | remote    | 0 | Job is still running. Status:
| INFO    | job0 | remote    | 0 |   Completed (7): syn0, floorplan0, place0, ...
| INFO    | job0 | remote    | 0 |   Failed (1): export1
| INFO    | job0 | remote    | 0 |   Fetching completed results:
| INFO    | job0 | remote    | 0 |     export0
| INFO    | job0 | remote    | 0 | Remote job completed! Retrieving final results...
---------------------------------------------------------------------------------------------------------------------------------------
SUMMARY:

design : heartbeat
params : None
jobdir : /home/martin-zeroasic/coding/siliconcompiler/build/heartbeat/job0
foundry : skywater
process : skywater130
targetlibs : sky130hd 

               units     syn0   floorplan0    place0      cts0      route0      dfm0     export0    export1 
 errors                   0          0          0          0          0          0          0          0    
 warnings                236         18         6          6          16         70         1          40   
 drvs                    ---         0          0          0          0          0         ---         0    
 unconstrained           ---         1          1          1          1          1         ---         1    
 cellarea       um^2   332.819    352.838    354.090    376.611    376.611    376.611      ---      376.611 
 totalarea      um^2     ---      1506.440   1506.440   1506.440   1506.440   1506.440     ---      1506.440
 utilization       %     ---       23.422     23.505     25.000     25.000     25.000      ---       25.000 
 peakpower        mw     ---       0.061      0.064      0.087      0.099      0.086       ---       0.086  
 leakagepower     mw     ---       0.000      0.000      0.000      0.000      0.000       ---       0.000  
 holdpaths               ---         0          0          0          0          0         ---         0    
 setuppaths              ---         0          0          0          0          0         ---         0    
 holdslack        ns     ---       0.263      0.277      0.283      0.318      0.269       ---       0.278  
 holdwns          ns     ---       0.000      0.000      0.000      0.000      0.000       ---       0.000  
 holdtns          ns     ---       0.000      0.000      0.000      0.000      0.000       ---       0.000  
 setupslack       ns     ---       4.265      4.098      4.034      3.732      4.139       ---       4.128  
 setupwns         ns     ---       0.000      0.000      0.000      0.000      0.000       ---       0.000  
 setuptns         ns     ---       0.000      0.000      0.000      0.000      0.000       ---       0.000  
 fmax             Hz     ---      174.382M   169.438M   167.617M   159.544M   170.630M     ---      170.312M
 macros                  ---         0          0          0          0          0         ---         0    
 cells                    21         37         37         40         40         40        ---         40   
 registers                9          9          9          9          9          9         ---         9    
 buffers                 ---         1          1          4          4          4         ---         4    
 pins                    ---         3          3          3          3          3         ---         3    
 nets                    ---         29         29         32         32         32        ---         32   
 vias                    ---        ---        ---        ---        147        ---        ---        ---   
 wirelength       um     ---        ---        ---        ---      405.000      ---        ---        ---   
 memory            B   67.223M    197.316M   322.324M   244.598M   597.629M   204.723M   549.672M   212.914M
 exetime           s    01.330     05.660     06.429     09.359     11.000     08.130     03.379     08.279 
 tasktime          s    05.184     06.507     07.305     10.266     11.928     09.089     04.528     09.278 
---------------------------------------------------------------------------------------------------------------------------------------
| INFO    | job0 | --        | - | Generated summary image at /home/martin-zeroasic/coding/siliconcompiler/build/heartbeat/job0/heartbeat.png
| INFO    | job0 | --        | - | Generated HTML report at /home/martin-zeroasic/coding/siliconcompiler/build/heartbeat/job0/report.html
```