### PR TITLE
Import data sources of an imported module

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -603,7 +603,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
 
         # Copy
         src_cfg[importname] = module.getdict(group, importname)
-        self.__import_data_sources(src_cfg)
+        self.__import_data_sources(module.schema.cfg)
 
     ###########################################################################
     def help(self, *keypath):


### PR DESCRIPTION
I noticed that since the recent changes to the data source importing, the `tests/test_paths.py` in lambdapdk fails.

I think this might be the reason: We're trying to get the 'package' information from the subgroup ('pdk', 'fpga', ...) instead of at the top level of the schema.