### PR TITLE
fix docstring on fpga

### DIFF
--- a/siliconcompiler/fpga.py
+++ b/siliconcompiler/fpga.py
@@ -117,7 +117,7 @@ class FPGAProject(Project):
 
         Creates the base Project, inserts an FPGAConstraint container at "constraint",
         adds FPGA metrics under "metric" (clobber allowed), and registers the
-        string parameter "fpga.device" for selecting the target FPGA device.
+        string parameter :keypath:`FPGAProject,fpga,device` for selecting the target FPGA device.
 
         Parameters:
             design (optional): Optional project design data passed to the base Project.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated FPGA project documentation to use keypath-based parameter notation for device selection, improving clarity and consistency with current configuration guidelines.
  * Enhances readability and reduces ambiguity when referencing configuration parameters in examples and guides.
  * No functional changes: existing workflows, commands, and APIs remain unchanged.
  * No migration required; the update is purely informational for better alignment with current documentation conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->