### PR TITLE
Fix Conda CI Tests and environment

### DIFF
--- a/.github/workflows/conda_ci.yml
+++ b/.github/workflows/conda_ci.yml
@@ -42,7 +42,7 @@ jobs:
           openroad -version
           surelog --version
           yosys --version
-          
+
       - name: Set up Python ${{ matrix.python-version }}
         id: setup-python
         uses: actions/setup-python@v5
@@ -55,11 +55,16 @@ jobs:
         run : |
           conda activate sc_env
           
+          echo "setup-python action provides path ${{ steps.setup-python.outputs.python-path }}"
           ${{ steps.setup-python.outputs.python-path }} -m venv clean_env
           source clean_env/bin/activate
-          python3 --version
+
+          which python3
+          which python
+
+          python --version
           
           cd $GITHUB_WORKSPACE
-          python3 -m pip install --upgrade pip
-          python3 -m pip install .[test]
+          python -m pip install --upgrade pip
+          python -m pip install .[test]
           pytest -n auto -k "not sim" tests/tools/test_openroad.py tests/tools/test_klayout.py tests/tools/test_surelog.py tests/tools/test_yosys.py tests/core/test_tool_tasks.py tests/flows/test_show.py tests/apps/test_sc_show.py tests/examples/test_heartbeat.py

--- a/setup/conda/environment.yml
+++ b/setup/conda/environment.yml
@@ -3,6 +3,7 @@ channels:
   - LiteX-Hub
   - conda-forge
 dependencies:
+  - python>=3.8
   - pip
   - pip:
     - siliconcompiler
@@ -14,4 +15,3 @@ dependencies:
   - yosys>=0.33+21
   - klayout>=0.28.0
   - fmt # Requirement for OpenROAD
-  - ruby==2.5.1 # Requirement for klayout


### PR DESCRIPTION
This fixes the Conda CI Test by forcing the environment setup to use python>=3.8, which apparently also solves the dependency problem with the old ruby version.