### PR TITLE
ensure local runs honor thread resources

### DIFF
--- a/siliconcompiler/apps/sc_issue.py
+++ b/siliconcompiler/apps/sc_issue.py
@@ -5,7 +5,7 @@ import siliconcompiler
 import tarfile
 import json
 import importlib
-from siliconcompiler.scheduler import _runtask
+from siliconcompiler.scheduler import _runtask, _executenode
 from siliconcompiler.issue import generate_testcase
 
 
@@ -174,7 +174,7 @@ To run a testcase, use:
         # Rerun setup task, assumed to be running in its own thread so
         # multiprocess is not needed
         flow = chip.get('option', 'flow')
-        _runtask(chip, flow, step, index, {}, replay=True)
+        _runtask(chip, flow, step, index, {}, _executenode, replay=True)
 
         return 0
 

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -14,7 +14,7 @@ from siliconcompiler import utils, SiliconCompilerError
 from siliconcompiler._metadata import default_server
 from siliconcompiler.schema import Schema
 from siliconcompiler.utils import default_credentials_file
-from siliconcompiler.scheduler import _setup_node, _runtask
+from siliconcompiler.scheduler import _setup_node, _runtask, _executenode
 from siliconcompiler.flowgraph import _get_flowgraph_entry_nodes, _get_flowgraph_node_outputs
 
 # Step name to use while logging
@@ -159,7 +159,12 @@ def _remote_preprocess(chip, remote_nodelist):
             # only look up a step's dependencies in this dictionary, and the first
             # step should have none.
             run_task = multiprocessor.Process(target=_runtask,
-                                              args=(chip, flow, local_step, index, {}))
+                                              args=(chip,
+                                                    flow,
+                                                    local_step,
+                                                    index,
+                                                    {},
+                                                    _executenode))
             run_task.start()
             run_task.join()
             if run_task.exitcode != 0:

--- a/siliconcompiler/scheduler/__init__.py
+++ b/siliconcompiler/scheduler/__init__.py
@@ -1149,7 +1149,7 @@ def _check_node_dependencies(chip, node, deps, status, deps_was_successful):
 
 def _launch_nodes(chip, nodes_to_run, processes, local_processes, status):
     running_nodes = {}
-    max_parallel_run = chip.get('option', 'scheduler', 'maxconcurrency')
+    max_parallel_run = chip.get('option', 'scheduler', 'maxnodes')
     max_threads = os.cpu_count()
     if not max_parallel_run:
         max_parallel_run = max_threads

--- a/siliconcompiler/scheduler/__init__.py
+++ b/siliconcompiler/scheduler/__init__.py
@@ -1153,9 +1153,8 @@ def _launch_nodes(chip, nodes_to_run, processes, local_processes, status):
     max_threads = os.cpu_count()
     if not max_parallel_run:
         max_parallel_run = max_threads
-    elif max_parallel_run < 0:
-        max_parallel_run = 1
 
+    # clip max parallel jobs to 1 <= jobs <= max_threads
     max_parallel_run = max(1, min(max_parallel_run, max_threads))
 
     def allow_start(node):
@@ -1175,7 +1174,7 @@ def _launch_nodes(chip, nodes_to_run, processes, local_processes, status):
             # not specified, marking it max to be safe
             requested_threads = max_threads
         # clamp to max_parallel to avoid getting locked up
-        requested_threads = min(1, max(max_threads, requested_threads))
+        requested_threads = min(1, max(requested_threads, max_threads))
 
         if requested_threads + sum(running_nodes.values()) > max_threads:
             # delay until there are enough core available

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from siliconcompiler.schema.utils import trim
 
-SCHEMA_VERSION = '0.40.4'
+SCHEMA_VERSION = '0.40.5'
 
 #############################################################################
 # PARAM DEFINITION
@@ -3507,6 +3507,16 @@ def schema_option(cfg):
             List of email addresses to message on a 'msgevent'. Support for
             email messages relies on job scheduler daemon support.
             For more information, see the job scheduler documentation. """)
+
+    scparam(cfg, ['option', 'scheduler', 'maxconcurrency'],
+            sctype='int',
+            shorthelp="Option: Maximum job concurrency",
+            switch="-maxconcurrency <int>",
+            example=["cli: -maxconcurrency 4",
+                     "api: chip.set('option', 'scheduler', 'maxconcurrency', 4)"],
+            schelp="""
+            Maximum number of concurrent job to run in a job. If not set this will default
+            to the number of cpu cores available.""")
 
     return cfg
 

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -3508,14 +3508,14 @@ def schema_option(cfg):
             email messages relies on job scheduler daemon support.
             For more information, see the job scheduler documentation. """)
 
-    scparam(cfg, ['option', 'scheduler', 'maxconcurrency'],
+    scparam(cfg, ['option', 'scheduler', 'maxnodes'],
             sctype='int',
-            shorthelp="Option: Maximum job concurrency",
-            switch="-maxconcurrency <int>",
-            example=["cli: -maxconcurrency 4",
-                     "api: chip.set('option', 'scheduler', 'maxconcurrency', 4)"],
+            shorthelp="Option: Maximum concurrent nodes",
+            switch="-maxnodes <int>",
+            example=["cli: -maxnodes 4",
+                     "api: chip.set('option', 'scheduler', 'maxnodes', 4)"],
             schelp="""
-            Maximum number of concurrent job to run in a job. If not set this will default
+            Maximum number of concurrent nodes to run in a job. If not set this will default
             to the number of cpu cores available.""")
 
     return cfg

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -11,7 +11,6 @@ Sources: https://github.com/The-OpenROAD-Project/OpenROAD
 Installation: https://github.com/The-OpenROAD-Project/OpenROAD
 '''
 
-import math
 import os
 import json
 from siliconcompiler import sc_open
@@ -60,7 +59,6 @@ def setup(chip):
 
     step = chip.get('arg', 'step')
     index = chip.get('arg', 'index')
-    flow = chip.get('option', 'flow')
     task = chip._get_task(step, index)
     pdkname = chip.get('option', 'pdk')
     targetlibs = chip.get('asic', 'logiclib', step=step, index=index)
@@ -81,12 +79,6 @@ def setup(chip):
     # Fixed for tool
     setup_tool(chip, exit=task != 'show', clobber=clobber)
 
-    # normalizing thread count based on parallelism and local
-    threads = os.cpu_count()
-    if not chip.get('option', 'remote') and step in chip.getkeys('flowgraph', flow):
-        np = len(chip.getkeys('flowgraph', flow, step))
-        threads = int(math.ceil(os.cpu_count() / np))
-
     # Input/Output requirements for default asicflow steps
 
     chip.set('tool', tool, 'task', task, 'refdir', refdir,
@@ -94,7 +86,7 @@ def setup(chip):
              package='siliconcompiler', clobber=clobber)
     chip.set('tool', tool, 'task', task, 'script', script,
              step=step, index=index, clobber=clobber)
-    chip.set('tool', tool, 'task', task, 'threads', threads,
+    chip.set('tool', tool, 'task', task, 'threads', os.cpu_count(),
              step=step, index=index, clobber=clobber)
 
     chip.add('tool', tool, 'task', task, 'output', design + '.sdc', step=step, index=index)

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -9219,6 +9219,31 @@
                 ],
                 "type": "str"
             },
+            "maxconcurrency": {
+                "example": [
+                    "cli: -maxconcurrency 4",
+                    "api: chip.set('option', 'scheduler', 'maxconcurrency', 4)"
+                ],
+                "help": "Maximum number of concurrent job to run in a job. If not set this will default\nto the number of cpu cores available.",
+                "lock": false,
+                "node": {
+                    "default": {
+                        "default": {
+                            "signature": null,
+                            "value": null
+                        }
+                    }
+                },
+                "notes": null,
+                "pernode": "never",
+                "require": null,
+                "scope": "job",
+                "shorthelp": "Option: Maximum job concurrency",
+                "switch": [
+                    "-maxconcurrency <int>"
+                ],
+                "type": "int"
+            },
             "memory": {
                 "example": [
                     "cli: -memory 8000",
@@ -12166,7 +12191,7 @@
             "default": {
                 "default": {
                     "signature": null,
-                    "value": "0.40.4"
+                    "value": "0.40.5"
                 }
             }
         },

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -9219,12 +9219,12 @@
                 ],
                 "type": "str"
             },
-            "maxconcurrency": {
+            "maxnodes": {
                 "example": [
-                    "cli: -maxconcurrency 4",
-                    "api: chip.set('option', 'scheduler', 'maxconcurrency', 4)"
+                    "cli: -maxnodes 4",
+                    "api: chip.set('option', 'scheduler', 'maxnodes', 4)"
                 ],
-                "help": "Maximum number of concurrent job to run in a job. If not set this will default\nto the number of cpu cores available.",
+                "help": "Maximum number of concurrent nodes to run in a job. If not set this will default\nto the number of cpu cores available.",
                 "lock": false,
                 "node": {
                     "default": {
@@ -9238,9 +9238,9 @@
                 "pernode": "never",
                 "require": null,
                 "scope": "job",
-                "shorthelp": "Option: Maximum job concurrency",
+                "shorthelp": "Option: Maximum concurrent nodes",
                 "switch": [
-                    "-maxconcurrency <int>"
+                    "-maxnodes <int>"
                 ],
                 "type": "int"
             },


### PR DESCRIPTION
Adds:
- option/scheduler/maxnodes to schema to control maximum number of parallel jobs allowed in the local scheduler
- honor requested number of threads against local machines total number of threads to avoid overloading system.
