### PR TITLE
Packaging related schema parameter name changes

### DIFF
--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -226,9 +226,9 @@ def schema_schematic(cfg, name='default'):
     scparam(cfg, ['schematic', 'component', name, 'partname'],
             sctype='str',
             shorthelp="Schematic: component model",
-            switch="-schematic_component_model 'name <str>'",
-            example=["cli: -schematic_component_model 'B0 NAND2X1'",
-                     "api: chip.set('schematic', 'component', 'B0, 'model', 'NAND2X1')"],
+            switch="-schematic_component_partname 'name <str>'",
+            example=["cli: -schematic_component_partname 'B0 NAND2X1'",
+                     "api: chip.set('schematic', 'component', 'B0, 'partname', 'NAND2X1')"],
             schelp="""Component part-name ("aka cell-name") specified on a per instance basis.""")
 
     scparam(cfg, ['schematic', 'pin', name, 'dir'],

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -3880,7 +3880,7 @@ def schema_constraint(cfg):
                     f"api: chip.set('constraint', 'pin', 'nreset', {i}, {v[1]})"],
                 schelp=f"""
                 Pin {v[0]} constraint. This parameter represents goal/intent, not an exact
-                specification. The layout system may adjust placements to meet
+                specification. The layout system may adjust dimensions to meet
                 competing goals such as manufacturing design rules and grid placement
                 guidelines.""")
 

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -3864,25 +3864,39 @@ def schema_constraint(cfg):
             may adjust sizes to meet competing goals such as manufacturing design
             rules and grid placement guidelines.""")
 
-    metrics = {'width': ['width (x-direction)', 1.0],
-               'height': ['height (y-direction)', 1.0]
-               }
+    scparam(cfg, ['constraint', 'pin', name, 'width'],
+            sctype='float',
+            unit='um',
+            pernode=PerNode.OPTIONAL,
+            shorthelp="Constraint: pin width",
+            switch="-constraint_pin_width 'name <float>'",
+            example=[
+                "cli: -constraint_pin_width 'nreset 1.0'",
+                "api: chip.set('constraint', 'pin', 'nreset', 'width', 1.0)"],
+            schelp="""
+            Pin width constraint.  Package pin width is the lateral
+            (side-to-side) thickness of a pin on a physical component.
+            This parameter represents goal/intent, not an exact
+            specification. The layout system may adjust dimensions to meet
+            competing goals such as manufacturing design rules and grid placement
+            guidelines.""")
 
-    for i, v in metrics.items():
-        scparam(cfg, ['constraint', 'pin', name, i],
-                sctype='float',
-                unit='um',
-                pernode=PerNode.OPTIONAL,
-                shorthelp=f"Constraint: pin {i}",
-                switch=f"-constraint_pin_{i} 'name <float>'",
-                example=[
-                    f"cli: -constraint_pin_{i} 'nreset {v[1]}'",
-                    f"api: chip.set('constraint', 'pin', 'nreset', {i}, {v[1]})"],
-                schelp=f"""
-                Pin {v[0]} constraint. This parameter represents goal/intent, not an exact
-                specification. The layout system may adjust dimensions to meet
-                competing goals such as manufacturing design rules and grid placement
-                guidelines.""")
+    scparam(cfg, ['constraint', 'pin', name, 'length'],
+            sctype='float',
+            unit='um',
+            pernode=PerNode.OPTIONAL,
+            shorthelp="Constraint: pin length",
+            switch="-constraint_pin_length 'name <float>'",
+            example=[
+                "cli: -constraint_pin_length 'nreset 1.0'",
+                "api: chip.set('constraint', 'pin', 'nreset', 'length', 1.0)"],
+            schelp="""
+            Pin length constraint.  Package pin length refers to the
+            length of the electrical pins extending out from (or into)
+            a component. This parameter represents goal/intent, not an exact
+            specification. The layout system may adjust dimensions to meet
+            competing goals such as manufacturing design rules and grid placement
+            guidelines.""")
 
     scparam(cfg, ['constraint', 'pin', name, 'shape'],
             sctype='enum',

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -3910,7 +3910,7 @@ def schema_constraint(cfg):
                 "cli: -constraint_pin_layer 'nreset m4'",
                 "api: chip.set('constraint', 'pin', 'nreset', 'layer', 'm4')"],
             schelp="""
-            Pin metal layer for pin placement specified on a per pin basis.
+            Pin metal layer constraint specified on a per pin basis.
             Metal names should either be the PDK specific metal stack name or
             an integer with '1' being the lowest routing layer.
             The wildcard character '*' is supported for pin names.""")

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     from siliconcompiler.schema.utils import trim
 
-SCHEMA_VERSION = '0.49.0'
+SCHEMA_VERSION = '0.50.0'
 
 #############################################################################
 # PARAM DEFINITION
@@ -3746,9 +3746,10 @@ def schema_constraint(cfg):
                 "cli: -constraint_component_partname 'i0 filler_x1'",
                 "api: chip.set('constraint', 'component', 'i0', 'partname', 'filler_x1')"],
             schelp="""
-            Part name of the instance. The parameter is required for instances
-            that are not contained within the design netlist (ie. physical only cells).
-            """)
+            Name of the model, type, or variant of the placed component. In the chip
+            design domain, 'partname' is synonymous to 'cellname' or 'cell'. The
+            'partname' is required for instances that are not represented within
+            the design netlist (ie. physical only cells).""")
 
     scparam(cfg, ['constraint', 'component', inst, 'halo'],
             sctype='(float,float)',
@@ -3815,9 +3816,9 @@ def schema_constraint(cfg):
                 "cli: -constraint_component_substrate 'i0 pcb0'",
                 "api: chip.set('constraint', 'component', 'i0', 'substrate', 'pcb0')"],
             schelp="""
-            Substrates are supporting material that components are placed upon.
-            List of supported substrates includes (but not limited to):
-            wafers, dies, panels, PCBs.""")
+            Name of physical substrates instance that components are placed upon.
+            Any flat surface can serve as a substrate (eg. wafers, dies, panels, PCBs,
+            substrates, interposers).""")
 
     scparam(cfg, ['constraint', 'component', inst, 'side'],
             sctype='enum',
@@ -3830,7 +3831,7 @@ def schema_constraint(cfg):
                 "api: chip.set('constraint', 'component', 'i0', 'side', 'top')"],
             schelp="""
             Side of the substrate where the component should be placed. The `side`
-            definitions are with respect to a viewer looking sideways at an object.
+            is defined with respect to a viewer looking sideways at an object.
             Top is towards the sky, front is the side closest to the viewer, and
             right is right. The maximum number of sides per substrate is six""")
 
@@ -3868,9 +3869,8 @@ def schema_constraint(cfg):
             may adjust sizes to meet competing goals such as manufacturing design
             rules and grid placement guidelines.""")
 
-    metrics = {'width': ['width', 1.0],
-               'length': ['length', 1.0],
-               'height': ['height', 1.0]
+    metrics = {'width': ['width (x-direction)', 1.0],
+               'height': ['height (y-direction)', 1.0]
                }
 
     for i, v in metrics.items():
@@ -3884,8 +3884,8 @@ def schema_constraint(cfg):
                     f"cli: -constraint_pin_{i} 'nreset {v[1]}'",
                     f"api: chip.set('constraint', 'pin', 'nreset', {i}, {v[1]})"],
                 schelp=f"""
-                Pin {i} constraint. This parameter represents goal/intent, not an exact
-                specification. The layout system may adjust sizes to meet
+                Pin {v[0]} constraint. This parameter represents goal/intent, not an exact
+                specification. The layout system may adjust placements to meet
                 competing goals such as manufacturing design rules and grid placement
                 guidelines.""")
 
@@ -3915,9 +3915,10 @@ def schema_constraint(cfg):
                 "cli: -constraint_pin_layer 'nreset m4'",
                 "api: chip.set('constraint', 'pin', 'nreset', 'layer', 'm4')"],
             schelp="""
-            Pin metal layer specified based on the SC standard layer stack
-            starting with m1 as the lowest routing layer and ending
-            with m<n> as the highest routing layer.""")
+            Pin metal layer for pin placement specified on a per pin basis.
+            Metal names should either be the PDK specific metal stack name or
+            an integer with '1' being the lowest routing layer.
+            The wildcard character '*' is supported for pin names.""")
 
     scparam(cfg, ['constraint', 'pin', name, 'side'],
             sctype='int',

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -223,13 +223,13 @@ def schema_schematic(cfg, name='default'):
     ''' Schematic
     '''
 
-    scparam(cfg, ['schematic', 'component', name, 'model'],
+    scparam(cfg, ['schematic', 'component', name, 'partname'],
             sctype='str',
             shorthelp="Schematic: component model",
             switch="-schematic_component_model 'name <str>'",
             example=["cli: -schematic_component_model 'B0 NAND2X1'",
                      "api: chip.set('schematic', 'component', 'B0, 'model', 'NAND2X1')"],
-            schelp="""Model of a component, specified on a per instance basis.""")
+            schelp="""Component part-name ("aka cell-name") specified on a per instance basis.""")
 
     scparam(cfg, ['schematic', 'pin', name, 'dir'],
             sctype='enum',
@@ -708,7 +708,7 @@ def schema_pdk(cfg, stackup='default'):
 ###############################################################################
 # Datasheet ("specification/contract")
 ###############################################################################
-def schema_datasheet(cfg, name='default', mode='default'):
+def schema_datasheet(cfg, partname='default', mode='default'):
 
     # Part type
     scparam(cfg, ['datasheet', 'type'],
@@ -896,7 +896,7 @@ def schema_datasheet(cfg, name='default', mode='default'):
     # IO
     ######################
 
-    scparam(cfg, ['datasheet', 'io', name, 'arch'],
+    scparam(cfg, ['datasheet', 'io', partname, 'arch'],
             sctype='enum',
             enum=['spi', 'uart', 'i2c', 'pwm', 'qspi', 'sdio', 'can', 'jtag',
                   'spdif', 'i2s',
@@ -914,7 +914,7 @@ def schema_datasheet(cfg, name='default', mode='default'):
                   '10gbase-kr', '25gbase-kr', 'xfi', 'cei28g',
                   'jesd204', 'cpri'],
             shorthelp="Datasheet: io standard",
-            switch="-datasheet_io_arch 'name <str>'",
+            switch="-datasheet_io_arch 'partname <str>'",
             example=[
                 "cli: -datasheet_io_arch 'pio spi'",
                 "api: chip.set('datasheet', 'io', 'pio', 'arch', 'spi')"],
@@ -927,14 +927,14 @@ def schema_datasheet(cfg, name='default', mode='default'):
                }
 
     for i, v in metrics.items():
-        scparam(cfg, ['datasheet', 'io', name, i],
+        scparam(cfg, ['datasheet', 'io', partname, i],
                 unit=v[3],
                 sctype=v[2],
                 shorthelp=f"Datasheet: io {v[0]}",
-                switch=f"-datasheet_io_{i} 'name <{v[2]}>'",
+                switch=f"-datasheet_io_{i} 'partname <{v[2]}>'",
                 example=[
-                    f"cli: -datasheet_io_{i} 'name {v[1]}'",
-                    f"api: chip.set('datasheet', 'io', name, '{i}', {v[1]})"],
+                    f"cli: -datasheet_io_{i} 'partname {v[1]}'",
+                    f"api: chip.set('datasheet', 'io', partname, '{i}', {v[1]})"],
                 schelp=f"""Datasheet: IO {v[1]} metrics specified on a per IO port basis.
                 """)
 
@@ -942,31 +942,31 @@ def schema_datasheet(cfg, name='default', mode='default'):
     # Processor
     ######################
 
-    scparam(cfg, ['datasheet', 'proc', name, 'arch'],
+    scparam(cfg, ['datasheet', 'proc', partname, 'arch'],
             sctype='str',
             shorthelp="Datasheet: processor architecture",
-            switch="-datasheet_proc_arch 'name <str>'",
+            switch="-datasheet_proc_arch 'partname <str>'",
             example=[
                 "cli: -datasheet_proc_arch '0 RV64GC'",
-                "api: chip.set('datasheet', 'proc', name, 'arch', 'openfpga')"],
+                "api: chip.set('datasheet', 'proc', partname, 'arch', 'openfpga')"],
             schelp="""Processor architecture specified on a per core basis.""")
 
-    scparam(cfg, ['datasheet', 'proc', name, 'features'],
+    scparam(cfg, ['datasheet', 'proc', partname, 'features'],
             sctype='[str]',
             shorthelp="Datasheet: processor features",
-            switch="-datasheet_proc_features 'name <str>'",
+            switch="-datasheet_proc_features 'partname <str>'",
             example=[
                 "cli: -datasheet_proc_features '0 SIMD'",
                 "api: chip.set('datasheet','proc','cpu','features', 'SIMD')"],
             schelp="""List of maker specified processor features specified on a per core basis.""")
 
-    scparam(cfg, ['datasheet', 'proc', name, 'datatypes'],
+    scparam(cfg, ['datasheet', 'proc', partname, 'datatypes'],
             sctype='[enum]',
             enum=['int4', 'int8', 'int16', 'int32', 'int64', 'int128',
                   'uint4', 'uint8', 'uint16', 'uint32', 'uint64', 'uint128',
                   'bfloat16', 'fp16', 'fp32', 'fp64', 'fp128'],
             shorthelp="Datasheet: processor datatypes",
-            switch="-datasheet_proc_datatypes 'name <str>'",
+            switch="-datasheet_proc_datatypes 'partname <str>'",
             example=[
                 "cli: -datasheet_proc_datatypes '0 int8'",
                 "api: chip.set('datasheet', 'proc', 'cpu', 'datatypes', 'int8')"],
@@ -986,11 +986,11 @@ def schema_datasheet(cfg, name='default', mode='default'):
                'nvm': ['local non-volatile memory', 128, 'KB']}
 
     for i, v in metrics.items():
-        scparam(cfg, ['datasheet', 'proc', name, i],
+        scparam(cfg, ['datasheet', 'proc', partname, i],
                 unit=v[2],
                 sctype='int',
                 shorthelp=f"Datasheet: processor {v[0]}",
-                switch=f"-datasheet_proc_{i} 'name <int>'",
+                switch=f"-datasheet_proc_{i} 'partname <int>'",
                 example=[
                     f"cli: -datasheet_proc_{i} 'cpu {v[1]}'",
                     f"api: chip.set('datasheet', 'proc', 'cpu', '{i}', {v[1]})"],
@@ -1000,37 +1000,37 @@ def schema_datasheet(cfg, name='default', mode='default'):
     # Memory
     ######################
 
-    scparam(cfg, ['datasheet', 'memory', name, 'bits'],
+    scparam(cfg, ['datasheet', 'memory', partname, 'bits'],
             sctype='int',
             shorthelp="Datasheet: memory total bits",
-            switch="-datasheet_memory_bits 'name <int>'",
+            switch="-datasheet_memory_bits 'partname <int>'",
             example=[
                 "cli: -datasheet_memory_bits 'm0 1024'",
                 "api: chip.set('datasheet', 'memory', 'm0', 'bits', 1024)"],
             schelp="""Memory total number of bits specified on a per memory basis.""")
 
-    scparam(cfg, ['datasheet', 'memory', name, 'width'],
+    scparam(cfg, ['datasheet', 'memory', partname, 'width'],
             sctype='int',
             shorthelp="Datasheet: memory width",
-            switch="-datasheet_memory_width 'name <int>'",
+            switch="-datasheet_memory_width 'partname <int>'",
             example=[
                 "cli: -datasheet_memory_width 'm0 16'",
                 "api: chip.set('datasheet', 'memory', 'm0', 'width', 16)"],
             schelp="""Memory width specified on a per memory basis.""")
 
-    scparam(cfg, ['datasheet', 'memory', name, 'depth'],
+    scparam(cfg, ['datasheet', 'memory', partname, 'depth'],
             sctype='int',
             shorthelp="Datasheet: memory depth",
-            switch="-datasheet_memory_depth 'name <int>'",
+            switch="-datasheet_memory_depth 'partname <int>'",
             example=[
                 "cli: -datasheet_memory_depth 'm0 128'",
                 "api: chip.set('datasheet', 'memory', 'm0', 'depth', 128)"],
             schelp="""Memory depth specified on a per memory basis.""")
 
-    scparam(cfg, ['datasheet', 'memory', name, 'banks'],
+    scparam(cfg, ['datasheet', 'memory', partname, 'banks'],
             sctype='int',
             shorthelp="Datasheet: memory banks",
-            switch="-datasheet_memory_banks 'name <int>'",
+            switch="-datasheet_memory_banks 'partname <int>'",
             example=[
                 "cli: -datasheet_memory_banks 'm0 4'",
                 "api: chip.set('datasheet', 'memory', 'm0', 'banks', 4)"],
@@ -1051,14 +1051,14 @@ def schema_datasheet(cfg, name='default', mode='default'):
                }
 
     for i, v in metrics.items():
-        scparam(cfg, ['datasheet', 'memory', name, i],
+        scparam(cfg, ['datasheet', 'memory', partname, i],
                 unit=v[2],
                 sctype='(float,float,float)',
                 shorthelp=f"Datasheet: memory {v[0]}",
-                switch=f"-datasheet_memory_{i} 'name <(float,float,float)>'",
+                switch=f"-datasheet_memory_{i} 'partname <(float,float,float)>'",
                 example=[
-                    f"cli: -datasheet_memory_{i} 'name {v[1]}'",
-                    f"api: chip.set('datasheet', 'memory', name, '{i}', {v[1]})"],
+                    f"cli: -datasheet_memory_{i} 'partname {v[1]}'",
+                    f"api: chip.set('datasheet', 'memory', partname, '{i}', {v[1]})"],
                 schelp=f"""Memory {v[1]} specified on a per memory basis.""")
 
     # Latency (cycles)
@@ -1069,24 +1069,24 @@ def schema_datasheet(cfg, name='default', mode='default'):
                }
 
     for i, v in metrics.items():
-        scparam(cfg, ['datasheet', 'memory', name, i],
+        scparam(cfg, ['datasheet', 'memory', partname, i],
                 unit=v[2],
                 sctype='(int,int,int)',
                 shorthelp=f"Datasheet: memory {v[0]}",
-                switch=f"-datasheet_memory_{i} 'name <(int,int,int)>'",
+                switch=f"-datasheet_memory_{i} 'partname <(int,int,int)>'",
                 example=[
-                    f"cli: -datasheet_memory_{i} 'name {v[1]}'",
-                    f"api: chip.set('datasheet', 'memory', name, '{i}', {v[1]})"],
+                    f"cli: -datasheet_memory_{i} 'partname {v[1]}'",
+                    f"api: chip.set('datasheet', 'memory', partname, '{i}', {v[1]})"],
                 schelp=f"""Memory {v[1]} specified on a per memory basis.""")
 
     ######################
     # FPGA
     ######################
 
-    scparam(cfg, ['datasheet', 'fpga', name, 'arch'],
+    scparam(cfg, ['datasheet', 'fpga', partname, 'arch'],
             sctype='str',
             shorthelp="Datasheet: fpga architecture",
-            switch="-datasheet_fpga_arch 'name <str>'",
+            switch="-datasheet_fpga_arch 'partname <str>'",
             example=[
                 "cli: -datasheet_fpga_arch 'i0 openfpga'",
                 "api: chip.set('datasheet', 'fpga', 'i0', 'arch', 'openfpga')"],
@@ -1102,11 +1102,11 @@ def schema_datasheet(cfg, name='default', mode='default'):
                'blockram': ['block ram', 128, 'Kb']}
 
     for i, v in metrics.items():
-        scparam(cfg, ['datasheet', 'fpga', name, i],
+        scparam(cfg, ['datasheet', 'fpga', partname, i],
                 unit=v[2],
                 sctype='int',
                 shorthelp=f"Datasheet: fpga {v[0]}",
-                switch=f"-datasheet_fpga_{i} 'name <int>'",
+                switch=f"-datasheet_fpga_{i} 'partname <int>'",
                 example=[
                     f"cli: -datasheet_fpga_{i} 'i0 {v[1]}'",
                     f"api: chip.set('datasheet', 'fpga', 'i0', '{i}', {v[1]})"],
@@ -1116,19 +1116,19 @@ def schema_datasheet(cfg, name='default', mode='default'):
     # Analog
     ######################
 
-    scparam(cfg, ['datasheet', 'analog', name, 'arch'],
+    scparam(cfg, ['datasheet', 'analog', partname, 'arch'],
             sctype='str',
             shorthelp="Datasheet: analog architecture",
-            switch="-datasheet_analog_arch 'name <str>'",
+            switch="-datasheet_analog_arch 'partname <str>'",
             example=[
                 "cli: -datasheet_analog_arch 'adc0 pipelined'",
                 "api: chip.set('datasheet', 'analog', 'adc0', 'arch', 'pipelined')"],
             schelp="""Analog component architecture.""")
 
-    scparam(cfg, ['datasheet', 'analog', name, 'features'],
+    scparam(cfg, ['datasheet', 'analog', partname, 'features'],
             sctype='[str]',
             shorthelp="Datasheet: analog features",
-            switch="-datasheet_analog_features 'name <str>'",
+            switch="-datasheet_analog_features 'partname <str>'",
             example=[
                 "cli: -datasheet_analog_features '0 differential input'",
                 "api: chip.set('datasheet','analog','adc0','features', 'differential input')"],
@@ -1138,10 +1138,10 @@ def schema_datasheet(cfg, name='default', mode='default'):
                'channels': ['parallel channels', 8]}
 
     for i, v in metrics.items():
-        scparam(cfg, ['datasheet', 'analog', name, i],
+        scparam(cfg, ['datasheet', 'analog', partname, i],
                 sctype='int',
                 shorthelp=f"Datasheet: analog {v[0]}",
-                switch=f"-datasheet_analog_{i} 'name <int>'",
+                switch=f"-datasheet_analog_{i} 'partname <int>'",
                 example=[
                     f"cli: -datasheet_analog_{i} 'i0 {v[1]}'",
                     f"api: chip.set('datasheet', 'analog', 'abc123', '{i}', {v[1]})"],
@@ -1180,11 +1180,11 @@ def schema_datasheet(cfg, name='default', mode='default'):
                }
 
     for i, v in metrics.items():
-        scparam(cfg, ['datasheet', 'analog', name, i],
+        scparam(cfg, ['datasheet', 'analog', partname, i],
                 unit=v[2],
                 sctype='(float,float,float)',
                 shorthelp=f"Datasheet: analog {v[0]}",
-                switch=f"-datasheet_analog_{i} 'name <(float,float,float)>'",
+                switch=f"-datasheet_analog_{i} 'partname <(float,float,float)>'",
                 example=[
                     f"cli: -datasheet_analog_{i} 'i0 {v[1]}'",
                     f"api: chip.set('datasheet', 'analog', 'abc123', '{i}', {v[1]})"],
@@ -1247,20 +1247,20 @@ def schema_datasheet(cfg, name='default', mode='default'):
     # Package Description
     #########################
 
-    scparam(cfg, ['datasheet', 'package', name, 'type'],
+    scparam(cfg, ['datasheet', 'package', partname, 'type'],
             sctype='enum',
             enum=['bga', 'lga', 'csp', 'qfn', 'qfp', 'sop', 'die', 'wafer'],
             shorthelp="Datasheet: package type",
-            switch="-datasheet_package_type 'name <str>'",
+            switch="-datasheet_package_type 'partname <str>'",
             example=[
                 "cli: -datasheet_package_type 'abcd bga'",
                 "api: chip.set('datasheet', 'package', 'abcd', 'type', 'bga')"],
             schelp="""Package type.""")
 
-    scparam(cfg, ['datasheet', 'package', name, 'footprint'],
+    scparam(cfg, ['datasheet', 'package', partname, 'footprint'],
             sctype='[file]',
             shorthelp="Datasheet: package footprint",
-            switch="-datasheet_package_footprint 'name <file>'",
+            switch="-datasheet_package_footprint 'partname <file>'",
             example=[
                 "cli: -datasheet_package_footprint 'abcd ./soic8.kicad_mod'",
                 "api: chip.set('datasheet', 'package', 'abcd', 'footprint', './soic8.kicad_mod')"],
@@ -1270,10 +1270,10 @@ def schema_datasheet(cfg, name='default', mode='default'):
 
             """)
 
-    scparam(cfg, ['datasheet', 'package', name, '3dmodel'],
+    scparam(cfg, ['datasheet', 'package', partname, '3dmodel'],
             sctype='[file]',
             shorthelp="Datasheet: package 3D model",
-            switch="-datasheet_package_3dmodel 'name <file>'",
+            switch="-datasheet_package_3dmodel 'partname <file>'",
             example=[
                 "cli: -datasheet_package_3dmodel 'abcd ./soic8.step'",
                 "api: chip.set('datasheet', 'package', 'abcd', '3dmodel', './soic8.step')"],
@@ -1285,10 +1285,10 @@ def schema_datasheet(cfg, name='default', mode='default'):
 
             """)
 
-    scparam(cfg, ['datasheet', 'package', name, 'drawing'],
+    scparam(cfg, ['datasheet', 'package', partname, 'drawing'],
             sctype='[file]',
             shorthelp="Datasheet: package drawing",
-            switch="-datasheet_package_drawing 'name <file>'",
+            switch="-datasheet_package_drawing 'partname <file>'",
             example=[
                 "cli: -datasheet_package_drawing 'abcd p484.pdf'",
                 "api: chip.set('datasheet', 'package', 'abcd', 'drawing', 'p484.pdf')"],
@@ -1303,11 +1303,11 @@ def schema_datasheet(cfg, name='default', mode='default'):
                }
 
     for i, v in metrics.items():
-        scparam(cfg, ['datasheet', 'package', name, i],
+        scparam(cfg, ['datasheet', 'package', partname, i],
                 unit=v[2],
                 sctype='(float,float,float)',
                 shorthelp=f"Datasheet: package {v[0]}",
-                switch=f"-datasheet_package_{i} 'name <(float,float,float)>'",
+                switch=f"-datasheet_package_{i} 'partname <(float,float,float)>'",
                 example=[
                     f"cli: -datasheet_package_{i} 'abcd {v[1]}'",
                     f"api: chip.set('datasheet', 'package', 'abcd', '{i}', {v[1]}"],
@@ -1315,20 +1315,20 @@ def schema_datasheet(cfg, name='default', mode='default'):
                 (min, nominal, max).""")
 
     # pin
-    scparam(cfg, ['datasheet', 'package', name, 'pincount'],
+    scparam(cfg, ['datasheet', 'package', partname, 'pincount'],
             sctype='int',
             shorthelp="Datasheet: package pin count",
-            switch="-datasheet_package_pincount 'name <int>'",
+            switch="-datasheet_package_pincount 'partname <int>'",
             example=[
                 "cli: -datasheet_package_pincount 'abcd 484'",
                 "api: chip.set('datasheet', 'package', 'abcd', 'pincount', '484')"],
             schelp="""Total number package pins.""")
 
     number = 'default'
-    scparam(cfg, ['datasheet', 'package', name, 'pin', number, 'signal'],
+    scparam(cfg, ['datasheet', 'package', partname, 'pin', number, 'signal'],
             sctype='str',
             shorthelp="Datasheet: package pin signal map",
-            switch="-datasheet_package_pin_signal 'name number <str>'",
+            switch="-datasheet_package_pin_signal 'partname number <str>'",
             example=[
                 "cli: -datasheet_package_pin_signal 'abcd B1 clk'",
                 "api: chip.set('datasheet', 'package', 'abcd', 'pin', 'B1', 'signal', 'clk')"],
@@ -1337,12 +1337,12 @@ def schema_datasheet(cfg, name='default', mode='default'):
             :keypath:`datasheet,pin`.""")
 
     # anchor
-    scparam(cfg, ['datasheet', 'package', name, 'anchor'],
+    scparam(cfg, ['datasheet', 'package', partname, 'anchor'],
             sctype='(float,float)',
             defvalue=(0.0, 0.0),
             unit='um',
             shorthelp="Datasheet: package anchor",
-            switch="-datasheet_package_anchor 'name <(float,float)>'",
+            switch="-datasheet_package_anchor 'partname <(float,float)>'",
             example=[
                 "cli: -datasheet_package_anchor 'i0 (3.0, 3.0)'",
                 "api: chip.set('datasheet', 'package', 'i0', 'anchor', (3.0, 3.0))"],
@@ -1357,32 +1357,32 @@ def schema_datasheet(cfg, name='default', mode='default'):
     ######################
 
     # Pin type
-    scparam(cfg, ['datasheet', 'pin', name, 'type', mode],
+    scparam(cfg, ['datasheet', 'pin', partname, 'type', mode],
             sctype='enum',
             enum=['digital', 'analog', 'clock', 'supply', 'ground'],
             shorthelp="Datasheet: pin type",
-            switch="-datasheet_pin_type 'name mode <str>'",
+            switch="-datasheet_pin_type 'partname mode <str>'",
             example=[
                 "cli: -datasheet_pin_type 'vdd global supply'",
                 "api: chip.set('datasheet', 'pin', 'vdd', 'type', 'global', 'supply')"],
             schelp="""Pin type specified on a per mode basis.""")
 
     # Pin direction
-    scparam(cfg, ['datasheet', 'pin', name, 'dir', mode],
+    scparam(cfg, ['datasheet', 'pin', partname, 'dir', mode],
             sctype='enum',
             enum=['input', 'output', 'inout'],
             shorthelp="Datasheet: pin direction",
-            switch="-datasheet_pin_dir 'name mode <str>'",
+            switch="-datasheet_pin_dir 'partname mode <str>'",
             example=[
                 "cli: -datasheet_pin_dir 'clk global input'",
                 "api: chip.set('datasheet', 'pin', 'clk', 'dir', 'global', 'input')"],
             schelp="""Pin direction specified on a per mode basis.""")
 
     # Pin complement (for differential pair)
-    scparam(cfg, ['datasheet', 'pin', name, 'complement', mode],
+    scparam(cfg, ['datasheet', 'pin', partname, 'complement', mode],
             sctype='str',
             shorthelp="Datasheet: pin complement",
-            switch="-datasheet_pin_complement 'name mode <str>'",
+            switch="-datasheet_pin_complement 'partname mode <str>'",
             example=[
                 "cli: -datasheet_pin_complement 'ina global inb'",
                 "api: chip.set('datasheet', 'pin', 'ina', 'complement', 'global', 'inb')"],
@@ -1390,31 +1390,31 @@ def schema_datasheet(cfg, name='default', mode='default'):
             signals.""")
 
     # Pin standard
-    scparam(cfg, ['datasheet', 'pin', name, 'standard', mode],
+    scparam(cfg, ['datasheet', 'pin', partname, 'standard', mode],
             sctype='[str]',
             shorthelp="Datasheet: pin standard",
-            switch="-datasheet_pin_standard 'name mode <str>'",
+            switch="-datasheet_pin_standard 'partname mode <str>'",
             example=[
                 "cli: -datasheet_pin_standard 'clk def LVCMOS'",
                 "api: chip.set('datasheet', 'pin', 'clk', 'standard', 'def', 'LVCMOS')"],
             schelp="""Pin electrical signaling standard (LVDS, LVCMOS, TTL, ...).""")
 
     # Pin interface map
-    scparam(cfg, ['datasheet', 'pin', name, 'interface', mode],
+    scparam(cfg, ['datasheet', 'pin', partname, 'interface', mode],
             sctype='[str]',
             shorthelp="Datasheet: pin interface map",
-            switch="-datasheet_pin_interface 'name mode <str>'",
+            switch="-datasheet_pin_interface 'partname mode <str>'",
             example=[
                 "cli: -datasheet_pin_interface 'clk0 ddr4 CLKN'",
                 "api: chip.set('datasheet', 'pin', 'clk0', 'interface', 'ddr4', 'CLKN')"],
             schelp="""Pin mapping to standardized interface names.""")
 
     # Pin reset value
-    scparam(cfg, ['datasheet', 'pin', name, 'resetvalue', mode],
+    scparam(cfg, ['datasheet', 'pin', partname, 'resetvalue', mode],
             sctype='enum',
             enum=['weak1', 'weak0', 'strong0', 'strong1', 'highz'],
             shorthelp="Datasheet: pin reset value",
-            switch="-datasheet_pin_resetvalue 'name mode <str>'",
+            switch="-datasheet_pin_resetvalue 'partname mode <str>'",
             example=[
                 "cli: -datasheet_pin_resetvalue 'clk global weak1'",
                 "api: chip.set('datasheet', 'pin', 'clk', 'resetvalue', 'global', 'weak1')"],
@@ -1465,7 +1465,7 @@ def schema_datasheet(cfg, name='default', mode='default'):
                }
 
     for item, val in metrics.items():
-        scparam(cfg, ['datasheet', 'pin', name, item, mode],
+        scparam(cfg, ['datasheet', 'pin', partname, item, mode],
                 unit=val[2],
                 sctype='(float,float,float)',
                 shorthelp=f"Datasheet: pin {val[0]}",
@@ -1488,7 +1488,7 @@ def schema_datasheet(cfg, name='default', mode='default'):
     relpin = 'default'
 
     for i, v in metrics.items():
-        scparam(cfg, ['datasheet', 'pin', name, i, mode, relpin],
+        scparam(cfg, ['datasheet', 'pin', partname, i, mode, relpin],
                 unit=v[2],
                 sctype='(float,float,float)',
                 shorthelp=f"Datasheet: pin {v[0]}",

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1710,7 +1710,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog architecture",
                     "switch": [
-                        "-datasheet_analog_arch 'name <str>'"
+                        "-datasheet_analog_arch 'partname <str>'"
                     ],
                     "type": "str"
                 },
@@ -1735,7 +1735,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog parallel channels",
                     "switch": [
-                        "-datasheet_analog_channels 'name <int>'"
+                        "-datasheet_analog_channels 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -1760,7 +1760,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog common mode rejection ratio",
                     "switch": [
-                        "-datasheet_analog_cmrr 'name <(float,float,float)>'"
+                        "-datasheet_analog_cmrr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -1786,7 +1786,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog differential nonlinearity",
                     "switch": [
-                        "-datasheet_analog_dnl 'name <(float,float,float)>'"
+                        "-datasheet_analog_dnl 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "LSB"
@@ -1812,7 +1812,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog effective number of bits",
                     "switch": [
-                        "-datasheet_analog_enob 'name <(float,float,float)>'"
+                        "-datasheet_analog_enob 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "bits"
@@ -1838,7 +1838,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog features",
                     "switch": [
-                        "-datasheet_analog_features 'name <str>'"
+                        "-datasheet_analog_features 'partname <str>'"
                     ],
                     "type": "[str]"
                 },
@@ -1863,7 +1863,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog gain",
                     "switch": [
-                        "-datasheet_analog_gain 'name <(float,float,float)>'"
+                        "-datasheet_analog_gain 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -1889,7 +1889,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog 2nd order harmonic distortion",
                     "switch": [
-                        "-datasheet_analog_hd2 'name <(float,float,float)>'"
+                        "-datasheet_analog_hd2 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBc"
@@ -1915,7 +1915,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog 3rd order harmonic distortion",
                     "switch": [
-                        "-datasheet_analog_hd3 'name <(float,float,float)>'"
+                        "-datasheet_analog_hd3 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBc"
@@ -1941,7 +1941,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog 4th order harmonic distortion",
                     "switch": [
-                        "-datasheet_analog_hd4 'name <(float,float,float)>'"
+                        "-datasheet_analog_hd4 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBc"
@@ -1967,7 +1967,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf in band 1 dB compression point",
                     "switch": [
-                        "-datasheet_analog_ib1db 'name <(float,float,float)>'"
+                        "-datasheet_analog_ib1db 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBm"
@@ -1993,7 +1993,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf 3rd order input intercept point",
                     "switch": [
-                        "-datasheet_analog_iip3 'name <(float,float,float)>'"
+                        "-datasheet_analog_iip3 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBm"
@@ -2019,7 +2019,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog 3rd order intermodulation distortion",
                     "switch": [
-                        "-datasheet_analog_imd3 'name <(float,float,float)>'"
+                        "-datasheet_analog_imd3 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBc"
@@ -2045,7 +2045,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog integral nonlinearity",
                     "switch": [
-                        "-datasheet_analog_inl 'name <(float,float,float)>'"
+                        "-datasheet_analog_inl 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "LSB"
@@ -2071,7 +2071,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf noise figure",
                     "switch": [
-                        "-datasheet_analog_noisefigure 'name <(float,float,float)>'"
+                        "-datasheet_analog_noisefigure 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2097,7 +2097,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog noise spectral density",
                     "switch": [
-                        "-datasheet_analog_nsd 'name <(float,float,float)>'"
+                        "-datasheet_analog_nsd 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBFS/Hz"
@@ -2123,7 +2123,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf out of band 1 dB compression point",
                     "switch": [
-                        "-datasheet_analog_oob1db 'name <(float,float,float)>'"
+                        "-datasheet_analog_oob1db 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBm"
@@ -2149,7 +2149,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog phase noise",
                     "switch": [
-                        "-datasheet_analog_phasenoise 'name <(float,float,float)>'"
+                        "-datasheet_analog_phasenoise 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBc/Hz"
@@ -2175,7 +2175,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog output power",
                     "switch": [
-                        "-datasheet_analog_pout 'name <(float,float,float)>'"
+                        "-datasheet_analog_pout 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBm"
@@ -2201,7 +2201,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog 2nd harmonic power",
                     "switch": [
-                        "-datasheet_analog_pout2 'name <(float,float,float)>'"
+                        "-datasheet_analog_pout2 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBm"
@@ -2227,7 +2227,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog 3rd harmonic power",
                     "switch": [
-                        "-datasheet_analog_pout3 'name <(float,float,float)>'"
+                        "-datasheet_analog_pout3 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBm"
@@ -2253,7 +2253,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog power supply noise rejection",
                     "switch": [
-                        "-datasheet_analog_psnr 'name <(float,float,float)>'"
+                        "-datasheet_analog_psnr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2279,7 +2279,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog architecture resolution",
                     "switch": [
-                        "-datasheet_analog_resolution 'name <int>'"
+                        "-datasheet_analog_resolution 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -2304,7 +2304,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf input return loss",
                     "switch": [
-                        "-datasheet_analog_s11 'name <(float,float,float)>'"
+                        "-datasheet_analog_s11 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2330,7 +2330,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf reverse isolation",
                     "switch": [
-                        "-datasheet_analog_s12 'name <(float,float,float)>'"
+                        "-datasheet_analog_s12 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2356,7 +2356,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf gain",
                     "switch": [
-                        "-datasheet_analog_s21 'name <(float,float,float)>'"
+                        "-datasheet_analog_s21 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2382,7 +2382,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf output return loss",
                     "switch": [
-                        "-datasheet_analog_s22 'name <(float,float,float)>'"
+                        "-datasheet_analog_s22 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2408,7 +2408,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog sample rate",
                     "switch": [
-                        "-datasheet_analog_samplerate 'name <(float,float,float)>'"
+                        "-datasheet_analog_samplerate 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "Hz"
@@ -2434,7 +2434,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog spurious-free dynamic range",
                     "switch": [
-                        "-datasheet_analog_sfdr 'name <(float,float,float)>'"
+                        "-datasheet_analog_sfdr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBc"
@@ -2460,7 +2460,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog signal to noise and distortion ratio",
                     "switch": [
-                        "-datasheet_analog_sinad 'name <(float,float,float)>'"
+                        "-datasheet_analog_sinad 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2486,7 +2486,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog signal to noise ratio",
                     "switch": [
-                        "-datasheet_analog_snr 'name <(float,float,float)>'"
+                        "-datasheet_analog_snr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2512,7 +2512,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog total harmonic distortion",
                     "switch": [
-                        "-datasheet_analog_thd 'name <(float,float,float)>'"
+                        "-datasheet_analog_thd 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2538,7 +2538,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog gain error",
                     "switch": [
-                        "-datasheet_analog_vgainerror 'name <(float,float,float)>'"
+                        "-datasheet_analog_vgainerror 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "mV"
@@ -2564,7 +2564,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog offset error",
                     "switch": [
-                        "-datasheet_analog_vofferror 'name <(float,float,float)>'"
+                        "-datasheet_analog_vofferror 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "mV"
@@ -2701,7 +2701,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga architecture",
                     "switch": [
-                        "-datasheet_fpga_arch 'name <str>'"
+                        "-datasheet_fpga_arch 'partname <str>'"
                     ],
                     "type": "str"
                 },
@@ -2726,7 +2726,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga block ram",
                     "switch": [
-                        "-datasheet_fpga_blockram 'name <int>'"
+                        "-datasheet_fpga_blockram 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "Kb"
@@ -2752,7 +2752,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga distributed ram",
                     "switch": [
-                        "-datasheet_fpga_distram 'name <int>'"
+                        "-datasheet_fpga_distram 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "Kb"
@@ -2778,7 +2778,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga LUTs",
                     "switch": [
-                        "-datasheet_fpga_luts 'name <int>'"
+                        "-datasheet_fpga_luts 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -2803,7 +2803,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga multiplier/dsp elements",
                     "switch": [
-                        "-datasheet_fpga_mults 'name <int>'"
+                        "-datasheet_fpga_mults 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -2828,7 +2828,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga pll blocks",
                     "switch": [
-                        "-datasheet_fpga_plls 'name <int>'"
+                        "-datasheet_fpga_plls 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -2853,7 +2853,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga registers",
                     "switch": [
-                        "-datasheet_fpga_registers 'name <int>'"
+                        "-datasheet_fpga_registers 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -2878,7 +2878,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga total ram",
                     "switch": [
-                        "-datasheet_fpga_totalram 'name <int>'"
+                        "-datasheet_fpga_totalram 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "Kb"
@@ -2991,14 +2991,14 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: io standard",
                     "switch": [
-                        "-datasheet_io_arch 'name <str>'"
+                        "-datasheet_io_arch 'partname <str>'"
                     ],
                     "type": "enum"
                 },
                 "channels": {
                     "example": [
-                        "cli: -datasheet_io_channels 'name 4'",
-                        "api: chip.set('datasheet', 'io', name, 'channels', 4)"
+                        "cli: -datasheet_io_channels 'partname 4'",
+                        "api: chip.set('datasheet', 'io', partname, 'channels', 4)"
                     ],
                     "help": "Datasheet: IO 4 metrics specified on a per IO port basis.",
                     "lock": false,
@@ -3016,14 +3016,14 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: io channels",
                     "switch": [
-                        "-datasheet_io_channels 'name <int>'"
+                        "-datasheet_io_channels 'partname <int>'"
                     ],
                     "type": "int"
                 },
                 "fmax": {
                     "example": [
-                        "cli: -datasheet_io_fmax 'name 100'",
-                        "api: chip.set('datasheet', 'io', name, 'fmax', 100)"
+                        "cli: -datasheet_io_fmax 'partname 100'",
+                        "api: chip.set('datasheet', 'io', partname, 'fmax', 100)"
                     ],
                     "help": "Datasheet: IO 100 metrics specified on a per IO port basis.",
                     "lock": false,
@@ -3041,15 +3041,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: io maximum frequency",
                     "switch": [
-                        "-datasheet_io_fmax 'name <float>'"
+                        "-datasheet_io_fmax 'partname <float>'"
                     ],
                     "type": "float",
                     "unit": "MHz"
                 },
                 "width": {
                     "example": [
-                        "cli: -datasheet_io_width 'name 4'",
-                        "api: chip.set('datasheet', 'io', name, 'width', 4)"
+                        "cli: -datasheet_io_width 'partname 4'",
+                        "api: chip.set('datasheet', 'io', partname, 'width', 4)"
                     ],
                     "help": "Datasheet: IO 4 metrics specified on a per IO port basis.",
                     "lock": false,
@@ -3067,7 +3067,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: io width",
                     "switch": [
-                        "-datasheet_io_width 'name <int>'"
+                        "-datasheet_io_width 'partname <int>'"
                     ],
                     "type": "int"
                 }
@@ -3512,7 +3512,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory banks",
                     "switch": [
-                        "-datasheet_memory_banks 'name <int>'"
+                        "-datasheet_memory_banks 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -3537,14 +3537,14 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory total bits",
                     "switch": [
-                        "-datasheet_memory_bits 'name <int>'"
+                        "-datasheet_memory_bits 'partname <int>'"
                     ],
                     "type": "int"
                 },
                 "bwrd": {
                     "example": [
-                        "cli: -datasheet_memory_bwrd 'name (1000000000.0, 1000000000.0, 1000000000.0)'",
-                        "api: chip.set('datasheet', 'memory', name, 'bwrd', (1000000000.0, 1000000000.0, 1000000000.0))"
+                        "cli: -datasheet_memory_bwrd 'partname (1000000000.0, 1000000000.0, 1000000000.0)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'bwrd', (1000000000.0, 1000000000.0, 1000000000.0))"
                     ],
                     "help": "Memory (1000000000.0, 1000000000.0, 1000000000.0) specified on a per memory basis.",
                     "lock": false,
@@ -3562,15 +3562,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory maximum read bandwidth",
                     "switch": [
-                        "-datasheet_memory_bwrd 'name <(float,float,float)>'"
+                        "-datasheet_memory_bwrd 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "bps"
                 },
                 "bwwr": {
                     "example": [
-                        "cli: -datasheet_memory_bwwr 'name (1000000000.0, 1000000000.0, 1000000000.0)'",
-                        "api: chip.set('datasheet', 'memory', name, 'bwwr', (1000000000.0, 1000000000.0, 1000000000.0))"
+                        "cli: -datasheet_memory_bwwr 'partname (1000000000.0, 1000000000.0, 1000000000.0)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'bwwr', (1000000000.0, 1000000000.0, 1000000000.0))"
                     ],
                     "help": "Memory (1000000000.0, 1000000000.0, 1000000000.0) specified on a per memory basis.",
                     "lock": false,
@@ -3588,7 +3588,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory maximum write bandwidth",
                     "switch": [
-                        "-datasheet_memory_bwwr 'name <(float,float,float)>'"
+                        "-datasheet_memory_bwwr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "bps"
@@ -3614,14 +3614,14 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory depth",
                     "switch": [
-                        "-datasheet_memory_depth 'name <int>'"
+                        "-datasheet_memory_depth 'partname <int>'"
                     ],
                     "type": "int"
                 },
                 "erd": {
                     "example": [
-                        "cli: -datasheet_memory_erd 'name (1e-12, 2e-12, 3e-12)'",
-                        "api: chip.set('datasheet', 'memory', name, 'erd', (1e-12, 2e-12, 3e-12))"
+                        "cli: -datasheet_memory_erd 'partname (1e-12, 2e-12, 3e-12)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'erd', (1e-12, 2e-12, 3e-12))"
                     ],
                     "help": "Memory (1e-12, 2e-12, 3e-12) specified on a per memory basis.",
                     "lock": false,
@@ -3639,15 +3639,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory read energy",
                     "switch": [
-                        "-datasheet_memory_erd 'name <(float,float,float)>'"
+                        "-datasheet_memory_erd 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "J"
                 },
                 "ewr": {
                     "example": [
-                        "cli: -datasheet_memory_ewr 'name (1e-12, 2e-12, 3e-12)'",
-                        "api: chip.set('datasheet', 'memory', name, 'ewr', (1e-12, 2e-12, 3e-12))"
+                        "cli: -datasheet_memory_ewr 'partname (1e-12, 2e-12, 3e-12)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'ewr', (1e-12, 2e-12, 3e-12))"
                     ],
                     "help": "Memory (1e-12, 2e-12, 3e-12) specified on a per memory basis.",
                     "lock": false,
@@ -3665,15 +3665,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory write energy",
                     "switch": [
-                        "-datasheet_memory_ewr 'name <(float,float,float)>'"
+                        "-datasheet_memory_ewr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "J"
                 },
                 "fmax": {
                     "example": [
-                        "cli: -datasheet_memory_fmax 'name (1000000000.0, 1000000000.0, 1000000000.0)'",
-                        "api: chip.set('datasheet', 'memory', name, 'fmax', (1000000000.0, 1000000000.0, 1000000000.0))"
+                        "cli: -datasheet_memory_fmax 'partname (1000000000.0, 1000000000.0, 1000000000.0)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'fmax', (1000000000.0, 1000000000.0, 1000000000.0))"
                     ],
                     "help": "Memory (1000000000.0, 1000000000.0, 1000000000.0) specified on a per memory basis.",
                     "lock": false,
@@ -3691,15 +3691,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory max frequency",
                     "switch": [
-                        "-datasheet_memory_fmax 'name <(float,float,float)>'"
+                        "-datasheet_memory_fmax 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "Hz"
                 },
                 "tcl": {
                     "example": [
-                        "cli: -datasheet_memory_tcl 'name (100, 100, 100)'",
-                        "api: chip.set('datasheet', 'memory', name, 'tcl', (100, 100, 100))"
+                        "cli: -datasheet_memory_tcl 'partname (100, 100, 100)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'tcl', (100, 100, 100))"
                     ],
                     "help": "Memory (100, 100, 100) specified on a per memory basis.",
                     "lock": false,
@@ -3717,15 +3717,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory column address latency",
                     "switch": [
-                        "-datasheet_memory_tcl 'name <(int,int,int)>'"
+                        "-datasheet_memory_tcl 'partname <(int,int,int)>'"
                     ],
                     "type": "(int,int,int)",
                     "unit": "cycles"
                 },
                 "tcycle": {
                     "example": [
-                        "cli: -datasheet_memory_tcycle 'name (9.0, 10.0, 11.0)'",
-                        "api: chip.set('datasheet', 'memory', name, 'tcycle', (9.0, 10.0, 11.0))"
+                        "cli: -datasheet_memory_tcycle 'partname (9.0, 10.0, 11.0)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'tcycle', (9.0, 10.0, 11.0))"
                     ],
                     "help": "Memory (9.0, 10.0, 11.0) specified on a per memory basis.",
                     "lock": false,
@@ -3743,15 +3743,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory access clock cycle",
                     "switch": [
-                        "-datasheet_memory_tcycle 'name <(float,float,float)>'"
+                        "-datasheet_memory_tcycle 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "ns"
                 },
                 "terase": {
                     "example": [
-                        "cli: -datasheet_memory_terase 'name (1e-06, 1e-06, 1e-06)'",
-                        "api: chip.set('datasheet', 'memory', name, 'terase', (1e-06, 1e-06, 1e-06))"
+                        "cli: -datasheet_memory_terase 'partname (1e-06, 1e-06, 1e-06)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'terase', (1e-06, 1e-06, 1e-06))"
                     ],
                     "help": "Memory (1e-06, 1e-06, 1e-06) specified on a per memory basis.",
                     "lock": false,
@@ -3769,15 +3769,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory erase time",
                     "switch": [
-                        "-datasheet_memory_terase 'name <(float,float,float)>'"
+                        "-datasheet_memory_terase 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "s"
                 },
                 "tras": {
                     "example": [
-                        "cli: -datasheet_memory_tras 'name (100, 100, 100)'",
-                        "api: chip.set('datasheet', 'memory', name, 'tras', (100, 100, 100))"
+                        "cli: -datasheet_memory_tras 'partname (100, 100, 100)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'tras', (100, 100, 100))"
                     ],
                     "help": "Memory (100, 100, 100) specified on a per memory basis.",
                     "lock": false,
@@ -3795,15 +3795,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory row active time latency",
                     "switch": [
-                        "-datasheet_memory_tras 'name <(int,int,int)>'"
+                        "-datasheet_memory_tras 'partname <(int,int,int)>'"
                     ],
                     "type": "(int,int,int)",
                     "unit": "cycles"
                 },
                 "trcd": {
                     "example": [
-                        "cli: -datasheet_memory_trcd 'name (100, 100, 100)'",
-                        "api: chip.set('datasheet', 'memory', name, 'trcd', (100, 100, 100))"
+                        "cli: -datasheet_memory_trcd 'partname (100, 100, 100)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'trcd', (100, 100, 100))"
                     ],
                     "help": "Memory (100, 100, 100) specified on a per memory basis.",
                     "lock": false,
@@ -3821,15 +3821,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory row address latency",
                     "switch": [
-                        "-datasheet_memory_trcd 'name <(int,int,int)>'"
+                        "-datasheet_memory_trcd 'partname <(int,int,int)>'"
                     ],
                     "type": "(int,int,int)",
                     "unit": "cycles"
                 },
                 "trd": {
                     "example": [
-                        "cli: -datasheet_memory_trd 'name (0.9, 1, 1.1)'",
-                        "api: chip.set('datasheet', 'memory', name, 'trd', (0.9, 1, 1.1))"
+                        "cli: -datasheet_memory_trd 'partname (0.9, 1, 1.1)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'trd', (0.9, 1, 1.1))"
                     ],
                     "help": "Memory (0.9, 1, 1.1) specified on a per memory basis.",
                     "lock": false,
@@ -3847,15 +3847,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory read clock cycle",
                     "switch": [
-                        "-datasheet_memory_trd 'name <(float,float,float)>'"
+                        "-datasheet_memory_trd 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "ns"
                 },
                 "trefresh": {
                     "example": [
-                        "cli: -datasheet_memory_trefresh 'name (99, 100, 101)'",
-                        "api: chip.set('datasheet', 'memory', name, 'trefresh', (99, 100, 101))"
+                        "cli: -datasheet_memory_trefresh 'partname (99, 100, 101)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'trefresh', (99, 100, 101))"
                     ],
                     "help": "Memory (99, 100, 101) specified on a per memory basis.",
                     "lock": false,
@@ -3873,15 +3873,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory refresh time",
                     "switch": [
-                        "-datasheet_memory_trefresh 'name <(float,float,float)>'"
+                        "-datasheet_memory_trefresh 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "ns"
                 },
                 "trp": {
                     "example": [
-                        "cli: -datasheet_memory_trp 'name (100, 100, 100)'",
-                        "api: chip.set('datasheet', 'memory', name, 'trp', (100, 100, 100))"
+                        "cli: -datasheet_memory_trp 'partname (100, 100, 100)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'trp', (100, 100, 100))"
                     ],
                     "help": "Memory (100, 100, 100) specified on a per memory basis.",
                     "lock": false,
@@ -3899,15 +3899,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory row precharge time latency",
                     "switch": [
-                        "-datasheet_memory_trp 'name <(int,int,int)>'"
+                        "-datasheet_memory_trp 'partname <(int,int,int)>'"
                     ],
                     "type": "(int,int,int)",
                     "unit": "cycles"
                 },
                 "twearout": {
                     "example": [
-                        "cli: -datasheet_memory_twearout 'name (100000.0, 1000000.0, 10000000.0)'",
-                        "api: chip.set('datasheet', 'memory', name, 'twearout', (100000.0, 1000000.0, 10000000.0))"
+                        "cli: -datasheet_memory_twearout 'partname (100000.0, 1000000.0, 10000000.0)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'twearout', (100000.0, 1000000.0, 10000000.0))"
                     ],
                     "help": "Memory (100000.0, 1000000.0, 10000000.0) specified on a per memory basis.",
                     "lock": false,
@@ -3925,15 +3925,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory write/erase wear-out",
                     "switch": [
-                        "-datasheet_memory_twearout 'name <(float,float,float)>'"
+                        "-datasheet_memory_twearout 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "cycles"
                 },
                 "twr": {
                     "example": [
-                        "cli: -datasheet_memory_twr 'name (0.9, 1, 1.1)'",
-                        "api: chip.set('datasheet', 'memory', name, 'twr', (0.9, 1, 1.1))"
+                        "cli: -datasheet_memory_twr 'partname (0.9, 1, 1.1)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'twr', (0.9, 1, 1.1))"
                     ],
                     "help": "Memory (0.9, 1, 1.1) specified on a per memory basis.",
                     "lock": false,
@@ -3951,7 +3951,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory write clock cycle",
                     "switch": [
-                        "-datasheet_memory_twr 'name <(float,float,float)>'"
+                        "-datasheet_memory_twr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "ns"
@@ -3977,7 +3977,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory width",
                     "switch": [
-                        "-datasheet_memory_width 'name <int>'"
+                        "-datasheet_memory_width 'partname <int>'"
                     ],
                     "type": "int"
                 }
@@ -4037,7 +4037,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package 3D model",
                     "switch": [
-                        "-datasheet_package_3dmodel 'name <file>'"
+                        "-datasheet_package_3dmodel 'partname <file>'"
                     ],
                     "type": "[file]"
                 },
@@ -4065,7 +4065,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package anchor",
                     "switch": [
-                        "-datasheet_package_anchor 'name <(float,float)>'"
+                        "-datasheet_package_anchor 'partname <(float,float)>'"
                     ],
                     "type": "(float,float)",
                     "unit": "um"
@@ -4097,7 +4097,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package drawing",
                     "switch": [
-                        "-datasheet_package_drawing 'name <file>'"
+                        "-datasheet_package_drawing 'partname <file>'"
                     ],
                     "type": "[file]"
                 },
@@ -4128,7 +4128,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package footprint",
                     "switch": [
-                        "-datasheet_package_footprint 'name <file>'"
+                        "-datasheet_package_footprint 'partname <file>'"
                     ],
                     "type": "[file]"
                 },
@@ -4153,7 +4153,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package length",
                     "switch": [
-                        "-datasheet_package_length 'name <(float,float,float)>'"
+                        "-datasheet_package_length 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "um"
@@ -4181,7 +4181,7 @@
                             "scope": "job",
                             "shorthelp": "Datasheet: package pin signal map",
                             "switch": [
-                                "-datasheet_package_pin_signal 'name number <str>'"
+                                "-datasheet_package_pin_signal 'partname number <str>'"
                             ],
                             "type": "str"
                         }
@@ -4208,7 +4208,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package pin count",
                     "switch": [
-                        "-datasheet_package_pincount 'name <int>'"
+                        "-datasheet_package_pincount 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -4233,7 +4233,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package pin pitch",
                     "switch": [
-                        "-datasheet_package_pinpitch 'name <(float,float,float)>'"
+                        "-datasheet_package_pinpitch 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "um"
@@ -4259,7 +4259,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package thickness",
                     "switch": [
-                        "-datasheet_package_thickness 'name <(float,float,float)>'"
+                        "-datasheet_package_thickness 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "um"
@@ -4295,7 +4295,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package type",
                     "switch": [
-                        "-datasheet_package_type 'name <str>'"
+                        "-datasheet_package_type 'partname <str>'"
                     ],
                     "type": "enum"
                 },
@@ -4320,7 +4320,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package width",
                     "switch": [
-                        "-datasheet_package_width 'name <(float,float,float)>'"
+                        "-datasheet_package_width 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "um"
@@ -4405,7 +4405,7 @@
                         "scope": "job",
                         "shorthelp": "Datasheet: pin complement",
                         "switch": [
-                            "-datasheet_pin_complement 'name mode <str>'"
+                            "-datasheet_pin_complement 'partname mode <str>'"
                         ],
                         "type": "str"
                     }
@@ -4437,7 +4437,7 @@
                         "scope": "job",
                         "shorthelp": "Datasheet: pin direction",
                         "switch": [
-                            "-datasheet_pin_dir 'name mode <str>'"
+                            "-datasheet_pin_dir 'partname mode <str>'"
                         ],
                         "type": "enum"
                     }
@@ -4548,7 +4548,7 @@
                         "scope": "job",
                         "shorthelp": "Datasheet: pin interface map",
                         "switch": [
-                            "-datasheet_pin_interface 'name mode <str>'"
+                            "-datasheet_pin_interface 'partname mode <str>'"
                         ],
                         "type": "[str]"
                     }
@@ -4806,7 +4806,7 @@
                         "scope": "job",
                         "shorthelp": "Datasheet: pin reset value",
                         "switch": [
-                            "-datasheet_pin_resetvalue 'name mode <str>'"
+                            "-datasheet_pin_resetvalue 'partname mode <str>'"
                         ],
                         "type": "enum"
                     }
@@ -4945,7 +4945,7 @@
                         "scope": "job",
                         "shorthelp": "Datasheet: pin standard",
                         "switch": [
-                            "-datasheet_pin_standard 'name mode <str>'"
+                            "-datasheet_pin_standard 'partname mode <str>'"
                         ],
                         "type": "[str]"
                     }
@@ -5357,7 +5357,7 @@
                         "scope": "job",
                         "shorthelp": "Datasheet: pin type",
                         "switch": [
-                            "-datasheet_pin_type 'name mode <str>'"
+                            "-datasheet_pin_type 'partname mode <str>'"
                         ],
                         "type": "enum"
                     }
@@ -5761,7 +5761,7 @@
                 "arch": {
                     "example": [
                         "cli: -datasheet_proc_arch '0 RV64GC'",
-                        "api: chip.set('datasheet', 'proc', name, 'arch', 'openfpga')"
+                        "api: chip.set('datasheet', 'proc', partname, 'arch', 'openfpga')"
                     ],
                     "help": "Processor architecture specified on a per core basis.",
                     "lock": false,
@@ -5779,7 +5779,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor architecture",
                     "switch": [
-                        "-datasheet_proc_arch 'name <str>'"
+                        "-datasheet_proc_arch 'partname <str>'"
                     ],
                     "type": "str"
                 },
@@ -5804,7 +5804,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor architecture size",
                     "switch": [
-                        "-datasheet_proc_archsize 'name <int>'"
+                        "-datasheet_proc_archsize 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -5829,7 +5829,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor number of cores",
                     "switch": [
-                        "-datasheet_proc_cores 'name <int>'"
+                        "-datasheet_proc_cores 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -5873,7 +5873,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor datatypes",
                     "switch": [
-                        "-datasheet_proc_datatypes 'name <str>'"
+                        "-datasheet_proc_datatypes 'partname <str>'"
                     ],
                     "type": "[enum]"
                 },
@@ -5898,7 +5898,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor l1 dcache size",
                     "switch": [
-                        "-datasheet_proc_dcache 'name <int>'"
+                        "-datasheet_proc_dcache 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "KB"
@@ -5924,7 +5924,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor features",
                     "switch": [
-                        "-datasheet_proc_features 'name <str>'"
+                        "-datasheet_proc_features 'partname <str>'"
                     ],
                     "type": "[str]"
                 },
@@ -5949,7 +5949,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor maximum frequency",
                     "switch": [
-                        "-datasheet_proc_fmax 'name <int>'"
+                        "-datasheet_proc_fmax 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "MHz"
@@ -5975,7 +5975,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor l1 icache size",
                     "switch": [
-                        "-datasheet_proc_icache 'name <int>'"
+                        "-datasheet_proc_icache 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "KB"
@@ -6001,7 +6001,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor l2 cache size",
                     "switch": [
-                        "-datasheet_proc_l2cache 'name <int>'"
+                        "-datasheet_proc_l2cache 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "KB"
@@ -6027,7 +6027,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor l3 cache size",
                     "switch": [
-                        "-datasheet_proc_l3cache 'name <int>'"
+                        "-datasheet_proc_l3cache 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "KB"
@@ -6053,7 +6053,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor hard multiplier units",
                     "switch": [
-                        "-datasheet_proc_mults 'name <int>'"
+                        "-datasheet_proc_mults 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -6078,7 +6078,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor local non-volatile memory",
                     "switch": [
-                        "-datasheet_proc_nvm 'name <int>'"
+                        "-datasheet_proc_nvm 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "KB"
@@ -6104,7 +6104,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor operations per cycle",
                     "switch": [
-                        "-datasheet_proc_ops 'name <int>'"
+                        "-datasheet_proc_ops 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -6129,7 +6129,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor local sram",
                     "switch": [
-                        "-datasheet_proc_sram 'name <int>'"
+                        "-datasheet_proc_sram 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "KB"
@@ -11573,12 +11573,12 @@
         },
         "component": {
             "default": {
-                "model": {
+                "partname": {
                     "example": [
-                        "cli: -schematic_component_model 'B0 NAND2X1'",
-                        "api: chip.set('schematic', 'component', 'B0, 'model', 'NAND2X1')"
+                        "cli: -schematic_component_partname 'B0 NAND2X1'",
+                        "api: chip.set('schematic', 'component', 'B0, 'partname', 'NAND2X1')"
                     ],
-                    "help": "Model of a component, specified on a per instance basis.",
+                    "help": "Component part-name (\"aka cell-name\") specified on a per instance basis.",
                     "lock": false,
                     "node": {
                         "default": {
@@ -11594,7 +11594,7 @@
                     "scope": "job",
                     "shorthelp": "Schematic: component model",
                     "switch": [
-                        "-schematic_component_model 'name <str>'"
+                        "-schematic_component_partname 'name <str>'"
                     ],
                     "type": "str"
                 }

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -761,7 +761,7 @@
                         "cli: -constraint_component_partname 'i0 filler_x1'",
                         "api: chip.set('constraint', 'component', 'i0', 'partname', 'filler_x1')"
                     ],
-                    "help": "Part name of the instance. The parameter is required for instances\nthat are not contained within the design netlist (ie. physical only cells).",
+                    "help": "Name of the model, type, or variant of the placed component. In the chip\ndesign domain, 'partname' is synonymous to 'cellname' or 'cell'. The\n'partname' is required for instances that are not represented within\nthe design netlist (ie. physical only cells).",
                     "lock": false,
                     "node": {
                         "default": {
@@ -871,7 +871,7 @@
                         "cli: -constraint_component_side 'i0 top'",
                         "api: chip.set('constraint', 'component', 'i0', 'side', 'top')"
                     ],
-                    "help": "Side of the substrate where the component should be placed. The `side`\ndefinitions are with respect to a viewer looking sideways at an object.\nTop is towards the sky, front is the side closest to the viewer, and\nright is right. The maximum number of sides per substrate is six",
+                    "help": "Side of the substrate where the component should be placed. The `side`\nis defined with respect to a viewer looking sideways at an object.\nTop is towards the sky, front is the side closest to the viewer, and\nright is right. The maximum number of sides per substrate is six",
                     "lock": false,
                     "node": {
                         "default": {
@@ -896,7 +896,7 @@
                         "cli: -constraint_component_substrate 'i0 pcb0'",
                         "api: chip.set('constraint', 'component', 'i0', 'substrate', 'pcb0')"
                     ],
-                    "help": "Substrates are supporting material that components are placed upon.\nList of supported substrates includes (but not limited to):\nwafers, dies, panels, PCBs.",
+                    "help": "Name of physical substrates instance that components are placed upon.\nAny flat surface can serve as a substrate (eg. wafers, dies, panels, PCBs,\nsubstrates, interposers).",
                     "lock": false,
                     "node": {
                         "default": {
@@ -1286,7 +1286,7 @@
                         "cli: -constraint_pin_height 'nreset 1.0'",
                         "api: chip.set('constraint', 'pin', 'nreset', height, 1.0)"
                     ],
-                    "help": "Pin height constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust sizes to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
+                    "help": "Pin height (y-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust placements to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
                     "lock": false,
                     "node": {
                         "default": {
@@ -1312,7 +1312,7 @@
                         "cli: -constraint_pin_layer 'nreset m4'",
                         "api: chip.set('constraint', 'pin', 'nreset', 'layer', 'm4')"
                     ],
-                    "help": "Pin metal layer specified based on the SC standard layer stack\nstarting with m1 as the lowest routing layer and ending\nwith m<n> as the highest routing layer.",
+                    "help": "Pin metal layer for pin placement specified on a per pin basis.\nMetal names should either be the PDK specific metal stack name or\nan integer with '1' being the lowest routing layer.\nThe wildcard character '*' is supported for pin names.",
                     "lock": false,
                     "node": {
                         "default": {
@@ -1331,32 +1331,6 @@
                         "-constraint_pin_layer 'name <str>'"
                     ],
                     "type": "str"
-                },
-                "length": {
-                    "example": [
-                        "cli: -constraint_pin_length 'nreset 1.0'",
-                        "api: chip.set('constraint', 'pin', 'nreset', length, 1.0)"
-                    ],
-                    "help": "Pin length constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust sizes to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "optional",
-                    "require": false,
-                    "scope": "job",
-                    "shorthelp": "Constraint: pin length",
-                    "switch": [
-                        "-constraint_pin_length 'name <float>'"
-                    ],
-                    "type": "float",
-                    "unit": "um"
                 },
                 "order": {
                     "example": [
@@ -1474,7 +1448,7 @@
                         "cli: -constraint_pin_width 'nreset 1.0'",
                         "api: chip.set('constraint', 'pin', 'nreset', width, 1.0)"
                     ],
-                    "help": "Pin width constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust sizes to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
+                    "help": "Pin width (x-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust placements to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
                     "lock": false,
                     "node": {
                         "default": {
@@ -11725,7 +11699,7 @@
             "default": {
                 "default": {
                     "signature": null,
-                    "value": "0.49.0"
+                    "value": "0.50.0"
                 }
             }
         },

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1312,7 +1312,7 @@
                         "cli: -constraint_pin_layer 'nreset m4'",
                         "api: chip.set('constraint', 'pin', 'nreset', 'layer', 'm4')"
                     ],
-                    "help": "Pin metal layer for pin placement specified on a per pin basis.\nMetal names should either be the PDK specific metal stack name or\nan integer with '1' being the lowest routing layer.\nThe wildcard character '*' is supported for pin names.",
+                    "help": "Pin metal layer constraint specified on a per pin basis.\nMetal names should either be the PDK specific metal stack name or\nan integer with '1' being the lowest routing layer.\nThe wildcard character '*' is supported for pin names.",
                     "lock": false,
                     "node": {
                         "default": {

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1281,32 +1281,6 @@
         },
         "pin": {
             "default": {
-                "height": {
-                    "example": [
-                        "cli: -constraint_pin_height 'nreset 1.0'",
-                        "api: chip.set('constraint', 'pin', 'nreset', height, 1.0)"
-                    ],
-                    "help": "Pin height (y-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust dimensions to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "optional",
-                    "require": false,
-                    "scope": "job",
-                    "shorthelp": "Constraint: pin height",
-                    "switch": [
-                        "-constraint_pin_height 'name <float>'"
-                    ],
-                    "type": "float",
-                    "unit": "um"
-                },
                 "layer": {
                     "example": [
                         "cli: -constraint_pin_layer 'nreset m4'",
@@ -1331,6 +1305,32 @@
                         "-constraint_pin_layer 'name <str>'"
                     ],
                     "type": "str"
+                },
+                "length": {
+                    "example": [
+                        "cli: -constraint_pin_length 'nreset 1.0'",
+                        "api: chip.set('constraint', 'pin', 'nreset', 'length', 1.0)"
+                    ],
+                    "help": "Pin length constraint.  Package pin length refers to the\nlength of the electrical pins extending out from (or into)\na component. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust dimensions to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "optional",
+                    "require": false,
+                    "scope": "job",
+                    "shorthelp": "Constraint: pin length",
+                    "switch": [
+                        "-constraint_pin_length 'name <float>'"
+                    ],
+                    "type": "float",
+                    "unit": "um"
                 },
                 "order": {
                     "example": [
@@ -1446,9 +1446,9 @@
                 "width": {
                     "example": [
                         "cli: -constraint_pin_width 'nreset 1.0'",
-                        "api: chip.set('constraint', 'pin', 'nreset', width, 1.0)"
+                        "api: chip.set('constraint', 'pin', 'nreset', 'width', 1.0)"
                     ],
-                    "help": "Pin width (x-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust dimensions to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
+                    "help": "Pin width constraint.  Package pin width is the lateral\n(side-to-side) thickness of a pin on a physical component.\nThis parameter represents goal/intent, not an exact\nspecification. The layout system may adjust dimensions to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
                     "lock": false,
                     "node": {
                         "default": {

--- a/tests/core/data/defaults.json
+++ b/tests/core/data/defaults.json
@@ -1286,7 +1286,7 @@
                         "cli: -constraint_pin_height 'nreset 1.0'",
                         "api: chip.set('constraint', 'pin', 'nreset', height, 1.0)"
                     ],
-                    "help": "Pin height (y-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust placements to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
+                    "help": "Pin height (y-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust dimensions to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
                     "lock": false,
                     "node": {
                         "default": {
@@ -1448,7 +1448,7 @@
                         "cli: -constraint_pin_width 'nreset 1.0'",
                         "api: chip.set('constraint', 'pin', 'nreset', width, 1.0)"
                     ],
-                    "help": "Pin width (x-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust placements to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
+                    "help": "Pin width (x-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust dimensions to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
                     "lock": false,
                     "node": {
                         "default": {

--- a/tests/core/data/last_minor.json
+++ b/tests/core/data/last_minor.json
@@ -756,38 +756,12 @@
                     "type": "(float,float)",
                     "unit": "um"
                 },
-                "height": {
-                    "example": [
-                        "cli: -constraint_component_height 'i0 100.0'",
-                        "api: chip.set('constraint', 'component', 'i0', 'height', 100.0)"
-                    ],
-                    "help": "Height above the substrate for component placement. The space\nbetween the component and substrate is occupied by material,\nsupporting scaffolding, and electrical connections (eg. bumps,\nvias).",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "optional",
-                    "require": false,
-                    "scope": "job",
-                    "shorthelp": "Constraint: component placement height",
-                    "switch": [
-                        "-constraint_component_height 'inst <float>'"
-                    ],
-                    "type": "float",
-                    "unit": "um"
-                },
                 "partname": {
                     "example": [
                         "cli: -constraint_component_partname 'i0 filler_x1'",
                         "api: chip.set('constraint', 'component', 'i0', 'partname', 'filler_x1')"
                     ],
-                    "help": "Part name of the instance. The parameter is required for instances\nthat are not contained within the design netlist (ie. physical only cells).",
+                    "help": "Name of the model, type, or variant of the placed component. In the chip\ndesign domain, 'partname' is synonymous to 'cellname' or 'cell'. The\n'partname' is required for instances that are not represented within\nthe design netlist (ie. physical only cells).",
                     "lock": false,
                     "node": {
                         "default": {
@@ -884,12 +858,45 @@
                     ],
                     "type": "enum"
                 },
+                "side": {
+                    "enum": [
+                        "left",
+                        "right",
+                        "front",
+                        "back",
+                        "top",
+                        "bottom"
+                    ],
+                    "example": [
+                        "cli: -constraint_component_side 'i0 top'",
+                        "api: chip.set('constraint', 'component', 'i0', 'side', 'top')"
+                    ],
+                    "help": "Side of the substrate where the component should be placed. The `side`\nis defined with respect to a viewer looking sideways at an object.\nTop is towards the sky, front is the side closest to the viewer, and\nright is right. The maximum number of sides per substrate is six",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "optional",
+                    "require": false,
+                    "scope": "job",
+                    "shorthelp": "Constraint: component side",
+                    "switch": [
+                        "-constraint_component_side 'inst <str>'"
+                    ],
+                    "type": "enum"
+                },
                 "substrate": {
                     "example": [
-                        "cli: -constraint_component_substrate 'i0 pcb0.top'",
-                        "api: chip.set('constraint', 'component', 'i0', 'substrate', 'pcb0.top')"
+                        "cli: -constraint_component_substrate 'i0 pcb0'",
+                        "api: chip.set('constraint', 'component', 'i0', 'substrate', 'pcb0')"
                     ],
-                    "help": "Component substrate forplacement. The substrate format is:\n`'name.top'` or `'name.bottom'`, where `name` is the substrate\ninstance and `top` or `bottom`  indicates the side of of the substrate.\nThe definition of `top` and `bottom` is design specific but must be consistent for a\ngiven substrate. The substrate constraint can be ommitted for\n2D layout systems where there is no substrate  ambiguity\n(eg. monolithic ASIC design).",
+                    "help": "Name of physical substrates instance that components are placed upon.\nAny flat surface can serve as a substrate (eg. wafers, dies, panels, PCBs,\nsubstrates, interposers).",
                     "lock": false,
                     "node": {
                         "default": {
@@ -908,6 +915,32 @@
                         "-constraint_component_substrate 'inst <str>'"
                     ],
                     "type": "str"
+                },
+                "zheight": {
+                    "example": [
+                        "cli: -constraint_component_zheight 'i0 100.0'",
+                        "api: chip.set('constraint', 'component', 'i0', 'zheight', 100.0)"
+                    ],
+                    "help": "Height above the substrate for component placement. The space\nbetween the component and substrate is occupied by material,\nsupporting scaffolding, and electrical connections (eg. bumps,\nvias, pillars).",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "optional",
+                    "require": false,
+                    "scope": "job",
+                    "shorthelp": "Constraint: component placement zheight",
+                    "switch": [
+                        "-constraint_component_zheight 'inst <float>'"
+                    ],
+                    "type": "float",
+                    "unit": "um"
                 }
             }
         },
@@ -1253,7 +1286,7 @@
                         "cli: -constraint_pin_height 'nreset 1.0'",
                         "api: chip.set('constraint', 'pin', 'nreset', height, 1.0)"
                     ],
-                    "help": "Pin height constraint. The parameter is a goal/intent, not an exact\nspecification. The layout system may adjust sizes to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
+                    "help": "Pin height (y-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust placements to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
                     "lock": false,
                     "node": {
                         "default": {
@@ -1264,7 +1297,7 @@
                         }
                     },
                     "notes": null,
-                    "pernode": "never",
+                    "pernode": "optional",
                     "require": false,
                     "scope": "job",
                     "shorthelp": "Constraint: pin height",
@@ -1279,7 +1312,7 @@
                         "cli: -constraint_pin_layer 'nreset m4'",
                         "api: chip.set('constraint', 'pin', 'nreset', 'layer', 'm4')"
                     ],
-                    "help": "Pin metal layer specified based on the SC standard layer stack\nstarting with m1 as the lowest routing layer and ending\nwith m<n> as the highest routing layer.",
+                    "help": "Pin metal layer for pin placement specified on a per pin basis.\nMetal names should either be the PDK specific metal stack name or\nan integer with '1' being the lowest routing layer.\nThe wildcard character '*' is supported for pin names.",
                     "lock": false,
                     "node": {
                         "default": {
@@ -1298,32 +1331,6 @@
                         "-constraint_pin_layer 'name <str>'"
                     ],
                     "type": "str"
-                },
-                "length": {
-                    "example": [
-                        "cli: -constraint_pin_length 'nreset 1.0'",
-                        "api: chip.set('constraint', 'pin', 'nreset', length, 1.0)"
-                    ],
-                    "help": "Pin length constraint. The parameter is a goal/intent, not an exact\nspecification. The layout system may adjust sizes to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "never",
-                    "require": false,
-                    "scope": "job",
-                    "shorthelp": "Constraint: pin length",
-                    "switch": [
-                        "-constraint_pin_length 'name <float>'"
-                    ],
-                    "type": "float",
-                    "unit": "um"
                 },
                 "order": {
                     "example": [
@@ -1391,7 +1398,7 @@
                         "cli: -constraint_pin_shape 'nreset circle'",
                         "api: chip.set('constraint', 'pin', 'nreset', 'shape', 'circle')"
                     ],
-                    "help": "Pin shape constraint specified on a per pin basis. In 3D design systems,\nthe pin shape represents the cross section of the pin in the direction\northogonal to the signal flow direction.",
+                    "help": "Pin shape constraint specified on a per pin basis. In 3D design systems,\nthe pin shape represents the cross section of the pin in the direction\northogonal to the signal flow direction. The 'pill' (aka stadium) shape,\nis rectangle with semicircles at a pair of opposite sides. The other\npin shapes represent common geometric shape definitions.",
                     "lock": false,
                     "node": {
                         "default": {
@@ -1402,7 +1409,7 @@
                         }
                     },
                     "notes": null,
-                    "pernode": "never",
+                    "pernode": "optional",
                     "require": false,
                     "scope": "job",
                     "shorthelp": "Constraint: pin shape",
@@ -1441,7 +1448,7 @@
                         "cli: -constraint_pin_width 'nreset 1.0'",
                         "api: chip.set('constraint', 'pin', 'nreset', width, 1.0)"
                     ],
-                    "help": "Pin width constraint. The parameter is a goal/intent, not an exact\nspecification. The layout system may adjust sizes to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
+                    "help": "Pin width (x-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust placements to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
                     "lock": false,
                     "node": {
                         "default": {
@@ -1452,7 +1459,7 @@
                         }
                     },
                     "notes": null,
-                    "pernode": "never",
+                    "pernode": "optional",
                     "require": false,
                     "scope": "job",
                     "shorthelp": "Constraint: pin width",
@@ -4010,7 +4017,7 @@
                         "api: chip.set('datasheet', 'package', 'abcd', '3dmodel', './soic8.step')"
                     ],
                     "hashalgo": "sha256",
-                    "help": "Package 3D model file. Common 3D model standards include STEP and WRL.",
+                    "help": "Package 3D model file. Supported 3D model file formats include:\n\n* (STEP) Standard for the Exchange of Product Data Format\n* (STL) Stereolithography Format\n* (WRL) Virtually Reality Modeling Language Format",
                     "lock": false,
                     "node": {
                         "default": {
@@ -4070,7 +4077,7 @@
                         "api: chip.set('datasheet', 'package', 'abcd', 'drawing', 'p484.pdf')"
                     ],
                     "hashalgo": "sha256",
-                    "help": "Mechanical package outline for documentation purposes.\nCommon file formats include PDF, DOC, SVG, and PNG.",
+                    "help": "Mechanical drawing for documentation purposes.\nSupported file formats include: PDF, DOC, SVG, and PNG.",
                     "lock": false,
                     "node": {
                         "default": {
@@ -4101,7 +4108,7 @@
                         "api: chip.set('datasheet', 'package', 'abcd', 'footprint', './soic8.kicad_mod')"
                     ],
                     "hashalgo": "sha256",
-                    "help": "Package footprint file.",
+                    "help": "Package footprint file. Supported 3D model file formats include:\n\n* (KICAD_MOD) KiCad Standard Footprint Format",
                     "lock": false,
                     "node": {
                         "default": {
@@ -4174,7 +4181,7 @@
                             "scope": "job",
                             "shorthelp": "Datasheet: package pin signal map",
                             "switch": [
-                                "-datasheet_package_pin_signal 'name <str>'"
+                                "-datasheet_package_pin_signal 'name number <str>'"
                             ],
                             "type": "str"
                         }
@@ -9046,7 +9053,7 @@
                     "cli: -scheduler slurm",
                     "api: chip.set('option', 'scheduler', 'name', 'slurm')"
                 ],
-                "help": "Sets the type of job scheduler to be used for each individual\nflowgraph steps. If the parameter is undefined, the steps are executed\non the same machine that the SC was launched on. If 'slurm' is used,\nthe host running the 'sc' command must be running a 'slurmctld' daemon\nmanaging a Slurm cluster. Additionally, the build directory ('-dir')\nmust be located in shared storage which can be accessed by all hosts\nin the cluster.",
+                "help": "Sets the type of job scheduler to be used for each individual\nflowgraph steps. If the parameter is undefined, the steps are executed\non the same machine that the SC was launched on. If 'slurm' is used,\nthe host running the 'sc' command must be running a 'slurmctld' daemon\nmanaging a Slurm cluster. Additionally, the build directory\n(:keypath:`option,builddir`) must be located in shared storage which\ncan be accessed by all hosts in the cluster.",
                 "lock": false,
                 "node": {
                     "default": {
@@ -11692,7 +11699,7 @@
             "default": {
                 "default": {
                     "signature": null,
-                    "value": "0.49.0"
+                    "value": "0.50.0"
                 }
             }
         },

--- a/tests/core/data/last_minor.json
+++ b/tests/core/data/last_minor.json
@@ -1710,7 +1710,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog architecture",
                     "switch": [
-                        "-datasheet_analog_arch 'name <str>'"
+                        "-datasheet_analog_arch 'partname <str>'"
                     ],
                     "type": "str"
                 },
@@ -1735,7 +1735,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog parallel channels",
                     "switch": [
-                        "-datasheet_analog_channels 'name <int>'"
+                        "-datasheet_analog_channels 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -1760,7 +1760,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog common mode rejection ratio",
                     "switch": [
-                        "-datasheet_analog_cmrr 'name <(float,float,float)>'"
+                        "-datasheet_analog_cmrr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -1786,7 +1786,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog differential nonlinearity",
                     "switch": [
-                        "-datasheet_analog_dnl 'name <(float,float,float)>'"
+                        "-datasheet_analog_dnl 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "LSB"
@@ -1812,7 +1812,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog effective number of bits",
                     "switch": [
-                        "-datasheet_analog_enob 'name <(float,float,float)>'"
+                        "-datasheet_analog_enob 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "bits"
@@ -1838,7 +1838,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog features",
                     "switch": [
-                        "-datasheet_analog_features 'name <str>'"
+                        "-datasheet_analog_features 'partname <str>'"
                     ],
                     "type": "[str]"
                 },
@@ -1863,7 +1863,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog gain",
                     "switch": [
-                        "-datasheet_analog_gain 'name <(float,float,float)>'"
+                        "-datasheet_analog_gain 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -1889,7 +1889,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog 2nd order harmonic distortion",
                     "switch": [
-                        "-datasheet_analog_hd2 'name <(float,float,float)>'"
+                        "-datasheet_analog_hd2 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBc"
@@ -1915,7 +1915,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog 3rd order harmonic distortion",
                     "switch": [
-                        "-datasheet_analog_hd3 'name <(float,float,float)>'"
+                        "-datasheet_analog_hd3 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBc"
@@ -1941,7 +1941,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog 4th order harmonic distortion",
                     "switch": [
-                        "-datasheet_analog_hd4 'name <(float,float,float)>'"
+                        "-datasheet_analog_hd4 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBc"
@@ -1967,7 +1967,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf in band 1 dB compression point",
                     "switch": [
-                        "-datasheet_analog_ib1db 'name <(float,float,float)>'"
+                        "-datasheet_analog_ib1db 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBm"
@@ -1993,7 +1993,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf 3rd order input intercept point",
                     "switch": [
-                        "-datasheet_analog_iip3 'name <(float,float,float)>'"
+                        "-datasheet_analog_iip3 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBm"
@@ -2019,7 +2019,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog 3rd order intermodulation distortion",
                     "switch": [
-                        "-datasheet_analog_imd3 'name <(float,float,float)>'"
+                        "-datasheet_analog_imd3 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBc"
@@ -2045,7 +2045,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog integral nonlinearity",
                     "switch": [
-                        "-datasheet_analog_inl 'name <(float,float,float)>'"
+                        "-datasheet_analog_inl 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "LSB"
@@ -2071,7 +2071,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf noise figure",
                     "switch": [
-                        "-datasheet_analog_noisefigure 'name <(float,float,float)>'"
+                        "-datasheet_analog_noisefigure 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2097,7 +2097,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog noise spectral density",
                     "switch": [
-                        "-datasheet_analog_nsd 'name <(float,float,float)>'"
+                        "-datasheet_analog_nsd 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBFS/Hz"
@@ -2123,7 +2123,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf out of band 1 dB compression point",
                     "switch": [
-                        "-datasheet_analog_oob1db 'name <(float,float,float)>'"
+                        "-datasheet_analog_oob1db 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBm"
@@ -2149,7 +2149,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog phase noise",
                     "switch": [
-                        "-datasheet_analog_phasenoise 'name <(float,float,float)>'"
+                        "-datasheet_analog_phasenoise 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBc/Hz"
@@ -2175,7 +2175,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog output power",
                     "switch": [
-                        "-datasheet_analog_pout 'name <(float,float,float)>'"
+                        "-datasheet_analog_pout 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBm"
@@ -2201,7 +2201,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog 2nd harmonic power",
                     "switch": [
-                        "-datasheet_analog_pout2 'name <(float,float,float)>'"
+                        "-datasheet_analog_pout2 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBm"
@@ -2227,7 +2227,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog 3rd harmonic power",
                     "switch": [
-                        "-datasheet_analog_pout3 'name <(float,float,float)>'"
+                        "-datasheet_analog_pout3 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBm"
@@ -2253,7 +2253,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog power supply noise rejection",
                     "switch": [
-                        "-datasheet_analog_psnr 'name <(float,float,float)>'"
+                        "-datasheet_analog_psnr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2279,7 +2279,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog architecture resolution",
                     "switch": [
-                        "-datasheet_analog_resolution 'name <int>'"
+                        "-datasheet_analog_resolution 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -2304,7 +2304,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf input return loss",
                     "switch": [
-                        "-datasheet_analog_s11 'name <(float,float,float)>'"
+                        "-datasheet_analog_s11 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2330,7 +2330,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf reverse isolation",
                     "switch": [
-                        "-datasheet_analog_s12 'name <(float,float,float)>'"
+                        "-datasheet_analog_s12 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2356,7 +2356,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf gain",
                     "switch": [
-                        "-datasheet_analog_s21 'name <(float,float,float)>'"
+                        "-datasheet_analog_s21 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2382,7 +2382,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog rf output return loss",
                     "switch": [
-                        "-datasheet_analog_s22 'name <(float,float,float)>'"
+                        "-datasheet_analog_s22 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2408,7 +2408,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog sample rate",
                     "switch": [
-                        "-datasheet_analog_samplerate 'name <(float,float,float)>'"
+                        "-datasheet_analog_samplerate 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "Hz"
@@ -2434,7 +2434,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog spurious-free dynamic range",
                     "switch": [
-                        "-datasheet_analog_sfdr 'name <(float,float,float)>'"
+                        "-datasheet_analog_sfdr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dBc"
@@ -2460,7 +2460,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog signal to noise and distortion ratio",
                     "switch": [
-                        "-datasheet_analog_sinad 'name <(float,float,float)>'"
+                        "-datasheet_analog_sinad 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2486,7 +2486,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog signal to noise ratio",
                     "switch": [
-                        "-datasheet_analog_snr 'name <(float,float,float)>'"
+                        "-datasheet_analog_snr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2512,7 +2512,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog total harmonic distortion",
                     "switch": [
-                        "-datasheet_analog_thd 'name <(float,float,float)>'"
+                        "-datasheet_analog_thd 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "dB"
@@ -2538,7 +2538,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog gain error",
                     "switch": [
-                        "-datasheet_analog_vgainerror 'name <(float,float,float)>'"
+                        "-datasheet_analog_vgainerror 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "mV"
@@ -2564,7 +2564,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: analog offset error",
                     "switch": [
-                        "-datasheet_analog_vofferror 'name <(float,float,float)>'"
+                        "-datasheet_analog_vofferror 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "mV"
@@ -2701,7 +2701,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga architecture",
                     "switch": [
-                        "-datasheet_fpga_arch 'name <str>'"
+                        "-datasheet_fpga_arch 'partname <str>'"
                     ],
                     "type": "str"
                 },
@@ -2726,7 +2726,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga block ram",
                     "switch": [
-                        "-datasheet_fpga_blockram 'name <int>'"
+                        "-datasheet_fpga_blockram 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "Kb"
@@ -2752,7 +2752,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga distributed ram",
                     "switch": [
-                        "-datasheet_fpga_distram 'name <int>'"
+                        "-datasheet_fpga_distram 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "Kb"
@@ -2778,7 +2778,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga LUTs",
                     "switch": [
-                        "-datasheet_fpga_luts 'name <int>'"
+                        "-datasheet_fpga_luts 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -2803,7 +2803,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga multiplier/dsp elements",
                     "switch": [
-                        "-datasheet_fpga_mults 'name <int>'"
+                        "-datasheet_fpga_mults 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -2828,7 +2828,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga pll blocks",
                     "switch": [
-                        "-datasheet_fpga_plls 'name <int>'"
+                        "-datasheet_fpga_plls 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -2853,7 +2853,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga registers",
                     "switch": [
-                        "-datasheet_fpga_registers 'name <int>'"
+                        "-datasheet_fpga_registers 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -2878,7 +2878,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: fpga total ram",
                     "switch": [
-                        "-datasheet_fpga_totalram 'name <int>'"
+                        "-datasheet_fpga_totalram 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "Kb"
@@ -2991,14 +2991,14 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: io standard",
                     "switch": [
-                        "-datasheet_io_arch 'name <str>'"
+                        "-datasheet_io_arch 'partname <str>'"
                     ],
                     "type": "enum"
                 },
                 "channels": {
                     "example": [
-                        "cli: -datasheet_io_channels 'name 4'",
-                        "api: chip.set('datasheet', 'io', name, 'channels', 4)"
+                        "cli: -datasheet_io_channels 'partname 4'",
+                        "api: chip.set('datasheet', 'io', partname, 'channels', 4)"
                     ],
                     "help": "Datasheet: IO 4 metrics specified on a per IO port basis.",
                     "lock": false,
@@ -3016,14 +3016,14 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: io channels",
                     "switch": [
-                        "-datasheet_io_channels 'name <int>'"
+                        "-datasheet_io_channels 'partname <int>'"
                     ],
                     "type": "int"
                 },
                 "fmax": {
                     "example": [
-                        "cli: -datasheet_io_fmax 'name 100'",
-                        "api: chip.set('datasheet', 'io', name, 'fmax', 100)"
+                        "cli: -datasheet_io_fmax 'partname 100'",
+                        "api: chip.set('datasheet', 'io', partname, 'fmax', 100)"
                     ],
                     "help": "Datasheet: IO 100 metrics specified on a per IO port basis.",
                     "lock": false,
@@ -3041,15 +3041,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: io maximum frequency",
                     "switch": [
-                        "-datasheet_io_fmax 'name <float>'"
+                        "-datasheet_io_fmax 'partname <float>'"
                     ],
                     "type": "float",
                     "unit": "MHz"
                 },
                 "width": {
                     "example": [
-                        "cli: -datasheet_io_width 'name 4'",
-                        "api: chip.set('datasheet', 'io', name, 'width', 4)"
+                        "cli: -datasheet_io_width 'partname 4'",
+                        "api: chip.set('datasheet', 'io', partname, 'width', 4)"
                     ],
                     "help": "Datasheet: IO 4 metrics specified on a per IO port basis.",
                     "lock": false,
@@ -3067,7 +3067,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: io width",
                     "switch": [
-                        "-datasheet_io_width 'name <int>'"
+                        "-datasheet_io_width 'partname <int>'"
                     ],
                     "type": "int"
                 }
@@ -3512,7 +3512,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory banks",
                     "switch": [
-                        "-datasheet_memory_banks 'name <int>'"
+                        "-datasheet_memory_banks 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -3537,14 +3537,14 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory total bits",
                     "switch": [
-                        "-datasheet_memory_bits 'name <int>'"
+                        "-datasheet_memory_bits 'partname <int>'"
                     ],
                     "type": "int"
                 },
                 "bwrd": {
                     "example": [
-                        "cli: -datasheet_memory_bwrd 'name (1000000000.0, 1000000000.0, 1000000000.0)'",
-                        "api: chip.set('datasheet', 'memory', name, 'bwrd', (1000000000.0, 1000000000.0, 1000000000.0))"
+                        "cli: -datasheet_memory_bwrd 'partname (1000000000.0, 1000000000.0, 1000000000.0)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'bwrd', (1000000000.0, 1000000000.0, 1000000000.0))"
                     ],
                     "help": "Memory (1000000000.0, 1000000000.0, 1000000000.0) specified on a per memory basis.",
                     "lock": false,
@@ -3562,15 +3562,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory maximum read bandwidth",
                     "switch": [
-                        "-datasheet_memory_bwrd 'name <(float,float,float)>'"
+                        "-datasheet_memory_bwrd 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "bps"
                 },
                 "bwwr": {
                     "example": [
-                        "cli: -datasheet_memory_bwwr 'name (1000000000.0, 1000000000.0, 1000000000.0)'",
-                        "api: chip.set('datasheet', 'memory', name, 'bwwr', (1000000000.0, 1000000000.0, 1000000000.0))"
+                        "cli: -datasheet_memory_bwwr 'partname (1000000000.0, 1000000000.0, 1000000000.0)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'bwwr', (1000000000.0, 1000000000.0, 1000000000.0))"
                     ],
                     "help": "Memory (1000000000.0, 1000000000.0, 1000000000.0) specified on a per memory basis.",
                     "lock": false,
@@ -3588,7 +3588,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory maximum write bandwidth",
                     "switch": [
-                        "-datasheet_memory_bwwr 'name <(float,float,float)>'"
+                        "-datasheet_memory_bwwr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "bps"
@@ -3614,14 +3614,14 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory depth",
                     "switch": [
-                        "-datasheet_memory_depth 'name <int>'"
+                        "-datasheet_memory_depth 'partname <int>'"
                     ],
                     "type": "int"
                 },
                 "erd": {
                     "example": [
-                        "cli: -datasheet_memory_erd 'name (1e-12, 2e-12, 3e-12)'",
-                        "api: chip.set('datasheet', 'memory', name, 'erd', (1e-12, 2e-12, 3e-12))"
+                        "cli: -datasheet_memory_erd 'partname (1e-12, 2e-12, 3e-12)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'erd', (1e-12, 2e-12, 3e-12))"
                     ],
                     "help": "Memory (1e-12, 2e-12, 3e-12) specified on a per memory basis.",
                     "lock": false,
@@ -3639,15 +3639,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory read energy",
                     "switch": [
-                        "-datasheet_memory_erd 'name <(float,float,float)>'"
+                        "-datasheet_memory_erd 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "J"
                 },
                 "ewr": {
                     "example": [
-                        "cli: -datasheet_memory_ewr 'name (1e-12, 2e-12, 3e-12)'",
-                        "api: chip.set('datasheet', 'memory', name, 'ewr', (1e-12, 2e-12, 3e-12))"
+                        "cli: -datasheet_memory_ewr 'partname (1e-12, 2e-12, 3e-12)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'ewr', (1e-12, 2e-12, 3e-12))"
                     ],
                     "help": "Memory (1e-12, 2e-12, 3e-12) specified on a per memory basis.",
                     "lock": false,
@@ -3665,15 +3665,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory write energy",
                     "switch": [
-                        "-datasheet_memory_ewr 'name <(float,float,float)>'"
+                        "-datasheet_memory_ewr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "J"
                 },
                 "fmax": {
                     "example": [
-                        "cli: -datasheet_memory_fmax 'name (1000000000.0, 1000000000.0, 1000000000.0)'",
-                        "api: chip.set('datasheet', 'memory', name, 'fmax', (1000000000.0, 1000000000.0, 1000000000.0))"
+                        "cli: -datasheet_memory_fmax 'partname (1000000000.0, 1000000000.0, 1000000000.0)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'fmax', (1000000000.0, 1000000000.0, 1000000000.0))"
                     ],
                     "help": "Memory (1000000000.0, 1000000000.0, 1000000000.0) specified on a per memory basis.",
                     "lock": false,
@@ -3691,15 +3691,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory max frequency",
                     "switch": [
-                        "-datasheet_memory_fmax 'name <(float,float,float)>'"
+                        "-datasheet_memory_fmax 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "Hz"
                 },
                 "tcl": {
                     "example": [
-                        "cli: -datasheet_memory_tcl 'name (100, 100, 100)'",
-                        "api: chip.set('datasheet', 'memory', name, 'tcl', (100, 100, 100))"
+                        "cli: -datasheet_memory_tcl 'partname (100, 100, 100)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'tcl', (100, 100, 100))"
                     ],
                     "help": "Memory (100, 100, 100) specified on a per memory basis.",
                     "lock": false,
@@ -3717,15 +3717,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory column address latency",
                     "switch": [
-                        "-datasheet_memory_tcl 'name <(int,int,int)>'"
+                        "-datasheet_memory_tcl 'partname <(int,int,int)>'"
                     ],
                     "type": "(int,int,int)",
                     "unit": "cycles"
                 },
                 "tcycle": {
                     "example": [
-                        "cli: -datasheet_memory_tcycle 'name (9.0, 10.0, 11.0)'",
-                        "api: chip.set('datasheet', 'memory', name, 'tcycle', (9.0, 10.0, 11.0))"
+                        "cli: -datasheet_memory_tcycle 'partname (9.0, 10.0, 11.0)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'tcycle', (9.0, 10.0, 11.0))"
                     ],
                     "help": "Memory (9.0, 10.0, 11.0) specified on a per memory basis.",
                     "lock": false,
@@ -3743,15 +3743,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory access clock cycle",
                     "switch": [
-                        "-datasheet_memory_tcycle 'name <(float,float,float)>'"
+                        "-datasheet_memory_tcycle 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "ns"
                 },
                 "terase": {
                     "example": [
-                        "cli: -datasheet_memory_terase 'name (1e-06, 1e-06, 1e-06)'",
-                        "api: chip.set('datasheet', 'memory', name, 'terase', (1e-06, 1e-06, 1e-06))"
+                        "cli: -datasheet_memory_terase 'partname (1e-06, 1e-06, 1e-06)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'terase', (1e-06, 1e-06, 1e-06))"
                     ],
                     "help": "Memory (1e-06, 1e-06, 1e-06) specified on a per memory basis.",
                     "lock": false,
@@ -3769,15 +3769,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory erase time",
                     "switch": [
-                        "-datasheet_memory_terase 'name <(float,float,float)>'"
+                        "-datasheet_memory_terase 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "s"
                 },
                 "tras": {
                     "example": [
-                        "cli: -datasheet_memory_tras 'name (100, 100, 100)'",
-                        "api: chip.set('datasheet', 'memory', name, 'tras', (100, 100, 100))"
+                        "cli: -datasheet_memory_tras 'partname (100, 100, 100)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'tras', (100, 100, 100))"
                     ],
                     "help": "Memory (100, 100, 100) specified on a per memory basis.",
                     "lock": false,
@@ -3795,15 +3795,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory row active time latency",
                     "switch": [
-                        "-datasheet_memory_tras 'name <(int,int,int)>'"
+                        "-datasheet_memory_tras 'partname <(int,int,int)>'"
                     ],
                     "type": "(int,int,int)",
                     "unit": "cycles"
                 },
                 "trcd": {
                     "example": [
-                        "cli: -datasheet_memory_trcd 'name (100, 100, 100)'",
-                        "api: chip.set('datasheet', 'memory', name, 'trcd', (100, 100, 100))"
+                        "cli: -datasheet_memory_trcd 'partname (100, 100, 100)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'trcd', (100, 100, 100))"
                     ],
                     "help": "Memory (100, 100, 100) specified on a per memory basis.",
                     "lock": false,
@@ -3821,15 +3821,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory row address latency",
                     "switch": [
-                        "-datasheet_memory_trcd 'name <(int,int,int)>'"
+                        "-datasheet_memory_trcd 'partname <(int,int,int)>'"
                     ],
                     "type": "(int,int,int)",
                     "unit": "cycles"
                 },
                 "trd": {
                     "example": [
-                        "cli: -datasheet_memory_trd 'name (0.9, 1, 1.1)'",
-                        "api: chip.set('datasheet', 'memory', name, 'trd', (0.9, 1, 1.1))"
+                        "cli: -datasheet_memory_trd 'partname (0.9, 1, 1.1)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'trd', (0.9, 1, 1.1))"
                     ],
                     "help": "Memory (0.9, 1, 1.1) specified on a per memory basis.",
                     "lock": false,
@@ -3847,15 +3847,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory read clock cycle",
                     "switch": [
-                        "-datasheet_memory_trd 'name <(float,float,float)>'"
+                        "-datasheet_memory_trd 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "ns"
                 },
                 "trefresh": {
                     "example": [
-                        "cli: -datasheet_memory_trefresh 'name (99, 100, 101)'",
-                        "api: chip.set('datasheet', 'memory', name, 'trefresh', (99, 100, 101))"
+                        "cli: -datasheet_memory_trefresh 'partname (99, 100, 101)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'trefresh', (99, 100, 101))"
                     ],
                     "help": "Memory (99, 100, 101) specified on a per memory basis.",
                     "lock": false,
@@ -3873,15 +3873,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory refresh time",
                     "switch": [
-                        "-datasheet_memory_trefresh 'name <(float,float,float)>'"
+                        "-datasheet_memory_trefresh 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "ns"
                 },
                 "trp": {
                     "example": [
-                        "cli: -datasheet_memory_trp 'name (100, 100, 100)'",
-                        "api: chip.set('datasheet', 'memory', name, 'trp', (100, 100, 100))"
+                        "cli: -datasheet_memory_trp 'partname (100, 100, 100)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'trp', (100, 100, 100))"
                     ],
                     "help": "Memory (100, 100, 100) specified on a per memory basis.",
                     "lock": false,
@@ -3899,15 +3899,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory row precharge time latency",
                     "switch": [
-                        "-datasheet_memory_trp 'name <(int,int,int)>'"
+                        "-datasheet_memory_trp 'partname <(int,int,int)>'"
                     ],
                     "type": "(int,int,int)",
                     "unit": "cycles"
                 },
                 "twearout": {
                     "example": [
-                        "cli: -datasheet_memory_twearout 'name (100000.0, 1000000.0, 10000000.0)'",
-                        "api: chip.set('datasheet', 'memory', name, 'twearout', (100000.0, 1000000.0, 10000000.0))"
+                        "cli: -datasheet_memory_twearout 'partname (100000.0, 1000000.0, 10000000.0)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'twearout', (100000.0, 1000000.0, 10000000.0))"
                     ],
                     "help": "Memory (100000.0, 1000000.0, 10000000.0) specified on a per memory basis.",
                     "lock": false,
@@ -3925,15 +3925,15 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory write/erase wear-out",
                     "switch": [
-                        "-datasheet_memory_twearout 'name <(float,float,float)>'"
+                        "-datasheet_memory_twearout 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "cycles"
                 },
                 "twr": {
                     "example": [
-                        "cli: -datasheet_memory_twr 'name (0.9, 1, 1.1)'",
-                        "api: chip.set('datasheet', 'memory', name, 'twr', (0.9, 1, 1.1))"
+                        "cli: -datasheet_memory_twr 'partname (0.9, 1, 1.1)'",
+                        "api: chip.set('datasheet', 'memory', partname, 'twr', (0.9, 1, 1.1))"
                     ],
                     "help": "Memory (0.9, 1, 1.1) specified on a per memory basis.",
                     "lock": false,
@@ -3951,7 +3951,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory write clock cycle",
                     "switch": [
-                        "-datasheet_memory_twr 'name <(float,float,float)>'"
+                        "-datasheet_memory_twr 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "ns"
@@ -3977,7 +3977,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: memory width",
                     "switch": [
-                        "-datasheet_memory_width 'name <int>'"
+                        "-datasheet_memory_width 'partname <int>'"
                     ],
                     "type": "int"
                 }
@@ -4037,7 +4037,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package 3D model",
                     "switch": [
-                        "-datasheet_package_3dmodel 'name <file>'"
+                        "-datasheet_package_3dmodel 'partname <file>'"
                     ],
                     "type": "[file]"
                 },
@@ -4065,7 +4065,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package anchor",
                     "switch": [
-                        "-datasheet_package_anchor 'name <(float,float)>'"
+                        "-datasheet_package_anchor 'partname <(float,float)>'"
                     ],
                     "type": "(float,float)",
                     "unit": "um"
@@ -4097,7 +4097,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package drawing",
                     "switch": [
-                        "-datasheet_package_drawing 'name <file>'"
+                        "-datasheet_package_drawing 'partname <file>'"
                     ],
                     "type": "[file]"
                 },
@@ -4128,7 +4128,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package footprint",
                     "switch": [
-                        "-datasheet_package_footprint 'name <file>'"
+                        "-datasheet_package_footprint 'partname <file>'"
                     ],
                     "type": "[file]"
                 },
@@ -4153,7 +4153,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package length",
                     "switch": [
-                        "-datasheet_package_length 'name <(float,float,float)>'"
+                        "-datasheet_package_length 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "um"
@@ -4181,7 +4181,7 @@
                             "scope": "job",
                             "shorthelp": "Datasheet: package pin signal map",
                             "switch": [
-                                "-datasheet_package_pin_signal 'name number <str>'"
+                                "-datasheet_package_pin_signal 'partname number <str>'"
                             ],
                             "type": "str"
                         }
@@ -4208,7 +4208,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package pin count",
                     "switch": [
-                        "-datasheet_package_pincount 'name <int>'"
+                        "-datasheet_package_pincount 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -4233,7 +4233,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package pin pitch",
                     "switch": [
-                        "-datasheet_package_pinpitch 'name <(float,float,float)>'"
+                        "-datasheet_package_pinpitch 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "um"
@@ -4259,7 +4259,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package thickness",
                     "switch": [
-                        "-datasheet_package_thickness 'name <(float,float,float)>'"
+                        "-datasheet_package_thickness 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "um"
@@ -4295,7 +4295,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package type",
                     "switch": [
-                        "-datasheet_package_type 'name <str>'"
+                        "-datasheet_package_type 'partname <str>'"
                     ],
                     "type": "enum"
                 },
@@ -4320,7 +4320,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: package width",
                     "switch": [
-                        "-datasheet_package_width 'name <(float,float,float)>'"
+                        "-datasheet_package_width 'partname <(float,float,float)>'"
                     ],
                     "type": "(float,float,float)",
                     "unit": "um"
@@ -4405,7 +4405,7 @@
                         "scope": "job",
                         "shorthelp": "Datasheet: pin complement",
                         "switch": [
-                            "-datasheet_pin_complement 'name mode <str>'"
+                            "-datasheet_pin_complement 'partname mode <str>'"
                         ],
                         "type": "str"
                     }
@@ -4437,7 +4437,7 @@
                         "scope": "job",
                         "shorthelp": "Datasheet: pin direction",
                         "switch": [
-                            "-datasheet_pin_dir 'name mode <str>'"
+                            "-datasheet_pin_dir 'partname mode <str>'"
                         ],
                         "type": "enum"
                     }
@@ -4548,7 +4548,7 @@
                         "scope": "job",
                         "shorthelp": "Datasheet: pin interface map",
                         "switch": [
-                            "-datasheet_pin_interface 'name mode <str>'"
+                            "-datasheet_pin_interface 'partname mode <str>'"
                         ],
                         "type": "[str]"
                     }
@@ -4806,7 +4806,7 @@
                         "scope": "job",
                         "shorthelp": "Datasheet: pin reset value",
                         "switch": [
-                            "-datasheet_pin_resetvalue 'name mode <str>'"
+                            "-datasheet_pin_resetvalue 'partname mode <str>'"
                         ],
                         "type": "enum"
                     }
@@ -4945,7 +4945,7 @@
                         "scope": "job",
                         "shorthelp": "Datasheet: pin standard",
                         "switch": [
-                            "-datasheet_pin_standard 'name mode <str>'"
+                            "-datasheet_pin_standard 'partname mode <str>'"
                         ],
                         "type": "[str]"
                     }
@@ -5357,7 +5357,7 @@
                         "scope": "job",
                         "shorthelp": "Datasheet: pin type",
                         "switch": [
-                            "-datasheet_pin_type 'name mode <str>'"
+                            "-datasheet_pin_type 'partname mode <str>'"
                         ],
                         "type": "enum"
                     }
@@ -5761,7 +5761,7 @@
                 "arch": {
                     "example": [
                         "cli: -datasheet_proc_arch '0 RV64GC'",
-                        "api: chip.set('datasheet', 'proc', name, 'arch', 'openfpga')"
+                        "api: chip.set('datasheet', 'proc', partname, 'arch', 'openfpga')"
                     ],
                     "help": "Processor architecture specified on a per core basis.",
                     "lock": false,
@@ -5779,7 +5779,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor architecture",
                     "switch": [
-                        "-datasheet_proc_arch 'name <str>'"
+                        "-datasheet_proc_arch 'partname <str>'"
                     ],
                     "type": "str"
                 },
@@ -5804,7 +5804,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor architecture size",
                     "switch": [
-                        "-datasheet_proc_archsize 'name <int>'"
+                        "-datasheet_proc_archsize 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -5829,7 +5829,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor number of cores",
                     "switch": [
-                        "-datasheet_proc_cores 'name <int>'"
+                        "-datasheet_proc_cores 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -5873,7 +5873,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor datatypes",
                     "switch": [
-                        "-datasheet_proc_datatypes 'name <str>'"
+                        "-datasheet_proc_datatypes 'partname <str>'"
                     ],
                     "type": "[enum]"
                 },
@@ -5898,7 +5898,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor l1 dcache size",
                     "switch": [
-                        "-datasheet_proc_dcache 'name <int>'"
+                        "-datasheet_proc_dcache 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "KB"
@@ -5924,7 +5924,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor features",
                     "switch": [
-                        "-datasheet_proc_features 'name <str>'"
+                        "-datasheet_proc_features 'partname <str>'"
                     ],
                     "type": "[str]"
                 },
@@ -5949,7 +5949,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor maximum frequency",
                     "switch": [
-                        "-datasheet_proc_fmax 'name <int>'"
+                        "-datasheet_proc_fmax 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "MHz"
@@ -5975,7 +5975,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor l1 icache size",
                     "switch": [
-                        "-datasheet_proc_icache 'name <int>'"
+                        "-datasheet_proc_icache 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "KB"
@@ -6001,7 +6001,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor l2 cache size",
                     "switch": [
-                        "-datasheet_proc_l2cache 'name <int>'"
+                        "-datasheet_proc_l2cache 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "KB"
@@ -6027,7 +6027,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor l3 cache size",
                     "switch": [
-                        "-datasheet_proc_l3cache 'name <int>'"
+                        "-datasheet_proc_l3cache 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "KB"
@@ -6053,7 +6053,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor hard multiplier units",
                     "switch": [
-                        "-datasheet_proc_mults 'name <int>'"
+                        "-datasheet_proc_mults 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -6078,7 +6078,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor local non-volatile memory",
                     "switch": [
-                        "-datasheet_proc_nvm 'name <int>'"
+                        "-datasheet_proc_nvm 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "KB"
@@ -6104,7 +6104,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor operations per cycle",
                     "switch": [
-                        "-datasheet_proc_ops 'name <int>'"
+                        "-datasheet_proc_ops 'partname <int>'"
                     ],
                     "type": "int"
                 },
@@ -6129,7 +6129,7 @@
                     "scope": "job",
                     "shorthelp": "Datasheet: processor local sram",
                     "switch": [
-                        "-datasheet_proc_sram 'name <int>'"
+                        "-datasheet_proc_sram 'partname <int>'"
                     ],
                     "type": "int",
                     "unit": "KB"
@@ -11573,12 +11573,12 @@
         },
         "component": {
             "default": {
-                "model": {
+                "partname": {
                     "example": [
-                        "cli: -schematic_component_model 'B0 NAND2X1'",
-                        "api: chip.set('schematic', 'component', 'B0, 'model', 'NAND2X1')"
+                        "cli: -schematic_component_partname 'B0 NAND2X1'",
+                        "api: chip.set('schematic', 'component', 'B0, 'partname', 'NAND2X1')"
                     ],
-                    "help": "Model of a component, specified on a per instance basis.",
+                    "help": "Component part-name (\"aka cell-name\") specified on a per instance basis.",
                     "lock": false,
                     "node": {
                         "default": {
@@ -11594,7 +11594,7 @@
                     "scope": "job",
                     "shorthelp": "Schematic: component model",
                     "switch": [
-                        "-schematic_component_model 'name <str>'"
+                        "-schematic_component_partname 'name <str>'"
                     ],
                     "type": "str"
                 }

--- a/tests/core/data/last_minor.json
+++ b/tests/core/data/last_minor.json
@@ -1312,7 +1312,7 @@
                         "cli: -constraint_pin_layer 'nreset m4'",
                         "api: chip.set('constraint', 'pin', 'nreset', 'layer', 'm4')"
                     ],
-                    "help": "Pin metal layer for pin placement specified on a per pin basis.\nMetal names should either be the PDK specific metal stack name or\nan integer with '1' being the lowest routing layer.\nThe wildcard character '*' is supported for pin names.",
+                    "help": "Pin metal layer constraint specified on a per pin basis.\nMetal names should either be the PDK specific metal stack name or\nan integer with '1' being the lowest routing layer.\nThe wildcard character '*' is supported for pin names.",
                     "lock": false,
                     "node": {
                         "default": {

--- a/tests/core/data/last_minor.json
+++ b/tests/core/data/last_minor.json
@@ -1281,32 +1281,6 @@
         },
         "pin": {
             "default": {
-                "height": {
-                    "example": [
-                        "cli: -constraint_pin_height 'nreset 1.0'",
-                        "api: chip.set('constraint', 'pin', 'nreset', height, 1.0)"
-                    ],
-                    "help": "Pin height (y-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust dimensions to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
-                    "lock": false,
-                    "node": {
-                        "default": {
-                            "default": {
-                                "signature": null,
-                                "value": null
-                            }
-                        }
-                    },
-                    "notes": null,
-                    "pernode": "optional",
-                    "require": false,
-                    "scope": "job",
-                    "shorthelp": "Constraint: pin height",
-                    "switch": [
-                        "-constraint_pin_height 'name <float>'"
-                    ],
-                    "type": "float",
-                    "unit": "um"
-                },
                 "layer": {
                     "example": [
                         "cli: -constraint_pin_layer 'nreset m4'",
@@ -1331,6 +1305,32 @@
                         "-constraint_pin_layer 'name <str>'"
                     ],
                     "type": "str"
+                },
+                "length": {
+                    "example": [
+                        "cli: -constraint_pin_length 'nreset 1.0'",
+                        "api: chip.set('constraint', 'pin', 'nreset', 'length', 1.0)"
+                    ],
+                    "help": "Pin length constraint.  Package pin length refers to the\nlength of the electrical pins extending out from (or into)\na component. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust dimensions to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
+                    "lock": false,
+                    "node": {
+                        "default": {
+                            "default": {
+                                "signature": null,
+                                "value": null
+                            }
+                        }
+                    },
+                    "notes": null,
+                    "pernode": "optional",
+                    "require": false,
+                    "scope": "job",
+                    "shorthelp": "Constraint: pin length",
+                    "switch": [
+                        "-constraint_pin_length 'name <float>'"
+                    ],
+                    "type": "float",
+                    "unit": "um"
                 },
                 "order": {
                     "example": [
@@ -1446,9 +1446,9 @@
                 "width": {
                     "example": [
                         "cli: -constraint_pin_width 'nreset 1.0'",
-                        "api: chip.set('constraint', 'pin', 'nreset', width, 1.0)"
+                        "api: chip.set('constraint', 'pin', 'nreset', 'width', 1.0)"
                     ],
-                    "help": "Pin width (x-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust dimensions to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
+                    "help": "Pin width constraint.  Package pin width is the lateral\n(side-to-side) thickness of a pin on a physical component.\nThis parameter represents goal/intent, not an exact\nspecification. The layout system may adjust dimensions to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
                     "lock": false,
                     "node": {
                         "default": {

--- a/tests/core/data/last_minor.json
+++ b/tests/core/data/last_minor.json
@@ -1286,7 +1286,7 @@
                         "cli: -constraint_pin_height 'nreset 1.0'",
                         "api: chip.set('constraint', 'pin', 'nreset', height, 1.0)"
                     ],
-                    "help": "Pin height (y-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust placements to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
+                    "help": "Pin height (y-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust dimensions to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
                     "lock": false,
                     "node": {
                         "default": {
@@ -1448,7 +1448,7 @@
                         "cli: -constraint_pin_width 'nreset 1.0'",
                         "api: chip.set('constraint', 'pin', 'nreset', width, 1.0)"
                     ],
-                    "help": "Pin width (x-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust placements to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
+                    "help": "Pin width (x-direction) constraint. This parameter represents goal/intent, not an exact\nspecification. The layout system may adjust dimensions to meet\ncompeting goals such as manufacturing design rules and grid placement\nguidelines.",
                     "lock": false,
                     "node": {
                         "default": {

--- a/tests/core/test_schematic.py
+++ b/tests/core/test_schematic.py
@@ -10,7 +10,7 @@ def test_schematic():
 
     # 4 input OR gate constructed from 2 input OR gates
     for inst in ['I0', 'I1', 'I2']:
-        chip.set('schematic', 'component', inst, 'model', 'OR2')
+        chip.set('schematic', 'component', inst, 'partname', 'OR2')
 
     # defining pins
     for pin in ['IN0', 'IN1', 'IN2', 'IN3']:


### PR DESCRIPTION
- Removing pin height constraint....not needed. Confuses things when trying to apply pin dimesions tp chip, package, pcb.

- Fixing schematic terminology issue. 'model' was confusing. Using "partname" instead of cell for consistency

- Refactor to use partname in place of name in datasheet for clarity

