### PR TITLE
[Scheduler] Do Not Forward non-Required Outputs

### DIFF
--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -614,10 +614,16 @@ class SchedulerNode:
             # copy inputs to outputs and skip execution
             for in_step, in_index in self.__record.get('inputnode',
                                                        step=self.__step, index=self.__index):
+                required_outputs = set(self.__task.get('task', self.__task.task(), 'output',
+                                                       step=self.__step, index=self.__index))
                 in_workdir = self.__chip.getworkdir(step=in_step, index=in_index)
                 for outfile in os.scandir(f"{in_workdir}/outputs"):
                     if outfile.name == f'{self.__design}.pkg.json':
                         # Dont forward manifest
+                        continue
+
+                    if outfile.name not in required_outputs:
+                        # Dont forward non-required outputs
                         continue
 
                     if outfile.is_file() or outfile.is_symlink():


### PR DESCRIPTION
When a scheduler node is skipped, it currently forwards all of its inputs to the output directory. If the tool was not expecting these files in the output directory, this can raise an issue.

To fix this issue, when a node is being skipped, we now only forward the input files which were required to be output files.