### PR TITLE
Add test for error handlers in codecs

### DIFF
--- a/tests/core/data/failing_tool.sh
+++ b/tests/core/data/failing_tool.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# This is a tool which outputs invalid UTF-8 chars and then errors out
+
+echo test
+
+echo -n -e '\xf5'
+
+echo test
+
+exit -1

--- a/tests/core/test_codecs.py
+++ b/tests/core/test_codecs.py
@@ -1,0 +1,38 @@
+import siliconcompiler
+from siliconcompiler._common import SiliconCompilerError
+
+import pytest
+import os
+import logging
+
+import tests.core.tools.run.run as run
+
+
+@pytest.mark.parametrize("quiet", [True, False])
+def test(datadir, capfd, quiet):
+
+    chip = siliconcompiler.Chip('test')
+    chip.logger = logging.getLogger()
+    chip.logger.setLevel(logging.INFO)
+    chip.set("option", "mode", "asic")
+
+    flow = siliconcompiler.Flow(chip, "testflow")
+    flow.node("testflow", "run", run)
+
+    chip.use(flow)
+    chip.set("option", "flow", "testflow")
+
+    chip.set("option", "quiet", quiet)
+
+    chip.set("tool", "run", "task", "run", "option",
+             os.path.join(datadir, "failing_tool.sh"),
+             step="run", index=0)
+
+    # We expect the run to fail
+    try:
+        chip.run()
+    except SiliconCompilerError:
+        ...
+
+    output = capfd.readouterr()
+    assert "UnicodeDecodeError" not in output.err

--- a/tests/core/tools/run/run.py
+++ b/tests/core/tools/run/run.py
@@ -1,0 +1,12 @@
+def setup(chip):
+    tool = 'run'
+
+    chip.set('tool', tool, 'exe', 'sh')
+
+
+def parse_version(stdout):
+    '''
+    Version check based on stdout
+    Depends on tool reported string
+    '''
+    return '0'


### PR DESCRIPTION
This test runs a step producing output/logfile with invalid UTF-8. This tests whether the codecs error handling works correctly in a spawned subprocess.