### PR TITLE
Enable tclint indent checks and fix violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,14 @@ exclude = [
     'siliconcompiler/tools/yosys/syn_strategies.tcl'
 ]
 
-# codebase uses mix of indent styles - can enforce once one is chosen
-ignore = ['indent']
-
 [tool.tclint.style]
 allow-aligned-sets = true
 line-length = 100
+indent = 4
+
+[[tool.tclint.fileset]]
+# This fileset overrides the global indent for OpenROAD scripts.
+paths = ["siliconcompiler/tools/openroad/scripts"]
+
+[tool.tclint.fileset.style]
+indent = 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ pytest-asyncio
 pytest-cov
 pyvirtualdisplay
 flake8 >= 5.0.0
-tclint == 0.1.2
+tclint == 0.1.5
 
 # Docker dependencies
 #:docker

--- a/siliconcompiler/tools/openroad/scripts/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_apr.tcl
@@ -23,24 +23,24 @@ proc sc_get_layer_name { name } {
 }
 
 proc has_tie_cell { type } {
-    upvar sc_cfg sc_cfg
-    upvar sc_mainlib sc_mainlib
-    upvar sc_tool sc_tool
+  upvar sc_cfg sc_cfg
+  upvar sc_mainlib sc_mainlib
+  upvar sc_tool sc_tool
 
-    set library_vars [dict get $sc_cfg library $sc_mainlib option {var}]
-    return [expr [dict exists $library_vars openroad_tie${type}_cell] && \
-                 [dict exists $library_vars openroad_tie${type}_port]]
+  set library_vars [dict get $sc_cfg library $sc_mainlib option {var}]
+  return [expr [dict exists $library_vars openroad_tie${type}_cell] && \
+               [dict exists $library_vars openroad_tie${type}_port]]
 }
 
 proc get_tie_cell { type } {
-    upvar sc_cfg sc_cfg
-    upvar sc_mainlib sc_mainlib
-    upvar sc_tool sc_tool
+  upvar sc_cfg sc_cfg
+  upvar sc_mainlib sc_mainlib
+  upvar sc_tool sc_tool
 
-    set cell [lindex [dict get $sc_cfg library $sc_mainlib option {var} openroad_tie${type}_cell] 0]
-    set port [lindex [dict get $sc_cfg library $sc_mainlib option {var} openroad_tie${type}_port] 0]
+  set cell [lindex [dict get $sc_cfg library $sc_mainlib option {var} openroad_tie${type}_cell] 0]
+  set port [lindex [dict get $sc_cfg library $sc_mainlib option {var} openroad_tie${type}_port] 0]
 
-    return "$cell/$port"
+  return "$cell/$port"
 }
 
 ##############################

--- a/siliconcompiler/tools/openroad/scripts/sc_constraints.sdc
+++ b/siliconcompiler/tools/openroad/scripts/sc_constraints.sdc
@@ -4,67 +4,67 @@ source sc_manifest.tcl
 
 ### Create clocks
 if {[dict exists $sc_cfg datasheet pin]} {
-    foreach pin [dict keys [dict get $sc_cfg datasheet pin]] {
-        if {[dict get $sc_cfg datasheet pin $pin type global] == "clock"} {
-            # If clock...
+  foreach pin [dict keys [dict get $sc_cfg datasheet pin]] {
+    if {[dict get $sc_cfg datasheet pin $pin type global] == "clock"} {
+      # If clock...
 
-            set periodtuple [dict get $sc_cfg datasheet pin $pin tperiod global]
-            set period [sta::time_sta_ui [lindex $periodtuple 1]]
-            set jittertuple [dict get $sc_cfg datasheet pin $pin tjitter global]
-            set jitter [sta::time_sta_ui [lindex $jittertuple 1]]
+      set periodtuple [dict get $sc_cfg datasheet pin $pin tperiod global]
+      set period [sta::time_sta_ui [lindex $periodtuple 1]]
+      set jittertuple [dict get $sc_cfg datasheet pin $pin tjitter global]
+      set jitter [sta::time_sta_ui [lindex $jittertuple 1]]
 
-            set period_fmt \
-                [sta::format_time [sta::time_ui_sta $period] 3][sta::unit_scale_abbreviation time]
-            set jitter_fmt \
-                [sta::format_time [sta::time_ui_sta $jitter] 3][sta::unit_scale_abbreviation time]
-            utl::info FLW 1 \
-                "Creating clock $pin with ${period_fmt}s period and ${jitter_fmt}s jitter."
-            create_clock -name $pin -period $period $pin
-            set_clock_uncertainty $jitter [get_clock $pin]
-        }
+      set period_fmt \
+        [sta::format_time [sta::time_ui_sta $period] 3][sta::unit_scale_abbreviation time]
+      set jitter_fmt \
+        [sta::format_time [sta::time_ui_sta $jitter] 3][sta::unit_scale_abbreviation time]
+      utl::info FLW 1 \
+        "Creating clock $pin with ${period_fmt}s period and ${jitter_fmt}s jitter."
+      create_clock -name $pin -period $period $pin
+      set_clock_uncertainty $jitter [get_clock $pin]
     }
+  }
 }
 
 ### Create IO constraints
 set sc_sdc_buffer [dict get $sc_cfg tool $sc_tool task $sc_task {var} sdc_buffer]
 set buffer_cell "NULL"
 if { [llength $sc_sdc_buffer] == 0 } {
-    foreach cell [get_lib_cells *] {
-        if { [$cell is_buffer] } {
-            # Find first buffer and use that as IO constraints
-            set buffer_cell $cell
-            break
-        }
+  foreach cell [get_lib_cells *] {
+    if { [$cell is_buffer] } {
+      # Find first buffer and use that as IO constraints
+      set buffer_cell $cell
+      break
     }
+  }
 } else {
-    set buffer_cell [get_lib_cells [lindex $sc_sdc_buffer 0]]
+  set buffer_cell [get_lib_cells [lindex $sc_sdc_buffer 0]]
 }
 
 if { $buffer_cell != "NULL" } {
-    utl::info FLW 1 "Using [$buffer_cell name] as the SDC IO constraint cell"
+  utl::info FLW 1 "Using [$buffer_cell name] as the SDC IO constraint cell"
 
-    set driving_port "NULL"
-    set load_cap 0.0
-    set port_itr [$buffer_cell liberty_port_iterator]
-    while {[$port_itr has_next]} {
-        set port [$port_itr next]
-        set mtrm [sta::sta_to_db_mterm $port]
-        set pcap [$port capacitance NULL max]
-        if { [$mtrm getIoType] == "INPUT" } {
-            set load_cap [expr 10 * $pcap]
-        } elseif { [$mtrm getIoType] == "OUTPUT" } {
-            set driving_port [$mtrm getName]
-        }
+  set driving_port "NULL"
+  set load_cap 0.0
+  set port_itr [$buffer_cell liberty_port_iterator]
+  while {[$port_itr has_next]} {
+    set port [$port_itr next]
+    set mtrm [sta::sta_to_db_mterm $port]
+    set pcap [$port capacitance NULL max]
+    if { [$mtrm getIoType] == "INPUT" } {
+      set load_cap [expr 10 * $pcap]
+    } elseif { [$mtrm getIoType] == "OUTPUT" } {
+      set driving_port [$mtrm getName]
     }
-    $port_itr finish
+  }
+  $port_itr finish
 
-    if { $load_cap > 0.0 } {
-        set cap_fmt [sta::format_capacitance $load_cap 3][sta::unit_scale_abbreviation capacitance]
-        utl::info FLW 1 "Setting output load constraint to ${cap_fmt}F."
-        set_load [sta::capacitance_sta_ui $load_cap] [all_outputs]
-    }
-    if { $driving_port != "NULL" } {
-        utl::info FLW 1 "Setting input driving pin constraint to [$buffer_cell name]/$driving_port."
-        set_driving_cell -lib_cell [$buffer_cell name] -pin $driving_port [all_inputs]
-    }
+  if { $load_cap > 0.0 } {
+    set cap_fmt [sta::format_capacitance $load_cap 3][sta::unit_scale_abbreviation capacitance]
+    utl::info FLW 1 "Setting output load constraint to ${cap_fmt}F."
+    set_load [sta::capacitance_sta_ui $load_cap] [all_outputs]
+  }
+  if { $driving_port != "NULL" } {
+    utl::info FLW 1 "Setting input driving pin constraint to [$buffer_cell name]/$driving_port."
+    set_driving_cell -lib_cell [$buffer_cell name] -pin $driving_port [all_inputs]
+  }
 }

--- a/siliconcompiler/tools/openroad/scripts/sc_physyn.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_physyn.tcl
@@ -1,7 +1,7 @@
 
 # while (not good enough):
-  # global placement
-  # estimate parasitics
-  # logic remapping, buffering
+#   global placement
+#   estimate parasitics
+#   logic remapping, buffering
 
 puts "NOP"

--- a/siliconcompiler/tools/openroad/scripts/sc_screenshot.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_screenshot.tcl
@@ -1,11 +1,11 @@
 gui::save_display_controls
 
 set sc_resolution \
-    [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} show_vertical_resolution] 0]
+  [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} show_vertical_resolution] 0]
 
 # Show the drc markers (if any)
 if {[file exists reports/${sc_design}_drc.rpt]} {
-    gui::load_drc reports/${sc_design}_drc.rpt
+  gui::load_drc reports/${sc_design}_drc.rpt
 }
 
 sc_image_setup_default
@@ -17,5 +17,5 @@ gui::restore_display_controls
 if { [dict exist $sc_cfg tool $sc_tool task $sc_task {var} include_report_images] &&
      [lindex [dict get $sc_cfg tool $sc_tool task $sc_task {var} include_report_images] 0]
      == "true"} {
-    source -echo "${sc_refdir}/sc_write_images.tcl"
+  source -echo "${sc_refdir}/sc_write_images.tcl"
 }

--- a/siliconcompiler/tools/openroad/scripts/sc_write_images.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_write_images.tcl
@@ -161,9 +161,9 @@ proc sc_image_power_density {} {
     gui::set_heatmap Power rebuild
 
     sc_image_heatmap "Power Density" \
-        "Power" \
-        "power_density/${corner_name}.png" \
-        "power density for $corner_name"
+      "Power" \
+      "power_density/${corner_name}.png" \
+      "power density for $corner_name"
   }
 }
 

--- a/siliconcompiler/tools/vivado/scripts/sc_syn_fpga.tcl
+++ b/siliconcompiler/tools/vivado/scripts/sc_syn_fpga.tcl
@@ -5,7 +5,7 @@ set_property target_language Verilog [current_project]
 
 # add imported files
 if {[string equal [get_filesets -quiet sources_1] ""]} {
-create_fileset -srcset sources_1
+    create_fileset -srcset sources_1
 }
 add_files -norecurse -fileset [get_filesets sources_1] "inputs/$sc_design.v"
 set_property top $sc_design [current_fileset]

--- a/siliconcompiler/tools/yosys/sc_syn.tcl
+++ b/siliconcompiler/tools/yosys/sc_syn.tcl
@@ -61,11 +61,11 @@ if { [file exists "inputs/$sc_design.v"] } {
 yosys chparam -list
 if {[dict exists $sc_cfg option param]} {
     dict for {key value} [dict get $sc_cfg option param] {
-	if !{[string is integer $value]} {
-	    set value [concat \"$value\"]
-	}
-	yosys chparam -set $key $value $sc_design
-   }
+        if !{[string is integer $value]} {
+            set value [concat \"$value\"]
+        }
+        yosys chparam -set $key $value $sc_design
+    }
 }
 
 ########################################################


### PR DESCRIPTION
This uses the new `tclint` fileset configuration feature to set an alternate indent for the OpenROAD scripts, which made it a lot quicker to clean up. There were 2 files in the OpenROAD scripts that used 4 space indent, but I transitioned them over in this PR. 