### PR TITLE
Fix liberty files templates issues when using multiple liberty files

### DIFF
--- a/siliconcompiler/tools/yosys/mergeLib.py
+++ b/siliconcompiler/tools/yosys/mergeLib.py
@@ -4,14 +4,28 @@
 import re
 
 
-library_match = re.compile(r"^\s*library\s*\(")
-cell_match = re.compile(r"^\s*cell\s*\(")
+library_match  = re.compile(r"^\s*library\s*\(")
+cell_match     = re.compile(r"^\s*cell\s*\(")
+# For templates renaming
+template_match = "_template("
+template_end   = "){"
 
 
 def mergeLib(lib_name, base_lib, additional_libs):
     new_lib = __copy_header(base_lib, lib_name)
 
-    for lib in [base_lib, *additional_libs]:
+    # First we have to rename all the templates from the other libraries (not the base one)
+    add_libs = []
+    for idx, lib in enumerate(additional_libs):
+        items = find_template_items(lib)
+        lib2  = re_template_items(lib, '_' + str(idx), items)
+        add_libs.append(lib2)
+
+    # Now we also have to copy all the templates for the different libraries
+    for lib in add_libs:
+        new_lib += __copy_templates(lib)
+
+    for lib in [base_lib, *add_libs]:
         new_lib += __copy_cells(lib)
 
     new_lib += "}\n"
@@ -47,3 +61,38 @@ def __copy_cells(lib):
             new_lib += line + "\n"
 
     return new_lib
+
+
+def __copy_templates(lib):
+    # Templates are expected to start from a _template( string and end with the first cell
+    new_lib = ""
+    start = 0
+    for line in lib.splitlines():
+        if line.find(template_match) != -1:
+            new_lib += line + "\n"
+            start = 1
+        elif cell_match.match(line):
+            break
+        elif start == 1:
+            new_lib += line + "\n"
+
+    return new_lib
+
+def find_template_items(lib):
+
+    items = []
+    for line in lib.splitlines():
+        idx = line.find(template_match)
+        if idx != -1:
+            idx_end = line.find(template_end)
+            items.append(line[idx+len(template_match):idx_end])
+    return items
+
+
+def re_template_items(lib, toadd, items):
+
+    for item in items:
+        pattern = re.compile(r"\b{}\b".format(item))
+        newitem = item[:len(item)] + toadd
+        lib     = re.sub(pattern, newitem, lib)
+    return lib


### PR DESCRIPTION
ABC does not support having multiple liberty files. Hence it is required to first merge all liberty files before passing it to abc. An issue can occur when those different liberty files contain templates that have the same name in different files but with different formats.

This fix does a proper merging by renaming the templates across the files.

This has been discussed in lambdapdk repository, see issue here: https://github.com/siliconcompiler/lambdapdk/issues/34
