### PR TITLE
Format Tcl code using `tclfmt`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,7 +64,8 @@ jobs:
           python3 -m venv .venv
           . .venv/bin/activate
           pip3 install .[test]
-          tclint .
+          tclfmt --check .
+          tclint --no-check-style .
 
   spelling:
     name: Check spelling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ test = [
     "pytest-cov == 5.0.0",
     "PyVirtualDisplay == 3.0",
     "flake8 == 7.1.1",
-    "tclint == 0.3.2",
+    "tclint == 0.4.0",
     "codespell == 2.3.0"
 ]
 docs = [

--- a/siliconcompiler/tools/_common/tcl/sc_pin_constraints.tcl
+++ b/siliconcompiler/tools/_common/tcl/sc_pin_constraints.tcl
@@ -3,12 +3,11 @@ proc sc_collect_pin_constraints { \
     ordered_pins_arg \
     sc_side_layer_func \
     { print_func puts } } {
-
     upvar 1 $placement_pins_arg placement_pins
     upvar 1 $ordered_pins_arg ordered_pins
 
     set pin_order [dict create]
-    set placement_pins [list ]
+    set placement_pins [list]
 
     dict for {name params} [sc_cfg_get constraint pin] {
         set order [dict get $params order]

--- a/siliconcompiler/tools/magic/sc_drc.tcl
+++ b/siliconcompiler/tools/magic/sc_drc.tcl
@@ -15,13 +15,13 @@
 
 source ./sc_manifest.tcl
 
-set sc_step    [sc_cfg_get arg step]
-set sc_index   [sc_cfg_get arg index]
-set sc_task    $sc_step
+set sc_step [sc_cfg_get arg step]
+set sc_index [sc_cfg_get arg index]
+set sc_task $sc_step
 
-set sc_design    [sc_top]
+set sc_design [sc_top]
 set sc_macrolibs [sc_get_asic_libraries macro]
-set sc_stackup   [sc_cfg_get option stackup]
+set sc_stackup [sc_cfg_get option stackup]
 
 if { [sc_cfg_tool_task_exists var exclude] } {
     set sc_exclude [sc_cfg_tool_task_get var exclude]

--- a/siliconcompiler/tools/magic/sc_extspice.tcl
+++ b/siliconcompiler/tools/magic/sc_extspice.tcl
@@ -1,8 +1,8 @@
 source ./sc_manifest.tcl
 
-set sc_step    [sc_cfg_get arg step]
-set sc_index   [sc_cfg_get arg index]
-set sc_task    $sc_step
+set sc_step [sc_cfg_get arg step]
+set sc_index [sc_cfg_get arg index]
+set sc_task $sc_step
 
 set sc_design [sc_top]
 set sc_logiclibs [sc_get_asic_libraries logic]

--- a/siliconcompiler/tools/magic/sc_magic.tcl
+++ b/siliconcompiler/tools/magic/sc_magic.tcl
@@ -36,8 +36,8 @@ if { $sc_pdk == "skywater130" } {
     cif istyle sky130(vendor)
 }
 
-set mydir      [file dirname [file normalize [info script]]]
-set sc_step    [sc_cfg_get arg step]
+set mydir [file dirname [file normalize [info script]]]
+set sc_step [sc_cfg_get arg step]
 
 if { [catch { source "$mydir/sc_${sc_step}.tcl" } err] } {
     puts $err

--- a/siliconcompiler/tools/netgen/sc_lvs.tcl
+++ b/siliconcompiler/tools/netgen/sc_lvs.tcl
@@ -1,8 +1,8 @@
 source ./sc_manifest.tcl
 
-set sc_step    [sc_cfg_get arg step]
-set sc_index   [sc_cfg_get arg index]
-set sc_task    $sc_step
+set sc_step [sc_cfg_get arg step]
+set sc_index [sc_cfg_get arg index]
+set sc_task $sc_step
 
 set sc_design [sc_top]
 set sc_macrolibs [sc_get_asic_libraries macro]

--- a/siliconcompiler/tools/openroad/scripts/sc_apr.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_apr.tcl
@@ -19,7 +19,7 @@ proc sc_get_layer_name { name } {
   if { [string length $name] == 0 } {
     return ""
   }
-  if { [ string is integer $name ] } {
+  if { [string is integer $name] } {
     set layer [[ord::get_db_tech] findRoutingLayer $name]
     if { $layer == "NULL" } {
       utl::error FLW 1 "$name is not a valid routing layer."
@@ -35,8 +35,10 @@ proc has_tie_cell { type } {
   upvar sc_tool sc_tool
 
   set library_vars [sc_cfg_get library $sc_mainlib option {var}]
-  return [expr { [dict exists $library_vars openroad_tie${type}_cell] && \
-                 [dict exists $library_vars openroad_tie${type}_port] }]
+  return [expr {
+    [dict exists $library_vars openroad_tie${type}_cell] &&
+    [dict exists $library_vars openroad_tie${type}_port]
+  }]
 }
 
 proc get_tie_cell { type } {
@@ -54,46 +56,46 @@ proc get_tie_cell { type } {
 # Schema Adapter
 ###############################
 
-set sc_tool   openroad
-set sc_step   [sc_cfg_get arg step]
-set sc_index  [sc_cfg_get arg index]
-set sc_flow   [sc_cfg_get option flow]
-set sc_task   [sc_cfg_get flowgraph $sc_flow $sc_step $sc_index task]
+set sc_tool openroad
+set sc_step [sc_cfg_get arg step]
+set sc_index [sc_cfg_get arg index]
+set sc_flow [sc_cfg_get option flow]
+set sc_task [sc_cfg_get flowgraph $sc_flow $sc_step $sc_index task]
 
-set sc_refdir [sc_cfg_tool_task_get refdir ]
+set sc_refdir [sc_cfg_tool_task_get refdir]
 
 # Design
-set sc_design     [sc_top]
-set sc_optmode    [sc_cfg_get option optmode]
-set sc_pdk        [sc_cfg_get option pdk]
-set sc_stackup    [sc_cfg_get option stackup]
+set sc_design [sc_top]
+set sc_optmode [sc_cfg_get option optmode]
+set sc_pdk [sc_cfg_get option pdk]
+set sc_stackup [sc_cfg_get option stackup]
 
 # APR Parameters
-set sc_targetlibs  [sc_get_asic_libraries logic]
-set sc_mainlib     [lindex $sc_targetlibs 0]
-set sc_delaymodel  [sc_cfg_get asic delaymodel]
-set sc_pdk_vars    [sc_cfg_get pdk $sc_pdk {var} $sc_tool]
-set sc_hpinmetal   [dict get $sc_pdk_vars pin_layer_horizontal $sc_stackup]
-set sc_vpinmetal   [dict get $sc_pdk_vars pin_layer_vertical $sc_stackup]
-set sc_rc_signal   [lindex [dict get $sc_pdk_vars rclayer_signal $sc_stackup] 0]
-set sc_rc_clk      [lindex [dict get $sc_pdk_vars rclayer_clock $sc_stackup] 0]
-set sc_minmetal    [sc_cfg_get pdk $sc_pdk minlayer $sc_stackup]
-set sc_maxmetal    [sc_cfg_get pdk $sc_pdk maxlayer $sc_stackup]
+set sc_targetlibs [sc_get_asic_libraries logic]
+set sc_mainlib [lindex $sc_targetlibs 0]
+set sc_delaymodel [sc_cfg_get asic delaymodel]
+set sc_pdk_vars [sc_cfg_get pdk $sc_pdk {var} $sc_tool]
+set sc_hpinmetal [dict get $sc_pdk_vars pin_layer_horizontal $sc_stackup]
+set sc_vpinmetal [dict get $sc_pdk_vars pin_layer_vertical $sc_stackup]
+set sc_rc_signal [lindex [dict get $sc_pdk_vars rclayer_signal $sc_stackup] 0]
+set sc_rc_clk [lindex [dict get $sc_pdk_vars rclayer_clock $sc_stackup] 0]
+set sc_minmetal [sc_cfg_get pdk $sc_pdk minlayer $sc_stackup]
+set sc_maxmetal [sc_cfg_get pdk $sc_pdk maxlayer $sc_stackup]
 set sc_aspectratio [sc_cfg_get constraint aspectratio]
-set sc_density     [sc_cfg_get constraint density]
-set sc_scenarios   [dict keys [sc_cfg_get constraint timing]]
+set sc_density [sc_cfg_get constraint density]
+set sc_scenarios [dict keys [sc_cfg_get constraint timing]]
 
 # Library
 set sc_libtype [sc_cfg_get library $sc_mainlib asic libarch]
 # TODO: handle multiple sites properly
-set sc_site         [lindex [sc_cfg_get library $sc_mainlib asic site $sc_libtype] 0]
-set sc_filler       [sc_cfg_get library $sc_mainlib asic cells filler]
-set sc_dontuse      [sc_cfg_get library $sc_mainlib asic cells dontuse]
-set sc_clkbuf       [lindex [sc_cfg_tool_task_get {var} cts_clock_buffer] 0]
-set sc_filler       [sc_cfg_get library $sc_mainlib asic cells filler]
-set sc_tap          [sc_cfg_get library $sc_mainlib asic cells tap]
-set sc_endcap       [sc_cfg_get library $sc_mainlib asic cells endcap]
-set sc_pex_corners  [sc_cfg_tool_task_get {var} pex_corners]
+set sc_site [lindex [sc_cfg_get library $sc_mainlib asic site $sc_libtype] 0]
+set sc_filler [sc_cfg_get library $sc_mainlib asic cells filler]
+set sc_dontuse [sc_cfg_get library $sc_mainlib asic cells dontuse]
+set sc_clkbuf [lindex [sc_cfg_tool_task_get {var} cts_clock_buffer] 0]
+set sc_filler [sc_cfg_get library $sc_mainlib asic cells filler]
+set sc_tap [sc_cfg_get library $sc_mainlib asic cells tap]
+set sc_endcap [sc_cfg_get library $sc_mainlib asic cells endcap]
+set sc_pex_corners [sc_cfg_tool_task_get {var} pex_corners]
 set sc_power_corner [lindex [sc_cfg_tool_task_get {var} power_corner] 0]
 
 # PDK Design Rules
@@ -394,7 +396,7 @@ if { $sc_task != "floorplan" } {
 
   # Adjust routing track density
   foreach layer [[ord::get_db_tech] getLayers] {
-    if { [ $layer getRoutingLevel ] == 0 } {
+    if { [$layer getRoutingLevel] == 0 } {
       continue
     }
 

--- a/siliconcompiler/tools/openroad/scripts/sc_cts.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_cts.tcl
@@ -4,7 +4,6 @@
 #######################################
 
 if { [llength [all_clocks]] > 0 } {
-
   # Clone clock tree inverters next to register loads
   # so cts does not try to buffer the inverted clocks.
   repair_clock_inverters

--- a/siliconcompiler/tools/openroad/scripts/sc_dfm.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_dfm.tcl
@@ -9,8 +9,10 @@ foreach obstruction [[ord::get_db_block] getObstructions] {
 }
 utl::info FLW 1 "Deleted $removed_obs routing obstructions"
 
-if { $openroad_fin_add_fill == "true" && \
-     [sc_cfg_exists pdk $sc_pdk aprtech openroad $sc_stackup $sc_libtype fill] } {
+if {
+  $openroad_fin_add_fill == "true" &&
+  [sc_cfg_exists pdk $sc_pdk aprtech openroad $sc_stackup $sc_libtype fill]
+} {
   set sc_fillrules \
     [lindex [sc_cfg_get pdk $sc_pdk aprtech openroad $sc_stackup $sc_libtype fill] 0]
   density_fill -rules $sc_fillrules

--- a/siliconcompiler/tools/openroad/scripts/sc_export.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_export.tcl
@@ -3,8 +3,10 @@
 ###########################
 
 set lef_args []
-if { [lindex [sc_cfg_tool_task_get {var} ord_abstract_lef_bloat_layers] 0] \
-      == "true" } {
+if {
+  [lindex [sc_cfg_tool_task_get {var} ord_abstract_lef_bloat_layers] 0]
+  == "true"
+} {
   lappend lef_args "-bloat_occupied_layers"
 } else {
   lappend lef_args \

--- a/siliconcompiler/tools/openroad/scripts/sc_floorplan.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_floorplan.tcl
@@ -23,12 +23,14 @@ if { [sc_cfg_exists input asic floorplan] } {
   read_def -floorplan_initialize $def
 } else {
   #NOTE: assuming a two tuple value as lower left, upper right
-  set sc_diearea   [sc_cfg_get constraint outline]
-  set sc_corearea  [sc_cfg_get constraint corearea]
-  if { $sc_diearea != "" && \
-       $sc_corearea != "" } {
+  set sc_diearea [sc_cfg_get constraint outline]
+  set sc_corearea [sc_cfg_get constraint corearea]
+  if {
+    $sc_diearea != "" &&
+    $sc_corearea != ""
+  } {
     # Use die and core sizes
-    set sc_diesize  "[lindex $sc_diearea 0] [lindex $sc_diearea 1]"
+    set sc_diesize "[lindex $sc_diearea 0] [lindex $sc_diearea 1]"
     set sc_coresize "[lindex $sc_corearea 0] [lindex $sc_corearea 1]"
 
     initialize_floorplan -die_area $sc_diesize \
@@ -61,8 +63,10 @@ if { [sc_cfg_exists library $sc_mainlib option file openroad_tracks] } {
 }
 
 set do_automatic_pins 1
-if { [sc_cfg_tool_task_exists file padring] && \
-     [llength [sc_cfg_tool_task_get file padring]] > 0 } {
+if {
+  [sc_cfg_tool_task_exists file padring] &&
+  [llength [sc_cfg_tool_task_get file padring]] > 0
+} {
   set do_automatic_pins 0
 
   ###########################
@@ -208,7 +212,7 @@ if { [sc_cfg_exists constraint component] } {
       }
 
       set site_height [$site getHeight]
-      set site_width  [$site getWidth]
+      set site_width [$site getWidth]
       if { $y_grid == 0 } {
         set y_grid $site_height
       } elseif { $y_grid > $site_height } {
@@ -241,7 +245,7 @@ if { [sc_cfg_exists constraint component] } {
       set rotation 0
     }
     set rotation [expr { int($rotation) }]
-    set flip     [dict get $params flip]
+    set flip [dict get $params flip]
     if { [dict exists $params partname] } {
       set cell [dict get $params partname]
     } else {
@@ -302,8 +306,10 @@ if { $do_automatic_pins } {
 # since we get an error otherwise.
 if { [sc_design_has_unplaced_macros] } {
   if { $openroad_rtlmp_enable == "true" } {
-    set halo_max [expr { max([lindex $openroad_mpl_macro_place_halo 0], \
-                             [lindex $openroad_mpl_macro_place_halo 1]) }]
+    set halo_max [expr {
+      max([lindex $openroad_mpl_macro_place_halo 0],
+        [lindex $openroad_mpl_macro_place_halo 1])
+    }]
 
     set rtlmp_args []
     if { $openroad_rtlmp_min_instances != "" } {
@@ -370,9 +376,11 @@ if { [sc_cfg_tool_task_exists {file} ifp_tapcell] } {
 # Power Network
 ###########################
 
-if { $openroad_pdn_enable == "true" && \
-     [sc_cfg_tool_task_exists {file} pdn_config] && \
-     [llength [sc_cfg_tool_task_get {file} pdn_config]] > 0 } {
+if {
+  $openroad_pdn_enable == "true" &&
+  [sc_cfg_tool_task_exists {file} pdn_config] &&
+  [llength [sc_cfg_tool_task_get {file} pdn_config]] > 0
+} {
   set pdn_files []
   foreach pdnconfig [sc_cfg_tool_task_get {file} pdn_config] {
     if { [lsearch -exact $pdn_files $pdnconfig] != -1 } {

--- a/siliconcompiler/tools/openroad/scripts/sc_metrics.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_metrics.tcl
@@ -59,8 +59,10 @@ if { [sc_cfg_tool_task_check_in_list unconstrained var reports] } {
     > reports/timing/unconstrained.topN.rpt
 }
 
-if { [sc_cfg_tool_task_check_in_list clock_skew var reports] && \
-     [llength [all_clocks]] > 0 } {
+if {
+  [sc_cfg_tool_task_check_in_list clock_skew var reports] &&
+  [llength [all_clocks]] > 0
+} {
   puts "$PREFIX clock_skew"
   report_clock_skew -setup -digits 4 > reports/timing/skew.setup.rpt
   sc_display_report reports/timing/skew.setup.rpt

--- a/siliconcompiler/tools/openroad/scripts/sc_physyn.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_physyn.tcl
@@ -1,4 +1,3 @@
-
 # while (not good enough):
 #   global placement
 #   estimate parasitics

--- a/siliconcompiler/tools/openroad/scripts/sc_procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_procs.tcl
@@ -19,8 +19,10 @@ proc sc_global_placement_density {} {
   # User specified adjustment
   if { $openroad_gpl_uniform_placement_adjustment > 0.0 } {
     set or_uniform_adjusted_density \
-      [expr { $or_uniform_density + ((1.0 - $or_uniform_density) * \
-              $openroad_gpl_uniform_placement_adjustment) + $or_adjust_density_adder }]
+      [expr {
+        $or_uniform_density + ((1.0 - $or_uniform_density) *
+          $openroad_gpl_uniform_placement_adjustment) + $or_adjust_density_adder
+      }]
     if { $or_uniform_adjusted_density > 1.00 } {
       utl::warn FLW 1 "Adjusted density exceeds 1.00 ([format %0.3f $or_uniform_adjusted_density]),\
         reverting to use ($openroad_gpl_place_density) for global placement"
@@ -56,8 +58,10 @@ proc sc_global_placement { args } {
   global openroad_gpl_padding
 
   set openroad_gpl_args []
-  if { $openroad_gpl_routability_driven == "true" && \
-       ![info exists flags(-disable_routability_driven)] } {
+  if {
+    $openroad_gpl_routability_driven == "true" &&
+    ![info exists flags(-disable_routability_driven)]
+  } {
     lappend openroad_gpl_args "-routability_driven"
   }
   if { $openroad_gpl_timing_driven == "true" } {
@@ -235,8 +239,10 @@ proc sc_design_has_unplaced_pads {} {
 
 proc sc_design_has_placeable_ios {} {
   foreach bterm [[ord::get_db_block] getBTerms] {
-    if { [$bterm getFirstPinPlacementStatus] != "FIXED" &&
-         [$bterm getFirstPinPlacementStatus] != "LOCKED" } {
+    if {
+      [$bterm getFirstPinPlacementStatus] != "FIXED" &&
+      [$bterm getFirstPinPlacementStatus] != "LOCKED"
+    } {
       return true
     }
   }

--- a/siliconcompiler/tools/openroad/scripts/sc_rcx.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_rcx.tcl
@@ -9,7 +9,7 @@ source ./sc_manifest.tcl > /dev/null
 ###############################
 
 proc sc_get_layer_name { name } {
-  if { [ string is integer $name ] } {
+  if { [string is integer $name] } {
     set layer [[ord::get_db_tech] findRoutingLayer $name]
     if { $layer == "NULL" } {
       utl::error FLW 1 "$name is not a valid routing layer."
@@ -23,18 +23,18 @@ proc sc_get_layer_name { name } {
 # Schema Adapter
 ###############################
 
-set sc_tool   openroad
-set sc_step   [sc_cfg_get arg step]
-set sc_index  [sc_cfg_get arg index]
-set sc_flow   [sc_cfg_get option flow]
-set sc_task   [sc_cfg_get flowgraph $sc_flow $sc_step $sc_index task]
+set sc_tool openroad
+set sc_step [sc_cfg_get arg step]
+set sc_index [sc_cfg_get arg index]
+set sc_flow [sc_cfg_get option flow]
+set sc_task [sc_cfg_get flowgraph $sc_flow $sc_step $sc_index task]
 
 set sc_refdir [sc_cfg_tool_task_get refdir]
 
 # Design
-set sc_design     [sc_top]
-set sc_pdk        [sc_cfg_get option pdk]
-set sc_stackup    [sc_cfg_get option stackup]
+set sc_design [sc_top]
+set sc_pdk [sc_cfg_get option pdk]
+set sc_stackup [sc_cfg_get option stackup]
 
 # Library
 set sc_libtype [lindex [sc_cfg_tool_task_get {var} libtype] 0]

--- a/siliconcompiler/tools/openroad/scripts/sc_route.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_route.tcl
@@ -71,10 +71,14 @@ global_route -guide_file "./route.guide" \
 ######################
 
 estimate_parasitics -global_routing
-if { $openroad_ant_check == "true" && \
-     [check_antennas -report_file "reports/${sc_design}_antenna.rpt"] != 0 } {
-  if { $openroad_ant_repair == "true" && \
-       [llength [sc_cfg_get library $sc_mainlib asic cells antenna]] != 0 } {
+if {
+  $openroad_ant_check == "true" &&
+  [check_antennas -report_file "reports/${sc_design}_antenna.rpt"] != 0
+} {
+  if {
+    $openroad_ant_repair == "true" &&
+    [llength [sc_cfg_get library $sc_mainlib asic cells antenna]] != 0
+  } {
     set sc_antenna [lindex [sc_cfg_get library $sc_mainlib asic cells antenna] 0]
 
     # Remove filler cells before attempting to repair antennas

--- a/siliconcompiler/tools/openroad/scripts/sc_screenshot.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_screenshot.tcl
@@ -14,8 +14,10 @@ sc_save_image "screenshot" "outputs/${sc_design}.png" $sc_resolution
 
 gui::restore_display_controls
 
-if { [sc_cfg_tool_task_exists {var} include_report_images] &&
-     [lindex [sc_cfg_tool_task_get {var} include_report_images] 0]
-     == "true" } {
+if {
+  [sc_cfg_tool_task_exists {var} include_report_images] &&
+  [lindex [sc_cfg_tool_task_get {var} include_report_images] 0]
+  == "true"
+} {
   source -echo "${sc_refdir}/sc_write_images.tcl"
 }

--- a/siliconcompiler/tools/openroad/scripts/sc_write_images.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_write_images.tcl
@@ -156,12 +156,13 @@ proc sc_image_estimated_routing_congestion {} {
   sc_image_setup_default
 
   suppress_message GRT 10
-  catch { \
+  catch {
     sc_image_heatmap "Estimated Congestion (RUDY)" \
       "RUDY" \
       "estimated_routing_congestion.png" \
       "estimated routing congestion" \
-      0 } err
+      0
+  } err
   unsuppress_message GRT 10
 }
 
@@ -271,30 +272,31 @@ proc sc_image_optimizer {} {
   gui::set_display_controls "Instances/*" visible true
   gui::set_display_controls "Instances/Physical/*" visible false
 
-  set hold_count       [select -name "hold*" -type Inst -highlight 0]       ;# green
-  set input_count      [select -name "input*" -type Inst -highlight 1]      ;# yellow
-  set output_count     [select -name "output*" -type Inst -highlight 1]
-  set repeater_count   [select -name "repeater*" -type Inst -highlight 3]   ;# magenta
-  set fanout_count     [select -name "fanout*" -type Inst -highlight 3]
-  set load_slew_count  [select -name "load_slew*" -type Inst -highlight 3]
-  set max_cap_count    [select -name "max_cap*" -type Inst -highlight 3]
+  set hold_count [select -name "hold*" -type Inst -highlight 0] ;# green
+  set input_count [select -name "input*" -type Inst -highlight 1] ;# yellow
+  set output_count [select -name "output*" -type Inst -highlight 1]
+  set repeater_count [select -name "repeater*" -type Inst -highlight 3] ;# magenta
+  set fanout_count [select -name "fanout*" -type Inst -highlight 3]
+  set load_slew_count [select -name "load_slew*" -type Inst -highlight 3]
+  set max_cap_count [select -name "max_cap*" -type Inst -highlight 3]
   set max_length_count [select -name "max_length*" -type Inst -highlight 3]
-  set wire_count       [select -name "wire*" -type Inst -highlight 3]
-  set rebuffer_count   [select -name "rebuffer*" -type Inst -highlight 4]   ;# red
-  set split_count      [select -name "split*" -type Inst -highlight 5]      ;# dark green
+  set wire_count [select -name "wire*" -type Inst -highlight 3]
+  set rebuffer_count [select -name "rebuffer*" -type Inst -highlight 4] ;# red
+  set split_count [select -name "split*" -type Inst -highlight 5] ;# dark green
 
-  set select_count [expr { \
-    $hold_count + \
-    $input_count + \
-    $output_count + \
-    $repeater_count + \
-    $fanout_count + \
-    $load_slew_count + \
-    $max_cap_count + \
-    $max_length_count + \
-    $wire_count + \
-    $rebuffer_count + \
-    $split_count }]
+  set select_count [expr {
+    $hold_count +
+    $input_count +
+    $output_count +
+    $repeater_count +
+    $fanout_count +
+    $load_slew_count +
+    $max_cap_count +
+    $max_length_count +
+    $wire_count +
+    $rebuffer_count +
+    $split_count
+  }]
 
   if { $select_count == 0 } {
     # Nothing selected

--- a/siliconcompiler/tools/opensta/scripts/sc_procs.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_procs.tcl
@@ -1,4 +1,3 @@
-
 ###########################
 # Count the logic depth of the critical path
 ###########################

--- a/siliconcompiler/tools/vivado/scripts/sc_run.tcl
+++ b/siliconcompiler/tools/vivado/scripts/sc_run.tcl
@@ -1,4 +1,3 @@
-
 ###############################
 # Reading SC Schema
 ###############################
@@ -15,13 +14,13 @@ if { [sc_cfg_exists input fpga xdc] } {
 } else {
     set sc_constraint ""
 }
-set sc_tool       "vivado"
-set sc_partname   [sc_cfg_get fpga partname]
-set sc_step       [sc_cfg_get arg step]
-set sc_index      [sc_cfg_get arg index]
-set sc_flow       [sc_cfg_get option flow]
-set sc_task       [sc_cfg_get flowgraph $sc_flow $sc_step $sc_index task]
-set sc_refdir     [sc_cfg_tool_task_get refdir]
+set sc_tool "vivado"
+set sc_partname [sc_cfg_get fpga partname]
+set sc_step [sc_cfg_get arg step]
+set sc_index [sc_cfg_get arg index]
+set sc_flow [sc_cfg_get option flow]
+set sc_task [sc_cfg_get flowgraph $sc_flow $sc_step $sc_index task]
+set sc_refdir [sc_cfg_tool_task_get refdir]
 
 source $sc_refdir/sc_$sc_task.tcl
 

--- a/siliconcompiler/tools/yosys/sc_lec.tcl
+++ b/siliconcompiler/tools/yosys/sc_lec.tcl
@@ -6,14 +6,14 @@ set sc_tool yosys
 yosys echo on
 
 #Handling remote/local script execution
-set sc_step   [sc_cfg_get arg step]
-set sc_index  [sc_cfg_get arg index]
-set sc_flow   [sc_cfg_get option flow]
-set sc_task   [sc_cfg_get flowgraph $sc_flow $sc_step $sc_index task]
-set sc_refdir [sc_cfg_tool_task_get refdir ]
+set sc_step [sc_cfg_get arg step]
+set sc_index [sc_cfg_get arg index]
+set sc_flow [sc_cfg_get option flow]
+set sc_task [sc_cfg_get flowgraph $sc_flow $sc_step $sc_index task]
+set sc_refdir [sc_cfg_tool_task_get refdir]
 
-set sc_design      [sc_top]
-set sc_targetlibs  [sc_get_asic_libraries logic]
+set sc_design [sc_top]
+set sc_targetlibs [sc_get_asic_libraries logic]
 
 # TODO: properly handle complexity here
 set lib [lindex $sc_targetlibs 0]

--- a/siliconcompiler/tools/yosys/sc_syn.tcl
+++ b/siliconcompiler/tools/yosys/sc_syn.tcl
@@ -10,21 +10,21 @@ yosys echo on
 # Schema Adapter
 ###############################
 
-set sc_tool   yosys
-set sc_step   [sc_cfg_get arg step]
-set sc_index  [sc_cfg_get arg index]
-set sc_flow   [sc_cfg_get option flow]
-set sc_task   [sc_cfg_get flowgraph $sc_flow $sc_step $sc_index task]
+set sc_tool yosys
+set sc_step [sc_cfg_get arg step]
+set sc_index [sc_cfg_get arg index]
+set sc_flow [sc_cfg_get option flow]
+set sc_task [sc_cfg_get flowgraph $sc_flow $sc_step $sc_index task]
 set sc_refdir [sc_cfg_tool_task_get refdir]
 
 ####################
 # DESIGNER's CHOICE
 ####################
 
-set sc_design      [sc_top]
-set sc_flow        [sc_cfg_get option flow]
-set sc_optmode     [sc_cfg_get option optmode]
-set sc_pdk         [sc_cfg_get option pdk]
+set sc_design [sc_top]
+set sc_flow [sc_cfg_get option flow]
+set sc_optmode [sc_cfg_get option optmode]
+set sc_pdk [sc_cfg_get option pdk]
 
 ########################################################
 # Design Inputs

--- a/siliconcompiler/tools/yosys/syn_asic.tcl
+++ b/siliconcompiler/tools/yosys/syn_asic.tcl
@@ -82,8 +82,8 @@ proc determine_keep_hierarchy { iter cell_limit } {
 # DESIGNER's CHOICE
 ####################
 
-set sc_logiclibs        [sc_get_asic_libraries logic]
-set sc_macrolibs        [sc_get_asic_libraries macro]
+set sc_logiclibs [sc_get_asic_libraries logic]
+set sc_macrolibs [sc_get_asic_libraries macro]
 
 set sc_libraries [sc_cfg_tool_task_get {file} synthesis_libraries]
 if { [sc_cfg_tool_task_exists {file} synthesis_libraries_macros] } {
@@ -127,8 +127,10 @@ proc has_tie_cell { type } {
     upvar sc_mainlib sc_mainlib
     upvar sc_tool sc_tool
 
-    return [expr { [sc_cfg_exists library $sc_mainlib option {var} yosys_tie${type}_cell] && \
-                   [sc_cfg_exists library $sc_mainlib option {var} yosys_tie${type}_port] }]
+    return [expr {
+        [sc_cfg_exists library $sc_mainlib option {var} yosys_tie${type}_cell] &&
+        [sc_cfg_exists library $sc_mainlib option {var} yosys_tie${type}_port]
+    }]
 }
 
 proc get_tie_cell { type } {
@@ -149,9 +151,11 @@ proc has_buffer_cell { } {
     upvar sc_mainlib sc_mainlib
     upvar sc_tool sc_tool
 
-    return [expr { [sc_cfg_exists library $sc_mainlib option {var} yosys_buffer_cell] && \
-                   [sc_cfg_exists library $sc_mainlib option {var} yosys_buffer_input] && \
-                   [sc_cfg_exists library $sc_mainlib option {var} yosys_buffer_output] }]
+    return [expr {
+        [sc_cfg_exists library $sc_mainlib option {var} yosys_buffer_cell] &&
+        [sc_cfg_exists library $sc_mainlib option {var} yosys_buffer_input] &&
+        [sc_cfg_exists library $sc_mainlib option {var} yosys_buffer_output]
+    }]
 }
 
 proc get_buffer_cell { } {
@@ -160,8 +164,8 @@ proc get_buffer_cell { } {
     upvar sc_tool sc_tool
 
     set cell [lindex [sc_cfg_get library $sc_mainlib option {var} yosys_buffer_cell] 0]
-    set in   [lindex [sc_cfg_get library $sc_mainlib option {var} yosys_buffer_input] 0]
-    set out  [lindex [sc_cfg_get library $sc_mainlib option {var} yosys_buffer_output] 0]
+    set in [lindex [sc_cfg_get library $sc_mainlib option {var} yosys_buffer_input] 0]
+    set out [lindex [sc_cfg_get library $sc_mainlib option {var} yosys_buffer_output] 0]
 
     return "$cell $in $out"
 }
@@ -207,8 +211,10 @@ yosys hierarchy -top $sc_design
 # Mark modules to keep from getting removed in flattening
 preserve_modules
 
-set flatten_design [expr { [lindex [sc_cfg_tool_task_get var flatten] 0] \
-    == "true" }]
+set flatten_design [expr {
+    [lindex [sc_cfg_tool_task_get var flatten] 0]
+    == "true"
+}]
 set synth_args []
 if { $flatten_design } {
     lappend synth_args "-flatten"
@@ -359,8 +365,10 @@ if { [llength $yosys_hilomap_args] != 0 } {
     yosys hilomap -singleton {*}$yosys_hilomap_args
 }
 
-if { [has_buffer_cell] && \
-     [sc_cfg_tool_task_get var add_buffers] == "true" } {
+if {
+    [has_buffer_cell] &&
+    [sc_cfg_tool_task_get var add_buffers] == "true"
+} {
     yosys insbuf -buf {*}[get_buffer_cell]
 }
 

--- a/siliconcompiler/tools/yosys/syn_fpga.tcl
+++ b/siliconcompiler/tools/yosys/syn_fpga.tcl
@@ -1,27 +1,31 @@
-
 source "$sc_refdir/syn_asic_fpga_shared.tcl"
 
 proc legalize_flops { feature_set } {
-
     set legalize_flop_types []
 
-    if { [lsearch -exact $feature_set enable] >= 0 && \
-         [lsearch -exact $feature_set async_set] >= 0 && \
-         [lsearch -exact $feature_set async_reset] >= 0 } {
+    if {
+        [lsearch -exact $feature_set enable] >= 0 &&
+        [lsearch -exact $feature_set async_set] >= 0 &&
+        [lsearch -exact $feature_set async_reset] >= 0
+    } {
         lappend legalize_flop_types \$_DFF_P_
         lappend legalize_flop_types \$_DFF_PN?_
         lappend legalize_flop_types \$_DFFE_PP_
         lappend legalize_flop_types \$_DFFE_PN?P_
         lappend legalize_flop_types \$_DFFSR_PNN_
         lappend legalize_flop_types \$_DFFSRE_PNNP_
-    } elseif { [lsearch -exact $feature_set enable] >= 0 && \
-               [lsearch -exact $feature_set async_set] >= 0 } {
+    } elseif {
+        [lsearch -exact $feature_set enable] >= 0 &&
+        [lsearch -exact $feature_set async_set] >= 0
+    } {
         lappend legalize_flop_types \$_DFF_P_
         lappend legalize_flop_types \$_DFF_PN1_
         lappend legalize_flop_types \$_DFFE_PP_
         lappend legalize_flop_types \$_DFFE_PN1P_
-    } elseif { [lsearch -exact $feature_set enable] >= 0 && \
-               [lsearch -exact $feature_set async_reset] >= 0 } {
+    } elseif {
+        [lsearch -exact $feature_set enable] >= 0 &&
+        [lsearch -exact $feature_set async_reset] >= 0
+    } {
         lappend legalize_flop_types \$_DFF_P_
         lappend legalize_flop_types \$_DFF_PN0_
         lappend legalize_flop_types \$_DFFE_PP_
@@ -31,8 +35,10 @@ proc legalize_flops { feature_set } {
         lappend legalize_flop_types \$_DFF_P??_
         lappend legalize_flop_types \$_DFFE_PP_
         lappend legalize_flop_types \$_DFFE_P??P_
-    } elseif { [lsearch -exact $feature_set async_set] >= 0 && \
-               [lsearch -exact $feature_set async_reset] >= 0 } {
+    } elseif {
+        [lsearch -exact $feature_set async_set] >= 0 &&
+        [lsearch -exact $feature_set async_reset] >= 0
+    } {
         lappend legalize_flop_types \$_DFF_P_
         lappend legalize_flop_types \$_DFF_PN?_
         lappend legalize_flop_types \$_DFFSR_PNN_
@@ -59,8 +65,7 @@ proc legalize_flops { feature_set } {
 }
 
 proc get_dsp_options { sc_syn_dsp_options } {
-
-    set option_text [ list ]
+    set option_text [list]
     foreach dsp_option $sc_syn_dsp_options {
         lappend option_text -D $dsp_option
     }
@@ -80,7 +85,7 @@ if { [sc_cfg_exists fpga $sc_partname var feature_set] } {
     set sc_syn_feature_set \
         [sc_cfg_get fpga $sc_partname var feature_set]
 } else {
-    set sc_syn_feature_set [ list ]
+    set sc_syn_feature_set [list]
 }
 
 if { [sc_cfg_exists fpga $sc_partname var yosys_dsp_options] } {
@@ -89,7 +94,7 @@ if { [sc_cfg_exists fpga $sc_partname var yosys_dsp_options] } {
         [sc_cfg_get fpga $sc_partname var yosys_dsp_options]
     yosys log "Yosys DSP techmap options = $sc_syn_dsp_options"
 } else {
-    set sc_syn_dsp_options [ list ]
+    set sc_syn_dsp_options [list]
 }
 
 # TODO: add logic that remaps yosys built in name based on part number
@@ -101,13 +106,11 @@ yosys hierarchy -top $sc_design
 if { [string match {ice*} $sc_partname] } {
     yosys synth_ice40 -top $sc_design -json "${sc_design}.netlist.json"
 } else {
-
     # Pre-processing step:  if DSPs instance are hard-coded into
     # the user's design, we can use a blackbox flow for DSP mapping
     # as follows:
 
     if { [sc_cfg_exists fpga $sc_partname file yosys_macrolib] } {
-
         set sc_syn_macrolibs \
             [sc_cfg_get fpga $sc_partname file yosys_macrolib]
 


### PR DESCRIPTION
Announcing that `tclint` finally includes a formatter (`tclfmt`) by way of this PR!

The first commit is the result of running the formatter on the code (`tcfmt --in-place .`). It mostly follows `tclint`'s style guide, and uses the same configuration. There are two categories of changes that are responsible for most of the diff that perhaps might be controversial:

- `tclfmt` pushes the braces for multi-line expressions onto different lines. There were a couple reasons for doing this, the main one is that it consistently looks good across differently configured indent levels (the style currently used by this repo can sometimes have a case where the expression of an if statement is indented the same as the body, for example). 
- It breaks `set` alignment. This was just a case of being more opinionated for simplicity, although I'm open to making `tclfmt` respect the `allow-aligned-sets` config if you feel strongly about preserving these.

I wrote up some docs describing usage of the utility plus a description of the style guide with some rationale, so that might be interesting to look through: https://github.com/nmoroze/tclint/blob/v0.4.0/docs/tclfmt.md.

The second commit adds the formatter to CI. Turns out it's much easier to comprehensively enforce a consistent style by diffing against formatted code rather than checking for different style violations piecemeal. Because of this, `tclfmt` is gonna be the canonical way of enforcing style going forward, and I'll eventually remove style checks from `tclint` itself. To preview this future behavior and reduce output noise, `tclint` got a new flag `--no-check-style`. `tclfmt` also doesn't automatically reducing line length yet, so `--no-check-style` still reports line length violations. 

As always, I'm open to any feedback!