### PR TITLE
Replace netifaces with psutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ defusedxml >= 0.7.1
 pandas >= 1.1.5
 Jinja2 >= 2.11.3
 graphviz >= 0.18.1
-netifaces >= 0.11.0
 distro >= 1.6.0
 packaging >= 21.3, < 24 # Less than 24 for streamlit
 psutil >= 5.8.0

--- a/tests/core/test_track.py
+++ b/tests/core/test_track.py
@@ -1,5 +1,6 @@
 import siliconcompiler
 from siliconcompiler.tools.builtin import nop
+import sys
 
 
 def test_track():
@@ -15,5 +16,11 @@ def test_track():
 
     for key in chip.getkeys('record'):
         if key in ('remoteid', 'publickey', 'toolversion', 'toolpath', 'toolargs'):
+            # wont get set based on run
             continue
+
+        if sys.platform != 'linux':
+            # wont get set on non-linux systems
+            if key in ('distro', ):
+                continue
         assert chip.get('record', key, step='import', index='0'), f"no record for {key}"

--- a/tests/core/test_track.py
+++ b/tests/core/test_track.py
@@ -1,0 +1,19 @@
+import siliconcompiler
+from siliconcompiler.tools.builtin import nop
+
+
+def test_track():
+    chip = siliconcompiler.Chip('test')
+
+    flow = 'test'
+    chip.set('option', 'flow', flow)
+    chip.node(flow, 'import', nop)
+    chip.set('option', 'mode', 'asic')
+    chip.set('option', 'track', True)
+
+    chip.run()
+
+    for key in chip.getkeys('record'):
+        if key in ('remoteid', 'publickey', 'toolversion', 'toolpath', 'toolargs'):
+            continue
+        assert chip.get('record', key, step='import', index='0'), f"no record for {key}"


### PR DESCRIPTION
netifaces does not have a maintainer and installing it requires you to compile the package which is cumbersome on windows.
adds a test for tracking to ensure values are logged.