### PR TITLE
Change layout options to read layouts with the technology dbus

### DIFF
--- a/siliconcompiler/tools/klayout/klayout_utils.py
+++ b/siliconcompiler/tools/klayout/klayout_utils.py
@@ -91,6 +91,7 @@ def technology(design, schema):
 
     layoutOptions.lefdef_config.lef_files = list(pathed_files)
     layoutOptions.lefdef_config.read_lef_with_def = False
+    layoutOptions.lefdef_config.dbu = tech.dbu
 
     for lef_file in layoutOptions.lefdef_config.lef_files:
         print(f"[INFO] LEF file: {lef_file}")


### PR DESCRIPTION
This fixes a problem where even though the dbu is set in the technology, the final layout after the export step was not adhering to that. The layoutOptions class was resetting the layout dbu to that of the layout being read in.