### PR TITLE
rename projects to remove extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ python3 -m pip install --upgrade siliconcompiler
 Converting RTL into DRC clean GDS takes 13 lines of simple Python code.
 
 ```python
-from siliconcompiler import ASICProject, Design        # import python package
+from siliconcompiler import ASIC, Design               # import python package
 from siliconcompiler.targets import skywater130_demo
 design = Design("heartbeat")                           # create design object
 design.set_topmodule("heartbeat", fileset="rtl")       # set top module
 design.add_file("heartbeat.v", fileset="rtl")          # add input sources
 design.add_file("heartbeat.sdc", fileset="sdc")        # add input sources
-project = ASICProject(design)                          # create project
+project = ASIC(design)                                 # create project
 project.add_fileset(["rtl", "sdc"])                    # enable filesets
 skywater130_demo(project)                              # load a pre-defined target
 project.set('option','remote', True)                   # enable remote execution

--- a/docs/development_guide/libraries.rst
+++ b/docs/development_guide/libraries.rst
@@ -72,7 +72,7 @@ To use either of these libraries in your design, you would instantiate the class
 
   import siliconcompiler
 
-  project = siliconcompiler.ASICProject()
+  project = siliconcompiler.ASIC()
 
   # Instantiate and add the hard IP library.
   hard_ip_lib = FakeHardIPLibrary()

--- a/docs/development_guide/pdks.rst
+++ b/docs/development_guide/pdks.rst
@@ -8,7 +8,7 @@ These kits are often complex and vary significantly between foundries.
 
 SiliconCompiler simplifies this by providing a standardized Python object, the :class:`.PDK`, to define and package a PDK.
 This object acts as a structured "manifest" that describes the PDK's properties and points to all the necessary files.
-Once defined, a PDK can be easily reused and loaded into any project with a single command: :meth:`.ASICProject.set_pdk()`.
+Once defined, a PDK can be easily reused and loaded into any project with a single command: :meth:`.ASIC.set_pdk()`.
 
 Key Concepts
 ------------
@@ -81,7 +81,7 @@ To use this PDK, you would instantiate it and pass it to your project:
   import siliconcompiler
 
   # Create a project
-  project = siliconcompiler.ASICProject()
+  project = siliconcompiler.ASIC()
 
   # Instantiate and set the PDK
   pdk = ExamplePDK()

--- a/docs/development_guide/targets.rst
+++ b/docs/development_guide/targets.rst
@@ -43,7 +43,7 @@ Let's create a target for a generic ASIC design. This function will load a stand
 
 .. code-block:: python
 
-  from siliconcompiler import ASICProject
+  from siliconcompiler import ASIC
   from siliconcompiler.flows import asicflow
   from siliconcompiler.tools.yosys import syn_asic
   from siliconcompiler.tools import get_task
@@ -53,7 +53,7 @@ Let's create a target for a generic ASIC design. This function will load a stand
   from my_designs.pdks import my_freepdk45
   from my_designs.libs import my_nangate45
 
-  def my_asic_target(project: ASICProject,
+  def my_asic_target(project: ASIC,
                      # Targets can be parameterized. Here, we allow the user
                      # to specify the number of cores for parallelizable steps.
                      place_np=1,
@@ -97,7 +97,7 @@ Once the target function is defined, you can load it into your project like this
   import siliconcompiler
 
   # Create a project
-  project = siliconcompiler.ASICProject()
+  project = siliconcompiler.ASIC()
 
   # Load the entire configuration by calling the target function.
   # We can also pass values for the parameterized arguments.

--- a/docs/reference_manual/schema.rst
+++ b/docs/reference_manual/schema.rst
@@ -107,24 +107,24 @@ Project Parameters
   :ref_root: Project
 
 .. schema::
-  :root: siliconcompiler/ASICProject
+  :root: siliconcompiler/ASIC
   :schema_only:
-  :ref_root: ASICProject
+  :ref_root: ASIC
 
 .. schema::
-  :root: siliconcompiler/FPGAProject
+  :root: siliconcompiler/FPGA
   :schema_only:
-  :ref_root: FPGAProject
+  :ref_root: FPGA
 
 .. schema::
-  :root: siliconcompiler/LintProject
+  :root: siliconcompiler/Lint
   :schema_only:
-  :ref_root: LintProject
+  :ref_root: Lint
 
 .. schema::
-  :root: siliconcompiler/SimProject
+  :root: siliconcompiler/Sim
   :schema_only:
-  :ref_root: SimProject
+  :ref_root: Sim
 
 Library Parameters
 ------------------

--- a/docs/reference_manual/schema_api.rst
+++ b/docs/reference_manual/schema_api.rst
@@ -46,25 +46,25 @@ Project Classes
     :inherited-members:
 
 
-.. autoclass:: siliconcompiler.ASICProject
+.. autoclass:: siliconcompiler.ASIC
     :members:
     :show-inheritance:
     :inherited-members:
 
 
-.. autoclass:: siliconcompiler.FPGAProject
+.. autoclass:: siliconcompiler.FPGA
     :members:
     :show-inheritance:
     :inherited-members:
 
 
-.. autoclass:: siliconcompiler.LintProject
+.. autoclass:: siliconcompiler.Lint
     :members:
     :show-inheritance:
     :inherited-members:
 
 
-.. autoclass:: siliconcompiler.SimProject
+.. autoclass:: siliconcompiler.Sim
     :members:
     :show-inheritance:
     :inherited-members:
@@ -331,7 +331,7 @@ Inheritance
 ===========
 
 .. scclassinherit::
-    :classes: siliconcompiler/ASICProject,siliconcompiler/FPGAProject,siliconcompiler/LintProject,siliconcompiler/SimProject
+    :classes: siliconcompiler/ASIC,siliconcompiler/FPGA,siliconcompiler/Lint,siliconcompiler/Sim
 
 .. scclassinherit::
     :classes: siliconcompiler/Design,siliconcompiler/PDK,siliconcompiler/FPGADevice,siliconcompiler/StdCellLibrary,siliconcompiler/Flowgraph,siliconcompiler/Checklist,siliconcompiler/Task

--- a/docs/user_guide/faq.rst
+++ b/docs/user_guide/faq.rst
@@ -40,8 +40,8 @@ How do I...
 
    .. code-block:: python
 
-      from siliconcompiler import ASICProject
-      project = ASICProject(design)
+      from siliconcompiler import ASIC
+      project = ASIC(design)
 
 ... active filesets?
 

--- a/docs/user_guide/quickstart.rst
+++ b/docs/user_guide/quickstart.rst
@@ -29,7 +29,7 @@ The following code snippet below shows how the :ref:`demo design <asic_demo>` wa
 
     #!/usr/bin/env python3
 
-    from siliconcompiler import ASICProject, Design  # import python package
+    from siliconcompiler import ASIC, Design  # import python package
     from siliconcompiler.targets import skywater130_demo
 
     if __name__ == "__main__":
@@ -37,7 +37,7 @@ The following code snippet below shows how the :ref:`demo design <asic_demo>` wa
         design.set_topmodule("heartbeat", fileset="rtl")       # set top module
         design.add_file("heartbeat.v", fileset="rtl")          # add input sources
         design.add_file("heartbeat.sdc", fileset="sdc")        # add input sources
-        project = ASICProject(design)                          # create project
+        project = ASIC(design)                          # create project
         project.add_fileset(["rtl", "sdc"])                    # enable filesets
         skywater130_demo(project)                              # load a pre-defined target
         project.set('option','remote', True)                   # enable remote execution
@@ -51,14 +51,14 @@ The following sub-sections will describe each line in more detail.
 Project and Design Creation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The hardware build flow centers around two main objects: the :class:`.Design`, which holds design-specific information, and the :class:`.ASICProject`, which manages project settings and execution.
+The hardware build flow centers around two main objects: the :class:`.Design`, which holds design-specific information, and the :class:`.ASIC`, which manages project settings and execution.
 
 .. code-block:: python
 
-    from siliconcompiler import ASICProject, Design
+    from siliconcompiler import ASIC, Design
 
     design = Design("heartbeat")
-    project = ASICProject(design)
+    project = ASIC(design)
 
 Defining the Design
 ^^^^^^^^^^^^^^^^^^^

--- a/examples/aes/aes.py
+++ b/examples/aes/aes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Import the core classes from the siliconcompiler library.
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 # Import a pre-defined "target" which sets up a specific PDK,
 # standard cell library, and tool flow.
 from siliconcompiler.targets import freepdk45_demo
@@ -37,9 +37,9 @@ def main():
         design.add_file("aes.sdc")
 
     # --- Project Setup ---
-    # The ASICProject object links the design blueprint to a specific
+    # The ASIC object links the design blueprint to a specific
     # technology target and compilation flow.
-    project = ASICProject(design)
+    project = ASIC(design)
 
     # Tell the project which filesets to use for this compilation run.
     # Both the RTL source and the SDC constraints are needed.

--- a/examples/blinky/blinky.py
+++ b/examples/blinky/blinky.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 # Import the necessary classes for an FPGA project. Note the use of
-# FPGAProject, which is specific to FPGA flows.
-from siliconcompiler import FPGAProject, Design
+# FPGA, which is specific to FPGA flows.
+from siliconcompiler import FPGA, Design
 # Import a pre-defined flow for FPGAs.
 from siliconcompiler.flows import fpgaflow
 from siliconcompiler.fpgas.lattice_ice40 import ICE40Up5k_sg48
@@ -36,8 +36,8 @@ def main():
         design.add_file("icebreaker.pcf")
 
     # --- Project Setup ---
-    # Create an FPGAProject, which is tailored for FPGA-specific needs.
-    project = FPGAProject(design)
+    # Create an FPGA, which is tailored for FPGA-specific needs.
+    project = FPGA(design)
 
     # Tell the project which filesets are required for this compilation.
     project.add_fileset("rtl")

--- a/examples/fibone/fibone.py
+++ b/examples/fibone/fibone.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Import the core classes from the siliconcompiler library.
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 # Import a pre-defined target for the FreePDK45 process.
 from siliconcompiler.targets import freepdk45_demo
 # Import the base ASIC flow to customize it.
@@ -34,7 +34,7 @@ def main():
 
     # --- Project Setup ---
     # Create a standard ASIC project.
-    project = ASICProject(design)
+    project = ASIC(design)
 
     # Tell the project to use the "rtl" fileset we defined.
     project.add_fileset("rtl")

--- a/examples/gcd/gcd.py
+++ b/examples/gcd/gcd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2020-2025 Silicon Compiler Authors. All Rights Reserved.
 
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 from siliconcompiler.targets import freepdk45_demo
 
 
@@ -34,7 +34,7 @@ def main():
 
     # --- Project Setup ---
     # Create an ASIC project from the design configuration.
-    project = ASICProject(design)
+    project = ASIC(design)
 
     # Tell the project which filesets are needed for the compilation flow.
     project.add_fileset(["rtl", "sdc"])

--- a/examples/gcd/gcd_chisel.py
+++ b/examples/gcd/gcd_chisel.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Import the core classes from the siliconcompiler library.
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 # Import a pre-defined target for the FreePDK45 process.
 from siliconcompiler.targets import freepdk45_demo
 # Import a specialized flow designed to handle Chisel source files.
@@ -37,7 +37,7 @@ def main():
 
     # --- Project Setup ---
     # Create an ASIC project from the design configuration.
-    project = ASICProject(design)
+    project = ASIC(design)
 
     # Tell the project which filesets are needed for the compilation flow.
     project.add_fileset(["rtl", "sdc"])

--- a/examples/gcd/gcd_gf180.py
+++ b/examples/gcd/gcd_gf180.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2020-2025 Silicon Compiler Authors. All Rights Reserved.
 
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 # Import the target for the GlobalFoundries 180nm open source PDK.
 from siliconcompiler.targets import gf180_demo
 
@@ -35,7 +35,7 @@ def main():
 
     # --- Project Setup ---
     # Create an ASIC project from the design configuration.
-    project = ASICProject(design)
+    project = ASIC(design)
 
     # Tell the project which filesets are needed for the compilation flow.
     project.add_fileset(["rtl", "sdc"])

--- a/examples/gcd/gcd_hls.py
+++ b/examples/gcd/gcd_hls.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2020-2025 Silicon Compiler Authors. All Rights Reserved.
 
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 from siliconcompiler.targets import freepdk45_demo
 # Import a specialized flow designed to handle High-Level Synthesis.
 from siliconcompiler.flows.asicflow import HLSASICFlow
@@ -36,7 +36,7 @@ def main():
 
     # --- Project Setup ---
     # Create an ASIC project from the design configuration.
-    project = ASICProject(design)
+    project = ASIC(design)
 
     # Enable the necessary filesets for the compilation flow.
     project.add_fileset(["rtl", "sdc"])

--- a/examples/gcd/gcd_ihp130.py
+++ b/examples/gcd/gcd_ihp130.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2024-2025 Silicon Compiler Authors. All Rights Reserved.
 
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 # Import the target for the IHP 130nm open source PDK.
 from siliconcompiler.targets import ihp130_demo
 # Import the specialized flow for running only DRC.
@@ -38,7 +38,7 @@ def main():
 
     # --- Project Setup ---
     # Create an ASIC project from the design configuration.
-    project = ASICProject(design)
+    project = ASIC(design)
 
     # Tell the project which filesets are needed for the compilation flow.
     project.add_fileset(["rtl", "sdc"])

--- a/examples/gcd/gcd_skywater.py
+++ b/examples/gcd/gcd_skywater.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 # Import the target for the Skywater 130nm open source PDK.
 from siliconcompiler.targets import skywater130_demo
 # Import the specialized flow for running signoff checks (DRC and LVS).
@@ -34,7 +34,7 @@ def main():
 
     # --- Project Setup ---
     # Create an ASIC project from the design configuration.
-    project = ASICProject(design)
+    project = ASIC(design)
 
     # Tell the project which filesets are needed for the compilation flow.
     project.add_fileset(["rtl", "sdc"])

--- a/examples/ghdl_fsynopsys/build.py
+++ b/examples/ghdl_fsynopsys/build.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Import the core classes from the siliconcompiler library.
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 # Import a pre-defined target for the FreePDK45 process.
 from siliconcompiler.targets import freepdk45_demo
 # Import a specialized flow designed to handle VHDL source files.
@@ -32,7 +32,7 @@ def main():
 
     # --- Project Setup ---
     # Create a standard ASIC project.
-    project = ASICProject(design)
+    project = ASIC(design)
 
     # Tell the project to use the "rtl" fileset we defined.
     project.add_fileset("rtl")

--- a/examples/heartbeat/heartbeat.py
+++ b/examples/heartbeat/heartbeat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2020-2025 Silicon Compiler Authors. All Rights Reserved.
 
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 from siliconcompiler.targets import skywater130_demo
 
 
@@ -27,7 +27,7 @@ def main():
     design.add_file("heartbeat.sdc", dataroot="heartbeat", fileset="sdc")
 
     # Create an ASIC project from the design configuration.
-    project = ASICProject(design)
+    project = ASIC(design)
 
     # Enable the necessary filesets for the compilation flow.
     project.add_fileset(["rtl", "sdc"])

--- a/examples/heartbeat/make.py
+++ b/examples/heartbeat/make.py
@@ -2,8 +2,8 @@
 # Copyright 2025 Silicon Compiler Authors. All Rights Reserved.
 
 from siliconcompiler import Design, FPGADevice
-from siliconcompiler.project import LintProject, SimProject
-from siliconcompiler import ASICProject, FPGAProject
+from siliconcompiler.project import Lint, Sim
+from siliconcompiler import ASIC, FPGA
 
 from siliconcompiler.flows.lintflow import LintFlow
 from siliconcompiler.flows.dvflow import DVFlow
@@ -79,7 +79,7 @@ def lint(N: str = None):
             Defaults to None, which uses the value set in the design schema.
     """
     # Create a project instance tailored for linting.
-    project = LintProject()
+    project = Lint()
 
     # Instantiate the design configuration.
     hb = HeartbeatDesign()
@@ -115,7 +115,7 @@ def syn(pdk: str = "freepdk45", N: str = None):
             Defaults to None, which uses the value set in the design schema.
     """
     # Create a project instance for an ASIC flow.
-    project = ASICProject()
+    project = ASIC()
 
     # Instantiate and configure the design.
     hb = HeartbeatDesign()
@@ -152,7 +152,7 @@ def asic(pdk: str = "freepdk45", N: str = None):
             Defaults to None, which uses the value set in the design schema.
     """
     # Create a project instance for an ASIC flow.
-    project = ASICProject()
+    project = ASIC()
 
     # Instantiate and configure the design.
     hb = HeartbeatDesign()
@@ -190,7 +190,7 @@ def sim(N: str = None, tool: str = "verilator"):
             'icarus'). Defaults to "verilator".
     """
     # Create a project instance tailored for simulation.
-    project = SimProject()
+    project = Sim()
 
     # Instantiate and configure the design.
     hb = HeartbeatDesign()
@@ -230,7 +230,7 @@ def fpga(N: str = None):
             Defaults to None, which uses the value set in the design schema.
     """
     # Create a project instance for an FPGA flow.
-    project = FPGAProject()
+    project = FPGA()
 
     # Instantiate and configure the design.
     hb = HeartbeatDesign()

--- a/examples/heartbeat/make.py
+++ b/examples/heartbeat/make.py
@@ -2,7 +2,7 @@
 # Copyright 2025 Silicon Compiler Authors. All Rights Reserved.
 
 from siliconcompiler import Design, FPGADevice
-from siliconcompiler.project import Lint, Sim
+from siliconcompiler import Lint, Sim
 from siliconcompiler import ASIC, FPGA
 
 from siliconcompiler.flows.lintflow import LintFlow

--- a/examples/heartbeat/make.py
+++ b/examples/heartbeat/make.py
@@ -249,7 +249,7 @@ def fpga(N: str = None):
 
     # Optionally override the 'N' parameter.
     if N is not None:
-        hb.set_param("N", N, fileset="testbench")
+        hb.set_param("N", N, fileset="rtl")
 
     # Run the FPGA flow (synthesis, place, route, bitstream generation).
     project.run()

--- a/examples/heartbeat_migen/heartbeat_migen.py
+++ b/examples/heartbeat_migen/heartbeat_migen.py
@@ -9,7 +9,7 @@ from migen.fhdl.verilog import convert
 
 # Import the core classes from the siliconcompiler library.
 from siliconcompiler import Design
-from siliconcompiler import ASICProject
+from siliconcompiler import ASIC
 # Import a pre-defined target for the FreePDK45 process.
 from siliconcompiler.targets import freepdk45_demo
 
@@ -88,7 +88,7 @@ def main():
 
     # --- SiliconCompiler Project Setup ---
     # Create an ASIC project from the design configuration.
-    project = ASICProject(design)
+    project = ASIC(design)
 
     # Tell the project which filesets are needed for the compilation flow.
     project.add_fileset(["rtl", "sdc"])

--- a/examples/interposer/interposer.py
+++ b/examples/interposer/interposer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2024 Silicon Compiler Authors. All Rights Reserved.
 
-from siliconcompiler import ASICProject, Design, Flowgraph
+from siliconcompiler import ASIC, Design, Flowgraph
 # Import a specialized target for interposer designs. This target is configured
 # with a technology setup (like layer stack) suitable for routing on an
 # interposer, which typically lacks standard cells.
@@ -35,7 +35,7 @@ def main():
 
     # --- Project Setup ---
     # Create a project, linking the design to a flow and target.
-    project = ASICProject(design)
+    project = ASIC(design)
 
     # Add the netlist fileset to the project for this run.
     project.add_fileset("netlist")

--- a/examples/interposer/interposer.py
+++ b/examples/interposer/interposer.py
@@ -47,7 +47,7 @@ def main():
     # Explicitly define the physical dimensions of the interposer die.
     # This is a critical piece of information for the routing tool.
     # The dimensions are specified in microns (width, height).
-    project.get_areaconstituents().set_diearea_rectangle(1000, 500)
+    project.constraint.area.set_diearea_rectangle(1000, 500)
 
     # --- Custom Flowgraph Creation ---
     # We will build a custom flow by combining two pre-defined flows.

--- a/examples/mlir_hls/mlir_hls.py
+++ b/examples/mlir_hls/mlir_hls.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Import necessary classes from the siliconcompiler library.
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 # Import a pre-defined target, which sets up the PDK, libraries, and toolchain.
 from siliconcompiler.targets import freepdk45_demo
 # Import the specialized High-Level Synthesis (HLS) flow.
@@ -29,9 +29,9 @@ def main():
         design.add_file("main_kernel.ll")
 
     # --- Project Setup ---
-    # An ASICProject links the design's sources to a specific physical
+    # An ASIC links the design's sources to a specific physical
     # implementation flow and target technology.
-    project = ASICProject(design)
+    project = ASIC(design)
 
     # Tell the project which fileset to use for the run.
     project.add_fileset("rtl")

--- a/examples/oh_experiments/adder_sweep.py
+++ b/examples/oh_experiments/adder_sweep.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Import necessary classes from the siliconcompiler library.
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 # Import a pre-defined target, which sets up the process technology (PDK),
 # standard cell libraries, and toolchain.
 from siliconcompiler.targets import freepdk45_demo
@@ -47,8 +47,8 @@ def main():
             design.set_param("N", str(n))
 
     # --- Project Setup ---
-    # An ASICProject links a design schema to a specific flow and target.
-    proj = ASICProject(design)
+    # An ASIC links a design schema to a specific flow and target.
+    proj = ASIC(design)
     # Load the freepdk45_demo target, which configures the project for the
     # FreePDK45 technology and a demonstration tool setup.
     freepdk45_demo(proj)

--- a/examples/oh_experiments/check_area.py
+++ b/examples/oh_experiments/check_area.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Import necessary classes from the siliconcompiler library.
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 # Import a pre-defined target, which sets up the PDK, libraries, and toolchain.
 from siliconcompiler.targets import freepdk45_demo
 
@@ -14,7 +14,7 @@ import os.path
 from typing import Callable, List
 
 
-def checkarea(design: Design, filesets: List[str], target: Callable[[ASICProject], None]):
+def checkarea(design: Design, filesets: List[str], target: Callable[[ASIC], None]):
     '''Runs synthesis for a list of designs and reports the area.
 
     This function iterates through a provided list of filesets (each representing
@@ -24,7 +24,7 @@ def checkarea(design: Design, filesets: List[str], target: Callable[[ASICProject
     Args:
         design (Design): The master design object containing all filesets.
         filesets (List[str]): A list of fileset names to process.
-        target (Callable[[ASICProject], None]): A SiliconCompiler target setup function, such as
+        target (Callable[[ASIC], None]): A SiliconCompiler target setup function, such as
             freepdk45_demo.
     '''
 
@@ -33,9 +33,9 @@ def checkarea(design: Design, filesets: List[str], target: Callable[[ASICProject
 
     # Loop through each fileset (i.e., each module) provided.
     for fileset in filesets:
-        # Create a new, clean ASICProject for each module. This is important
+        # Create a new, clean ASIC for each module. This is important
         # to ensure that the settings from one run do not affect the next.
-        proj = ASICProject(design)
+        proj = ASIC(design)
         # Add the specific fileset for the current module to the project.
         proj.add_fileset(fileset)
 

--- a/examples/picorv32/make.py
+++ b/examples/picorv32/make.py
@@ -4,7 +4,7 @@
 # Import necessary classes from the siliconcompiler library.
 from siliconcompiler import Design
 from siliconcompiler import ASIC
-from siliconcompiler.project import Lint
+from siliconcompiler import Lint
 
 # Import pre-defined flows and targets.
 from siliconcompiler.flows.lintflow import LintFlow

--- a/examples/picorv32/make.py
+++ b/examples/picorv32/make.py
@@ -3,8 +3,8 @@
 
 # Import necessary classes from the siliconcompiler library.
 from siliconcompiler import Design
-from siliconcompiler import ASICProject
-from siliconcompiler.project import LintProject
+from siliconcompiler import ASIC
+from siliconcompiler.project import Lint
 
 # Import pre-defined flows and targets.
 from siliconcompiler.flows.lintflow import LintFlow
@@ -81,7 +81,7 @@ def lint(fileset: str = "rtl"):
     Linting checks the code for stylistic errors, syntax issues, and common mistakes.
     """
     # Create a project specifically for linting.
-    project = LintProject()
+    project = Lint()
 
     # Load the design configuration defined in the PicoRV32Design class.
     project.set_design(PicoRV32Design())
@@ -102,7 +102,7 @@ def syn(fileset: str = "rtl", pdk: str = "freepdk45"):
     Synthesis converts the RTL code into a gate-level netlist using a specific PDK.
     """
     # Create a standard ASIC project.
-    project = ASICProject()
+    project = ASIC()
 
     # Load the design configuration.
     project.set_design(PicoRV32Design())
@@ -126,7 +126,7 @@ def asic(fileset: str = "rtl", pdk: str = "freepdk45"):
     Configures and runs the full default ASIC flow (synthesis, place-and-route, etc.).
     """
     # Create a standard ASIC project.
-    project = ASICProject()
+    project = ASIC()
 
     # Load the design configuration.
     project.set_design(PicoRV32Design())

--- a/scripts/methods.py
+++ b/scripts/methods.py
@@ -6,7 +6,7 @@ from argparse import ArgumentParser
 import pandas as pd
 
 from siliconcompiler import Project, ASIC, FPGA, Lint, Sim
-from siliconcompiler import Design, PDK, Flowgraph, Checklist, StdCellLibrary, FPGA
+from siliconcompiler import Design, PDK, Flowgraph, Checklist, StdCellLibrary, FPGADevice
 from siliconcompiler.tool import Task, ShowTask, ScreenshotTask
 from siliconcompiler.asic import ASICTask
 from siliconcompiler.constraints import ASICTimingConstraintSchema, ASICAreaConstraint, \
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     else:
         classes = [
             Project, ASIC, FPGA, Lint, Sim,
-            Design, PDK, Flowgraph, Checklist, StdCellLibrary, FPGA,
+            Design, PDK, Flowgraph, Checklist, StdCellLibrary, FPGADevice,
             Task, ShowTask, ScreenshotTask,
             ASICTask,
             ASICTimingConstraintSchema, ASICAreaConstraint, ASICComponentConstraints,

--- a/scripts/methods.py
+++ b/scripts/methods.py
@@ -5,7 +5,7 @@ from argparse import ArgumentParser
 
 import pandas as pd
 
-from siliconcompiler import Project, ASICProject, FPGAProject, LintProject, SimProject
+from siliconcompiler import Project, ASIC, FPGA, Lint, Sim
 from siliconcompiler import Design, PDK, Flowgraph, Checklist, StdCellLibrary, FPGA
 from siliconcompiler.tool import Task, ShowTask, ScreenshotTask
 from siliconcompiler.asic import ASICTask
@@ -32,7 +32,7 @@ if __name__ == "__main__":
         classes = [schema_cls]
     else:
         classes = [
-            Project, ASICProject, FPGAProject, LintProject, SimProject,
+            Project, ASIC, FPGA, Lint, Sim,
             Design, PDK, Flowgraph, Checklist, StdCellLibrary, FPGA,
             Task, ShowTask, ScreenshotTask,
             ASICTask,

--- a/scripts/profile_sc.py
+++ b/scripts/profile_sc.py
@@ -9,7 +9,7 @@ import tempfile
 import os
 import gprof2dot
 
-from siliconcompiler import ASICProject, Project, Flowgraph, Design
+from siliconcompiler import ASIC, Project, Flowgraph, Design
 from siliconcompiler.demos import asic_demo
 
 
@@ -49,7 +49,7 @@ def run_read_manifest(pr, extra):
     else:
         path = extra
 
-    proj = ASICProject()
+    proj = ASIC()
 
     pr.enable()
     proj.read_manifest(path)

--- a/siliconcompiler/__init__.py
+++ b/siliconcompiler/__init__.py
@@ -52,3 +52,4 @@ __all__ = [
 
 # Back-compat: will be removed in future PR
 ASICProject = ASIC
+LintProject = Lint

--- a/siliconcompiler/__init__.py
+++ b/siliconcompiler/__init__.py
@@ -16,10 +16,10 @@ from siliconcompiler.tool import Task, ShowTask, ScreenshotTask, TaskSkip
 
 # Projects
 from siliconcompiler.project import Project
-from siliconcompiler.asic import ASICProject
-from siliconcompiler.fpga import FPGAProject
-from siliconcompiler.project import LintProject
-from siliconcompiler.project import SimProject
+from siliconcompiler.asic import ASIC
+from siliconcompiler.fpga import FPGA
+from siliconcompiler.project import Lint
+from siliconcompiler.project import Sim
 
 from siliconcompiler.fpga import FPGADevice
 
@@ -43,8 +43,12 @@ __all__ = [
     "ScreenshotTask",
 
     "Project",
-    "ASICProject",
-    "FPGAProject",
-    "LintProject",
-    "SimProject"
+    "ASIC",
+    "FPGA",
+    "Lint",
+    "Sim"
 ]
+
+
+# Back-compat: will be removed in future PR
+ASICProject = ASIC

--- a/siliconcompiler/asic.py
+++ b/siliconcompiler/asic.py
@@ -74,9 +74,9 @@ class ASICConstraint(BaseSchema):
         return self.get("area", field="schema")
 
 
-class ASICProject(Project):
+class ASIC(Project):
     """
-    The ASICProject class extends the base Project class to provide
+    The ASIC class extends the base Project class to provide
     specialized functionality and schema parameters for Application-Specific
     Integrated Circuit (ASIC) design flows.
 
@@ -87,7 +87,7 @@ class ASICProject(Project):
 
     def __init__(self, design=None):
         """
-        Initialize an ASICProject and register ASIC-specific schemas, metrics, and
+        Initialize an ASIC and register ASIC-specific schemas, metrics, and
         global ASIC parameters.
 
         This constructor sets up an EditableSchema for the project that:
@@ -165,17 +165,17 @@ class ASICProject(Project):
     def _getdict_type(cls) -> str:
         """
         Returns the meta data for getdict, specifically the class name
-        'ASICProject'.
+        'ASIC'.
 
         This method overrides the parent `Project._getdict_type` to ensure
-        that when an `ASICProject` instance is serialized or deserialized,
-        it is correctly identified as an `ASICProject` type.
+        that when an `ASIC` instance is serialized or deserialized,
+        it is correctly identified as an `ASIC` type.
 
         Returns:
-            str: The name of the `ASICProject` class.
+            str: The name of the `ASIC` class.
         """
 
-        return ASICProject.__name__
+        return ASIC.__name__
 
     def add_dep(self, obj):
         """
@@ -220,14 +220,14 @@ class ASICProject(Project):
         This method first calls the :meth:`.Project.check_manifest()` method.
         Then, it performs additional ASIC-specific validations:
 
-            - Asserts that :keypath:`ASICProject,asic,pdk` is set and refers to a
+            - Asserts that :keypath:`ASIC,asic,pdk` is set and refers to a
               loaded PDK library.
-            - Checks if :keypath:`ASICProject,asic,mainlib` is set and refers to a loaded
+            - Checks if :keypath:`ASIC,asic,mainlib` is set and refers to a loaded
               library (warns if not set).
-            - Asserts that :keypath:`ASICProject,asic,asiclib` contains at least one library
+            - Asserts that :keypath:`ASIC,asic,asiclib` contains at least one library
               and all listed libraries are loaded.
             - Ensures that the `mainlib` is included in the `asiclib` list if both are set.
-            - Asserts that :keypath:`ASICProject,asic,delaymodel` is set.
+            - Asserts that :keypath:`ASIC,asic,delaymodel` is set.
 
         Returns:
             bool: True if the manifest is valid and all checks pass, False otherwise.
@@ -414,12 +414,12 @@ class ASICProject(Project):
         Infer and ensure ASIC project main library and PDK are configured, and make sure the
         main library is listed in `asiclib`.
 
-        If :keypath:`ASICProject,asic,mainlib` is unset but :keypath:`ASICProject,asic,asiclib`
+        If :keypath:`ASIC,asic,mainlib` is unset but :keypath:`ASIC,asic,asiclib`
         contains entries, sets `mainlib` from the first `asiclib` entry.
-        If :keypath:`ASICProject,asic,pdk` is unset but the resolved main library declares a PDK,
-        sets :keypath:`ASICProject,asic,pdk` from that declaration.
-        Ensures the value of :keypath:`ASICProject,asic,mainlib` is present in
-        :keypath:`ASICProject,asic,asiclib` and adds it if missing.
+        If :keypath:`ASIC,asic,pdk` is unset but the resolved main library declares a PDK,
+        sets :keypath:`ASIC,asic,pdk` from that declaration.
+        Ensures the value of :keypath:`ASIC,asic,mainlib` is present in
+        :keypath:`ASIC,asic,asiclib` and adds it if missing.
         """
         super()._init_run()
 

--- a/siliconcompiler/constraints/asic_timing.py
+++ b/siliconcompiler/constraints/asic_timing.py
@@ -79,7 +79,7 @@ class ASICTimingScenarioSchema(NamedSchema):
                 example=["api: asic.set('constraint', 'timing', 'worst', 'opcond', 'typical_1.0')"],
                 help="""Operating condition applied to the scenario. The value
                 can be used to access specific conditions within the library
-                timing models from the :keypath:`ASICProject,asic,asiclib` timing models."""))
+                timing models from the :keypath:`ASIC,asic,asiclib` timing models."""))
 
         schema.insert(
             'mode',

--- a/siliconcompiler/demos/asic_demo.py
+++ b/siliconcompiler/demos/asic_demo.py
@@ -1,8 +1,8 @@
-from siliconcompiler import ASICProject, Design
+from siliconcompiler import ASIC, Design
 from siliconcompiler.targets import skywater130_demo
 
 
-class ASICDemo(ASICProject):
+class ASICDemo(ASIC):
     '''
     "Self-test" target which builds a small 8-bit counter design as an ASIC,
     targeting the Skywater130 PDK.

--- a/siliconcompiler/demos/fpga_demo.py
+++ b/siliconcompiler/demos/fpga_demo.py
@@ -1,6 +1,6 @@
 # Copyright 2025 Zero ASIC Corporation
 
-from siliconcompiler import FPGAProject, Design
+from siliconcompiler import FPGA, Design
 from siliconcompiler.flows.fpgaflow import FPGAVPROpenSTAFlow
 
 from siliconcompiler.tools.vpr import VPRFPGA
@@ -45,7 +45,7 @@ class Z1000(YosysFPGA, VPRFPGA, OpenSTAFPGA):
                 self.add_opensta_liberty_fileset()
 
 
-class FPGADemo(FPGAProject):
+class FPGADemo(FPGA):
     '''
     "Self-test" target which builds a small 8-bit counter design as an FPGA,
     targeting the z1000.

--- a/siliconcompiler/fpga.py
+++ b/siliconcompiler/fpga.py
@@ -146,7 +146,7 @@ class FPGADevice(ToolLibrarySchema):
         return FPGADevice.__name__
 
 
-class FPGAProject(Project):
+class FPGA(Project):
     """
     A class for managing FPGA projects, inheriting from the base Project class.
 
@@ -158,11 +158,11 @@ class FPGAProject(Project):
 
     def __init__(self, design=None):
         """
-        Initialize an FPGAProject with FPGA-specific schemas and parameters.
+        Initialize an FPGA with FPGA-specific schemas and parameters.
 
         Creates the base Project, inserts an FPGAConstraint container at "constraint",
         adds FPGA metrics under "metric" (clobber allowed), and registers the
-        string parameter :keypath:`FPGAProject,fpga,device` for selecting the target FPGA device.
+        string parameter :keypath:`FPGA,fpga,device` for selecting the target FPGA device.
 
         Parameters:
             design (optional): Optional project design data passed to the base Project.
@@ -177,8 +177,8 @@ class FPGAProject(Project):
         schema.insert("fpga", "device", Parameter("str"))
 
     @classmethod
-    def _getdict_type(cls):
-        return FPGAProject.__name__
+    def _getdict_type(cls) -> str:
+        return FPGA.__name__
 
     def add_dep(self, obj):
         """
@@ -229,7 +229,7 @@ class FPGAProject(Project):
         """
         Validate the project manifest for FPGA configuration and library availability.
 
-        Runs the base project manifest checks, verifies that the :keypath:`FPGAProject,fpga,device`
+        Runs the base project manifest checks, verifies that the :keypath:`FPGA,fpga,device`
         parameter is set, and confirms the corresponding FPGA library has been
         loaded into the project.
 

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -275,7 +275,7 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
     @classmethod
     def convert(cls, obj: "Project") -> "Project":
         """
-        Converts a project from one type to another (e.g., Project to SimProject).
+        Converts a project from one type to another (e.g., Project to Sim).
 
         Args:
             obj (Project): Source object to convert from.
@@ -1278,21 +1278,27 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
             return proj.find_result('png', step=task.task())
 
 
-class SimProject(Project):
+class Sim(Project):
     """
     A specialized Project class tailored for simulation tasks.
 
     This class can be extended with simulation-specific schema parameters,
     methods, and flows.
     """
-    pass
+
+    @classmethod
+    def _getdict_type(cls) -> str:
+        return Sim.__name__
 
 
-class LintProject(Project):
+class Lint(Project):
     """
     A specialized Project class tailored for linting tasks.
 
     This class can be extended with linting-specific schema parameters,
     methods, and flows.
     """
-    pass
+
+    @classmethod
+    def _getdict_type(cls) -> str:
+        return Lint.__name__

--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -93,7 +93,7 @@ class BaseSchema:
                         found = True
                         break
                 if not found:
-                    raise RuntimeError(f"fatal error at: {cls_type}")
+                    raise RuntimeError(f"fatal error at: {cls_type}: {clss}")
             else:
                 cls_map[cls_type] = list(clss)[0]
         return cls_map

--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -93,7 +93,10 @@ class BaseSchema:
                         found = True
                         break
                 if not found:
-                    raise RuntimeError(f"fatal error at: {cls_type}: {clss}")
+                    candidates = sorted(f"{c.__module__}/{c.__name__}" for c in clss)
+                    raise RuntimeError(
+                        f"Ambiguous schema type '{cls_type}'. Candidates: {', '.join(candidates)}"
+                    )
             else:
                 cls_map[cls_type] = list(clss)[0]
         return cls_map

--- a/siliconcompiler/schema/docs/utils.py
+++ b/siliconcompiler/schema/docs/utils.py
@@ -151,7 +151,7 @@ class KeyPath:
     @staticmethod
     def keypath(key_path, refdoc, key_text=None):
         '''Helper function for displaying Schema keypaths.'''
-        from siliconcompiler import Project, ASICProject, FPGAProject, LintProject, SimProject
+        from siliconcompiler import Project, ASIC, FPGA, Lint, Sim
         from siliconcompiler import PDK, StdCellLibrary, Schematic, Design
 
         text_parts = []
@@ -160,14 +160,14 @@ class KeyPath:
         if key_path[0][0].upper() == key_path[0][0]:
             schema_name = key_path[0]
             key_path = key_path[1:]
-            if schema_name == "ASICProject":
-                schema = ASICProject()
-            elif schema_name == "FPGAProject":
-                schema = FPGAProject()
-            elif schema_name == "LintProject":
-                schema = LintProject()
-            elif schema_name == "SimProject":
-                schema = SimProject()
+            if schema_name == "ASIC":
+                schema = ASIC()
+            elif schema_name == "FPGA":
+                schema = FPGA()
+            elif schema_name == "Lint":
+                schema = Lint()
+            elif schema_name == "Sim":
+                schema = Sim()
             elif schema_name == "Project":
                 schema = Project()
             elif schema_name == "PDK":

--- a/siliconcompiler/targets/__init__.py
+++ b/siliconcompiler/targets/__init__.py
@@ -7,11 +7,11 @@ from .interposer_demo import interposer_demo
 
 from typing import Optional
 
-from siliconcompiler import ASICProject
+from siliconcompiler import ASIC
 
 
-def asic_target(proj: ASICProject, pdk: Optional[str] = None):
-    '''A factory function to configure an ASICProject for a given PDK.
+def asic_target(proj: ASIC, pdk: Optional[str] = None):
+    '''A factory function to configure an ASIC for a given PDK.
 
     This function acts as a dispatcher, calling the appropriate setup function
     (e.g., `skywater130_demo`, `asap7_demo`) based on the provided PDK name.
@@ -19,7 +19,7 @@ def asic_target(proj: ASICProject, pdk: Optional[str] = None):
     processes by centralizing the selection logic.
 
     Args:
-        proj (ASICProject): The siliconcompiler project to configure.
+        proj (ASIC): The siliconcompiler project to configure.
         pdk (Optional[str]): The name of the Process Design Kit to target. Supported
             values are "asap7", "freepdk45", "gf180", "ihp130", and
             "skywater130".

--- a/siliconcompiler/targets/asap7_demo.py
+++ b/siliconcompiler/targets/asap7_demo.py
@@ -1,5 +1,5 @@
 # Import necessary classes from the siliconcompiler framework and the LambdaPDK.
-from siliconcompiler import ASICProject
+from siliconcompiler import ASIC
 from siliconcompiler.flows import asicflow, synflow
 
 from lambdapdk.asap7.libs.asap7sc7p5t import ASAP7SC7p5RVT, ASAP7SC7p5SLVT, ASAP7SC7p5LVT
@@ -11,12 +11,12 @@ from lambdapdk.asap7.libs.fakeio7 import FakeIO7Lambdalib_IO
 # Target Setup Function
 ####################################################
 def asap7_demo(
-        project: ASICProject,
+        project: ASIC,
         syn_np: int = 1,
         floorplan_np: int = 1, place_np: int = 1, cts_np: int = 1, route_np: int = 1,
         timing_np: int = 1):
     """
-        Configure an ASICProject for the ASAP7 PDK with multi-Vt libraries, flows, timing corners,
+        Configure an ASIC for the ASAP7 PDK with multi-Vt libraries, flows, timing corners,
         and physical constraints.
 
         Sets the main and additional standard-cell libraries (RVT, LVT, SLVT), installs synthesis
@@ -25,7 +25,7 @@ def asap7_demo(
         and registers example IP/macro library aliases.
 
         Parameters:
-            * project (ASICProject): The siliconcompiler project to configure.
+            * project (ASIC): The siliconcompiler project to configure.
             * syn_np (int): Parallel process count for synthesis.
             * floorplan_np (int): Parallel process count for floorplanning.
             * place_np (int): Parallel process count for placement.

--- a/siliconcompiler/targets/freepdk45_demo.py
+++ b/siliconcompiler/targets/freepdk45_demo.py
@@ -1,5 +1,5 @@
 # Import necessary classes from the siliconcompiler framework and the LambdaPDK.
-from siliconcompiler import ASICProject
+from siliconcompiler import ASIC
 from siliconcompiler.flows import asicflow, synflow
 
 from lambdapdk.freepdk45.libs.nangate45 import Nangate45
@@ -10,17 +10,17 @@ from lambdapdk.freepdk45.libs.fakeram45 import FakeRAM45Lambdalib_SinglePort
 # Target Setup Function
 ####################################################
 def freepdk45_demo(
-        project: ASICProject,
+        project: ASIC,
         syn_np: int = 1,
         floorplan_np: int = 1, place_np: int = 1, cts_np: int = 1, route_np: int = 1,
         timing_np: int = 1):
     """
-        Configure an ASICProject for the FreePDK45 process: load Nangate45 standard-cell library,
+        Configure an ASIC for the FreePDK45 process: load Nangate45 standard-cell library,
         set synthesis/implementation flows, select the PDK, apply a typical timing scenario and
         NLDM delay model, set area constraints, and alias the fake RAM library.
 
         Parameters:
-            * project (ASICProject): Project to configure.
+            * project (ASIC): Project to configure.
             * syn_np (int): Parallelism (number of worker processes) for synthesis.
             * floorplan_np (int): Parallelism for floorplanning.
             * place_np (int): Parallelism for placement.

--- a/siliconcompiler/targets/gf180_demo.py
+++ b/siliconcompiler/targets/gf180_demo.py
@@ -1,5 +1,5 @@
 # Import necessary classes from the siliconcompiler framework and the LambdaPDK.
-from siliconcompiler import ASICProject
+from siliconcompiler import ASIC
 from siliconcompiler.flows import asicflow, synflow
 
 from lambdapdk.gf180 import GF180_5LM_1TM_9K_9t
@@ -12,17 +12,17 @@ from lambdapdk.gf180.libs.gf180io import GF180Lambdalib_IO_5LM
 # Target Setup Function
 ####################################################
 def gf180_demo(
-        project: ASICProject,
+        project: ASIC,
         syn_np: int = 1,
         floorplan_np: int = 1, place_np: int = 1, cts_np: int = 1, route_np: int = 1,
         timing_np: int = 1):
     """
-        Configure an ASICProject for the GlobalFoundries 180nm (GF180) process by registering
+        Configure an ASIC for the GlobalFoundries 180nm (GF180) process by registering
         the PDK and standard-cell/IP libraries, installing compilation flows, creating STA
         timing corners, and setting physical area constraints.
 
         Parameters:
-            * project (ASICProject): The siliconcompiler project to configure.
+            * project (ASIC): The siliconcompiler project to configure.
             * syn_np (int): Parallelism for synthesis.
             * floorplan_np (int): Parallelism for floorplanning.
             * place_np (int): Parallelism for placement.

--- a/siliconcompiler/targets/ihp130_demo.py
+++ b/siliconcompiler/targets/ihp130_demo.py
@@ -1,5 +1,5 @@
 # Import necessary classes from the siliconcompiler framework and the LambdaPDK.
-from siliconcompiler import ASICProject
+from siliconcompiler import ASIC
 from siliconcompiler.flows import asicflow, synflow
 
 from lambdapdk.ihp130.libs.sg13g2_stdcell import IHP130StdCell_1p2
@@ -11,12 +11,12 @@ from lambdapdk.ihp130.libs.sg13g2_io import IHP130LambdaLib_IO_1p2
 # Target Setup Function
 ####################################################
 def ihp130_demo(
-        project: ASICProject,
+        project: ASIC,
         syn_np: int = 1,
         floorplan_np: int = 1, place_np: int = 1, cts_np: int = 1, route_np: int = 1,
         timing_np: int = 1):
     """
-        Configure a siliconcompiler ASICProject for the IHP 130nm PDK, including libraries,
+        Configure a siliconcompiler ASIC for the IHP 130nm PDK, including libraries,
         flows, timing scenarios, and basic physical constraints.
 
         Sets the project's main standard-cell library, configures full ASIC and synthesis-only
@@ -25,7 +25,7 @@ def ihp130_demo(
         constraints, and registers the IHP130 SRAM and IO libraries.
 
         Parameters:
-            * project (ASICProject): The siliconcompiler project to configure.
+            * project (ASIC): The siliconcompiler project to configure.
             * syn_np (int): Parallelism for synthesis-related steps.
             * floorplan_np (int): Parallelism for floorplanning.
             * place_np (int): Parallelism for placement.

--- a/siliconcompiler/targets/interposer_demo.py
+++ b/siliconcompiler/targets/interposer_demo.py
@@ -1,5 +1,5 @@
 # Import necessary classes from the siliconcompiler framework and the LambdaPDK.
-from siliconcompiler import ASICProject
+from siliconcompiler import ASIC
 
 from lambdapdk.interposer import Interposer_3ML_0400
 from lambdapdk.interposer.libs.bumps import BumpLibrary
@@ -11,7 +11,7 @@ from siliconcompiler.flows import drcflow
 ####################################################
 # Target Setup Function
 ####################################################
-def interposer_demo(project: ASICProject):
+def interposer_demo(project: ASIC):
     """
     Configure a siliconcompiler project for generating a passive interposer layout.
 
@@ -22,7 +22,7 @@ def interposer_demo(project: ASICProject):
     (40% routing density and 1 unit core margin). No lambdalib/IP aliases are defined.
 
     Parameters:
-        * project (ASICProject): The siliconcompiler project to configure.
+        * project (ASIC): The siliconcompiler project to configure.
     """
 
     # 1. Load Interposer PDK and Bump Library

--- a/siliconcompiler/targets/skywater130_demo.py
+++ b/siliconcompiler/targets/skywater130_demo.py
@@ -1,5 +1,5 @@
 # Import necessary classes from the siliconcompiler framework and the LambdaPDK.
-from siliconcompiler import ASICProject
+from siliconcompiler import ASIC
 
 from siliconcompiler.flows import asicflow, synflow
 
@@ -12,7 +12,7 @@ from lambdapdk.sky130.libs.sky130io import Sky130LambdaLib_IO
 # Target Setup Function
 ####################################################
 def skywater130_demo(
-        project: ASICProject,
+        project: ASIC,
         syn_np: int = 1,
         floorplan_np: int = 1, place_np: int = 1, cts_np: int = 1, route_np: int = 1,
         timing_np: int = 1):
@@ -24,7 +24,7 @@ def skywater130_demo(
     physical design parameters for a Skywater130 target.
 
     Args:
-        * project (:class:`ASICProject`): The siliconcompiler project to configure.
+        * project (:class:`ASIC`): The siliconcompiler project to configure.
         * syn_np (int): Number of parallel processes for synthesis.
         * floorplan_np (int): Number of parallel processes for floorplanning.
         * place_np (int): Number of parallel processes for placement.

--- a/siliconcompiler/tools/klayout/__init__.py
+++ b/siliconcompiler/tools/klayout/__init__.py
@@ -201,13 +201,13 @@ class KLayoutTask(ASICTask):
 
     @classmethod
     def make_docs(cls):
-        from siliconcompiler import Flowgraph, Design, ASICProject
+        from siliconcompiler import Flowgraph, Design, ASIC
         from siliconcompiler.scheduler import SchedulerNode
         from siliconcompiler.targets import freepdk45_demo
         design = Design("<design>")
         with design.active_fileset("docs"):
             design.set_topmodule("top")
-        proj = ASICProject(design)
+        proj = ASIC(design)
         proj.add_fileset("docs")
         freepdk45_demo(proj)
         flow = Flowgraph("docsflow")

--- a/siliconcompiler/tools/nextpnr/apr.py
+++ b/siliconcompiler/tools/nextpnr/apr.py
@@ -61,12 +61,12 @@ class APRTask(Task):
 
     @classmethod
     def make_docs(cls):
-        from siliconcompiler import Flowgraph, Design, FPGAProject, FPGADevice
+        from siliconcompiler import Flowgraph, Design, FPGA, FPGADevice
         from siliconcompiler.scheduler import SchedulerNode
         design = Design("<design>")
         with design.active_fileset("docs"):
             design.set_topmodule("top")
-        proj = FPGAProject(design)
+        proj = FPGA(design)
         proj.add_fileset("docs")
         flow = Flowgraph("docsflow")
         flow.node("<step>", cls(), index="<index>")

--- a/siliconcompiler/tools/openroad/__init__.py
+++ b/siliconcompiler/tools/openroad/__init__.py
@@ -380,13 +380,13 @@ class OpenROADTask(ASICTask):
 
     @classmethod
     def make_docs(cls):
-        from siliconcompiler import Flowgraph, Design, ASICProject
+        from siliconcompiler import Flowgraph, Design, ASIC
         from siliconcompiler.scheduler import SchedulerNode
         from siliconcompiler.targets import freepdk45_demo
         design = Design("<design>")
         with design.active_fileset("docs"):
             design.set_topmodule("top")
-        proj = ASICProject(design)
+        proj = ASIC(design)
         proj.add_fileset("docs")
         freepdk45_demo(proj)
         flow = Flowgraph("docsflow")

--- a/siliconcompiler/tools/opensta/__init__.py
+++ b/siliconcompiler/tools/opensta/__init__.py
@@ -51,13 +51,13 @@ class OpenSTATask(Task):
 
     @classmethod
     def make_docs(cls):
-        from siliconcompiler import Flowgraph, Design, ASICProject
+        from siliconcompiler import Flowgraph, Design, ASIC
         from siliconcompiler.scheduler import SchedulerNode
         from siliconcompiler.targets import freepdk45_demo
         design = Design("<design>")
         with design.active_fileset("docs"):
             design.set_topmodule("top")
-        proj = ASICProject(design)
+        proj = ASIC(design)
         proj.add_fileset("docs")
         freepdk45_demo(proj)
         flow = Flowgraph("docsflow")

--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -125,13 +125,13 @@ class _ASICTask(ASICTask, YosysTask):
 
     @classmethod
     def make_docs(cls):
-        from siliconcompiler import Flowgraph, Design, ASICProject
+        from siliconcompiler import Flowgraph, Design, ASIC
         from siliconcompiler.scheduler import SchedulerNode
         from siliconcompiler.targets import freepdk45_demo
         design = Design("<design>")
         with design.active_fileset("docs"):
             design.set_topmodule("top")
-        proj = ASICProject(design)
+        proj = ASIC(design)
         proj.add_fileset("docs")
         freepdk45_demo(proj)
         flow = Flowgraph("docsflow")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,15 +11,13 @@ import time
 
 import os.path
 
-import siliconcompiler
-
 from pathlib import Path
 from pyvirtualdisplay import Display
 from unittest.mock import patch
 
 from typing import Optional
 
-from siliconcompiler import utils, ASICProject, Design, Project
+from siliconcompiler import utils, ASIC, Design, Project
 from siliconcompiler.tools.openroad._apr import APRTask
 from siliconcompiler.flows.asicflow import ASICFlow
 from siliconcompiler.targets import freepdk45_demo
@@ -73,14 +71,14 @@ def use_cache(monkeypatch, request):
     if not cachedir:
         return
 
-    old_init = siliconcompiler.Project._init_run
+    old_init = Project._init_run
 
     def mock_init(self):
         self.set('option', 'cachedir', cachedir)
 
         return old_init(self)
 
-    monkeypatch.setattr(siliconcompiler.Project, '_init_run', mock_init)
+    monkeypatch.setattr(Project, '_init_run', mock_init)
 
 
 @pytest.fixture(autouse=True)
@@ -140,9 +138,9 @@ def disable_or_images(monkeypatch, request):
     '''
     if 'eda' not in request.keywords:
         return
-    old_init = siliconcompiler.Project._init_run
+    old_init = Project._init_run
 
-    def mock_init(self: siliconcompiler.Project):
+    def mock_init(self: Project):
         tasks = get_task(self, filter=APRTask)
         if not isinstance(tasks, set):
             tasks = [tasks]
@@ -151,7 +149,7 @@ def disable_or_images(monkeypatch, request):
 
         return old_init(self)
 
-    monkeypatch.setattr(siliconcompiler.Project, '_init_run', mock_init)
+    monkeypatch.setattr(Project, '_init_run', mock_init)
 
 
 @pytest.fixture(scope='session')
@@ -198,7 +196,7 @@ def asic_heartbeat(heartbeat_design):
     '''Returns a fully configured project object that will compile the heartbeat example
     design using freepdk45 and the asicflow.'''
 
-    project = ASICProject(heartbeat_design)
+    project = ASIC(heartbeat_design)
     project.add_fileset("rtl")
     project.add_fileset("sdc")
 
@@ -229,7 +227,7 @@ def asic_gcd(gcd_design):
     '''Returns a fully configured project object that will compile the GCD example
     design using freepdk45 and the asicflow.'''
 
-    project = ASICProject(gcd_design)
+    project = ASIC(gcd_design)
     project.add_fileset("rtl")
     project.add_fileset("sdc")
 

--- a/tests/data/defaults.json
+++ b/tests/data/defaults.json
@@ -3050,7 +3050,7 @@
         "sctype": "Project"
       }
     },
-    "fpgaproject": {
+    "fpga": {
       "schemaversion": {
         "type": "str",
         "require": true,
@@ -6859,11 +6859,11 @@
         }
       },
       "__meta__": {
-        "class": "siliconcompiler.fpga/FPGAProject",
-        "sctype": "FPGAProject"
+        "class": "siliconcompiler.fpga/FPGA",
+        "sctype": "FPGA"
       }
     },
-    "asicproject": {
+    "asic": {
       "schemaversion": {
         "type": "str",
         "require": true,
@@ -10943,7 +10943,7 @@
               "example": [
                 "api: asic.set('constraint', 'timing', 'worst', 'opcond', 'typical_1.0')"
               ],
-              "help": "Operating condition applied to the scenario. The value\n                can be used to access specific conditions within the library\n                timing models from the :keypath:`ASICProject,asic,asiclib` timing models.",
+              "help": "Operating condition applied to the scenario. The value\n                can be used to access specific conditions within the library\n                timing models from the :keypath:`ASIC,asic,asiclib` timing models.",
               "notes": null,
               "pernode": "optional",
               "node": {
@@ -11580,11 +11580,11 @@
         }
       },
       "__meta__": {
-        "class": "siliconcompiler.asic/ASICProject",
-        "sctype": "ASICProject"
+        "class": "siliconcompiler.asic/ASIC",
+        "sctype": "ASIC"
       }
     },
-    "simproject": {
+    "sm": {
       "schemaversion": {
         "type": "str",
         "require": true,
@@ -14630,11 +14630,11 @@
       },
       "history": {},
       "__meta__": {
-        "class": "siliconcompiler.project/SimProject",
-        "sctype": "Project"
+        "class": "siliconcompiler.project/Sim",
+        "sctype": "Sim"
       }
     },
-    "lintproject": {
+    "lint": {
       "schemaversion": {
         "type": "str",
         "require": true,
@@ -17680,8 +17680,8 @@
       },
       "history": {},
       "__meta__": {
-        "class": "siliconcompiler.project/LintProject",
-        "sctype": "Project"
+        "class": "siliconcompiler.project/Lint",
+        "sctype": "Lint"
       }
     }
   },

--- a/tests/data/defaults.json
+++ b/tests/data/defaults.json
@@ -11584,7 +11584,7 @@
         "sctype": "ASIC"
       }
     },
-    "sm": {
+    "sim": {
       "schemaversion": {
         "type": "str",
         "require": true,

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -2807,7 +2807,10 @@ def test___get_child_classes_invalid_child(monkeypatch):
     with patch("siliconcompiler.schema.BaseSchema.__subclasses__") as subclasses:
         subclasses.return_value = set([DummySchema0, DummySchema1])
 
-        with pytest.raises(RuntimeError, match="fatal error at: dummy_schema"):
+        with pytest.raises(RuntimeError,
+                           match=r"^Ambiguous schema type 'dummy_schema'\. "
+                                 r"Candidates: test_baseschema/DummySchema0, "
+                                 r"test_baseschema/DummySchema1$"):
             BaseSchema._BaseSchema__get_child_classes.cache_clear()
             BaseSchema._BaseSchema__get_child_classes()
         subclasses.assert_called_once()

--- a/tests/targets/test_targets.py
+++ b/tests/targets/test_targets.py
@@ -3,7 +3,7 @@ from siliconcompiler.targets import \
     asap7_demo, freepdk45_demo, \
     gf180_demo, ihp130_demo, interposer_demo, skywater130_demo
 
-from siliconcompiler import ASICProject
+from siliconcompiler import ASIC
 
 
 @pytest.mark.parametrize("target", (
@@ -14,7 +14,7 @@ from siliconcompiler import ASICProject
         interposer_demo,
         skywater130_demo))
 def test_target_loading_asic(target):
-    proj = ASICProject()
+    proj = ASIC()
     target(proj)
 
     assert len(proj.getkeys('library')) != 0

--- a/tests/test_asic.py
+++ b/tests/test_asic.py
@@ -5,7 +5,7 @@ import os.path
 
 from unittest.mock import patch
 
-from siliconcompiler import ASICProject, Design, Flowgraph
+from siliconcompiler import ASIC, Design, Flowgraph
 from siliconcompiler.asic import ASICTask, ASICConstraint
 from siliconcompiler.library import ToolLibrarySchema
 
@@ -23,7 +23,7 @@ from siliconcompiler.scheduler import SchedulerNode
 
 @pytest.fixture
 def running_project():
-    class TestProject(ASICProject):
+    class TestProject(ASIC):
         def __init__(self):
             super().__init__()
 
@@ -52,7 +52,7 @@ def running_node(running_project):
 
 
 def test_keys():
-    assert ASICProject().getkeys() == (
+    assert ASIC().getkeys() == (
         'arg',
         'asic',
         'checklist',
@@ -68,7 +68,7 @@ def test_keys():
 
 
 def test_keys_asic():
-    assert ASICProject().getkeys("asic") == (
+    assert ASIC().getkeys("asic") == (
         'asiclib',
         'delaymodel',
         'mainlib',
@@ -78,8 +78,8 @@ def test_keys_asic():
 
 
 def test_keys_constraint():
-    assert isinstance(ASICProject().get("constraint", field="schema"), ASICConstraint)
-    assert ASICProject().getkeys("constraint") == (
+    assert isinstance(ASIC().get("constraint", field="schema"), ASICConstraint)
+    assert ASIC().getkeys("constraint") == (
         'area',
         'component',
         'pin',
@@ -88,22 +88,22 @@ def test_keys_constraint():
 
 
 def test_metrics():
-    assert isinstance(ASICProject().get("metric", field="schema"), ASICMetricsSchema)
+    assert isinstance(ASIC().get("metric", field="schema"), ASICMetricsSchema)
 
 
 def test_getdict_type():
-    assert ASICProject._getdict_type() == "ASICProject"
+    assert ASIC._getdict_type() == "ASIC"
 
 
 @pytest.mark.parametrize("type", [1, None])
 def test_set_mainlib_invalid(type):
     with pytest.raises(TypeError,
                        match="main library must be string or standard cell library object"):
-        ASICProject().set_mainlib(type)
+        ASIC().set_mainlib(type)
 
 
 def test_set_mainlib_string():
-    proj = ASICProject()
+    proj = ASIC()
 
     assert proj.get("asic", "mainlib") is None
     proj.set_mainlib("mainlib")
@@ -112,7 +112,7 @@ def test_set_mainlib_string():
 
 def test_set_mainlib_obj():
     lib = StdCellLibrary("thislib")
-    proj = ASICProject()
+    proj = ASIC()
 
     assert proj.get("asic", "mainlib") is None
     proj.set_mainlib(lib)
@@ -124,11 +124,11 @@ def test_set_mainlib_obj():
 def test_set_pdk_invalid(type):
     with pytest.raises(TypeError,
                        match="pdk must be string or PDK object"):
-        ASICProject().set_pdk(type)
+        ASIC().set_pdk(type)
 
 
 def test_set_pdk_string():
-    proj = ASICProject()
+    proj = ASIC()
 
     assert proj.get("asic", "pdk") is None
     proj.set_pdk("thispdk")
@@ -137,7 +137,7 @@ def test_set_pdk_string():
 
 def test_set_pdk_obj():
     pdk = PDK("thispdk")
-    proj = ASICProject()
+    proj = ASIC()
 
     assert proj.get("asic", "pdk") is None
     proj.set_pdk(pdk)
@@ -149,11 +149,11 @@ def test_set_pdk_obj():
 def test_add_asiclib_invalid(type):
     with pytest.raises(TypeError,
                        match="asic library must be string or standard cell library object"):
-        ASICProject().add_asiclib(type)
+        ASIC().add_asiclib(type)
 
 
 def test_add_asiclib_string():
-    proj = ASICProject()
+    proj = ASIC()
 
     assert proj.get("asic", "asiclib") == []
     proj.add_asiclib("thislib")
@@ -162,7 +162,7 @@ def test_add_asiclib_string():
 
 def test_add_asiclib_obj():
     lib = StdCellLibrary("thislib")
-    proj = ASICProject()
+    proj = ASIC()
 
     assert proj.get("asic", "asiclib") == []
     proj.add_asiclib(lib)
@@ -171,7 +171,7 @@ def test_add_asiclib_obj():
 
 
 def test_add_asiclib_list():
-    proj = ASICProject()
+    proj = ASIC()
 
     assert proj.get("asic", "asiclib") == []
     proj.add_asiclib(["lib0", "lib1"])
@@ -179,7 +179,7 @@ def test_add_asiclib_list():
 
 
 def test_add_asiclib_list_clobber():
-    proj = ASICProject()
+    proj = ASIC()
 
     assert proj.get("asic", "asiclib") == []
     proj.add_asiclib(["lib0", "lib1"])
@@ -189,7 +189,7 @@ def test_add_asiclib_list_clobber():
 
 
 def test_add_asiclib_clobber():
-    proj = ASICProject()
+    proj = ASIC()
 
     assert proj.get("asic", "asiclib") == []
     proj.add_asiclib(["lib0", "lib1"])
@@ -199,20 +199,20 @@ def test_add_asiclib_clobber():
 
 
 def test_constraint():
-    proj = ASICProject()
+    proj = ASIC()
     assert isinstance(proj.constraint, ASICConstraint)
     assert proj.get("constraint", field="schema") is proj.constraint
 
 
 def test_set_asic_routinglayers():
-    proj = ASICProject()
+    proj = ASIC()
     proj.set_asic_routinglayers("M1", "M5")
     assert proj.get("asic", "minlayer") == "M1"
     assert proj.get("asic", "maxlayer") == "M5"
 
 
 def test_set_asic_delaymodel():
-    proj = ASICProject()
+    proj = ASIC()
     proj.set_asic_delaymodel("ccs")
     assert proj.get("asic", "delaymodel") == "ccs"
 
@@ -220,7 +220,7 @@ def test_set_asic_delaymodel():
 def test_add_dep_list():
     lib0 = StdCellLibrary("thislib")
     lib1 = StdCellLibrary("thatlib")
-    proj = ASICProject()
+    proj = ASIC()
 
     proj.add_dep([lib0, lib1])
     assert proj.get("library", "thislib", field="schema") is lib0
@@ -228,7 +228,7 @@ def test_add_dep_list():
 
 
 def test_add_dep_handoff():
-    proj = ASICProject()
+    proj = ASIC()
 
     with patch("siliconcompiler.Project.add_dep") as add_dep:
         proj.add_dep(None)
@@ -236,7 +236,7 @@ def test_add_dep_handoff():
 
 
 def test_check_manifest_empty(monkeypatch, caplog):
-    proj = ASICProject()
+    proj = ASIC()
     monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
     proj.logger.setLevel(logging.INFO)
 
@@ -251,7 +251,7 @@ def test_check_manifest_empty(monkeypatch, caplog):
 
 
 def test_check_manifest_missing_pdk(monkeypatch, caplog):
-    proj = ASICProject()
+    proj = ASIC()
     monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
     proj.logger.setLevel(logging.INFO)
 
@@ -268,7 +268,7 @@ def test_check_manifest_missing_pdk(monkeypatch, caplog):
 
 
 def test_check_manifest_incorrect_type_pdk(monkeypatch, caplog):
-    proj = ASICProject()
+    proj = ASIC()
     monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
     proj.logger.setLevel(logging.INFO)
 
@@ -286,7 +286,7 @@ def test_check_manifest_incorrect_type_pdk(monkeypatch, caplog):
 
 
 def test_check_manifest_main_libmissing(monkeypatch, caplog):
-    proj = ASICProject()
+    proj = ASIC()
     monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
     proj.logger.setLevel(logging.INFO)
 
@@ -304,7 +304,7 @@ def test_check_manifest_main_libmissing(monkeypatch, caplog):
 
 
 def test_check_manifest_asiclib_missing(monkeypatch, caplog):
-    proj = ASICProject()
+    proj = ASIC()
     monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
     proj.logger.setLevel(logging.INFO)
 
@@ -321,7 +321,7 @@ def test_check_manifest_asiclib_missing(monkeypatch, caplog):
 
 
 def test_check_manifest_pass(monkeypatch, caplog):
-    proj = ASICProject()
+    proj = ASIC()
     monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
     proj.logger.setLevel(logging.INFO)
 
@@ -338,7 +338,7 @@ def test_check_manifest_pass(monkeypatch, caplog):
 
 
 def test_check_manifest_pass_missing_mainlib(monkeypatch, caplog):
-    proj = ASICProject()
+    proj = ASIC()
     monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
     proj.logger.setLevel(logging.INFO)
 
@@ -354,7 +354,7 @@ def test_check_manifest_pass_missing_mainlib(monkeypatch, caplog):
 
 
 def test_init_run_set_mainlib(monkeypatch, caplog):
-    proj = ASICProject()
+    proj = ASIC()
     monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
     proj.logger.setLevel(logging.INFO)
 
@@ -371,7 +371,7 @@ def test_init_run_set_mainlib(monkeypatch, caplog):
 
 
 def test_init_run_set_pdk_asiclib(monkeypatch, caplog):
-    proj = ASICProject()
+    proj = ASIC()
     monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
     proj.logger.setLevel(logging.INFO)
 
@@ -393,7 +393,7 @@ def test_init_run_set_pdk_asiclib(monkeypatch, caplog):
 
 
 def test_init_run_handling_missing_lib(monkeypatch, caplog):
-    proj = ASICProject()
+    proj = ASIC()
     monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
     proj.logger.setLevel(logging.INFO)
 
@@ -411,7 +411,7 @@ def test_init_run_handling_missing_lib(monkeypatch, caplog):
 
 
 def test_summary_headers():
-    proj = ASICProject()
+    proj = ASIC()
 
     proj.set_pdk("thispdk")
     proj.set_mainlib("thislib")
@@ -876,7 +876,7 @@ def test_get_clock_none(running_project, running_node):
 
 
 def test_snapshot_info_empty():
-    proj = ASICProject(Design("testdesign"))
+    proj = ASIC(Design("testdesign"))
 
     assert proj._snapshot_info() == [
         ("Design", "testdesign")
@@ -884,7 +884,7 @@ def test_snapshot_info_empty():
 
 
 def test_snapshot_info_pdk():
-    proj = ASICProject(Design("testdesign"))
+    proj = ASIC(Design("testdesign"))
     proj.set("asic", "pdk", "testpdk")
 
     assert proj._snapshot_info() == [

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -3,7 +3,7 @@ import pytest
 
 from unittest.mock import patch
 
-from siliconcompiler import FPGADevice, FPGAProject
+from siliconcompiler import FPGADevice, FPGA
 from siliconcompiler.metrics import FPGAMetricsSchema
 from siliconcompiler.constraints import FPGAComponentConstraints, \
     FPGAPinConstraints, FPGATimingConstraintSchema
@@ -50,7 +50,7 @@ def test_set_lutsize():
 
 
 def test_project_keys():
-    assert FPGAProject().getkeys() == (
+    assert FPGA().getkeys() == (
         'arg',
         'checklist',
         'constraint',
@@ -66,12 +66,12 @@ def test_project_keys():
 
 
 def test_project_keys_fpga():
-    assert FPGAProject().getkeys("fpga") == ('device',)
+    assert FPGA().getkeys("fpga") == ('device',)
 
 
 def test_project_keys_constraint():
-    assert isinstance(FPGAProject().get("constraint", field="schema"), FPGAConstraint)
-    assert FPGAProject().getkeys("constraint") == (
+    assert isinstance(FPGA().get("constraint", field="schema"), FPGAConstraint)
+    assert FPGA().getkeys("constraint") == (
         'component',
         'pin',
         'timing'
@@ -79,15 +79,15 @@ def test_project_keys_constraint():
 
 
 def test_project_metrics():
-    assert isinstance(FPGAProject().get("metric", field="schema"), FPGAMetricsSchema)
+    assert isinstance(FPGA().get("metric", field="schema"), FPGAMetricsSchema)
 
 
 def test_project_getdict_type():
-    assert FPGAProject._getdict_type() == "FPGAProject"
+    assert FPGA._getdict_type() == "FPGA"
 
 
 def test_project_constraint():
-    proj = FPGAProject()
+    proj = FPGA()
     assert isinstance(proj.constraint, FPGAConstraint)
     assert proj.get("constraint", field="schema") is proj.constraint
 
@@ -95,7 +95,7 @@ def test_project_constraint():
 def test_project_add_dep_list():
     fpga0 = FPGADevice("thisfpga")
     fpga1 = FPGADevice("thatfpga")
-    proj = FPGAProject()
+    proj = FPGA()
 
     proj.add_dep([fpga0, fpga1])
     assert proj.get("library", "thisfpga", field="schema") is fpga0
@@ -103,7 +103,7 @@ def test_project_add_dep_list():
 
 
 def test_project_add_dep_handoff():
-    proj = FPGAProject()
+    proj = FPGA()
 
     with patch("siliconcompiler.Project.add_dep") as add_dep:
         proj.add_dep(None)
@@ -111,7 +111,7 @@ def test_project_add_dep_handoff():
 
 
 def test_project_check_manifest_empty(monkeypatch, caplog):
-    proj = FPGAProject()
+    proj = FPGA()
     monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
     proj.logger.setLevel(logging.INFO)
 
@@ -123,7 +123,7 @@ def test_project_check_manifest_empty(monkeypatch, caplog):
 
 
 def test_project_check_manifest_missing_fpga(monkeypatch, caplog):
-    proj = FPGAProject()
+    proj = FPGA()
     monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
     proj.logger.setLevel(logging.INFO)
 
@@ -137,7 +137,7 @@ def test_project_check_manifest_missing_fpga(monkeypatch, caplog):
 
 
 def test_project_check_manifest_pass(monkeypatch, caplog):
-    proj = FPGAProject()
+    proj = FPGA()
     monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
     proj.logger.setLevel(logging.INFO)
 
@@ -151,7 +151,7 @@ def test_project_check_manifest_pass(monkeypatch, caplog):
 
 
 def test_project_summary_headers():
-    proj = FPGAProject()
+    proj = FPGA()
 
     proj.set_fpga("thisfpga")
 
@@ -168,11 +168,11 @@ def test_project_summary_headers():
 def test_project_set_fpga_invalid(type):
     with pytest.raises(TypeError,
                        match=r"^fpga must be an FPGADevice object or a string\.$"):
-        FPGAProject().set_fpga(type)
+        FPGA().set_fpga(type)
 
 
 def test_project_set_fpga_string():
-    proj = FPGAProject()
+    proj = FPGA()
 
     assert proj.get("fpga", "device") is None
     proj.set_fpga("thisfpga")
@@ -181,7 +181,7 @@ def test_project_set_fpga_string():
 
 def test_project_set_fpga_obj():
     fpga = FPGADevice("thisfpga")
-    proj = FPGAProject()
+    proj = FPGA()
 
     assert proj.get("fpga", "device") is None
     proj.set_fpga(fpga)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -10,6 +10,7 @@ from PIL import Image
 from unittest.mock import patch
 
 from siliconcompiler import Project
+from siliconcompiler import Lint, Sim
 from siliconcompiler import Design, Flowgraph, Checklist
 from siliconcompiler import Task
 from siliconcompiler.library import LibrarySchema
@@ -284,22 +285,22 @@ def test_add_fileset_invalid():
 
 
 def test_convert():
-    class ASICProject(Project):
+    class ASIC(Project):
         def __init__(self, design=None):
             super().__init__(design)
 
             EditableSchema(self).insert("asic", Parameter("str"))
 
-    class FPGAProject(Project):
+    class FPGA(Project):
         def __init__(self, design=None):
             super().__init__(design)
 
             EditableSchema(self).insert("fpga", Parameter("str"))
 
     design = Design("design0")
-    proj0 = ASICProject(design)
+    proj0 = ASIC(design)
 
-    proj1 = FPGAProject.convert(proj0)
+    proj1 = FPGA.convert(proj0)
 
     assert proj0.allkeys("library") == proj1.allkeys("library")
     assert proj0.allkeys("library") == proj1.allkeys("library")
@@ -1634,3 +1635,11 @@ def test_reset_job_params():
     assert proj.get("arg", "step") is None
     assert proj.get("option", "breakpoint") is False
     assert proj.get("option", "design") == "testdesign"
+
+
+def test_lint_getdict_type():
+    assert Lint._getdict_type() == "Lint"
+
+
+def test_sim_getdict_type():
+    assert Sim._getdict_type() == "Sim"

--- a/tests/test_schema_information.py
+++ b/tests/test_schema_information.py
@@ -9,7 +9,7 @@ from siliconcompiler.schema import BaseSchema, EditableSchema, PerNode
 from siliconcompiler.schema.parametertype import NodeType
 
 from siliconcompiler import Project
-from siliconcompiler import FPGAProject, ASICProject, SimProject, LintProject
+from siliconcompiler import FPGA, ASIC, Sim, Lint
 from siliconcompiler import Design, PDK, StdCellLibrary, FPGADevice, Schematic
 
 
@@ -19,10 +19,10 @@ class CompositeProject(BaseSchema):
         super().__init__()
 
         EditableSchema(self).insert("project", "project", Project())
-        EditableSchema(self).insert("project", "fpgaproject", FPGAProject())
-        EditableSchema(self).insert("project", "asicproject", ASICProject())
-        EditableSchema(self).insert("project", "simproject", SimProject())
-        EditableSchema(self).insert("project", "lintproject", LintProject())
+        EditableSchema(self).insert("project", "fpga", FPGA())
+        EditableSchema(self).insert("project", "asic", ASIC())
+        EditableSchema(self).insert("project", "sm", Sim())
+        EditableSchema(self).insert("project", "lint", Lint())
 
         EditableSchema(self).insert("library", "design", Design())
         EditableSchema(self).insert("library", "pdk", PDK())
@@ -55,7 +55,7 @@ def test_modified_schema(datadir, cleanup_manifest):
     assert check == expected, "Golden manifest does not match"
 
 
-@pytest.mark.parametrize("root", [Project, ASICProject, FPGAProject])
+@pytest.mark.parametrize("root", [Project, ASIC, FPGA])
 def test_cli_examples(monkeypatch, root):
     did_something = True
     example_index = 0

--- a/tests/test_schema_information.py
+++ b/tests/test_schema_information.py
@@ -21,7 +21,7 @@ class CompositeProject(BaseSchema):
         EditableSchema(self).insert("project", "project", Project())
         EditableSchema(self).insert("project", "fpga", FPGA())
         EditableSchema(self).insert("project", "asic", ASIC())
-        EditableSchema(self).insert("project", "sm", Sim())
+        EditableSchema(self).insert("project", "sim", Sim())
         EditableSchema(self).insert("project", "lint", Lint())
 
         EditableSchema(self).insert("library", "design", Design())

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -11,7 +11,7 @@ from siliconcompiler.tools.klayout import convert_drc_db
 
 from siliconcompiler.targets import freepdk45_demo
 
-from siliconcompiler import ASICProject, Flowgraph, Design
+from siliconcompiler import ASIC, Flowgraph, Design
 from siliconcompiler.scheduler import SchedulerNode
 from siliconcompiler.tools.klayout.export import ExportTask
 from siliconcompiler.tools.klayout import KLayoutLibrary
@@ -56,7 +56,7 @@ def test_export(datadir):
     with design.active_fileset("layout"):
         design.set_topmodule("heartbeat_wrapper")
 
-    proj = ASICProject(design)
+    proj = ASIC(design)
     proj.add_fileset(["layout"])
     freepdk45_demo(proj)
     proj.add_asiclib(lib)
@@ -88,7 +88,7 @@ def test_klayout_operations(datadir):
     with design.active_fileset("layout"):
         design.set_topmodule("heartbeat")
 
-    proj = ASICProject(design)
+    proj = ASIC(design)
     proj.add_fileset(["layout"])
     freepdk45_demo(proj)
 
@@ -169,7 +169,7 @@ def test_drc_pass(setup_pdk_test, datadir):
     with design.active_fileset("layout"):
         design.set_topmodule("interposer")
 
-    proj = ASICProject(design)
+    proj = ASIC(design)
     proj.add_fileset(["layout"])
     proj.set_pdk(klayout_pdk.FauxPDK())
     proj.set_asic_delaymodel("nldm")
@@ -199,7 +199,7 @@ def test_drc_fail(setup_pdk_test, datadir):
     with design.active_fileset("layout"):
         design.set_topmodule("interposer")
 
-    proj = ASICProject(design)
+    proj = ASIC(design)
     proj.add_fileset(["layout"])
     proj.set_pdk(klayout_pdk.FauxPDK())
     proj.set_asic_delaymodel("nldm")
@@ -229,7 +229,7 @@ def test_convert_drc(setup_pdk_test, datadir):
     with design.active_fileset("layout"):
         design.set_topmodule("interposer")
 
-    proj = ASICProject(design)
+    proj = ASIC(design)
     proj.add_fileset(["layout"])
     proj.set_pdk(klayout_pdk.FauxPDK())
     proj.set_asic_delaymodel("nldm")

--- a/tests/tools/test_nextpnr.py
+++ b/tests/tools/test_nextpnr.py
@@ -1,6 +1,6 @@
 import pytest
 
-from siliconcompiler import FPGAProject, Flowgraph
+from siliconcompiler import FPGA, Flowgraph
 from siliconcompiler.scheduler import SchedulerNode
 from siliconcompiler.tools.nextpnr.apr import APRTask
 
@@ -9,7 +9,7 @@ from siliconcompiler.tools.nextpnr.apr import APRTask
 @pytest.mark.quick
 @pytest.mark.ready
 def test_version(gcd_design):
-    proj = FPGAProject(gcd_design)
+    proj = FPGA(gcd_design)
     proj.add_fileset("rtl")
     proj.set("fpga", "device", "ice40")
 

--- a/tests/tools/test_opensta.py
+++ b/tests/tools/test_opensta.py
@@ -3,7 +3,7 @@ import pytest
 
 import os.path
 
-from siliconcompiler import ASICProject, Design, Flowgraph
+from siliconcompiler import ASIC, Design, Flowgraph
 from siliconcompiler.tools.opensta import timing
 
 from siliconcompiler.targets import freepdk45_demo
@@ -23,7 +23,7 @@ def test_opensta(datadir):
         design.add_file(os.path.join("lec", "foo.vg"))
     with design.active_dataroot("root"), design.active_fileset("sdc"):
         design.add_file(os.path.join("lec", "foo.sdc"))
-    proj = ASICProject(design)
+    proj = ASIC(design)
     proj.add_fileset(["rtl", "sdc"])
     freepdk45_demo(proj)
 
@@ -50,7 +50,7 @@ def test_opensta_sdf(datadir):
         design.add_file(os.path.join("lec", "foo.vg"))
     with design.active_dataroot("root"), design.active_fileset("sdc"):
         design.add_file(os.path.join("lec", "foo.sdc"))
-    proj = ASICProject(design)
+    proj = ASIC(design)
     proj.add_fileset(["rtl", "sdc"])
     freepdk45_demo(proj)
 

--- a/tests/tools/test_vpr.py
+++ b/tests/tools/test_vpr.py
@@ -2,7 +2,7 @@ import pytest
 
 import os.path
 
-from siliconcompiler import FPGAProject, Flowgraph, Design
+from siliconcompiler import FPGA, Flowgraph, Design
 from siliconcompiler.scheduler import SchedulerNode
 from siliconcompiler.tools.vpr.place import PlaceTask
 from siliconcompiler.tools.vpr.route import RouteTask
@@ -17,7 +17,7 @@ from tools.inputimporter import ImporterTask
 @pytest.mark.quick
 @pytest.mark.ready
 def test_version(gcd_design):
-    proj = FPGAProject(gcd_design)
+    proj = FPGA(gcd_design)
     proj.add_fileset("rtl")
 
     flow = Flowgraph("testflow")
@@ -38,7 +38,7 @@ def test_run(datadir):
     with design.active_fileset("rtl"):
         design.set_topmodule("adder")
 
-    proj = FPGAProject(design)
+    proj = FPGA(design)
     proj.add_fileset("rtl")
 
     flow = Flowgraph("testflow")
@@ -73,7 +73,7 @@ def test_run(datadir):
 
 
 def test_vpr_max_router_iterations(gcd_design):
-    proj = FPGAProject(gcd_design)
+    proj = FPGA(gcd_design)
     proj.add_fileset("rtl")
 
     flow = Flowgraph("testflow")
@@ -135,7 +135,7 @@ def test_vpr_max_router_iterations(gcd_design):
 
 
 def test_vpr_place_with_constraint(gcd_design, monkeypatch):
-    proj = FPGAProject(gcd_design)
+    proj = FPGA(gcd_design)
     proj.add_fileset("rtl")
 
     flow = Flowgraph("testflow")
@@ -204,7 +204,7 @@ def test_vpr_gen_post_implementation_netlist(gcd_design):
     with open('test.sdc', 'w') as f:
         f.write('test')
 
-    proj = FPGAProject(gcd_design)
+    proj = FPGA(gcd_design)
     proj.add_fileset(["rtl", "sdc-test"])
 
     flow = Flowgraph("testflow")

--- a/tests/tools/test_yosys.py
+++ b/tests/tools/test_yosys.py
@@ -6,7 +6,7 @@ from siliconcompiler.targets import freepdk45_demo
 
 from tools.inputimporter import ImporterTask
 
-from siliconcompiler import ASICProject, Design, Flowgraph
+from siliconcompiler import ASIC, Design, Flowgraph
 from siliconcompiler.scheduler import SchedulerNode
 from siliconcompiler.tools.yosys.lec_asic import ASICLECTask
 from siliconcompiler.tools import get_task
@@ -16,7 +16,7 @@ from siliconcompiler.tools import get_task
 @pytest.mark.quick
 @pytest.mark.ready
 def test_version(gcd_design):
-    proj = ASICProject(gcd_design)
+    proj = ASIC(gcd_design)
     proj.add_fileset("rtl")
 
     flow = Flowgraph("testflow")
@@ -37,7 +37,7 @@ def test_yosys_lec(datadir):
     with design.active_fileset("rtl"):
         design.set_topmodule("foo")
 
-    proj = ASICProject(design)
+    proj = ASIC(design)
     proj.add_fileset(["rtl"])
     freepdk45_demo(proj)
 
@@ -64,7 +64,7 @@ def test_yosys_lec_broken(datadir):
     with design.active_fileset("rtl"):
         design.set_topmodule("foo")
 
-    proj = ASICProject(design)
+    proj = ASIC(design)
     proj.add_fileset(["rtl"])
     freepdk45_demo(proj)
 

--- a/tests/utils/test_showtools.py
+++ b/tests/utils/test_showtools.py
@@ -5,7 +5,7 @@ import os.path
 
 from unittest.mock import patch
 
-from siliconcompiler import Project, ASICProject, Design, PDK
+from siliconcompiler import Project, ASIC, Design, PDK
 from siliconcompiler import ShowTask, ScreenshotTask
 
 from siliconcompiler.tools.klayout import show as klayout_show
@@ -49,7 +49,7 @@ def test_show_def(target, testfile, task, datadir, display):
     design = Design("heartbeat")
     with design.active_fileset("rtl"):
         design.set_topmodule("heartbeat")
-    proj = ASICProject(design)
+    proj = ASIC(design)
     target(proj)
 
     ShowTask.register_task(task)
@@ -71,7 +71,7 @@ def test_screenshot_def(target, testfile, task, datadir, display):
     design = Design("heartbeat")
     with design.active_fileset("rtl"):
         design.set_topmodule("heartbeat")
-    proj = ASICProject(design)
+    proj = ASIC(design)
     target(proj)
 
     ScreenshotTask.register_task(task)
@@ -89,7 +89,7 @@ def test_show_lyp_tool_klayout(datadir, display):
     design = Design("heartbeat")
     with design.active_fileset("rtl"):
         design.set_topmodule("heartbeat")
-    proj = ASICProject(design)
+    proj = ASIC(design)
     freepdk45_demo(proj)
     pdk: PDK = proj.get("library", "freepdk45", field="schema")
     pdk.set("pdk", "layermapfileset", "klayout", "def", "klayout", [], clobber=True)
@@ -107,7 +107,7 @@ def test_show_nopdk_tool_klayout(datadir, display):
     design = Design("heartbeat")
     with design.active_fileset("rtl"):
         design.set_topmodule("heartbeat")
-    proj = ASICProject(design)
+    proj = ASIC(design)
     freepdk45_demo(proj)
 
     assert isinstance(ShowTask.get_task("gds"), klayout_show.ShowTask)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - ASIC object now includes convenience methods: run(), summary(), and show().
- Refactor
  - Public API rename: ASICProject → ASIC, FPGAProject → FPGA, SimProject → Sim, LintProject → Lint.
  - Schema and type hints updated to reflect new names; defaults and examples aligned.
  - Clearer errors: unsupported PDK validation and improved messages when multiple class types match.
- Documentation
  - Quickstart, FAQ, development guides, and reference updated to the new class names and usage.
- Tests
  - Test suites updated to use the renamed classes and methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->