### PR TITLE
Expanding sc-install help

### DIFF
--- a/siliconcompiler/apps/sc_install.py
+++ b/siliconcompiler/apps/sc_install.py
@@ -189,7 +189,7 @@ To system debugging information (this should only be used to debug):
     parser.add_argument(
         "-prefix",
         default=Path.home() / ".local",
-        help="Prefix to use when installing tool",
+        help="Prefix to use when installing tool (default is $HOME/.local)",
         metavar="<path>")
 
     parser.add_argument(


### PR DESCRIPTION
It wasn't clear (to me) where the programs were being installed.  
Happened on this because I was editing my bashrc and must have accidentally removed the $HOME/.local/bin