### PR TITLE
Add missing backslash

### DIFF
--- a/siliconcompiler/tools/openroad/scripts/sc_write_images.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_write_images.tcl
@@ -141,7 +141,7 @@ proc sc_image_routing_congestion {} {
   sc_image_heatmap "Routing Congestion" \
     "Routing" \
     "routing_congestion.png" \
-    "routing congestion"
+    "routing congestion" \
     0
 }
 


### PR DESCRIPTION
Fixes a small bug caught by the tclint indent check. 