### PR TITLE
Move dash.stop at main thread exit

### DIFF
--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1,6 +1,5 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 
-import atexit
 import copy
 import tarfile
 import os
@@ -2691,7 +2690,6 @@ class Chip:
             self._dash = WebDashboard(self, port=port, graph_chips=graph_chips)
         elif type == DashboardType.CLI:
             self._dash = CliDashboard(self)
-            atexit.register(self._dash.stop)
             wait = False
 
         self._dash.open_dashboard()

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -2691,9 +2691,9 @@ class Chip:
             self._dash = WebDashboard(self, port=port, graph_chips=graph_chips)
         elif type == DashboardType.CLI:
             self._dash = CliDashboard(self)
+            atexit.register(self._dash.stop)
             wait = False
 
-        atexit.register(self._dash.stop)
         self._dash.open_dashboard()
 
         if wait:

--- a/siliconcompiler/core.py
+++ b/siliconcompiler/core.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 
+import atexit
 import copy
 import tarfile
 import os
@@ -2692,6 +2693,7 @@ class Chip:
             self._dash = CliDashboard(self)
             wait = False
 
+        atexit.register(self._dash.stop)
         self._dash.open_dashboard()
 
         if wait:

--- a/siliconcompiler/report/dashboard/cli/board.py
+++ b/siliconcompiler/report/dashboard/cli/board.py
@@ -1,4 +1,3 @@
-import atexit
 import logging
 import os
 import math
@@ -343,8 +342,6 @@ class Board(metaclass=BoardSingleton):
             auto_refresh=True
         )
 
-        atexit.register(self._stop_on_exit)
-
         self._active = self._console.is_terminal
         if not self._active:
             self._console = None
@@ -382,9 +379,6 @@ class Board(metaclass=BoardSingleton):
 
     def make_log_hander(self) -> logging.Handler:
         return self._log_handler.make_handler()
-
-    def _stop_on_exit(self):
-        self.stop()
 
     def open_dashboard(self):
         """Starts the dashboard rendering thread if it is not already running."""

--- a/siliconcompiler/report/dashboard/cli/board.py
+++ b/siliconcompiler/report/dashboard/cli/board.py
@@ -1,3 +1,4 @@
+import atexit
 import logging
 import os
 import math
@@ -291,6 +292,8 @@ class BoardSingleton(type):
             if cls not in cls._instances:
                 cls._instances[cls] = super(BoardSingleton, cls).__call__(*args, **kwargs)
                 cls._instances[cls]._init_singleton()
+                atexit.register(cls._instances[cls]._stop_on_exit)
+
         return cls._instances[cls]
 
 
@@ -379,6 +382,9 @@ class Board(metaclass=BoardSingleton):
 
     def make_log_hander(self) -> logging.Handler:
         return self._log_handler.make_handler()
+
+    def _stop_on_exit(self):
+        self.stop()
 
     def open_dashboard(self):
         """Starts the dashboard rendering thread if it is not already running."""


### PR DESCRIPTION
@gadfort  there is a slight issue with the dashboard. Apparently the `atexit` won't work if it's not in the main thread. That would leave dashbord open, causing a mess of the terminal. Moving this into the `core.py` right after we open the dashboard solves the issue. 