### PR TITLE
add apt-get update to install scripts

### DIFF
--- a/siliconcompiler/toolscripts/ubuntu20/install-bambu.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-bambu.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y autoconf autoconf-archive automake libtool \
     libbdd-dev libboost-all-dev libmpc-dev libmpfr-dev \
     libxml2-dev liblzma-dev libmpfi-dev zlib1g-dev libicu-dev bison doxygen flex \

--- a/siliconcompiler/toolscripts/ubuntu20/install-bluespec.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-bluespec.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y ghc libghc-regex-compat-dev libghc-syb-dev \
     libghc-old-time-dev libghc-split-dev tcl-dev build-essential pkg-config \
     autoconf gperf flex bison

--- a/siliconcompiler/toolscripts/ubuntu20/install-chisel.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-chisel.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y wget
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu20/install-ghdl.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-ghdl.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y gnat libgnat-9 libz-dev
 
 sudo apt-get install -y git build-essential

--- a/siliconcompiler/toolscripts/ubuntu20/install-gtkwave.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-gtkwave.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential gperf libgtk-3-dev \
     libbz2-dev libjudy-dev liblzma-dev tcl-dev tk-dev
 

--- a/siliconcompiler/toolscripts/ubuntu20/install-icarus.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-icarus.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential bison flex gperf libreadline-dev libncurses-dev
 
 sudo apt-get install -y git automake autoconf

--- a/siliconcompiler/toolscripts/ubuntu20/install-icepack.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-icepack.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential clang bison flex libreadline-dev \
                         gawk tcl-dev libffi-dev git mercurial graphviz   \
                         xdot pkg-config python python3 libftdi-dev \

--- a/siliconcompiler/toolscripts/ubuntu20/install-klayout.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-klayout.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y wget lsb-core
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu20/install-magic.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-magic.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential m4 tcsh csh libx11-dev tcl-dev tk-dev
 
 sudo apt-get install -y git

--- a/siliconcompiler/toolscripts/ubuntu20/install-montage.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-montage.sh
@@ -2,4 +2,6 @@
 
 set -ex
 
+sudo apt-get update
+
 sudo apt-get install -y imagemagick

--- a/siliconcompiler/toolscripts/ubuntu20/install-netgen.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-netgen.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential tcl-dev tk-dev
 
 sudo apt-get install -y git autotools-dev automake

--- a/siliconcompiler/toolscripts/ubuntu20/install-nextpnr.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-nextpnr.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential clang bison flex libreadline-dev \
                         gawk tcl-dev libffi-dev git mercurial graphviz   \
                         xdot pkg-config python python3 libftdi-dev \

--- a/siliconcompiler/toolscripts/ubuntu20/install-openroad.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-openroad.sh
@@ -11,6 +11,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y git
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu20/install-opensta.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-opensta.sh
@@ -4,6 +4,8 @@ set -ex
 
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 sudo apt-get install -y git build-essential wget
 sudo apt-get install -y tcl-dev tcl-tclreadline \
     bison flex libfl-dev zlib1g-dev automake autotools-dev

--- a/siliconcompiler/toolscripts/ubuntu20/install-slurm.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-slurm.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+sudo apt-get update
+
 sudo apt-get install -y munge libmunge-dev build-essential libmariadb-dev lbzip2 libjson-c-dev
 sudo apt-get install -y libdbus-1-dev
 

--- a/siliconcompiler/toolscripts/ubuntu20/install-surelog.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-surelog.sh
@@ -5,6 +5,8 @@ set -ex
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 # These dependencies are up-to-date with instructions from the INSTALL.md from the commit we are pinned to below
 sudo apt-get install -y build-essential cmake git pkg-config \
     tclsh swig uuid-dev libgoogle-perftools-dev python3 \

--- a/siliconcompiler/toolscripts/ubuntu20/install-sv2v.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-sv2v.sh
@@ -8,6 +8,8 @@ src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 mkdir -p deps
 cd deps
 
+sudo apt-get update
+
 sudo apt-get install -y curl git
 
 haskell_args=""

--- a/siliconcompiler/toolscripts/ubuntu20/install-verible.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-verible.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y wget
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu20/install-verilator.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-verilator.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y git perl python3 make autoconf g++ flex bison ccache
 sudo apt-get install -y libgoogle-perftools-dev numactl perl-doc help2man
 sudo apt-get install -y libfl2

--- a/siliconcompiler/toolscripts/ubuntu20/install-xdm.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-xdm.sh
@@ -5,6 +5,8 @@ set -ex
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 sudo apt-get install -y wget unzip
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu20/install-xyce.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-xyce.sh
@@ -5,6 +5,8 @@ set -ex
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 # Install core dependencies.
 sudo apt-get install -y build-essential gcc g++ make cmake automake autoconf bison flex git libblas-dev \
     liblapack-dev liblapack64-dev libfftw3-dev libsuitesparse-dev libopenmpi-dev libboost-all-dev \

--- a/siliconcompiler/toolscripts/ubuntu22/install-bambu.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-bambu.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y autoconf autoconf-archive automake libtool \
     libbdd-dev libboost-all-dev libmpc-dev libmpfr-dev \
     libxml2-dev liblzma-dev libmpfi-dev zlib1g-dev libicu-dev bison doxygen flex \

--- a/siliconcompiler/toolscripts/ubuntu22/install-bluespec.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-bluespec.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y tcl-dev build-essential pkg-config \
     autoconf gperf flex bison
 

--- a/siliconcompiler/toolscripts/ubuntu22/install-chisel.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-chisel.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y wget
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu22/install-ghdl.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-ghdl.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y llvm-dev clang gnat libgnat-9 libz-dev
 
 sudo apt-get install -y git build-essential

--- a/siliconcompiler/toolscripts/ubuntu22/install-gtkwave.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-gtkwave.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential gperf libgtk-3-dev \
     libbz2-dev libjudy-dev liblzma-dev tcl-dev tk-dev
 

--- a/siliconcompiler/toolscripts/ubuntu22/install-icarus.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-icarus.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential bison flex gperf libreadline-dev libncurses-dev
 
 sudo apt-get install -y git automake autoconf

--- a/siliconcompiler/toolscripts/ubuntu22/install-icepack.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-icepack.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential clang bison flex libreadline-dev \
                         gawk tcl-dev libffi-dev git mercurial graphviz   \
                         xdot pkg-config python3 libftdi-dev \

--- a/siliconcompiler/toolscripts/ubuntu22/install-klayout.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-klayout.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y wget lsb-core
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu22/install-magic.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-magic.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential m4 tcsh csh libx11-dev tcl-dev tk-dev
 
 sudo apt-get install -y git

--- a/siliconcompiler/toolscripts/ubuntu22/install-montage.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-montage.sh
@@ -2,4 +2,6 @@
 
 set -ex
 
+sudo apt-get update
+
 sudo apt-get install -y imagemagick

--- a/siliconcompiler/toolscripts/ubuntu22/install-netgen.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-netgen.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential tcl-dev tk-dev
 
 sudo apt-get install -y git autotools-dev automake

--- a/siliconcompiler/toolscripts/ubuntu22/install-nextpnr.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-nextpnr.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential clang bison flex libreadline-dev \
                         gawk tcl-dev libffi-dev git mercurial graphviz   \
                         xdot pkg-config python3 libftdi-dev \

--- a/siliconcompiler/toolscripts/ubuntu22/install-openroad.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-openroad.sh
@@ -11,6 +11,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y git
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu22/install-opensta.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-opensta.sh
@@ -4,6 +4,8 @@ set -ex
 
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 sudo apt-get install -y git build-essential wget
 sudo apt-get install -y tcl-dev tcl-tclreadline \
     bison flex libfl-dev zlib1g-dev automake autotools-dev

--- a/siliconcompiler/toolscripts/ubuntu22/install-slurm.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-slurm.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+sudo apt-get update
+
 sudo apt-get install -y munge libmunge-dev build-essential libmariadb-dev lbzip2 libjson-c-dev
 sudo apt-get install -y libdbus-1-dev
 

--- a/siliconcompiler/toolscripts/ubuntu22/install-surelog.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-surelog.sh
@@ -5,6 +5,8 @@ set -ex
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 # These dependencies are up-to-date with instructions from the INSTALL.md from the commit we are pinned to below
 sudo apt-get install -y build-essential cmake git pkg-config \
     tclsh swig uuid-dev libgoogle-perftools-dev python3 \

--- a/siliconcompiler/toolscripts/ubuntu22/install-surfer.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-surfer.sh
@@ -8,6 +8,8 @@ src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 mkdir -p deps
 cd deps
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential curl git libssl-dev openssl pkg-config
 
 USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"

--- a/siliconcompiler/toolscripts/ubuntu22/install-sv2v.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-sv2v.sh
@@ -8,6 +8,8 @@ src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 mkdir -p deps
 cd deps
 
+sudo apt-get update
+
 sudo apt-get install -y curl git
 
 haskell_args=""

--- a/siliconcompiler/toolscripts/ubuntu22/install-verible.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-verible.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y wget
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu22/install-verilator.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-verilator.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y git perl python3 make autoconf g++ flex bison ccache
 sudo apt-get install -y libgoogle-perftools-dev numactl perl-doc help2man
 sudo apt-get install -y libfl2

--- a/siliconcompiler/toolscripts/ubuntu22/install-vpr.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-vpr.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y git wget
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu22/install-xdm.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-xdm.sh
@@ -5,6 +5,8 @@ set -ex
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 sudo apt-get install -y wget unzip
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu22/install-xyce.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-xyce.sh
@@ -5,6 +5,8 @@ set -ex
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 # Install core dependencies.
 sudo apt-get install -y build-essential gcc g++ make cmake automake autoconf bison flex git libblas-dev \
     liblapack-dev liblapack64-dev libfftw3-dev libsuitesparse-dev libopenmpi-dev libboost-all-dev \

--- a/siliconcompiler/toolscripts/ubuntu22/install-yosys-moosic.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-yosys-moosic.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y git
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu22/install-yosys-slang.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-yosys-slang.sh
@@ -5,6 +5,8 @@ set -ex
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 sudo apt-get install -y git
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu22/install-yosys.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-yosys.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 # From: https://github.com/YosysHQ/yosys/blob/f2c689403ace0637b7455bac8f1e8d4bc312e74f/README.md
 sudo apt-get install -y build-essential clang bison flex \
 	libreadline-dev gawk tcl-dev libffi-dev git libfl-dev \

--- a/siliconcompiler/toolscripts/ubuntu24/install-bambu.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-bambu.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y autoconf autoconf-archive automake libtool \
     libbdd-dev libboost-all-dev libmpc-dev libmpfr-dev \
     libxml2-dev liblzma-dev libmpfi-dev zlib1g-dev libicu-dev bison doxygen flex \

--- a/siliconcompiler/toolscripts/ubuntu24/install-bluespec.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-bluespec.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y ghc libghc-regex-compat-dev libghc-syb-dev \
     libghc-old-time-dev libghc-split-dev tcl-dev build-essential pkg-config \
     autoconf gperf flex bison

--- a/siliconcompiler/toolscripts/ubuntu24/install-chisel.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-chisel.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y wget
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu24/install-ghdl.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-ghdl.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y llvm-dev clang gnat libgnat-9 libz-dev
 
 sudo apt-get install -y git build-essential

--- a/siliconcompiler/toolscripts/ubuntu24/install-gtkwave.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-gtkwave.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential gperf libgtk-3-dev \
     libbz2-dev libjudy-dev liblzma-dev tcl-dev tk-dev autotools-dev \
     automake

--- a/siliconcompiler/toolscripts/ubuntu24/install-icarus.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-icarus.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential bison flex gperf libreadline-dev libncurses-dev \
     autotools-dev automake
 

--- a/siliconcompiler/toolscripts/ubuntu24/install-icepack.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-icepack.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential clang bison flex libreadline-dev \
                         gawk tcl-dev libffi-dev git mercurial graphviz   \
                         xdot pkg-config python3 libftdi-dev \

--- a/siliconcompiler/toolscripts/ubuntu24/install-klayout.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-klayout.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y wget software-properties-common
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu24/install-magic.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-magic.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential m4 tcsh csh libx11-dev tcl-dev tk-dev
 
 sudo apt-get install -y git

--- a/siliconcompiler/toolscripts/ubuntu24/install-montage.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-montage.sh
@@ -2,4 +2,6 @@
 
 set -ex
 
+sudo apt-get update
+
 sudo apt-get install -y imagemagick

--- a/siliconcompiler/toolscripts/ubuntu24/install-netgen.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-netgen.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential tcl-dev tk-dev m4
 
 sudo apt-get install -y git autotools-dev automake

--- a/siliconcompiler/toolscripts/ubuntu24/install-nextpnr.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-nextpnr.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential clang bison flex libreadline-dev \
                         gawk tcl-dev libffi-dev git mercurial graphviz   \
                         xdot pkg-config python3 libftdi-dev \

--- a/siliconcompiler/toolscripts/ubuntu24/install-openroad.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-openroad.sh
@@ -11,6 +11,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y git
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu24/install-opensta.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-opensta.sh
@@ -4,6 +4,8 @@ set -ex
 
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 sudo apt-get install -y git build-essential wget
 sudo apt-get install -y tcl-dev tcl-tclreadline \
     bison flex libfl-dev zlib1g-dev automake autotools-dev

--- a/siliconcompiler/toolscripts/ubuntu24/install-slurm.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-slurm.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+sudo apt-get update
+
 sudo apt-get install -y munge libmunge-dev build-essential libmariadb-dev lbzip2 libjson-c-dev
 sudo apt-get install -y libdbus-1-dev
 

--- a/siliconcompiler/toolscripts/ubuntu24/install-surelog.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-surelog.sh
@@ -5,6 +5,8 @@ set -ex
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 # These dependencies are up-to-date with instructions from the INSTALL.md from the commit we are pinned to below
 sudo apt-get install -y build-essential cmake git pkg-config \
     tclsh swig uuid-dev libgoogle-perftools-dev python3 \

--- a/siliconcompiler/toolscripts/ubuntu24/install-surfer.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-surfer.sh
@@ -8,6 +8,8 @@ src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 mkdir -p deps
 cd deps
 
+sudo apt-get update
+
 sudo apt-get install -y build-essential curl git libssl-dev openssl pkg-config
 
 USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"

--- a/siliconcompiler/toolscripts/ubuntu24/install-sv2v.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-sv2v.sh
@@ -8,6 +8,8 @@ src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 mkdir -p deps
 cd deps
 
+sudo apt-get update
+
 sudo apt-get install -y curl git
 
 haskell_args=""

--- a/siliconcompiler/toolscripts/ubuntu24/install-verible.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-verible.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y wget
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu24/install-verilator.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-verilator.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y git perl python3 make autoconf g++ flex bison ccache
 sudo apt-get install -y libgoogle-perftools-dev numactl perl-doc help2man
 sudo apt-get install -y libfl2

--- a/siliconcompiler/toolscripts/ubuntu24/install-vpr.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-vpr.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y git wget
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu24/install-xdm.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-xdm.sh
@@ -5,6 +5,8 @@ set -ex
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 sudo apt-get install -y wget unzip
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu24/install-xyce.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-xyce.sh
@@ -5,6 +5,8 @@ set -ex
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 # Install core dependencies.
 sudo apt-get install -y build-essential gcc g++ make cmake automake autoconf bison flex git libblas-dev \
     liblapack-dev liblapack64-dev libfftw3-dev libsuitesparse-dev libopenmpi-dev libboost-all-dev \

--- a/siliconcompiler/toolscripts/ubuntu24/install-yosys-moosic.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-yosys-moosic.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 sudo apt-get install -y git
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu24/install-yosys-slang.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-yosys-slang.sh
@@ -5,6 +5,8 @@ set -ex
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
+sudo apt-get update
+
 sudo apt-get install -y git
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu24/install-yosys.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-yosys.sh
@@ -12,6 +12,8 @@ else
     SUDO_INSTALL=""
 fi
 
+sudo apt-get update
+
 # From: https://github.com/YosysHQ/yosys/blob/f2c689403ace0637b7455bac8f1e8d4bc312e74f/README.md
 sudo apt-get install -y build-essential clang bison flex \
 	libreadline-dev gawk tcl-dev libffi-dev git libfl-dev \


### PR DESCRIPTION
Closes #4206 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of all Ubuntu 20.04/22.04/24.04 installer scripts by running apt-get update before package installation to avoid stale index failures.

- Chores
  - Expanded dependency sets to ensure successful builds for select tools: icepack, surelog, xyce, yosys (Ubuntu 22/24), and verilator (Ubuntu 22).
  - Preserved existing installation flows; minor formatting cleanups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->