### PR TITLE
Remove dependency on klayout Qt bindings for saving screenshots

### DIFF
--- a/siliconcompiler/tools/klayout/klayout_show.py
+++ b/siliconcompiler/tools/klayout/klayout_show.py
@@ -90,9 +90,8 @@ def __screenshot(schema, layout_view, output_path):
                                          'show_vertical_resolution',
                                          step=step, index=index)[0])
 
-    gds_img = layout_view.get_image(horizontal_resolution, vertical_resolution)
     print(f'[INFO] Saving screenshot to {output_path}')
-    gds_img.save(output_path, 'PNG')
+    layout_view.save_image(output_path, horizontal_resolution, vertical_resolution)
 
 
 def __screenshot_montage(schema, view, xbins, ybins):

--- a/siliconcompiler/tools/klayout/show.py
+++ b/siliconcompiler/tools/klayout/show.py
@@ -88,7 +88,8 @@ def pre_process(chip):
     index = chip.get('arg', 'index')
     tool, task = chip._get_tool_task(step, index)
 
-    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath'):
+    if chip.valid('tool', tool, 'task', task, 'var', 'show_filepath') and \
+       chip.get('tool', tool, 'task', task, 'var', 'show_filepath', step=step, index=index):
         show_file = chip.get('tool', tool, 'task', task, 'var', 'show_filepath',
                              step=step, index=index)[0]
 


### PR DESCRIPTION
This allows using klayout built without Qt bindings with siliconcompiler. The Qt bindings were only used to grab an image of a `LayoutView` and then save it to a .png. This can be achieved by calling `save_image()` directly which combines those two steps in a single call without the need of handling an intermediate Qt object.

Tested this with the normal klayout export task as well as the gcd_screenshot example.