### PR TITLE
Error and warning parsing should split the print of errors and warnings

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2751,14 +2751,22 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             checks[suffix]['args'] = regexes
             matches[suffix] = 0
 
+        # Order suffixes as follows: [..., 'warnings', 'errors']
+        ordered_suffixes = list(filter(lambda key:
+                                       key not in ['warnings', 'errors'], checks.keys()))
+        if 'warnings' in checks:
+            ordered_suffixes.append('warnings')
+        if 'errors' in checks:
+            ordered_suffixes.append('errors')
+
         # Looping through patterns for each line
         with open(logfile, errors='ignore_with_warning') as f:
             line_count = sum(1 for _ in f)
             right_align = len(str(line_count))
             # Start at the beginning of file again
             f.seek(0)
-            for num, line in enumerate(f, start=1):
-                for suffix in checks:
+            for suffix in ordered_suffixes:
+                for num, line in enumerate(f, start=1):
                     string = line
                     for item in checks[suffix]['args']:
                         if string is None:
@@ -2778,8 +2786,11 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                                 self.logger.warning(line_with_num)
                             else:
                                 self.logger.info(f'{suffix}: {line_with_num}')
+                f.seek(0)
 
-        for suffix in checks:
+        for suffix in ordered_suffixes:
+            if display:
+                self.logger.info(f'Number of {suffix}: {matches[suffix]}')
             checks[suffix]['report'].close()
 
         return matches

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2763,9 +2763,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         with open(logfile, errors='ignore_with_warning') as f:
             line_count = sum(1 for _ in f)
             right_align = len(str(line_count))
-            # Start at the beginning of file again
-            f.seek(0)
             for suffix in ordered_suffixes:
+                # Start at the beginning of file again
+                f.seek(0)
                 for num, line in enumerate(f, start=1):
                     string = line
                     for item in checks[suffix]['args']:
@@ -2786,7 +2786,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                                 self.logger.warning(line_with_num)
                             else:
                                 self.logger.info(f'{suffix}: {line_with_num}')
-                f.seek(0)
 
         for suffix in ordered_suffixes:
             if display:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2789,13 +2789,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         for suffix in ordered_suffixes:
             if display:
-                summary = f'Number of {suffix}: {matches[suffix]}'
-                if suffix == 'errors':
-                    self.logger.error(summary)
-                elif suffix == 'warnings':
-                    self.logger.warning(summary)
-                else:
-                    self.logger.info(summary)
+                self.logger.info(f'Number of {suffix}: {matches[suffix]}')
             checks[suffix]['report'].close()
 
         return matches

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2790,7 +2790,13 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         for suffix in ordered_suffixes:
             if display:
-                self.logger.info(f'Number of {suffix}: {matches[suffix]}')
+                summary = f'Number of {suffix}: {matches[suffix]}'
+                if suffix == 'errors':
+                    self.logger.error(summary)
+                elif suffix == 'warnings':
+                    self.logger.warning(summary)
+                else:
+                    self.logger.info(summary)
             checks[suffix]['report'].close()
 
         return matches

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2788,8 +2788,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
                                 self.logger.info(f'{suffix}: {line_with_num}')
 
         for suffix in ordered_suffixes:
-            if display:
-                self.logger.info(f'Number of {suffix}: {matches[suffix]}')
+            self.logger.info(f'Number of {suffix}: {matches[suffix]}')
             checks[suffix]['report'].close()
 
         return matches

--- a/tests/core/data/place.log
+++ b/tests/core/data/place.log
@@ -2,6 +2,7 @@ OpenROAD 1 4dca404c76b3302aa4e6ef8af1cd976c8de91cb4
 This program is licensed under the BSD-3 license. See the LICENSE file for details.
 Components of this program may be licensed under more restrictive licenses which must be honored.
 [INFO ODB-0222] Reading LEF file: /tmp/siliconcompiler/third_party/pdks/virtual/freepdk45/pdk/r1p0/apr/freepdk45.tech.lef
+[ERROR XYZ-123] Test error
 [INFO ODB-0223]     Created 22 technology layers
 [INFO ODB-0224]     Created 27 technology vias
 [INFO ODB-0226] Finished LEF file:  /tmp/siliconcompiler/third_party/pdks/virtual/freepdk45/pdk/r1p0/apr/freepdk45.tech.lef

--- a/tests/core/test_check_logfile.py
+++ b/tests/core/test_check_logfile.py
@@ -8,7 +8,6 @@ def test_check_logfile(datadir, caplog):
 
     chip = siliconcompiler.Chip('gcd')
     chip.logger = logging.getLogger()
-    chip.logger.setLevel(logging.INFO)
     chip.load_target('freepdk45_demo')
 
     # add regex

--- a/tests/core/test_check_logfile.py
+++ b/tests/core/test_check_logfile.py
@@ -8,6 +8,7 @@ def test_check_logfile(datadir, caplog):
 
     chip = siliconcompiler.Chip('gcd')
     chip.logger = logging.getLogger()
+    chip.logger.setLevel(logging.INFO)
     chip.load_target('freepdk45_demo')
 
     # add regex

--- a/tests/core/test_check_logfile.py
+++ b/tests/core/test_check_logfile.py
@@ -24,10 +24,13 @@ def test_check_logfile(datadir, caplog):
     chip.check_logfile(step='place', logfile=logfile)
 
     # check line numbers in log and file
-    warning_with_line_number = ' 89: [WARNING GRT-0043] No OR_DEFAULT vias defined.'
-    assert warning_with_line_number in caplog.text
+    warning_with_line_number = ' 90: [WARNING GRT-0043] No OR_DEFAULT vias defined.'
     # newline insures warnings are printed first, errors second
-    warning_error_number = 'Number of warnings: 1\n.*Number of errors: 0'
+    error_with_line_number = r'\n.*  5: \[ERROR XYZ-123\] Test error'
+    assert re.search(re.escape(warning_with_line_number)+error_with_line_number, caplog.text)
+
+    # newline insures warnings are printed first, errors second
+    warning_error_number = 'Number of warnings: 1\n.*Number of errors: 1'
     assert re.search(warning_error_number, caplog.text)
     warnings_file = 'place.warnings'
     assert os.path.isfile(warnings_file)

--- a/tests/core/test_check_logfile.py
+++ b/tests/core/test_check_logfile.py
@@ -1,15 +1,19 @@
 import os
 import siliconcompiler
 import logging
+import re
 
 
 def test_check_logfile(datadir, caplog):
 
     chip = siliconcompiler.Chip('gcd')
     chip.logger = logging.getLogger()
+    chip.logger.setLevel(logging.INFO)
     chip.load_target('freepdk45_demo')
 
     # add regex
+    chip.add('tool', 'openroad', 'task', 'place', 'regex', 'errors', "ERROR",
+             step='place', index='0')
     chip.add('tool', 'openroad', 'task', 'place', 'regex', 'warnings', "WARNING",
              step='place', index='0')
     chip.add('tool', 'openroad', 'task', 'place', 'regex', 'warnings', "-v DPL",
@@ -22,6 +26,9 @@ def test_check_logfile(datadir, caplog):
     # check line numbers in log and file
     warning_with_line_number = ' 89: [WARNING GRT-0043] No OR_DEFAULT vias defined.'
     assert warning_with_line_number in caplog.text
+    # newline insures warnings are printed first, errors second
+    warning_error_number = 'Number of warnings: 1\n.*Number of errors: 0'
+    assert re.search(warning_error_number, caplog.text)
     warnings_file = 'place.warnings'
     assert os.path.isfile(warnings_file)
     with open(warnings_file) as file:


### PR DESCRIPTION
**What?**
Order matched suffixes in logfiles from tools as follows `[..., 'warnings', 'errors']`.
Also show a small summary of the number of each suffix.

**Why?**
Improves readability of log output.

**How?**
Reorder the way the log files are scanned.

**Example output:**
```
| WARNING | job0 | export | 0 | 28: [WARNING] no fill config file specified
| INFO    | job0 | export | 0 | Number of warnings: 1
| INFO    | job0 | export | 0 | Number of errors: 0
```