### PR TITLE
implement package schema

### DIFF
--- a/docs/reference_manual/schema_api.rst
+++ b/docs/reference_manual/schema_api.rst
@@ -188,3 +188,8 @@ Supporting Classes
     :members:
     :show-inheritance:
     :inherited-members:
+
+.. autoclass:: siliconcompiler.PackageSchema
+    :members:
+    :show-inheritance:
+    :inherited-members:

--- a/siliconcompiler/__init__.py
+++ b/siliconcompiler/__init__.py
@@ -12,6 +12,7 @@ from siliconcompiler.tool import ToolSchema, TaskSchema
 from siliconcompiler.checklist import ChecklistSchema
 from siliconcompiler.asic import ASICSchema
 from siliconcompiler.fpga import FPGASchema
+from siliconcompiler.packageschema import PackageSchema
 
 from siliconcompiler.core import Chip
 
@@ -41,5 +42,6 @@ __all__ = [
     "TaskSchema",
     "ChecklistSchema",
     "ASICSchema",
-    "FPGASchema"
+    "FPGASchema",
+    "PackageSchema"
 ]

--- a/siliconcompiler/packageschema.py
+++ b/siliconcompiler/packageschema.py
@@ -23,7 +23,7 @@ class PackageSchema(PathSchema):
         Args:
             desc (str): The description string.
         """
-        return self.set("description", trim(desc))
+        return self.set("package", "description", trim(desc))
 
     def get_description(self) -> str:
         """Get the description of the package.
@@ -31,7 +31,7 @@ class PackageSchema(PathSchema):
         Returns:
             str: The description string.
         """
-        return self.get("description")
+        return self.get("package", "description")
 
     def set_version(self, version: str):
         """
@@ -40,7 +40,7 @@ class PackageSchema(PathSchema):
         Args:
             version (str): The version string.
         """
-        return self.set("version", version)
+        return self.set("package", "version", version)
 
     def get_version(self) -> str:
         """
@@ -49,7 +49,7 @@ class PackageSchema(PathSchema):
         Returns:
             str: The version string.
         """
-        return self.get("version")
+        return self.get("package", "version")
 
     def add_license(self, name: str):
         """
@@ -58,7 +58,7 @@ class PackageSchema(PathSchema):
         Args:
             name (str): The name of the license.
         """
-        return self.add("license", "name", name)
+        return self.add("package", "license", name)
 
     def add_license_file(self, file: str, dataroot: str = None):
         """
@@ -72,19 +72,19 @@ class PackageSchema(PathSchema):
         if not dataroot:
             dataroot = self._get_active("package")
         with self.active_dataroot(dataroot):
-            return self.add("license", "file", file)
+            return self.add("package", "licensefile", file)
 
     def get_licenses(self) -> List[str]:
         """
         Get a list of license names associated with the package.
         """
-        return self.get("license", "name")
+        return self.get("package", "license")
 
     def get_license_files(self) -> List[str]:
         """
         Get a list of license file paths associated with the package.
         """
-        return self.find_files("license", "file")
+        return self.find_files("package", "licensefile")
 
     def add_author(self,
                    identifier: str,
@@ -102,11 +102,11 @@ class PackageSchema(PathSchema):
         """
         params = []
         if name:
-            params.append(self.set("author", identifier, "name", name))
+            params.append(self.set("package", "author", identifier, "name", name))
         if email:
-            params.append(self.set("author", identifier, "email", email))
+            params.append(self.set("package", "author", identifier, "email", email))
         if organization:
-            params.append(self.set("author", identifier, "organization", organization))
+            params.append(self.set("package", "author", identifier, "organization", organization))
         return [p for p in params if p]
 
     def add_documentation(self, type: str, path: str, dataroot: str = None):
@@ -125,7 +125,7 @@ class PackageSchema(PathSchema):
         if not dataroot:
             dataroot = self._get_active("package")
         with self.active_dataroot(dataroot):
-            return self.add("doc", type, path)
+            return self.add("package", "doc", type, path)
 
     def get_documentation(self, type: str = None) -> Union[List[str], Dict[str, List[str]]]:
         """
@@ -136,11 +136,11 @@ class PackageSchema(PathSchema):
                                 returns all documentation organized by type. Defaults to None.
         """
         if type:
-            return self.find_files("doc", type)
+            return self.find_files("package", "doc", type)
 
         docs = {}
-        for type in self.getkeys("doc"):
-            doc_files = self.find_files("doc", type)
+        for type in self.getkeys("package", "doc"):
+            doc_files = self.find_files("package", "doc", type)
             if doc_files:
                 docs[type] = doc_files
         return docs
@@ -153,7 +153,7 @@ def schema_package(schema):
     schema = EditableSchema(schema)
 
     schema.insert(
-        'version',
+        'package', 'version',
         Parameter(
             'str',
             scope=Scope.GLOBAL,
@@ -166,7 +166,7 @@ def schema_package(schema):
             or a semver compatible version.""")))
 
     schema.insert(
-        'description',
+        'package', 'description',
         Parameter(
             'str',
             scope=Scope.GLOBAL,
@@ -188,7 +188,7 @@ def schema_package(schema):
             'signoff',
             'tutorial']:
         schema.insert(
-            'doc', item,
+            'package', 'doc', item,
             Parameter(
                 '[file]',
                 scope=Scope.GLOBAL,
@@ -200,7 +200,7 @@ def schema_package(schema):
                 help=trim(f"""Package list of {item} documents.""")))
 
     schema.insert(
-        'license', 'name',
+        'package', 'license',
         Parameter(
             '[str]',
             scope=Scope.GLOBAL,
@@ -212,7 +212,7 @@ def schema_package(schema):
             help=trim("""Package list of SPDX license identifiers.""")))
 
     schema.insert(
-        'license', 'file',
+        'package', 'licensefile',
         Parameter(
             '[file]',
             scope=Scope.GLOBAL,
@@ -230,7 +230,7 @@ def schema_package(schema):
             'email',
             'organization']:
         schema.insert(
-            'author', 'default', item,
+            'package', 'author', 'default', item,
             Parameter(
                 'str',
                 scope=Scope.GLOBAL,

--- a/siliconcompiler/packageschema.py
+++ b/siliconcompiler/packageschema.py
@@ -60,18 +60,18 @@ class PackageSchema(PathSchema):
         """
         return self.add("license", "name", name)
 
-    def add_license_file(self, file: str, dataref: str = None):
+    def add_license_file(self, file: str, dataroot: str = None):
         """
         Add a license file to the package.
 
         Args:
             file (str): The path to the license file.
-            dataref (str, optional): The data reference for the package. Defaults to None,
+            dataroot (str, optional): The data reference for the package. Defaults to None,
                                     which uses the active package.
         """
-        if not dataref:
-            dataref = self._get_active("package")
-        with self.active_dataref(dataref):
+        if not dataroot:
+            dataroot = self._get_active("package")
+        with self.active_dataroot(dataroot):
             return self.add("license", "file", file)
 
     def get_licenses(self) -> List[str]:
@@ -109,22 +109,22 @@ class PackageSchema(PathSchema):
             params.append(self.set("author", identifier, "organization", organization))
         return [p for p in params if p]
 
-    def add_documentation(self, type: str, path: str, dataref: str = None):
+    def add_documentation(self, type: str, path: str, dataroot: str = None):
         """
         Add documentation to the package.
 
         Args:
             type (str): The type of documentation (e.g., "manual", "api").
             path (str): The path to the documentation file.
-            dataref (str, optional): The data reference for the package. Defaults to None,
+            dataroot (str, optional): The data reference for the package. Defaults to None,
                                     which uses the active package.
 
         Returns:
             The result of the `add` operation.
         """
-        if not dataref:
-            dataref = self._get_active("package")
-        with self.active_dataref(dataref):
+        if not dataroot:
+            dataroot = self._get_active("package")
+        with self.active_dataroot(dataroot):
             return self.add("doc", type, path)
 
     def get_documentation(self, type: str = None) -> Union[List[str], Dict[str, List[str]]]:

--- a/siliconcompiler/packageschema.py
+++ b/siliconcompiler/packageschema.py
@@ -17,33 +17,89 @@ class PackageSchema(PathSchema):
         schema_package(self)
 
     def set_description(self, desc: str):
+        """
+        Set the description of the package.
+
+        Args:
+            desc (str): The description string.
+        """
         return self.set("description", trim(desc))
 
     def get_description(self) -> str:
+        """Get the description of the package.
+
+        Returns:
+            str: The description string.
+        """
         return self.get("description")
 
     def set_version(self, version: str):
+        """
+        Set the version of the package.
+
+        Args:
+            version (str): The version string.
+        """
         return self.set("version", version)
 
     def get_version(self) -> str:
+        """
+        Get the version of the package.
+
+        Returns:
+            str: The version string.
+        """
         return self.get("version")
 
     def add_license(self, name: str):
+        """
+        Add a license name to the package.
+
+        Args:
+            name (str): The name of the license.
+        """
         return self.add("license", "name", name)
 
     def add_license_file(self, file: str, dataref: str = None):
+        """
+        Add a license file to the package.
+
+        Args:
+            file (str): The path to the license file.
+            dataref (str, optional): The data reference for the package. Defaults to None,
+                                    which uses the active package.
+        """
         if not dataref:
             dataref = self._get_active("package")
         with self.active_dataref(dataref):
             return self.add("license", "file", file)
 
     def get_licenses(self) -> List[str]:
+        """
+        Get a list of license names associated with the package.
+        """
         return self.get("license", "name")
 
     def get_license_files(self) -> List[str]:
+        """
+        Get a list of license file paths associated with the package.
+        """
         return self.find_files("license", "file")
 
-    def add_author(self, identifier: str, name: str = None, email: str = None, organization: str = None):
+    def add_author(self,
+                   identifier: str,
+                   name: str = None,
+                   email: str = None,
+                   organization: str = None):
+        """
+        Add or update author information for the package.
+
+        Args:
+            identifier (str): A unique identifier for the author.
+            name (str, optional): The author's name. Defaults to None.
+            email (str, optional): The author's email address. Defaults to None.
+            organization (str, optional): The author's organization. Defaults to None.
+        """
         params = []
         if name:
             params.append(self.set("author", identifier, "name", name))
@@ -54,12 +110,31 @@ class PackageSchema(PathSchema):
         return [p for p in params if p]
 
     def add_documentation(self, type: str, path: str, dataref: str = None):
+        """
+        Add documentation to the package.
+
+        Args:
+            type (str): The type of documentation (e.g., "manual", "api").
+            path (str): The path to the documentation file.
+            dataref (str, optional): The data reference for the package. Defaults to None,
+                                    which uses the active package.
+
+        Returns:
+            The result of the `add` operation.
+        """
         if not dataref:
             dataref = self._get_active("package")
         with self.active_dataref(dataref):
             return self.add("doc", type, path)
 
     def get_documentation(self, type: str = None) -> Union[List[str], Dict[str, List[str]]]:
+        """
+        Get documentation files for the package.
+
+        Args:
+            type (str, optional): The type of documentation to retrieve. If None,
+                                returns all documentation organized by type. Defaults to None.
+        """
         if type:
             return self.find_files("doc", type)
 

--- a/siliconcompiler/packageschema.py
+++ b/siliconcompiler/packageschema.py
@@ -60,7 +60,7 @@ class PackageSchema(PathSchema):
         """
         return self.add("package", "license", name)
 
-    def add_license_file(self, file: str, dataroot: str = None):
+    def add_licensefile(self, file: str, dataroot: str = None):
         """
         Add a license file to the package.
 
@@ -74,13 +74,13 @@ class PackageSchema(PathSchema):
         with self.active_dataroot(dataroot):
             return self.add("package", "licensefile", file)
 
-    def get_licenses(self) -> List[str]:
+    def get_license(self) -> List[str]:
         """
         Get a list of license names associated with the package.
         """
         return self.get("package", "license")
 
-    def get_license_files(self) -> List[str]:
+    def get_licensefile(self) -> List[str]:
         """
         Get a list of license file paths associated with the package.
         """
@@ -109,7 +109,25 @@ class PackageSchema(PathSchema):
             params.append(self.set("package", "author", identifier, "organization", organization))
         return [p for p in params if p]
 
-    def add_documentation(self, type: str, path: str, dataroot: str = None):
+    def get_author(self, identifier: str = None):
+        """
+        Returns the author information for a specific author or all authors.
+
+        Args:
+            identifier (str): A unique identifier for the author, if None returns all
+        """
+        if identifier is None:
+            authors = []
+            for author in self.getkeys("package", "author"):
+                authors.append(self.get_author(author))
+            return authors
+        return {
+            "name": self.get("package", "author", identifier, "name"),
+            "email": self.get("package", "author", identifier, "email"),
+            "organization": self.get("package", "author", identifier, "organization")
+        }
+
+    def add_doc(self, type: str, path: str, dataroot: str = None):
         """
         Add documentation to the package.
 
@@ -127,7 +145,7 @@ class PackageSchema(PathSchema):
         with self.active_dataroot(dataroot):
             return self.add("package", "doc", type, path)
 
-    def get_documentation(self, type: str = None) -> Union[List[str], Dict[str, List[str]]]:
+    def get_doc(self, type: str = None) -> Union[List[str], Dict[str, List[str]]]:
         """
         Get documentation files for the package.
 

--- a/siliconcompiler/packageschema.py
+++ b/siliconcompiler/packageschema.py
@@ -8,11 +8,11 @@ from siliconcompiler.schema.utils import trim
 from siliconcompiler.package import Resolver
 
 
-class PackageSchema(BaseSchema):
+class PackageSchemaTmp(BaseSchema):
     def __init__(self):
         super().__init__()
 
-        schema_package(self)
+        schema_package_tmp(self)
 
     def register(self, name, path, ref=None, clobber=True):
         """
@@ -74,7 +74,7 @@ class PackageSchema(BaseSchema):
 ############################################
 # Package information
 ############################################
-def schema_package(schema):
+def schema_package_tmp(schema):
     schema = EditableSchema(schema)
 
     schema.insert(

--- a/siliconcompiler/schema/schema_cfg.py
+++ b/siliconcompiler/schema/schema_cfg.py
@@ -1773,8 +1773,8 @@ def schema_option_frontend(cfg):
 # Package information
 ############################################
 def schema_package(cfg):
-    from siliconcompiler.packageschema import PackageSchema
-    cfg.insert("package", PackageSchema())
+    from siliconcompiler.packageschema import PackageSchemaTmp
+    cfg.insert("package", PackageSchemaTmp())
     return cfg
 
 

--- a/siliconcompiler/schema_obj.py
+++ b/siliconcompiler/schema_obj.py
@@ -9,7 +9,6 @@ from siliconcompiler.schema import SafeSchema
 from siliconcompiler.schema import EditableSchema
 from siliconcompiler.schema import CommandLineSchema
 from siliconcompiler.schema import Parameter
-from siliconcompiler.schema.baseschema import json
 
 from siliconcompiler.schema.schema_cfg import schema_cfg
 
@@ -118,5 +117,5 @@ class SchemaTmp(Schema, CommandLineSchema):
 ##############################################################################
 # Main routine
 if __name__ == "__main__":
-    import json as main_json
-    print(main_json.dumps(SchemaTmp().getdict(), indent=4, sort_keys=True))
+    import json
+    print(json.dumps(SchemaTmp().getdict(), indent=4, sort_keys=True))

--- a/tests/test_packageschema_impl.py
+++ b/tests/test_packageschema_impl.py
@@ -1,5 +1,10 @@
+import os
+
 import os.path
 
+from pathlib import Path
+
+from siliconcompiler.packageschema import PackageSchema
 from siliconcompiler.packageschema import PackageSchemaTmp
 
 
@@ -62,3 +67,105 @@ def test_register_ref_dir():
 def test_get_resolvers_empty():
     schema = PackageSchemaTmp()
     assert schema.get_resolvers() == {}
+
+
+def test_description():
+    schema = PackageSchema()
+    assert schema.set_description("this is the description")
+    assert schema.get("description") == "this is the description"
+    assert schema.get_description() == "this is the description"
+
+
+def test_version():
+    schema = PackageSchema()
+    assert schema.set_version("1.0")
+    assert schema.get("version") == "1.0"
+    assert schema.get_version() == "1.0"
+
+
+def test_author():
+    schema = PackageSchema()
+    assert len(schema.add_author("person0", name="Bob", email="bob@org.com", organization="Bob Inc.")) == 3
+    assert schema.get("author", "person0", "name") == "Bob"
+    assert schema.get("author", "person0", "email") == "bob@org.com"
+    assert schema.get("author", "person0", "organization") == "Bob Inc."
+
+
+def test_author_overwrite():
+    schema = PackageSchema()
+    assert len(schema.add_author("person0", name="Bob", email="bob@org.com", organization="Bob Inc.")) == 3
+    assert len(schema.add_author("person0", name="Bob0")) == 1
+    assert schema.get("author", "person0", "name") == "Bob0"
+    assert schema.get("author", "person0", "email") == "bob@org.com"
+    assert schema.get("author", "person0", "organization") == "Bob Inc."
+
+
+def test_license():
+    schema = PackageSchema()
+    assert schema.add_license("fake0")
+    assert schema.add_license("fake1")
+    assert schema.get_licenses() == ["fake0", "fake1"]
+
+
+def test_license_file():
+    schema = PackageSchema()
+    Path("lic").touch()
+
+    assert schema.add_license_file("./lic")
+    assert schema.get_license_files() == [os.path.abspath("lic")]
+
+
+def test_license_file_with_dataref():
+    schema = PackageSchema()
+
+    os.makedirs("lics", exist_ok=True)
+    Path("lics/lic").touch()
+
+    schema.register_dataref("testdata", os.path.abspath("lics"))
+
+    with schema.active_dataref("testdata"):
+        assert schema.add_license_file("./lic")
+    assert schema.get_license_files() == [os.path.abspath("lics/lic")]
+
+
+def test_add_documentation():
+    schema = PackageSchema()
+
+    Path("doc").touch()
+
+    assert schema.add_documentation("userguide", "doc")
+    assert schema.get("doc", "userguide") == ["doc"]
+    assert schema.get_documentation("userguide") == [os.path.abspath("doc")]
+
+
+def test_add_documentation_with_dataref():
+    schema = PackageSchema()
+
+    os.makedirs("docs", exist_ok=True)
+    Path("docs/quick").touch()
+
+    schema.register_dataref("testdata", os.path.abspath("docs"))
+
+    with schema.active_dataref("testdata"):
+        assert schema.add_documentation("quickstart", "quick")
+    assert schema.get("doc", "quickstart") == ["quick"]
+    assert schema.get_documentation("quickstart") == [os.path.abspath("docs/quick")]
+
+
+def test_get_documentation_all():
+    schema = PackageSchema()
+
+    os.makedirs("docs", exist_ok=True)
+    Path("docs/quick").touch()
+    Path("user").touch()
+
+    assert schema.add_documentation("userguide", "user")
+    schema.register_dataref("testdata", os.path.abspath("docs"))
+
+    with schema.active_dataref("testdata"):
+        assert schema.add_documentation("quickstart", "quick")
+
+    assert schema.get_documentation() == {
+        "quickstart": [os.path.abspath("docs/quick")],
+        "userguide": [os.path.abspath("user")],
+    }

--- a/tests/test_packageschema_impl.py
+++ b/tests/test_packageschema_impl.py
@@ -72,14 +72,14 @@ def test_get_resolvers_empty():
 def test_description():
     schema = PackageSchema()
     assert schema.set_description("this is the description")
-    assert schema.get("description") == "this is the description"
+    assert schema.get("package", "description") == "this is the description"
     assert schema.get_description() == "this is the description"
 
 
 def test_version():
     schema = PackageSchema()
     assert schema.set_version("1.0")
-    assert schema.get("version") == "1.0"
+    assert schema.get("package", "version") == "1.0"
     assert schema.get_version() == "1.0"
 
 
@@ -89,9 +89,9 @@ def test_author():
                                  name="Bob",
                                  email="bob@org.com",
                                  organization="Bob Inc.")) == 3
-    assert schema.get("author", "person0", "name") == "Bob"
-    assert schema.get("author", "person0", "email") == "bob@org.com"
-    assert schema.get("author", "person0", "organization") == "Bob Inc."
+    assert schema.get("package", "author", "person0", "name") == "Bob"
+    assert schema.get("package", "author", "person0", "email") == "bob@org.com"
+    assert schema.get("package", "author", "person0", "organization") == "Bob Inc."
 
 
 def test_author_overwrite():
@@ -101,9 +101,9 @@ def test_author_overwrite():
                                  email="bob@org.com",
                                  organization="Bob Inc.")) == 3
     assert len(schema.add_author("person0", name="Bob0")) == 1
-    assert schema.get("author", "person0", "name") == "Bob0"
-    assert schema.get("author", "person0", "email") == "bob@org.com"
-    assert schema.get("author", "person0", "organization") == "Bob Inc."
+    assert schema.get("package", "author", "person0", "name") == "Bob0"
+    assert schema.get("package", "author", "person0", "email") == "bob@org.com"
+    assert schema.get("package", "author", "person0", "organization") == "Bob Inc."
 
 
 def test_license():
@@ -140,7 +140,7 @@ def test_add_documentation():
     Path("doc").touch()
 
     assert schema.add_documentation("userguide", "doc")
-    assert schema.get("doc", "userguide") == ["doc"]
+    assert schema.get("package", "doc", "userguide") == ["doc"]
     assert schema.get_documentation("userguide") == [os.path.abspath("doc")]
 
 
@@ -154,7 +154,7 @@ def test_add_documentation_with_dataroot():
 
     with schema.active_dataroot("testdata"):
         assert schema.add_documentation("quickstart", "quick")
-    assert schema.get("doc", "quickstart") == ["quick"]
+    assert schema.get("package", "doc", "quickstart") == ["quick"]
     assert schema.get_documentation("quickstart") == [os.path.abspath("docs/quick")]
 
 

--- a/tests/test_packageschema_impl.py
+++ b/tests/test_packageschema_impl.py
@@ -69,6 +69,28 @@ def test_get_resolvers_empty():
     assert schema.get_resolvers() == {}
 
 
+def test_keys():
+    assert PackageSchema().allkeys() == set([
+        ('dataroot', 'default', 'path'),
+        ('dataroot', 'default', 'tag'),
+        ('package', 'author', 'default', 'email'),
+        ('package', 'author', 'default', 'name'),
+        ('package', 'author', 'default', 'organization'),
+        ('package', 'description'),
+        ('package', 'doc', 'datasheet'),
+        ('package', 'doc', 'quickstart'),
+        ('package', 'doc', 'reference'),
+        ('package', 'doc', 'releasenotes'),
+        ('package', 'doc', 'signoff'),
+        ('package', 'doc', 'testplan'),
+        ('package', 'doc', 'tutorial'),
+        ('package', 'doc', 'userguide'),
+        ('package', 'license'),
+        ('package', 'licensefile'),
+        ('package', 'version'),
+    ])
+
+
 def test_description():
     schema = PackageSchema()
     assert schema.set_description("this is the description")

--- a/tests/test_packageschema_impl.py
+++ b/tests/test_packageschema_impl.py
@@ -121,15 +121,15 @@ def test_license_file():
     assert schema.get_license_files() == [os.path.abspath("lic")]
 
 
-def test_license_file_with_dataref():
+def test_license_file_with_dataroot():
     schema = PackageSchema()
 
     os.makedirs("lics", exist_ok=True)
     Path("lics/lic").touch()
 
-    schema.register_dataref("testdata", os.path.abspath("lics"))
+    schema.set_dataroot("testdata", os.path.abspath("lics"))
 
-    with schema.active_dataref("testdata"):
+    with schema.active_dataroot("testdata"):
         assert schema.add_license_file("./lic")
     assert schema.get_license_files() == [os.path.abspath("lics/lic")]
 
@@ -144,15 +144,15 @@ def test_add_documentation():
     assert schema.get_documentation("userguide") == [os.path.abspath("doc")]
 
 
-def test_add_documentation_with_dataref():
+def test_add_documentation_with_dataroot():
     schema = PackageSchema()
 
     os.makedirs("docs", exist_ok=True)
     Path("docs/quick").touch()
 
-    schema.register_dataref("testdata", os.path.abspath("docs"))
+    schema.set_dataroot("testdata", os.path.abspath("docs"))
 
-    with schema.active_dataref("testdata"):
+    with schema.active_dataroot("testdata"):
         assert schema.add_documentation("quickstart", "quick")
     assert schema.get("doc", "quickstart") == ["quick"]
     assert schema.get_documentation("quickstart") == [os.path.abspath("docs/quick")]
@@ -166,9 +166,9 @@ def test_get_documentation_all():
     Path("user").touch()
 
     assert schema.add_documentation("userguide", "user")
-    schema.register_dataref("testdata", os.path.abspath("docs"))
+    schema.set_dataroot("testdata", os.path.abspath("docs"))
 
-    with schema.active_dataref("testdata"):
+    with schema.active_dataroot("testdata"):
         assert schema.add_documentation("quickstart", "quick")
 
     assert schema.get_documentation() == {

--- a/tests/test_packageschema_impl.py
+++ b/tests/test_packageschema_impl.py
@@ -85,7 +85,10 @@ def test_version():
 
 def test_author():
     schema = PackageSchema()
-    assert len(schema.add_author("person0", name="Bob", email="bob@org.com", organization="Bob Inc.")) == 3
+    assert len(schema.add_author("person0",
+                                 name="Bob",
+                                 email="bob@org.com",
+                                 organization="Bob Inc.")) == 3
     assert schema.get("author", "person0", "name") == "Bob"
     assert schema.get("author", "person0", "email") == "bob@org.com"
     assert schema.get("author", "person0", "organization") == "Bob Inc."
@@ -93,7 +96,10 @@ def test_author():
 
 def test_author_overwrite():
     schema = PackageSchema()
-    assert len(schema.add_author("person0", name="Bob", email="bob@org.com", organization="Bob Inc.")) == 3
+    assert len(schema.add_author("person0",
+                                 name="Bob",
+                                 email="bob@org.com",
+                                 organization="Bob Inc.")) == 3
     assert len(schema.add_author("person0", name="Bob0")) == 1
     assert schema.get("author", "person0", "name") == "Bob0"
     assert schema.get("author", "person0", "email") == "bob@org.com"

--- a/tests/test_packageschema_impl.py
+++ b/tests/test_packageschema_impl.py
@@ -93,6 +93,12 @@ def test_author():
     assert schema.get("package", "author", "person0", "email") == "bob@org.com"
     assert schema.get("package", "author", "person0", "organization") == "Bob Inc."
 
+    assert schema.get_author("person0") == {
+        "email": "bob@org.com",
+        "name": "Bob",
+        "organization": "Bob Inc."
+    }
+
 
 def test_author_overwrite():
     schema = PackageSchema()
@@ -106,22 +112,47 @@ def test_author_overwrite():
     assert schema.get("package", "author", "person0", "organization") == "Bob Inc."
 
 
+def test_author_multiple():
+    schema = PackageSchema()
+    assert len(schema.add_author("person0",
+                                 name="Bob",
+                                 email="bob@org.com",
+                                 organization="AMCE Inc.")) == 3
+    assert len(schema.add_author("person1",
+                                 name="Alice",
+                                 email="alice@org.com",
+                                 organization="AMCE Inc.")) == 3
+
+    assert schema.get_author() == [
+        {
+            "email": "bob@org.com",
+            "name": "Bob",
+            "organization": "AMCE Inc."
+        },
+        {
+            "email": "alice@org.com",
+            "name": "Alice",
+            "organization": "AMCE Inc."
+        }
+    ]
+
+
 def test_license():
     schema = PackageSchema()
     assert schema.add_license("fake0")
     assert schema.add_license("fake1")
-    assert schema.get_licenses() == ["fake0", "fake1"]
+    assert schema.get_license() == ["fake0", "fake1"]
 
 
-def test_license_file():
+def test_licensefile():
     schema = PackageSchema()
     Path("lic").touch()
 
-    assert schema.add_license_file("./lic")
-    assert schema.get_license_files() == [os.path.abspath("lic")]
+    assert schema.add_licensefile("./lic")
+    assert schema.get_licensefile() == [os.path.abspath("lic")]
 
 
-def test_license_file_with_dataroot():
+def test_licensefile_with_dataroot():
     schema = PackageSchema()
 
     os.makedirs("lics", exist_ok=True)
@@ -130,21 +161,21 @@ def test_license_file_with_dataroot():
     schema.set_dataroot("testdata", os.path.abspath("lics"))
 
     with schema.active_dataroot("testdata"):
-        assert schema.add_license_file("./lic")
-    assert schema.get_license_files() == [os.path.abspath("lics/lic")]
+        assert schema.add_licensefile("./lic")
+    assert schema.get_licensefile() == [os.path.abspath("lics/lic")]
 
 
-def test_add_documentation():
+def test_add_doc():
     schema = PackageSchema()
 
     Path("doc").touch()
 
-    assert schema.add_documentation("userguide", "doc")
+    assert schema.add_doc("userguide", "doc")
     assert schema.get("package", "doc", "userguide") == ["doc"]
-    assert schema.get_documentation("userguide") == [os.path.abspath("doc")]
+    assert schema.get_doc("userguide") == [os.path.abspath("doc")]
 
 
-def test_add_documentation_with_dataroot():
+def test_add_doc_with_dataroot():
     schema = PackageSchema()
 
     os.makedirs("docs", exist_ok=True)
@@ -153,25 +184,25 @@ def test_add_documentation_with_dataroot():
     schema.set_dataroot("testdata", os.path.abspath("docs"))
 
     with schema.active_dataroot("testdata"):
-        assert schema.add_documentation("quickstart", "quick")
+        assert schema.add_doc("quickstart", "quick")
     assert schema.get("package", "doc", "quickstart") == ["quick"]
-    assert schema.get_documentation("quickstart") == [os.path.abspath("docs/quick")]
+    assert schema.get_doc("quickstart") == [os.path.abspath("docs/quick")]
 
 
-def test_get_documentation_all():
+def test_get_doc_all():
     schema = PackageSchema()
 
     os.makedirs("docs", exist_ok=True)
     Path("docs/quick").touch()
     Path("user").touch()
 
-    assert schema.add_documentation("userguide", "user")
+    assert schema.add_doc("userguide", "user")
     schema.set_dataroot("testdata", os.path.abspath("docs"))
 
     with schema.active_dataroot("testdata"):
-        assert schema.add_documentation("quickstart", "quick")
+        assert schema.add_doc("quickstart", "quick")
 
-    assert schema.get_documentation() == {
+    assert schema.get_doc() == {
         "quickstart": [os.path.abspath("docs/quick")],
         "userguide": [os.path.abspath("user")],
     }

--- a/tests/test_packageschema_impl.py
+++ b/tests/test_packageschema_impl.py
@@ -1,10 +1,10 @@
 import os.path
 
-from siliconcompiler.packageschema import PackageSchema
+from siliconcompiler.packageschema import PackageSchemaTmp
 
 
 def test_register():
-    schema = PackageSchema()
+    schema = PackageSchemaTmp()
     assert schema.getkeys("source") == tuple()
     assert schema.register("testpackage", "pathtosource") is True
     assert schema.get("source", "testpackage", "path") == "pathtosource"
@@ -12,7 +12,7 @@ def test_register():
 
 
 def test_register_ref():
-    schema = PackageSchema()
+    schema = PackageSchemaTmp()
     assert schema.getkeys("source") == tuple()
     assert schema.register("testpackage", "pathtosource", ref="123456") is True
     assert schema.get("source", "testpackage", "path") == "pathtosource"
@@ -20,7 +20,7 @@ def test_register_ref():
 
 
 def test_register_ref_no_clobber():
-    schema = PackageSchema()
+    schema = PackageSchemaTmp()
     assert schema.getkeys("source") == tuple()
     assert schema.register("testpackage", "pathtosource", ref="123456") is True
     assert schema.get("source", "testpackage", "path") == "pathtosource"
@@ -30,7 +30,7 @@ def test_register_ref_no_clobber():
 
 
 def test_register_ref_with_clobber():
-    schema = PackageSchema()
+    schema = PackageSchemaTmp()
     assert schema.getkeys("source") == tuple()
     assert schema.register("testpackage", "pathtosource", ref="123456") is True
     assert schema.get("source", "testpackage", "path") == "pathtosource"
@@ -40,7 +40,7 @@ def test_register_ref_with_clobber():
 
 
 def test_register_ref_file():
-    schema = PackageSchema()
+    schema = PackageSchemaTmp()
     assert schema.getkeys("source") == tuple()
     with open("test.txt", "w") as f:
         f.write("test")
@@ -51,7 +51,7 @@ def test_register_ref_file():
 
 
 def test_register_ref_dir():
-    schema = PackageSchema()
+    schema = PackageSchemaTmp()
     assert schema.getkeys("source") == tuple()
 
     assert schema.register("testpackage", ".") is True
@@ -60,5 +60,5 @@ def test_register_ref_dir():
 
 
 def test_get_resolvers_empty():
-    schema = PackageSchema()
+    schema = PackageSchemaTmp()
     assert schema.get_resolvers() == {}

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -12,7 +12,6 @@ from unittest.mock import patch, ANY
 
 from siliconcompiler import RecordSchema, MetricSchema, FlowgraphSchema
 from siliconcompiler import ToolSchema, TaskSchema
-from siliconcompiler.packageschema import PackageSchema
 from siliconcompiler.schema import BaseSchema, EditableSchema, Parameter, SafeSchema
 from siliconcompiler.schema.parameter import PerNode, Scope
 from siliconcompiler.tool import TaskExecutableNotFound, TaskError, TaskTimeout
@@ -116,7 +115,6 @@ def running_project():
             schema.insert("tool", "default", ToolSchema(None))
             EditableSchema(
                 self.get("tool", "builtin", "task", field="schema")).insert("nop", NOPTask())
-            schema.insert("package", PackageSchema())
 
         def top(self, **kwargs):
             return "designtop"


### PR DESCRIPTION
Notes:
- ~could move all this down a level to `package` or another phrase to avoid generating too much of a flat schema.~
Some fields removed from the current implementation: 
- `docs/homepage` -> seems covered by the `docs/*`
- `author/username`, `author/location`, `author/publickey` were removed, could added back, but dont seem needed for packaging
- ~`license` and `licensefile` were moved to `license/name`, `license/file`~