### PR TITLE
add use schema class to augment child classes

### DIFF
--- a/docs/reference_manual/schema_api.rst
+++ b/docs/reference_manual/schema_api.rst
@@ -104,6 +104,9 @@ Full API
     :show-inheritance:
     :inherited-members:
 
+.. autoclass:: UseSchema
+    :members:
+
 .. autoclass:: PackageSchema
     :members:
     :show-inheritance:

--- a/siliconcompiler/schema/__init__.py
+++ b/siliconcompiler/schema/__init__.py
@@ -6,6 +6,7 @@ from .baseschema import BaseSchema
 from .cmdlineschema import CommandLineSchema
 from .namedschema import NamedSchema
 from .packageschema import PackageSchema
+from .useschema import UseSchema
 
 from .schema_cfg import SCHEMA_VERSION
 
@@ -20,5 +21,6 @@ __all__ = [
     "Parameter",
     "Scope",
     "PerNode",
-    "Journal"
+    "Journal",
+    "UseSchema"
 ]

--- a/siliconcompiler/schema/namedschema.py
+++ b/siliconcompiler/schema/namedschema.py
@@ -26,6 +26,12 @@ class NamedSchema(BaseSchema):
         '''
         return self.__name
 
+    def _reset(self) -> None:
+        """
+        Resets the state of the object
+        """
+        pass
+
     @classmethod
     def from_manifest(cls, name, filepath=None, cfg=None):
         '''

--- a/siliconcompiler/schema/useschema.py
+++ b/siliconcompiler/schema/useschema.py
@@ -1,0 +1,176 @@
+import os.path
+
+from .namedschema import NamedSchema
+
+
+class UseSchema:
+    '''
+    Schema extention to add :meth:`.use` capability to a schema section.
+    '''
+
+    def __init__(self):
+        self.__imported = {}
+
+    def use(self, obj: NamedSchema, clobber: bool = True) -> bool:
+        """
+        Adds a module as a dependency.
+
+        Returns:
+            True if object was imported, otherwise false.
+
+        Args:
+            obj (:class:`NamedSchema`): Dependency to add
+        """
+
+        if not isinstance(obj, NamedSchema):
+            raise TypeError(f"Cannot use an object of type: {type(obj)}")
+
+        if not clobber and obj.name() in self.__imported:
+            return False
+
+        self.__imported[obj.name()] = obj
+        obj._reset()
+
+        return True
+
+    def write_dependencygraph(self, filename: str,
+                              fontcolor: str = '#000000',
+                              background: str = 'transparent',
+                              fontsize: str = '14',
+                              border: bool = True, landscape: bool = False) -> None:
+        r'''
+        Renders and saves the dependency graph to a file.
+
+        Args:
+            filename (filepath): Output filepath
+            fontcolor (str): Node font RGB color hex value
+            background (str): Background color
+            fontsize (str): Node text font size
+            border (bool): Enables node border if True
+            landscape (bool): Renders graph in landscape layout if True
+
+        Examples:
+            >>> use.write_dependencygraph('mydump.png')
+            Renders the object dependency graph and writes the result to a png file.
+        '''
+        import graphviz
+
+        filepath = os.path.abspath(filename)
+        fileroot, ext = os.path.splitext(filepath)
+        fileformat = ext[1:]
+
+        # controlling border width
+        if border:
+            penwidth = '1'
+        else:
+            penwidth = '0'
+
+        # controlling graph direction
+        if landscape:
+            rankdir = 'LR'
+        else:
+            rankdir = 'TB'
+
+        dot = graphviz.Digraph(format=fileformat)
+        dot.graph_attr['rankdir'] = rankdir
+        dot.attr(bgcolor=background)
+
+        def make_label(dep):
+            return f"lib-{dep.name()}"
+
+        nodes = {
+            self.name(): {
+                "text": self.name(),
+                "shape": "box",
+                "color": background,
+                "connects_to": set([make_label(subdep) for subdep in self.__imported.values()])
+            }
+        }
+        for dep in self.get_all_dependencies():
+            nodes[make_label(dep)] = {
+                "text": dep.name(),
+                "shape": "oval",
+                "color": background,
+                "connects_to": set([make_label(subdep) for subdep in dep.__imported.values()])
+            }
+
+        for label, info in nodes.items():
+            dot.node(label, label=info['text'], bordercolor=fontcolor, style='filled',
+                     fontcolor=fontcolor, fontsize=fontsize, ordering="in",
+                     penwidth=penwidth, fillcolor=info["color"], shape=info['shape'])
+
+            for conn in info['connects_to']:
+                dot.edge(label, conn, dir='back')
+
+        try:
+            dot.render(filename=fileroot, cleanup=True)
+        except graphviz.ExecutableNotFound as e:
+            raise RuntimeError(f'Unable to save flowgraph: {e}')
+
+    def get_dependency(self, name: str) -> NamedSchema:
+        '''
+        Returns a dependency which has been imported.
+
+        Raises:
+            KeyError: if the dependency is not found
+
+        Args:
+            name (str): name of the dependency
+        '''
+
+        if name not in self.__imported:
+            raise KeyError(f"{name} is not an imported dependency")
+
+        return self.__imported[name]
+
+    def __get_all_dependencies(self, seen: set) -> list:
+        '''
+        Loop through the dependency tree and generate a flat list
+        '''
+        deps = []
+
+        for obj in self.__imported.values():
+            if obj.name() in seen:
+                continue
+
+            deps.append(obj)
+            seen.add(obj.name())
+
+            if not isinstance(obj, UseSchema):
+                # nothing to iterate over
+                continue
+
+            for obj_dep in obj.__get_all_dependencies(seen):
+                deps.append(obj_dep)
+                seen.add(obj_dep.name())
+
+        return deps
+
+    def get_all_dependencies(self, hierarchy: bool = True) -> list:
+        '''
+        Returns all dependencies associated with this object.
+
+        Args:
+            hierarchy (bool): if True, will return all dependencies including childen
+                otherwise only this objects dependencies are returned.
+        '''
+
+        if hierarchy:
+            return self.__get_all_dependencies(set())
+        return list(self.__imported.values())
+
+    def remove_dependency(self, name: str) -> bool:
+        '''
+        Removes a previously registered dependency.
+
+        Args:
+            name (str): name of the dependency
+
+        Returns:
+            True if the dependency was removed, False is not found.
+        '''
+        if name not in self.__imported:
+            return False
+
+        del self.__imported[name]
+        return True

--- a/tests/schema/test_namedschema.py
+++ b/tests/schema/test_namedschema.py
@@ -10,6 +10,10 @@ def test_name():
     assert NamedSchema("myname").name() == "myname"
 
 
+def test_reset():
+    NamedSchema("myname")._reset()
+
+
 def test_copy_name():
     schema = NamedSchema("myname")
     assert schema.name() == "myname"

--- a/tests/schema/test_useschema.py
+++ b/tests/schema/test_useschema.py
@@ -1,0 +1,329 @@
+import graphviz
+import pytest
+
+import os.path
+
+from unittest.mock import patch
+
+from siliconcompiler.schema import UseSchema, NamedSchema, BaseSchema
+
+
+def test_use_invalid():
+    use = UseSchema()
+
+    with pytest.raises(TypeError,
+                       match="Cannot use an object of type: <class "
+                       "'siliconcompiler.schema.baseschema.BaseSchema'>"):
+        use.use(BaseSchema())
+
+
+def test_use():
+    use = UseSchema()
+
+    dep = NamedSchema("thisname")
+    assert use.use(dep)
+    assert use.get_dependency("thisname") is dep
+
+
+def test_use_confirm_reset():
+    class Test(NamedSchema):
+        def __init__(self):
+            super().__init__("thisname")
+            self.state_info = "notthis"
+
+        def _reset(self):
+            super()._reset()
+            self.state_info = None
+
+    use = UseSchema()
+
+    dep = Test()
+    assert dep.state_info == "notthis"
+    assert use.use(dep)
+    assert dep.state_info is None
+
+
+def test_use_clobber():
+    use = UseSchema()
+
+    dep0 = NamedSchema("thisname")
+    dep1 = NamedSchema("thisname")
+    assert use.use(dep0)
+    assert use.get_dependency("thisname") is dep0
+    assert use.use(dep1, clobber=True)
+    assert use.get_dependency("thisname") is dep1
+
+
+def test_use_no_clobber():
+    use = UseSchema()
+
+    dep0 = NamedSchema("thisname")
+    dep1 = NamedSchema("thisname")
+    assert use.use(dep0)
+    assert use.get_dependency("thisname") is dep0
+    assert use.use(dep1, clobber=False) is False
+    assert use.get_dependency("thisname") is dep0
+
+
+def test_get_dependency_not_found():
+    use = UseSchema()
+
+    with pytest.raises(KeyError, match="notthere is not an imported dependency"):
+        use.get_dependency("notthere")
+
+
+def test_remove_dependency_not_there():
+    use = UseSchema()
+    assert use.remove_dependency("notthere") is False
+
+
+def test_remove_dependency():
+    use = UseSchema()
+    use.use(NamedSchema("thisname"))
+    assert use.get_dependency("thisname")
+    assert use.remove_dependency("thisname") is True
+    assert use.get_all_dependencies() == []
+
+
+def test_get_all_dependencies_empty():
+    assert UseSchema().get_all_dependencies() == []
+
+
+def test_get_all_dependencies():
+    class Test(NamedSchema, UseSchema):
+        def __init__(self, name):
+            NamedSchema.__init__(self, name)
+            UseSchema.__init__(self)
+
+    use = UseSchema()
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep10 = Test("level1-0")
+    dep11 = Test("level1-1")
+
+    assert dep00.use(dep10)
+    assert dep01.use(dep11)
+
+    assert use.use(dep00)
+    assert use.use(dep01)
+
+    assert use.get_all_dependencies() == [dep00, dep10, dep01, dep11]
+
+
+def test_get_all_dependencies_no_hier():
+    class Test(NamedSchema, UseSchema):
+        def __init__(self, name):
+            NamedSchema.__init__(self, name)
+            UseSchema.__init__(self)
+
+    use = UseSchema()
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep10 = Test("level1-0")
+    dep11 = Test("level1-1")
+
+    assert dep00.use(dep10)
+    assert dep01.use(dep11)
+
+    assert use.use(dep00)
+    assert use.use(dep01)
+
+    assert use.get_all_dependencies(hierarchy=False) == [dep00, dep01]
+
+
+def test_get_all_dependencies_repeats():
+    class Test(NamedSchema, UseSchema):
+        def __init__(self, name):
+            NamedSchema.__init__(self, name)
+            UseSchema.__init__(self)
+
+    use = UseSchema()
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep10 = Test("level1-0")
+    dep11 = Test("level1-1")
+
+    assert dep00.use(dep10)
+    assert dep00.use(dep11)
+    assert dep01.use(dep11)
+
+    assert use.use(dep00)
+    assert use.use(dep01)
+
+    assert use.get_all_dependencies() == [dep00, dep10, dep11, dep01]
+
+
+def test_get_all_dependencies_non_use():
+    class Test(NamedSchema, UseSchema):
+        def __init__(self, name):
+            NamedSchema.__init__(self, name)
+            UseSchema.__init__(self)
+
+    use = UseSchema()
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep10 = Test("level1-0")
+    dep11 = Test("level1-1")
+    dep20 = NamedSchema("level2-0")
+    dep21 = NamedSchema("level2-1")
+
+    assert dep00.use(dep10)
+    assert dep10.use(dep20)
+    assert dep01.use(dep11)
+    assert dep11.use(dep21)
+
+    assert use.use(dep00)
+    assert use.use(dep01)
+
+    assert use.get_all_dependencies() == \
+        [dep00, dep10, dep20, dep01, dep11, dep21]
+
+
+def test_get_all_dependencies_circle():
+    class Test(NamedSchema, UseSchema):
+        def __init__(self, name):
+            NamedSchema.__init__(self, name)
+            UseSchema.__init__(self)
+
+    use = UseSchema()
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep10 = Test("level1-0")
+    dep11 = Test("level1-1")
+
+    assert dep00.use(dep10)
+    assert dep10.use(dep01)
+    assert dep01.use(dep11)
+    assert dep11.use(dep00)
+
+    assert use.use(dep00)
+
+    assert use.get_all_dependencies() == [dep00, dep10, dep01, dep11]
+
+
+def test_write_dependencygraph_no_graphviz_exe():
+    class Test(NamedSchema, UseSchema):
+        def __init__(self, name):
+            NamedSchema.__init__(self, name)
+            UseSchema.__init__(self)
+
+    use = Test("top")
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep10 = Test("level1-0")
+    dep11 = Test("level1-1")
+
+    assert dep00.use(dep10)
+    assert dep01.use(dep11)
+
+    assert use.use(dep00)
+    assert use.use(dep01)
+
+    with patch("graphviz.Digraph.render") as render:
+        def raise_error(*args, **kwargs):
+            raise graphviz.ExecutableNotFound("args")
+        render.side_effect = raise_error
+
+        with pytest.raises(RuntimeError, match="Unable to save flowgraph: failed to execute"):
+            use.write_dependencygraph("test.png")
+        render.assert_called_once()
+
+
+def test_write_dependencygraph():
+    class Test(NamedSchema, UseSchema):
+        def __init__(self, name):
+            NamedSchema.__init__(self, name)
+            UseSchema.__init__(self)
+
+    use = Test("top")
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep10 = Test("level1-0")
+    dep11 = Test("level1-1")
+
+    assert dep00.use(dep10)
+    assert dep01.use(dep11)
+
+    assert use.use(dep00)
+    assert use.use(dep01)
+
+    use.write_dependencygraph("test.png")
+    assert os.path.exists("test.png")
+
+
+def test_write_dependencygraph_alt_config():
+    class Test(NamedSchema, UseSchema):
+        def __init__(self, name):
+            NamedSchema.__init__(self, name)
+            UseSchema.__init__(self)
+
+    use = Test("top")
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep10 = Test("level1-0")
+    dep11 = Test("level1-1")
+
+    assert dep00.use(dep10)
+    assert dep01.use(dep11)
+
+    assert use.use(dep00)
+    assert use.use(dep01)
+
+    use.write_dependencygraph("test.png", landscape=True, border=False)
+    assert os.path.exists("test.png")
+
+
+def test_write_dependencygraph_repeats():
+    class Test(NamedSchema, UseSchema):
+        def __init__(self, name):
+            NamedSchema.__init__(self, name)
+            UseSchema.__init__(self)
+
+    use = Test("top")
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep10 = Test("level1-0")
+    dep11 = Test("level1-1")
+
+    assert dep00.use(dep10)
+    assert dep00.use(dep11)
+    assert dep01.use(dep11)
+
+    assert use.use(dep00)
+    assert use.use(dep01)
+
+    use.write_dependencygraph("test.png")
+    assert os.path.exists("test.png")
+
+
+def test_write_dependencygraph_circle():
+    class Test(NamedSchema, UseSchema):
+        def __init__(self, name):
+            NamedSchema.__init__(self, name)
+            UseSchema.__init__(self)
+
+    use = Test("top")
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep10 = Test("level1-0")
+    dep11 = Test("level1-1")
+
+    assert dep00.use(dep10)
+    assert dep10.use(dep01)
+    assert dep01.use(dep11)
+    assert dep11.use(dep00)
+
+    assert use.use(dep00)
+
+    use.write_dependencygraph("test.png")
+    assert os.path.exists("test.png")


### PR DESCRIPTION
Adds `.use` to classes that implement this along with accessors for the dependency data:
* `.get_dependency()`
* `.get_all_dependencies()`
* `.write_dependencygraph()`
* `.remove_dependency()`

+ callback to NamedSchema with `._reset()` to enable removing state information
