### PR TITLE
Fix "benchmark" example

### DIFF
--- a/examples/benchmark/benchmark.py
+++ b/examples/benchmark/benchmark.py
@@ -2,57 +2,53 @@ import os
 import time
 import siliconcompiler
 
+
 # Setting up the experiment
 def main():
     rootdir = os.path.dirname(__file__)
-    parent = os.path.abspath(rootdir + '/..')
+    parent = os.path.abspath(rootdir + "/..")
 
-    examples = [{'heartbeat': 1000},
-                {'picorv32': 1000},
-                {'aes': 1500}]
-    
+    examples = [{"heartbeat": 1000}, {"picorv32": 1000}, {"aes": 1500}]
+
     results = {}
 
     for item in examples:
         design = list(item.keys())[0]
         size = list(item.values())[0]
-        
+
         rootdir = os.path.join(parent, design)
         results[design] = {}
         for n in [1, 2, 4, 8, 16]:
             wall_start = time.time()
 
-            chip = siliconcompiler.Chip(design)            
-            chip.set('option', 'jobname', f'job{n}')
-            chip.set('option', 'relax', True)
-            chip.set('option', 'quiet', True)
-            chip.set('option', 'remote', False)
+            chip = siliconcompiler.Chip(design)
+            chip.set("option", "jobname", f"job{n}")
+            chip.set("option", "relax", True)
+            chip.set("option", "quiet", True)
+            chip.set("option", "remote", False)
 
-            asic_flow_args = {
-                'syn_np': n,
-                'place_np': n,
-                'cts_np': n,
-                'route_np': n
-            }
-            chip.load_target('skywater130_demo', **asic_flow_args)
-            
+            asic_flow_args = {"syn_np": n, "place_np": n, "cts_np": n, "route_np": n}
+            chip.load_target("skywater130_demo", **asic_flow_args)
+
             # Set router to 1 thread to not interfere with measurement
-            chip.set('tool', 'openroad', 'task', 'route', 'threads', 1)
+            chip.set("tool", "openroad", "task", "route", "threads", 1)
 
             # load design
-            if design == 'picorv32':
+            if design == "picorv32":
                 # picorv32 design is not shipped with sc, but can be automatically cloned from git
-                chip.register_package_source(name='picorv32',
-                                                path='git+https://github.com/YosysHQ/picorv32.git',
-                                                ref='c0acaebf0d50afc6e4d15ea9973b60f5f4d03c42')
-                chip.input(f'picorv32.v', package='picorv32')
-                chip.clock('clk', period=25)
+                chip.register_package_source(
+                    name="picorv32",
+                    path="git+https://github.com/YosysHQ/picorv32.git",
+                    ref="c0acaebf0d50afc6e4d15ea9973b60f5f4d03c42",
+                )
+                chip.input("picorv32.v", package="picorv32")
+                chip.clock("clk", period=50)
             else:
-                chip.input(f'{rootdir}/{design}.v')
-                chip.input(f'{rootdir}/{design}.sdc')
+                chip.input(f"{rootdir}/{design}.v")
+                chip.input(f"{rootdir}/{design}.sdc")
 
-            chip.set('constraint', 'outline', [(0, 0), (size, size)])
-            chip.set('constraint', 'corearea', [(10, 10), (size - 10, size - 10)])
+            chip.set("constraint", "outline", [(0, 0), (size, size)])
+            chip.set("constraint", "corearea", [(10, 10), (size - 10, size - 10)])
 
             # RUN
             chip.run()
@@ -62,9 +58,9 @@ def main():
             wall_end = time.time()
             walltime = round((wall_end - wall_start), 2)
             results[design][n] = walltime
-            with open('results.txt', 'a') as f:
-                f.write(f'{design}, {n}, {walltime}\n')
+            with open("results.txt", "a") as f:
+                f.write(f"{design}, {n}, {walltime}\n")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/examples/benchmark/benchmark.py
+++ b/examples/benchmark/benchmark.py
@@ -1,16 +1,12 @@
 import os
 import time
 import siliconcompiler
-from siliconcompiler.flows import asicflow
 
 # Setting up the experiment
-
-
 def main():
     rootdir = os.path.dirname(__file__)
 
     examples = [{'heartbeat': 1000},
-                {'picorv32': 1000},
                 {'aes': 1500}]
 
     results = {}
@@ -18,34 +14,33 @@ def main():
     for item in examples:
         design = list(item.keys())[0]
         size = list(item.values())[0]
-        parent = os.path.abspath("..")
+        parent = os.path.abspath(rootdir + "/..")
         rootdir = os.path.join(parent, design)
         results[design] = {}
-        for n in ['1', '2', '4', '8', '16']:
+        for n in [1, 2, 4, 8, 16]:
             wall_start = time.time()
             chip = siliconcompiler.Chip(design)
-            chip.set('jobname', f"job{n}")
-            chip.load_target("skywater130_demo")
-            chip.set('relax', True)
-            chip.set('quiet', True)
-            chip.set('remote', False)
+            chip.set('option', 'jobname', f"job{n}")
+            chip.set('option', 'relax', True)
+            chip.set('option', 'quiet', True)
+            chip.set('option', 'remote', False)
 
-            # load dsign
+            asic_flow_args = {
+                'syn_np': n,
+                'place_np': n,
+                'cts_np': n,
+                'route_np': n
+            }
+            chip.load_target("skywater130_demo", **asic_flow_args)
+            
+            # Set router to 1 thread to not interfere with measurement
+            chip.set('tool', 'openroad', 'task', 'route', 'threads', 1)
+
+            # load design
             chip.input(os.path.join(rootdir, f"{design}.v"))
             chip.input(os.path.join(rootdir, f"{design}.sdc"))
             chip.set('constraint', 'outline', [(0, 0), (size, size)])
             chip.set('constraint', 'corearea', [(10, 10), (size - 10, size - 10)])
-
-            # load flow
-            chip.set('flowarg', 'syn_np', n)
-            chip.set('flowarg', 'place_np', n)
-            chip.set('flowarg', 'cts_np', n)
-            chip.use(asicflow)
-            chip.set('flow', 'asicflow')
-
-            # Set router to 1 thread to not interfere with measurement
-            for i in range(int(n)):
-                chip.set('eda', 'openroad', 'threads', 'route', str(i), 1)
 
             # RUN
             chip.run()
@@ -55,8 +50,8 @@ def main():
             wall_end = time.time()
             walltime = round((wall_end - wall_start), 2)
             results[design][n] = walltime
-            with open("results.txt", 'w') as f:
-                f.write(results)
+            with open("results.txt", 'a') as f:
+                f.write(f"{design}, {n}, {walltime}\n")
 
 
 if __name__ == '__main__':

--- a/examples/benchmark/benchmark.py
+++ b/examples/benchmark/benchmark.py
@@ -5,22 +5,25 @@ import siliconcompiler
 # Setting up the experiment
 def main():
     rootdir = os.path.dirname(__file__)
+    parent = os.path.abspath(rootdir + '/..')
 
     examples = [{'heartbeat': 1000},
+                {'picorv32': 1000},
                 {'aes': 1500}]
-
+    
     results = {}
 
     for item in examples:
         design = list(item.keys())[0]
         size = list(item.values())[0]
-        parent = os.path.abspath(rootdir + "/..")
+        
         rootdir = os.path.join(parent, design)
         results[design] = {}
         for n in [1, 2, 4, 8, 16]:
             wall_start = time.time()
-            chip = siliconcompiler.Chip(design)
-            chip.set('option', 'jobname', f"job{n}")
+
+            chip = siliconcompiler.Chip(design)            
+            chip.set('option', 'jobname', f'job{n}')
             chip.set('option', 'relax', True)
             chip.set('option', 'quiet', True)
             chip.set('option', 'remote', False)
@@ -31,14 +34,23 @@ def main():
                 'cts_np': n,
                 'route_np': n
             }
-            chip.load_target("skywater130_demo", **asic_flow_args)
+            chip.load_target('skywater130_demo', **asic_flow_args)
             
             # Set router to 1 thread to not interfere with measurement
             chip.set('tool', 'openroad', 'task', 'route', 'threads', 1)
 
             # load design
-            chip.input(os.path.join(rootdir, f"{design}.v"))
-            chip.input(os.path.join(rootdir, f"{design}.sdc"))
+            if design == 'picorv32':
+                # picorv32 design is not shipped with sc, but can be automatically cloned from git
+                chip.register_package_source(name='picorv32',
+                                                path='git+https://github.com/YosysHQ/picorv32.git',
+                                                ref='c0acaebf0d50afc6e4d15ea9973b60f5f4d03c42')
+                chip.input(f'picorv32.v', package='picorv32')
+                chip.clock('clk', period=25)
+            else:
+                chip.input(f'{rootdir}/{design}.v')
+                chip.input(f'{rootdir}/{design}.sdc')
+
             chip.set('constraint', 'outline', [(0, 0), (size, size)])
             chip.set('constraint', 'corearea', [(10, 10), (size - 10, size - 10)])
 
@@ -50,8 +62,8 @@ def main():
             wall_end = time.time()
             walltime = round((wall_end - wall_start), 2)
             results[design][n] = walltime
-            with open("results.txt", 'a') as f:
-                f.write(f"{design}, {n}, {walltime}\n")
+            with open('results.txt', 'a') as f:
+                f.write(f'{design}, {n}, {walltime}\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I wasn't able to run the "benchmark" example, it seems like some of the schema keypaths are from an older version of siliconcompiler.