### PR TITLE
Separate step index

### DIFF
--- a/siliconcompiler/apps/_common.py
+++ b/siliconcompiler/apps/_common.py
@@ -114,7 +114,7 @@ def pick_manifest(chip, src_file=None):
         if (step, index) in all_manifests[chip.design][jobname]:
             return all_manifests[chip.design][jobname][(step, index)]
         else:
-            chip.logger.error(f'{step}{index} is not a valid node.')
+            chip.logger.error(f'{step}/{index} is not a valid node.')
             return None
 
     if (None, None) in all_manifests[chip.design][jobname]:

--- a/siliconcompiler/apps/sc_issue.py
+++ b/siliconcompiler/apps/sc_issue.py
@@ -142,7 +142,7 @@ To run a testcase, use:
         chip.set('arg', 'step', step)
         chip.set('arg', 'index', index)
         tool, task = get_tool_task(chip, step, index)
-        chip.logger.info(f'Preparing run for {step}{index} - {tool}/{task}')
+        chip.logger.info(f'Preparing run for {step}/{index} - {tool}/{task}')
 
         # Modify run environment to point to extracted files
         builddir_key = ['option', 'builddir']

--- a/siliconcompiler/checklist.py
+++ b/siliconcompiler/checklist.py
@@ -101,13 +101,13 @@ class ChecklistSchema(NamedSchema):
                     if (step, index) not in flow.get_nodes():
                         error = True
                         if logger:
-                            logger.error(f'{step}{index} not found in flowgraph for {job}')
+                            logger.error(f'{step}/{index} not found in flowgraph for {job}')
                         continue
 
                     if job_data.get('record', 'status', step=step, index=index) == \
                             NodeStatus.SKIPPED:
                         if logger:
-                            logger.warning(f'{step}{index} was skipped')
+                            logger.warning(f'{step}/{index} was skipped')
                         continue
 
                     has_check = True
@@ -142,7 +142,7 @@ class ChecklistSchema(NamedSchema):
 
                     criteria_str = f'{metric}{op}{goal:{number_format}}'
                     compare_str = f'{value:{number_format}}{op}{goal:{number_format}}'
-                    step_desc = f'job {job} with step {step}{index} and task {tool}/{task}'
+                    step_desc = f'job {job} with step {step}/{index} and task {tool}/{task}'
                     if not criteria_ok and waivers:
                         if logger:
                             logger.warning(f'{item} criteria {criteria_str} ({compare_str}) unmet '

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1631,7 +1631,7 @@ class Chip:
                         NodeStatus.SUCCESS:
                     # this task has already completed successfully, OK
                     continue
-                self.logger.error(f'{step}{index} relies on {in_step}{in_index}, '
+                self.logger.error(f'{step}/{index} relies on {in_step}/{in_index}, '
                                   'but this task has not been run and is not in the '
                                   'current nodes to execute.')
                 error = True
@@ -1676,12 +1676,12 @@ class Chip:
             if not self._get_tool_module(step, index, flow=flow, error=False):
                 error = True
                 self.logger.error(f"Tool module {tool_name} could not be found or "
-                                  f"loaded for {step}{index}.")
+                                  f"loaded for {step}/{index}.")
             if not self._get_task_module(step, index, flow=flow, error=False):
                 error = True
                 task_module = self.get('flowgraph', flow, step, index, 'taskmodule')
                 self.logger.error(f"Task module {task_module} for {tool_name}/{task_name} "
-                                  f"could not be found or loaded for {step}{index}.")
+                                  f"could not be found or loaded for {step}/{index}.")
 
         # 5. Check per tool parameter requirements (when tool exists)
         for (step, index) in nodes:
@@ -2530,7 +2530,7 @@ class Chip:
     ###########################################################################
     def _archive_node(self, tar, step, index, include=None, verbose=True):
         if verbose:
-            self.logger.info(f'Archiving {step}{index}...')
+            self.logger.info(f'Archiving {step}/{index}...')
 
         basedir = self.getworkdir(step=step, index=index)
 
@@ -2539,7 +2539,7 @@ class Chip:
 
         if not os.path.isdir(basedir):
             if self.get('record', 'status', step=step, index=index) != NodeStatus.SKIPPED:
-                self.logger.error(f'Unable to archive {step}{index} due to missing node directory')
+                self.logger.error(f'Unable to archive {step}/{index} due to missing node directory')
             return
 
         if include:
@@ -2613,7 +2613,7 @@ class Chip:
 
         if not archive_name:
             if step and index:
-                archive_name = f"{design}_{jobname}_{step}{index}.tgz"
+                archive_name = f"{design}_{jobname}_{step}_{index}.tgz"
             elif step:
                 archive_name = f"{design}_{jobname}_{step}.tgz"
             else:
@@ -3179,7 +3179,7 @@ class Chip:
         self.unset('option', 'prune')
         self.unset('option', 'from')
         # build new job name
-        self.set('option', 'jobname', f'_{taskname}_{sc_job}_{sc_step}{sc_index}', clobber=True)
+        self.set('option', 'jobname', f'_{taskname}_{sc_job}_{sc_step}_{sc_index}', clobber=True)
 
         # Setup in step/index variables
         for step, index in self.get("flowgraph", "showflow", field="schema").get_nodes():

--- a/siliconcompiler/data/templates/email/general.j2
+++ b/siliconcompiler/data/templates/email/general.j2
@@ -9,11 +9,11 @@
     </head>
 
     <body>
-        <h2>Node Summary: "{{ step }}{{ index }}"</h2>
+        <h2>Node Summary: "{{ step }}/{{ index }}"</h2>
         <span>
             <p><b>Design</b>: {{ design }}</p>
             <p><b>Job</b>: {{ job }}</p>
-            <p><b>Node</b>: {{ step }}{{ index }}</p>
+            <p><b>Node</b>: {{ step }}/{{ index }}</p>
             <p><b>Status</b>: {{ status }}</p>
         </span>
         <span>
@@ -36,7 +36,7 @@
                     <th>Metrics</th>
                     <th>units</th>
                     {% for step, index in nodes %}
-                    <th align="center">{{ step }}{{ index }}</th>
+                    <th align="center">{{ step }}/{{ index }}</th>
                     {% endfor %}
                 </tr>
                 {% for metric in metric_keys %}

--- a/siliconcompiler/data/templates/email/summary.j2
+++ b/siliconcompiler/data/templates/email/summary.j2
@@ -14,7 +14,7 @@
                 <th>-</th>
                 <th>units</th>
                 {% for step, index in nodes %}
-                <th align="center">{{ step }}{{ index }}</th>
+                <th align="center">{{ step }}/{{ index }}</th>
                 {% endfor %}
             </tr>
             {% for metric in metric_keys %}

--- a/siliconcompiler/data/templates/issue/README.txt
+++ b/siliconcompiler/data/templates/issue/README.txt
@@ -13,7 +13,7 @@ Schema: {{ version['schema'] }}
 Testcase built: {{ date }}
 Tool: {{ run['tool'] }} {% if run['toolversion'] %}{{ run['toolversion'] }}{% endif %}
 Task: {{ run['task'] }}
-Node: {{ run['step'] }}{{ run['index'] }}
+Node: {{ run['step'] }}/{{ run['index'] }}
 
 ** Python **
 Version: {{ python['version'] }}

--- a/siliconcompiler/data/templates/report/sc_report.j2
+++ b/siliconcompiler/data/templates/report/sc_report.j2
@@ -271,12 +271,12 @@
         {% for metric in metric_keys %}
           {% for step, index in nodes %}
             {% if reports[step, index][metric] %}
-              var sim_log_btn = document.getElementById("{{ step }}{{ index }}_{{ metric }}_metlink");
+              var sim_log_btn = document.getElementById("{{ step }}_{{ index }}_{{ metric }}_metlink");
               sim_log_btn.addEventListener('click', () => {
                 log_link = "{{ step }}/{{ index }}/{{ reports[step, index][metric][0] }}";
                 window.open(log_link, "_blank");
               });
-              var sim_log_btn = document.getElementById("{{ step }}{{ index }}_{{ metric }}_ddmetlink");
+              var sim_log_btn = document.getElementById("{{ step }}_{{ index }}_{{ metric }}_ddmetlink");
               sim_log_btn.addEventListener('click', () => {
                 log_link = "{{ step }}/{{ index }}/{{ reports[step, index][metric][0] }}";
                 window.open(log_link, "_blank");
@@ -333,7 +333,7 @@
               <th>-</th>
               <th>units</th>
               {% for step, index in nodes %}
-                <th>{{ step }}{{ index }}</th>
+                <th>{{ step }}/{{ index }}</th>
               {% endfor %}
             </tr>
             {% for metric in metric_keys %}
@@ -372,12 +372,12 @@
         <h2>Metrics for {{ design }} Tasks</h2>
         {% for step, index in nodes %}
           <div>
-            <a class="btn btn-success" data-bs-toggle="collapse" href="#{{ step }}{{ index }}_dropdown_div", role="button", aria-controls="{{ step }}{{ index }}_dropdown_div">
-              Toggle {{ step }}{{ index }} Metrics
+            <a class="btn btn-success" data-bs-toggle="collapse" href="#{{ step }}_{{ index }}_dropdown_div", role="button", aria-controls="{{ step }}_{{ index }}_dropdown_div">
+              Toggle {{ step }}/{{ index }} Metrics
             </a>
           </div>
-          <div id="{{ step }}{{ index }}_dropdown_div" class="collapse">
-            <table id="{{ step }}{{ index }}_metrics_table" class="table table-dark table-striped table-bordered">
+          <div id="{{ step }}_{{ index }}_dropdown_div" class="collapse">
+            <table id="{{ step }}_{{ index }}_metrics_table" class="table table-dark table-striped table-bordered">
               <tr>
                 {% for metric in metric_keys %}
                   <th>{{ metric }}</th>

--- a/siliconcompiler/flowgraph.py
+++ b/siliconcompiler/flowgraph.py
@@ -114,7 +114,7 @@ class FlowgraphSchema(NamedSchema):
 
         for step, index in [(head, head_index), (tail, tail_index)]:
             if not self.valid(step, index):
-                raise ValueError(f"{step}{index} is not a defined node in {self.name()}.")
+                raise ValueError(f"{step}/{index} is not a defined node in {self.name()}.")
 
         tail_node = (tail, tail_index)
         if tail_node in self.get(head, head_index, 'input'):
@@ -183,7 +183,7 @@ class FlowgraphSchema(NamedSchema):
         before_index = str(before_index)
 
         if (before_step, before_index) not in self.get_nodes():
-            raise ValueError(f'{before_step}{before_index} is not a valid node in {self.name()}')
+            raise ValueError(f'{before_step}/{before_index} is not a valid node in {self.name()}')
 
         # add the node
         self.node(step, task, index=index)
@@ -388,7 +388,7 @@ class FlowgraphSchema(NamedSchema):
         index = str(index)
 
         if (step, index) not in self.get_nodes():
-            raise ValueError(f"{step}{index} is not a valid node")
+            raise ValueError(f"{step}/{index} is not a valid node")
 
         if self.__cache_node_outputs is not None:
             return self.__cache_node_outputs[(step, index)]
@@ -464,15 +464,15 @@ class FlowgraphSchema(NamedSchema):
                 if input_nodes.count(node) > 1:
                     in_step, in_index = node
                     if logger:
-                        logger.error(f'Duplicate edge from {in_step}{in_index} to '
-                                     f'{step}{index} in the {self.name()} flowgraph')
+                        logger.error(f'Duplicate edge from {in_step}/{in_index} to '
+                                     f'{step}/{index} in the {self.name()} flowgraph')
                     error = True
 
         diff_nodes = check_nodes.difference(self.get_nodes())
         if diff_nodes:
             if logger:
                 for step, index in diff_nodes:
-                    logger.error(f'{step}{index} is missing in the {self.name()} flowgraph')
+                    logger.error(f'{step}/{index} is missing in the {self.name()} flowgraph')
             error = True
 
         # Detect missing definitions
@@ -480,7 +480,7 @@ class FlowgraphSchema(NamedSchema):
             for item in ('tool', 'task', 'taskmodule'):
                 if not self.get(step, index, item):
                     if logger:
-                        logger.error(f'{step}{index} is missing a {item} definition in the '
+                        logger.error(f'{step}/{index} is missing a {item} definition in the '
                                      f'{self.name()} flowgraph')
                     error = True
 
@@ -490,7 +490,7 @@ class FlowgraphSchema(NamedSchema):
             if loop_path:
                 error = True
                 if logger:
-                    loop_path = [f"{step}{index}" for step, index in loop_path]
+                    loop_path = [f"{step}/{index}" for step, index in loop_path]
                     logger.error(f"{' -> '.join(loop_path)} forms a loop in {self.name()}")
 
         return not error
@@ -649,13 +649,13 @@ class RuntimeFlowgraph:
         index = str(index)
 
         if (step, index) not in self.get_nodes():
-            raise ValueError(f"{step}{index} is not a valid node")
+            raise ValueError(f"{step}/{index} is not a valid node")
 
         return tuple(sorted(self.__walk_graph((step, str(index)), reverse=False)))
 
     def get_node_inputs(self, step, index, record=None):
         if (step, index) not in self.get_nodes():
-            raise ValueError(f"{step}{index} is not a valid node")
+            raise ValueError(f"{step}/{index} is not a valid node")
 
         if record is None:
             inputs = set()
@@ -722,7 +722,7 @@ class RuntimeFlowgraph:
         # Check for undefined prunes
         for step, index in sorted(prune_nodes.difference(flow.get_nodes())):
             if logger:
-                logger.error(f'{step}{index} is not defined in the {flow.name()} flowgraph')
+                logger.error(f'{step}/{index} is not defined in the {flow.name()} flowgraph')
             error = True
 
         if not error:
@@ -763,7 +763,7 @@ class RuntimeFlowgraph:
                         if entrynode in runtime.__walk_graph(exitnode):
                             found = True
                     if not found:
-                        exits = ",".join([f"{step}{index}"
+                        exits = ",".join([f"{step}/{index}"
                                           for step, index in runtime.get_exit_nodes()])
                         missing.append(f'no path from {entrynode[0]}{entrynode[1]} to {exits} '
                                        f'in the {flow.name()} flowgraph')

--- a/siliconcompiler/flowgraph.py
+++ b/siliconcompiler/flowgraph.py
@@ -79,6 +79,11 @@ class FlowgraphSchema(NamedSchema):
             raise ValueError(f"{task} is not a valid task, it must be associated with "
                              "a tool '<tool>.<task>'.")
 
+        if '/' in step:
+            raise ValueError(f"{step} is not a valid step, it cannot contain '/'")
+        if '/' in index:
+            raise ValueError(f"{index} is not a valid index, it cannot contain '/'")
+
         tool_name, task_name = task_parts[-2:]
 
         # bind tool to node

--- a/siliconcompiler/flowgraph.py
+++ b/siliconcompiler/flowgraph.py
@@ -770,7 +770,7 @@ class RuntimeFlowgraph:
                     if not found:
                         exits = ",".join([f"{step}/{index}"
                                           for step, index in runtime.get_exit_nodes()])
-                        missing.append(f'no path from {entrynode[0]}{entrynode[1]} to {exits} '
+                        missing.append(f'no path from {entrynode[0]}/{entrynode[1]} to {exits} '
                                        f'in the {flow.name()} flowgraph')
                     if found:
                         found_any = True

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -676,7 +676,7 @@ service, provided by SiliconCompiler, is not intended to process proprietary IP.
                 "imported": done,
                 "fetched": done
             }
-            self.__node_information[f'{step}/{index}'] = node_info
+            self.__node_information[f'{step}{index}'] = node_info
 
     def __run_loop(self):
         self.__ensure_run_loop_information()

--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -676,7 +676,7 @@ service, provided by SiliconCompiler, is not intended to process proprietary IP.
                 "imported": done,
                 "fetched": done
             }
-            self.__node_information[f'{step}{index}'] = node_info
+            self.__node_information[f'{step}/{index}'] = node_info
 
     def __run_loop(self):
         self.__ensure_run_loop_information()

--- a/siliconcompiler/remote/server.py
+++ b/siliconcompiler/remote/server.py
@@ -113,7 +113,7 @@ class Server:
             self.sc_jobs[job_name][None]["status"] = start_status
 
             for step, index in nodes:
-                name = f"{step}/{index}"
+                name = f"{step}{index}"
                 if name not in self.sc_jobs[job_name]:
                     continue
                 self.sc_jobs[job_name][name]["status"] = \
@@ -122,7 +122,7 @@ class Server:
     def __node_start(self, chip, step, index):
         with self.sc_jobs_lock:
             job_name = self.sc_chip_lookup[chip]["name"]
-            self.sc_jobs[job_name][f"{step}/{index}"]["status"] = NodeStatus.RUNNING
+            self.sc_jobs[job_name][f"{step}{index}"]["status"] = NodeStatus.RUNNING
 
     def __node_end(self, chip, step, index):
         with self.sc_jobs_lock:
@@ -133,12 +133,12 @@ class Server:
         chip.cwd = os.path.join(chip.get('option', 'builddir'), '..')
         with tarfile.open(os.path.join(self.nfs_mount,
                                        job_hash,
-                                       f'{job_hash}_{step}_{index}.tar.gz'),
+                                       f'{job_hash}_{step}{index}.tar.gz'),
                           mode='w:gz') as tf:
             chip._archive_node(tf, step=step, index=index, include="*")
 
         with self.sc_jobs_lock:
-            self.sc_jobs[job_name][f"{step}/{index}"]["status"] = \
+            self.sc_jobs[job_name][f"{step}{index}"]["status"] = \
                 chip.get('record', 'status', step=step, index=index)
 
     def run(self):
@@ -457,7 +457,7 @@ class Server:
                 status = SCNodeStatus.PENDING
             if SCNodeStatus.is_done(status):
                 status = NodeStatus.UPLOADED
-            nodes[f"{step}/{index}"] = {
+            nodes[f"{step}{index}"] = {
                 "status": status
             }
 

--- a/siliconcompiler/remote/server.py
+++ b/siliconcompiler/remote/server.py
@@ -113,7 +113,7 @@ class Server:
             self.sc_jobs[job_name][None]["status"] = start_status
 
             for step, index in nodes:
-                name = f"{step}{index}"
+                name = f"{step}/{index}"
                 if name not in self.sc_jobs[job_name]:
                     continue
                 self.sc_jobs[job_name][name]["status"] = \
@@ -122,7 +122,7 @@ class Server:
     def __node_start(self, chip, step, index):
         with self.sc_jobs_lock:
             job_name = self.sc_chip_lookup[chip]["name"]
-            self.sc_jobs[job_name][f"{step}{index}"]["status"] = NodeStatus.RUNNING
+            self.sc_jobs[job_name][f"{step}/{index}"]["status"] = NodeStatus.RUNNING
 
     def __node_end(self, chip, step, index):
         with self.sc_jobs_lock:
@@ -133,12 +133,12 @@ class Server:
         chip.cwd = os.path.join(chip.get('option', 'builddir'), '..')
         with tarfile.open(os.path.join(self.nfs_mount,
                                        job_hash,
-                                       f'{job_hash}_{step}{index}.tar.gz'),
+                                       f'{job_hash}_{step}_{index}.tar.gz'),
                           mode='w:gz') as tf:
             chip._archive_node(tf, step=step, index=index, include="*")
 
         with self.sc_jobs_lock:
-            self.sc_jobs[job_name][f"{step}{index}"]["status"] = \
+            self.sc_jobs[job_name][f"{step}/{index}"]["status"] = \
                 chip.get('record', 'status', step=step, index=index)
 
     def run(self):
@@ -457,7 +457,7 @@ class Server:
                 status = SCNodeStatus.PENDING
             if SCNodeStatus.is_done(status):
                 status = NodeStatus.UPLOADED
-            nodes[f"{step}{index}"] = {
+            nodes[f"{step}/{index}"] = {
                 "status": status
             }
 

--- a/siliconcompiler/report/dashboard/web/components/__init__.py
+++ b/siliconcompiler/report/dashboard/web/components/__init__.py
@@ -494,7 +494,7 @@ def node_viewer(chip, step, index, metric_dataframe, height=None):
 
     metrics_col, records_col, logs_and_reports_col = streamlit.columns(3, gap='small')
 
-    node_name = f'{step}{index}'
+    node_name = f'{step}/{index}'
 
     with metrics_col:
         streamlit.subheader(f'{node_name} metrics')
@@ -504,7 +504,7 @@ def node_viewer(chip, step, index, metric_dataframe, height=None):
                 use_container_width=True,
                 height=height)
     with records_col:
-        streamlit.subheader(f'{step}{index} details')
+        streamlit.subheader(f'{step}/{index} details')
         nodes = {}
         nodes[step + index] = report.get_flowgraph_nodes(chip, step, index)
         streamlit.dataframe(
@@ -512,7 +512,7 @@ def node_viewer(chip, step, index, metric_dataframe, height=None):
             use_container_width=True,
             height=height)
     with logs_and_reports_col:
-        streamlit.subheader(f'{step}{index} files')
+        streamlit.subheader(f'{step}/{index} files')
         node_file_tree_viewer(chip, step, index)
 
 

--- a/siliconcompiler/report/dashboard/web/components/flowgraph.py
+++ b/siliconcompiler/report/dashboard/web/components/flowgraph.py
@@ -60,7 +60,7 @@ def get_nodes_and_edges(chip):
         node_color = NODE_COLORS[node_status]
 
         tool, task = get_tool_task(chip, step, index)
-        node_name = f'{step}{index}'
+        node_name = f'{step}/{index}'
         label = node_name + "\n" + tool + "/" + task
         if tool == 'builtin':
             label = node_name + "\n" + tool
@@ -95,7 +95,7 @@ def get_nodes_and_edges(chip):
                 dashes = True
 
             edges.append(Edge(
-                source=f'{source_step}{source_index}',
+                source=f'{source_step}/{source_index}',
                 target=node_name,
                 dir='up',
                 width=edge_width,

--- a/siliconcompiler/report/dashboard/web/components/graph.py
+++ b/siliconcompiler/report/dashboard/web/components/graph.py
@@ -67,7 +67,7 @@ def settings(metrics, nodes, graph_number):
 
     Args:
         metrics (list) : A list of metrics that are set for all chips given in chips.
-        nodes (list) : A list of nodes given in the form f'{step}{index}'
+        nodes (list) : A list of nodes given in the form f'{step}/{index}'
         graph_number (int) : The number of graphs there are. Used to create
             keys to distinguish selectboxes from each other.
     """
@@ -147,7 +147,7 @@ def graph(metrics, nodes, node_to_step_index_map, graph_number):
 
     labels = {
         "runs": state.get_key(state.GRAPH_JOBS),
-        "nodes": [f'{step}{index}' for step, index in data]
+        "nodes": [f'{step}/{index}' for step, index in data]
     }
 
     if nodes:

--- a/siliconcompiler/report/dashboard/web/state.py
+++ b/siliconcompiler/report/dashboard/web/state.py
@@ -125,7 +125,7 @@ def init():
         chip_index = chip.get('arg', 'index')
 
         if chip_step and chip_index:
-            set_key(SELECTED_NODE, f'{chip_step}{chip_index}')
+            set_key(SELECTED_NODE, f'{chip_step}/{chip_index}')
 
     chip = get_chip("default")
     chip.unset('arg', 'step')

--- a/siliconcompiler/report/dashboard/web/utils/__init__.py
+++ b/siliconcompiler/report/dashboard/web/utils/__init__.py
@@ -26,7 +26,7 @@ def make_node_to_step_index_map(chip, metric_dataframe):
     if chip.get('option', 'flow'):
         for step, index in chip.schema.get("flowgraph", chip.get('option', 'flow'),
                                            field="schema").get_nodes():
-            node_to_step_index_map[f'{step}{index}'] = (step, index)
+            node_to_step_index_map[f'{step}/{index}'] = (step, index)
 
     # concatenate step and index
     metric_dataframe.columns = metric_dataframe.columns.map(lambda x: f'{x[0]}{x[1]}')

--- a/siliconcompiler/report/report.py
+++ b/siliconcompiler/report/report.py
@@ -61,7 +61,7 @@ def get_flowgraph_nodes(chip, step, index):
             value = chip.get('record', key, step=step, index=index)
         if value is not None:
             if key == 'inputnode':
-                value = ", ".join([f'{step}{index}' for step, index in value])
+                value = ", ".join([f'{step}/{index}' for step, index in value])
             if key == 'pythonpackage':
                 value = ", ".join(value)
             nodes[key] = str(value)
@@ -363,7 +363,7 @@ def get_chart_selection_options(chips):
         chip = chip_and_chip_name['chip_object']
         nodes_list, _, _, _, chip_metrics, _ = \
             utils._collect_data(chip, format_as_string=False)
-        nodes.update(set([f'{step}{index}' for step, index in nodes_list]))
+        nodes.update(set([f'{step}/{index}' for step, index in nodes_list]))
         metrics.update(set(chip_metrics))
     return nodes, metrics
 

--- a/siliconcompiler/report/summary_table.py
+++ b/siliconcompiler/report/summary_table.py
@@ -44,7 +44,7 @@ def _show_summary_table(chip, flow, flowgraph_nodes, show_all_indices):
 
     # trim labels to column width
     column_labels = []
-    labels = [f'{step}{index}' for step, index in nodes_to_show]
+    labels = [f'{step}/{index}' for step, index in nodes_to_show]
     if labels:
         column_width = min([column_width, max([len(label) for label in labels])])
 

--- a/siliconcompiler/scheduler/docker.py
+++ b/siliconcompiler/scheduler/docker.py
@@ -215,7 +215,7 @@ class DockerSchedulerNode(SchedulerNode):
                 volumes=volumes,
                 labels=[
                     "siliconcompiler",
-                    f"sc_node:{self.chip.design}:{self.step}{self.index}"
+                    f"sc_node:{self.chip.design}:{self.step}:{self.index}"
                 ],
                 user=user,
                 detach=True,

--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -53,7 +53,7 @@ class SchedulerNode:
             "output": os.path.join(self.__workdir, "outputs", f"{self.__design}.pkg.json")
         }
         self.__logs = {
-            "sc": os.path.join(self.__workdir, f"sc_{self.__step}_{self.__index}.log"),
+            "sc": os.path.join(self.__workdir, f"sc_{self.__step}{self.__index}.log"),
             "exe": os.path.join(self.__workdir, f"{self.__step}.log")
         }
         self.__replay_script = os.path.join(self.__workdir, "replay.sh")

--- a/siliconcompiler/scheduler/send_messages.py
+++ b/siliconcompiler/scheduler/send_messages.py
@@ -110,7 +110,7 @@ def send(chip, msg_type, step, index):
                 metric_keys=metrics_to_show)
         else:
             # Attach logs
-            for log in (f'sc_{step}_{index}.log', f'{step}.log'):
+            for log in (f'sc_{step}{index}.log', f'{step}.log'):
                 log_file = f'{chip.getworkdir(step=step, index=index)}/{log}'
                 if os.path.exists(log_file):
                     with sc_open(log_file) as f:

--- a/siliconcompiler/scheduler/send_messages.py
+++ b/siliconcompiler/scheduler/send_messages.py
@@ -66,7 +66,7 @@ def send(chip, msg_type, step, index):
     msg = MIMEMultipart()
 
     if step and index:
-        subject = f'SiliconCompiler : {chip.design} | {jobname} | {step}{index} | {msg_type}'
+        subject = f'SiliconCompiler : {chip.design} | {jobname} | {step} | {index} | {msg_type}'
     else:
         subject = f'SiliconCompiler : {chip.design} | {jobname} | {msg_type}'
 
@@ -110,7 +110,7 @@ def send(chip, msg_type, step, index):
                 metric_keys=metrics_to_show)
         else:
             # Attach logs
-            for log in (f'sc_{step}{index}.log', f'{step}.log'):
+            for log in (f'sc_{step}_{index}.log', f'{step}.log'):
                 log_file = f'{chip.getworkdir(step=step, index=index)}/{log}'
                 if os.path.exists(log_file):
                     with sc_open(log_file) as f:

--- a/siliconcompiler/scheduler/slurm.py
+++ b/siliconcompiler/scheduler/slurm.py
@@ -65,7 +65,7 @@ class SlurmSchedulerNode(SchedulerNode):
 
     @staticmethod
     def get_job_name(jobhash, step, index):
-        return f'{jobhash}_{step}{index}'
+        return f'{jobhash}_{step}_{index}'
 
     @staticmethod
     def get_runtime_file_name(jobhash, step, index, ext):

--- a/siliconcompiler/scheduler/taskscheduler.py
+++ b/siliconcompiler/scheduler/taskscheduler.py
@@ -79,7 +79,7 @@ class TaskScheduler:
             threads = max(1, min(threads, self.__max_threads))
 
             task = {
-                "name": f"{step}{index}",
+                "name": f"{step}/{index}",
                 "inputs": runtime.get_node_inputs(step, index, record=self.__record),
                 "proc": None,
                 "parent_pipe": None,

--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -716,7 +716,7 @@ class BaseSchema:
                                 if index is None:
                                     node_indicator = f" ({step})"
                                 else:
-                                    node_indicator = f" ({step}{index})"
+                                    node_indicator = f" ({step}/{index})"
 
                             logger.error(f"Parameter [{','.join(keypath)}]{node_indicator} path "
                                          f"{check_file} is invalid")

--- a/siliconcompiler/tools/_common/__init__.py
+++ b/siliconcompiler/tools/_common/__init__.py
@@ -388,9 +388,9 @@ def input_file_node_name(filename, step, index):
 
         total_ext.reverse()
 
-        return f'{base}.{step}{index}.{".".join(total_ext)}'
+        return f'{base}.{step}.{index}.{".".join(total_ext)}'
     else:
-        return f'{filename}.{step}{index}'
+        return f'{filename}.{step}.{index}'
 
 
 def add_common_file(chip, key, file):

--- a/siliconcompiler/tools/_common/__init__.py
+++ b/siliconcompiler/tools/_common/__init__.py
@@ -388,9 +388,9 @@ def input_file_node_name(filename, step, index):
 
         total_ext.reverse()
 
-        return f'{base}.{step}.{index}.{".".join(total_ext)}'
+        return f'{base}.{step}{index}.{".".join(total_ext)}'
     else:
-        return f'{filename}.{step}.{index}'
+        return f'{filename}.{step}{index}'
 
 
 def add_common_file(chip, key, file):

--- a/siliconcompiler/tools/builtin/_common.py
+++ b/siliconcompiler/tools/builtin/_common.py
@@ -83,10 +83,10 @@ def _minmax(chip, *nodes, op=None):
                     real = chip.get('metric', metric, step=step, index=index)
                     if real is None:
                         raise SiliconCompilerError(
-                            f'Metric {metric} has goal for {step}{index} '
+                            f'Metric {metric} has goal for {step}/{index} '
                             'but it has not been set.', chip=chip)
                     if abs(real) > goal:
-                        chip.logger.warning(f"Step {step}{index} failed "
+                        chip.logger.warning(f"Step {step}/{index} failed "
                                             f"because it didn't meet goals for '{metric}' "
                                             "metric.")
                         failed[step][index] = True
@@ -122,7 +122,7 @@ def _minmax(chip, *nodes, op=None):
             real = chip.get('metric', metric, step=step, index=index)
             if real is None:
                 raise SiliconCompilerError(
-                    f'Metric {metric} has weight for {step}{index} '
+                    f'Metric {metric} has weight for {step}/{index} '
                     'but it has not been set.', chip=chip)
 
             if not (max_val[metric] - min_val[metric]) == 0:

--- a/siliconcompiler/tools/builtin/verify.py
+++ b/siliconcompiler/tools/builtin/verify.py
@@ -25,13 +25,13 @@ def _select_inputs(chip, step, index):
     inputs = _common._select_inputs(chip, step, index)
     if len(inputs) != 1:
         raise SiliconCompilerError(
-            f'{step}{index} receives {len(inputs)} inputs, but only supports one', chip=chip)
+            f'{step}/{index} receives {len(inputs)} inputs, but only supports one', chip=chip)
     inputs = inputs[0]
     flow = chip.get('option', 'flow')
     arguments = chip.get('flowgraph', flow, step, index, 'args')
 
     if len(arguments) == 0:
-        raise SiliconCompilerError(f'{step}{index} requires arguments for verify', chip=chip)
+        raise SiliconCompilerError(f'{step}/{index} requires arguments for verify', chip=chip)
 
     passes = True
     for criteria in arguments:
@@ -55,7 +55,7 @@ def _select_inputs(chip, step, index):
         metric_type = chip.get('metric', metric, field=None)
         goal = NodeType.normalize(goal, metric_type.get(field='type'))
         if not utils.safecompare(chip, value, op, goal):
-            chip.error(f"{step}{index} fails '{metric}' metric: {value}{op}{goal}")
+            chip.error(f"{step}/{index} fails '{metric}' metric: {value}{op}{goal}")
 
     if not passes:
         return []

--- a/siliconcompiler/tools/execute/exec_input.py
+++ b/siliconcompiler/tools/execute/exec_input.py
@@ -34,7 +34,7 @@ def pre_process(chip):
         break
 
     if not exec:
-        chip.error(f'{step}{index} did not receive an executable file')
+        chip.error(f'{step}/{index} did not receive an executable file')
 
     chip.set('tool', tool, 'exe', exec)
 

--- a/siliconcompiler/tools/openroad/antenna_repair.py
+++ b/siliconcompiler/tools/openroad/antenna_repair.py
@@ -68,7 +68,7 @@ def pre_process(chip):
             chip.get('tool', tool, 'task', task, 'var', 'ant_check',
                      step=step, index=index)[0] == 'false':
         chip.set('record', 'status', NodeStatus.SKIPPED, step=step, index=index)
-        chip.logger.warning(f'{step}{index} will be skipped since antenna repair is disabled.')
+        chip.logger.warning(f'{step}/{index} will be skipped since antenna repair is disabled.')
         return
 
     define_ord_files(chip)

--- a/siliconcompiler/tools/openroad/macro_placement.py
+++ b/siliconcompiler/tools/openroad/macro_placement.py
@@ -62,7 +62,7 @@ def pre_process(chip):
             for in_step, in_index in input_nodes
             ]):
         chip.set('record', 'status', NodeStatus.SKIPPED, step=step, index=index)
-        chip.logger.warning(f'{step}{index} will be skipped since are no macros to place.')
+        chip.logger.warning(f'{step}/{index} will be skipped since are no macros to place.')
         return
 
     build_pex_corners(chip)

--- a/siliconcompiler/tools/openroad/power_grid.py
+++ b/siliconcompiler/tools/openroad/power_grid.py
@@ -60,7 +60,7 @@ def pre_process(chip):
             (chip.get('tool', tool, 'task', task, 'var', 'pdn_enable',
                       step=step, index=index)[0] == 'false' or len(pdncfg) == 0):
         chip.set('record', 'status', NodeStatus.SKIPPED, step=step, index=index)
-        chip.logger.warning(f'{step}{index} will be skipped since power grid is disabled.')
+        chip.logger.warning(f'{step}/{index} will be skipped since power grid is disabled.')
         return
 
     define_ord_files(chip)

--- a/siliconcompiler/tools/slang/__init__.py
+++ b/siliconcompiler/tools/slang/__init__.py
@@ -212,5 +212,5 @@ def _diagnostics(chip, driver, compilation):
     for diag in compilation.getAllDiagnostics():
         diags.issue(diag)
 
-    record_metric(chip, step, index, 'errors', diags.numErrors, [f'sc_{step}_{index}.log'])
-    record_metric(chip, step, index, 'warnings', diags.numWarnings, [f'sc_{step}_{index}.log'])
+    record_metric(chip, step, index, 'errors', diags.numErrors, [f'sc_{step}{index}.log'])
+    record_metric(chip, step, index, 'warnings', diags.numWarnings, [f'sc_{step}{index}.log'])

--- a/siliconcompiler/tools/slang/__init__.py
+++ b/siliconcompiler/tools/slang/__init__.py
@@ -212,5 +212,5 @@ def _diagnostics(chip, driver, compilation):
     for diag in compilation.getAllDiagnostics():
         diags.issue(diag)
 
-    record_metric(chip, step, index, 'errors', diags.numErrors, [f'sc_{step}{index}.log'])
-    record_metric(chip, step, index, 'warnings', diags.numWarnings, [f'sc_{step}{index}.log'])
+    record_metric(chip, step, index, 'errors', diags.numErrors, [f'sc_{step}_{index}.log'])
+    record_metric(chip, step, index, 'warnings', diags.numWarnings, [f'sc_{step}_{index}.log'])

--- a/siliconcompiler/utils/flowgraph.py
+++ b/siliconcompiler/utils/flowgraph.py
@@ -173,7 +173,8 @@ def _get_flowgraph_information(chip, flow, io=True):
 
         rank_diff = {}
         for in_step, in_index in runtime_flow.get_node_inputs(step, index, record=record):
-            rank_diff[f'{in_step}/{in_index}'] = node_rank[node] - node_rank[f'{in_step}/{in_index}']
+            in_node_name = f'{in_step}/{in_index}'
+            rank_diff[in_node_name] = node_rank[node] - node_rank[in_node_name]
         nodes[node]["rank_diff"] = rank_diff
 
     for step, index in all_nodes:

--- a/siliconcompiler/utils/flowgraph.py
+++ b/siliconcompiler/utils/flowgraph.py
@@ -73,14 +73,14 @@ def _check_flowgraph_io(chip, nodes=None):
                 if node_inp in requirements:
                     inp = node_inp
                 if inp in all_inputs:
-                    chip.logger.error(f'Invalid flow: {step}{index} '
+                    chip.logger.error(f'Invalid flow: {step}/{index} '
                                       f'receives {inp} from multiple input tasks')
                     return False
                 all_inputs.add(inp)
 
         for requirement in requirements:
             if requirement not in all_inputs:
-                chip.logger.error(f'Invalid flow: {step}{index} will '
+                chip.logger.error(f'Invalid flow: {step}/{index} will '
                                   f'not receive required input {requirement}.')
                 return False
 
@@ -107,7 +107,7 @@ def _get_flowgraph_information(chip, flow, io=True):
     node_rank = {}
     for rank, rank_nodes in enumerate(node_exec_order):
         for step, index in rank_nodes:
-            node_rank[f'{step}{index}'] = rank
+            node_rank[f'{step}/{index}'] = rank
 
     graph_inputs = {}
     all_graph_inputs = set()
@@ -122,7 +122,7 @@ def _get_flowgraph_information(chip, flow, io=True):
         for inputs in graph_inputs.values():
             all_graph_inputs.update(inputs)
 
-    exit_nodes = [f'{step}{index}' for step, index in chip.schema.get(
+    exit_nodes = [f'{step}/{index}' for step, index in chip.schema.get(
         "flowgraph", flow, field="schema").get_exit_nodes()]
 
     nodes = {}
@@ -153,7 +153,7 @@ def _get_flowgraph_information(chip, flow, io=True):
             inputs = []
             outputs = []
 
-        node = f'{step}{index}'
+        node = f'{step}/{index}'
         if io and (step, index) in graph_inputs:
             inputs.extend(graph_inputs[(step, index)])
 
@@ -173,11 +173,11 @@ def _get_flowgraph_information(chip, flow, io=True):
 
         rank_diff = {}
         for in_step, in_index in runtime_flow.get_node_inputs(step, index, record=record):
-            rank_diff[f'{in_step}{in_index}'] = node_rank[node] - node_rank[f'{in_step}{in_index}']
+            rank_diff[f'{in_step}/{in_index}'] = node_rank[node] - node_rank[f'{in_step}/{in_index}']
         nodes[node]["rank_diff"] = rank_diff
 
     for step, index in all_nodes:
-        node = f'{step}{index}'
+        node = f'{step}/{index}'
         if io:
             # get inputs
             edge_stats = {}
@@ -189,9 +189,9 @@ def _get_flowgraph_information(chip, flow, io=True):
                         infile = input_file_node_name(infile, in_step, in_index)
                         if infile not in nodes[node]["file_inputs"]:
                             continue
-                    in_node_name = f"{in_step}{in_index}"
+                    in_node_name = f"{in_step}/{in_index}"
                     outlabel = f"{in_node_name}:output-{clean_label(outfile)}"
-                    inlabel = f"{step}{index}:input-{clean_label(infile)}"
+                    inlabel = f"{step}/{index}:input-{clean_label(infile)}"
 
                     if in_node_name not in edge_stats:
                         edge_stats[in_node_name] = {
@@ -229,12 +229,12 @@ def _get_flowgraph_information(chip, flow, io=True):
 
             if (step, index) in graph_inputs:
                 for key in graph_inputs[(step, index)]:
-                    inlabel = f"{step}{index}:input-{clean_label(key)}"
+                    inlabel = f"{step}/{index}:input-{clean_label(key)}"
                     edges.append((key, inlabel, 1))
         else:
             all_inputs = []
             for in_step, in_index in chip.get('flowgraph', flow, step, index, 'input'):
-                all_inputs.append(f'{in_step}{in_index}')
+                all_inputs.append(f'{in_step}/{in_index}')
             for item in all_inputs:
                 edges.append((item, node, 1 if node in exit_nodes else 2))
 

--- a/siliconcompiler/utils/issue.py
+++ b/siliconcompiler/utils/issue.py
@@ -234,7 +234,7 @@ def generate_testcase(chip,
         design = chip.design
         job = chip.get('option', 'jobname')
         file_time = datetime.fromtimestamp(issue_time).strftime('%Y%m%d-%H%M%S')
-        archive_name = f'sc_issue_{design}_{job}_{step}{index}_{file_time}.tar.gz'
+        archive_name = f'sc_issue_{design}_{job}_{step}_{index}_{file_time}.tar.gz'
 
     # Make support files
     issue_path = os.path.join(issue_dir.name, 'issue.json')
@@ -254,7 +254,7 @@ def generate_testcase(chip,
         with open(run_path, 'w') as f:
             replay_dir = os.path.relpath(chip.getworkdir(step=step, index=index),
                                          chip.cwd)
-            issue_title = f'{chip.design} for {step}{index} using {tool}/{task}'
+            issue_title = f'{chip.design} for {step}/{index} using {tool}/{task}'
             f.write(get_file_template('issue/run.sh').render(
                 title=issue_title,
                 exec_dir=replay_dir
@@ -288,7 +288,7 @@ def generate_testcase(chip,
 
     issue_dir.cleanup()
 
-    chip.logger.info(f'Generated testcase for {step}{index} in: '
+    chip.logger.info(f'Generated testcase for {step}/{index} in: '
                      f'{full_archive_path}')
 
     # Restore original schema

--- a/tests/apps/test_common.py
+++ b/tests/apps/test_common.py
@@ -9,7 +9,7 @@ from siliconcompiler.apps import _common
 @pytest.fixture
 def make_manifests():
     def impl(chip):
-        for s in chip.schema.get("flowgraph", "asicflow", field="schema").get_execution_order():
+        for nodes in chip.schema.get("flowgraph", "asicflow", field="schema").get_execution_order():
             for step, index in nodes:
                 for d in ('inputs', 'outputs'):
                     path = os.path.join(chip.getworkdir(step=step, index=index), d)

--- a/tests/apps/test_common.py
+++ b/tests/apps/test_common.py
@@ -9,7 +9,7 @@ from siliconcompiler.apps import _common
 @pytest.fixture
 def make_manifests():
     def impl(chip):
-        for nodes in chip.schema.get("flowgraph", "asicflow", field="schema").get_execution_order():
+        for s in chip.schema.get("flowgraph", "asicflow", field="schema").get_execution_order():
             for step, index in nodes:
                 for d in ('inputs', 'outputs'):
                     path = os.path.join(chip.getworkdir(step=step, index=index), d)
@@ -238,7 +238,7 @@ def test_pick_manifest_step_index_invalid(gcd_chip, monkeypatch, caplogger):
 
     assert gcd_chip.design == "gcd"
 
-    assert "syn0 is not a valid node." in log()
+    assert "syn/0 is not a valid node." in log()
 
 
 def test_pick_manifest_step_index_manifest(gcd_chip, monkeypatch):
@@ -306,4 +306,4 @@ def test_pick_manifest_step_index_invalid_combo(gcd_chip, monkeypatch, caplogger
 
     assert gcd_chip.design == "gcd"
 
-    assert "syn0 is not a valid node." in log()
+    assert "syn/0 is not a valid node." in log()

--- a/tests/apps/test_sc_issue.py
+++ b/tests/apps/test_sc_issue.py
@@ -8,16 +8,16 @@ from siliconcompiler.apps import sc_issue
 
 @pytest.mark.parametrize('flags,outputfileglob', [
     (['-cfg', 'build/heartbeat/job0/syn/0/outputs/heartbeat.pkg.json'],
-     'sc_issue_heartbeat_job0_syn0_*.tar.gz'),
+     'sc_issue_heartbeat_job0_syn_0_*.tar.gz'),
     (['-cfg', 'build/heartbeat/job0/place.global/0/outputs/heartbeat.pkg.json',
       '-arg_step', 'syn', '-arg_index', '0'],
-     'sc_issue_heartbeat_job0_syn0_*.tar.gz'),
+     'sc_issue_heartbeat_job0_syn_0_*.tar.gz'),
     (['-cfg', 'build/heartbeat/job0/place.global/0/outputs/heartbeat.pkg.json',
       '-arg_step', 'place.global', '-arg_index', '0'],
-     'sc_issue_heartbeat_job0_place.global0_*.tar.gz'),
+     'sc_issue_heartbeat_job0_place.global_0_*.tar.gz'),
     (['-cfg', 'build/heartbeat/job0/heartbeat.pkg.json',
       '-arg_step', 'place.global', '-arg_index', '0'],
-     'sc_issue_heartbeat_job0_place.global0_*.tar.gz')
+     'sc_issue_heartbeat_job0_place.global_0_*.tar.gz')
 ])
 @pytest.mark.eda
 @pytest.mark.quick

--- a/tests/core/test_archive.py
+++ b/tests/core/test_archive.py
@@ -72,9 +72,9 @@ def test_archive(chip):
 def test_archive_step_index(chip):
     chip.archive(step='import.verilog', index='0')
 
-    assert os.path.isfile('oh_parity_job0_import.verilog0.tgz')
+    assert os.path.isfile('oh_parity_job0_import.verilog_0.tgz')
 
-    with tarfile.open('oh_parity_job0_import.verilog0.tgz', 'r:gz') as f:
+    with tarfile.open('oh_parity_job0_import.verilog_0.tgz', 'r:gz') as f:
         contents = f.getnames()
 
     for item in ('build/oh_parity/job0/oh_parity.pkg.json',

--- a/tests/core/test_summary.py
+++ b/tests/core/test_summary.py
@@ -51,13 +51,13 @@ def test_from_to(gcd_with_metrics, capfd):
     # Summary output is hidden by capfd, so we print it to aid in debugging
     print(stdout)
 
-    assert 'import.verilog0' in stdout
-    assert 'import.convert0' in stdout
-    assert 'import.chisel0' in stdout
-    assert 'import.c0' in stdout
+    assert 'import.veri...0' in stdout
+    assert 'import.conv...0' in stdout
+    assert 'import.chisel/0' in stdout
+    assert 'import.c/0' in stdout
     assert 'import.blue...0' in stdout
-    assert 'import.vhdl0' in stdout
-    assert 'syn0' in stdout
+    assert 'import.vhdl/0' in stdout
+    assert 'syn/0' in stdout
     assert 'floorplan' not in stdout
 
 
@@ -97,9 +97,9 @@ def test_parallel_path(capfd):
     stdout, _ = capfd.readouterr()
     # Summary output is hidden by capfd, so we print it to aid in debugging
     print(stdout)
-    assert 'place1' in stdout
-    assert 'cts1' in stdout
-    assert 'place0' not in stdout
-    assert 'cts0' not in stdout
-    assert 'place2' not in stdout
-    assert 'cts2' not in stdout
+    assert 'place/1' in stdout
+    assert 'cts/1' in stdout
+    assert 'place/0' not in stdout
+    assert 'cts/0' not in stdout
+    assert 'place/2' not in stdout
+    assert 'cts/2' not in stdout

--- a/tests/flows/test_prune.py
+++ b/tests/flows/test_prune.py
@@ -45,7 +45,7 @@ def test_prune_middle(caplogger):
                        match="test flowgraph contains errors and cannot be run"):
         chip.run(raise_exception=True)
 
-    assert "no path from import0 to place0 in the test flowgraph" in log()
+    assert "no path from import/0 to place/0 in the test flowgraph" in log()
 
 
 def test_prune_split():
@@ -90,7 +90,7 @@ def test_prune_split_join(caplogger):
                        match="test flowgraph contains errors and cannot be run."):
         chip.run(raise_exception=True)
 
-    assert "no path from import0 to place0 in the test flowgraph" in log()
+    assert "no path from import/0 to place/0 in the test flowgraph" in log()
 
 
 def test_prune_split_disc3235():
@@ -300,7 +300,7 @@ def test_prune_nodenotpresent(caplogger):
                        match="test flowgraph contains errors and cannot be run."):
         chip.run(raise_exception=True)
 
-    assert "sim13 is not defined in the test flowgraph" in log()
+    assert "sim1/3 is not defined in the test flowgraph" in log()
 
 
 def test_prune_min():
@@ -362,4 +362,4 @@ def test_prune_max_all_inputs_pruned(caplogger):
                        match="test flowgraph contains errors and cannot be run."):
         chip.run(raise_exception=True)
 
-    assert "no path from import0 to place0 in the test flowgraph" in log()
+    assert "no path from import/0 to place/0 in the test flowgraph" in log()

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -152,7 +152,7 @@ def test_get_manifest_input(chip):
 @pytest.mark.parametrize(
     "type,expect_name", [
         ("exe", "steptwo.log"),
-        ("sc", "sc_steptwo0.log"),
+        ("sc", "sc_steptwo/0.log"),
     ])
 def test_get_log(chip, type, expect_name):
     node = SchedulerNode(chip, "steptwo", "0")
@@ -204,7 +204,7 @@ def test_setup_error(chip, monkeypatch, caplog):
 
     with pytest.raises(ValueError, match="Find this"):
         node.setup()
-    assert "Failed to run setup() for steptwo0 with builtin/nop" in caplog.text
+    assert "Failed to run setup() for steptwo/0 with builtin/nop" in caplog.text
 
 
 def test_setup_skipped(chip, monkeypatch, caplog):
@@ -217,7 +217,7 @@ def test_setup_skipped(chip, monkeypatch, caplog):
 
     assert node.setup() is False
     assert chip.get("record", "status", step="steptwo", index="0") == NodeStatus.SKIPPED
-    assert "Removing steptwo0 due to skip me" in caplog.text
+    assert "Removing steptwo/0 due to skip me" in caplog.text
 
 
 def test_clean_directory(chip):
@@ -310,7 +310,7 @@ def test_check_values_changed_change(chip, caplog):
     other_chip.set("option", "param", "N", "128")
 
     assert node.check_values_changed(other, [("option", "param", "N")]) is True
-    assert "[option,param,N] in steptwo0 has been modified from previous run" in caplog.text
+    assert "[option,param,N] in steptwo/0 has been modified from previous run" in caplog.text
 
 
 def test_check_values_changed_change_missing(chip, caplog):
@@ -321,7 +321,7 @@ def test_check_values_changed_change_missing(chip, caplog):
     node.init_state(assign_runtime=True)
 
     assert node.check_values_changed(node, [("option", "params", "N")]) is True
-    assert "[option,params,N] in steptwo0 has been modified from previous run" in caplog.text
+    assert "[option,params,N] in steptwo/0 has been modified from previous run" in caplog.text
 
 
 def test_check_previous_run_status_flow(chip, caplog):
@@ -431,7 +431,7 @@ def test_check_previous_run_status_inputs_changed(chip, monkeypatch, caplog):
     monkeypatch.setattr(node.task, "select_input_nodes", dummy_select)
 
     assert node.check_previous_run_status(node) is False
-    assert "inputs to steptwo0 has been modified from previous run" in caplog.text
+    assert "inputs to steptwo/0 has been modified from previous run" in caplog.text
 
 
 def test_check_previous_run_status_no_change(chip, monkeypatch):
@@ -474,7 +474,7 @@ def test_check_files_changed_timestamp(chip, caplog):
     chip.set("option", "file", "test", "testfile.txt")
 
     assert node.check_files_changed(node, now, [("option", "file", "test")]) is True
-    assert "[option,file,test] (timestamp) in steptwo0 has been modified from previous run" in \
+    assert "[option,file,test] (timestamp) in steptwo/0 has been modified from previous run" in \
         caplog.text
 
 
@@ -509,7 +509,7 @@ def test_check_files_changed_timestamp_directory(chip, caplog):
     chip.set("option", "dir", "test", "testdir")
 
     assert node.check_files_changed(node, now, [("option", "dir", "test")]) is True
-    assert "[option,dir,test] (timestamp) in steptwo0 has been modified from previous run" in \
+    assert "[option,dir,test] (timestamp) in steptwo/0 has been modified from previous run" in \
         caplog.text
 
 
@@ -532,7 +532,7 @@ def test_check_files_changed_package(chip, caplog):
     chip.set("option", "file", "test", "testfile.txt", package="testing")
 
     assert node.check_files_changed(node_other, now, [("option", "file", "test")]) is True
-    assert "[option,file,test] (file package) in steptwo0 has been modified from previous run" in \
+    assert "[option,file,test] (file package) in steptwo/0 has been modified from previous run" in \
         caplog.text
 
 
@@ -555,7 +555,7 @@ def test_check_files_changed_timestamp_current_hash(chip, caplog):
     node.init_state(assign_runtime=True)
 
     assert node.check_files_changed(node_other, now, [("option", "file", "test")]) is True
-    assert "[option,file,test] (timestamp) in steptwo0 has been modified from previous run" in \
+    assert "[option,file,test] (timestamp) in steptwo/0 has been modified from previous run" in \
         caplog.text
 
 
@@ -579,7 +579,7 @@ def test_check_files_changed_timestamp_previous_hash(chip, caplog):
     node_other.init_state(assign_runtime=True)
 
     assert node.check_files_changed(node_other, now, [("option", "file", "test")]) is True
-    assert "[option,file,test] (timestamp) in steptwo0 has been modified from previous run" in \
+    assert "[option,file,test] (timestamp) in steptwo/0 has been modified from previous run" in \
         caplog.text
 
 
@@ -634,7 +634,7 @@ def test_check_files_changed_hash_directory(chip, caplog):
     node_other.init_state(assign_runtime=True)
 
     assert node.check_files_changed(node_other, now, [("option", "dir", "test")]) is True
-    assert "[option,dir,test] (file hash) in steptwo0 has been modified from previous run" in \
+    assert "[option,dir,test] (file hash) in steptwo/0 has been modified from previous run" in \
         caplog.text
 
 
@@ -1046,7 +1046,7 @@ def test_setup_input_directory_renames_dir(chip):
     dir0.mkdir(exist_ok=True)
 
     chip.set("record", "inputnode", ("stepone", "0"), step="steptwo", index="0")
-    chip.set("tool", "builtin", "task", "nop", "input", "dir0.stepone0", step="steptwo", index="0")
+    chip.set("tool", "builtin", "task", "nop", "input", "dir0.stepone/0", step="steptwo", index="0")
 
     node = SchedulerNode(chip, "steptwo", "0")
     node.init_state(assign_runtime=True)
@@ -1054,7 +1054,7 @@ def test_setup_input_directory_renames_dir(chip):
     node.setup_input_directory()
 
     assert not os.path.exists(input_dir / "dir0")
-    assert os.path.isdir(input_dir / "dir0.stepone0")
+    assert os.path.isdir(input_dir / "dir0.stepone/0")
     assert not os.path.isfile(input_dir / "dummy.pkg.json")
 
 
@@ -1072,7 +1072,7 @@ def test_setup_input_directory_renames_file(chip):
     file1.touch()
 
     chip.set("record", "inputnode", ("stepone", "0"), step="steptwo", index="0")
-    chip.set("tool", "builtin", "task", "nop", "input", "file0.stepone0.txt",
+    chip.set("tool", "builtin", "task", "nop", "input", "file0.stepone/0.txt",
              step="steptwo", index="0")
 
     node = SchedulerNode(chip, "steptwo", "0")
@@ -1081,7 +1081,7 @@ def test_setup_input_directory_renames_file(chip):
     node.setup_input_directory()
 
     assert not os.path.exists(input_dir / "file0.txt")
-    assert os.path.isfile(input_dir / "file0.stepone0.txt")
+    assert os.path.isfile(input_dir / "file0.stepone/0.txt")
     assert not os.path.isfile(input_dir / "dummy.pkg.json")
 
 
@@ -1103,7 +1103,7 @@ def test_setup_input_directory_no_input_dir(chip, caplog):
     with pytest.raises(SystemExit):
         node.setup_input_directory()
 
-    assert "Unable to locate outputs directory for stepone0: " in caplog.text
+    assert "Unable to locate outputs directory for stepone/0: " in caplog.text
 
 
 @pytest.mark.parametrize("error", [NodeStatus.ERROR, NodeStatus.TIMEOUT])
@@ -1126,7 +1126,7 @@ def test_setup_input_directory_input_error(chip, error, caplog):
     with pytest.raises(SystemExit):
         node.setup_input_directory()
 
-    assert "Halting steptwo0 due to errors" in caplog.text
+    assert "Halting steptwo/0 due to errors" in caplog.text
 
 
 def test_validate(chip):
@@ -1144,7 +1144,7 @@ def test_validate_missing_inputs(chip, caplog):
     node = SchedulerNode(chip, "steptwo", "0")
     node.init_state(assign_runtime=True)
     assert node.validate() is False
-    assert "Required input file0.txt not received for steptwo0" in caplog.text
+    assert "Required input file0.txt not received for steptwo/0" in caplog.text
 
 
 def test_validate_missing_required_key(chip, caplog):
@@ -1219,8 +1219,8 @@ def test_report_output_files_missing_outputs_dir(echo_chip, caplog):
     with pytest.raises(SystemExit):
         node._SchedulerNode__report_output_files()
     assert "Output directory is missing" in caplog.text
-    assert "Failed to write manifest for steptwo0" in caplog.text
-    assert "Halting steptwo0 due to errors" in caplog.text
+    assert "Failed to write manifest for steptwo/0" in caplog.text
+    assert "Halting steptwo/0 due to errors" in caplog.text
 
 
 def test_report_output_files_missing_manifest(echo_chip, caplog):
@@ -1232,7 +1232,7 @@ def test_report_output_files_missing_manifest(echo_chip, caplog):
     with pytest.raises(SystemExit):
         node._SchedulerNode__report_output_files()
     assert "Output manifest (dummy.pkg.json) is missing." in caplog.text
-    assert "Halting steptwo0 due to errors" in caplog.text
+    assert "Halting steptwo/0 due to errors" in caplog.text
 
 
 def test_report_output_files_missing_outputs(echo_chip, caplog):
@@ -1248,7 +1248,7 @@ def test_report_output_files_missing_outputs(echo_chip, caplog):
     with pytest.raises(SystemExit):
         node._SchedulerNode__report_output_files()
     assert "Expected output files are missing: echothis.txt" in caplog.text
-    assert "Halting steptwo0 due to errors" in caplog.text
+    assert "Halting steptwo/0 due to errors" in caplog.text
 
 
 def test_report_output_files_extra_outputs(echo_chip, caplog):
@@ -1269,7 +1269,7 @@ def test_report_output_files_extra_outputs(echo_chip, caplog):
     with pytest.raises(SystemExit):
         node._SchedulerNode__report_output_files()
     assert "Unexpected output files found: extra.txt" in caplog.text
-    assert "Halting steptwo0 due to errors" in caplog.text
+    assert "Halting steptwo/0 due to errors" in caplog.text
 
 
 def test_report_output_files_extra_outputs_not_strict(echo_chip, caplog):
@@ -1290,7 +1290,7 @@ def test_report_output_files_extra_outputs_not_strict(echo_chip, caplog):
 
     node._SchedulerNode__report_output_files()
     assert "Unexpected output files found: extra.txt" in caplog.text
-    assert "Halting steptwo0 due to errors" not in caplog.text
+    assert "Halting steptwo/0 due to errors" not in caplog.text
 
 
 def test_run_pass(chip):
@@ -1366,7 +1366,7 @@ def test_run_failed_to_validate(chip, caplog):
     assert chip.get("record", "status", step="stepone", index="0") == NodeStatus.ERROR
 
     assert "Failed to validate node setup. See previous errors" in caplog.text
-    assert "Halting stepone0 due to errors" in caplog.text
+    assert "Halting stepone/0 due to errors" in caplog.text
 
 
 def test_run_failed_select_input(chip, caplog):
@@ -1387,8 +1387,8 @@ def test_run_failed_select_input(chip, caplog):
     assert chip.get("metric", "totaltime", step="steptwo", index="0") is None
     assert chip.get("record", "status", step="steptwo", index="0") == NodeStatus.ERROR
 
-    assert "No inputs selected for steptwo0" in caplog.text
-    assert "Halting steptwo0 due to errors" in caplog.text
+    assert "No inputs selected for steptwo/0" in caplog.text
+    assert "Halting steptwo/0 due to errors" in caplog.text
 
 
 def test_run_failed_to_execute(chip, caplog):
@@ -1410,7 +1410,7 @@ def test_run_failed_to_execute(chip, caplog):
     assert chip.get("record", "status", step="stepone", index="0") == NodeStatus.ERROR
 
     assert "thiserrorisraised" in caplog.text
-    assert "Halting stepone0 due to errors" in caplog.text
+    assert "Halting stepone/0 due to errors" in caplog.text
 
 
 def test_run_without_queue(chip):
@@ -1499,7 +1499,7 @@ def test_copy_from(chip, caplog):
     assert not os.path.exists(node.get_manifest("output"))
 
     node.copy_from("job0")
-    assert "Importing stepone0 from job0" in caplog.text
+    assert "Importing stepone/0 from job0" in caplog.text
 
     assert os.path.exists(node.replay_script)
     with open(node.replay_script, "r") as f:

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -152,7 +152,7 @@ def test_get_manifest_input(chip):
 @pytest.mark.parametrize(
     "type,expect_name", [
         ("exe", "steptwo.log"),
-        ("sc", "sc_steptwo/0.log"),
+        ("sc", "sc_steptwo0.log"),
     ])
 def test_get_log(chip, type, expect_name):
     node = SchedulerNode(chip, "steptwo", "0")
@@ -1046,7 +1046,7 @@ def test_setup_input_directory_renames_dir(chip):
     dir0.mkdir(exist_ok=True)
 
     chip.set("record", "inputnode", ("stepone", "0"), step="steptwo", index="0")
-    chip.set("tool", "builtin", "task", "nop", "input", "dir0.stepone/0", step="steptwo", index="0")
+    chip.set("tool", "builtin", "task", "nop", "input", "dir0.stepone0", step="steptwo", index="0")
 
     node = SchedulerNode(chip, "steptwo", "0")
     node.init_state(assign_runtime=True)
@@ -1054,7 +1054,7 @@ def test_setup_input_directory_renames_dir(chip):
     node.setup_input_directory()
 
     assert not os.path.exists(input_dir / "dir0")
-    assert os.path.isdir(input_dir / "dir0.stepone/0")
+    assert os.path.isdir(input_dir / "dir0.stepone0")
     assert not os.path.isfile(input_dir / "dummy.pkg.json")
 
 
@@ -1072,7 +1072,7 @@ def test_setup_input_directory_renames_file(chip):
     file1.touch()
 
     chip.set("record", "inputnode", ("stepone", "0"), step="steptwo", index="0")
-    chip.set("tool", "builtin", "task", "nop", "input", "file0.stepone/0.txt",
+    chip.set("tool", "builtin", "task", "nop", "input", "file0.stepone0.txt",
              step="steptwo", index="0")
 
     node = SchedulerNode(chip, "steptwo", "0")
@@ -1081,7 +1081,7 @@ def test_setup_input_directory_renames_file(chip):
     node.setup_input_directory()
 
     assert not os.path.exists(input_dir / "file0.txt")
-    assert os.path.isfile(input_dir / "file0.stepone/0.txt")
+    assert os.path.isfile(input_dir / "file0.stepone0.txt")
     assert not os.path.isfile(input_dir / "dummy.pkg.json")
 
 

--- a/tests/scheduler/test_slurm.py
+++ b/tests/scheduler/test_slurm.py
@@ -60,9 +60,9 @@ def test_get_configuration_directory(chip):
 
 
 def test_get_job_name():
-    assert SlurmSchedulerNode.get_job_name("hash", "step", "index") == "hash_stepindex"
+    assert SlurmSchedulerNode.get_job_name("hash", "step", "index") == "hash_step_index"
 
 
 def test_get_runtime_file_name():
     assert SlurmSchedulerNode.get_runtime_file_name("hash", "step", "index", "sh") == \
-        "hash_stepindex.sh"
+        "hash_step_index.sh"

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -1362,7 +1362,7 @@ def test_check_filepaths_not_found_logger_step_index(caplog):
     logger.setLevel(logging.INFO)
 
     assert schema.check_filepaths(logger=logger) is False
-    assert "Parameter [directory] (thisstep0) path test0 is invalid" in caplog.text
+    assert "Parameter [directory] (thisstep/0) path test0 is invalid" in caplog.text
 
 
 def test_check_filepaths_not_found_ignored():

--- a/tests/test_checklistschema.py
+++ b/tests/test_checklistschema.py
@@ -62,7 +62,7 @@ def test_check_fail_unmet_spec(project, caplog):
     project.logger.setLevel(logging.INFO)
 
     assert checklist.check() is False
-    assert "d0 criteria errors==0 (1==0) unmet by job job0 with step teststep0 and task " \
+    assert "d0 criteria errors==0 (1==0) unmet by job job0 with step teststep/0 and task " \
         "testtool/testtask" in caplog.text
 
 
@@ -87,7 +87,7 @@ def test_check_fail_invalid_node(project, caplog):
     project.logger.setLevel(logging.INFO)
 
     assert checklist.check() is False
-    assert "notvalid0 not found in flowgraph for job0" in caplog.text
+    assert "notvalid/0 not found in flowgraph for job0" in caplog.text
 
 
 def test_check_fail_invalid_missing_docs(project, caplog):
@@ -103,9 +103,9 @@ def test_check_fail_invalid_missing_docs(project, caplog):
     project.logger.setLevel(logging.INFO)
 
     assert checklist.check() is False
-    assert "d0 criteria errors==1 met by job job0 with step teststep0 and task testtool/testtask" \
+    assert "d0 criteria errors==1 met by job job0 with step teststep/0 and task testtool/testtask" \
         in caplog.text
-    assert "No reports generated for metric errors in job job0 with step teststep0 and task " \
+    assert "No reports generated for metric errors in job job0 with step teststep/0 and task " \
         "testtool/testtask" in caplog.text
     assert "No report documenting item d0" in caplog.text
 
@@ -132,7 +132,7 @@ def test_check_pass(project, caplog):
 
     # automated pass
     assert checklist.check() is True
-    assert "d1 criteria errors<2 met by job job0 with step teststep0 and task testtool/testtask" \
+    assert "d1 criteria errors<2 met by job job0 with step teststep/0 and task testtool/testtask" \
         in caplog.text
 
 
@@ -184,7 +184,7 @@ def test_check_node_skipped(project, caplog):
 
     # automated pass
     assert checklist.check() is True
-    assert "teststep0 was skipped" in caplog.text
+    assert "teststep/0 was skipped" in caplog.text
 
 
 def test_check_non_metric(project, caplog):

--- a/tests/test_flowgraph.py
+++ b/tests/test_flowgraph.py
@@ -73,6 +73,28 @@ def test_node_invalid_tool_task():
         flow.node("teststep", "nop")
 
 
+def test_node_step_name():
+    flow = FlowgraphSchema("testflow")
+
+    # Valid step
+    flow.node("teststep", nop)
+
+    # Invalid step
+    with pytest.raises(ValueError, match="teststep/ is not a valid step, it cannot contain '/'"):
+        flow.node("teststep/", nop)
+
+
+def test_node_index_name():
+    flow = FlowgraphSchema("testflow")
+
+    # Valid index
+    flow.node("teststep", nop, index="index")
+
+    # Invalid index
+    with pytest.raises(ValueError, match="index/ is not a valid index, it cannot contain '/'"):
+        flow.node("teststep", nop, index="index/")
+
+
 def test_node_index():
     flow = FlowgraphSchema("testflow")
     flow.node("teststep", "siliconcompiler.tools.builtin.nop", index=1)

--- a/tests/test_flowgraph.py
+++ b/tests/test_flowgraph.py
@@ -177,7 +177,7 @@ def test_edge_undefined():
     flow = FlowgraphSchema("testflow")
     flow.node("stepone", "siliconcompiler.tools.builtin.nop")
 
-    with pytest.raises(ValueError, match="steptwo0 is not a defined node in testflow"):
+    with pytest.raises(ValueError, match="steptwo/0 is not a defined node in testflow"):
         flow.edge("stepone", "steptwo")
 
 
@@ -249,7 +249,7 @@ def test_insert_node_branch(large_flow):
 
 
 def test_insert_node_invalid(large_flow):
-    with pytest.raises(ValueError, match="invalid0 is not a valid node in testflow"):
+    with pytest.raises(ValueError, match="invalid/0 is not a valid node in testflow"):
         large_flow.insert_node(
             "newnode", "siliconcompiler.tools.builtin.nop", before_step="invalid"
         )
@@ -360,7 +360,7 @@ def test_get_node_outputs(large_flow):
 
 
 def test_get_node_outputs_invalid(large_flow):
-    with pytest.raises(ValueError, match="testnode0 is not a valid node"):
+    with pytest.raises(ValueError, match="testnode/0 is not a valid node"):
         large_flow.get_node_outputs("testnode", "0")
 
 
@@ -487,28 +487,28 @@ def test_validate(large_flow):
 def test_validate_duplicate_edge(large_flow, caplog):
     large_flow.add("joinone", "0", "input", ("stepone", "0"))
     assert not large_flow.validate(logger=logging.getLogger())
-    assert "Duplicate edge from stepone0 to joinone0 in the testflow flowgraph" in caplog.text
+    assert "Duplicate edge from stepone/0 to joinone/0 in the testflow flowgraph" in caplog.text
 
 
 def test_validate_missing_node(large_flow, caplog):
     large_flow.add("joinone", "0", "input", ("notvalid", "0"))
     assert not large_flow.validate(logger=logging.getLogger())
-    assert "notvalid0 is missing in the testflow flowgraph" in caplog.text
+    assert "notvalid/0 is missing in the testflow flowgraph" in caplog.text
 
 
 @pytest.mark.parametrize("item", ["tool", "task", "taskmodule"])
 def test_validate_missing_config(large_flow, caplog, item):
     large_flow.unset("joinone", "0", item)
     assert not large_flow.validate(logger=logging.getLogger())
-    assert f"joinone0 is missing a {item} definition in the testflow flowgraph" in caplog.text
+    assert f"joinone/0 is missing a {item} definition in the testflow flowgraph" in caplog.text
 
 
 def test_validate_loop(large_flow, caplog):
     large_flow.add("stepone", "2", "input", ("jointwo", "0"))
     assert not large_flow.validate(logger=logging.getLogger())
-    assert "stepone0 -> joinone0 -> steptwo0 -> jointwo0 -> stepone2 -> joinone0 forms " \
+    assert "stepone/0 -> joinone/0 -> steptwo/0 -> jointwo/0 -> stepone/2 -> joinone/0 forms " \
         "a loop in testflow" in caplog.text
-    assert "stepone1 -> joinone0 -> steptwo0 -> jointwo0 -> stepone2 -> joinone0 forms " \
+    assert "stepone/1 -> joinone/0 -> steptwo/0 -> jointwo/0 -> stepone/2 -> joinone/0 forms " \
         "a loop in testflow" in caplog.text
 
 
@@ -624,7 +624,7 @@ def test_runtime_get_entry_nodes_prune_from(large_flow):
 def test_runtime_get_nodes_starting_at_invalid(large_flow):
     runtime = RuntimeFlowgraph(large_flow, prune_nodes=[
         ("stepone", "0"), ("steptwo", "1"), ("stepthree", "2")])
-    with pytest.raises(ValueError, match="stepone0 is not a valid node"):
+    with pytest.raises(ValueError, match="stepone/0 is not a valid node"):
         runtime.get_nodes_starting_at("stepone", "0")
 
 
@@ -949,7 +949,7 @@ def test_get_node_inputs_invalid(large_flow):
     runtime = RuntimeFlowgraph(large_flow, prune_nodes=[
         ("stepone", "0"), ("steptwo", "1"), ("stepthree", "2")])
 
-    with pytest.raises(ValueError, match="stepone0 is not a valid node"):
+    with pytest.raises(ValueError, match="stepone/0 is not a valid node"):
         runtime.get_node_inputs("stepone", "0")
 
 
@@ -985,7 +985,7 @@ def test_runtime_validate_invalid_node(large_flow, caplog):
         large_flow,
         prune_nodes=[("notthis", "0")], logger=logging.getLogger()) is False
 
-    assert "notthis0 is not defined in the testflow flowgraph" in caplog.text
+    assert "notthis/0 is not defined in the testflow flowgraph" in caplog.text
 
 
 def test_runtime_validate_prune_exits(large_flow, caplog):
@@ -1016,8 +1016,8 @@ def test_runtime_validate_prune_path(large_flow, caplog):
         large_flow,
         prune_nodes=[("joinone", "0"), ("stepone", "2")], logger=logging.getLogger()) is False
 
-    assert "no path from stepone0 to jointhree0 in the testflow flowgraph" in caplog.text
-    assert "no path from stepone1 to jointhree0 in the testflow flowgraph" in caplog.text
+    assert "no path from stepone/0 to jointhree/0 in the testflow flowgraph" in caplog.text
+    assert "no path from stepone/1 to jointhree/0 in the testflow flowgraph" in caplog.text
 
 
 def test_runtime_validate_disjoint(caplog):
@@ -1031,4 +1031,4 @@ def test_runtime_validate_disjoint(caplog):
         from_steps=["stepone"],
         to_steps=["steptwo"], logger=logging.getLogger()) is False
 
-    assert "no path from stepone0 to steptwo0 in the testflow flowgraph" in caplog.text
+    assert "no path from stepone/0 to steptwo/0 in the testflow flowgraph" in caplog.text


### PR DESCRIPTION
Targeting #3713 

I divided all step and index pairs found by the following regex:
- `logger.*step\}\{.*index`
- `f'.*step\}\{.*index`
- `f".*step\}\{.*index`
- .*step.*\}\{