### PR TITLE
Gracefully handle encoding errors in logfile when in quiet mode

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -43,6 +43,7 @@ from siliconcompiler.report import _generate_summary_image, _open_summary_image
 from siliconcompiler.report import _generate_html_report, _open_html_report
 from siliconcompiler.report import Dashboard
 from siliconcompiler import package as sc_package
+from siliconcompiler.utils import sc_open
 import psutil
 import subprocess
 import glob
@@ -3353,7 +3354,7 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             if logfile:
                 if quiet:
                     # Print last 10 lines of log when in quiet mode
-                    with open(logfile, 'r') as logfd:
+                    with sc_open(logfile) as logfd:
                         loglines = logfd.read().splitlines()
                         for logline in loglines[-10:]:
                             self.logger.error(logline)

--- a/tests/core/data/failing_tool.sh
+++ b/tests/core/data/failing_tool.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# This is a tool which outputs invalid UTF-8 chars and then errors out
+
+echo test
+
+echo -n -e '\xf5'
+
+echo test
+
+exit -1

--- a/tests/core/test_codecs.py
+++ b/tests/core/test_codecs.py
@@ -1,0 +1,37 @@
+import pytest
+
+import os
+import siliconcompiler
+import logging
+
+import tests.core.tools.run.run as run
+
+@pytest.mark.parametrize("quiet", [True, False])
+def test(datadir, capfd, quiet):
+
+    chip = siliconcompiler.Chip('test')
+    chip.logger = logging.getLogger()
+    chip.logger.setLevel(logging.INFO)
+    chip.set("option", "mode", "asic")
+
+    flow = siliconcompiler.Flow(chip, "testflow")
+    flow.node("testflow", "run", run)
+
+    chip.use(flow)
+    chip.set("option", "flow", "testflow")
+
+    chip.set("option", "quiet", quiet)
+
+    chip.set("tool", "run", "task", "run", "option",
+             os.path.join(datadir, "failing_tool.sh"),
+             step="run", index=0)
+    
+    # We expect the run to fail
+    try:
+        chip.run()
+    except:
+        ...
+
+    output = capfd.readouterr()
+    assert("UnicodeDecodeError" not in output.err)
+

--- a/tests/core/tools/run/run.py
+++ b/tests/core/tools/run/run.py
@@ -1,0 +1,15 @@
+def setup(chip):
+    tool = 'run'
+    step = chip.get('arg', 'step')
+    index = chip.get('arg', 'index')
+    task = chip._get_task(step, index)
+
+    chip.set('tool', tool, 'exe', 'sh')
+
+
+def parse_version(stdout):
+    '''
+    Version check based on stdout
+    Depends on tool reported string
+    '''
+    return '0'


### PR DESCRIPTION
The error handlers for invalid encoding were missing here which can lead to a crash when in quiet mode and log contains invalid characters.