### PR TITLE
move daily tests to use scgallery

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -69,17 +69,7 @@ jobs:
           pytest -n auto --durations=0 --clean
 
   gallery:
-    name: 'SC Gallery'
-    timeout-minutes: 240
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Trigger Gallery
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        with:
-          github_token: ${{ secrets.ZA_TOKEN }}
-          owner: siliconcompiler
-          repo: scgallery
-          workflow_file_name: designs.yml
-          wait_interval: 120
-          client_payload: '{"concurrency": "20", "sc-ref": "${{ github.sha }}"}'
+    uses: siliconcompiler/scgallery/.github/workflows/run-designs.yml@fix-designs
+    with:
+      sc-ref: ${{ github.event.pull_request.head.ref || github.sha }}
+      concurrency: 20

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -68,51 +68,18 @@ jobs:
           python3 -m pip install .[test,examples]
           pytest -n auto --durations=0 --clean
 
-  zerosoc:
-    name: 'ZeroSOC'
-    needs: docker_image
-    timeout-minutes: 150
+  gallery:
+    name: 'SC Gallery'
+    timeout-minutes: 240
     runs-on: ubuntu-latest
-    container:
-      image: ${{ needs.docker_image.outputs.sc_tool }}
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ github.token }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config: ["flat", "hierarchy"]
 
     steps:
-      - name: Checkout SiliconCompiler
-        uses: actions/checkout@v4
-
-      - name: Checkout ZeroSOC
-        uses: actions/checkout@v4
+      - name: Trigger Gallery
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
-          repository: siliconcompiler/zerosoc
-          path: zerosoc
-
-      - name: Setup workspace
-        run: |
-          python3 -m venv clean_env
-          source clean_env/bin/activate
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r zerosoc/python-requirements.txt
-          python3 -m pip install .
-
-      - name: Run flat
-        if: matrix.config == 'flat'
-        run: |
-          source clean_env/bin/activate
-          cd $GITHUB_WORKSPACE/zerosoc
-          ./build.py --top-flat
-
-      - name: Run hierarchy
-        if: matrix.config == 'hierarchy'
-        run: |
-          source clean_env/bin/activate
-          cd $GITHUB_WORKSPACE/zerosoc
-          ./build.py --core-only
-          ./build.py --top-only
+          github_token: ${{ secrets.ZA_TOKEN }}
+          owner: siliconcompiler
+          repo: scgallery
+          workflow_file_name: designs.yml
+          wait_interval: 120
+          client_payload: '{"concurrency": "20", "sc-ref": "${{ github.sha }}"}'

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -69,7 +69,7 @@ jobs:
           pytest -n auto --durations=0 --clean
 
   gallery:
-    uses: siliconcompiler/scgallery/.github/workflows/run-designs.yml@fix-designs
+    uses: siliconcompiler/scgallery/.github/workflows/run-designs.yml@main
     with:
       sc-ref: ${{ github.event.pull_request.head.ref || github.sha }}
-      concurrency: 20
+      concurrency: 30


### PR DESCRIPTION
Currently entire gallery with no rules are enforced, except timeout.

This will increase the runtime from ~50 minutes to 3:30 hours, but for the daily/nightly tests this is acceptable.

https://github.com/siliconcompiler/siliconcompiler/actions/runs/9537997312