### PR TITLE
use pickle deepcopy over copy.deepcopy due to 2x speedup

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -15,7 +15,6 @@ import inspect
 import textwrap
 import graphviz
 import codecs
-import copy
 from inspect import getfullargspec
 from siliconcompiler.remote import client
 from siliconcompiler.schema import Schema, SCHEMA_VERSION
@@ -1973,9 +1972,9 @@ class Chip:
         keeps = ['asic', 'design', 'fpga', 'option', 'output', 'package']
         if keep_input:
             keeps.append('input')
-        for section in list(libcfg.keys()):
+        for section, section_cfg in libcfg.items():
             if section in keeps:
-                cfg[libname][section] = copy.deepcopy(libcfg[section])
+                cfg[libname][section] = schema_utils.deepcopy(section_cfg)
 
     ###########################################################################
     def write_flowgraph(self, filename, flow=None,

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Silicon Compiler Authors. All Rights Reserved.
 
 import json
+import pickle
 
 # Default import must be relative, to facilitate tools with Python interfaces
 # (such as KLayout) directly importing the schema package. However, the fallback
@@ -15,6 +16,9 @@ SCHEMA_VERSION = '0.48.2'
 #############################################################################
 # PARAM DEFINITION
 #############################################################################
+
+
+Schema_CFG = None
 
 
 def scparam(cfg,
@@ -63,7 +67,6 @@ def scparam(cfg,
                 enum=enum,
                 pernode=pernode)
     else:
-
         # removing leading spaces as if schelp were a docstring
         schelp = trim(schelp)
 
@@ -128,6 +131,10 @@ def schema_cfg():
     '''Method for defining Chip configuration schema
     All the keys defined in this dictionary are reserved words.
     '''
+
+    global Schema_CFG
+    if Schema_CFG:
+        return pickle.loads(Schema_CFG)
 
     # SC version number (bump on every non trivial change)
     # Version number following semver standard.
@@ -215,8 +222,11 @@ def schema_cfg():
     # Packaging
     cfg = schema_package(cfg)
 
-    # Packaging
+    # Schematic
     cfg = schema_schematic(cfg)
+
+    # Store schema
+    Schema_CFG = pickle.dumps(cfg)
 
     return cfg
 

--- a/siliconcompiler/schema/schema_obj.py
+++ b/siliconcompiler/schema/schema_obj.py
@@ -39,7 +39,7 @@ except ImportError:
     _has_yaml = False
 
 from .schema_cfg import schema_cfg
-from .utils import escape_val_tcl, PACKAGE_ROOT, translate_loglevel
+from .utils import escape_val_tcl, PACKAGE_ROOT, translate_loglevel, deepcopy
 
 
 class Schema:
@@ -78,7 +78,7 @@ class Schema:
             # Normalize value to string in case we receive a pathlib.Path
             cfg, self.__journal = Schema.__read_manifest_file(str(manifest))
         else:
-            cfg = copy.deepcopy(cfg)
+            cfg = deepcopy(cfg)
 
         if cfg is not None:
             try:
@@ -363,7 +363,7 @@ class Schema:
             if step not in cfg['node']:
                 cfg['node'][step] = {}
             if index not in cfg['node'][step]:
-                cfg['node'][step][index] = copy.deepcopy(cfg['node']['default']['default'])
+                cfg['node'][step][index] = deepcopy(cfg['node']['default']['default'])
             cfg['node'][step][index][field] = value
         else:
             cfg[field] = value
@@ -427,7 +427,7 @@ class Schema:
             if modified_step not in cfg['node']:
                 cfg['node'][modified_step] = {}
             if modified_index not in cfg['node'][modified_step]:
-                cfg['node'][modified_step][modified_index] = copy.deepcopy(
+                cfg['node'][modified_step][modified_index] = deepcopy(
                     cfg['node']['default']['default'])
             cfg['node'][modified_step][modified_index][field].extend(value)
         else:
@@ -625,7 +625,7 @@ class Schema:
         documentation.
         """
         cfg = self.__search(*keypath)
-        return copy.deepcopy(cfg)
+        return deepcopy(cfg)
 
     ###########################################################################
     def valid(self, *args, default_valid=False, job=None, check_complete=False):
@@ -965,7 +965,7 @@ class Schema:
                 cfg = cfg[key]
             elif 'default' in cfg:
                 if insert_defaults:
-                    cfg[key] = copy.deepcopy(cfg['default'])
+                    cfg[key] = deepcopy(cfg['default'])
                     cfg = cfg[key]
                 elif use_default:
                     cfg = cfg['default']
@@ -1026,7 +1026,7 @@ class Schema:
         else:
             for key in cfgsrc.keys():
                 if key not in ('example', 'switch', 'help'):
-                    cfgdst[key] = copy.deepcopy(cfgsrc[key])
+                    cfgdst[key] = deepcopy(cfgsrc[key])
 
     ###########################################################################
     def write_json(self, fout):
@@ -1123,7 +1123,7 @@ class Schema:
         '''Returns deep copy of Schema object.'''
         newscheme = Schema(cfg=self.cfg)
         if self.__journal:
-            newscheme.__journal = copy.deepcopy(self.__journal)
+            newscheme.__journal = deepcopy(self.__journal)
         return newscheme
 
     ###########################################################################

--- a/siliconcompiler/schema/utils.py
+++ b/siliconcompiler/schema/utils.py
@@ -7,6 +7,7 @@
 import os
 import re
 import sys
+import pickle
 
 PACKAGE_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
 
@@ -91,3 +92,7 @@ def trim(docstring):
 
 def translate_loglevel(level):
     return level.upper()
+
+
+def deepcopy(cfg):
+    return pickle.loads(pickle.dumps(cfg))


### PR DESCRIPTION
This shaves about 50% off the loading of large targets by avoiding expensive calls to deepcopy and instead using the pickling to ensure unique-ness of the data

https://github.com/siliconcompiler/siliconcompiler/actions/runs/11501050162