### PR TITLE
Add expr to unwrapped Tcl return expressions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ pytest-asyncio
 pytest-cov
 pyvirtualdisplay
 flake8 >= 5.0.0
-tclint == 0.1.1
+tclint == 0.1.2
 
 # Docker dependencies
 #:docker

--- a/siliconcompiler/tools/openroad/scripts/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_apr.tcl
@@ -27,8 +27,9 @@ proc has_tie_cell { type } {
     upvar sc_mainlib sc_mainlib
     upvar sc_tool sc_tool
 
-    return [dict exists $sc_cfg library $sc_mainlib option {var} openroad_tie${type}_cell] && \
-           [dict exists $sc_cfg library $sc_mainlib option {var} openroad_tie${type}_port]
+    set library_vars [dict get $sc_cfg library $sc_mainlib option {var}]
+    return [expr [dict exists $library_vars openroad_tie${type}_cell] && \
+                 [dict exists $library_vars openroad_tie${type}_port]]
 }
 
 proc get_tie_cell { type } {

--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -107,8 +107,8 @@ proc has_tie_cell { type } {
     upvar sc_mainlib sc_mainlib
     upvar sc_tool sc_tool
 
-    return [dict exists $sc_cfg library $sc_mainlib option {var} yosys_tie${type}_cell] && \
-           [dict exists $sc_cfg library $sc_mainlib option {var} yosys_tie${type}_port]
+    return [expr [dict exists $sc_cfg library $sc_mainlib option {var} yosys_tie${type}_cell] && \
+                 [dict exists $sc_cfg library $sc_mainlib option {var} yosys_tie${type}_port]]
 }
 
 proc get_tie_cell { type } {
@@ -129,9 +129,9 @@ proc has_buffer_cell { } {
     upvar sc_mainlib sc_mainlib
     upvar sc_tool sc_tool
 
-    return [dict exists $sc_cfg library $sc_mainlib option {var} yosys_buffer_cell] && \
-           [dict exists $sc_cfg library $sc_mainlib option {var} yosys_buffer_input] && \
-           [dict exists $sc_cfg library $sc_mainlib option {var} yosys_buffer_output]
+    return [expr [dict exists $sc_cfg library $sc_mainlib option {var} yosys_buffer_cell] && \
+                 [dict exists $sc_cfg library $sc_mainlib option {var} yosys_buffer_input] && \
+                 [dict exists $sc_cfg library $sc_mainlib option {var} yosys_buffer_output]]
 }
 
 proc get_buffer_cell { } {


### PR DESCRIPTION
I think I caught a subtle bug in a few Tcl procs caused by supplying an expression directly to `return`. 

It seems like Tcl will always return the last word of the expression:

```tcl
proc foo {} {
  return 0 && 1
}

puts [foo]
```

prints 1 for me. This can be fixed by adding an `expr` command to wrap the expression.

`tclint` 0.1.2 now catches this issue. 