### PR TITLE
Add OpenROAD command checking with tclint

### DIFF
--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -204,7 +204,7 @@ jobs:
           context: ./sc_tools/
           push: true
           tags: ${{ needs.build_tool_builder.outputs.sc_tools }}
-  
+
   runner_image:
     if: always() && github.event_name == 'release'
     needs: [build_tool_builder, build_sc_tools]
@@ -341,3 +341,34 @@ jobs:
           workflow_file_name: containers.yml
           client_payload: '{"sc-ref": "${{ github.event.pull_request.head.ref || github.sha }}"}'
           wait_interval: 60
+
+  lint_tcl:
+    name: Lint OpenROAD TCL scripts
+    if: always()
+    needs: [build_tool_builder, build_sc_tools]
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.build_tool_builder.outputs.sc_tools }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+    env:
+      COMMAND_SPEC_PATH: tclint-openroad-spec.json
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Install tclint
+        run: |
+          python3 -m pip install tclint -c requirements.txt
+
+      - name: Generate OpenROAD command spec
+        run: |
+          tclint-plugins make-spec openroad --output $COMMAND_SPEC_PATH
+
+      - name: Lint with tclint
+        run: |
+          tclint --commands $COMMAND_SPEC_PATH \
+            siliconcompiler/tools/openroad/scripts \
+            siliconcompiler/tools/opensta/scripts

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ pytest-asyncio == 0.23.7
 pytest-cov == 5.0.0
 pyvirtualdisplay
 flake8 == 7.0.0
-tclint == 0.2.5
+tclint == 0.3.0
 
 # Docker dependencies
 #:docker

--- a/siliconcompiler/tools/openroad/scripts/sc_rcx_bench.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_rcx_bench.tcl
@@ -11,7 +11,7 @@ set openroad_top_metal_number [[[ord::get_db_tech] findLayer $sc_maxmetal] getRo
 # store it in the database
 bench_wires \
   -len $openroad_bench_length \
-  -met $openroad_top_metal_number \
+  -met_cnt $openroad_top_metal_number \
   -all
 
 # Writes the verilog netlist


### PR DESCRIPTION
I just released a new version of tclint that adds an OpenROAD plugin for checking its tool-specific commands. This PR fixes an issue it caught and demonstrates how you can add it to CI.

Using the plugin is more involved than just enabling it in the regular job - in order to be responsive to OpenROAD API changes, the plugin requires generating a "command spec" in an environment that has OpenROAD installed. I figured the simplest approach to adding it to the SC CI was to add it as a new job to the tool CI workflow. I kept the regular Tcl lint check as a fast failure path.

Here's an example of a [passing](https://github.com/nmoroze/siliconcompiler/actions/runs/9440700733/job/26000427774) and [failing](https://github.com/nmoroze/siliconcompiler/actions/runs/9440506425/job/25999939939) check in my own fork. 

See this [docs page](https://github.com/nmoroze/tclint/blob/main/docs/plugins.md) for more info on the feature. 

This is fairly fresh so no need to merge if you have any concerns, but I'm curious if you have any feedback on the feature! I'm still thinking about how best to design the UX around enabling plugins and managing command specs. 


