### PR TITLE
avoid putting color information into text logs

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -87,7 +87,7 @@ jobs:
           mkdir testrun
           cd testrun
 
-          pytest $GITHUB_WORKSPACE -n auto -m "not eda and not docker" --cov --cov-report=xml
+          pytest $GITHUB_WORKSPACE -n auto -m "not eda and not docker" --cov --cov-report=xml --durations=0
 
       - name: Setup Python (windows)
         if: runner.os == 'Windows'
@@ -107,7 +107,7 @@ jobs:
           mkdir testrun
           cd testrun
 
-          pytest $Env:GITHUB_WORKSPACE -n auto -m "not eda and not docker" --cov --cov-report=xml
+          pytest $Env:GITHUB_WORKSPACE -n auto -m "not eda and not docker" --cov --cov-report=xml --durations=0
 
       - name: Upload coverage reports to Codecov
         continue-on-error: true

--- a/siliconcompiler/scheduler/docker_runner.py
+++ b/siliconcompiler/scheduler/docker_runner.py
@@ -115,7 +115,8 @@ def run(chip, step, index, replay):
     start_cwd = os.getcwd()
 
     # Remove handlers from logger
-    chip.logger.handlers.clear()
+    for handler in chip.logger.handlers.copy():
+        chip.logger.removeHander(handler)
 
     # Reinit logger
     chip._init_logger(step=step, index=index, in_run=True)

--- a/siliconcompiler/scheduler/docker_runner.py
+++ b/siliconcompiler/scheduler/docker_runner.py
@@ -116,7 +116,7 @@ def run(chip, step, index, replay):
 
     # Remove handlers from logger
     for handler in chip.logger.handlers.copy():
-        chip.logger.removeHander(handler)
+        chip.logger.removeHandler(handler)
 
     # Reinit logger
     chip._init_logger(step=step, index=index, in_run=True)

--- a/siliconcompiler/utils/logging.py
+++ b/siliconcompiler/utils/logging.py
@@ -55,7 +55,7 @@ class ColorStreamFormatter(LoggerFormatter):
 
     @staticmethod
     def supports_color(handler):
-        if not isinstance(handler, logging.StreamHandler):
+        if type(handler) is not logging.StreamHandler:
             return False
 
         supported_platform = sys.platform != 'win32'


### PR DESCRIPTION
Avoids direct access of `.handlers` parameter in `logger` as well, steps towards cleanup of logger use