### PR TITLE
Initialize codec error handlers in each spawned subprocess

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -77,6 +77,10 @@ class Chip:
             self.error("""SiliconCompiler must be run from a directory that exists.
 If you are sure that your working directory is valid, try running `cd $(pwd)`.""", fatal=True)
 
+        # Initialize custom error handling for codecs. This has to be called
+        # by each spawned (as opposed to forked) subprocess
+        self._init_codecs()
+
         self._init_logger()
 
         self.schema = Schema(logger=self.logger)
@@ -119,10 +123,6 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             'libs': [],
             'checklists': []
         }
-
-        # Initialize custom error handling for codecs. This has to be called
-        # by each spawned (as opposed to forked) subprocess
-        self._init_codecs()
 
     ###########################################################################
     @property
@@ -3446,6 +3446,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         '''
 
         self._init_codecs()
+
         self._init_logger(step, index, in_run=True)
 
         # Make record of sc version and machine

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -120,22 +120,9 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             'checklists': []
         }
 
-        # Custom error handlers used to provide warnings when invalid characters
-        # are encountered in a file for a given encoding. The names
-        # 'replace_with_warning' and 'ignore_with_warning' are supplied to
-        # open() via the 'errors' kwarg.
-
-        # Warning message/behavior for invalid characters while running tool
-        def display_error_handler(e):
-            self.logger.warning('Invalid character in tool output, displaying as �')
-            return codecs.replace_errors(e)
-        codecs.register_error('replace_with_warning', display_error_handler)
-
-        # Warning message/behavior for invalid characters while processing log
-        def log_error_handler(e):
-            self.logger.warning('Ignoring invalid character found while reading log')
-            return codecs.ignore_errors(e)
-        codecs.register_error('ignore_with_warning', log_error_handler)
+        # Initialize custom error handling for codecs. This has to be called
+        # by each spawned (as opposed to forked) subprocess
+        self._init_codecs()
 
     ###########################################################################
     @property
@@ -301,6 +288,25 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             handler.setFormatter(formatter)
 
         self.logger.setLevel(loglevel)
+
+    ###########################################################################
+    def _init_codecs(self):
+        # Custom error handlers used to provide warnings when invalid characters
+        # are encountered in a file for a given encoding. The names
+        # 'replace_with_warning' and 'ignore_with_warning' are supplied to
+        # open() via the 'errors' kwarg.
+
+        # Warning message/behavior for invalid characters while running tool
+        def display_error_handler(e):
+            self.logger.warning('Invalid character in tool output, displaying as �')
+            return codecs.replace_errors(e)
+        codecs.register_error('replace_with_warning', display_error_handler)
+
+        # Warning message/behavior for invalid characters while processing log
+        def log_error_handler(e):
+            self.logger.warning('Ignoring invalid character found while reading log')
+            return codecs.ignore_errors(e)
+        codecs.register_error('ignore_with_warning', log_error_handler)
 
     ###########################################################################
     def create_cmdline(self,
@@ -3439,6 +3445,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
         to the filesystem to communicate updates between processes.
         '''
 
+        self._init_codecs()
         self._init_logger(step, index, in_run=True)
 
         # Make record of sc version and machine


### PR DESCRIPTION
Logfile parsing (`check_logfile`) happens in the spawned subprocess and uses (when encountering invalid encoding) the error handlers registered with the `codecs` registry in the main process. This works when using `fork`, but not with `spawn` which will lead to an error like this when a logfile contains invalid characters:

```
Process SpawnProcess-1:
Traceback (most recent call last):
[...]
LookupError: unknown error handler name 'ignore_with_warning'
```

This example shows the difference in passing on the codec registry to child processes when using `spawn`/`fork`:

```python
import codecs
import multiprocessing

def subprocess():
    print("Triggering error in sub process")
    b"\xf5".decode(encoding="UTF-8", errors="ignore_with_warning")

def main():
    def log_error_handler(e):
        print("I am the handler")
        return codecs.ignore_errors(e)
        
    codecs.register_error('ignore_with_warning', log_error_handler)

    print("Triggering error in main process")
    b"\xf5".decode(encoding="UTF-8", errors="ignore_with_warning")

    multiprocessor = multiprocessing.get_context('spawn')
    #multiprocessor = multiprocessing.get_context('fork')
    p = multiprocessor.Process(target=subprocess, args=())
    p.start()
    p.join()


if __name__ == "__main__":
    main()
```

And this patch fixes the problem by moving the registration of error handlers to it's own method and then calling that in `_runtask()`.