### PR TITLE
Removing pip installs from surelog setup

### DIFF
--- a/setup/install-surelog.sh
+++ b/setup/install-surelog.sh
@@ -10,8 +10,8 @@ sudo apt-get install -y build-essential cmake git pkg-config \
     tclsh swig uuid-dev libgoogle-perftools-dev python3 \
     python3-orderedmultidict python3-psutil python3-dev \
     default-jre lcov zlib1g-dev
-pip3 install orderedmultidict
-pip3 install cmake
+#pip3 install orderedmultidict
+#pip3 install cmake
 
 mkdir -p deps
 cd deps

--- a/setup/install-surelog.sh
+++ b/setup/install-surelog.sh
@@ -10,8 +10,6 @@ sudo apt-get install -y build-essential cmake git pkg-config \
     tclsh swig uuid-dev libgoogle-perftools-dev python3 \
     python3-orderedmultidict python3-psutil python3-dev \
     default-jre lcov zlib1g-dev
-#pip3 install orderedmultidict
-#pip3 install cmake
 
 mkdir -p deps
 cd deps


### PR DESCRIPTION
- pip cmake package install fails, not needed for machine install
- mutidict for venv seems misplaced, looking at commit log it was to fix something in venv, which doesn't belong here?

Install now works correctly on a clean ubuntu 22.04 machine