### PR TITLE
Add a hook to map ROMs to logic when there are no initializable block…

### DIFF
--- a/siliconcompiler/tools/yosys/syn_fpga.tcl
+++ b/siliconcompiler/tools/yosys/syn_fpga.tcl
@@ -200,7 +200,7 @@ if {[string match {ice*} $sc_partname]} {
 
     }
 
-    if { ( [lsearch -exact $sc_syn_feature_set mem_init] < 0 ) } {
+    if {[lsearch -exact $sc_syn_feature_set mem_init] < 0} {
         yosys memory_map -rom-only
     }
 

--- a/siliconcompiler/tools/yosys/syn_fpga.tcl
+++ b/siliconcompiler/tools/yosys/syn_fpga.tcl
@@ -200,6 +200,11 @@ if {[string match {ice*} $sc_partname]} {
 
     }
 
+    if { ( [lsearch -exact $sc_syn_feature_set mem_init] < 0 ) } {
+        yosys memory_map -rom-only
+        post_techmap
+    }
+
     if {[dict exists $sc_cfg fpga $sc_partname file yosys_memory_techmap]} {
 
         set sc_syn_memory_library \

--- a/siliconcompiler/tools/yosys/syn_fpga.tcl
+++ b/siliconcompiler/tools/yosys/syn_fpga.tcl
@@ -202,7 +202,6 @@ if {[string match {ice*} $sc_partname]} {
 
     if { ( [lsearch -exact $sc_syn_feature_set mem_init] < 0 ) } {
         yosys memory_map -rom-only
-        post_techmap
     }
 
     if {[dict exists $sc_cfg fpga $sc_partname file yosys_memory_techmap]} {


### PR DESCRIPTION
… RAMs in the architecture.

In this small PR, a memory_map call is made if the FPGA part's feature set does not contain an entry called "mem_init".  The objective is as follows:

* In the case where the FPGA's block RAMs can be initialized as part of bitstream loading, the memory_libmap file used in the memory_libmap will contain hooks that allow yosys $mem_v2 instances to be mapped to block RAM.  The instances of this type that yosys infers from code that implies ROMs will then get techmapped to block RAMs, and to support this flow working we require the FPGA part module to include chip.add('fpga', part_name, 'var', 'feature_set', 'mem_init')

* In the event that the block RAMs are not initializable (currently all of them, as FPGA Architect does not yet support initializable BRAMs), then the memory_map -rom-only pass should execute to prevent $mem_v2 instances from being passed to the output netlist.

Some feedback needed to support this PR:

1.  Suggestions on an HDL design to use for testing this feature, and more broadly a good test plan for the feature overall.
2.  A sanity check that the "mem_init" feature_set entry is really needed.  Will yosys behave cleanly if the memory_map -rom-only pass is run all the time, on the assumption that it will do no work if initiializable memories are detected in the previous pass?
