### PR TITLE
update openroad pdk parameters: Add help validation, OpenROAD params, PDK to APR, multi-lib filler

### DIFF
--- a/siliconcompiler/library.py
+++ b/siliconcompiler/library.py
@@ -67,6 +67,10 @@ class ToolLibrarySchema(LibrarySchema):
         if isinstance(help, str):
             # grab first line for short help
             help = trim(help)
+
+            if not help:
+                raise ValueError("help is required")
+
             shorthelp = help.splitlines()[0].strip()
         else:
             raise TypeError("help must be a string")

--- a/siliconcompiler/tools/openroad/__init__.py
+++ b/siliconcompiler/tools/openroad/__init__.py
@@ -44,6 +44,17 @@ class OpenROADPDK(PDK):
         self.define_tool_parameter("openroad", "rcx_maxlayer", "str",
                                    "Max layer to generate an OpenRCX extraction bench for.")
 
+        self.define_tool_parameter("openroad", "drt_process_node", "str",
+                                   "Detailed routing node name")
+        self.define_tool_parameter("openroad", "drt_disable_via_gen", "bool",
+                                   "true/false, when true turns off via generation in detailed "
+                                   "router and only uses the specified tech vias")
+        self.define_tool_parameter("openroad", "drt_repair_pdn_vias", "str",
+                                   "Via layer to repair after detailed routing")
+
+        self.define_tool_parameter("openroad", "dpl_disallow_one_site", "bool",
+                                   "true/false, disallow single site gaps in detail placement")
+
     def set_openroad_rclayers(self, signal: str = None, clock: str = None):
         """
         Sets the signal and/or clock layers for RC extraction.
@@ -116,6 +127,47 @@ class OpenROADPDK(PDK):
             layer (str): The name of the top-most layer to be used for RC extraction.
         """
         self.set("tool", "openroad", "rcx_maxlayer", layer)
+
+    def set_openroad_processnode(self, node: str):
+        """Sets the detailed routing process node name.
+
+        Args:
+            node (str): The name of the process node.
+        """
+        self.set("tool", "openroad", "drt_process_node", node)
+
+    def set_openroad_detailedroutedisableviagen(self, value: bool):
+        """Enables or disables automatic via generation in the detailed router.
+
+        When set to True, the router will only use vias explicitly defined in the
+        technology LEF, rather than generating new ones.
+
+        Args:
+            value (bool): The boolean value to set. True disables via generation.
+        """
+        self.set("tool", "openroad", "drt_disable_via_gen", value)
+
+    def set_openroad_detailedrouteviarepair(self, layer: str):
+        """Specifies the via layer to repair after detailed routing.
+
+        This is used to fix issues on a specific via layer in the power delivery
+        network (PDN) post-routing.
+
+        Args:
+            layer (str): The name of the via layer to repair.
+        """
+        self.set("tool", "openroad", "drt_repair_pdn_vias", layer)
+
+    def set_openroad_disallowonesitegaps(self, value: bool):
+        """Disallows or allows single-site gaps in detailed placement.
+
+        Setting this to True can help prevent unroutable situations by avoiding
+        very small gaps between cells.
+
+        Args:
+            value (bool): The boolean value to set. True disallows single-site gaps.
+        """
+        self.set("tool", "openroad", "dpl_disallow_one_site", value)
 
 
 class OpenROADStdCellLibrary(StdCellLibrary):

--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -358,7 +358,7 @@ class _OpenROADDRTCommonParameter(OpenROADTask):
         super().setup()
 
         if not self.get("var", "drt_process_node"):
-            if self.pdk.valid("tool", "openroad", "drt_process_node"):
+            if self.pdk.get("tool", "openroad", "drt_process_node"):
                 self.add_required_key(self.pdk, "tool", "openroad", "drt_process_node")
                 self.set("var", "drt_process_node",
                          self.pdk.get("tool", "openroad", "drt_process_node"))
@@ -396,13 +396,13 @@ class OpenROADDRTParameter(_OpenROADDRTCommonParameter):
         super().setup()
 
         if not self.get("var", "drt_disable_via_gen"):
-            if self.pdk.valid("tool", "openroad", "drt_disable_via_gen"):
+            if self.pdk.get("tool", "openroad", "drt_disable_via_gen"):
                 self.add_required_key(self.pdk, "tool", "openroad", "drt_disable_via_gen")
                 self.set("var", "drt_disable_via_gen",
                          self.pdk.get("tool", "openroad", "drt_disable_via_gen"))
 
         if not self.get("var", "drt_repair_pdn_vias"):
-            if self.pdk.valid("tool", "openroad", "drt_repair_pdn_vias"):
+            if self.pdk.get("tool", "openroad", "drt_repair_pdn_vias"):
                 self.add_required_key(self.pdk, "tool", "openroad", "drt_repair_pdn_vias")
                 self.set("var", "drt_repair_pdn_vias",
                          self.pdk.get("tool", "openroad", "drt_repair_pdn_vias"))

--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -200,6 +200,11 @@ class OpenROADDPLParameter(OpenROADTask):
         self.add_required_key("var", "dpl_max_displacement")
         self.add_required_key("var", "dpl_disallow_one_site")
 
+        self.add_required_key(self.pdk, "tool", "openroad", "dpl_disallow_one_site")
+        self.set("var", "dpl_disallow_one_site",
+                 self.pdk.get("tool", "openroad", "dpl_disallow_one_site"),
+                 clobber=False)
+
 
 class OpenROADFillCellsParameter(OpenROADTask):
     def __init__(self):
@@ -352,6 +357,12 @@ class _OpenROADDRTCommonParameter(OpenROADTask):
     def setup(self):
         super().setup()
 
+        if not self.get("var", "drt_process_node"):
+            if self.pdk.valid("tool", "openroad", "drt_process_node"):
+                self.add_required_key(self.pdk, "tool", "openroad", "drt_process_node")
+                self.set("var", "drt_process_node",
+                         self.pdk.get("tool", "openroad", "drt_process_node"))
+
         if self.get("var", "drt_process_node"):
             self.add_required_key("var", "drt_process_node")
         if self.get("var", "detailed_route_default_via"):
@@ -383,6 +394,18 @@ class OpenROADDRTParameter(_OpenROADDRTCommonParameter):
 
     def setup(self):
         super().setup()
+
+        if not self.get("var", "drt_disable_via_gen"):
+            if self.pdk.valid("tool", "openroad", "drt_disable_via_gen"):
+                self.add_required_key(self.pdk, "tool", "openroad", "drt_disable_via_gen")
+                self.set("var", "drt_disable_via_gen",
+                         self.pdk.get("tool", "openroad", "drt_disable_via_gen"))
+
+        if not self.get("var", "drt_repair_pdn_vias"):
+            if self.pdk.valid("tool", "openroad", "drt_repair_pdn_vias"):
+                self.add_required_key(self.pdk, "tool", "openroad", "drt_repair_pdn_vias")
+                self.set("var", "drt_repair_pdn_vias",
+                         self.pdk.get("tool", "openroad", "drt_repair_pdn_vias"))
 
         self.add_required_key("var", "drt_disable_via_gen")
         if self.get("var", "drt_via_in_pin_bottom_layer"):

--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -729,12 +729,17 @@ proc sc_setup_parasitics { } {
 }
 
 proc sc_insert_fillers { } {
-    global sc_mainlib
+    global sc_logiclibs
 
-    set fillers [sc_cfg_get library $sc_mainlib asic cells filler]
+    set fillers []
+    foreach lib $sc_logiclibs {
+        lappend fillers {*}[sc_cfg_get library $lib asic cells filler]
+    }
 
     if { [sc_cfg_tool_task_get var dpl_use_decap_fillers] } {
-        lappend fillers {*}[sc_cfg_get library $sc_mainlib asic cells decap]
+        foreach lib $sc_logiclibs {
+            lappend fillers {*}[sc_cfg_get library $lib asic cells decap]
+        }
     }
     if { $fillers != "" } {
         filler_placement $fillers

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -172,6 +172,16 @@ def test_define_tool_parameter_invalid_help():
         )
 
 
+def test_define_tool_parameter_empty_help():
+    with pytest.raises(ValueError, match="help is required"):
+        ToolLibrarySchema("test").define_tool_parameter(
+            "yosys",
+            "timingcorner",
+            "str",
+            ""
+        )
+
+
 def test_define_tool_parameter_multiline_help_empty_first_line():
     lib = ToolLibrarySchema("test")
     lib.define_tool_parameter(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added OpenROAD options (process node, disable via generation, PDN via repair layer, disallow one-site gaps) that can auto-populate from PDK settings.
  - Filler and decap filler insertion now aggregates cells across all logic libraries instead of a single main library.
- Bug Fixes
  - Stricter validation: defining a tool parameter now errors if help text is empty or whitespace.
- Tests
  - Added test to verify an error is raised for empty help text in tool parameter definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->