### PR TITLE
escape brackets in cli dashboard log handler

### DIFF
--- a/siliconcompiler/report/dashboard/cli/__init__.py
+++ b/siliconcompiler/report/dashboard/cli/__init__.py
@@ -44,6 +44,7 @@ class LogBufferHandler(logging.Handler):
             record (logging.LogRecord): The log record to process.
         """
         log_entry = self.format(record)
+        log_entry = log_entry.replace("[", "\\[")
         with self._lock:
             self.buffer.append(log_entry)
         if self.event:


### PR DESCRIPTION
Some tools, `make` especially, generate lines that use brackets, which confuses the `rich` text rendering. 

`make[2]: Entering directory ... ` 