### PR TITLE
speedup server tests by reducing checks from 30 seconds to 1 second

### DIFF
--- a/siliconcompiler/remote/schema.py
+++ b/siliconcompiler/remote/schema.py
@@ -2,7 +2,7 @@ from siliconcompiler.schema.schema_cfg import scparam
 from siliconcompiler.schema import Schema
 
 
-SCHEMA_VERSION = '0.0.1'
+SCHEMA_VERSION = '0.0.2'
 
 
 def schema_cfg():
@@ -92,6 +92,16 @@ def schema_cfg():
                 "api: server.set('option', 'loglevel', 'info')"],
             schelp="""
             Provides explicit control over the level of debug logging printed.""")
+
+    scparam(cfg, ['option', 'checkinterval'],
+            sctype='int',
+            defvalue=30,
+            shorthelp="Interval for client",
+            switch="-checkinterval <int>",
+            example=["cli: -checkinterval 10",
+                     "api: chip.set('option', 'checkinterval', 10)"],
+            schelp="""
+            Interval between checks to announce to clients""")
 
     return cfg
 

--- a/siliconcompiler/remote/server.py
+++ b/siliconcompiler/remote/server.py
@@ -239,7 +239,7 @@ class Server:
 
         # Return a response to the client.
         return web.json_response({'message': f"Starting job: {job_hash}",
-                                  'interval': 30,
+                                  'interval': self.checkinterval,
                                   'job_hash': job_hash})
 
     ####################
@@ -375,7 +375,7 @@ class Server:
                 'sc_schema': sc_schema_version,
                 'sc_server': Server.__version__,
             },
-            'progress_interval': 30
+            'progress_interval': self.checkinterval
         }
 
         username = job_params['username']
@@ -489,6 +489,11 @@ class Server:
     def nfs_mount(self):
         # Ensure that NFS mounting path is absolute.
         return os.path.abspath(self.get('option', 'nfsmount'))
+
+    ###################
+    @property
+    def checkinterval(self):
+        return self.get('option', 'checkinterval')
 
     def get(self, *keypath, field='value'):
         return self.schema.get(*keypath, field=field)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,7 +176,8 @@ def scserver(scserver_nfs_path, unused_tcp_port, request, wait_for_port):
         args = [
             '-nfsmount', scserver_nfs_path,
             '-cluster', cluster,
-            '-port', str(unused_tcp_port)
+            '-port', str(unused_tcp_port),
+            '-checkinterval', '1'
         ]
         if auth:
             args.append('-auth')


### PR DESCRIPTION
Before
```
112.94s call     tests/server/test_slurm_server.py::test_gcd_server
 85.01s call     tests/server/test_server.py::test_gcd_server
 84.55s call     tests/server/test_gcd_server_auth.py::test_gcd_server_authenticated
```

After
```
85.50s call     tests/server/test_slurm_server.py::test_gcd_server
62.80s call     tests/server/test_server.py::test_gcd_server
51.81s call     tests/server/test_gcd_server_auth.py::test_gcd_server_authenticated
```