### PR TITLE
Add an option to resume jobs using a different jobname.

### DIFF
--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from siliconcompiler.schema.utils import trim
 
-SCHEMA_VERSION = '0.37.1'
+SCHEMA_VERSION = '0.38.0'
 
 
 #############################################################################
@@ -2433,6 +2433,18 @@ def schema_option(cfg):
             defined director structure (<dir>/<design>/<jobname>/<step>/<index>)
             enables multiple levels of transparent job, step, and index
             introspection.""")
+
+    scparam(cfg, ['option', 'resumename'],
+            sctype='str',
+            scope='job',
+            defvalue=None,
+            shorthelp="Resume Job name",
+            switch="-resumename <str>",
+            example=[
+                "cli: -resumename may2",
+                "api: chip.set('option', 'resumename', 'may2')"],
+            schelp="""Resume a previous run with a new jobname.
+            Has no effect if ('option', 'resume') is not set.""")
 
     # TODO: remove?
     scparam(cfg, ['option', 'jobinput', 'default', 'default'],

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -2438,7 +2438,7 @@ def schema_option(cfg):
             sctype='str',
             scope='job',
             defvalue=None,
-            shorthelp="Resume Job name",
+            shorthelp="Resume job name",
             switch="-resumename <str>",
             example=[
                 "cli: -resumename may2",

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -7140,6 +7140,31 @@
             ],
             "type": "bool"
         },
+        "resumename": {
+            "example": [
+                "cli: -resumename may2",
+                "api: chip.set('option', 'resumename', 'may2')"
+            ],
+            "help": "Resume a previous run with a new jobname.\nHas no effect if ('option', 'resume') is not set.",
+            "lock": false,
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
+            "notes": null,
+            "pernode": "never",
+            "require": null,
+            "scope": "job",
+            "shorthelp": "Resume job name",
+            "switch": [
+                "-resumename <str>"
+            ],
+            "type": "str"
+        },
         "scheduler": {
             "cores": {
                 "example": [
@@ -10325,7 +10350,7 @@
             "default": {
                 "default": {
                     "signature": null,
-                    "value": "0.37.1"
+                    "value": "0.38.0"
                 }
             }
         },

--- a/tests/core/data/last_minor.json
+++ b/tests/core/data/last_minor.json
@@ -4808,31 +4808,6 @@
                         ],
                         "type": "str"
                     },
-                    "valid": {
-                        "example": [
-                            "cli: -flowgraph_valid 'asicflow cts 0 true'",
-                            "api: chip.set('flowgraph', 'asicflow', 'cts', '0', 'valid', True)"
-                        ],
-                        "help": "Flowgraph valid bit specified on a per step and per index basis.\nThe parameter can be used to control flow execution. If the bit\nis cleared (0), then the step/index combination is invalid and\nshould not be run.",
-                        "lock": false,
-                        "node": {
-                            "default": {
-                                "default": {
-                                    "signature": null,
-                                    "value": false
-                                }
-                            }
-                        },
-                        "notes": null,
-                        "pernode": "never",
-                        "require": "all",
-                        "scope": "job",
-                        "shorthelp": "Flowgraph: task valid bit",
-                        "switch": [
-                            "-flowgraph_valid 'flow step index <str>'"
-                        ],
-                        "type": "bool"
-                    },
                     "weight": {
                         "default": {
                             "example": [
@@ -7164,6 +7139,31 @@
                 "-resume <bool>"
             ],
             "type": "bool"
+        },
+        "resumename": {
+            "example": [
+                "cli: -resumename may2",
+                "api: chip.set('option', 'resumename', 'may2')"
+            ],
+            "help": "Resume a previous run with a new jobname.\nHas no effect if ('option', 'resume') is not set.",
+            "lock": false,
+            "node": {
+                "default": {
+                    "default": {
+                        "signature": null,
+                        "value": null
+                    }
+                }
+            },
+            "notes": null,
+            "pernode": "never",
+            "require": null,
+            "scope": "job",
+            "shorthelp": "Resume job name",
+            "switch": [
+                "-resumename <str>"
+            ],
+            "type": "str"
         },
         "scheduler": {
             "cores": {
@@ -10350,7 +10350,7 @@
             "default": {
                 "default": {
                     "signature": null,
-                    "value": "0.37.0"
+                    "value": "0.38.0"
                 }
             }
         },

--- a/tests/flows/test_resume.py
+++ b/tests/flows/test_resume.py
@@ -37,6 +37,7 @@ def test_resume(gcd_chip):
     assert gcd_chip.find_result('def', step='place') is not None
     assert gcd_chip.find_result('gds', step='export') is not None
 
+
 @pytest.mark.eda
 @pytest.mark.timeout(600)
 def test_resume_newjobname(gcd_chip):

--- a/tests/flows/test_resume.py
+++ b/tests/flows/test_resume.py
@@ -36,3 +36,39 @@ def test_resume(gcd_chip):
     # Ensure flow finished successfully
     assert gcd_chip.find_result('def', step='place') is not None
     assert gcd_chip.find_result('gds', step='export') is not None
+
+@pytest.mark.eda
+@pytest.mark.timeout(600)
+def test_resume_newjobname(gcd_chip):
+    # Set a value that will cause place to break
+    gcd_chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', 'asdf',
+                 step='place', index='0')
+
+    with pytest.raises(siliconcompiler.SiliconCompilerError):
+        gcd_chip.run()
+
+    # Ensure flow failed at placement, and store last modified time of floorplan
+    fp_result = gcd_chip.find_result('def', step='floorplan')
+    assert fp_result is not None
+    old_fp_mtime = os.path.getmtime(fp_result)
+
+    assert gcd_chip.find_result('def', step='place') is None
+    assert gcd_chip.find_result('gds', step='export') is None
+
+    # Fix place step, change jobname, and re-run
+    gcd_chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', '0.40',
+                 step='place', index='0')
+    gcd_chip.set('option', 'resume', True)
+    gcd_chip.set('option', 'resumename', 'job1')
+    gcd_chip.run()
+
+    # Ensure floorplan did not get re-run
+    fp_result = gcd_chip.find_result('def', step='floorplan')
+    assert fp_result is not None
+    assert os.path.getmtime(fp_result) == old_fp_mtime
+
+    # Ensure flow finished successfully
+    assert gcd_chip.find_result('def', step='place', jobname='job1') is not None
+    assert gcd_chip.find_result('gds', step='export', jobname='job1') is not None
+    assert gcd_chip.find_result('def', step='place', jobname='job0') is None
+    assert gcd_chip.find_result('gds', step='export', jobname='job0') is None

--- a/tests/flows/test_resume.py
+++ b/tests/flows/test_resume.py
@@ -68,6 +68,9 @@ def test_resume_newjobname(gcd_chip):
     assert fp_result is not None
     assert os.path.getmtime(fp_result) == old_fp_mtime
 
+    # Ensure place/0 directory was not cleared out.
+    assert len(os.listdir(gcd_chip._getworkdir(step='place', index='0', jobname='job0'))) != 0
+
     # Ensure flow finished successfully
     assert gcd_chip.find_result('def', step='place', jobname='job1') is not None
     assert gcd_chip.find_result('gds', step='export', jobname='job1') is not None


### PR DESCRIPTION
We want a way to let people re-run partially completed jobs with a different job name. Based on designers' experience, it should help with debugging by avoiding the deletion of partial results for any failed steps in the old job.

Unfortunately, we don't have a good way to find what the "last" job name was, especially if the user has been running design experiments with many different names. I've added a Schema parameter to let people specify a new name to resume the job with, but I am open to other approaches.

Includes a CI test which verifies that jobs can be resumed with a new name, without deleting old results/logs/etc.