### PR TITLE
fix editable wheel install speed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,12 +1,1 @@
-include pyproject.toml
-include README.md
-
 graft siliconcompiler/*
-
-prune docs
-prune examples
-prune tests
-prune setup
-prune scripts
-prune .*
-exclude .*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,12 @@
 [build-system]
 requires = [
-    "setuptools >= 61.2",
-    "setuptools_scm[toml] >= 6.2"
+    "setuptools >= 64",
+    "setuptools_scm[toml] >= 8"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# Presence of this section activates setuptools_scm, even though it's empty
 
 [project]
 name = "siliconcompiler"
@@ -93,7 +96,7 @@ examples = [
 include-package-data = true
 
 [tool.setuptools.packages]
-find = {}
+find = {namespaces = false}  # Disable implicit namespaces
 
 [tool.setuptools.dynamic]
 version = {attr = "siliconcompiler._metadata.version"}


### PR DESCRIPTION
The wheel install slows down a good amount when installing as editable because its iterating over all files. this avoids this.
https://github.com/siliconcompiler/siliconcompiler/actions/runs/10838253192