### PR TITLE
Update tclint to check blank lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ exclude = [
 allow-aligned-sets = true
 line-length = 100
 indent = 4
+max-blank-lines = 1
 
 [[tool.tclint.fileset]]
 # This fileset overrides the global indent for OpenROAD scripts.

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ pytest-asyncio
 pytest-cov
 pyvirtualdisplay
 flake8 >= 5.0.0
-tclint == 0.1.5
+tclint == 0.1.6
 
 # Docker dependencies
 #:docker

--- a/siliconcompiler/tools/netgen/sc_lvs.tcl
+++ b/siliconcompiler/tools/netgen/sc_lvs.tcl
@@ -23,7 +23,6 @@ if {[dict exists $sc_cfg "input" netlist verilog]} {
     set schematic_file "inputs/$sc_design.vg"
 }
 
-
 # readnet returns a number that can be used to associate additional files with
 # each netlist read in here
 set layout_fileset [readnet spice $layout_file]

--- a/siliconcompiler/tools/openroad/scripts/sc_procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_procs.tcl
@@ -338,7 +338,6 @@ proc sc_image_resolution { pixels } {
   return [expr [ord::dbu_to_microns [$box maxDXDY]] / $pixels]
 }
 
-
 ###########################
 # Clear gui selections
 ###########################

--- a/siliconcompiler/tools/openroad/scripts/sc_route.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_route.tcl
@@ -17,7 +17,6 @@ proc insert_fillers {} {
   global_connect
 }
 
-
 #######################
 # Add Fillers
 #######################


### PR DESCRIPTION
This PR updates `tclint` with the latest version that implements your suggestion (https://github.com/nmoroze/tclint/issues/5), and fixes violations accordingly.

Note that the default allows for 2 consecutive newlines (since I've seen that commonly used), but I updated it here to match your suggestion in the tclint issue. 