### PR TITLE
Update dashboard

### DIFF
--- a/examples/heartbeat/config.json
+++ b/examples/heartbeat/config.json
@@ -1,0 +1,5 @@
+{
+    "nodes": ["cts0", "floorplan0"],
+    "metrics": ["errors", "*area"],
+    "files": ["inputs/*", "*.log"]
+}

--- a/siliconcompiler/apps/sc_dashboard.py
+++ b/siliconcompiler/apps/sc_dashboard.py
@@ -41,12 +41,12 @@ To include another chip object to compare to:
                        'help': 'chip name - optional, path to chip manifest (json)',
                        'metavar': '<[manifest name, manifest path>',
                        'sc_print': False},
-        "--configuration" : {'type': str,
-                       'nargs': '+',
-                       'action': 'append',
-                       'help': 'path to chip configuration file (json)',
-                       'metavar': '<path to JSON>',
-                       'sc_print': False}
+        "--configuration": {'type': str,
+                            'nargs': '+',
+                            'action': 'append',
+                            'help': 'path to chip configuration file (json)',
+                            'metavar': '<path to JSON>',
+                            'sc_print': False}
     }
 
     try:
@@ -91,7 +91,8 @@ To include another chip object to compare to:
             graph_chips.append({'chip': graph_chip, 'name': name})
 
     if (switches["configuration"] is not None):
-        chip._dashboard(wait=True, port=switches['port'], graph_chips=graph_chips, dashboard_configuration=switches["configuration"][0][0])
+        chip._dashboard(wait=True, port=switches['port'], graph_chips=graph_chips,
+                        dashboard_configuration=switches["configuration"][0][0])
     else:
         chip._dashboard(wait=True, port=switches['port'], graph_chips=graph_chips)
 

--- a/siliconcompiler/apps/sc_dashboard.py
+++ b/siliconcompiler/apps/sc_dashboard.py
@@ -40,6 +40,12 @@ To include another chip object to compare to:
                        'action': 'append',
                        'help': 'chip name - optional, path to chip manifest (json)',
                        'metavar': '<[manifest name, manifest path>',
+                       'sc_print': False},
+        "--configuration" : {'type': str,
+                       'nargs': '+',
+                       'action': 'append',
+                       'help': 'path to chip configuration file (json)',
+                       'metavar': '<path to JSON>',
                        'sc_print': False}
     }
 
@@ -84,7 +90,10 @@ To include another chip object to compare to:
             graph_chip.read_manifest(file_path)
             graph_chips.append({'chip': graph_chip, 'name': name})
 
-    chip._dashboard(wait=True, port=switches['port'], graph_chips=graph_chips)
+    if (switches["configuration"] is not None):
+        chip._dashboard(wait=True, port=switches['port'], graph_chips=graph_chips, dashboard_configuration=switches["configuration"][0][0])
+    else:
+        chip._dashboard(wait=True, port=switches['port'], graph_chips=graph_chips)
 
     return 0
 

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2786,7 +2786,8 @@ If you are sure that your working directory is valid, try running `cd $(pwd)`.""
             >>> chip._dashboard()
             Opens a sesison of the dashboard.
         '''
-        dash = Dashboard(self, port=port, graph_chips=graph_chips, dashboard_configuration=dashboard_configuration)
+        dash = Dashboard(self, port=port, graph_chips=graph_chips,
+                         dashboard_configuration=dashboard_configuration)
         dash.open_dashboard()
         if wait:
             try:

--- a/siliconcompiler/report/report.py
+++ b/siliconcompiler/report/report.py
@@ -351,13 +351,14 @@ def get_chart_data(chips, metric, nodes):
         raise ValueError('Not all measurements were made with the same units')
     return metric_datapoints, metric_unit
 
+
 def match_nodes(configuration, all_node_list):
     '''
-    Expands the regular expressions (unix globs) in the nodes configuration and 
+    Expands the regular expressions (unix globs) in the nodes configuration and
     returns a dictionary
 
     Args:
-        configuration (dictionary) : A dictionary corresponding to the JSON file 
+        configuration (dictionary) : A dictionary corresponding to the JSON file
         all_node_list (list) : A list of all possible nodes
     '''
     nodes = []
@@ -365,13 +366,14 @@ def match_nodes(configuration, all_node_list):
         nodes += fnmatch.filter(all_node_list, i)
     return nodes
 
+
 def match_metrics(configuration, all_metric_list):
     '''
-    Expands the regular expressions (unix globs) in the metrics configuration 
+    Expands the regular expressions (unix globs) in the metrics configuration
     and returns a dictionary
 
     Args:
-        configuration (dictionary) : A dictionary corresponding to the JSON file 
+        configuration (dictionary) : A dictionary corresponding to the JSON file
         all_metric_list (list) : A list of all possible metrics
     '''
     metrics = []
@@ -379,13 +381,14 @@ def match_metrics(configuration, all_metric_list):
         metrics += fnmatch.filter(all_metric_list, i)
     return metrics
 
+
 def match_files(configuration, Tree):
     '''
-    Expands the regular expressions (unix globs) in the files configuration 
+    Expands the regular expressions (unix globs) in the files configuration
     and returns a list of matching files
 
     Args:
-        configuration (dictionary) : A dictionary corresponding to the JSON file 
+        configuration (dictionary) : A dictionary corresponding to the JSON file
         Tree (list) : A list of dictionaries in the format expected by
             streamlit_tree_select. This is also the format outputed by
             _convert_filepaths in streamlit_viewer.py.
@@ -398,9 +401,10 @@ def match_files(configuration, Tree):
             if fnmatch.fnmatch(file, "*" + i):
                 matches = True
                 break
-        if matches: 
+        if matches:
             res += [file]
-        
-        if 'children' in tree: res += match_files(configuration, tree['children'])
+
+        if 'children' in tree:
+            res += match_files(configuration, tree['children'])
 
     return res

--- a/siliconcompiler/report/streamlit_report.py
+++ b/siliconcompiler/report/streamlit_report.py
@@ -15,7 +15,7 @@ import shutil
 class Dashboard():
     __port = 8501
 
-    def __init__(self, chip, port=None, graph_chips=None):
+    def __init__(self, chip, port=None, graph_chips=None, dashboard_configuration=None):
         if not port:
             port = Dashboard.__port
 
@@ -53,7 +53,8 @@ class Dashboard():
                 self.__graph_chips_names.append(chip_file_path)
 
         self.__config = {"manifest": self.__manifest,
-                         "graph_chips": self.__graph_chips_names}
+                         "graph_chips": self.__graph_chips_names,
+                         "dashboard_configuration": dashboard_configuration}
 
         self.__sleep_time = 0.5
 

--- a/siliconcompiler/report/streamlit_viewer.py
+++ b/siliconcompiler/report/streamlit_viewer.py
@@ -80,7 +80,7 @@ if 'job' not in streamlit.session_state:
         config = json.load(f)
     chip = Chip(design='')
     if (dashboard_configuration is None and config["dashboard_configuration"] is not None):
-        dashboard_configuration = json.load(open(config["dashboard_configuration"], 'r')) # needs to be a route to a proper file
+        dashboard_configuration = json.load(open(config["dashboard_configuration"], 'r'))
     chip.read_manifest(config["manifest"])
     for file_path in config['graph_chips']:
         graph_chip = Chip(design='')
@@ -275,10 +275,10 @@ def show_files(chip, step, index):
     # kinda janky at the moment, does not always flip immediately
     # TODO make so that selection changes on first click
     if "selected" not in streamlit.session_state:
-        streamlit.session_state['selected'] = [] 
+        streamlit.session_state['selected'] = []
         if dashboard_configuration is not None:
-            streamlit.session_state['selected'] = report.match_files(dashboard_configuration, logs_and_reports)
-            print(streamlit.session_state['selected']) #THIS WORKS
+            streamlit.session_state['selected'] = \
+                report.match_files(dashboard_configuration, logs_and_reports)
     if "expanded" not in streamlit.session_state:
         streamlit.session_state['expanded'] = []
 
@@ -449,22 +449,27 @@ def metrics_dataframe_module(metric_dataframe, metric_to_metric_unit_map):
             selected_nodes = []
             selected_metrics = []
             if "nodes_list" not in streamlit.session_state and dashboard_configuration is not None:
-                streamlit.session_state["nodes_list"] = report.match_nodes(dashboard_configuration, node_list)
+                streamlit.session_state["nodes_list"] = \
+                    report.match_nodes(dashboard_configuration, node_list)
             if "nodes_list" not in streamlit.session_state:
                 selected_nodes = []
             else:
                 selected_nodes = streamlit.session_state["nodes_list"]
-            nodes = streamlit.multiselect('Pick nodes to include', node_list, default=selected_nodes)
+            nodes = streamlit.multiselect('Pick nodes to include',
+                                          node_list, default=selected_nodes)
             options['nodes'] = nodes
 
-            if "metrics_list" not in streamlit.session_state and dashboard_configuration is not None:
-                streamlit.session_state["metrics_list"] = report.match_metrics(dashboard_configuration, display_options)
+            if "metrics_list" not in streamlit.session_state and \
+                    dashboard_configuration is not None:
+                streamlit.session_state["metrics_list"] = \
+                    report.match_metrics(dashboard_configuration, display_options)
             if "metrics_list" not in streamlit.session_state:
                 selected_metrics = []
             else:
                 selected_metrics = streamlit.session_state["metrics_list"]
-            
-            metrics = streamlit.multiselect('Pick metrics to include', display_options, selected_metrics)
+
+            metrics = streamlit.multiselect('Pick metrics to include',
+                                            display_options, selected_metrics)
             options['metrics'] = []
             for metric in metrics:
                 options['metrics'].append(display_to_data[metric])

--- a/siliconcompiler/report/streamlit_viewer.py
+++ b/siliconcompiler/report/streamlit_viewer.py
@@ -73,10 +73,14 @@ args = parser.parse_args()
 if not args.cfg:
     raise ValueError('configuration not provided')
 
+dashboard_configuration = None
+
 if 'job' not in streamlit.session_state:
     with open(args.cfg, 'r') as f:
         config = json.load(f)
     chip = Chip(design='')
+    if (dashboard_configuration is None and config["dashboard_configuration"] is not None):
+        dashboard_configuration = json.load(open(config["dashboard_configuration"], 'r')) # needs to be a route to a proper file
     chip.read_manifest(config["manifest"])
     for file_path in config['graph_chips']:
         graph_chip = Chip(design='')
@@ -271,7 +275,10 @@ def show_files(chip, step, index):
     # kinda janky at the moment, does not always flip immediately
     # TODO make so that selection changes on first click
     if "selected" not in streamlit.session_state:
-        streamlit.session_state['selected'] = []
+        streamlit.session_state['selected'] = [] 
+        if dashboard_configuration is not None:
+            streamlit.session_state['selected'] = report.match_files(dashboard_configuration, logs_and_reports)
+            print(streamlit.session_state['selected']) #THIS WORKS
     if "expanded" not in streamlit.session_state:
         streamlit.session_state['expanded'] = []
 
@@ -439,9 +446,25 @@ def metrics_dataframe_module(metric_dataframe, metric_to_metric_unit_map):
     # pick parameters
     with streamlit.expander("Select Parameters"):
         with streamlit.form("params"):
-            nodes = streamlit.multiselect('Pick nodes to include', node_list, [])
+            selected_nodes = []
+            selected_metrics = []
+            if "nodes_list" not in streamlit.session_state and dashboard_configuration is not None:
+                streamlit.session_state["nodes_list"] = report.match_nodes(dashboard_configuration, node_list)
+            if "nodes_list" not in streamlit.session_state:
+                selected_nodes = []
+            else:
+                selected_nodes = streamlit.session_state["nodes_list"]
+            nodes = streamlit.multiselect('Pick nodes to include', node_list, default=selected_nodes)
             options['nodes'] = nodes
-            metrics = streamlit.multiselect('Pick metrics to include?', display_options, [])
+
+            if "metrics_list" not in streamlit.session_state and dashboard_configuration is not None:
+                streamlit.session_state["metrics_list"] = report.match_metrics(dashboard_configuration, display_options)
+            if "metrics_list" not in streamlit.session_state:
+                selected_metrics = []
+            else:
+                selected_metrics = streamlit.session_state["metrics_list"]
+            
+            metrics = streamlit.multiselect('Pick metrics to include', display_options, selected_metrics)
             options['metrics'] = []
             for metric in metrics:
                 options['metrics'].append(display_to_data[metric])

--- a/siliconcompiler/report/streamlit_viewer.py
+++ b/siliconcompiler/report/streamlit_viewer.py
@@ -307,7 +307,7 @@ def show_metrics_for_file(chip, step, index):
     Displays the metrics that are included in each file.
 
     Args:
-        chip (Chip) : The chip object that conains the schema read from.
+        chip (Chip) : The chip object that contains the schema read from.
         step (string) : Step of node.
         index (string) : Index of node.
     """


### PR DESCRIPTION
There are two main changes done in this pull request: 

1. Change to dashboard layout. 
We created a split, one page layout where the left side would display Visuals (toggles between Flowgraph, Design Preview, and View File), and the right side would display Information (toggles between Metrics, Node Information, and Manifest). This reduced the need  to go back and forth between pages and provided as much information as possible in one glance.

<img width="1357" alt="image" src="https://github.com/siliconcompiler/siliconcompiler/assets/60679089/f065911a-af6d-42e1-b705-9efdd02136e8">

This was done by modifying streamlit_viewer.py. 

2. Added the ability to parse a configuration file for the dashboard to preselect nodes, metrics and files.

Run sc-dashboard with the --configuration <path to file> flag in order to specify the path to a JSON file holding the configuration. An example JSON file is also included in this pull request under examples/heartbeat/config.json.

The JSON file can include unix globs and the parser will expand them automatically.

An example video of the configuration file can be found at https://drive.google.com/file/d/1aqRgLnUTnqwF_p5nvKye-Nss0kBGc69k/view?resourcekey, where the first run is without the example configuration file and the second run is with the example configuration file.
