### PR TITLE
switch to pyslang

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dependencies = [
     "fastjsonschema == 2.21.1",
     "docker == 7.1.0",
     "importlib_metadata; python_version < '3.10'",
-    "sc-surelog == 1.84.1",
     "orjson == 3.10.15",
     "pyslang == 8.0.0",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "importlib_metadata; python_version < '3.10'",
     "sc-surelog == 1.84.1",
     "orjson == 3.10.15",
+    "pyslang == 8.0.0",
 
     # dashboard, streamlit does not support 3.9.7
     "streamlit == 1.40.1; python_version <= '3.8'",

--- a/siliconcompiler/flows/_common.py
+++ b/siliconcompiler/flows/_common.py
@@ -23,9 +23,9 @@ def _make_docs(chip):
     chip.use(freepdk45_demo)
 
 
-def __get_frontends(allow_system_verilog):
+def __get_frontends(allow_system_verilog, use_surelog=False):
     parser = surelog_parse
-    if has_pyslang():
+    if not use_surelog and has_pyslang():
         parser = slang_preprocess
     systemverilog_frontend = [
         ('import.verilog', parser)
@@ -42,7 +42,7 @@ def __get_frontends(allow_system_verilog):
     }
 
 
-def setup_multiple_frontends(flow, allow_system_verilog=False):
+def setup_multiple_frontends(flow, allow_system_verilog=False, use_surelog=False):
     '''
     Sets of multiple frontends if different frontends are required.
 
@@ -51,7 +51,7 @@ def setup_multiple_frontends(flow, allow_system_verilog=False):
 
     concat_nodes = []
     flowname = flow.design
-    for _, pipe in __get_frontends(allow_system_verilog).items():
+    for _, pipe in __get_frontends(allow_system_verilog, use_surelog=use_surelog).items():
         prev_step = None
         for step, task in pipe:
             flow.node(flowname, step, task)

--- a/siliconcompiler/flows/_common.py
+++ b/siliconcompiler/flows/_common.py
@@ -1,4 +1,5 @@
 from siliconcompiler.tools.surelog import parse as surelog_parse
+from siliconcompiler.tools.slang import elaborate as slang_preprocess
 from siliconcompiler.tools.chisel import convert as chisel_convert
 from siliconcompiler.tools.bambu import convert as bambu_convert
 from siliconcompiler.tools.bluespec import convert as bluespec_convert
@@ -6,6 +7,8 @@ from siliconcompiler.tools.ghdl import convert as ghdl_convert
 from siliconcompiler.tools.sv2v import convert as sv2v_convert
 
 from siliconcompiler.tools.builtin import concatenate
+
+from siliconcompiler.tools.slang import has_pyslang
 
 
 def _make_docs(chip):
@@ -21,8 +24,11 @@ def _make_docs(chip):
 
 
 def __get_frontends(allow_system_verilog):
+    parser = surelog_parse
+    if has_pyslang():
+        parser = slang_preprocess
     systemverilog_frontend = [
-        ('import.verilog', surelog_parse)
+        ('import.verilog', parser)
     ]
     if not allow_system_verilog:
         systemverilog_frontend.append(('import.convert', sv2v_convert))

--- a/siliconcompiler/tools/slang/__init__.py
+++ b/siliconcompiler/tools/slang/__init__.py
@@ -10,6 +10,8 @@ Sources: https://github.com/MikePopoloski/slang
 
 Installation: https://sv-lang.com/building.html
 '''
+import os
+
 try:
     import pyslang
 except ModuleNotFoundError:
@@ -188,8 +190,14 @@ def _diagnostics(chip, driver, compilation):
             report_level = "error"
 
         if report_level:
-            for line in diags.reportAll(driver.sourceManager, [diag]).splitlines():
+            for n, line in enumerate(diags.reportAll(driver.sourceManager, [diag]).splitlines()):
                 if line.strip():
+                    if n == 0:
+                        line_parts = line.split(":")
+                        if os.path.exists(line_parts[0]):
+                            line_parts[0] = os.path.abspath(line_parts[0])
+                        line = ":".join(line_parts)
+
                     report[report_level].append(line)
 
     if not chip.get('option', 'quiet', step=step, index=index):

--- a/siliconcompiler/tools/slang/elaborate.py
+++ b/siliconcompiler/tools/slang/elaborate.py
@@ -60,12 +60,6 @@ def __get_files(manager, tree):
 
 
 def run(chip):
-    driver, exitcode = slang._get_driver(chip, runtime_options)
-    if exitcode:
-        return exitcode
-
-    compilation, ok = slang._compile(chip, driver)
-
     # Override default errors
     ignored = [
         pyslang.Diags.MissingTimeScale,
@@ -82,10 +76,15 @@ def run(chip):
         pyslang.Diags.UnusedGenvar,
         pyslang.Diags.UnusedAssertionDecl
     ]
-    for ignore in ignored:
-        driver.diagEngine.setSeverity(
-            ignore,
-            pyslang.DiagnosticSeverity.Ignored)
+
+    driver, exitcode = slang._get_driver(
+        chip,
+        runtime_options,
+        ignored_diagnotics=ignored)
+    if exitcode:
+        return exitcode
+
+    compilation, ok = slang._compile(chip, driver)
 
     slang._diagnostics(chip, driver, compilation)
 

--- a/siliconcompiler/tools/slang/elaborate.py
+++ b/siliconcompiler/tools/slang/elaborate.py
@@ -9,6 +9,13 @@ def setup(chip):
     '''
     Elaborate verilog design files and generate a unified file.
     '''
+    if slang.test_version():
+        return slang.test_version()
+
+    if not has_input_files(chip, 'input', 'rtl', 'verilog') and \
+       not has_input_files(chip, 'input', 'rtl', 'systemverilog'):
+        return "no files in [input,rtl,systemverilog] or [input,rtl,verilog]"
+
     slang.setup(chip)
 
     step = chip.get('arg', 'step')

--- a/siliconcompiler/tools/slang/elaborate.py
+++ b/siliconcompiler/tools/slang/elaborate.py
@@ -1,7 +1,8 @@
 from siliconcompiler import utils
 from siliconcompiler.tools import slang
-from siliconcompiler.tools._common import \
-    add_require_input, add_frontend_requires, get_tool_task, has_input_files
+import os
+from siliconcompiler.tools._common import get_tool_task, has_input_files
+from siliconcompiler.tools.slang import pyslang
 
 
 def setup(chip):
@@ -17,26 +18,15 @@ def setup(chip):
     chip.set('tool', tool, 'task', task, 'threads', utils.get_cores(chip),
              clobber=False, step=step, index=index)
 
-    add_require_input(chip, 'input', 'rtl', 'verilog')
-    add_require_input(chip, 'input', 'rtl', 'systemverilog')
-    add_frontend_requires(chip, ['ydir', 'idir', 'vlib', 'libext', 'define', 'param'])
-
-    chip.set('tool', tool, 'task', task, 'stdout', 'destination', 'output', step=step, index=index)
-    chip.set('tool', tool, 'task', task, 'stdout', 'suffix', 'v', step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'stdout', 'destination', 'log', step=step, index=index)
+    chip.set('tool', tool, 'task', task, 'stderr', 'destination', 'log', step=step, index=index)
 
     chip.set('tool', tool, 'task', task, 'output', __outputfile(chip), step=step, index=index)
 
-
-def runtime_options(chip):
-    options = slang.common_runtime_options(chip)
-    options.extend([
-        "--preprocess",
-        "--comments",
-        "--ignore-unknown-modules",
-        "--allow-use-before-declare"
-    ])
-
-    return options
+    chip.set('tool', tool, 'task', task, 'var', 'include_source_paths', True,
+             step=step, index=index, clobber=False)
+    chip.set('tool', tool, 'task', task, 'var', 'include_source_paths',
+             "true/false, if true add the source file path information", field="help")
 
 
 def __outputfile(chip):
@@ -44,3 +34,112 @@ def __outputfile(chip):
     if is_systemverilog:
         return f'{chip.top()}.sv'
     return f'{chip.top()}.v'
+
+
+def __get_files(manager, tree):
+    files = set()
+
+    from queue import Queue
+    nodes = Queue(maxsize=0)
+    nodes.put(tree.root)
+
+    def procRange(range):
+        files.add(manager.getFileName(range.start))
+        files.add(manager.getFileName(range.end))
+
+    while not nodes.empty():
+        node = nodes.get()
+        procRange(node.sourceRange)
+        for token in node:
+            if isinstance(token, pyslang.Token):
+                procRange(token.range)
+            else:
+                nodes.put(token)
+
+    return sorted([os.path.abspath(f) for f in files if os.path.isfile(f)])
+
+
+def run(chip):
+    driver, exitcode = slang._get_driver(chip, runtime_options)
+    if exitcode:
+        return exitcode
+
+    compilation, ok = slang._compile(chip, driver)
+
+    # Override default errors
+    ignored = [
+        pyslang.Diags.MissingTimeScale,
+        pyslang.Diags.UsedBeforeDeclared,
+        pyslang.Diags.UnusedParameter,
+        pyslang.Diags.UnusedDefinition,
+        pyslang.Diags.UnusedVariable,
+        pyslang.Diags.UnusedPort,
+        pyslang.Diags.UnusedButSetNet,
+        pyslang.Diags.UnusedImplicitNet,
+        pyslang.Diags.UnusedButSetVariable,
+        pyslang.Diags.UnusedButSetPort,
+        pyslang.Diags.UnusedTypedef,
+        pyslang.Diags.UnusedGenvar,
+        pyslang.Diags.UnusedAssertionDecl
+    ]
+    for ignore in ignored:
+        driver.diagEngine.setSeverity(
+            ignore,
+            pyslang.DiagnosticSeverity.Ignored)
+
+    slang._diagnostics(chip, driver, compilation)
+
+    manager = compilation.sourceManager
+
+    step = chip.get('arg', 'step')
+    index = chip.get('arg', 'index')
+    tool, task = get_tool_task(chip, step, index)
+    add_source = chip.get('tool', tool, 'task', task, 'var', 'include_source_paths',
+                          step=step, index=index)[0] == 'true'
+
+    def printFiles(out, files):
+        for src_file in files:
+            out.write(f'//   File: {src_file}\n')
+
+    with open(f'outputs/{__outputfile(chip)}', 'w') as out:
+        for tree in compilation.getSyntaxTrees():
+            files = []
+            if add_source:
+                files = __get_files(manager, tree)
+
+            writer = pyslang.SyntaxPrinter(manager)
+
+            writer.setIncludeMissing(False)
+            writer.setIncludeSkipped(False)
+            writer.setIncludeDirectives(False)
+
+            writer.setIncludePreprocessed(True)
+            writer.setIncludeTrivia(True)
+            writer.setIncludeComments(True)
+            writer.setSquashNewlines(True)
+
+            out.write("////////////////////////////////////////////////////////////////\n")
+            out.write("// Start:\n")
+            printFiles(out, files)
+
+            out.write(writer.print(tree).str() + '\n')
+
+            out.write("// End:\n")
+            printFiles(out, files)
+            out.write("////////////////////////////////////////////////////////////////\n")
+
+    if ok:
+        return 0
+    else:
+        return 1
+
+
+def runtime_options(chip):
+    options = slang.common_runtime_options(chip)
+    options.extend([
+        "--allow-use-before-declare",
+        "--ignore-unknown-modules",
+        "-Weverything"
+    ])
+
+    return options

--- a/siliconcompiler/tools/surelog/__init__.py
+++ b/siliconcompiler/tools/surelog/__init__.py
@@ -10,7 +10,12 @@ Sources: https://github.com/chipsalliance/Surelog
 Installation: https://github.com/chipsalliance/Surelog
 '''
 
-import surelog
+import platform
+try:
+    import surelog
+except ModuleNotFoundError:
+    surelog = None
+
 from siliconcompiler.tools._common import get_tool_task
 
 
@@ -31,9 +36,17 @@ def setup(chip):
 
     is_docker = chip.get('option', 'scheduler', 'name', step=step, index=index) == 'docker'
     if not is_docker:
-        exe = surelog.get_bin()
+        if surelog:
+            exe = surelog.get_bin()
+        else:
+            exe = 'surelog'
+            if platform.startswith("win32"):
+                exe = f"{exe}.exe"
     else:
-        exe = surelog.get_bin('linux')
+        if surelog:
+            exe = surelog.get_bin('linux')
+        else:
+            exe = 'surelog'
 
     # Standard Setup
     chip.set('tool', tool, 'exe', exe)
@@ -43,7 +56,7 @@ def setup(chip):
     # We package SC wheels with a precompiled copy of Surelog installed to
     # tools/surelog/bin. If the user doesn't have Surelog installed on their
     # system path, set the path to the bundled copy in the schema.
-    if not surelog.has_system_surelog() and not is_docker:
+    if surelog and not surelog.has_system_surelog() and not is_docker:
         chip.set('tool', tool, 'path', surelog.get_path(), clobber=False)
 
     # Log file parsing

--- a/siliconcompiler/tools/surelog/__init__.py
+++ b/siliconcompiler/tools/surelog/__init__.py
@@ -10,7 +10,7 @@ Sources: https://github.com/chipsalliance/Surelog
 Installation: https://github.com/chipsalliance/Surelog
 '''
 
-import platform
+import sys
 try:
     import surelog
 except ModuleNotFoundError:
@@ -40,7 +40,7 @@ def setup(chip):
             exe = surelog.get_bin()
         else:
             exe = 'surelog'
-            if platform.startswith("win32"):
+            if sys.platform.startswith("win32"):
                 exe = f"{exe}.exe"
     else:
         if surelog:

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -20,7 +20,7 @@ def __check_gcd(chip):
                     step='syn', index='0') == ['reports/stat.json']
 
     # "No timescale set..."
-    assert chip.get('metric', 'warnings', step='import.verilog', index='0') == 10
+    assert chip.get('metric', 'warnings', step='import.verilog', index='0') == 7
 
     # 2 ABC Warnings
     assert chip.get('metric', 'warnings', step='syn', index='0') == 2

--- a/tests/flows/test_failure.py
+++ b/tests/flows/test_failure.py
@@ -22,50 +22,6 @@ def chip(datadir):
     return chip
 
 
-@pytest.mark.eda
-@pytest.mark.quick
-def test_failure_notquiet(chip):
-    '''Test that SC exits early on errors without -quiet switch.
-
-    This is a regression test for an issue where SC would only exit early on a
-    command failure in cases where the -quiet switch was included.
-
-    TODO: these tests are somewhat bad because unrelated failures can cause
-    them to pass. Needs a more specific check.
-    '''
-
-    # Expect that command exits early
-    with pytest.raises(siliconcompiler.SiliconCompilerError):
-        chip.run(raise_exception=True)
-
-    # Check we made it past initial setup
-    assert os.path.isdir('build/bad/job0/import.verilog')
-    assert not os.path.isdir('build/bad/job0/syn')
-
-    # Expect that there is no import output
-    assert chip.find_result('v', step='import.verilog') is None
-
-
-@pytest.mark.eda
-@pytest.mark.quick
-def test_failure_quiet(chip):
-    '''Test that SC exits early on errors with -quiet switch.
-    '''
-
-    chip.set('option', 'quiet', True)
-
-    # Expect that command exits early
-    with pytest.raises(siliconcompiler.SiliconCompilerError):
-        chip.run(raise_exception=True)
-
-    # Check we made it past initial setup
-    assert os.path.isdir('build/bad/job0/import.verilog')
-    assert not os.path.isdir('build/bad/job0/syn')
-
-    # Expect that there is no import output
-    assert chip.find_result('v', step='import') is None
-
-
 def test_incomplete_flowgraph():
     '''Test that SC exits early when flowgraph is incomplete
     '''

--- a/tests/flows/test_timeout.py
+++ b/tests/flows/test_timeout.py
@@ -3,9 +3,10 @@ import siliconcompiler
 
 
 @pytest.mark.eda
+@pytest.mark.quick
 def test_timeout(gcd_chip):
     # 0 seconds guarantees a timeout
-    gcd_chip.set('option', 'timeout', 0, step='import.verilog', index='0')
+    gcd_chip.set('option', 'timeout', 0, step='syn', index='0')
 
     # Expect that command exits early
     # TODO: automated check that run timed out vs failed for a different reason


### PR DESCRIPTION
Removes surelog as verilog frontend and replaces it with slang.

Why?
- slang provides better coverage of system verilog and verilog.