### PR TITLE
speedup slurm for CI

### DIFF
--- a/setup/docker/builder.py
+++ b/setup/docker/builder.py
@@ -309,6 +309,27 @@ def _get_tool_image_check_tag(tool):
     build_file = os.path.join(_install_script_path, f'install-{tool}.sh')
     if os.path.exists(build_file):
         hash.update(get_file_hash(build_file).encode('utf-8'))
+    cmds = _tools.get_field(tool, 'docker-cmds')
+    if cmds:
+        for cmd in cmds:
+            hash.update(cmd.encode('utf-8'))
+
+    extra_files = _tools.get_field(tool, 'docker-extra-files')
+    if extra_files:
+        for extra_file in extra_files:
+            path = os.path.join(_builder_path, extra_file)
+            files = []
+            if os.path.isdir(path):
+                for file in os.listdir(path):
+                    file = os.path.join(path, file)
+                    if os.path.isfile(file):
+                        files.append(file)
+            else:
+                files = [path]
+
+            for file in sorted(files):
+                hash.update(get_file_hash(file).encode('utf-8'))
+
     depends_on = _tools.get_field(tool, 'docker-depends')
     if depends_on:
         depends_hash = _get_tool_image_check_tag(depends_on)

--- a/setup/docker/builder.py
+++ b/setup/docker/builder.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import sys
 
 import argparse
 import docker
@@ -11,16 +10,16 @@ import shutil
 import requests
 from siliconcompiler import __version__
 from siliconcompiler import utils
+# Import tools which contains all the version information
+from siliconcompiler.toolscripts import _tools
+
 
 _file_path = os.path.dirname(__file__)
 _builder_path = os.path.abspath(os.path.join(_file_path, '..'))
 _tools_path = os.path.abspath(
     os.path.join(_file_path, '..', '..', 'siliconcompiler', 'toolscripts'))
 _install_script_path = os.path.join(_tools_path, 'ubuntu20')
-sys.path.append(_tools_path)
 
-# Import tools which contains all the version information
-import _tools  # noqa E402
 
 _registry = 'ghcr.io'
 _images = {}

--- a/setup/docker/slurm/slurm.conf.in
+++ b/setup/docker/slurm/slurm.conf.in
@@ -20,7 +20,7 @@ SrunPortRange=50001-52000
 MinJobAge=30
 MessageTimeout=30
 SchedulerType=sched/builtin
-SchedulerParameters=batch_sched_delay=20,step_retry_time=10,sched_interval=10,sched_min_interval=200000
+SchedulerParameters=batch_sched_delay=20,step_retry_time=2,sched_interval=1,sched_min_interval=200000
 SelectType=select/linear
 
 ClusterName=I10


### PR DESCRIPTION
Before
```
112.05s call     tests/flows/test_slurm_local.py::test_slurm_local_py
```
After
```
76.10s call     tests/flows/test_slurm_local.py::test_slurm_local_py
```