### PR TITLE
deprecate load_target

### DIFF
--- a/docs/user_guide/examples/heartbeat_flowgraph.py
+++ b/docs/user_guide/examples/heartbeat_flowgraph.py
@@ -5,6 +5,7 @@
 
 import os
 import siliconcompiler                         # import python package
+from siliconcompiler.targets import freepdk45_demo  # import target
 
 # import pre-defined python packages for setting up tools used in flowgraph
 from siliconcompiler.tools.surelog import parse
@@ -18,7 +19,7 @@ chip.set('input', 'rtl', 'verilog', f'{root}/heartbeat.v')           # define li
 chip.set('input', 'constraint', 'sdc', f'{root}/heartbeat.sdc')      # set constraints file
 
 # set up pdk, libs and flow
-chip.load_target('freepdk45_demo')             # load freepdk45
+chip.load_target(freepdk45_demo)             # load freepdk45
 
 # modify flowgraph:
 # start of flowgraph setup <docs reference>

--- a/examples/fibone/fibone.py
+++ b/examples/fibone/fibone.py
@@ -2,6 +2,7 @@
 
 import siliconcompiler
 import os
+from siliconcompiler.targets import freepdk45_demo
 
 
 def main():
@@ -10,7 +11,7 @@ def main():
     chip.input(os.path.join(root, "FibOne.bsv"))
     # default Bluespec clock pin is 'CLK'
     chip.clock(pin='CLK', period=5)
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
     chip.run()
     chip.summary()
     chip.show()

--- a/examples/gcd/gcd.py
+++ b/examples/gcd/gcd.py
@@ -3,6 +3,7 @@
 
 import os
 import siliconcompiler
+from siliconcompiler.targets import freepdk45_demo
 
 
 def main():
@@ -18,7 +19,7 @@ def main():
     chip.set('option', 'nodisplay', True)
     chip.set('constraint', 'outline', [(0, 0), (100.13, 100.8)])
     chip.set('constraint', 'corearea', [(10.07, 11.2), (90.25, 91)])
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
     chip.run()
     chip.summary()
 

--- a/examples/gcd/gcd_gf180.py
+++ b/examples/gcd/gcd_gf180.py
@@ -3,6 +3,7 @@
 
 import os
 import siliconcompiler
+from siliconcompiler.targets import gf180_demo
 
 
 def main():
@@ -16,7 +17,7 @@ def main():
     chip.set('option', 'track', True)
     chip.set('option', 'hash', True)
     chip.set('option', 'nodisplay', True)
-    chip.load_target("gf180_demo")
+    chip.load_target(gf180_demo)
     chip.run()
     chip.summary()
 

--- a/examples/gcd/gcd_skywater.py
+++ b/examples/gcd/gcd_skywater.py
@@ -4,6 +4,7 @@ import siliconcompiler
 
 import os
 import sys
+from siliconcompiler.targets import skywater130_demo
 
 
 def main():
@@ -18,7 +19,7 @@ def main():
 
     chip.clock('clk', period=20)
 
-    chip.load_target("skywater130_demo")
+    chip.load_target(skywater130_demo)
 
     chip.set('datasheet', 'pin', 'vdd', 'type', 'global', 'supply')
     chip.set('datasheet', 'pin', 'vss', 'type', 'global', 'ground')

--- a/examples/gcd/gcd_sta.py
+++ b/examples/gcd/gcd_sta.py
@@ -3,6 +3,7 @@
 
 import os
 import siliconcompiler
+from siliconcompiler.targets import freepdk45_demo
 
 
 def main():
@@ -16,7 +17,7 @@ def main():
     chip.set('option', 'track', True)
     chip.set('option', 'hash', True)
     chip.set('option', 'nodisplay', True)
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
     chip.set('option', 'flow', 'synflow')
     chip.run()
     chip.summary()

--- a/examples/gcd_chisel/gcd_chisel.py
+++ b/examples/gcd_chisel/gcd_chisel.py
@@ -2,6 +2,7 @@
 
 import siliconcompiler
 import os
+from siliconcompiler.targets import freepdk45_demo
 
 
 def main():
@@ -10,7 +11,7 @@ def main():
     chip.input(os.path.join(root, "GCD.scala"))
     # default Chisel clock pin is 'clock'
     chip.clock(pin='clock', period=5)
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
     chip.run()
     chip.summary()
     chip.show()

--- a/examples/gcd_hls/gcd_hls.py
+++ b/examples/gcd_hls/gcd_hls.py
@@ -2,6 +2,7 @@
 
 import siliconcompiler
 import os
+from siliconcompiler.targets import freepdk45_demo
 
 
 def main():
@@ -10,7 +11,7 @@ def main():
     chip.input(os.path.join(root, "gcd.c"))
     # default Bambu clock pin is 'clock'
     chip.clock(pin='clock', period=5)
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
     chip.run()
     chip.summary()
     chip.show()

--- a/examples/ghdl_fsynopsys/build.py
+++ b/examples/ghdl_fsynopsys/build.py
@@ -2,6 +2,7 @@
 
 import siliconcompiler
 import os
+from siliconcompiler.targets import freepdk45_demo
 
 
 def main():
@@ -12,7 +13,7 @@ def main():
     # see PR #1015 (https://github.com/siliconcompiler/siliconcompiler/pull/1015)
     chip.set('tool', 'ghdl', 'task', 'convert', 'var', 'extraopts', '-fsynopsys')
 
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
     chip.run()
     chip.summary()

--- a/examples/heartbeat/heartbeat.py
+++ b/examples/heartbeat/heartbeat.py
@@ -2,6 +2,7 @@
 
 import siliconcompiler                        # import python package
 import os
+from siliconcompiler.targets import freepdk45_demo
 
 
 def main():
@@ -9,7 +10,7 @@ def main():
     chip = siliconcompiler.Chip('heartbeat')  # create chip object
     chip.input(os.path.join(root, "heartbeat.v"))                 # define list of source files
     chip.input(os.path.join(root, "heartbeat.sdc"))               # set constraints file
-    chip.load_target("freepdk45_demo")        # load predefined target
+    chip.load_target(freepdk45_demo)        # load predefined target
     chip.run()                                # run compilation
     chip.summary()                            # print results summary
     chip.show()                               # show layout file

--- a/examples/heartbeat/parallel.py
+++ b/examples/heartbeat/parallel.py
@@ -6,6 +6,7 @@ import multiprocessing
 import siliconcompiler
 import time
 import os
+from siliconcompiler.targets import freepdk45_demo
 
 
 # Shared setup routine
@@ -23,7 +24,7 @@ def run_design(design, M, job):
         'cts_np': M,
         'route_np': M
     }
-    chip.load_target("freepdk45_demo", **asic_flow_args)
+    chip.load_target(freepdk45_demo, **asic_flow_args)
     chip.run()
 
 

--- a/examples/heartbeat_migen/heartbeat_migen.py
+++ b/examples/heartbeat_migen/heartbeat_migen.py
@@ -4,6 +4,7 @@ from migen import Module, Signal, Cat, Replicate
 from migen.fhdl.verilog import convert
 
 import siliconcompiler
+from siliconcompiler.targets import freepdk45_demo
 
 
 class Heartbeat(Module):
@@ -25,7 +26,7 @@ def main():
     chip.input('heartbeat.v')
     # default Migen clock pin is named 'sys_clk'
     chip.clock(pin='sys_clk', period=1)
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
     chip.run()
     chip.summary()
     chip.show()

--- a/examples/oh_experiments/adder_sweep.py
+++ b/examples/oh_experiments/adder_sweep.py
@@ -2,6 +2,7 @@
 
 import os
 import siliconcompiler
+from siliconcompiler.targets import freepdk45_demo
 
 try:
     import matplotlib.pyplot as plt
@@ -25,7 +26,7 @@ def main():
         chip.register_source('oh',
                              'git+https://github.com/aolofsson/oh',
                              '23b26c4a938d4885a2a340967ae9f63c3c7a3527')
-        chip.load_target("freepdk45_demo")
+        chip.load_target(freepdk45_demo)
         chip.input(source, package='oh')
         chip.set('option', 'quiet', True)
         chip.set('option', 'to', ['syn'])

--- a/examples/oh_experiments/feedback_loop.py
+++ b/examples/oh_experiments/feedback_loop.py
@@ -2,6 +2,7 @@
 
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 import siliconcompiler
+from siliconcompiler.targets import freepdk45_demo
 
 
 def main(limit=0):
@@ -17,7 +18,7 @@ def main(limit=0):
     chip.input('mathlib/hdl/' + design + '.v', package='oh')
     chip.set('option', 'param', 'N', str(N))
     chip.set('option', 'quiet', True)
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
     chip.set('option', 'jobincr', True)
 
     # First run (import + run)

--- a/examples/picorv32_ram/picorv32_ram.py
+++ b/examples/picorv32_ram/picorv32_ram.py
@@ -39,7 +39,7 @@ def build_top():
                                         (die_w - margin, die_h - margin)])
 
     # Setup SRAM macro library.
-    chip.use(sky130_sram_2k)
+    chip.use(sky130_sram_2k, stackup=chip.get('option', 'stackup'))
     chip.add('asic', 'macrolib', 'sky130_sram_2k')
 
     # SRAM pins are inside the macro boundary; no routing blockage padding is needed.

--- a/examples/picorv32_ram/sky130_sram_2k.py
+++ b/examples/picorv32_ram/sky130_sram_2k.py
@@ -2,13 +2,15 @@ import os
 import siliconcompiler
 
 
-def setup(chip):
+def setup(stackup=None):
     # Core values.
     design = 'sky130_sram_2k'
-    stackup = chip.get('option', 'stackup')
+
+    if stackup is None:
+        raise RuntimeError('stackup cannot be None')
 
     # Create library Chip object.
-    lib = siliconcompiler.Library(chip, design)
+    lib = siliconcompiler.Library(design)
     lib.register_source('vlsida',
                         'git+https://github.com/VLSIDA/sky130_sram_macros',
                         'c2333394e0b0b9d9d71185678a8d8087715d5e3b')

--- a/scripts/profile_sc.py
+++ b/scripts/profile_sc.py
@@ -9,6 +9,7 @@ import argparse
 import tempfile
 import os
 import gprof2dot
+from siliconcompiler.targets import freepdk45_demo, skywater130_demo, asap7_demo, asic_demo
 
 
 def print_stats(pr):
@@ -38,9 +39,9 @@ def run_read_manifest(pr, extra):
     remove_path = False
     if not extra:
         chip = Chip('write')
-        chip.load_target('freepdk45_demo')
-        chip.load_target('skywater130_demo')
-        chip.load_target('asap7_demo')
+        chip.load_target(freepdk45_demo)
+        chip.load_target(skywater130_demo)
+        chip.load_target(asap7_demo)
 
         fd, path = tempfile.mkstemp(prefix='read_manifest', suffix='.json')
         os.close(fd)
@@ -66,9 +67,9 @@ def run_write_manifest_abspath(pr, extra):
 
 def run_write_manifest(pr, extra, abspath=False):
     chip = Chip('write')
-    chip.load_target('freepdk45_demo')
-    chip.load_target('skywater130_demo')
-    chip.load_target('asap7_demo')
+    chip.load_target(freepdk45_demo)
+    chip.load_target(skywater130_demo)
+    chip.load_target(asap7_demo)
     if extra:
         chip.load_target(extra)
 
@@ -89,9 +90,9 @@ def run_load_target(pr, extra):
     if extra:
         chip.load_target(extra)
     else:
-        chip.load_target('freepdk45_demo')
-        chip.load_target('skywater130_demo')
-        chip.load_target('asap7_demo')
+        chip.load_target(freepdk45_demo)
+        chip.load_target(skywater130_demo)
+        chip.load_target(asap7_demo)
     pr.disable()
 
 
@@ -99,7 +100,7 @@ def run_asic_demo(pr, extra):
     chip = Chip('')
 
     pr.enable()
-    chip.load_target('asic_demo')
+    chip.load_target(asic_demo)
     chip.run()
     chip.summary()
     pr.disable()

--- a/siliconcompiler/checklists/oh_tapeout.py
+++ b/siliconcompiler/checklists/oh_tapeout.py
@@ -1,14 +1,14 @@
 import siliconcompiler
 
 
-def setup(chip):
+def setup():
     '''Subset of OH! library tapeout checklist.
 
     https://github.com/aolofsson/oh/blob/master/docs/tapeout_checklist.md
     '''
     standard = 'oh_tapeout'
 
-    checklist = siliconcompiler.Checklist(chip, standard)
+    checklist = siliconcompiler.Checklist(standard)
 
     # Automated
     checklist.set('checklist', standard, 'drc_clean', 'description',

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -3076,7 +3076,7 @@ class Chip:
 
         try:
             from siliconcompiler.flows import showflow
-            self.use(showflow, filetype=filetype, screenshot=screenshot)
+            self.use(showflow, filetype=filetype, screenshot=screenshot, showtools=self._showtools)
         except Exception as e:
             self.logger.error(f"Flow setup failed: {e}")
             # restore environment

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -586,7 +586,7 @@ class Chip:
                 use_modules = func(*args, **kwargs)
 
                 if args_len == 1 and use_modules:
-                    self.logger.warning('Target returned items, which is should not have')
+                    self.logger.warning('Target returned items, which it should not have')
             except Exception as e:
                 self.logger.error(f'Unable to run {func.__name__}() for {module.__name__}')
                 raise e

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -392,7 +392,18 @@ class Chip:
             # Read in target if set
             if 'option_target' in cmdargs:
                 # running target command
-                self.load_target(cmdargs['option_target'])
+                # Search order "{name}", and "siliconcompiler.targets.{name}"
+                modules = []
+                module = cmdargs['option_target']
+                for mod_name in [module, f'siliconcompiler.targets.{module}']:
+                    mod = self._load_module(mod_name)
+                    if mod:
+                        modules.append(mod)
+
+                if len(modules) == 0:
+                    raise SiliconCompilerError(f'Could not find target {module}', chip=self)
+
+                self.load_target(modules[0])
 
             if "use" in extra_params:
                 if extra_params["use"]:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -511,7 +511,7 @@ class Chip:
             Loads the 'freepdk45_demo' target with 5 parallel synthesis tasks
         """
 
-        self.logger.warn(".load_target is deprecated, use .use() instead.")
+        self.logger.warning(".load_target is deprecated, use .use() instead.")
 
         # Check for setup in modules
         load_function = getattr(module, 'setup', None)

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -569,24 +569,28 @@ class Chip:
         from siliconcompiler import Library
         from siliconcompiler import Checklist
 
+        func = None
+
+        if module is None:
+            raise ValueError('module parameter cannot be None')
+
         if isinstance(module, ModuleType):
-            setup_func = getattr(module, 'setup', None)
-            if setup_func:
-                # Call the module setup function.
-                try:
-                    use_modules = setup_func(self, **kwargs)
-                except Exception as e:
-                    self.logger.error(f'Unable to run setup() for {module.__name__}')
-                    raise e
+            func = getattr(module, 'setup', None)
+            if func is None:
+                raise NotImplementedError(f'{module} does not have a setup()')
         elif isinstance(module, FunctionType):
-            try:
-                use_modules = module(self, **kwargs)
-            except Exception as e:
-                self.logger.error(f'Unable to run setup() for {module.__name__}')
-                raise e
+            func = module
         else:
             # Import directly
             use_modules = module
+
+        if func:
+            # Call the setup function.
+            try:
+                use_modules = func(self, **kwargs)
+            except Exception as e:
+                self.logger.error(f'Unable to run {func.__name__}() for {module.__name__}')
+                raise e
 
         if use_modules is None:
             # loaded a target so done

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -511,6 +511,8 @@ class Chip:
             Loads the 'freepdk45_demo' target with 5 parallel synthesis tasks
         """
 
+        self.logger.warn(".load_target is deprecated, use .use() instead.")
+
         # Check for setup in modules
         load_function = getattr(module, 'setup', None)
         if load_function:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -514,7 +514,7 @@ class Chip:
 
         self.logger.warning(".load_target is deprecated, use .use() instead.")
 
-        self.use(module)
+        self.use(module, **kwargs)
 
         # Record target
         self.set('option', 'target', module.__name__)

--- a/siliconcompiler/flows/_common.py
+++ b/siliconcompiler/flows/_common.py
@@ -36,7 +36,7 @@ def __get_frontends(allow_system_verilog):
     }
 
 
-def setup_multiple_frontends(chip, flow, allow_system_verilog=False):
+def setup_multiple_frontends(flow, allow_system_verilog=False):
     '''
     Sets of multiple frontends if different frontends are required.
 

--- a/siliconcompiler/flows/asicflow.py
+++ b/siliconcompiler/flows/asicflow.py
@@ -22,14 +22,13 @@ from siliconcompiler.tools.builtin import minimum
 def make_docs(chip):
     n = 3
     _make_docs(chip)
-    return setup(chip, syn_np=n, floorplan_np=n, physyn_np=n, place_np=n, cts_np=n, route_np=n)
+    return setup(syn_np=n, floorplan_np=n, physyn_np=n, place_np=n, cts_np=n, route_np=n)
 
 
 ###########################################################################
 # Flowgraph Setup
 ############################################################################
-def setup(chip,
-          flowname='asicflow',
+def setup(flowname='asicflow',
           syn_np=1,
           floorplan_np=1,
           physyn_np=1,
@@ -68,7 +67,7 @@ def setup(chip,
     * route_np : Number of parallel routing jobs to launch
     '''
 
-    flow = siliconcompiler.Flow(chip, flowname)
+    flow = siliconcompiler.Flow(flowname)
 
     # Linear flow, up until branch to run parallel verification steps.
     longpipe = ['syn',
@@ -126,7 +125,7 @@ def setup(chip,
         flowtasks.append((step, tasks[step]))
 
     # Programmatically build linear portion of flowgraph and fanin/fanout args
-    prevstep = setup_multiple_frontends(chip, flow)
+    prevstep = setup_multiple_frontends(flow)
     for step, task in flowtasks:
         fanout = 1
         if step in np:

--- a/siliconcompiler/flows/asictopflow.py
+++ b/siliconcompiler/flows/asictopflow.py
@@ -6,14 +6,14 @@ from siliconcompiler.tools.klayout import export
 from siliconcompiler.flows._common import _make_docs
 
 
-def setup(chip):
+def setup():
     '''A flow for stitching together hardened blocks without doing any automated
     place-and-route.
 
     This flow generates a GDS and a netlist for passing to a
     verification/signoff flow.
     '''
-    flow = siliconcompiler.Flow(chip, 'asictopflow')
+    flow = siliconcompiler.Flow('asictopflow')
 
     flow.node(flow.design, 'import', surelog_parse)
     flow.node(flow.design, 'syn', syn_asic)
@@ -33,6 +33,6 @@ def setup(chip):
 if __name__ == "__main__":
     chip = siliconcompiler.Chip('design')
     _make_docs(chip)
-    flow = setup(chip)
+    flow = setup()
     chip.use(flow)
     chip.write_flowgraph(f"{flow.top()}.png", flow=flow.top())

--- a/siliconcompiler/flows/dvflow.py
+++ b/siliconcompiler/flows/dvflow.py
@@ -10,14 +10,13 @@ from siliconcompiler.tools.execute import exec_input
 ############################################################################
 def make_docs(chip):
     chip.set('input', 'rtl', 'netlist', 'test')
-    return setup(chip, np=5)
+    return setup(np=5)
 
 
 #############################################################################
 # Flowgraph Setup
 #############################################################################
-def setup(chip,
-          flowname='dvflow',
+def setup(flowname='dvflow',
           tool='icarus',
           np=1):
     '''
@@ -35,7 +34,7 @@ def setup(chip,
     This flow is a WIP
     '''
 
-    flow = siliconcompiler.Flow(chip, flowname)
+    flow = siliconcompiler.Flow(flowname)
 
     tasks = {
         'compile': None,

--- a/siliconcompiler/flows/fpgaflow.py
+++ b/siliconcompiler/flows/fpgaflow.py
@@ -23,14 +23,13 @@ from siliconcompiler.tools.nextpnr import apr as nextpnr_apr
 ############################################################################
 def make_docs(chip):
     _make_docs(chip)
-    chip.set('fpga', 'partname', 'example_arch')
-    return setup(chip)
+    return setup(partname='example_arch')
 
 
 ############################################################################
 # Flowgraph Setup
 ############################################################################
-def setup(chip, flowname='fpgaflow', fpgaflow_type=None, partname=None):
+def setup(flowname='fpgaflow', fpgaflow_type=None, partname=None):
     '''
     A configurable FPGA compilation flow.
 
@@ -60,10 +59,7 @@ def setup(chip, flowname='fpgaflow', fpgaflow_type=None, partname=None):
           flow instead of one selected from the partname set in the schema.
     '''
 
-    flow = siliconcompiler.Flow(chip, flowname)
-
-    if not partname:
-        partname = chip.get('fpga', 'partname')
+    flow = siliconcompiler.Flow(flowname)
 
     if fpgaflow_type:
         flow_pipe = flow_lookup_by_type(fpgaflow_type)
@@ -71,7 +67,7 @@ def setup(chip, flowname='fpgaflow', fpgaflow_type=None, partname=None):
         flow_pipe = flow_lookup(partname)
 
     # Minimal setup
-    prevstep = setup_multiple_frontends(chip, flow)
+    prevstep = setup_multiple_frontends(flow)
     for step, tool_module in flow_pipe:
         # Flow
         flow.node(flowname, step, tool_module)

--- a/siliconcompiler/flows/generate_openroad_rcx.py
+++ b/siliconcompiler/flows/generate_openroad_rcx.py
@@ -11,20 +11,20 @@ from siliconcompiler.flows._common import _make_docs
 ############################################################################
 def make_docs(chip):
     _make_docs(chip)
-    return setup(chip, corners=5)
+    return setup(corners=5)
 
 
 ###########################################################################
 # Flowgraph Setup
 ############################################################################
-def setup(chip, extraction_task=None, corners=1, serial_extraction=False):
+def setup(extraction_task=None, corners=1, serial_extraction=False):
     '''
     Flow to generate the OpenRCX decks needed by OpenROAD to do parasitic
     extraction.
     '''
 
     flowname = 'generate_rcx'
-    flow = siliconcompiler.Flow(chip, flowname)
+    flow = siliconcompiler.Flow(flowname)
 
     if not extraction_task:
         chip.logger.warning('Valid extraction not specified, defaulting to builtin/nop')

--- a/siliconcompiler/flows/lintflow.py
+++ b/siliconcompiler/flows/lintflow.py
@@ -8,13 +8,13 @@ from siliconcompiler.tools.slang import lint as slang_lint
 ###########################################################################
 # Flowgraph Setup
 ############################################################################
-def setup(chip, tool='verilator'):
+def setup(tool='verilator'):
     '''
     An RTL linting flow.
     '''
 
     flowname = 'lintflow'
-    flow = siliconcompiler.Flow(chip, flowname)
+    flow = siliconcompiler.Flow(flowname)
 
     if tool == 'verilator':
         flow.node(flowname, 'lint', verilator_lint)
@@ -30,6 +30,6 @@ def setup(chip, tool='verilator'):
 if __name__ == "__main__":
     chip = siliconcompiler.Chip('design')
     _make_docs(chip)
-    flow = setup(chip)
+    flow = setup()
     chip.use(flow)
     chip.write_flowgraph(f"{flow.top()}.png", flow=flow.top())

--- a/siliconcompiler/flows/screenshotflow.py
+++ b/siliconcompiler/flows/screenshotflow.py
@@ -11,10 +11,10 @@ def make_docs(chip):
     chip.set('tool', 'klayout', 'task', 'screenshot', 'var', 'ybins', 2)
     chip.set('tool', 'montage', 'task', 'tile', 'var', 'xbins', 2)
     chip.set('tool', 'montage', 'task', 'tile', 'var', 'ybins', 2)
-    return setup(chip)
+    return setup()
 
 
-def setup(chip, flowname='screenshotflow'):
+def setup(flowname='screenshotflow'):
     '''
     Flow to generate a high resolution design image from a GDS or OAS file.
 

--- a/siliconcompiler/flows/showflow.py
+++ b/siliconcompiler/flows/showflow.py
@@ -8,13 +8,13 @@ from siliconcompiler.targets import freepdk45_demo
 ############################################################################
 def make_docs(chip):
     chip.load_target(freepdk45_demo)
-    return setup(chip, filetype='gds', np=3)
+    return setup(filetype='gds', showtools=chip._showtools, np=3)
 
 
 ###########################################################################
 # Flowgraph Setup
 ############################################################################
-def setup(chip, flowname='showflow', filetype=None, screenshot=False, np=1):
+def setup(flowname='showflow', filetype=None, screenshot=False, showtools=None, np=1):
     '''
     A flow to show the output files generated from other flows.
 
@@ -34,10 +34,13 @@ def setup(chip, flowname='showflow', filetype=None, screenshot=False, np=1):
     if not filetype:
         raise ValueError('filetype is a required argument')
 
-    if filetype not in chip._showtools:
+    if not showtools:
+        raise ValueError('showtools is a required argument')
+
+    if filetype not in showtools:
         raise SiliconCompilerError(f'Show tool for {filetype} is not defined.')
 
-    show_tool = chip._showtools[filetype]
+    show_tool = showtools[filetype]
 
     stepname = 'show'
     if screenshot:

--- a/siliconcompiler/flows/showflow.py
+++ b/siliconcompiler/flows/showflow.py
@@ -26,7 +26,7 @@ def setup(flowname='showflow', filetype=None, screenshot=False, showtools=None, 
 
     * np : Number of parallel show jobs to launch
     * screenshot : true/false, indicate if this should be configured as a screenshot
-    * showtools: dictionary of file extentions with the associated show and screenshot tasks
+    * showtools: dictionary of file extensions with the associated show and screenshot tasks
     '''
 
     flow = siliconcompiler.Flow(flowname)

--- a/siliconcompiler/flows/showflow.py
+++ b/siliconcompiler/flows/showflow.py
@@ -8,13 +8,13 @@ from siliconcompiler.targets import freepdk45_demo
 ############################################################################
 def make_docs(chip):
     chip.load_target(freepdk45_demo)
-    return setup(chip, filetype='gds', np=3)
+    return setup(filetype='gds', np=3)
 
 
 ###########################################################################
 # Flowgraph Setup
 ############################################################################
-def setup(chip, flowname='showflow', filetype=None, screenshot=False, np=1):
+def setup(flowname='showflow', filetype=None, screenshot=False, np=1):
     '''
     A flow to show the output files generated from other flows.
 
@@ -28,7 +28,7 @@ def setup(chip, flowname='showflow', filetype=None, screenshot=False, np=1):
     * screenshot : true/false, indicate if this should be configured as a screenshot
     '''
 
-    flow = siliconcompiler.Flow(chip, flowname)
+    flow = siliconcompiler.Flow(flowname)
 
     # Get required parameters first
     if not filetype:

--- a/siliconcompiler/flows/showflow.py
+++ b/siliconcompiler/flows/showflow.py
@@ -26,6 +26,7 @@ def setup(flowname='showflow', filetype=None, screenshot=False, showtools=None, 
 
     * np : Number of parallel show jobs to launch
     * screenshot : true/false, indicate if this should be configured as a screenshot
+    * showtools: dictionary of file extentions with the associated show and screenshot tasks
     '''
 
     flow = siliconcompiler.Flow(flowname)

--- a/siliconcompiler/flows/showflow.py
+++ b/siliconcompiler/flows/showflow.py
@@ -8,13 +8,13 @@ from siliconcompiler.targets import freepdk45_demo
 ############################################################################
 def make_docs(chip):
     chip.load_target(freepdk45_demo)
-    return setup(filetype='gds', np=3)
+    return setup(chip, filetype='gds', np=3)
 
 
 ###########################################################################
 # Flowgraph Setup
 ############################################################################
-def setup(flowname='showflow', filetype=None, screenshot=False, np=1):
+def setup(chip, flowname='showflow', filetype=None, screenshot=False, np=1):
     '''
     A flow to show the output files generated from other flows.
 

--- a/siliconcompiler/flows/showflow.py
+++ b/siliconcompiler/flows/showflow.py
@@ -1,12 +1,13 @@
 import siliconcompiler
 from siliconcompiler import SiliconCompilerError
+from siliconcompiler.targets import freepdk45_demo
 
 
 ############################################################################
 # DOCS
 ############################################################################
 def make_docs(chip):
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     return setup(chip, filetype='gds', np=3)
 
 

--- a/siliconcompiler/flows/signoffflow.py
+++ b/siliconcompiler/flows/signoffflow.py
@@ -9,10 +9,10 @@ from siliconcompiler.tools.builtin import join
 
 def make_docs(chip):
     chip.set('input', 'netlist', 'verilog', 'test')
-    return setup(chip)
+    return setup()
 
 
-def setup(chip):
+def setup():
     '''A flow for running LVS/DRC signoff on a GDS layout.
 
     Inputs must be passed to this flow as follows::
@@ -22,7 +22,7 @@ def setup(chip):
     '''
     flowname = 'signoffflow'
 
-    flow = siliconcompiler.Flow(chip, flowname)
+    flow = siliconcompiler.Flow(flowname)
 
     # nop import since we don't need to pull in any sources
     flow.node(flowname, 'import', nop)

--- a/siliconcompiler/flows/synflow.py
+++ b/siliconcompiler/flows/synflow.py
@@ -15,14 +15,13 @@ from siliconcompiler.tools.builtin import minimum
 def make_docs(chip):
     n = 3
     _make_docs(chip)
-    return setup(chip, syn_np=n, timing_np=n)
+    return setup(syn_np=n, timing_np=n)
 
 
 ###########################################################################
 # Flowgraph Setup
 ############################################################################
-def setup(chip,
-          flowname='synflow',
+def setup(flowname='synflow',
           syn_np=1,
           timing_np=1):
     '''
@@ -44,7 +43,7 @@ def setup(chip,
     * timing_np : Number of parallel timing jobs to launch
     '''
 
-    flow = siliconcompiler.Flow(chip, flowname)
+    flow = siliconcompiler.Flow(flowname)
 
     # Linear flow, up until branch to run parallel verification steps.
     longpipe = ['syn',
@@ -80,7 +79,7 @@ def setup(chip,
         flowtasks.append((step, tasks[step]))
 
     # Programmatically build linear portion of flowgraph and fanin/fanout args
-    prevstep = setup_multiple_frontends(chip, flow)
+    prevstep = setup_multiple_frontends(flow)
     for step, task in flowtasks:
         fanout = 1
         if step in np:

--- a/siliconcompiler/fpgas/lattice_ice40.py
+++ b/siliconcompiler/fpgas/lattice_ice40.py
@@ -5,7 +5,7 @@ from siliconcompiler.utils import register_sc_data_source
 ####################################################
 # Setup for ICE40 Family FPGAs
 ####################################################
-def setup(chip):
+def setup():
     '''
     Lattice ICE40 FPGAs are a family of small parts
     made by Lattice Semiconductor.  A fully open source
@@ -23,10 +23,9 @@ def setup(chip):
         "ice40up5k-sg48",
     ]
 
-    register_sc_data_source(chip)
-
     for part_name in all_part_names:
-        fpga = siliconcompiler.FPGA(chip, part_name, package='siliconcompiler_data')
+        fpga = siliconcompiler.FPGA(part_name, package='siliconcompiler_data')
+        register_sc_data_source(fpga)
 
         fpga.set('fpga', part_name, 'vendor', vendor)
         fpga.set('fpga', part_name, 'lutsize', lut_size)

--- a/siliconcompiler/fpgas/vpr_example.py
+++ b/siliconcompiler/fpgas/vpr_example.py
@@ -6,7 +6,7 @@ from siliconcompiler.utils import register_sc_data_source
 ####################################################
 # Setup for vpr_example Family FPGAs
 ####################################################
-def setup(chip):
+def setup():
     '''
     The vpr_example FPGA family is a set of
     open source architectures used as illustrative
@@ -36,11 +36,10 @@ def setup(chip):
         'example_arch_X030Y030',
     ]
 
-    register_sc_data_source(chip)
-
     # Settings common to all parts in family
     for part_name in all_part_names:
-        fpga = siliconcompiler.FPGA(chip, part_name, package='siliconcompiler_data')
+        fpga = siliconcompiler.FPGA(part_name, package='siliconcompiler_data')
+        register_sc_data_source(fpga)
 
         fpga.set('fpga', part_name, 'vendor', vendor)
 

--- a/siliconcompiler/scheduler/send_messages.py
+++ b/siliconcompiler/scheduler/send_messages.py
@@ -12,6 +12,7 @@ import fastjsonschema
 from pathlib import Path
 from siliconcompiler.flowgraph import get_executed_nodes
 import uuid
+from siliconcompiler.targets import freepdk45_demo
 
 
 # Compile validation code for API request bodies.
@@ -172,7 +173,7 @@ def send(chip, msg_type, step, index):
 if __name__ == "__main__":
     from siliconcompiler import Chip
     chip = Chip('test')
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
     chip.set('option', 'scheduler', 'msgevent', 'ALL')
     # chip.set('option', 'scheduler', 'msgcontact', 'fillin')
     send(chip, "BEGIN", "import", "0")

--- a/siliconcompiler/sphinx_ext/dynamicgen.py
+++ b/siliconcompiler/sphinx_ext/dynamicgen.py
@@ -386,7 +386,7 @@ class DynamicGen(SphinxDirective):
         setup = self.get_setup_method(module)
         if not setup:
             return None
-        new_chip = setup(chip)
+        new_chip = setup()
         if new_chip:
             return new_chip
         else:
@@ -399,7 +399,7 @@ class DynamicGen(SphinxDirective):
         if docs_chip and docs_configured:
             return docs_chip
 
-        return self._handle_setup(chip, module)
+        return self._handle_setup(module)
 
     def get_ref_prefix(self):
         return self.REF_PREFIX
@@ -635,7 +635,7 @@ class ToolGen(DynamicGen):
         if toolmodule:
             return chip
         else:
-            return self._handle_setup(chip, module)
+            return self._handle_setup(module)
 
     def display_config(self, chip, modname):
         '''Display config under `eda, <modname>` in a single table.'''
@@ -726,7 +726,7 @@ class ToolGen(DynamicGen):
             s += p
 
         try:
-            task_setup(chip)
+            task_setup()
 
             config = build_section("Configuration", self.get_configuration_ref_key(toolname,
                                                                                    taskname))

--- a/siliconcompiler/targets/fpgaflow_demo.py
+++ b/siliconcompiler/targets/fpgaflow_demo.py
@@ -34,7 +34,7 @@ def setup(chip):
         raise SiliconCompilerError(f'{part_name} has not been loaded', chip=chip)
 
     # 3. Load flow
-    chip.use(fpgaflow)
+    chip.use(fpgaflow, partname=part_name)
 
     # 4. Select default flow
     chip.set('option', 'flow', 'fpgaflow', clobber=False)

--- a/siliconcompiler/tools/klayout/klayout.py
+++ b/siliconcompiler/tools/klayout/klayout.py
@@ -15,13 +15,14 @@ from pathlib import Path
 import platform
 import shutil
 from siliconcompiler.tools._common import get_tool_task
+from siliconcompiler.targets import freepdk45_demo
 
 
 ####################################################################
 # Make Docs
 ####################################################################
 def make_docs(chip):
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
 
 ####################################################################

--- a/siliconcompiler/tools/magic/magic.py
+++ b/siliconcompiler/tools/magic/magic.py
@@ -11,13 +11,14 @@ Sources: https://github.com/RTimothyEdwards/magic
 
 import os
 from siliconcompiler.tools._common import input_provides, get_tool_task
+from siliconcompiler.targets import freepdk45_demo
 
 
 ####################################################################
 # Make Docs
 ####################################################################
 def make_docs(chip):
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
 
 ################################

--- a/siliconcompiler/tools/openroad/openroad.py
+++ b/siliconcompiler/tools/openroad/openroad.py
@@ -18,13 +18,14 @@ from siliconcompiler import utils
 from siliconcompiler.tools._common import input_provides, add_common_file, \
     get_tool_task, record_metric
 from siliconcompiler.tools._common.asic import get_mainlib, set_tool_task_var, get_libraries
+from siliconcompiler.targets import asap7_demo
 
 
 ####################################################################
 # Make Docs
 ####################################################################
 def make_docs(chip):
-    chip.load_target("asap7_demo")
+    chip.load_target(asap7_demo)
 
 
 ################################

--- a/siliconcompiler/tools/opensta/__init__.py
+++ b/siliconcompiler/tools/opensta/__init__.py
@@ -12,13 +12,14 @@ import os
 from siliconcompiler.tools.openroad.openroad import get_library_timing_keypaths
 from siliconcompiler.tools._common import get_tool_task
 from siliconcompiler.tools._common.asic import get_libraries
+from siliconcompiler.targets import asap7_demo
 
 
 ####################################################################
 # Make Docs
 ####################################################################
 def make_docs(chip):
-    chip.load_target("asap7_demo")
+    chip.load_target(asap7_demo)
 
 
 ################################

--- a/siliconcompiler/tools/verilator/verilator.py
+++ b/siliconcompiler/tools/verilator/verilator.py
@@ -33,13 +33,14 @@ from siliconcompiler.tools._common import (
     get_tool_task,
     input_provides
 )
+from siliconcompiler.targets import freepdk45_demo
 
 
 ####################################################################
 # Make Docs
 ####################################################################
 def make_docs(chip):
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
 
 def setup(chip):

--- a/siliconcompiler/tools/vivado/vivado.py
+++ b/siliconcompiler/tools/vivado/vivado.py
@@ -10,11 +10,12 @@ import os
 import re
 from siliconcompiler import sc_open
 from siliconcompiler.tools._common import record_metric
+from siliconcompiler.targets import fpgaflow_demo
 
 
 def make_docs(chip):
     chip.set('fpga', 'partname', 'ice40up5k-sg48')
-    chip.load_target("fpgaflow_demo")
+    chip.load_target(fpgaflow_demo)
 
 
 tool = 'vivado'

--- a/siliconcompiler/tools/vpr/vpr.py
+++ b/siliconcompiler/tools/vpr/vpr.py
@@ -22,6 +22,7 @@ import json
 import re
 from siliconcompiler import sc_open, SiliconCompilerError
 from siliconcompiler.tools._common import get_tool_task, record_metric
+from siliconcompiler.targets import fpgaflow_demo
 
 
 __block_file = "reports/block_usage.json"
@@ -32,7 +33,7 @@ __block_file = "reports/block_usage.json"
 ######################################################################
 def make_docs(chip):
     chip.set('fpga', 'partname', 'example_arch_X005Y005')
-    chip.load_target("fpgaflow_demo")
+    chip.load_target(fpgaflow_demo)
     setup_tool(chip)
     return chip
 

--- a/siliconcompiler/tools/vpr/vpr.py
+++ b/siliconcompiler/tools/vpr/vpr.py
@@ -22,7 +22,6 @@ import json
 import re
 from siliconcompiler import sc_open, SiliconCompilerError
 from siliconcompiler.tools._common import get_tool_task, record_metric
-from siliconcompiler.targets import fpgaflow_demo
 
 
 __block_file = "reports/block_usage.json"
@@ -32,6 +31,7 @@ __block_file = "reports/block_usage.json"
 # Make Docs
 ######################################################################
 def make_docs(chip):
+    from siliconcompiler.targets import fpgaflow_demo
     chip.set('fpga', 'partname', 'example_arch_X005Y005')
     chip.load_target(fpgaflow_demo)
     setup_tool(chip)

--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -7,10 +7,11 @@ from siliconcompiler import sc_open
 from siliconcompiler import utils
 from siliconcompiler.tools._common.asic import set_tool_task_var, get_libraries, get_mainlib
 from siliconcompiler.tools._common import get_tool_task
+from siliconcompiler.targets import asap7_demo
 
 
 def make_docs(chip):
-    chip.load_target("asap7_demo")
+    chip.load_target(asap7_demo)
 
 
 def setup(chip):

--- a/siliconcompiler/tools/yosys/syn_fpga.py
+++ b/siliconcompiler/tools/yosys/syn_fpga.py
@@ -2,6 +2,7 @@ from siliconcompiler.tools.yosys.yosys import syn_setup, syn_post_process
 import json
 from siliconcompiler import sc_open
 from siliconcompiler.tools._common import get_tool_task, record_metric
+from siliconcompiler.targets import fpgaflow_demo
 
 
 ######################################################################
@@ -9,7 +10,7 @@ from siliconcompiler.tools._common import get_tool_task, record_metric
 ######################################################################
 def make_docs(chip):
     chip.set('fpga', 'partname', 'ice40up5k-sg48')
-    chip.load_target("fpgaflow_demo")
+    chip.load_target(fpgaflow_demo)
 
 
 def setup(chip):

--- a/siliconcompiler/tools/yosys/yosys.py
+++ b/siliconcompiler/tools/yosys/yosys.py
@@ -17,13 +17,14 @@ import re
 import json
 from siliconcompiler import sc_open
 from siliconcompiler.tools._common import get_tool_task, record_metric
+from siliconcompiler.targets import asap7_demo
 
 
 ######################################################################
 # Make Docs
 ######################################################################
 def make_docs(chip):
-    chip.load_target("asap7_demo")
+    chip.load_target(asap7_demo)
 
 
 ################################

--- a/siliconcompiler/use.py
+++ b/siliconcompiler/use.py
@@ -4,12 +4,11 @@ from siliconcompiler import Chip
 
 
 class PackageChip(Chip):
-    def __init__(self, chip, name, package=None):
+    def __init__(self, name, package=None):
         # Start with None as init setting will not depend on package
         self.__package = None
 
         super().__init__(name)
-        self.logger = chip.logger
 
         path = None
         ref = None
@@ -83,7 +82,6 @@ class PDK(PackageChip):
     This inherits all methods from :class:`~siliconcompiler.Chip`.
 
     Args:
-        chip (Chip): A real only copy of the parent chip.
         name (string): Name of the PDK.
         package (string): Name of the data source
     Examples:
@@ -101,7 +99,6 @@ class FPGA(PackageChip):
     This inherits all methods from :class:`~siliconcompiler.Chip`.
 
     Args:
-        chip (Chip): A real only copy of the parent chip.
         name (string): Name of the FPGA.
         package (string): Name of the data source
     Examples:
@@ -119,7 +116,6 @@ class Library(PackageChip):
     This inherits all methods from :class:`~siliconcompiler.Chip`.
 
     Args:
-        chip (Chip): A real only copy of the parent chip.
         name (string): Name of the library.
         package (string): Name of the data source
         auto_enable (boolean): If True, will automatically be added to ['option','library'].
@@ -146,15 +142,13 @@ class Flow(Chip):
     This inherits all methods from :class:`~siliconcompiler.Chip`.
 
     Args:
-        chip (Chip): A real only copy of the parent chip.
         name (string): Name of the flow.
     Examples:
         >>> siliconcompiler.Flow(chip, "asicflow")
         Creates a flow object with name "asicflow".
     """
-    def __init__(self, chip, name):
+    def __init__(self, name):
         super().__init__(name)
-        self.logger = chip.logger
 
 
 class Checklist(Chip):
@@ -166,12 +160,10 @@ class Checklist(Chip):
     This inherits all methods from :class:`~siliconcompiler.Chip`.
 
     Args:
-        chip (Chip): A real only copy of the parent chip.
         name (string): Name of the checklist.
     Examples:
         >>> siliconcompiler.Checklist(chip, "tapeout")
         Creates a checklist object with name "tapeout".
     """
-    def __init__(self, chip, name):
+    def __init__(self, name):
         super().__init__(name)
-        self.logger = chip.logger

--- a/siliconcompiler/use.py
+++ b/siliconcompiler/use.py
@@ -85,7 +85,7 @@ class PDK(PackageChip):
         name (string): Name of the PDK.
         package (string): Name of the data source
     Examples:
-        >>> siliconcompiler.PDK(chip, "asap7")
+        >>> siliconcompiler.PDK("asap7")
         Creates a flow object with name "asap7".
     """
 
@@ -102,7 +102,7 @@ class FPGA(PackageChip):
         name (string): Name of the FPGA.
         package (string): Name of the data source
     Examples:
-        >>> siliconcompiler.FPGA(chip, "lattice_ice40")
+        >>> siliconcompiler.FPGA("lattice_ice40")
         Creates a flow object with name "lattice_ice40".
     """
 
@@ -121,11 +121,11 @@ class Library(PackageChip):
         auto_enable (boolean): If True, will automatically be added to ['option','library'].
             This is only valid for non-logiclibs and macrolibs
     Examples:
-        >>> siliconcompiler.Library(chip, "asap7sc7p5t")
+        >>> siliconcompiler.Library("asap7sc7p5t")
         Creates a library object with name "asap7sc7p5t".
     """
-    def __init__(self, chip, name, package=None, auto_enable=False):
-        super().__init__(chip, name, package=package)
+    def __init__(self, name, package=None, auto_enable=False):
+        super().__init__(name, package=package)
 
         self.__auto_enable = auto_enable
 
@@ -144,7 +144,7 @@ class Flow(Chip):
     Args:
         name (string): Name of the flow.
     Examples:
-        >>> siliconcompiler.Flow(chip, "asicflow")
+        >>> siliconcompiler.Flow("asicflow")
         Creates a flow object with name "asicflow".
     """
     def __init__(self, name):
@@ -162,7 +162,7 @@ class Checklist(Chip):
     Args:
         name (string): Name of the checklist.
     Examples:
-        >>> siliconcompiler.Checklist(chip, "tapeout")
+        >>> siliconcompiler.Checklist("tapeout")
         Creates a checklist object with name "tapeout".
     """
     def __init__(self, name):

--- a/siliconcompiler/use.py
+++ b/siliconcompiler/use.py
@@ -4,11 +4,15 @@ from siliconcompiler import Chip
 
 
 class PackageChip(Chip):
-    def __init__(self, name, package=None):
+    def __init__(self, *args, package=None):
         # Start with None as init setting will not depend on package
         self.__package = None
 
+        name = args[-1]
         super().__init__(name)
+
+        if len(args) == 2:
+            self.logger.warning(f'passing Chip object to {type(self)} is deprecated')
 
         path = None
         ref = None
@@ -124,8 +128,8 @@ class Library(PackageChip):
         >>> siliconcompiler.Library("asap7sc7p5t")
         Creates a library object with name "asap7sc7p5t".
     """
-    def __init__(self, name, package=None, auto_enable=False):
-        super().__init__(name, package=package)
+    def __init__(self, *args, package=None, auto_enable=False):
+        super().__init__(*args, package=package)
 
         self.__auto_enable = auto_enable
 
@@ -147,8 +151,10 @@ class Flow(Chip):
         >>> siliconcompiler.Flow("asicflow")
         Creates a flow object with name "asicflow".
     """
-    def __init__(self, name):
-        super().__init__(name)
+    def __init__(self, *args):
+        super().__init__(args[-1])
+        if len(args) == 2:
+            self.logger.warning(f'passing Chip object to {type(self)} is deprecated')
 
 
 class Checklist(Chip):
@@ -165,5 +171,7 @@ class Checklist(Chip):
         >>> siliconcompiler.Checklist("tapeout")
         Creates a checklist object with name "tapeout".
     """
-    def __init__(self, name):
-        super().__init__(name)
+    def __init__(self, *args):
+        super().__init__(args[-1])
+        if len(args) == 2:
+            self.logger.warning(f'passing Chip object to {type(self)} is deprecated')

--- a/tests/apps/test_sc_issue.py
+++ b/tests/apps/test_sc_issue.py
@@ -6,6 +6,7 @@ import siliconcompiler
 
 from siliconcompiler.apps import sc_issue
 import shutil
+from siliconcompiler.targets import freepdk45_demo
 
 
 # TODO: I think moving back to something like a tarfile would be nice here to
@@ -26,7 +27,7 @@ def heartbeat_dir(tmpdir_factory):
     chip.set('option', 'quiet', True)
     chip.input(os.path.join(datadir, 'heartbeat.v'))
     chip.input(os.path.join(datadir, 'heartbeat.sdc'))
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.run()
 
     return cwd

--- a/tests/apps/test_sc_remote.py
+++ b/tests/apps/test_sc_remote.py
@@ -10,6 +10,7 @@ import uuid
 import sys
 from pathlib import Path
 from siliconcompiler.utils import default_credentials_file
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.fixture(autouse=True)
@@ -131,7 +132,7 @@ def test_sc_remote_check_progress(monkeypatch, unused_tcp_port, scroot, scserver
     chip.set('option', 'remote', True)
     chip.set('option', 'credentials', tmp_creds)
     chip.set('option', 'nodisplay', True)
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     # Start the run, but don't wait for it to finish.
     client._remote_preprocess(chip)
     client._request_remote_run(chip)
@@ -165,7 +166,7 @@ def test_sc_remote_reconnect(monkeypatch, unused_tcp_port, scroot, scserver_cred
     chip.set('option', 'remote', True)
     chip.set('option', 'credentials', tmp_creds)
     chip.set('option', 'nodisplay', True)
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     # Start the run, but don't wait for it to finish.
     client._remote_preprocess(chip)
     client._request_remote_run(chip)

--- a/tests/apps/test_sc_show.py
+++ b/tests/apps/test_sc_show.py
@@ -5,6 +5,7 @@ import siliconcompiler
 
 from siliconcompiler.apps import sc_show
 from siliconcompiler.flowgraph import _get_flowgraph_exit_nodes
+from siliconcompiler.targets import freepdk45_demo
 
 
 # TODO: I think moving back to something like a tarfile would be nice here to
@@ -25,7 +26,7 @@ def heartbeat_dir(tmpdir_factory):
     chip.set('option', 'quiet', True)
     chip.input(os.path.join(datadir, 'heartbeat.v'))
     chip.input(os.path.join(datadir, 'heartbeat.sdc'))
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.run()
 
     return cwd

--- a/tests/builtin/test_nop.py
+++ b/tests/builtin/test_nop.py
@@ -2,6 +2,7 @@
 import siliconcompiler
 
 from siliconcompiler.tools.builtin import nop
+from siliconcompiler.targets import freepdk45_demo
 
 
 ##################################
@@ -10,7 +11,7 @@ def test_nop():
     '''
 
     chip = siliconcompiler.Chip('gcd')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('option', 'flow', 'test')
     chip.node('test', 'import', nop)
     chip.node('test', 'nop1', nop)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 import siliconcompiler
 from siliconcompiler.tools.openroad import openroad
 from siliconcompiler.tools._common import get_tool_tasks
+from siliconcompiler.targets import freepdk45_demo
 from pathlib import Path
 import subprocess
 import json
@@ -131,7 +132,7 @@ def gcd_chip(examples_root):
     gcd_ex_dir = os.path.join(examples_root, 'gcd')
 
     chip = siliconcompiler.Chip('gcd')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.input(os.path.join(gcd_ex_dir, 'gcd.v'))
     chip.input(os.path.join(gcd_ex_dir, 'gcd.sdc'))
     chip.set('constraint', 'outline', [(0, 0), (100.13, 100.8)])

--- a/tests/core/test_archive.py
+++ b/tests/core/test_archive.py
@@ -3,6 +3,7 @@ import siliconcompiler
 import os
 import tarfile
 import pytest
+from siliconcompiler.targets import freepdk45_demo
 
 
 def all_files(job):
@@ -41,7 +42,7 @@ def all_files(job):
 def chip():
     chip = siliconcompiler.Chip('oh_parity')
     chip.set('option', 'to', ['syn'])
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     for path in all_files('job0') + all_files('job1'):
         os.makedirs(os.path.dirname(path), exist_ok=True)

--- a/tests/core/test_calc.py
+++ b/tests/core/test_calc.py
@@ -2,6 +2,7 @@
 import siliconcompiler
 from siliconcompiler.utils import asic
 import pytest
+from siliconcompiler.targets import freepdk45_demo, skywater130_demo
 
 
 @pytest.mark.nostrict
@@ -36,7 +37,7 @@ def test_calc_area_with_stepindex():
 def test_calc_dpw():
 
     chip = siliconcompiler.Chip('test')
-    chip.load_target('skywater130_demo')
+    chip.load_target(skywater130_demo)
 
     chip.set('constraint', 'outline', [(0, 0), (150000, 75000)])
     assert asic.calc_dpw(chip) == 0
@@ -51,7 +52,7 @@ def test_calc_dpw():
 def test_calc_dpw_with_stepindex():
 
     chip = siliconcompiler.Chip('test')
-    chip.load_target('skywater130_demo')
+    chip.load_target(skywater130_demo)
 
     chip.set('constraint', 'outline', [(0, 0), (150000, 75000)], step='floorplan', index='0')
     chip.set('constraint', 'outline', [(0, 0), (75000, 75000)], step='floorplan', index='1')
@@ -65,7 +66,7 @@ def test_calc_dpw_with_stepindex():
 @pytest.mark.nostrict
 def test_calc_yield_poisson():
     chip = siliconcompiler.Chip('test')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     chip.set('constraint', 'outline', [(0, 0), (150000, 75000)])
     assert int(1000 * asic.calc_yield(chip)) == 245
@@ -79,7 +80,7 @@ def test_calc_yield_poisson():
 
 def test_calc_yield_poisson_with_stepindex():
     chip = siliconcompiler.Chip('test')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     chip.set('constraint', 'outline', [(0, 0), (150000, 75000)], step='floorplan', index='0')
     chip.set('constraint', 'outline', [(0, 0), (75000, 75000)], step='floorplan', index='1')
@@ -93,7 +94,7 @@ def test_calc_yield_poisson_with_stepindex():
 @pytest.mark.nostrict
 def test_calc_yield_murphy():
     chip = siliconcompiler.Chip('test')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     chip.set('constraint', 'outline', [(0, 0), (150000, 75000)])
     # Rounding to int(1000x) to avoid noise in float
@@ -108,7 +109,7 @@ def test_calc_yield_murphy():
 
 def test_calc_yield_murphy_with_stepindex():
     chip = siliconcompiler.Chip('test')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     chip.set('constraint', 'outline', [(0, 0), (150000, 75000)], step='floorplan', index='0')
     chip.set('constraint', 'outline', [(0, 0), (75000, 75000)], step='floorplan', index='1')

--- a/tests/core/test_check_flowgraph.py
+++ b/tests/core/test_check_flowgraph.py
@@ -33,7 +33,7 @@ def test_check_flowgraph_extra_to_steps():
 def test_check_flowgraph_disjoint():
     chip = siliconcompiler.Chip('test')
     chip.set('input', 'rtl', 'verilog', 'fake.v')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     flow = 'test'
     chip.set('option', 'flow', flow)
     chip.node(flow, 'import', parse)

--- a/tests/core/test_check_flowgraph_io.py
+++ b/tests/core/test_check_flowgraph_io.py
@@ -9,11 +9,12 @@ from tests.core.tools.fake import fake_in
 from siliconcompiler.tools.builtin import join
 from siliconcompiler.tools.builtin import minimum
 from siliconcompiler.flowgraph import _check_flowgraph_io
+from siliconcompiler.targets import freepdk45_demo
 
 
 def test_check_flowgraph():
     chip = siliconcompiler.Chip('foo')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.input('foo.v')
 
     flow = 'test'

--- a/tests/core/test_check_logfile.py
+++ b/tests/core/test_check_logfile.py
@@ -3,6 +3,7 @@ import siliconcompiler
 import logging
 import re
 from siliconcompiler.scheduler import check_logfile
+from siliconcompiler.targets import freepdk45_demo
 
 
 def test_check_logfile(datadir, caplog):
@@ -10,7 +11,7 @@ def test_check_logfile(datadir, caplog):
     chip = siliconcompiler.Chip('gcd')
     chip.logger = logging.getLogger()
     chip.logger.setLevel(logging.INFO)
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     # add regex
     chip.add('tool', 'openroad', 'task', 'place', 'regex', 'errors', "ERROR",

--- a/tests/core/test_check_manifest.py
+++ b/tests/core/test_check_manifest.py
@@ -14,11 +14,12 @@ from tests.core.tools.echo import echo
 from siliconcompiler.tools.builtin import nop
 from siliconcompiler.flowgraph import _check_flowgraph, \
     _get_flowgraph_execution_order
+from siliconcompiler.targets import freepdk45_demo, gf180_demo
 
 
 def test_check_manifest():
     chip = siliconcompiler.Chip('gcd')
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
     chip.input('examples/gcd/gcd.v')
     chip.set('option', 'to', ['syn'])
 
@@ -37,7 +38,7 @@ def test_check_allowed_filepaths_pass(scroot, monkeypatch):
     chip = siliconcompiler.Chip('gcd')
 
     chip.input(os.path.join(scroot, 'examples', 'gcd', 'gcd.v'))
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
     for layer_nodes in _get_flowgraph_execution_order(chip, 'asicflow'):
         for step, index in layer_nodes:
@@ -62,7 +63,7 @@ def test_check_allowed_filepaths_fail(scroot, monkeypatch):
     chip.input(os.path.join(scroot, 'examples', 'gcd', 'gcd.v'))
     chip.input('/random/abs/path/to/file.sdc')
     chip.set('input', 'constraint', 'sdc', False, field='copy')
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
     # collect input files
     workdir = chip.getworkdir(step='import', index='0')
@@ -77,7 +78,7 @@ def test_check_allowed_filepaths_fail(scroot, monkeypatch):
 
 def test_check_missing_file_param():
     chip = siliconcompiler.Chip('gcd')
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
     _setup_node(chip, 'syn', '0')
 
@@ -175,7 +176,7 @@ def test_merged_graph_bad_missing(merge_flow_chip):
 def test_check_missing_task_module():
     chip = siliconcompiler.Chip('gcd')
 
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
     chip.set('flowgraph', chip.get('option', 'flow'), 'place', '0', 'taskmodule', 'missing.place')
 
@@ -205,7 +206,7 @@ def test_check_graph_duplicate_edge():
 
 def test_check_missing_library():
     chip = siliconcompiler.Chip('test')
-    chip.load_target("gf180_demo")
+    chip.load_target(gf180_demo)
     chip.input('test.v')
 
     chip.add('option', 'library', 'sc_test')

--- a/tests/core/test_checklist.py
+++ b/tests/core/test_checklist.py
@@ -4,11 +4,13 @@ from siliconcompiler import NodeStatus
 from siliconcompiler.flowgraph import _get_flowgraph_nodes
 import pytest
 
+from siliconcompiler.targets import freepdk45_demo
+
 
 @pytest.fixture
 def chip():
     chip = siliconcompiler.Chip('test')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     for step, index in _get_flowgraph_nodes(chip, 'asicflow'):
         chip.set('record', 'status', NodeStatus.SUCCESS, step=step, index=index)

--- a/tests/core/test_codecs.py
+++ b/tests/core/test_codecs.py
@@ -15,7 +15,7 @@ def test(datadir, capfd, quiet):
     chip.logger = logging.getLogger()
     chip.logger.setLevel(logging.INFO)
 
-    flow = siliconcompiler.Flow(chip, "testflow")
+    flow = siliconcompiler.Flow("testflow")
     flow.node("testflow", "run", run)
 
     chip.use(flow)

--- a/tests/core/test_env_schema.py
+++ b/tests/core/test_env_schema.py
@@ -4,6 +4,7 @@ import pytest
 import multiprocessing
 
 from tools.dummy import environment
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.mark.skipif(
@@ -15,7 +16,7 @@ def test_env(monkeypatch):
     # File doesn't need to resolve, just need to put something in the schema so
     # we don't fail the initial static check_manifest().
     chip.input('fake.v')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('option', 'to', ['import'])
     flow = chip.get('option', 'flow')
     chip.modules.clear()

--- a/tests/core/test_error_manifest.py
+++ b/tests/core/test_error_manifest.py
@@ -2,6 +2,7 @@ import siliconcompiler
 from siliconcompiler.tools.surelog import parse
 from siliconcompiler._common import SiliconCompilerError
 import os
+from siliconcompiler.targets import freepdk45_demo
 
 
 def test_error_manifest():
@@ -10,7 +11,7 @@ def test_error_manifest():
     '''
     chip = siliconcompiler.Chip('test')
     chip.set('input', 'rtl', 'verilog', 'fake.v')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     flow = 'test'
     chip.set('option', 'flow', flow)
     step = 'import'

--- a/tests/core/test_fail_early.py
+++ b/tests/core/test_fail_early.py
@@ -4,12 +4,13 @@ from siliconcompiler.tools.surelog import parse
 from siliconcompiler._common import SiliconCompilerError
 import pytest
 import os
+from siliconcompiler.targets import freepdk45_demo
 
 
 def test_fail_early(capfd):
     chip = siliconcompiler.Chip('test')
     chip.set('input', 'rtl', 'verilog', 'fake.v')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     flow = 'test'
     chip.set('option', 'flow', flow)
     chip.node(flow, 'import', parse)
@@ -29,7 +30,7 @@ def test_fail_early(capfd):
 def test_tool_failure_manifest(datadir):
     chip = siliconcompiler.Chip('gcd')
     chip.set('input', 'rtl', 'verilog', f'{datadir}/gcd_bad_inst.v')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     flow = 'test'
     chip.set('option', 'flow', flow)
     chip.node(flow, 'import', parse)

--- a/tests/core/test_find_file.py
+++ b/tests/core/test_find_file.py
@@ -7,6 +7,7 @@ import pytest
 import siliconcompiler
 from siliconcompiler.core import SiliconCompilerError
 from siliconcompiler.utils import find_sc_file
+from siliconcompiler.targets import freepdk45_demo
 
 
 def test_find_sc_file(datadir):
@@ -55,7 +56,7 @@ def test_invalid_script():
     '''Regression test: find_files(missing_ok=False) should error out if script
     not found.'''
     chip = siliconcompiler.Chip('test')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     chip.set('tool', 'yosys', 'task', 'syn_asic', 'script', 'fakescript.tcl')
 

--- a/tests/core/test_flowgraph.py
+++ b/tests/core/test_flowgraph.py
@@ -1,10 +1,11 @@
 from siliconcompiler import Chip
 from siliconcompiler.flowgraph import get_nodes_from
+from siliconcompiler.targets import freepdk45_demo
 
 
 def test_get_nodes_from():
     chip = Chip('test')
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
     nodes = get_nodes_from(chip, chip.get('option', 'flow'), [('dfm', '0')])
     assert ('route', '0') not in nodes
@@ -15,7 +16,7 @@ def test_get_nodes_from():
 
 def test_get_nodes_from_with_prune():
     chip = Chip('test')
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
     chip.set('option', 'prune', ('write_gds', '0'))
 
@@ -28,7 +29,7 @@ def test_get_nodes_from_with_prune():
 
 def test_get_nodes_from_with_to():
     chip = Chip('test')
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
     chip.set('option', 'to', 'dfm')
 

--- a/tests/core/test_getdict.py
+++ b/tests/core/test_getdict.py
@@ -1,11 +1,12 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 import siliconcompiler
+from siliconcompiler.targets import freepdk45_demo
 
 
 def test_getdict():
 
     chip = siliconcompiler.Chip('test')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     localcfg = chip.getdict('pdk')
 
     glbl_key = siliconcompiler.Schema.GLOBAL_KEY

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -23,6 +23,7 @@ from tests.core.tools.fake import fake_out
 
 from siliconcompiler.flowgraph import _get_flowgraph_exit_nodes, \
     _get_flowgraph_entry_nodes, _get_flowgraph_nodes
+from siliconcompiler.targets import freepdk45_demo
 
 
 def test_graph():
@@ -121,7 +122,7 @@ def test_graph_entry():
 def test_graph_exit():
 
     chip = siliconcompiler.Chip('foo')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     flow = chip.get('option', 'flow')
     assert _get_flowgraph_exit_nodes(chip, flow) == [('write_gds', '0'), ('write_data', '0')]
@@ -130,7 +131,7 @@ def test_graph_exit():
 def test_graph_exit_with_steps():
 
     chip = siliconcompiler.Chip('foo')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     steps = ['import', 'syn', 'floorplan']
 

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -31,7 +31,7 @@ def test_graph():
     chip = siliconcompiler.Chip('test')
 
     # RTL
-    rtl_flow = siliconcompiler.Flow(chip, 'rtl')
+    rtl_flow = siliconcompiler.Flow('rtl')
     prevstep = None
     for step, task in [('import', parse),
                        ('syn', syn_asic),
@@ -43,7 +43,7 @@ def test_graph():
     chip.use(rtl_flow)
 
     # APR
-    apr_flow = siliconcompiler.Flow(chip, 'apr')
+    apr_flow = siliconcompiler.Flow('apr')
     prevstep = None
     for step, task in [('import', nop),
                        ('floorplan', floorplan),

--- a/tests/core/test_hash_files.py
+++ b/tests/core/test_hash_files.py
@@ -2,12 +2,13 @@
 import pytest
 import os
 import siliconcompiler
+from siliconcompiler.targets import freepdk45_demo, asic_demo
 
 
 def test_hash_files():
     chip = siliconcompiler.Chip('top')
 
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
     chip.write_manifest("raw.json")
     allkeys = chip.allkeys()
     for keypath in allkeys:
@@ -28,7 +29,7 @@ def test_err_mismatch():
     chip = siliconcompiler.Chip('top')
 
     # Necessary due to find_files() quirk, we need a flow w/ an import step
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     # Create foo.txt and compute its hash
     with open('foo.txt', 'w', newline='\n') as f:
@@ -71,7 +72,7 @@ def test_changed_algorithm(algorithm, expected):
     chip = siliconcompiler.Chip('top')
 
     # Necessary due to find_files() quirk, we need a flow w/ an import step
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('input', 'rtl', 'verilog', 'foo.txt')
     chip.set('input', 'rtl', 'verilog', algorithm, field='hashalgo')
     print(chip.hash_files('input', 'rtl', 'verilog'))
@@ -89,7 +90,7 @@ def test_directory_hash():
     chip = siliconcompiler.Chip('top')
 
     # Necessary due to find_files() quirk, we need a flow w/ an import step
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('option', 'idir', 'test1')
     print(chip.hash_files('option', 'idir'))
     assert chip.hash_files('option', 'idir') == \
@@ -107,7 +108,7 @@ def test_directory_hash_rename():
     chip = siliconcompiler.Chip('top')
 
     # Necessary due to find_files() quirk, we need a flow w/ an import step
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('option', 'idir', 'test1')
 
     assert chip.hash_files('option', 'idir') == \
@@ -127,7 +128,7 @@ def test_hash_no_check():
     chip = siliconcompiler.Chip('top')
 
     # Necessary due to find_files() quirk, we need a flow w/ an import step
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('input', 'rtl', 'verilog', 'foo.txt')
     print(chip.hash_files('input', 'rtl', 'verilog'))
     assert chip.hash_files('input', 'rtl', 'verilog') == \
@@ -150,7 +151,7 @@ def test_hash_no_update():
     chip = siliconcompiler.Chip('top')
 
     # Necessary due to find_files() quirk, we need a flow w/ an import step
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('input', 'rtl', 'verilog', 'foo.txt')
     print(chip.hash_files('input', 'rtl', 'verilog'))
     assert chip.hash_files('input', 'rtl', 'verilog') == \
@@ -174,7 +175,7 @@ def test_hash_global_file():
     chip = siliconcompiler.Chip('top')
 
     # Necessary due to find_files() quirk, we need a flow w/ an import step
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('input', 'rtl', 'verilog', 'foo.txt')
     assert chip.hash_files('input', 'rtl', 'verilog', step='test', index=0) == \
         ['aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f']
@@ -194,7 +195,7 @@ def test_hash_step_file():
     chip = siliconcompiler.Chip('top')
 
     # Necessary due to find_files() quirk, we need a flow w/ an import step
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('input', 'rtl', 'verilog', 'foo.txt', step='test')
     assert chip.hash_files('input', 'rtl', 'verilog', step='test', index=0) == \
         ['aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f']
@@ -213,7 +214,7 @@ def test_hash_node_file():
     chip = siliconcompiler.Chip('top')
 
     # Necessary due to find_files() quirk, we need a flow w/ an import step
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('input', 'rtl', 'verilog', 'foo.txt', step='test', index=0)
     assert chip.hash_files('input', 'rtl', 'verilog', step='test', index=0) == \
         ['aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f']
@@ -255,7 +256,7 @@ def test_error_in_run_while_hashing(gcd_chip):
 @pytest.mark.timeout(150)
 def test_rerunning_with_hashing():
     chip = siliconcompiler.Chip('')
-    chip.load_target('asic_demo')
+    chip.load_target(asic_demo)
 
     chip.set('option', 'hash', True)
     chip.set('option', 'to', 'floorplan')
@@ -272,7 +273,7 @@ def test_hash_no_cache():
     chip = siliconcompiler.Chip('top')
 
     # Necessary due to find_files() quirk, we need a flow w/ an import step
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('input', 'rtl', 'verilog', 'foo.txt', step='test', index=0)
     assert chip.hash_files('input', 'rtl', 'verilog', step='test', index=0) == \
         ['aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f']

--- a/tests/core/test_history.py
+++ b/tests/core/test_history.py
@@ -1,10 +1,11 @@
 import siliconcompiler
+from siliconcompiler.targets import freepdk45_demo
 
 
 def test_history(datadir):
 
     chip = siliconcompiler.Chip('gcd')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     # Set values in manifest
     chip.set('metric', 'utilization', 10, step='floorplan', index='0')

--- a/tests/core/test_import_library.py
+++ b/tests/core/test_import_library.py
@@ -8,8 +8,8 @@ import pytest
 def test_auto_enable_sublibrary_no_main():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib')
-    sub_lib = Library(chip, 'sub_lib', auto_enable=True)
+    lib = Library('main_lib')
+    sub_lib = Library('sub_lib', auto_enable=True)
     lib.use(sub_lib)
 
     chip.use(lib)
@@ -22,8 +22,8 @@ def test_auto_enable_sublibrary_no_main():
 def test_auto_enable_sublibrary_with_main():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib', auto_enable=True)
-    sub_lib = Library(chip, 'sub_lib', auto_enable=True)
+    lib = Library('main_lib', auto_enable=True)
+    sub_lib = Library('sub_lib', auto_enable=True)
     lib.use(sub_lib)
 
     chip.use(lib)
@@ -36,7 +36,7 @@ def test_auto_enable_sublibrary_with_main():
 def test_auto_enable():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib', auto_enable=True)
+    lib = Library('main_lib', auto_enable=True)
     chip.use(lib)
 
     assert chip.get('option', 'library') == ['main_lib']
@@ -46,8 +46,8 @@ def test_auto_enable():
 def test_recursive_import_lib_only():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib')
-    sub_lib = Library(chip, 'sub_lib')
+    lib = Library('main_lib')
+    sub_lib = Library('sub_lib')
     lib.use(sub_lib)
 
     chip.use(lib)
@@ -60,8 +60,8 @@ def test_recursive_import_lib_only():
 def test_recursive_import_with_package_source():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib')
-    sub_lib = Library(chip, 'sub_lib')
+    lib = Library('main_lib')
+    sub_lib = Library('sub_lib')
     sub_lib.register_source('test', 'test_path', 'test_ref')
     lib.use(sub_lib)
 
@@ -75,7 +75,7 @@ def test_recursive_import_with_package_source():
 def test_import_pdk_with_data_source():
     chip = Chip('<test>')
 
-    pdk = PDK(chip, 'main_pdk')
+    pdk = PDK('main_pdk')
     pdk.register_source('test', 'test_path', 'test_ref')
 
     chip.use(pdk)
@@ -121,7 +121,7 @@ def test_import_library_as_chip():
 def test_import_library_as_library():
     chip = Chip('<test>')
 
-    lib = Library(chip, '<lib>')
+    lib = Library('<lib>')
     assert 'pdk' in lib.getkeys()
     assert 'history' in lib.getkeys()
     assert 'library' in lib.getkeys()

--- a/tests/core/test_record_metric.py
+++ b/tests/core/test_record_metric.py
@@ -3,13 +3,14 @@ import pytest
 import siliconcompiler
 from siliconcompiler.scheduler import _clear_metric
 from siliconcompiler.tools._common import record_metric
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.fixture
 def chip():
     # Create instance of Chip class
     chip = siliconcompiler.Chip('test')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     return chip
 

--- a/tests/core/test_runtime_exception.py
+++ b/tests/core/test_runtime_exception.py
@@ -2,12 +2,13 @@
 import pytest
 
 import siliconcompiler
+from siliconcompiler.targets import asic_demo
 
 
 def test_version():
     chip = siliconcompiler.Chip('test')
 
-    chip.load_target('asic_demo')
+    chip.load_target(asic_demo)
 
     flow = chip.get('option', 'flow')
     chip.set('flowgraph', flow, 'import', '0', 'tool', 'dummy')

--- a/tests/core/test_setget.py
+++ b/tests/core/test_setget.py
@@ -4,6 +4,7 @@ import re
 import siliconcompiler
 import logging
 from siliconcompiler import Schema
+from siliconcompiler.targets import freepdk45_demo
 
 
 def _cast(val, sctype):
@@ -376,7 +377,7 @@ def test_lock():
 
     # Create instance of Chip class
     chip = siliconcompiler.Chip('gcd')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('design', True, field="lock")
     chip.set('design', "FAIL")
 
@@ -390,7 +391,7 @@ def test_unlock():
 
     # Create instance of Chip class
     chip = siliconcompiler.Chip('gcd')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('design', True, field="lock")
     chip.set('design', "FAIL")
     assert chip.get('design') == "gcd"

--- a/tests/core/test_swap_library.py
+++ b/tests/core/test_swap_library.py
@@ -7,8 +7,8 @@ import pytest
 def test_swap_library_sublibrary_no_main():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib')
-    sub_lib = Library(chip, 'sub_lib', auto_enable=True)
+    lib = Library('main_lib')
+    sub_lib = Library('sub_lib', auto_enable=True)
     lib.use(sub_lib)
 
     chip.use(lib)
@@ -25,8 +25,8 @@ def test_swap_library_sublibrary_no_main():
 def test_swap_library_sublibrary_no_main_stepindex():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib')
-    sub_lib = Library(chip, 'sub_lib', auto_enable=True)
+    lib = Library('main_lib')
+    sub_lib = Library('sub_lib', auto_enable=True)
     lib.use(sub_lib)
 
     chip.use(lib)
@@ -52,8 +52,8 @@ def test_swap_library_sublibrary_no_main_stepindex():
 def test_auto_enable_sublibrary_with_main():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib', auto_enable=True)
-    sub_lib = Library(chip, 'sub_lib', auto_enable=True)
+    lib = Library('main_lib', auto_enable=True)
+    sub_lib = Library('sub_lib', auto_enable=True)
     lib.use(sub_lib)
 
     chip.use(lib)
@@ -71,8 +71,8 @@ def test_auto_enable_sublibrary_with_main():
 def test_auto_swap_to_none():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib', auto_enable=True)
-    sub_lib = Library(chip, 'sub_lib', auto_enable=True)
+    lib = Library('main_lib', auto_enable=True)
+    sub_lib = Library('sub_lib', auto_enable=True)
     lib.use(sub_lib)
 
     chip.use(lib)
@@ -90,8 +90,8 @@ def test_auto_swap_to_none():
 def test_auto_swap_sublib_to_none():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib', auto_enable=True)
-    sub_lib = Library(chip, 'sub_lib', auto_enable=True)
+    lib = Library('main_lib', auto_enable=True)
+    sub_lib = Library('sub_lib', auto_enable=True)
     lib.use(sub_lib)
 
     chip.use(lib)

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -3,12 +3,13 @@ import pytest
 
 from siliconcompiler.pdks import asap7, freepdk45, skywater130
 from siliconcompiler.targets import fpgaflow_demo
+from siliconcompiler.targets import freepdk45_demo
 
 
 def test_target_valid():
     '''Basic test of target function.'''
     chip = siliconcompiler.Chip('test')
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
     assert chip.get('option', 'flow') == 'asicflow'
 

--- a/tests/core/test_use.py
+++ b/tests/core/test_use.py
@@ -5,7 +5,7 @@ from siliconcompiler import Chip, Library
 def test_module_input():
     chip = Chip('test')
 
-    lib = Library(chip, 'testlib')
+    lib = Library('testlib')
     chip.use(lib)
 
     assert 'testlib' in chip.getkeys('library')
@@ -15,7 +15,7 @@ def test_function_input():
     chip = Chip('test')
 
     def func(chip):
-        return Library(chip, 'testlib')
+        return Library('testlib')
     chip.use(func)
 
     assert 'testlib' in chip.getkeys('library')
@@ -62,7 +62,7 @@ def test_target_return():
     chip._add_file_logger('log')
 
     def func(chip):
-        return [Library(chip, 'test')]
+        return [Library('test')]
 
     chip.use(func)
 
@@ -76,7 +76,7 @@ def test_library_return():
     chip._add_file_logger('log')
 
     def func():
-        return [Library(chip, 'test')]
+        return [Library('test')]
 
     chip.use(func)
 

--- a/tests/core/test_use.py
+++ b/tests/core/test_use.py
@@ -55,3 +55,31 @@ def test_chip_not_passing():
 
     with pytest.raises(EnvironmentError):
         chip.use(func)
+
+
+def test_target_return():
+    chip = Chip('test')
+    chip._add_file_logger('log')
+
+    def func(chip):
+        return [Library(chip, 'test')]
+
+    chip.use(func)
+
+    with open('log') as f:
+        text = f.read()
+        assert "Target returned items, which it should not have" in text
+
+
+def test_library_return():
+    chip = Chip('test')
+    chip._add_file_logger('log')
+
+    def func():
+        return [Library(chip, 'test')]
+
+    chip.use(func)
+
+    with open('log') as f:
+        text = f.read()
+        assert "Target returned items, which it should not have" not in text

--- a/tests/core/test_use.py
+++ b/tests/core/test_use.py
@@ -26,3 +26,32 @@ def test_none_input():
 
     with pytest.raises(ValueError):
         chip.use(None)
+
+
+def test_function_spec():
+    chip = Chip('test')
+
+    def func(chip, other):
+        pass
+
+    with pytest.raises(RuntimeError):
+        chip.use(func)
+
+
+def test_chip_passing():
+    chip = Chip('test')
+
+    def func(chip):
+        assert isinstance(chip, Chip)
+
+    chip.use(func)
+
+
+def test_chip_not_passing():
+    chip = Chip('test')
+
+    def func():
+        raise EnvironmentError
+
+    with pytest.raises(EnvironmentError):
+        chip.use(func)

--- a/tests/core/test_use.py
+++ b/tests/core/test_use.py
@@ -1,3 +1,4 @@
+import pytest
 from siliconcompiler import Chip, Library
 
 
@@ -18,3 +19,10 @@ def test_function_input():
     chip.use(func)
 
     assert 'testlib' in chip.getkeys('library')
+
+
+def test_none_input():
+    chip = Chip('test')
+
+    with pytest.raises(ValueError):
+        chip.use(None)

--- a/tests/core/test_use.py
+++ b/tests/core/test_use.py
@@ -1,0 +1,20 @@
+from siliconcompiler import Chip, Library
+
+
+def test_module_input():
+    chip = Chip('test')
+
+    lib = Library(chip, 'testlib')
+    chip.use(lib)
+
+    assert 'testlib' in chip.getkeys('library')
+
+
+def test_function_input():
+    chip = Chip('test')
+
+    def func(chip):
+        return Library(chip, 'testlib')
+    chip.use(func)
+
+    assert 'testlib' in chip.getkeys('library')

--- a/tests/core/test_valid.py
+++ b/tests/core/test_valid.py
@@ -1,11 +1,12 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 import siliconcompiler
+from siliconcompiler.targets import freepdk45_demo
 
 
 def test_valid():
 
     chip = siliconcompiler.Chip('test')
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
     # basic
     valid = chip.valid('design')
     assert valid

--- a/tests/core/test_write_dependencygraph.py
+++ b/tests/core/test_write_dependencygraph.py
@@ -7,8 +7,8 @@ import os
 def test_auto_enable_sublibrary_no_main():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib')
-    sub_lib = Library(chip, 'sub_lib', auto_enable=True)
+    lib = Library('main_lib')
+    sub_lib = Library('sub_lib', auto_enable=True)
     lib.use(sub_lib)
 
     chip.use(lib)
@@ -21,8 +21,8 @@ def test_auto_enable_sublibrary_no_main():
 def test_auto_enable_sublibrary_with_main():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib', auto_enable=True)
-    sub_lib = Library(chip, 'sub_lib', auto_enable=True)
+    lib = Library('main_lib', auto_enable=True)
+    sub_lib = Library('sub_lib', auto_enable=True)
     lib.use(sub_lib)
 
     chip.use(lib)
@@ -35,7 +35,7 @@ def test_auto_enable_sublibrary_with_main():
 def test_auto_enable():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib', auto_enable=True)
+    lib = Library('main_lib', auto_enable=True)
     chip.use(lib)
 
     chip.write_dependencygraph('dep.png')
@@ -45,8 +45,8 @@ def test_auto_enable():
 def test_recursive_import_lib_only():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib')
-    sub_lib = Library(chip, 'sub_lib')
+    lib = Library('main_lib')
+    sub_lib = Library('sub_lib')
     lib.use(sub_lib)
 
     chip.use(lib)

--- a/tests/core/test_write_flowgraph.py
+++ b/tests/core/test_write_flowgraph.py
@@ -4,6 +4,7 @@ import os
 
 from siliconcompiler.pdks import freepdk45
 from siliconcompiler.flows import dvflow
+from siliconcompiler.targets import freepdk45_demo
 
 
 def test_write_flowgraph_serial():
@@ -13,7 +14,7 @@ def test_write_flowgraph_serial():
     ################################################
 
     chip = siliconcompiler.Chip('test')
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
     chip.write_flowgraph('serial.png')
 
     assert os.path.isfile('serial.png')
@@ -26,7 +27,7 @@ def test_write_flowgraph_forkjoin():
     ################################################
 
     chip = siliconcompiler.Chip('test')
-    chip.load_target("freepdk45_demo", syn_np=4, place_np=4, route_np=4)
+    chip.load_target(freepdk45_demo, syn_np=4, place_np=4, route_np=4)
     chip.write_flowgraph('forkjoin.png')
 
     assert os.path.isfile('forkjoin.png')

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -1,6 +1,7 @@
 import siliconcompiler
 import os
 import pytest
+from siliconcompiler.targets import freepdk45_demo
 
 
 def __check_gcd(chip):
@@ -80,7 +81,7 @@ def test_py_read_manifest(scroot):
     chip.set('option', 'nodisplay', True)
     chip.set('constraint', 'outline', [(0, 0), (100.13, 100.8)])
     chip.set('constraint', 'corearea', [(10.07, 11.2), (90.25, 91)])
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
     chip.write_manifest('./test.json')
     chip = siliconcompiler.Chip('gcd')

--- a/tests/flows/test_entrypoint.py
+++ b/tests/flows/test_entrypoint.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 import siliconcompiler
+from siliconcompiler.targets import skywater130_demo
 
 
 @pytest.mark.eda
@@ -16,7 +17,7 @@ def test_entrypoint(scroot):
 
     chip.set('option', 'entrypoint', 'heartbeat_top')
 
-    chip.load_target('skywater130_demo')
+    chip.load_target(skywater130_demo)
     chip.set('option', 'to', 'syn')
 
     chip.run()

--- a/tests/flows/test_failure.py
+++ b/tests/flows/test_failure.py
@@ -2,6 +2,7 @@ import os
 import siliconcompiler
 
 import pytest
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.fixture
@@ -14,7 +15,7 @@ def chip(datadir):
     chip.set('design', 'bad')
     chip.set('constraint', 'outline', [(0, 0), (10, 10)])
     chip.set('constraint', 'corearea', [(1, 1), (9, 9)])
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
     chip.add('option', 'to', 'syn')
 
@@ -70,7 +71,7 @@ def test_incomplete_flowgraph():
     '''
 
     chip = siliconcompiler.Chip('gcd')
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
     flow = chip.get('option', 'flow')
 

--- a/tests/flows/test_flowstatus.py
+++ b/tests/flows/test_flowstatus.py
@@ -10,6 +10,7 @@ from siliconcompiler.tools.openroad import cts
 
 from siliconcompiler.tools.builtin import nop
 from siliconcompiler.tools.builtin import minimum
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.mark.eda
@@ -28,7 +29,7 @@ def test_flowstatus(scroot, to):
     chip.set('option', 'quiet', True)
     chip.set('option', 'jobname', jobname)
 
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     flow = 'test'
     # no-op import since we're not preprocessing source files
@@ -87,7 +88,7 @@ def test_long_branch(scroot):
     chip.set('option', 'quiet', True)
     chip.set('option', 'jobname', jobname)
 
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     flow = 'test'
     # no-op import since we're not preprocessing source files

--- a/tests/flows/test_from_to.py
+++ b/tests/flows/test_from_to.py
@@ -5,6 +5,7 @@ import siliconcompiler
 import pytest
 
 from siliconcompiler import NodeStatus
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.mark.eda
@@ -45,7 +46,7 @@ def test_from_to_mutliple_starts(gcd_chip, datadir):
     gcd_chip.set('option', 'entrypoint', 'binary_4_bit_adder_top', step='import_vhdl')
     gcd_chip.set('tool', 'ghdl', 'task', 'convert', 'var', 'extraopts', '-fsynopsys')
     gcd_chip.remove('flowgraph', 'asicflow')
-    gcd_chip.load_target('freepdk45_demo')
+    gcd_chip.load_target(freepdk45_demo)
 
     fresh_chip = siliconcompiler.Chip(gcd_chip.design)
     fresh_chip.schema = gcd_chip.schema.copy()

--- a/tests/flows/test_param_instantiation.py
+++ b/tests/flows/test_param_instantiation.py
@@ -1,6 +1,7 @@
 import os
 import siliconcompiler
 import pytest
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.mark.eda
@@ -12,7 +13,7 @@ def test_parameterized_instantiation(datadir):
     '''
 
     chip = siliconcompiler.Chip('gate')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     chip.input(os.path.join(datadir, 'test_param_instantiation', 'wrapper.v'))
     chip.input(os.path.join(datadir, 'test_param_instantiation', 'gate.v'))

--- a/tests/flows/test_prune.py
+++ b/tests/flows/test_prune.py
@@ -3,6 +3,7 @@ import siliconcompiler
 from siliconcompiler.tools.builtin import nop, minimum, maximum
 from tests.core.tools.dummy import dummy
 from siliconcompiler._common import SiliconCompilerError
+from siliconcompiler.targets import freepdk45_demo
 
 import pytest
 import logging
@@ -11,7 +12,7 @@ import logging
 def test_prune_end(caplog):
     chip = siliconcompiler.Chip('foo')
     chip.logger = logging.getLogger()
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     flow = 'test'
     chip.set('option', 'flow', flow)
@@ -29,7 +30,7 @@ def test_prune_end(caplog):
 def test_prune_middle(caplog):
     chip = siliconcompiler.Chip('foo')
     chip.logger = logging.getLogger()
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     flow = 'test'
     chip.set('option', 'flow', flow)
@@ -48,7 +49,7 @@ def test_prune_middle(caplog):
 
 def test_prune_split():
     chip = siliconcompiler.Chip('foo')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     flow = 'test'
     chip.set('option', 'flow', flow)
@@ -69,7 +70,7 @@ def test_prune_split():
 def test_prune_split_join(caplog):
     chip = siliconcompiler.Chip('foo')
     chip.logger = logging.getLogger()
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     flow = 'test'
     chip.set('option', 'flow', flow)
@@ -93,7 +94,7 @@ def test_prune_split_join(caplog):
 
 def test_prune_min():
     chip = siliconcompiler.Chip('foo')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     flow = 'test'
     chip.set('option', 'flow', flow)
@@ -112,7 +113,7 @@ def test_prune_min():
 
 def test_prune_max():
     chip = siliconcompiler.Chip('foo')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     flow = 'test'
     chip.set('option', 'flow', flow)
@@ -132,7 +133,7 @@ def test_prune_max():
 def test_prune_max_all_inputs_pruned(caplog):
     chip = siliconcompiler.Chip('foo')
     chip.logger = logging.getLogger()
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     flow = 'test'
     chip.set('option', 'flow', flow)

--- a/tests/flows/test_show.py
+++ b/tests/flows/test_show.py
@@ -9,7 +9,7 @@ from siliconcompiler.tools.klayout import show as klayout_show
 from siliconcompiler.tools.openroad import show as openroad_show
 from siliconcompiler.tools.klayout import screenshot as klayout_screenshot
 from siliconcompiler.tools.openroad import screenshot as openroad_screenshot
-from siliconcompiler.targets import freepdk45_demo
+from siliconcompiler.targets import freepdk45_demo, skywater130_demo
 
 
 def adjust_exe_options(chip, headless):
@@ -39,12 +39,12 @@ def display():
 @pytest.mark.eda
 @pytest.mark.quick
 @pytest.mark.parametrize('task', [klayout_show, openroad_show])
-@pytest.mark.parametrize('project, testfile',
-                         [('freepdk45_demo', 'heartbeat_freepdk45.def'),
-                          ('skywater130_demo', 'heartbeat_sky130.def')])
-def test_show_def(project, testfile, task, datadir, display, headless=True):
+@pytest.mark.parametrize('target, testfile',
+                         [(freepdk45_demo, 'heartbeat_freepdk45.def'),
+                          (skywater130_demo, 'heartbeat_sky130.def')])
+def test_show_def(target, testfile, task, datadir, display, headless=True):
     chip = siliconcompiler.Chip('heartbeat')
-    chip.load_target(project)
+    chip.load_target(target)
 
     chip.register_showtool('def', task)
 
@@ -57,12 +57,12 @@ def test_show_def(project, testfile, task, datadir, display, headless=True):
 @pytest.mark.eda
 @pytest.mark.quick
 @pytest.mark.parametrize('task', [klayout_screenshot, openroad_screenshot])
-@pytest.mark.parametrize('project, testfile',
-                         [('freepdk45_demo', 'heartbeat_freepdk45.def'),
-                          ('skywater130_demo', 'heartbeat_sky130.def')])
-def test_screenshot_def(project, testfile, task, datadir, display, headless=True):
+@pytest.mark.parametrize('target, testfile',
+                         [(freepdk45_demo, 'heartbeat_freepdk45.def'),
+                          (skywater130_demo, 'heartbeat_sky130.def')])
+def test_screenshot_def(target, testfile, task, datadir, display, headless=True):
     chip = siliconcompiler.Chip('heartbeat')
-    chip.load_target(project)
+    chip.load_target(target)
 
     chip.register_showtool('def', task)
 

--- a/tests/flows/test_show.py
+++ b/tests/flows/test_show.py
@@ -9,6 +9,7 @@ from siliconcompiler.tools.klayout import show as klayout_show
 from siliconcompiler.tools.openroad import show as openroad_show
 from siliconcompiler.tools.klayout import screenshot as klayout_screenshot
 from siliconcompiler.tools.openroad import screenshot as openroad_screenshot
+from siliconcompiler.targets import freepdk45_demo
 
 
 def adjust_exe_options(chip, headless):
@@ -79,7 +80,7 @@ def test_show_lyp(datadir, display, headless=True):
     ''' Test sc-show with only a KLayout .lyp file for layer properties '''
 
     chip = siliconcompiler.Chip('heartbeat')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     chip.register_showtool('def', klayout_show)
 
@@ -98,7 +99,7 @@ def test_show_lyp(datadir, display, headless=True):
 @pytest.mark.quick
 def test_show_nopdk(datadir, display):
     chip = siliconcompiler.Chip('heartbeat')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     testfile = os.path.join(datadir, 'heartbeat.gds.gz')
 

--- a/tests/flows/test_sv.py
+++ b/tests/flows/test_sv.py
@@ -1,6 +1,7 @@
 import siliconcompiler
 import os
 import pytest
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.mark.eda
@@ -18,7 +19,7 @@ def test_sv(datadir):
     chip.add('option', 'idir', os.path.join(datadir, 'sv', 'inc/'))
     chip.add('option', 'define', 'SYNTHESIS')
 
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     chip.add('option', 'to', 'syn')
 

--- a/tests/flows/test_tool_option.py
+++ b/tests/flows/test_tool_option.py
@@ -9,6 +9,7 @@ from siliconcompiler.tools.builtin import join
 from siliconcompiler.tools.builtin import minimum
 
 from siliconcompiler import NodeStatus
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.mark.eda
@@ -28,7 +29,7 @@ def test_tool_option(scroot):
     chip.set('constraint', 'outline', [(0, 0), (100.13, 100.8)])
     chip.set('constraint', 'corearea', [(10.07, 11.2), (90.25, 91)])
     chip.set('option', 'quiet', 'true')
-    chip.load_target('freepdk45_demo', place_np=2)
+    chip.load_target(freepdk45_demo, place_np=2)
 
     chip.set('tool', 'openroad', 'task', 'place', 'var', 'place_density', '0.4',
              step='place', index='0')
@@ -63,7 +64,7 @@ def chip(scroot):
     chip = siliconcompiler.Chip(design)
     chip.input(def_file)
     chip.set('option', 'quiet', True)
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     # Important: set up our own flow instead of using asicflow.
     chip.set('option', 'flow', 'test')

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -101,7 +101,7 @@ def test_dependency_path_dirty_warning(caplog):
 def test_package_with_import():
     chip = siliconcompiler.Chip('test')
 
-    lib = siliconcompiler.Library(chip, 'lib')
+    lib = siliconcompiler.Library('lib')
     lib.register_source('test-source', 'path', 'ref')
 
     assert 'test-source' not in chip.getkeys('package', 'source')
@@ -181,8 +181,7 @@ def test_register_python_data_source_with_append(monkeypatch):
 
 
 def test_register_source_tuple_2():
-    chip = siliconcompiler.Chip('')
-    lib = siliconcompiler.Library(chip, "test", package=(
+    lib = siliconcompiler.Library("test", package=(
         "test", "path_to_test"))
 
     assert lib.get('package', 'source', 'test', 'path') == "path_to_test"
@@ -190,8 +189,7 @@ def test_register_source_tuple_2():
 
 
 def test_register_source_tuple_3():
-    chip = siliconcompiler.Chip('')
-    lib = siliconcompiler.Library(chip, "test", package=(
+    lib = siliconcompiler.Library("test", package=(
         "test", "path_to_test", "ref"))
 
     assert lib.get('package', 'source', 'test', 'path') == "path_to_test"
@@ -199,14 +197,12 @@ def test_register_source_tuple_3():
 
 
 def test_register_source_tuple_error():
-    chip = siliconcompiler.Chip('')
     with pytest.raises(ValueError):
-        siliconcompiler.Library(chip, "test", package=("test",))
+        siliconcompiler.Library("test", package=("test",))
 
 
 def test_register_source_dict_path():
-    chip = siliconcompiler.Chip('')
-    lib = siliconcompiler.Library(chip, "test", package={
+    lib = siliconcompiler.Library("test", package={
         "test": {"path": "path_to_test"}})
 
     assert lib.get('package', 'source', 'test', 'path') == "path_to_test"
@@ -214,8 +210,7 @@ def test_register_source_dict_path():
 
 
 def test_register_source_dict_ref():
-    chip = siliconcompiler.Chip('')
-    lib = siliconcompiler.Library(chip, "test", package={
+    lib = siliconcompiler.Library("test", package={
         "test": {"path": "path_to_test", "ref": "ref"}})
 
     assert lib.get('package', 'source', 'test', 'path') == "path_to_test"
@@ -223,13 +218,11 @@ def test_register_source_dict_ref():
 
 
 def test_register_source_dict_error():
-    chip = siliconcompiler.Chip('')
     with pytest.raises(ValueError):
-        siliconcompiler.Library(chip, "test", package={
+        siliconcompiler.Library("test", package={
             "test": {"ref": "ref"}})
 
 
 def test_register_source_int():
-    chip = siliconcompiler.Chip('')
     with pytest.raises(ValueError):
-        siliconcompiler.Library(chip, "test", package=4)
+        siliconcompiler.Library("test", package=4)

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -5,6 +5,7 @@ import pytest
 from siliconcompiler.schema import Schema
 from siliconcompiler.schema.schema_cfg import scparam
 from siliconcompiler import Chip
+from siliconcompiler.targets import asic_demo
 
 
 def test_list_of_lists():
@@ -129,7 +130,7 @@ def test_merge_with_init_new_has_values():
 
 def test_merge_with_init_with_lib():
     chip = Chip('')
-    chip.load_target('asic_demo')
+    chip.load_target(asic_demo)
 
     chip.schema._merge_with_init_schema()
 

--- a/tests/targets/test_asic_demo.py
+++ b/tests/targets/test_asic_demo.py
@@ -3,6 +3,7 @@ import siliconcompiler
 from siliconcompiler.apps import sc
 
 import pytest
+from siliconcompiler.targets import asic_demo
 
 
 @pytest.mark.eda
@@ -11,7 +12,7 @@ import pytest
 def test_self_test():
     ''' Verify self-test functionality w/ Python build script '''
     chip = siliconcompiler.Chip('')
-    chip.load_target('asic_demo')
+    chip.load_target(asic_demo)
     chip.run()
     assert os.path.isfile('build/heartbeat/job0/write_gds/0/outputs/heartbeat.gds')
     assert chip.get('metric', 'holdslack', step='write_data', index='0') >= 0.0

--- a/tests/tools/test_common.py
+++ b/tests/tools/test_common.py
@@ -64,7 +64,7 @@ def test_input_file_node_name():
 def test_get_libraries():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'test')
+    lib = Library('test')
     chip.set('option', 'library', 'test')
     chip.use(lib)
 
@@ -77,7 +77,7 @@ def test_get_libraries():
 def test_get_libraries_recuriveloop():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib')
+    lib = Library('main_lib')
     lib.set('option', 'library', 'main_lib')
 
     chip.use(lib)
@@ -92,8 +92,8 @@ def test_get_libraries_recuriveloop():
 def test_get_libraries_recurive():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib')
-    tlib = Library(chip, 'test')
+    lib = Library('main_lib')
+    tlib = Library('test')
     lib.set('option', 'library', 'test')
     lib.use(tlib)
 
@@ -109,8 +109,8 @@ def test_get_libraries_recurive():
 def test_recursive_import_with_option_library():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'main_lib')
-    sub_lib = Library(chip, 'sub_lib')
+    lib = Library('main_lib')
+    sub_lib = Library('sub_lib')
     lib.set('option', 'library', 'sub_lib')
     lib.use(sub_lib)
 
@@ -127,7 +127,7 @@ def test_recursive_import_with_option_library():
 def test_get_libraries_asic_none(libtype):
     chip = Chip('<test>')
 
-    lib = Library(chip, 'test')
+    lib = Library('test')
     chip.set('option', 'library', 'test')
     chip.use(lib)
 
@@ -140,7 +140,7 @@ def test_get_libraries_asic_none(libtype):
 def test_get_libraries_asic_invalid():
     chip = Chip('<test>')
 
-    lib = Library(chip, 'test')
+    lib = Library('test')
     chip.set('option', 'library', 'test')
     chip.use(lib)
 
@@ -155,7 +155,7 @@ def test_get_libraries_asic_invalid():
 def test_get_libraries_asic_single(libtype):
     chip = Chip('<test>')
 
-    lib = Library(chip, 'test')
+    lib = Library('test')
     chip.set('option', 'library', 'test')
     chip.use(lib)
     chip.add('asic', f'{libtype}lib', 'testlib')
@@ -170,7 +170,7 @@ def test_get_libraries_asic_single(libtype):
 def test_get_libraries_asic_sub_import_single(libtype):
     chip = Chip('<test>')
 
-    lib = Library(chip, 'test')
+    lib = Library('test')
     lib.add('asic', f'{libtype}lib', 'testlib')
     chip.set('option', 'library', 'test')
     chip.use(lib)
@@ -185,7 +185,7 @@ def test_get_libraries_asic_sub_import_single(libtype):
 def test_get_libraries_asic_sub_import_overlapping(libtype):
     chip = Chip('<test>')
 
-    lib = Library(chip, 'test')
+    lib = Library('test')
     lib.add('asic', f'{libtype}lib', 'testlib')
     chip.set('option', 'library', 'test')
     chip.use(lib)
@@ -201,7 +201,7 @@ def test_get_libraries_asic_sub_import_overlapping(libtype):
 def test_get_libraries_asic_sub_import_differnet(libtype):
     chip = Chip('<test>')
 
-    lib = Library(chip, 'test')
+    lib = Library('test')
     lib.add('asic', f'{libtype}lib', 'testlib')
     chip.set('option', 'library', 'test')
     chip.use(lib)
@@ -217,7 +217,7 @@ def test_get_libraries_asic_sub_import_differnet(libtype):
 def test_get_libraries_asic_sub_not_enabled(libtype):
     chip = Chip('<test>')
 
-    lib = Library(chip, 'test')
+    lib = Library('test')
     lib.add('asic', f'{libtype}lib', 'testlib')
     chip.use(lib)
     chip.add('asic', f'{libtype}lib', 'testlib2')

--- a/tests/tools/test_docker.py
+++ b/tests/tools/test_docker.py
@@ -5,6 +5,7 @@ import glob
 import docker
 import pytest
 import sys
+from siliconcompiler.targets import asic_demo
 
 
 @pytest.fixture
@@ -32,7 +33,7 @@ def docker_image(scroot):
 @pytest.mark.skipif(sys.platform != 'linux', reason='Not supported in testing')
 def test_docker_run(docker_image, capfd):
     chip = Chip('test')
-    chip.load_target('asic_demo')
+    chip.load_target(asic_demo)
 
     chip.set('option', 'scheduler', 'name', 'docker')
     chip.set('option', 'scheduler', 'queue', docker_image)
@@ -54,7 +55,7 @@ def test_docker_run(docker_image, capfd):
 @pytest.mark.skipif(sys.platform != 'linux', reason='Not supported in testing')
 def test_docker_run_with_failure(docker_image, capfd):
     chip = Chip('test')
-    chip.load_target('asic_demo')
+    chip.load_target(asic_demo)
 
     chip.set('option', 'scheduler', 'name', 'docker')
     chip.set('option', 'scheduler', 'queue', docker_image)

--- a/tests/tools/test_ghdl.py
+++ b/tests/tools/test_ghdl.py
@@ -4,6 +4,7 @@ import siliconcompiler
 import pytest
 
 from siliconcompiler.tools.ghdl import convert
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.mark.eda
@@ -13,7 +14,7 @@ def test_ghdl(datadir):
     design_src = os.path.join(datadir, f'{design}.vhdl')
 
     chip = siliconcompiler.Chip(design)
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.input(design_src)
 
     chip.node('ghdl', 'import', convert)

--- a/tests/tools/test_icarus.py
+++ b/tests/tools/test_icarus.py
@@ -6,6 +6,7 @@ import pytest
 from siliconcompiler.tools.icarus import compile
 
 from siliconcompiler.tools.builtin import nop
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.mark.eda
@@ -22,7 +23,7 @@ def test_icarus():
                          'git+https://github.com/aolofsson/oh',
                          '23b26c4a938d4885a2a340967ae9f63c3c7a3527')
 
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.set('option', 'ydir', ydir, package='oh')
     chip.input(topfile, package='oh')
 

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -25,7 +25,7 @@ def test_klayout(datadir):
 
     chip.add('asic', 'macrolib', 'heartbeat')
 
-    lib = siliconcompiler.Library(chip, 'heartbeat')
+    lib = siliconcompiler.Library('heartbeat')
     lib.set('output', '10M', 'lef', library_lef)
     lib.set('output', '10M', 'gds', library_gds)
     chip.use(lib)

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -8,6 +8,7 @@ from siliconcompiler.tools.klayout import export
 from siliconcompiler.tools.klayout import operations
 
 from siliconcompiler.tools.builtin import nop
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.mark.eda
@@ -18,7 +19,7 @@ def test_klayout(datadir):
     library_lef = os.path.join(datadir, 'heartbeat.lef')
 
     chip = siliconcompiler.Chip('heartbeat_wrapper')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     chip.input(in_def)
 
@@ -52,7 +53,7 @@ def test_klayout_operations(datadir):
     library_gds = os.path.join(datadir, 'heartbeat.gds')
 
     chip = siliconcompiler.Chip('heartbeat')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     chip.input(library_gds)
 

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -6,6 +6,7 @@ import pytest
 from siliconcompiler.tools.openroad import floorplan
 
 from siliconcompiler.tools.builtin import nop
+from siliconcompiler.targets import freepdk45_demo
 
 
 def _setup_fifo(scroot):
@@ -22,7 +23,7 @@ def _setup_fifo(scroot):
     chip.set('constraint', 'corearea', [(10.07, 11.2), (90.25, 91)])
 
     # load tech
-    chip.load_target("freepdk45_demo")
+    chip.load_target(freepdk45_demo)
 
     # set up tool for floorplan
     flow = 'floorplan'

--- a/tests/tools/test_surelog.py
+++ b/tests/tools/test_surelog.py
@@ -6,6 +6,7 @@ import sys
 import pytest
 
 from siliconcompiler.tools.surelog import parse
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.mark.eda
@@ -16,7 +17,7 @@ def test_surelog(scroot):
     step = "parse"
 
     chip = siliconcompiler.Chip(design)
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     chip.input(gcd_src)
     chip.node('surelog', step, parse)
@@ -36,7 +37,7 @@ def test_surelog_duplicate_inputs(scroot):
     step = "parse"
 
     chip = siliconcompiler.Chip(design)
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     # Set duplicate input files.
     chip.input(gcd_src)
@@ -68,7 +69,7 @@ def test_surelog_preproc_regression(datadir):
     step = "parse"
 
     chip = siliconcompiler.Chip(design)
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
     chip.node('surelog', step, parse)
     chip.input(src)
     chip.add('option', 'define', 'MEM_ROOT=test')
@@ -93,7 +94,7 @@ def test_replay(scroot, run_cli):
     step = "parse"
 
     chip = siliconcompiler.Chip(design)
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     chip.input(src)
     chip.node('surelog', step, parse)
@@ -121,7 +122,7 @@ def test_replay(scroot, run_cli):
 @pytest.mark.quick
 def test_github_issue_1789():
     chip = siliconcompiler.Chip('encode_stream_sc_module_8')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     i_file = os.path.join(os.path.dirname(__file__),
                           'data',

--- a/tests/tools/test_yosys.py
+++ b/tests/tools/test_yosys.py
@@ -5,6 +5,7 @@ import pytest
 from siliconcompiler.tools.yosys import lec
 
 from siliconcompiler.tools.builtin import nop
+from siliconcompiler.targets import freepdk45_demo
 
 
 @pytest.mark.eda
@@ -13,7 +14,7 @@ def test_yosys_lec(datadir):
     lec_dir = os.path.join(datadir, 'lec')
 
     chip = siliconcompiler.Chip('foo')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     flow = 'lec'
     chip.node(flow, 'import', nop)
@@ -37,7 +38,7 @@ def test_yosys_lec_broken(datadir):
     lec_dir = os.path.join(datadir, 'lec')
 
     chip = siliconcompiler.Chip('foo')
-    chip.load_target('freepdk45_demo')
+    chip.load_target(freepdk45_demo)
 
     flow = 'lec'
     chip.node(flow, 'import', nop)


### PR DESCRIPTION
moves everything to `.use` and removes the chip input to library modules.