### PR TITLE
remove get_*constraint from FPGA and ASIC projects and replace with property access

### DIFF
--- a/docs/development_guide/targets.rst
+++ b/docs/development_guide/targets.rst
@@ -71,14 +71,14 @@ Let's create a target for a generic ASIC design. This function will load a stand
 
       # Timing Constraints: Define a "typical" corner for setup/hold analysis.
       # This sets the performance goals for the design.
-      scenario = project.get_timingconstraints().make_scenario("typical")
+      scenario = project.constraint.timing.make_scenario("typical")
       scenario.add_libcorner("typical")
       scenario.set_pexcorner("typical")
       scenario.add_check(["setup", "hold"])
 
       # Physical Constraints: Define the physical layout goals.
       # Here, we aim for 40% core utilization and a 1-micron margin.
-      area = project.get_areaconstraints()
+      area = project.constraint.area
       area.set_density(40)
       area.set_coremargin(1)
 

--- a/docs/reference_manual/schema_api.rst
+++ b/docs/reference_manual/schema_api.rst
@@ -110,6 +110,11 @@ User Classes
 ASIC Constraint Classes
 =======================
 
+.. autoclass:: siliconcompiler.asic.ASICConstraint
+    :members:
+    :show-inheritance:
+    :inherited-members:
+
 .. autoclass:: siliconcompiler.constraints.ASICTimingConstraintSchema
     :members:
     :show-inheritance:
@@ -147,6 +152,11 @@ ASIC Constraint Classes
 
 FPGA Constraint Classes
 =======================
+
+.. autoclass:: siliconcompiler.fpga.FPGAConstraint
+    :members:
+    :show-inheritance:
+    :inherited-members:
 
 .. autoclass:: siliconcompiler.constraints.FPGATimingConstraintSchema
     :members:

--- a/siliconcompiler/asic.py
+++ b/siliconcompiler/asic.py
@@ -3,7 +3,7 @@ import re
 
 from typing import Union, Tuple
 
-from siliconcompiler.schema import EditableSchema, Parameter, Scope
+from siliconcompiler.schema import EditableSchema, Parameter, Scope, BaseSchema
 from siliconcompiler.schema.utils import trim
 
 from siliconcompiler import Project, sc_open
@@ -18,6 +18,60 @@ from siliconcompiler.utils import units
 
 from siliconcompiler import PDK
 from siliconcompiler import StdCellLibrary
+
+
+class ASICConstraint(BaseSchema):
+    """A container for ASIC (Application-Specific Integrated Circuit) design constraints.
+
+    This class aggregates various types of constraints necessary for the physical
+    design flow, such as timing, component placement, pin assignments, and
+    floorplan area.
+    """
+    def __init__(self):
+        """Initializes the ASICConstraint schema."""
+        super().__init__()
+
+        schema = EditableSchema(self)
+        schema.insert("timing", ASICTimingConstraintSchema())
+        schema.insert("component", ASICComponentConstraints())
+        schema.insert("pin", ASICPinConstraints())
+        schema.insert("area", ASICAreaConstraint())
+
+    @property
+    def timing(self) -> ASICTimingConstraintSchema:
+        """Provides access to the timing constraints.
+
+        Returns:
+            ASICTimingConstraintSchema: The schema object for timing constraints.
+        """
+        return self.get("timing", field="schema")
+
+    @property
+    def component(self) -> ASICComponentConstraints:
+        """Provides access to the component placement constraints.
+
+        Returns:
+            ASICComponentConstraints: The schema object for component constraints.
+        """
+        return self.get("component", field="schema")
+
+    @property
+    def pin(self) -> ASICPinConstraints:
+        """Provides access to pin assignment constraints.
+
+        Returns:
+            ASICPinConstraints: The schema object for pin constraints.
+        """
+        return self.get("pin", field="schema")
+
+    @property
+    def area(self) -> ASICAreaConstraint:
+        """Provides access to the floorplan/area constraints.
+
+        Returns:
+            ASICAreaConstraint: The schema object for area constraints.
+        """
+        return self.get("area", field="schema")
 
 
 class ASICProject(Project):
@@ -35,10 +89,7 @@ class ASICProject(Project):
         super().__init__(design)
 
         schema = EditableSchema(self)
-        schema.insert("constraint", "timing", ASICTimingConstraintSchema())
-        schema.insert("constraint", "component", ASICComponentConstraints())
-        schema.insert("constraint", "pin", ASICPinConstraints())
-        schema.insert("constraint", "area", ASICAreaConstraint())
+        schema.insert("constraint", ASICConstraint())
 
         # Replace metrics with asic metrics
         schema.insert("metric", ASICMetricsSchema(), clobber=True)
@@ -330,41 +381,14 @@ class ASICProject(Project):
         """
         self.set("asic", "delaymodel", model)
 
-    def get_timingconstraints(self) -> ASICTimingConstraintSchema:
-        """
-        Retrieves the ASIC timing constraint schema for the project.
+    @property
+    def constraint(self) -> ASICConstraint:
+        """Provides access to the project's ASIC design constraints.
 
         Returns:
-            ASICTimingConstraintSchema: The timing constraint schema object.
+            ASICConstraint: The schema object containing all design constraints.
         """
-        return self.get("constraint", "timing", field="schema")
-
-    def get_pinconstraints(self) -> ASICPinConstraints:
-        """
-        Retrieves the ASIC pin constraint schema for the project.
-
-        Returns:
-            ASICPinConstraints: The pin constraint schema object.
-        """
-        return self.get("constraint", "pin", field="schema")
-
-    def get_componentconstraints(self) -> ASICComponentConstraints:
-        """
-        Retrieves the ASIC component constraint schema for the project.
-
-        Returns:
-            ASICComponentConstraints: The component constraint schema object.
-        """
-        return self.get("constraint", "component", field="schema")
-
-    def get_areaconstraints(self) -> ASICAreaConstraint:
-        """
-        Retrieves the ASIC area constraint schema for the project.
-
-        Returns:
-            ASICAreaConstraint: The area constraint schema object.
-        """
-        return self.get("constraint", "area", field="schema")
+        return self.get("constraint", field="schema")
 
     def _init_run(self):
         """

--- a/siliconcompiler/targets/asap7_demo.py
+++ b/siliconcompiler/targets/asap7_demo.py
@@ -66,19 +66,19 @@ def asap7_demo(
     # process, voltage, and temperature (PVT) conditions.
 
     # Slow corner: Checks for setup time violations at worst-case conditions.
-    scenario = project.get_timingconstraints().make_scenario("slow")
+    scenario = project.constraint.timing.make_scenario("slow")
     scenario.add_libcorner(["slow", "generic"])
     scenario.set_pexcorner("typical")
     scenario.add_check("setup")
 
     # Typical corner: Used for power analysis under nominal conditions.
-    scenario = project.get_timingconstraints().make_scenario("typical")
+    scenario = project.constraint.timing.make_scenario("typical")
     scenario.add_libcorner(["typical", "generic"])
     scenario.set_pexcorner("typical")
     scenario.add_check("power")
 
     # Fast corner: Checks for hold time violations at best-case conditions.
-    scenario = project.get_timingconstraints().make_scenario("fast")
+    scenario = project.constraint.timing.make_scenario("fast")
     scenario.add_libcorner(["fast", "generic"])
     scenario.set_pexcorner("typical")
     scenario.add_check("hold")
@@ -88,7 +88,7 @@ def asap7_demo(
 
     # 5. Define Physical Design Constraints
     # These constraints guide the place-and-route tools.
-    area = project.get_areaconstraints()
+    area = project.constraint.area
     # Target a core utilization of 40%.
     area.set_density(40)
     # Set a margin of 1 micron around the core area.

--- a/siliconcompiler/targets/freepdk45_demo.py
+++ b/siliconcompiler/targets/freepdk45_demo.py
@@ -58,7 +58,7 @@ def freepdk45_demo(
     # For this demonstration target, a single "typical" timing corner is
     # configured to check for both setup and hold violations. In a real
     # production flow, separate slow and fast corners would be used.
-    scenario = project.get_timingconstraints().make_scenario("typical")
+    scenario = project.constraint.timing.make_scenario("typical")
     scenario.add_libcorner(["typical", "generic"])
     scenario.set_pexcorner("typical")
     scenario.add_check(["setup", "hold"])
@@ -68,7 +68,7 @@ def freepdk45_demo(
 
     # 5. Define Physical Design Constraints
     # These constraints guide the place-and-route tools.
-    area = project.get_areaconstraints()
+    area = project.constraint.area
     # Target a core utilization of 40%.
     area.set_density(40)
     # Set a margin of 1 micron around the core area.

--- a/siliconcompiler/targets/gf180_demo.py
+++ b/siliconcompiler/targets/gf180_demo.py
@@ -61,14 +61,14 @@ def gf180_demo(
 
     # Slow corner: Checks for setup time violations at worst-case conditions
     # (slow process, low voltage).
-    scenario = project.get_timingconstraints().make_scenario("slow")
+    scenario = project.constraint.timing.make_scenario("slow")
     scenario.add_libcorner("slow")
     scenario.set_pexcorner("wst")
     scenario.add_check("setup")
     scenario.set_pin_voltage("VDD", 4.5)
 
     # Typical corner: Used for power analysis under nominal conditions.
-    scenario = project.get_timingconstraints().make_scenario("typical")
+    scenario = project.constraint.timing.make_scenario("typical")
     scenario.add_libcorner("typical")
     scenario.set_pexcorner("typ")
     scenario.add_check("power")
@@ -76,7 +76,7 @@ def gf180_demo(
 
     # Fast corner: Checks for hold time violations at best-case conditions
     # (fast process, high voltage).
-    scenario = project.get_timingconstraints().make_scenario("fast")
+    scenario = project.constraint.timing.make_scenario("fast")
     scenario.add_libcorner("fast")
     scenario.set_pexcorner("bst")
     scenario.add_check("hold")
@@ -87,7 +87,7 @@ def gf180_demo(
 
     # 4. Define Physical Design Constraints
     # These constraints guide the place-and-route tools.
-    area = project.get_areaconstraints()
+    area = project.constraint.area
     # Target a core utilization of 40%.
     area.set_density(40)
     # Set a margin of 1 micron around the core area.

--- a/siliconcompiler/targets/ihp130_demo.py
+++ b/siliconcompiler/targets/ihp130_demo.py
@@ -60,19 +60,19 @@ def ihp130_demo(
     # process, voltage, and temperature (PVT) conditions.
 
     # Slow corner: Checks for setup time violations at worst-case conditions.
-    scenario = project.get_timingconstraints().make_scenario("slow")
+    scenario = project.constraint.timing.make_scenario("slow")
     scenario.add_libcorner("slow")
     scenario.set_pexcorner("typical")
     scenario.add_check("setup")
 
     # Typical corner: Used for power analysis under nominal conditions.
-    scenario = project.get_timingconstraints().make_scenario("typical")
+    scenario = project.constraint.timing.make_scenario("typical")
     scenario.add_libcorner("typical")
     scenario.set_pexcorner("typical")
     scenario.add_check("power")
 
     # Fast corner: Checks for hold time violations at best-case conditions.
-    scenario = project.get_timingconstraints().make_scenario("fast")
+    scenario = project.constraint.timing.make_scenario("fast")
     scenario.add_libcorner("fast")
     scenario.set_pexcorner("typical")
     scenario.add_check("hold")
@@ -82,7 +82,7 @@ def ihp130_demo(
 
     # 5. Define Physical Design Constraints
     # These constraints guide the place-and-route tools.
-    area = project.get_areaconstraints()
+    area = project.constraint.area
     # Target a core utilization of 40%.
     area.set_density(40)
     # Set a margin of 4.8 microns around the core area.

--- a/siliconcompiler/targets/interposer_demo.py
+++ b/siliconcompiler/targets/interposer_demo.py
@@ -44,7 +44,7 @@ def interposer_demo(project: ASICProject):
     # While passive interposers do not have active logic for traditional setup/hold
     # timing analysis, a basic scenario is defined. This can be used for signal
     # integrity analysis, delay extraction, or to satisfy tool requirements.
-    scenario = project.get_timingconstraints().make_scenario("typical")
+    scenario = project.constraint.timing.make_scenario("typical")
     scenario.add_libcorner("typical")
     scenario.set_pexcorner("typical")
     # Checks for setup, hold, and power are included mainly for tool compatibility.
@@ -55,7 +55,7 @@ def interposer_demo(project: ASICProject):
 
     # 4. Define Physical Design Constraints
     # These constraints guide the routing tools.
-    area = project.get_areaconstraints()
+    area = project.constraint.area
     # Target a routing density of 40%.
     area.set_density(40)
     # Set a margin of 1 unit (e.g., microns) around the interposer area.

--- a/siliconcompiler/targets/skywater130_demo.py
+++ b/siliconcompiler/targets/skywater130_demo.py
@@ -61,19 +61,19 @@ def skywater130_demo(
     # process, voltage, and temperature (PVT) conditions.
 
     # Slow corner: Checks for setup time violations at worst-case conditions.
-    scenario = project.get_timingconstraints().make_scenario("slow")
+    scenario = project.constraint.timing.make_scenario("slow")
     scenario.add_libcorner(["slow", "generic"])
     scenario.set_pexcorner("typical")
     scenario.add_check("setup")
 
     # Typical corner: Used for power analysis under nominal conditions.
-    scenario = project.get_timingconstraints().make_scenario("typical")
+    scenario = project.constraint.timing.make_scenario("typical")
     scenario.add_libcorner(["typical", "generic"])
     scenario.set_pexcorner("typical")
     scenario.add_check("power")
 
     # Fast corner: Checks for hold time violations at best-case conditions.
-    scenario = project.get_timingconstraints().make_scenario("fast")
+    scenario = project.constraint.timing.make_scenario("fast")
     scenario.add_libcorner(["fast", "generic"])
     scenario.set_pexcorner("typical")
     scenario.add_check("hold")
@@ -83,7 +83,7 @@ def skywater130_demo(
 
     # 5. Define Physical Design Constraints
     # These constraints guide the place-and-route tools.
-    area = project.get_areaconstraints()
+    area = project.constraint.area
     # Target a core utilization of 40%.
     area.set_density(40)
     # Set a margin of 1 micron around the core area.

--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -477,7 +477,7 @@ class APRTask(OpenROADTask):
                 self.add_required_key("library", lib, "fileset", fileset, "file", "tcl")
 
         libcorners = set()
-        for scenario in self.project.get_timingconstraints().get_scenario().values():
+        for scenario in self.project.constraint.timing.get_scenario().values():
             libcorners.update(scenario.get_libcorner(self.step, self.index))
         delay_model = self.project.get("asic", "delaymodel")
         for asiclib in self.project.get("asic", "asiclib"):

--- a/siliconcompiler/tools/opensta/timing.py
+++ b/siliconcompiler/tools/opensta/timing.py
@@ -198,7 +198,7 @@ class TimingTask(TimingTaskBase):
                 self.add_required_key(obj, *key)
 
         added_spef = False
-        for scenario in self.project.get_timingconstraints().get_scenario().values():
+        for scenario in self.project.constraint.timing.get_scenario().values():
             if scenario.get("pexcorner") is None:
                 continue
             if f"{self.design_topmodule}.{scenario.get('pexcorner')}.spef" in \
@@ -206,7 +206,7 @@ class TimingTask(TimingTaskBase):
                 self.add_input_file(ext=f"{scenario.get('pexcorner')}.spef")
                 added_spef = True
         if not added_spef:
-            for scenario in self.project.get_timingconstraints().get_scenario().values():
+            for scenario in self.project.constraint.timing.get_scenario().values():
                 if scenario.get("pexcorner") is None:
                     continue
                 if f"{self.design_topmodule}.{scenario.get('pexcorner')}.sdf" in \

--- a/tests/data/defaults.json
+++ b/tests/data/defaults.json
@@ -8350,6 +8350,10 @@
             "class": "siliconcompiler.constraints/FPGAPinConstraints",
             "sctype": "BaseSchema"
           }
+        },
+        "__meta__": {
+          "class": "siliconcompiler.fpga/FPGAConstraint",
+          "sctype": "BaseSchema"
         }
       },
       "fpga": {
@@ -13715,6 +13719,10 @@
             "class": "siliconcompiler.constraints.asic_floorplan/ASICAreaConstraint",
             "sctype": "BaseSchema"
           }
+        },
+        "__meta__": {
+          "class": "siliconcompiler.asic/ASICConstraint",
+          "sctype": "BaseSchema"
         }
       },
       "asic": {

--- a/tests/test_asic.py
+++ b/tests/test_asic.py
@@ -6,7 +6,7 @@ import os.path
 from unittest.mock import patch
 
 from siliconcompiler import ASICProject, Design, Flowgraph
-from siliconcompiler.asic import ASICTask
+from siliconcompiler.asic import ASICTask, ASICConstraint
 from siliconcompiler.library import ToolLibrarySchema
 
 from siliconcompiler.asic import CellArea
@@ -78,6 +78,7 @@ def test_keys_asic():
 
 
 def test_keys_constraint():
+    assert isinstance(ASICProject().get("constraint", field="schema"), ASICConstraint)
     assert ASICProject().getkeys("constraint") == (
         'area',
         'component',
@@ -197,28 +198,10 @@ def test_add_asiclib_clobber():
     assert proj.get("asic", "asiclib") == ["lib2"]
 
 
-def test_get_timingconstraints():
+def test_constraint():
     proj = ASICProject()
-    assert isinstance(proj.get_timingconstraints(), ASICTimingConstraintSchema)
-    assert proj.get("constraint", "timing", field="schema") is proj.get_timingconstraints()
-
-
-def test_get_pinconstraints():
-    proj = ASICProject()
-    assert isinstance(proj.get_pinconstraints(), ASICPinConstraints)
-    assert proj.get("constraint", "pin", field="schema") is proj.get_pinconstraints()
-
-
-def test_get_componentconstraints():
-    proj = ASICProject()
-    assert isinstance(proj.get_componentconstraints(), ASICComponentConstraints)
-    assert proj.get("constraint", "component", field="schema") is proj.get_componentconstraints()
-
-
-def test_get_areaconstraints():
-    proj = ASICProject()
-    assert isinstance(proj.get_areaconstraints(), ASICAreaConstraint)
-    assert proj.get("constraint", "area", field="schema") is proj.get_areaconstraints()
+    assert isinstance(proj.constraint, ASICConstraint)
+    assert proj.get("constraint", field="schema") is proj.constraint
 
 
 def test_set_asic_routinglayers():
@@ -937,3 +920,27 @@ def test_snapshot_info_metrics_mixed_nodes(running_project):
         ("Area", "20.000um^2"),
         ("Fmax", "5.000Hz")
     ]
+
+
+def test_constraint_timing():
+    const = ASICConstraint()
+    assert isinstance(const.timing, ASICTimingConstraintSchema)
+    assert const.get("timing", field="schema") is const.timing
+
+
+def test_constraint_pin():
+    const = ASICConstraint()
+    assert isinstance(const.pin, ASICPinConstraints)
+    assert const.get("pin", field="schema") is const.pin
+
+
+def test_constraint_component():
+    const = ASICConstraint()
+    assert isinstance(const.component, ASICComponentConstraints)
+    assert const.get("component", field="schema") is const.component
+
+
+def test_constraint_area():
+    const = ASICConstraint()
+    assert isinstance(const.area, ASICAreaConstraint)
+    assert const.get("area", field="schema") is const.area

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -7,6 +7,7 @@ from siliconcompiler import FPGA, FPGAProject
 from siliconcompiler.metrics import FPGAMetricsSchema
 from siliconcompiler.constraints import FPGAComponentConstraints, \
     FPGAPinConstraints, FPGATimingConstraintSchema
+from siliconcompiler.fpga import FPGAConstraint
 
 
 def test_set_add():
@@ -69,6 +70,7 @@ def test_project_keys_fpga():
 
 
 def test_project_keys_constraint():
+    assert isinstance(FPGAProject().get("constraint", field="schema"), FPGAConstraint)
     assert FPGAProject().getkeys("constraint") == (
         'component',
         'pin',
@@ -84,22 +86,10 @@ def test_project_getdict_type():
     assert FPGAProject._getdict_type() == "FPGAProject"
 
 
-def test_project_get_timingconstraints():
+def test_project_constraint():
     proj = FPGAProject()
-    assert isinstance(proj.get_timingconstraints(), FPGATimingConstraintSchema)
-    assert proj.get("constraint", "timing", field="schema") is proj.get_timingconstraints()
-
-
-def test_project_get_pinconstraints():
-    proj = FPGAProject()
-    assert isinstance(proj.get_pinconstraints(), FPGAPinConstraints)
-    assert proj.get("constraint", "pin", field="schema") is proj.get_pinconstraints()
-
-
-def test_project_get_componentconstraints():
-    proj = FPGAProject()
-    assert isinstance(proj.get_componentconstraints(), FPGAComponentConstraints)
-    assert proj.get("constraint", "component", field="schema") is proj.get_componentconstraints()
+    assert isinstance(proj.constraint, FPGAConstraint)
+    assert proj.get("constraint", field="schema") is proj.constraint
 
 
 def test_project_add_dep_list():
@@ -197,3 +187,21 @@ def test_project_set_fpga_obj():
     proj.set_fpga(fpga)
     assert proj.get("fpga", "device") == "thisfpga"
     assert proj.get("library", "thisfpga", field="schema") is fpga
+
+
+def test_constraint_timing():
+    const = FPGAConstraint()
+    assert isinstance(const.timing, FPGATimingConstraintSchema)
+    assert const.get("timing", field="schema") is const.timing
+
+
+def test_constraint_pin():
+    const = FPGAConstraint()
+    assert isinstance(const.pin, FPGAPinConstraints)
+    assert const.get("pin", field="schema") is const.pin
+
+
+def test_constraint_component():
+    const = FPGAConstraint()
+    assert isinstance(const.component, FPGAComponentConstraints)
+    assert const.get("component", field="schema") is const.component


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Unified constraints access: use project.constraint.[timing|area|pin|component] for ASIC and FPGA.
  - FPGA constructor accepts an optional device name on initialization.

- Refactor
  - Replaced multiple per-type constraint getters with a single constraint property; tools updated to use the new path with no behavior change.

- Documentation
  - Added reference entries for ASICConstraint and FPGAConstraint; guides updated to reflect new access pattern.

- Tests
  - Expanded tests to cover the unified constraints API.

- Chores
  - Updated schema metadata to align constraint classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->