### PR TITLE
[Tools][Tests] Added OpenSTA Tool Driver Test

### DIFF
--- a/tests/tools/data/lec/foo.sdc
+++ b/tests/tools/data/lec/foo.sdc
@@ -1,0 +1,2 @@
+create_clock -period 0 -name clk [get_ports clk]
+set_output_delay -clock clk -max 0 [get_ports out[*]]

--- a/tests/tools/test_opensta.py
+++ b/tests/tools/test_opensta.py
@@ -1,0 +1,33 @@
+# Copyright 2025 Silicon Compiler Authors. All Rights Reserved.
+import os
+import pytest
+
+from siliconcompiler import Chip
+from siliconcompiler.tools.opensta import timing
+
+from siliconcompiler.targets import freepdk45_demo
+
+
+@pytest.mark.eda
+@pytest.mark.quick
+def test_opensta(datadir):
+    design = 'foo'
+    netlist = os.path.join(datadir, 'lec', f'{design}.vg')
+    sdc = os.path.join(datadir, 'lec', f'{design}.sdc')
+
+    chip = Chip(design)
+    chip.use(freepdk45_demo)
+
+    flow = 'opensta_timing'
+    chip.node(flow, 'opensta', timing)
+    chip.set('option', 'flow', flow)
+
+    chip.input(netlist)
+    chip.input(sdc)
+
+    # Check that OpenSTA ran successfully
+    assert chip.run()
+
+    # Check that the setup and hold slacks are the expected values.
+    assert chip.get('metric', 'setupslack', step='opensta', index='0') == -0.220
+    assert chip.get('metric', 'holdslack', step='opensta', index='0') == 0.050


### PR DESCRIPTION
The OpenSTA driver did not have a test in the tests directory. Added a basic test which takes the foo design used for the Parmys test and performs timing analysis.

In order to make the test interesting, wrote a simple SDC file for this testcase.