### PR TITLE
[VPR] Updated the VTR Version Parsing

### DIFF
--- a/siliconcompiler/tools/genfasm/genfasm.py
+++ b/siliconcompiler/tools/genfasm/genfasm.py
@@ -1,5 +1,4 @@
 from siliconcompiler.tools.vpr.vpr import parse_version as vpr_parse_version
-from siliconcompiler.tools.vpr.vpr import normalize_version as vpr_normalize_version
 from siliconcompiler.tools.vpr.vpr import add_tool_requirements as add_vpr_requirements
 
 '''
@@ -24,7 +23,7 @@ def make_docs(chip):
 def setup(chip):
     chip.set('tool', 'genfasm', 'exe', 'genfasm', clobber=False)
     chip.set('tool', 'genfasm', 'vswitch', '--version')
-    chip.set('tool', 'genfasm', 'version', '>=9.0.0', clobber=False)
+    chip.set('tool', 'genfasm', 'version', '>=v8.0.0-12677', clobber=False)
 
     add_tool_requirements(chip)
 
@@ -35,10 +34,6 @@ def add_tool_requirements(chip):
 
 def parse_version(chip):
     return vpr_parse_version(chip)
-
-
-def normalize_version(chip):
-    return vpr_normalize_version(chip)
 
 
 ##################################################

--- a/siliconcompiler/tools/vpr/vpr.py
+++ b/siliconcompiler/tools/vpr/vpr.py
@@ -43,7 +43,7 @@ def setup_tool(chip, clobber=True):
 
     chip.set('tool', 'vpr', 'exe', 'vpr', clobber=clobber)
     chip.set('tool', 'vpr', 'vswitch', '--version')
-    chip.set('tool', 'vpr', 'version', '>=9.0.0', clobber=clobber)
+    chip.set('tool', 'vpr', 'version', '>=v8.0.0-12677', clobber=clobber)
 
     step = chip.get('arg', 'step')
     index = chip.get('arg', 'index')
@@ -298,14 +298,19 @@ def parse_version(stdout):
     # This is free open source code under MIT license.
     #
     #
-    return stdout.split()[6]
 
+    # Grab the revision. Which will be of the form:
+    #       v8.0.0-7887-gc4156f225
+    revision = stdout.split()[8]
 
-def normalize_version(version):
-    if '-' in version:
-        return version.split('-')[0]
+    # VTR infrequently makes even minor releases, use the number of commits
+    # since the last release of VTR as another part of the release segment.
+    pieces = revision.split("-")
+    if len(pieces) == 3:
+        # Strip off the hash if it exists.
+        return "-".join(pieces[:-1])
     else:
-        return version
+        return revision
 
 
 def auto_constraints():


### PR DESCRIPTION
VTR updates its versions infrequently enough to make it so the minor versions cannot only be used to check the version of VTR.

Updated the version parsing for VTR to include the number of commits since the last release as another release segment.