### PR TITLE
Ensure external contributors can run tools CI [SC-668]

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -23,8 +23,8 @@ jobs:
     container:
       image: ${{ needs.docker_image.outputs.sc_tool }}
       credentials:
-        username: ${{ secrets.PACKAGES_ACTOR }}
-        password: ${{ secrets.PACKAGES_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
 
     name: 'All tests'
     strategy:
@@ -75,8 +75,8 @@ jobs:
     container:
       image: ${{ needs.docker_image.outputs.sc_tool }}
       credentials:
-        username: ${{ secrets.PACKAGES_ACTOR }}
-        password: ${{ secrets.PACKAGES_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -32,12 +32,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # Read-only credentials, can be accessed by external contributors
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.PACKAGES_ACTOR }}
-          password: ${{ secrets.PACKAGES_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Generate tool docker files
         id: docker
@@ -59,6 +60,15 @@ jobs:
           name: tools
           path: docker/
           retention-days: 1
+
+      # Read/write credentials, can only be accessed by repo members
+      - name: Log in to the Container registry
+        if: steps.docker.outputs.has_builder != 'true'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.PACKAGES_ACTOR }}
+          password: ${{ secrets.PACKAGES_TOKEN }}
 
       - name: Build and Push SiliconCompiler Builder Docker image
         if: steps.docker.outputs.has_builder != 'true'
@@ -189,8 +199,8 @@ jobs:
     container:
       image: ${{ needs.build_tool_builder.outputs.sc_tools }}
       credentials:
-        username: ${{ secrets.PACKAGES_ACTOR }}
-        password: ${{ secrets.PACKAGES_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
 
     timeout-minutes: 45
     name: 'Tool-based tests'


### PR DESCRIPTION
Reworks container credentials to use Github actor/token for read-only
access, only using secrets for write access where needed. This means if
tools aren't changed, external contributors can run the tools CI
normally. If tools are changed, a member will have to trigger the
workflow themself.

There was an administrative change required to make this work. In order to keep the packages private for now, and ensure `{{ github.token }}` provides read access, each package has to have the following set in its individual Package Settings:

![Screenshot from 2023-11-02 12-14-05](https://github.com/siliconcompiler/siliconcompiler/assets/4412459/7f4dc4f8-d9fe-475f-8522-1c620f6ad865)

Most packages had nothing here, although a few were set to "Admin". I've set them all to have "Read" permissions in order to be consistent. 

Test PRs:
- External contribution with no tools changed (expect pass): https://github.com/siliconcompiler/siliconcompiler/pull/2066
- External contribution with tools changed (expect fail): https://github.com/siliconcompiler/siliconcompiler/pull/2072
- Internal contribution with tool changed (expect pass): https://github.com/siliconcompiler/siliconcompiler/pull/2073
  - (note: this failed, but it looks to be a genuine issue with the tool update... the container builds all went successfully) 