### PR TITLE
cli dashboard: ensure errors get priority in printing and print final table

### DIFF
--- a/siliconcompiler/report/dashboard/cli/__init__.py
+++ b/siliconcompiler/report/dashboard/cli/__init__.py
@@ -553,21 +553,21 @@ class CliDashboard(AbstractDashboard):
         finally:
             try:
                 if live:
-                    live.update(self._get_rendable(final=True), refresh=True)
+                    live.update(self._get_rendable(), refresh=True)
                     live.stop()
                 else:
-                    self._console.print(self._get_rendable(final=True))
+                    self._console.print(self._get_rendable())
             finally:
                 # Restore the prompt
                 print("\033[?25h", end="")
 
-    def _update_layout(self, height=None):
+    def _update_layout(self):
         with self._render_data_lock:
             visible_progress_bars = len(self._render_data.jobs)
             visible_jobs_count = self._render_data.total - self._render_data.skipped
 
         self._layout.update(
-            height or self._console.height,
+            self._console.height,
             self._console.width,
             visible_jobs_count,
             visible_progress_bars,
@@ -575,7 +575,7 @@ class CliDashboard(AbstractDashboard):
 
         return self._layout
 
-    def _get_rendable(self, final=False):
+    def _get_rendable(self):
         """
         Combines all dashboard components (job table, progress bars, final summary)
         into a single renderable group.
@@ -584,13 +584,7 @@ class CliDashboard(AbstractDashboard):
             Group: A Rich Group object containing all dashboard components.
         """
 
-        height = None
-        if final:
-            with self._render_data_lock:
-                # 5x is arbitrary to ensure it covers all jobs
-                height = 5 * self._render_data.total
-
-        layout = self._update_layout(height=height)
+        layout = self._update_layout()
 
         new_table = self._render_job_dashboard(layout)
         new_bar = self._render_progress_bar(layout)

--- a/siliconcompiler/report/dashboard/cli/__init__.py
+++ b/siliconcompiler/report/dashboard/cli/__init__.py
@@ -553,21 +553,21 @@ class CliDashboard(AbstractDashboard):
         finally:
             try:
                 if live:
-                    live.update(self._get_rendable(), refresh=True)
+                    live.update(self._get_rendable(final=True), refresh=True)
                     live.stop()
                 else:
-                    self._console.print(self._get_rendable())
+                    self._console.print(self._get_rendable(final=True))
             finally:
                 # Restore the prompt
                 print("\033[?25h", end="")
 
-    def _update_layout(self):
+    def _update_layout(self, height=None):
         with self._render_data_lock:
             visible_progress_bars = len(self._render_data.jobs)
             visible_jobs_count = self._render_data.total - self._render_data.skipped
 
         self._layout.update(
-            self._console.height,
+            height or self._console.height,
             self._console.width,
             visible_jobs_count,
             visible_progress_bars,
@@ -575,7 +575,7 @@ class CliDashboard(AbstractDashboard):
 
         return self._layout
 
-    def _get_rendable(self):
+    def _get_rendable(self, final=False):
         """
         Combines all dashboard components (job table, progress bars, final summary)
         into a single renderable group.
@@ -584,7 +584,13 @@ class CliDashboard(AbstractDashboard):
             Group: A Rich Group object containing all dashboard components.
         """
 
-        layout = self._update_layout()
+        height = None
+        if final:
+            with self._render_data_lock:
+                # 5x is arbitrary to ensure it covers all jobs
+                height = 5 * self._render_data.total
+
+        layout = self._update_layout(height=height)
 
         new_table = self._render_job_dashboard(layout)
         new_bar = self._render_progress_bar(layout)

--- a/siliconcompiler/report/dashboard/cli/__init__.py
+++ b/siliconcompiler/report/dashboard/cli/__init__.py
@@ -718,10 +718,9 @@ class CliDashboard(AbstractDashboard):
                 priority_node.setdefault(min(levels), set()).add(node)
             for level, level_nodes in priority_node.items():
                 for node in level_nodes:
-                    if node in node_priority:
-                        node_priority[node] = min(node_priority[node], level)
-                    else:
-                        node_priority[node] = level
+                    if node not in node_priority:
+                        continue
+                    node_priority[node] = min(node_priority[node], level)
         except SiliconCompilerError:
             pass
 


### PR DESCRIPTION
Closes #3463 

@Ciprian167 try this out and see if it works for you.

There was a bug that caused the priority printing order to overwrite the errors.

I also switched the final render to show the entire table (not 100% sold on that one, yet).