### PR TITLE
Yosys: Introduce parameter allowing to mask out RTL modules

### DIFF
--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -128,6 +128,9 @@ def setup_asic(chip):
     # document parameters
     chip.set('tool', tool, 'task', task, 'var', 'preserve_modules',
              'List of modules in input files to prevent flatten from "flattening"', field='help')
+    chip.set('tool', tool, 'task', task, 'var', 'blackbox_modules',
+             'List of modules in input files to exclude from synthesis by replacing them '
+             'with empty blackboxes"', field='help')
     chip.set('tool', tool, 'task', task, 'var', 'flatten',
              'true/false, invoke synth with the -flatten option', field='help')
     chip.set('tool', tool, 'task', task, 'var', 'autoname',

--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -163,6 +163,15 @@ foreach bb_file $sc_blackboxes {
 # Synthesis
 ########################################################
 
+# Before working on the design, we mask out any module supplied via 
+# `blackbox_modules`. This allows synthesis of parts of the design without having
+# to modify the input RTL.
+if { [dict exists $sc_cfg tool $sc_tool task $sc_task var blackbox_modules] } {
+    foreach bb [dict get $sc_cfg tool $sc_tool task $sc_task var blackbox_modules] {
+        yosys blackbox $bb
+    }
+}
+
 # Although the `synth` command also runs `hierarchy`, we run it here without the
 # `-check` flag first in order to resolve parameters before looking for missing
 # modules. This works around the fact that Surelog doesn't pickle modules that

--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -155,7 +155,7 @@ foreach lib_file "$sc_libraries $sc_macro_libraries" {
     yosys read_liberty -lib $lib_file
 }
 foreach bb_file $sc_blackboxes {
-    puts "Reading blackbox model file: $bb_file"
+    yosys log "Reading blackbox model file: $bb_file"
     yosys read_verilog -sv $bb_file
 }
 
@@ -168,7 +168,7 @@ foreach bb_file $sc_blackboxes {
 # to modify the input RTL.
 if { [dict exists $sc_cfg tool $sc_tool task $sc_task var blackbox_modules] } {
     foreach bb [dict get $sc_cfg tool $sc_tool task $sc_task var blackbox_modules] {
-        puts "Blackboxing module: $bb"
+        yosys log "Blackboxing module: $bb"
         yosys blackbox $bb
     }
 }

--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -163,11 +163,12 @@ foreach bb_file $sc_blackboxes {
 # Synthesis
 ########################################################
 
-# Before working on the design, we mask out any module supplied via 
+# Before working on the design, we mask out any module supplied via
 # `blackbox_modules`. This allows synthesis of parts of the design without having
 # to modify the input RTL.
 if { [dict exists $sc_cfg tool $sc_tool task $sc_task var blackbox_modules] } {
     foreach bb [dict get $sc_cfg tool $sc_tool task $sc_task var blackbox_modules] {
+        puts "Blackboxing module: $bb"
         yosys blackbox $bb
     }
 }


### PR DESCRIPTION
I think this is quite a useful option to have when running only a yosys frontend flow through siliconcompiler. It allows masking out RTL modules, which would later be replaced my macro cells without having to modify the RTL.