### PR TITLE
switch tools refdir to use siliconcompiler package

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -979,9 +979,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         """
         Returns the absolute path for the filename provided.
 
-        Searches the SC root directory for the
-        filename provided and returns the absolute path. If no valid absolute
-        path is found during the search, None is returned.
+        Searches the for the filename provided and returns the absolute path.
+        If no valid absolute path is found during the search, None is returned.
 
         Shell variables ('$' followed by strings consisting of numbers,
         underscores, and digits) are replaced with the variable value.
@@ -1016,7 +1015,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         # Otherwise, search relative to search_paths
         if search_paths is None:
             search_paths = [self.cwd]
-            search_paths.append(self.scroot)
 
         searchdirs = ', '.join([str(p) for p in search_paths])
         self.logger.debug(f"Searching for file {filename} in {searchdirs}")

--- a/siliconcompiler/tools/bambu/convert.py
+++ b/siliconcompiler/tools/bambu/convert.py
@@ -19,7 +19,8 @@ def setup(chip):
     chip.set('tool', tool, 'version', '>=0.9.6', clobber=False)
 
     chip.set('tool', tool, 'task', task, 'refdir', refdir,
-             step=step, index=index, clobber=False)
+             step=step, index=index,
+             package='siliconcompiler', clobber=False)
     chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(),
              step=step, index=index, clobber=False)
 

--- a/siliconcompiler/tools/bluespec/convert.py
+++ b/siliconcompiler/tools/bluespec/convert.py
@@ -24,7 +24,8 @@ def setup(chip):
     chip.set('tool', tool, 'version', '>=2021.07', clobber=False)
 
     chip.set('tool', tool, 'task', task, 'refdir', refdir,
-             step=step, index=index, clobber=False)
+             step=step, index=index,
+             package='siliconcompiler', clobber=False)
     chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(),
              step=step, index=index, clobber=False)
 

--- a/siliconcompiler/tools/chisel/convert.py
+++ b/siliconcompiler/tools/chisel/convert.py
@@ -20,7 +20,8 @@ def setup(chip):
     chip.set('tool', tool, 'version', '>=1.5.5', clobber=False)
 
     chip.set('tool', tool, 'task', task, 'refdir', refdir,
-             step=step, index=index, clobber=False)
+             step=step, index=index,
+             package='siliconcompiler', clobber=False)
     chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(),
              step=step, index=index, clobber=False)
 

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -78,7 +78,8 @@ def setup(chip, mode="batch"):
     chip.set('tool', tool, 'version', '>=0.28.0', clobber=clobber)
     chip.set('tool', tool, 'format', 'json', clobber=clobber)
 
-    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=clobber)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index,
+             package='siliconcompiler', clobber=clobber)
 
     if chip.get('option', 'nodisplay'):
         # Tells QT to use the offscreen platform if nodisplay is used

--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -45,7 +45,8 @@ def setup(chip):
     chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(),
              step=step, index=index, clobber=False)
     chip.set('tool', tool, 'task', task, 'refdir', refdir,
-             step=step, index=index, clobber=False)
+             step=step, index=index,
+             package='siliconcompiler', clobber=False)
     chip.set('tool', tool, 'task', task, 'script', script,
              step=step, index=index, clobber=False)
 

--- a/siliconcompiler/tools/netgen/lvs.py
+++ b/siliconcompiler/tools/netgen/lvs.py
@@ -25,7 +25,8 @@ def setup(chip):
     chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(),
              step=step, index=index, clobber=False)
     chip.set('tool', tool, 'task', task, 'refdir', refdir,
-             step=step, index=index, clobber=False)
+             step=step, index=index,
+             package='siliconcompiler', clobber=False)
     chip.set('tool', tool, 'task', task, 'script', script,
              step=step, index=index, clobber=False)
 

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -88,7 +88,8 @@ def setup(chip):
     # Input/Output requirements for default asicflow steps
 
     chip.set('tool', tool, 'task', task, 'refdir', refdir,
-             step=step, index=index, clobber=clobber)
+             step=step, index=index,
+             package='siliconcompiler', clobber=clobber)
     chip.set('tool', tool, 'task', task, 'script', script,
              step=step, index=index, clobber=clobber)
     chip.set('tool', tool, 'task', task, 'threads', threads,

--- a/siliconcompiler/tools/template/template.py
+++ b/siliconcompiler/tools/template/template.py
@@ -64,7 +64,8 @@ def setup(chip):
 
     # Required for script based tools
     chip.set('tool', tool, 'task', task, 'refdir', refdir,
-             step=step, index=index, clobber=False)
+             step=step, index=index,
+             package='siliconcompiler', clobber=False)
     chip.set('tool', tool, 'task', task, 'script', refdir + script,
              step=step, index=index, clobber=False)
     for key in variables:

--- a/siliconcompiler/tools/vivado/vivado.py
+++ b/siliconcompiler/tools/vivado/vivado.py
@@ -41,7 +41,8 @@ def setup_task(chip, task):
     refdir = f'tools/{tool}/scripts'
     option = ['-nolog', '-nojournal', '-mode', 'batch', '-source']
 
-    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index,
+             package='siliconcompiler', clobber=False)
     chip.set('tool', tool, 'task', task, 'script', script, step=step, index=index, clobber=False)
     chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(),
              step=step, index=index, clobber=False)

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -51,7 +51,8 @@ def setup(chip):
         option.append('-C')
     option.append('-c')
     chip.set('tool', tool, 'task', task, 'option', option, step=step, index=index, clobber=False)
-    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'refdir', refdir, step=step, index=index,
+             package='siliconcompiler', clobber=False)
     chip.set('tool', tool, 'task', task, 'regex', 'warnings', "Warning:",
              step=step, index=index, clobber=False)
     chip.set('tool', tool, 'task', task, 'regex', 'errors', "^ERROR",

--- a/tests/core/test_find_file.py
+++ b/tests/core/test_find_file.py
@@ -12,8 +12,8 @@ def test_find_sc_file(datadir):
 
     chip = siliconcompiler.Chip('test')
 
-    assert chip._find_sc_file("flows/asicflow.py") is not None
-    assert chip._find_sc_file("pdks/freepdk45.py") is not None
+    assert chip._find_sc_file("flows/asicflow.py", search_paths=[chip.scroot]) is not None
+    assert chip._find_sc_file("pdks/freepdk45.py", search_paths=[chip.scroot]) is not None
 
     assert chip._find_sc_file('my_file_that_doesnt_exist.blah', missing_ok=True) is None
 


### PR DESCRIPTION
Removes searching of scroot from SC and relies only on the packaging