### PR TITLE
Grossmann/add vpr device option

### DIFF
--- a/examples/fpga_flow/arch/example_arch_X008Y008/example_arch_X008Y008.xml
+++ b/examples/fpga_flow/arch/example_arch_X008Y008/example_arch_X008Y008.xml
@@ -3,7 +3,7 @@
 <architecture>
 	<models/>
 	<layout>
-		<fixed_layout name="zafg000sc_X008Y008" width="8" height="8">
+		<fixed_layout name="example_arch_X008Y008" width="8" height="8">
 			<single type="EMPTY" priority="1" x="0" y="0"/>
 			<single type="iob_left" priority="10" x="0" y="1">
 				<metadata>

--- a/siliconcompiler/fpgas/vpr_example.py
+++ b/siliconcompiler/fpgas/vpr_example.py
@@ -47,9 +47,9 @@ def setup():
         # which <fixed_layout> name to use when running VPR.  These examples
         # use the following names:
         if (part_name == 'example_arch_X005Y005'):
-            fpga.set('fpga', part_name, 'var', 'device_code', 'fpga_beta')
+            fpga.set('fpga', part_name, 'var', 'vpr_device_code', 'fpga_beta')
         else:
-            fpga.set('fpga', part_name, 'var', 'device_code', part_name)
+            fpga.set('fpga', part_name, 'var', 'vpr_device_code', part_name)
 
         fpga.set('fpga', part_name, 'lutsize', lut_size)
 

--- a/siliconcompiler/fpgas/vpr_example.py
+++ b/siliconcompiler/fpgas/vpr_example.py
@@ -48,7 +48,7 @@ def setup():
         # use the following names:
         if (part_name == 'example_arch_X005Y005'):
             fpga.set('fpga', part_name, 'var', 'device_code', 'fpga_beta')
-        else :
+        else:
             fpga.set('fpga', part_name, 'var', 'device_code', part_name)
 
         fpga.set('fpga', part_name, 'lutsize', lut_size)

--- a/siliconcompiler/fpgas/vpr_example.py
+++ b/siliconcompiler/fpgas/vpr_example.py
@@ -43,6 +43,14 @@ def setup():
 
         fpga.set('fpga', part_name, 'vendor', vendor)
 
+        # Part name is specified per architecture file.  Device code specifies
+        # which <fixed_layout> name to use when running VPR.  These examples
+        # use the following names:
+        if (part_name == 'example_arch_X005Y005'):
+            fpga.set('fpga', part_name, 'var', 'device_code', 'fpga_beta')
+        else :
+            fpga.set('fpga', part_name, 'var', 'device_code', part_name)
+
         fpga.set('fpga', part_name, 'lutsize', lut_size)
 
         arch_root = os.path.join(flow_root, 'arch', part_name)

--- a/siliconcompiler/tools/genfasm/genfasm.py
+++ b/siliconcompiler/tools/genfasm/genfasm.py
@@ -1,5 +1,6 @@
 from siliconcompiler.tools.vpr.vpr import parse_version as vpr_parse_version
 from siliconcompiler.tools.vpr.vpr import normalize_version as vpr_normalize_version
+from siliconcompiler.tools.vpr.vpr import add_tool_requirements as add_vpr_requirements
 
 '''
 Generate a `FSAM <https://github.com/chipsalliance/fasm>`_ file from the output of
@@ -24,6 +25,12 @@ def setup(chip):
     chip.set('tool', 'genfasm', 'exe', 'genfasm', clobber=False)
     chip.set('tool', 'genfasm', 'vswitch', '--version')
     chip.set('tool', 'genfasm', 'version', '>=8.1.0', clobber=False)
+
+    add_tool_requirements(chip)
+
+
+def add_tool_requirements(chip):
+    add_vpr_requirements(chip)
 
 
 def parse_version(chip):

--- a/siliconcompiler/tools/vpr/vpr.py
+++ b/siliconcompiler/tools/vpr/vpr.py
@@ -66,7 +66,7 @@ def setup_tool(chip, clobber=True):
         chip.add('tool', tool, 'task', task, 'require', f'fpga,{part_name},var,{resource}',
                  step=step, index=index)
 
-    chip.add('tool', tool, 'task', task, 'require', f'fpga,{part_name},var,device_code',
+    chip.add('tool', tool, 'task', task, 'require', f'fpga,{part_name},var,vpr_device_code',
              step=step, index=index)
 
 
@@ -79,7 +79,7 @@ def runtime_options(chip):
 
     options = []
 
-    device_code = chip.get('fpga', part_name, 'var', 'device_code')
+    device_code = chip.get('fpga', part_name, 'var', 'vpr_device_code')
 
     options.append(f"--device {device_code[0]}")
 

--- a/siliconcompiler/tools/vpr/vpr.py
+++ b/siliconcompiler/tools/vpr/vpr.py
@@ -66,6 +66,16 @@ def setup_tool(chip, clobber=True):
         chip.add('tool', tool, 'task', task, 'require', f'fpga,{part_name},var,{resource}',
                  step=step, index=index)
 
+    add_tool_requirements(chip)
+
+def add_tool_requirements(chip):
+
+    step = chip.get('arg', 'step')
+    index = chip.get('arg', 'index')
+    tool, task = get_tool_task(chip, step, index)
+
+    part_name = chip.get('fpga', 'partname')
+
     chip.add('tool', tool, 'task', task, 'require', f'fpga,{part_name},var,vpr_device_code',
              step=step, index=index)
 

--- a/siliconcompiler/tools/vpr/vpr.py
+++ b/siliconcompiler/tools/vpr/vpr.py
@@ -68,6 +68,7 @@ def setup_tool(chip, clobber=True):
 
     add_tool_requirements(chip)
 
+
 def add_tool_requirements(chip):
 
     step = chip.get('arg', 'step')

--- a/siliconcompiler/tools/vpr/vpr.py
+++ b/siliconcompiler/tools/vpr/vpr.py
@@ -66,6 +66,9 @@ def setup_tool(chip, clobber=True):
         chip.add('tool', tool, 'task', task, 'require', f'fpga,{part_name},var,{resource}',
                  step=step, index=index)
 
+    chip.add('tool', tool, 'task', task, 'require', f'fpga,{part_name},var,device_code',
+             step=step, index=index)
+
 
 def runtime_options(chip):
 
@@ -75,6 +78,10 @@ def runtime_options(chip):
     tool, task = get_tool_task(chip, step, index)
 
     options = []
+
+    device_code = chip.get('fpga', part_name, 'var', 'device_code')
+
+    options.append(f"--device {device_code[0]}")
 
     options.append(f"--write_block_usage {__block_file}")
     options.append("--outfile_prefix outputs/")


### PR DESCRIPTION
VPR has a ``--device`` option that defaults to the value ``auto``.  The default value is intended to set VPR's default behavior to automatically select a minimum size array for the circuit being mapped, which it normally does by processing the content of an ``<auto_layout>`` section of the XML file.  However, VPR is smart enough to use ``<fixed_layout>`` sections if no ``<auto_layout>`` section is provided and the default ``--device`` setting is in place.

The above behavior is not really appropriate for an SC flow, which is aimed at producing output for a specific architecture size.  As a result, this PR proposes to make setting ``--device`` to a valid value in all cases using a part name variable called ``device_code``.  This will have the following effects

* All FPGA part drivers will need to have an equivalent to the following

``chip.set('fpga', part_name, 'var', 'device_code', <string>)``

* It will still be possible to use VPR in its traditional size-independent manner by setting this variable's value to ``auto`` in the applicable FPGA part driver.
* Writing a part driver for an XML file that has multiple subsections to its ``<layout>`` tag (examples:  both ``<auto_layout>`` and ``<fixed_layout>`` in the same file, multiple ``<fixed_layout>`` sections in the same file) will have a clear "best practice" to define each layout option as a separate part name in the same architecture family's Python module, and simply have the same architecture XML file specified for each part with the correct device code specified for each part name.  In such a regime, providing an rr_graph XML file will not be appropriate unless a separate RR graph is provided for each device code.

The above observations probably beg the question why part name and device code should ever have different values or be independent variables.  For logik testing/validation of revisions of existing architectures it is necessary to introduce a temporary part name to disambiguate the new version from the old version as an assist to the package manager.  While the device code is a fixed string inside an XML file, the part name can be selected independently of any file content.  For this reason I do not recommend forcing them to be identical in all circumstances, even if their having equal values will be a common case.  The existing CI suite in fact has divergence between part names and device codes already due to some historical phenomena, so this case is already tested.

