### PR TITLE
add `with_fileset` to design

### DIFF
--- a/siliconcompiler/design.py
+++ b/siliconcompiler/design.py
@@ -512,7 +512,7 @@ class DesignSchema(NamedSchema, DependencySchema):
         return self.get('fileset', fileset, option)
 
     @contextlib.contextmanager
-    def with_fileset(self, fileset: str):
+    def active_fileset(self, fileset: str):
         """
         Use this context to temporarily set a design fileset.
 
@@ -524,7 +524,7 @@ class DesignSchema(NamedSchema, DependencySchema):
             fileset (str): name of the fileset
 
         Example:
-            >>> with design.with_fileset("rtl"):
+            >>> with design.active_fileset("rtl"):
             ...     design.set_topmodule("top")
             Sets the top module for the rtl fileset as top.
         """

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -258,23 +258,23 @@ def test_heartbeat_example(datadir):
     assert dut.get("deps") == ["increment"]
 
 
-def test_with_fileset_invalid():
+def test_active_fileset_invalid():
     d = DesignSchema("test")
 
     with pytest.raises(TypeError, match="fileset must a string"):
-        with d.with_fileset(None):
+        with d.active_fileset(None):
             pass
 
     with pytest.raises(ValueError, match="fileset cannot be an empty string"):
-        with d.with_fileset(""):
+        with d.active_fileset(""):
             pass
 
 
-def test_options_with_fileset():
+def test_options_active_fileset():
     d = DesignSchema("test")
 
     # create fileset context
-    with d.with_fileset("rtl"):
+    with d.active_fileset("rtl"):
         # top module
         d.set_topmodule('mytop')
         assert d.get_topmodule() == 'mytop'
@@ -310,11 +310,11 @@ def test_options_with_fileset():
         assert d.get_undefine() == undefs
 
 
-def test_options_with_fileset_overide_context():
+def test_options_active_fileset_overide_context():
     d = DesignSchema("test")
 
     # create fileset context
-    with d.with_fileset("rtl"):
+    with d.active_fileset("rtl"):
         # top module
         d.set_topmodule('mytop')
         assert d.get_topmodule() == 'mytop'
@@ -323,27 +323,27 @@ def test_options_with_fileset_overide_context():
         assert d.get_topmodule("notrtl") == 'mytop_other'
 
 
-def test_options_with_fileset_ensure_no_leftovers():
+def test_options_active_fileset_ensure_no_leftovers():
     d = DesignSchema("test")
 
     assert d._DesignSchema__fileset is None
     # create fileset context
-    with d.with_fileset("rtl"):
+    with d.active_fileset("rtl"):
         assert d._DesignSchema__fileset == "rtl"
     assert d._DesignSchema__fileset is None
 
 
-def test_add_file_with_fileset():
+def test_add_file_active_fileset():
     d = DesignSchema("test")
 
-    with d.with_fileset("rtl"):
+    with d.active_fileset("rtl"):
         # explicit file add
         files = ['one.v', 'two.v']
         d.add_file(files, filetype='verilog')
         assert d.get_file(filetype="verilog") == files
     assert d.get('fileset', "rtl", 'file', 'verilog') == files
 
-    with d.with_fileset("testbench"):
+    with d.active_fileset("testbench"):
         # filetype mapping
         d.add_file('tb.v')
         d.add_file('dut.v')


### PR DESCRIPTION
Adds:
```
with design.with_fileset("something"):
    ...
```
context manager to allow setting a default fielset within the context of the `with`.

Notes:
- it was added to both setters and getters. Seemed like parity for the getters provided a nice parity to the setters.