### PR TITLE
remove double the

### DIFF
--- a/siliconcompiler/checklist.py
+++ b/siliconcompiler/checklist.py
@@ -320,7 +320,7 @@ def schema_checklist(schema):
                 "cli: -checklist_rationale 'ISO D000 reliability'",
                 "api: check.set('checklist', 'ISO', 'D000', 'rationale', 'reliability')"],
             help=trim("""
-            Rationale for the the checklist item. Rationale should be a
+            Rationale for the checklist item. Rationale should be a
             unique alphanumeric code used by the standard or a short one line
             or single word description.""")))
 

--- a/tests/data/defaults.json
+++ b/tests/data/defaults.json
@@ -166,7 +166,7 @@
                 "cli: -checklist_rationale 'ISO D000 reliability'",
                 "api: check.set('checklist', 'ISO', 'D000', 'rationale', 'reliability')"
               ],
-              "help": "Rationale for the the checklist item. Rationale should be a\nunique alphanumeric code used by the standard or a short one line\nor single word description.",
+              "help": "Rationale for the checklist item. Rationale should be a\nunique alphanumeric code used by the standard or a short one line\nor single word description.",
               "notes": null,
               "pernode": "never",
               "node": {
@@ -3216,7 +3216,7 @@
                 "cli: -checklist_rationale 'ISO D000 reliability'",
                 "api: check.set('checklist', 'ISO', 'D000', 'rationale', 'reliability')"
               ],
-              "help": "Rationale for the the checklist item. Rationale should be a\nunique alphanumeric code used by the standard or a short one line\nor single word description.",
+              "help": "Rationale for the checklist item. Rationale should be a\nunique alphanumeric code used by the standard or a short one line\nor single word description.",
               "notes": null,
               "pernode": "never",
               "node": {
@@ -7025,7 +7025,7 @@
                 "cli: -checklist_rationale 'ISO D000 reliability'",
                 "api: check.set('checklist', 'ISO', 'D000', 'rationale', 'reliability')"
               ],
-              "help": "Rationale for the the checklist item. Rationale should be a\nunique alphanumeric code used by the standard or a short one line\nor single word description.",
+              "help": "Rationale for the checklist item. Rationale should be a\nunique alphanumeric code used by the standard or a short one line\nor single word description.",
               "notes": null,
               "pernode": "never",
               "node": {
@@ -11742,7 +11742,7 @@
                 "cli: -checklist_rationale 'ISO D000 reliability'",
                 "api: check.set('checklist', 'ISO', 'D000', 'rationale', 'reliability')"
               ],
-              "help": "Rationale for the the checklist item. Rationale should be a\nunique alphanumeric code used by the standard or a short one line\nor single word description.",
+              "help": "Rationale for the checklist item. Rationale should be a\nunique alphanumeric code used by the standard or a short one line\nor single word description.",
               "notes": null,
               "pernode": "never",
               "node": {
@@ -14792,7 +14792,7 @@
                 "cli: -checklist_rationale 'ISO D000 reliability'",
                 "api: check.set('checklist', 'ISO', 'D000', 'rationale', 'reliability')"
               ],
-              "help": "Rationale for the the checklist item. Rationale should be a\nunique alphanumeric code used by the standard or a short one line\nor single word description.",
+              "help": "Rationale for the checklist item. Rationale should be a\nunique alphanumeric code used by the standard or a short one line\nor single word description.",
               "notes": null,
               "pernode": "never",
               "node": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the rationale help text for checklist items by removing a duplicated word (“the”).
  * Updated help/descriptive strings to improve readability and clarity across relevant checklist help outputs.
  * No changes to behavior or functionality; this update is purely textual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->