### PR TITLE
Add line numbers to parsed logs

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2757,7 +2757,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             right_align = len(str(line_count))
             # Start at the beginning of file again
             f.seek(0)
-            for num, line in enumerate(f, 1):
+            for num, line in enumerate(f, start=1):
                 for suffix in checks:
                     string = line
                     for item in checks[suffix]['args']:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2753,6 +2753,10 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         # Looping through patterns for each line
         with open(logfile, errors='ignore_with_warning') as f:
+            line_count = sum(1 for _ in f)
+            right_align = len(str(line_count))
+            # Start at the beginning of file again
+            f.seek(0)
             for num, line in enumerate(f, 1):
                 for suffix in checks:
                     string = line
@@ -2764,15 +2768,16 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                     if string is not None:
                         matches[suffix] += 1
                         # always print to file
-                        print(f'{num}: {string.strip()}', file=checks[suffix]['report'])
+                        line_with_num = f'{num: >{right_align}}: {string.strip()}'
+                        print(line_with_num, file=checks[suffix]['report'])
                         # selectively print to display
                         if display:
                             if suffix == 'errors':
-                                self.logger.error(f'{num}: {string.strip()}')
+                                self.logger.error(line_with_num)
                             elif suffix == 'warnings':
-                                self.logger.warning(f'{num}: {string.strip()}')
+                                self.logger.warning(line_with_num)
                             else:
-                                self.logger.info(f'{suffix}: {num}: {string.strip()}')
+                                self.logger.info(f'{suffix}: {line_with_num}')
 
         for suffix in checks:
             checks[suffix]['report'].close()

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2698,7 +2698,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         Reads the content of the task's log file and compares the content found
         with the task's 'regex' parameter. The matches are stored in the file
-        '<design>.<suffix>' in the current directory. The matches are logged
+        '<step>.<suffix>' in the current directory. The matches are logged
         if display is set to True.
 
         Args:
@@ -2753,7 +2753,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         # Looping through patterns for each line
         with open(logfile, errors='ignore_with_warning') as f:
-            for line in f:
+            for num, line in enumerate(f, 1):
                 for suffix in checks:
                     string = line
                     for item in checks[suffix]['args']:
@@ -2764,15 +2764,15 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                     if string is not None:
                         matches[suffix] += 1
                         # always print to file
-                        print(string.strip(), file=checks[suffix]['report'])
+                        print(f'{num}: {string.strip()}', file=checks[suffix]['report'])
                         # selectively print to display
                         if display:
                             if suffix == 'errors':
-                                self.logger.error(string.strip())
+                                self.logger.error(f'{num}: {string.strip()}')
                             elif suffix == 'warnings':
-                                self.logger.warning(string.strip())
+                                self.logger.warning(f'{num}: {string.strip()}')
                             else:
-                                self.logger.info(f'{suffix}: {string.strip()}')
+                                self.logger.info(f'{suffix}: {num}: {string.strip()}')
 
         for suffix in checks:
             checks[suffix]['report'].close()

--- a/tests/core/test_check_logfile.py
+++ b/tests/core/test_check_logfile.py
@@ -1,10 +1,12 @@
 import os
 import siliconcompiler
+import logging
 
 
-def test_check_logfile(datadir):
+def test_check_logfile(datadir, caplog):
 
     chip = siliconcompiler.Chip('gcd')
+    chip.logger = logging.getLogger()
     chip.load_target('freepdk45_demo')
 
     # add regex
@@ -16,6 +18,14 @@ def test_check_logfile(datadir):
     # check log
     logfile = os.path.join(datadir, 'place.log')
     chip.check_logfile(step='place', logfile=logfile)
+
+    # check line numbers in log and file
+    warning_with_line_number = '89: [WARNING GRT-0043] No OR_DEFAULT vias defined.'
+    assert warning_with_line_number in caplog.text
+    warnings_file = 'place.warnings'
+    assert os.path.isfile(warnings_file)
+    with open(warnings_file) as file:
+        assert warning_with_line_number in file.read()
 
 
 #########################

--- a/tests/core/test_check_logfile.py
+++ b/tests/core/test_check_logfile.py
@@ -20,7 +20,7 @@ def test_check_logfile(datadir, caplog):
     chip.check_logfile(step='place', logfile=logfile)
 
     # check line numbers in log and file
-    warning_with_line_number = '89: [WARNING GRT-0043] No OR_DEFAULT vias defined.'
+    warning_with_line_number = ' 89: [WARNING GRT-0043] No OR_DEFAULT vias defined.'
     assert warning_with_line_number in caplog.text
     warnings_file = 'place.warnings'
     assert os.path.isfile(warnings_file)


### PR DESCRIPTION
**Why?**
This makes it easier to figure out where the warning and errors come from in the original log.

@gadfort I added it to infos and the logger output as well.
Do you think that's a good idea or should I remove it?