### PR TITLE
Run python and tools CI on pull requests

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -3,6 +3,7 @@ name: 'Python CI Tests'
 on:
   workflow_dispatch:
   push:
+  pull_request:
 
 jobs:
   python_test_job:

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -3,6 +3,7 @@ name: 'Tools CI Tests'
 on:
   workflow_dispatch:
   push:
+  pull_request:
 
 defaults:
   run:


### PR DESCRIPTION
**Why?**
The Python CI and Tools CI don't get executed on pull requests currently. See for example [here](https://github.com/siliconcompiler/siliconcompiler/pull/2004).

**Testing:**
After merging this into main we should double check that changes to the workflows from external contributors are only executed after approval: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks