### PR TITLE
ensure sets return a list to preserve ordering

### DIFF
--- a/siliconcompiler/schema/parametervalue.py
+++ b/siliconcompiler/schema/parametervalue.py
@@ -227,7 +227,7 @@ class NodeSetValue:
             if field is None:
                 continue
 
-            value = self.get(field=field, ordered=True)
+            value = self.get(field=field)
             manifest.setdefault(field, []).extend(value)
 
             if field == "author":
@@ -261,13 +261,12 @@ class NodeSetValue:
                     continue
                 param.set(manifest[field][n], field=field)
 
-    def get(self, field='value', ordered: bool = False):
+    def get(self, field='value'):
         """
         Returns the value in the specified field
 
         Args:
             field (str): name of schema field.
-            ordered (bool): if true, returns a list instead of set for values
         """
 
         vals = []
@@ -280,8 +279,6 @@ class NodeSetValue:
         else:
             vals.append(self.__base.get(field=field))
 
-        if not ordered and field == "value":
-            return set(vals)
         return vals
 
     def gettcl(self):
@@ -291,7 +288,7 @@ class NodeSetValue:
         Args:
             field (str): name of schema field.
         """
-        return NodeType.to_tcl(self.get(ordered=True), [self.__base.type])
+        return NodeType.to_tcl(self.get(), [self.__base.type])
 
     def set(self, value, field='value'):
         value = NodeType.normalize(value, [self.__base.type])

--- a/tests/constraints/test_asic_timing.py
+++ b/tests/constraints/test_asic_timing.py
@@ -47,29 +47,29 @@ def test_timing_scanario_libcorner():
     assert scene.add_libcorner("slow0")
     assert scene.add_libcorner("slow1")
     assert scene.add_libcorner("slow2", step="step0", index="1")
-    assert scene.get("libcorner") == set(["slow0", "slow1"])
-    assert scene.get_libcorner() == set(["slow0", "slow1"])
-    assert scene.get("libcorner", step="step0", index="1") == set(["slow2"])
-    assert scene.get_libcorner(step="step0", index="1") == set(["slow2"])
+    assert scene.get("libcorner") == ["slow0", "slow1"]
+    assert scene.get_libcorner() == ["slow0", "slow1"]
+    assert scene.get("libcorner", step="step0", index="1") == ["slow2"]
+    assert scene.get_libcorner(step="step0", index="1") == ["slow2"]
 
 
 def test_timing_scanario_libcorner_clobber():
     scene = ASICTimingScenarioSchema()
     assert scene.add_libcorner("slow0")
-    assert scene.get_libcorner() == set(["slow0"])
+    assert scene.get_libcorner() == ["slow0"]
     assert scene.add_libcorner("slow1", clobber=True)
-    assert scene.get_libcorner() == set(["slow1"])
+    assert scene.get_libcorner() == ["slow1"]
 
 
 def test_timing_scanario_libcorner_clobber_step_index():
     scene = ASICTimingScenarioSchema()
     assert scene.add_libcorner("slow0")
     assert scene.add_libcorner("slow1", step="step0", index="1")
-    assert scene.get_libcorner() == set(["slow0"])
-    assert scene.get_libcorner(step="step0", index="1") == set(["slow1"])
+    assert scene.get_libcorner() == ["slow0"]
+    assert scene.get_libcorner(step="step0", index="1") == ["slow1"]
     assert scene.add_libcorner("slow2", step="step0", index="1", clobber=True)
-    assert scene.get_libcorner() == set(["slow0"])
-    assert scene.get_libcorner(step="step0", index="1") == set(["slow2"])
+    assert scene.get_libcorner() == ["slow0"]
+    assert scene.get_libcorner(step="step0", index="1") == ["slow2"]
 
 
 def test_timing_scanario_pexcorner():
@@ -116,29 +116,29 @@ def test_timing_scanario_check():
     scene = ASICTimingScenarioSchema()
     assert scene.add_check("setup")
     assert scene.add_check("hold", step="step0", index="1")
-    assert scene.get("check") == set(["setup"])
-    assert scene.get_check() == set(["setup"])
-    assert scene.get("check", step="step0", index="1") == set(["hold"])
-    assert scene.get_check(step="step0", index="1") == set(["hold"])
+    assert scene.get("check") == ["setup"]
+    assert scene.get_check() == ["setup"]
+    assert scene.get("check", step="step0", index="1") == ["hold"]
+    assert scene.get_check(step="step0", index="1") == ["hold"]
 
 
 def test_timing_scanario_check_clobber():
     scene = ASICTimingScenarioSchema()
     assert scene.add_check("setup")
-    assert scene.get_check() == set(["setup"])
+    assert scene.get_check() == ["setup"]
     assert scene.add_check("hold", clobber=True)
-    assert scene.get_check() == set(["hold"])
+    assert scene.get_check() == ["hold"]
 
 
 def test_timing_scanario_check_clobber_step_index():
     scene = ASICTimingScenarioSchema()
     assert scene.add_check("setup")
     assert scene.add_check("hold", step="step0", index="1")
-    assert scene.get_check() == set(["setup"])
-    assert scene.get_check(step="step0", index="1") == set(["hold"])
+    assert scene.get_check() == ["setup"]
+    assert scene.get_check(step="step0", index="1") == ["hold"]
     assert scene.add_check("power", step="step0", index="1", clobber=True)
-    assert scene.get_check() == set(["setup"])
-    assert scene.get_check(step="step0", index="1") == set(["power"])
+    assert scene.get_check() == ["setup"]
+    assert scene.get_check(step="step0", index="1") == ["power"]
 
 
 def test_timing_scanario_sdcfileset_invalid_type_design():

--- a/tests/schema/test_parameter.py
+++ b/tests/schema/test_parameter.py
@@ -329,12 +329,12 @@ def test_add_fields_enum():
 def test_set_add_set():
     param = Parameter("{str}")
 
-    assert param.get() == set()
+    assert param.get() == []
     assert param.set("test0")
-    assert param.get() == set(["test0"])
+    assert param.get() == ["test0"]
 
     assert param.add("test1")
-    assert param.get() == set(["test0", "test1"])
+    assert param.get() == ["test0", "test1"]
 
 
 def test_from_dict_round_trip():
@@ -1860,7 +1860,7 @@ def test_defvalue_file_list_package():
 
 def test_defvalue_file_set_package():
     param = Parameter("{file}", defvalue="thisfile", package="thispackage")
-    assert param.default.get() == set(["thisfile"])
+    assert param.default.get() == ["thisfile"]
     assert param.default.get(field="package") == ["thispackage"]
 
 

--- a/tests/schema/test_parametervalue.py
+++ b/tests/schema/test_parametervalue.py
@@ -1263,30 +1263,28 @@ def test_nodeset_set_type():
 def test_nodeset_get_ordering():
     value = NodeSetValue(NodeValue("str"))
     value.set(["test0", "test1", "test1", "test3"])
-    assert value.get() == set(["test0", "test1", "test3"])
-    assert value.get(ordered=True) == ["test0", "test1", "test3"]
+    assert value.get() == ["test0", "test1", "test3"]
 
 
 def test_nodeset_set_reject_dups():
     value = NodeSetValue(NodeValue("str"))
     value.set(["test0", "test1", "test1", "test3"])
-    assert value.get() == set(["test0", "test1", "test3"])
+    assert value.get() == ["test0", "test1", "test3"]
 
 
 def test_nodeset_add_reject_dups():
     value = NodeSetValue(NodeValue("str"))
     value.add(["test0", "test1", "test1", "test3"])
-    assert value.get() == set(["test0", "test1", "test3"])
+    assert value.get() == ["test0", "test1", "test3"]
     value.add(["test0", "test1", "test1", "test3", "test4"])
-    assert value.get() == set(["test0", "test1", "test3", "test4"])
+    assert value.get() == ["test0", "test1", "test3", "test4"]
 
 
 def test_nodeset_get_defvalue():
     defvalue = NodeValue("str")
     defvalue.set("this")
     value = NodeSetValue(defvalue)
-    assert value.get() == set(["this"])
-    assert value.get(ordered=True) == ["this"]
+    assert value.get() == ["this"]
 
 
 def test_nodeset_gettcl():

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -287,7 +287,7 @@ def test_add_asic_libcornerfileset():
     with lib.active_fileset("models"):
         lib.add_file("test.lib")
         assert lib.add_asic_libcornerfileset("slow", "nldm")
-    assert lib.get("asic", "libcornerfileset", "slow", "nldm") == set(["models"])
+    assert lib.get("asic", "libcornerfileset", "slow", "nldm") == ["models"]
 
 
 def test_add_asic_libcornerfileset_multiple():
@@ -298,7 +298,7 @@ def test_add_asic_libcornerfileset_multiple():
     with lib.active_fileset("models2"):
         lib.add_file("test.lib")
         assert lib.add_asic_libcornerfileset("slow", "nldm")
-    assert lib.get("asic", "libcornerfileset", "slow", "nldm") == set(["models1", "models2"])
+    assert lib.get("asic", "libcornerfileset", "slow", "nldm") == ["models1", "models2"]
 
 
 def test_add_asic_libcornerfileset_without_active():
@@ -306,7 +306,7 @@ def test_add_asic_libcornerfileset_without_active():
     with lib.active_fileset("models"):
         lib.add_file("test.lib")
     assert lib.add_asic_libcornerfileset("slow", "nldm", "models")
-    assert lib.get("asic", "libcornerfileset", "slow", "nldm") == set(["models"])
+    assert lib.get("asic", "libcornerfileset", "slow", "nldm") == ["models"]
 
 
 def test_add_asic_libcornerfileset_missing_fileset():
@@ -329,7 +329,7 @@ def test_add_asic_pexcornerfileset():
     with lib.active_fileset("models"):
         lib.add_file("test.sp")
         assert lib.add_asic_pexcornerfileset("slow", "spice")
-    assert lib.get("asic", "pexcornerfileset", "slow", "spice") == set(["models"])
+    assert lib.get("asic", "pexcornerfileset", "slow", "spice") == ["models"]
 
 
 def test_add_asic_pexcornerfileset_multiple():
@@ -340,7 +340,7 @@ def test_add_asic_pexcornerfileset_multiple():
     with lib.active_fileset("models2"):
         lib.add_file("test.sp")
         assert lib.add_asic_pexcornerfileset("slow", "spice")
-    assert lib.get("asic", "pexcornerfileset", "slow", "spice") == set(["models1", "models2"])
+    assert lib.get("asic", "pexcornerfileset", "slow", "spice") == ["models1", "models2"]
 
 
 def test_add_asic_pexcornerfileset_without_active():
@@ -348,7 +348,7 @@ def test_add_asic_pexcornerfileset_without_active():
     with lib.active_fileset("models"):
         lib.add_file("test.sp")
     assert lib.add_asic_pexcornerfileset("slow", "spice", "models")
-    assert lib.get("asic", "pexcornerfileset", "slow", "spice") == set(["models"])
+    assert lib.get("asic", "pexcornerfileset", "slow", "spice") == ["models"]
 
 
 def test_add_asic_pexcornerfileset_missing_fileset():
@@ -371,7 +371,7 @@ def test_add_asic_aprfileset():
     with lib.active_fileset("models"):
         lib.add_file("test.lef")
         assert lib.add_asic_aprfileset()
-    assert lib.get("asic", "aprfileset") == set(["models"])
+    assert lib.get("asic", "aprfileset") == ["models"]
 
 
 def test_add_asic_aprfileset_multiple():
@@ -382,7 +382,7 @@ def test_add_asic_aprfileset_multiple():
     with lib.active_fileset("models2"):
         lib.add_file("test.gds")
         assert lib.add_asic_aprfileset()
-    assert lib.get("asic", "aprfileset") == set(["models1", "models2"])
+    assert lib.get("asic", "aprfileset") == ["models1", "models2"]
 
 
 def test_add_asic_aprfileset_without_active():
@@ -390,7 +390,7 @@ def test_add_asic_aprfileset_without_active():
     with lib.active_fileset("models"):
         lib.add_file("test.lef")
     assert lib.add_asic_aprfileset("models")
-    assert lib.get("asic", "aprfileset") == set(["models"])
+    assert lib.get("asic", "aprfileset") == ["models"]
 
 
 def test_add_asic_aprfileset_missing_fileset():
@@ -422,7 +422,7 @@ def test_add_asic_pdk():
     pdk.set_stackup("10M")
     lib.add_asic_pdk(pdk)
     assert lib.get("asic", "pdk") == "test"
-    assert lib.get("asic", "stackup") == set(["10M"])
+    assert lib.get("asic", "stackup") == ["10M"]
 
 
 def test_add_asic_pdk_notdefault():
@@ -454,6 +454,6 @@ def test_add_asic_pdk_string_invalid():
 def test_add_asic_stackup():
     lib = StdCellLibrarySchema("lib")
     lib.add_asic_stackup("10M")
-    assert lib.get("asic", "stackup") == set(["10M"])
+    assert lib.get("asic", "stackup") == ["10M"]
     lib.add_asic_stackup("11M")
-    assert lib.get("asic", "stackup") == set(["10M", "11M"])
+    assert lib.get("asic", "stackup") == ["10M", "11M"]

--- a/tests/test_schema_information.py
+++ b/tests/test_schema_information.py
@@ -111,6 +111,8 @@ def test_cli_examples(monkeypatch, root):
                 args.append(value)
 
             if expected_val:
+                if typestr[0] == "{":
+                    typestr = f"[{typestr[1:-1]}]"
                 nodetype = NodeType(typestr)
                 expected = (replaced_keypath, step, index,
                             NodeType.normalize(cast_value, nodetype))


### PR DESCRIPTION
Working with sets resolves in indeterminate ordering this ensures a set is a list of unique values