### PR TITLE
Replace utils.copytree() with shutil.copytree()

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2267,7 +2267,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 if os.path.exists(dst_path):
                     continue
                 self.logger.info(f"Copying directory {abspath} to '{directory}' directory")
-                utils.copytree(abspath, dst_path)
+                shutil.copytree(abspath, dst_path)
             else:
                 self.error(f'Failed to copy {path}', fatal=True)
 
@@ -3136,10 +3136,10 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             # Skip copying pkg.json files here, since we write the current chip
             # configuration into inputs/{design}.pkg.json earlier in _runstep.
             if not replay:
-                utils.copytree(f"../../../{in_job}/{in_step}/{in_index}/outputs", 'inputs/',
-                               dirs_exist_ok=True,
-                               ignore=[f'{design}.pkg.json'],
-                               link=True)
+                shutil.copytree(f"../../../{in_job}/{in_step}/{in_index}/outputs", 'inputs/',
+                                dirs_exist_ok=True,
+                                ignore=shutil.ignore_patterns(f'{design}.pkg.json'),
+                                copy_function=utils.link_symlink_copy)
 
     def _pre_process(self, step, index):
         flow = self.get('option', 'flow')
@@ -5003,7 +5003,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         self.cwd = original_cwd
 
         # Copy in issue run files
-        utils.copytree(work_dir, new_work_dir, dirs_exist_ok=True)
+        shutil.copytree(work_dir, new_work_dir, dirs_exist_ok=True)
         # Copy in source files
         self._collect(directory=collection_dir)
 

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -708,9 +708,7 @@ def fetch_results(chip, node, results_path=None):
     # Copy the results into the local build directory, and remove the
     # unzipped directory.
     basedir = os.path.join(node, job_hash) if node else job_hash
-    utils.copytree(basedir,
-                   local_dir,
-                   dirs_exist_ok=True)
+    shutil.copytree(basedir, local_dir, dirs_exist_ok=True)
     shutil.rmtree(node if node else job_hash)
 
     # Print a message pointing to the results.

--- a/siliconcompiler/tools/builtin/_common.py
+++ b/siliconcompiler/tools/builtin/_common.py
@@ -1,6 +1,7 @@
 
 from siliconcompiler import NodeStatus
 from siliconcompiler import utils
+import shutil
 
 
 ###########################################################################
@@ -139,4 +140,4 @@ def run(chip):
 
 
 def post_process(chip):
-    utils.copytree('inputs', 'outputs', dirs_exist_ok=True, link=True)
+    shutil.copytree('inputs', 'outputs', dirs_exist_ok=True, copy_function=utils.link_symlink_copy)

--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -8,45 +8,16 @@ from pathlib import Path
 PACKAGE_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 
-def copytree(src, dst, ignore=[], dirs_exist_ok=False, link=False):
-    '''Simple implementation of shutil.copytree to give us a dirs_exist_ok
-    option in Python < 3.8.
-
-    If link is True, create hard links in dst pointing to files in src
-    instead of copying them.
-    '''
-    os.makedirs(dst, exist_ok=dirs_exist_ok)
-
-    for name in os.listdir(src):
-        if name in ignore:
-            continue
-
-        srcfile = os.path.join(src, name)
-        dstfile = os.path.join(dst, name)
-
-        if os.path.islink(srcfile):
-            # Get the true filepath if its a link
-            srcfile = os.path.realpath(srcfile)
-
-        if os.path.isdir(srcfile):
-            # Continue to copy the hierarchy
-            copytree(srcfile, dstfile,
-                     ignore=ignore,
-                     dirs_exist_ok=dirs_exist_ok,
-                     link=link)
-        elif link:
-            # first try hard linking, then symbolic linking,
-            # and finally just copy the file
-            for method in [os.link, os.symlink, shutil.copy2]:
-                try:
-                    # create link
-                    method(srcfile, dstfile)
-                    # success, no need to continue trying
-                except OSError:
-                    pass
-        else:
-            # copy file
-            shutil.copy2(srcfile, dstfile)
+def link_symlink_copy(srcfile, dstfile):
+    # first try hard linking, then symbolic linking,
+    # and finally just copy the file
+    for method in [os.link, os.symlink, shutil.copy2]:
+        try:
+            # create link
+            return method(srcfile, dstfile)
+            # success, no need to continue trying
+        except OSError:
+            pass
 
 
 def terminate_process(pid, timeout=3):

--- a/tests/apps/test_sc_issue.py
+++ b/tests/apps/test_sc_issue.py
@@ -5,7 +5,7 @@ import pytest
 import siliconcompiler
 
 from siliconcompiler.apps import sc_issue
-from siliconcompiler import utils
+import shutil
 
 
 # TODO: I think moving back to something like a tarfile would be nice here to
@@ -55,7 +55,7 @@ def heartbeat_dir(tmpdir_factory):
 def test_sc_issue_generate_success(flags, outputfileglob, monkeypatch, heartbeat_dir):
     '''Test sc-issue app on a few sets of flags.'''
 
-    utils.copytree(heartbeat_dir, './', dirs_exist_ok=True)
+    shutil.copytree(heartbeat_dir, './', dirs_exist_ok=True)
 
     monkeypatch.setattr('sys.argv', ['sc-issue'] + flags)
     assert sc_issue.main() == 0
@@ -71,7 +71,7 @@ def test_sc_issue_generate_success(flags, outputfileglob, monkeypatch, heartbeat
 def test_sc_issue_generate_fail(flags, monkeypatch, heartbeat_dir):
     '''Test sc-issue app on a few sets of flags.'''
 
-    utils.copytree(heartbeat_dir, './', dirs_exist_ok=True)
+    shutil.copytree(heartbeat_dir, './', dirs_exist_ok=True)
 
     monkeypatch.setattr('sys.argv', ['sc-issue'] + flags)
     assert sc_issue.main() == 1
@@ -83,7 +83,7 @@ def test_sc_issue_generate_fail(flags, monkeypatch, heartbeat_dir):
 def test_sc_issue_run(monkeypatch, heartbeat_dir):
     '''Test sc-issue app on a few sets of flags.'''
 
-    utils.copytree(heartbeat_dir, './', dirs_exist_ok=True)
+    shutil.copytree(heartbeat_dir, './', dirs_exist_ok=True)
 
     monkeypatch.setattr('sys.argv', ['sc-issue',
                                      '-generate',


### PR DESCRIPTION
**Why?**
We [deprecated python 3.6 and 3.7 ](https://github.com/siliconcompiler/siliconcompiler/commit/84ce9c1f060cbce78877ea55365f7d3e0dbb13ed)so now we can rely on `shutil.copytree()`.

**How?**
Using `shutil.copytree()` and its `copy_function` and `ignore` parameters we can achieve the same functionality as `utils.copytree()`.