### PR TITLE
Remove valid bit from schema

### DIFF
--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from siliconcompiler.schema.utils import trim
 
-SCHEMA_VERSION = '0.37.0'
+SCHEMA_VERSION = '0.37.1'
 
 
 #############################################################################
@@ -1156,19 +1156,6 @@ def schema_flowgraph(cfg, flow='default', step='default', index='default'):
                 "api: chip.add('flowgraph', 'asicflow', 'cts', '0', 'args', '0')"],
             schelp="""User specified flowgraph string arguments specified on a per
             step and per index basis.""")
-
-    # flowgraph valid bits
-    scparam(cfg, ['flowgraph', flow, step, index, 'valid'],
-            sctype='bool',
-            shorthelp="Flowgraph: task valid bit",
-            switch="-flowgraph_valid 'flow step index <str>'",
-            example=[
-                "cli: -flowgraph_valid 'asicflow cts 0 true'",
-                "api: chip.set('flowgraph', 'asicflow', 'cts', '0', 'valid', True)"],
-            schelp="""Flowgraph valid bit specified on a per step and per index basis.
-            The parameter can be used to control flow execution. If the bit
-            is cleared (0), then the step/index combination is invalid and
-            should not be run.""")
 
     # flowgraph timeout value
     scparam(cfg, ['flowgraph', flow, step, index, 'timeout'],

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -4808,31 +4808,6 @@
                         ],
                         "type": "str"
                     },
-                    "valid": {
-                        "example": [
-                            "cli: -flowgraph_valid 'asicflow cts 0 true'",
-                            "api: chip.set('flowgraph', 'asicflow', 'cts', '0', 'valid', True)"
-                        ],
-                        "help": "Flowgraph valid bit specified on a per step and per index basis.\nThe parameter can be used to control flow execution. If the bit\nis cleared (0), then the step/index combination is invalid and\nshould not be run.",
-                        "lock": false,
-                        "node": {
-                            "default": {
-                                "default": {
-                                    "signature": null,
-                                    "value": false
-                                }
-                            }
-                        },
-                        "notes": null,
-                        "pernode": "never",
-                        "require": "all",
-                        "scope": "job",
-                        "shorthelp": "Flowgraph: task valid bit",
-                        "switch": [
-                            "-flowgraph_valid 'flow step index <str>'"
-                        ],
-                        "type": "bool"
-                    },
                     "weight": {
                         "default": {
                             "example": [
@@ -10350,7 +10325,7 @@
             "default": {
                 "default": {
                     "signature": null,
-                    "value": "0.37.0"
+                    "value": "0.37.1"
                 }
             }
         },


### PR DESCRIPTION
**What?**
Remove the valid bit from the schema. 
Change the `patch` number in the schemaversion because it was never implemented to begin with.

**Why?**
Now we have `-prune` to specify which paths/nodes in the flowgraph will not be run.
Therefore attaching the valid bit to nodes in the flowgraph is not necessary.