### PR TITLE
Completly switch to Python internal symlinking

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3139,7 +3139,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                 shutil.copytree(f"../../../{in_job}/{in_step}/{in_index}/outputs", 'inputs/',
                                 dirs_exist_ok=True,
                                 ignore=shutil.ignore_patterns(f'{design}.pkg.json'),
-                                copy_function=utils.link_symlink_copy)
+                                symlinks=True)
 
     def _pre_process(self, step, index):
         flow = self.get('option', 'flow')

--- a/siliconcompiler/tools/builtin/_common.py
+++ b/siliconcompiler/tools/builtin/_common.py
@@ -1,6 +1,5 @@
 
 from siliconcompiler import NodeStatus
-from siliconcompiler import utils
 import shutil
 
 
@@ -140,4 +139,4 @@ def run(chip):
 
 
 def post_process(chip):
-    shutil.copytree('inputs', 'outputs', dirs_exist_ok=True, copy_function=utils.link_symlink_copy)
+    shutil.copytree('inputs', 'outputs', dirs_exist_ok=True, symlinks=True)

--- a/siliconcompiler/utils.py
+++ b/siliconcompiler/utils.py
@@ -1,23 +1,10 @@
 import os
-import shutil
 import psutil
 import xml.etree.ElementTree as ET
 import re
 from pathlib import Path
 
 PACKAGE_ROOT = os.path.dirname(os.path.abspath(__file__))
-
-
-def link_symlink_copy(srcfile, dstfile):
-    # first try hard linking, then symbolic linking,
-    # and finally just copy the file
-    for method in [os.link, os.symlink, shutil.copy2]:
-        try:
-            # create link
-            return method(srcfile, dstfile)
-            # success, no need to continue trying
-        except OSError:
-            pass
 
 
 def terminate_process(pid, timeout=3):


### PR DESCRIPTION
**What?**
Cleanup based on discussion here: https://github.com/siliconcompiler/siliconcompiler/pull/2041#discussion_r1357214986

**Why & How?**
We should not try changing symlinks into hardlinks like we currently do.
With the `symlinks=True` the behavior of `shutil.copytree()` is to recreate the symlink (with the same metadata) instead of copying over the content.