### PR TITLE
fix klayout

### DIFF
--- a/.github/workflows/bin/setup_wheel_env_linux.sh
+++ b/.github/workflows/bin/setup_wheel_env_linux.sh
@@ -9,6 +9,5 @@ klayout_version=$(python3 ${src_path}/setup/_tools.py --tool klayout --field ver
 wget --no-check-certificate \
     -O klayout.rpm \
     "https://www.klayout.org/downloads/CentOS_7/klayout-${klayout_version}-0.x86_64.rpm"
-yum install -y python3 ruby qt-x11
 # This may fail on ARM64
-rpm -i klayout.rpm || true
+yum install -y klayout.rpm || true

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -99,6 +99,7 @@ def runtime_options(chip):
     # environment than the user, it needs to import the limited Schema class
     # that has no 3rd-party dependencies.
     # This must be done at runtime to work in a remote context.
+
     return ['-rd', f'SC_ROOT={chip.scroot}']
 
 

--- a/siliconcompiler/tools/klayout/klayout_export.py
+++ b/siliconcompiler/tools/klayout/klayout_export.py
@@ -211,11 +211,15 @@ def main():
     # SC_ROOT provided by CLI
     sys.path.append(SC_ROOT)  # noqa: F821
 
-    from schema import Schema  # noqa E402
-    from tools.klayout.klayout_utils import technology, get_streams, save_technology  # noqa E402
+    from tools.klayout.klayout_utils import (
+        technology,
+        get_streams,
+        save_technology,
+        get_schema
+    )
     from tools.klayout.klayout_show import show  # noqa E402
 
-    schema = Schema(manifest='sc_manifest.json')
+    schema = get_schema(manifest='sc_manifest.json')
 
     # Extract info from manifest
     sc_step = schema.get('arg', 'step')

--- a/siliconcompiler/tools/klayout/klayout_operations.py
+++ b/siliconcompiler/tools/klayout/klayout_operations.py
@@ -1,5 +1,4 @@
 import pya
-
 import sys
 import os
 
@@ -313,10 +312,13 @@ if __name__ == "__main__":
     # SC_ROOT provided by CLI
     sys.path.append(SC_ROOT)  # noqa: F821
 
-    from schema import Schema
-    from tools.klayout.klayout_utils import technology, get_streams
+    from tools.klayout.klayout_utils import (
+        technology,
+        get_streams,
+        get_schema
+    )
 
-    schema = Schema(manifest='sc_manifest.json')
+    schema = get_schema(manifest='sc_manifest.json')
 
     # Extract info from manifest
     sc_step = schema.get('arg', 'step')

--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -1,5 +1,4 @@
 import pya
-
 import os
 import sys
 
@@ -195,10 +194,12 @@ def main():
     # SC_ROOT provided by CLI, and is only accessible when this is main module
     sys.path.append(SC_ROOT)  # noqa: F821
 
-    from tools.klayout.klayout_utils import technology
-    from schema import Schema
+    from tools.klayout.klayout_utils import (
+        technology,
+        get_schema
+    )
 
-    schema = Schema(manifest='sc_manifest.json')
+    schema = get_schema(manifest='sc_manifest.json')
 
     flow = schema.get('option', 'flow')
     step = schema.get('arg', 'step')

--- a/siliconcompiler/tools/klayout/klayout_utils.py
+++ b/siliconcompiler/tools/klayout/klayout_utils.py
@@ -1,6 +1,8 @@
 import pya
+import importlib.util as importlib_util
 import os
 import shutil
+import sys
 
 
 def get_streams(schema):
@@ -156,3 +158,15 @@ def get_write_options(filename, timestamps):
     write_options.set_format_from_filename(filename)
 
     return write_options
+
+
+def get_schema(manifest):
+    scroot = os.path.join(os.path.dirname(__file__), '..', '..')
+    module_name = 'schema'
+    schema_base = os.path.join(scroot, module_name, '__init__.py')
+    spec = importlib_util.spec_from_file_location(module_name, schema_base)
+    module = importlib_util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    # Return schema
+    return module.Schema(manifest=manifest)

--- a/tests/flows/test_show.py
+++ b/tests/flows/test_show.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 import siliconcompiler
 import os
+import platform
 import pytest
 from pyvirtualdisplay import Display
 import sys
@@ -18,6 +19,9 @@ def adjust_exe_options(chip, headless):
 
 @pytest.fixture
 def display():
+    if "WSL2" in platform.platform():
+        os.environ["PYVIRTUALDISPLAY_DISPLAYFD"] = "0"
+
     if sys.platform != 'win32':
         display = Display(visible=False)
         display.start()


### PR DESCRIPTION
Switch to importing schema module by file to avoid name collision with other `schema` module.
Fix wheels to correctly install klayout again and re-enable those tests