### PR TITLE
Ensure show runs on wheels ci for linux

### DIFF
--- a/.github/workflows/bin/setup_wheel_env_linux.sh
+++ b/.github/workflows/bin/setup_wheel_env_linux.sh
@@ -7,7 +7,7 @@ yum install -y zlib-devel graphviz xorg-x11-server-Xvfb wget
 # Install Klayout (for chip.show() test)
 klayout_version=$(python3 ${src_path}/setup/_tools.py --tool klayout --field version)
 wget --no-check-certificate \
-    -O klayout.rpm
+    -O klayout.rpm \
     "https://www.klayout.org/downloads/CentOS_7/klayout-${klayout_version}-0.x86_64.rpm"
 yum install -y python3 ruby qt-x11
 # This may fail on ARM64

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -165,7 +165,7 @@ jobs:
     - uses: pypa/cibuildwheel@v2.12.1
       env:
         CIBW_BEFORE_ALL_LINUX: >
-          {package}/.github/workflows/bin/setup_wheel_env_linux.sh
+          src_path="{package}" {package}/.github/workflows/bin/setup_wheel_env_linux.sh
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_BUILD: ${{ matrix.python-version }}
         CIBW_SKIP: "pp* *win32 *i686 *-musllinux_*"


### PR DESCRIPTION
**What?**
Fix tests depending on Klayout

**Why?**
Klayout was not installed on Linux and `show` based tests were skipped.

**How?**
Turns out all source files including the `setup` directory are getting copied as expeted.
So it was just necessary to pass in the source directory and fix a typo.

**Before:**
https://github.com/siliconcompiler/siliconcompiler/actions/runs/6527358684/job/17722145244
![Screenshot from 2023-10-16 16-42-39](https://github.com/siliconcompiler/siliconcompiler/assets/34752929/4c711a14-7160-4d1b-8a0b-e290fae6c76c)

**After:**
https://github.com/siliconcompiler/siliconcompiler/actions/runs/6535081745/job/17743780717
![Screenshot from 2023-10-16 16-39-21](https://github.com/siliconcompiler/siliconcompiler/assets/34752929/856edc05-b853-4b01-a97c-9737aa185a1d)
