### PR TITLE
rename package to dataroot in schema

### DIFF
--- a/siliconcompiler/remote/client.py
+++ b/siliconcompiler/remote/client.py
@@ -571,21 +571,21 @@ service, provided by SiliconCompiler, is not intended to process proprietary IP.
         Helper method to run a local import stage for remote jobs.
         '''
 
-        # Ensure packages with python sources are copied
+        # Ensure dataroots with python sources are copied
         for key in self.__project.allkeys():
             key_type = self.__project.get(*key, field='type')
 
             if 'dir' in key_type or 'file' in key_type:
                 for _, step, index in self.__project.get(*key, field=None).getvalues(
                         return_defvalue=False):
-                    packages = self.__project.get(*key, field='package', step=step, index=index)
-                    if not isinstance(packages, list):
-                        packages = [packages]
+                    dataroots = self.__project.get(*key, field='dataroot', step=step, index=index)
+                    if not isinstance(dataroots, list):
+                        dataroots = [dataroots]
                     force_copy = False
-                    for package in packages:
-                        if not package:
+                    for dataroot in dataroots:
+                        if not dataroot:
                             continue
-                        if package.startswith('python://'):
+                        if dataroot.startswith('python://'):
                             force_copy = True
                     if force_copy:
                         self.__project.set(*key, True, field='copy', step=step, index=index)

--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -516,11 +516,13 @@ class SchedulerNode:
                     return True
             else:
                 # check package values
-                check_val = self.__project.get(*key, field='package', step=step, index=index)
-                prev_val = previous_run.__project.get(*key, field='package', step=step, index=index)
+                check_val = self.__project.get(*key, field='dataroot',
+                                               step=step, index=index)
+                prev_val = previous_run.__project.get(*key, field='dataroot',
+                                                      step=step, index=index)
 
                 if check_val != prev_val:
-                    print_warning(key, "file package")
+                    print_warning(key, "file dataroot")
                     return True
 
                 files = self.__project.find_files(*key, step=step, index=index)

--- a/siliconcompiler/schema/_metadata.py
+++ b/siliconcompiler/schema/_metadata.py
@@ -1,2 +1,2 @@
 # Version number following semver standard.
-version = '0.51.5'
+version = '0.52.0'

--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -780,7 +780,7 @@ class BaseSchema:
 
     def find_files(self, *keypath: str, missing_ok: bool = False,
                    step: str = None, index: Union[int, str] = None,
-                   packages: Dict[str, Union[str, Callable]] = None,
+                   dataroots: Dict[str, Union[str, Callable]] = None,
                    collection_dir: str = None,
                    cwd: str = None) -> Union[str, List[str], Set[str]]:
         """
@@ -798,7 +798,7 @@ class BaseSchema:
                 on a per-node basis.
             index (str): Index name to access for parameters that may be specified
                 on a per-node basis.
-            packages (dict of resolvers): dirctionary of path resolvers for package
+            dataroots (dict of resolvers): dirctionary of path resolvers for dataroot
                 paths, these can either be a path or a callable function
             collection_dir (path): optional path to a collections directory
             cwd (path): optional path to current working directory, this will default
@@ -818,13 +818,13 @@ class BaseSchema:
         return self.__find_files_or_hash(
             *keypath, missing_ok=missing_ok,
             step=step, index=index,
-            packages=packages,
+            dataroots=dataroots,
             collection_dir=collection_dir,
             cwd=cwd, hash=False)
 
     def __find_files_or_hash(self, *keypath: str, missing_ok: bool = False,
                              step: str = None, index: Union[int, str] = None,
-                             packages: Dict[str, Union[str, Callable]] = None,
+                             dataroots: Dict[str, Union[str, Callable]] = None,
                              collection_dir: str = None,
                              cwd: str = None,
                              hash: bool = False) -> Union[str, List[str], Set[str]]:
@@ -843,7 +843,7 @@ class BaseSchema:
                 on a per-node basis.
             index (str): Index name to access for parameters that may be specified
                 on a per-node basis.
-            packages (dict of resolvers): dirctionary of path resolvers for package
+            dataroots (dict of resolvers): dirctionary of path resolvers for dataroot
                 paths, these can either be a path or a callable function
             collection_dir (path): optional path to a collections directory
             cwd (path): optional path to current working directory, this will default
@@ -890,26 +890,26 @@ class BaseSchema:
         if cwd is None:
             cwd = os.getcwd()
 
-        if packages is None:
-            packages = base_schema._find_files_dataroot_resolvers()
+        if dataroots is None:
+            dataroots = base_schema._find_files_dataroot_resolvers()
 
         resolved_paths = []
         root_search_paths = base_schema._find_files_search_paths(keypath[-1], step, index)
         for path in paths:
             search_paths = root_search_paths.copy()
 
-            package = path.get(field="package")
-            if package:
-                if package not in packages:
-                    raise ValueError(f"Resolver for {package} not provided: "
+            dataroot = path.get(field="dataroot")
+            if dataroot:
+                if dataroot not in dataroots:
+                    raise ValueError(f"Resolver for {dataroot} not provided: "
                                      f"{self.__format_key(*keypath)}")
-                package_path = packages[package]
-                if isinstance(package_path, str):
-                    search_paths.append(os.path.abspath(package_path))
-                elif callable(package_path):
-                    search_paths.append(package_path())
+                dataroot_path = dataroots[dataroot]
+                if isinstance(dataroot_path, str):
+                    search_paths.append(os.path.abspath(dataroot_path))
+                elif callable(dataroot_path):
+                    search_paths.append(dataroot_path())
                 else:
-                    raise TypeError(f"Resolver for {package} is not a recognized type: "
+                    raise TypeError(f"Resolver for {dataroot} is not a recognized type: "
                                     f"{self.__format_key(*keypath)}")
             else:
                 if cwd:
@@ -927,9 +927,9 @@ class BaseSchema:
                 resolved = None
                 if not missing_ok:
                     report_paths = ", ".join(search_paths)
-                    if package:
+                    if dataroot:
                         raise FileNotFoundError(
-                            f'Could not find "{path.get()}" in {package} '
+                            f'Could not find "{path.get()}" in {dataroot} '
                             f'{self.__format_key(*keypath)}: {report_paths}')
                     else:
                         raise FileNotFoundError(
@@ -945,7 +945,7 @@ class BaseSchema:
 
     def check_filepaths(self, ignore_keys: bool = None,
                         logger: logging.Logger = None,
-                        packages: Dict[str, Union[str, Callable]] = None,
+                        dataroots: Dict[str, Union[str, Callable]] = None,
                         collection_dir: str = None,
                         cwd: str = None) -> bool:
         '''
@@ -954,7 +954,7 @@ class BaseSchema:
         Args:
             ignore_keys (list of keypaths): list of keypaths to ignore while checking
             logger (:class:`logging.Logger`): optional logger to use to report errors
-            packages (dict of resolvers): dirctionary of path resolvers for package
+            dataroots (dict of resolvers): dirctionary of path resolvers for dataroot
                 paths, these can either be a path or a callable function
             collection_dir (path): optional path to a collections directory
             cwd (path): optional path to current working directory, this will default
@@ -990,7 +990,7 @@ class BaseSchema:
 
                 found_files = BaseSchema.find_files(
                     self, *keypath, missing_ok=True, step=step, index=index,
-                    packages=packages, collection_dir=collection_dir, cwd=cwd)
+                    dataroots=dataroots, collection_dir=collection_dir, cwd=cwd)
 
                 if not param.is_list():
                     check_files = [check_files]
@@ -1014,7 +1014,7 @@ class BaseSchema:
 
     def hash_files(self, *keypath, missing_ok: bool = False,
                    step: str = None, index: Union[int, str] = None,
-                   packages: Dict[str, Union[str, Callable]] = None,
+                   dataroots: Dict[str, Union[str, Callable]] = None,
                    collection_dir: str = None,
                    cwd: str = None):
         '''Generates hash values for a list of parameter files.
@@ -1040,7 +1040,7 @@ class BaseSchema:
                 on a per-node basis.
             index (str): Index name to access for parameters that may be specified
                 on a per-node basis.
-            packages (dict of resolvers): dirctionary of path resolvers for package
+            dataroots (dict of resolvers): dirctionary of path resolvers for dataroot
                 paths, these can either be a path or a callable function
             collection_dir (path): optional path to a collections directory
             cwd (path): optional path to current working directory, this will default
@@ -1056,7 +1056,7 @@ class BaseSchema:
         return self.__find_files_or_hash(
             *keypath, missing_ok=missing_ok,
             step=step, index=index,
-            packages=packages,
+            dataroots=dataroots,
             collection_dir=collection_dir,
             cwd=cwd, hash=True)
 
@@ -1084,9 +1084,9 @@ class BaseSchema:
             kwargs (dict of str): keyword arguments that are used for setting values
 
         Example:
-            >>> with schema._active(package="lambdalib"):
+            >>> with schema._active(dataroot="lambdalib"):
             ...     schema.set("file", "top.v")
-            Sets the file to top.v and associates lambdalib as the package.
+            Sets the file to top.v and associates lambdalib as the dataroot.
         '''
 
         # Collect child schemas

--- a/siliconcompiler/schema/docs/utils.py
+++ b/siliconcompiler/schema/docs/utils.py
@@ -291,7 +291,7 @@ def build_schema_value_table(params, refdoc, keypath_prefix=None, trim_prefix=No
             is_filedir = 'file' in val_type or 'dir' in val_type
             if is_filedir:
                 val_node = format_value_file(val_type.startswith('['), value,
-                                             param.get(field='package',
+                                             param.get(field='dataroot',
                                                        step=step, index=index))
             else:
                 val_node = format_value(val_type.startswith('['), val_type.startswith('{'), value)

--- a/siliconcompiler/schema/parametervalue.py
+++ b/siliconcompiler/schema/parametervalue.py
@@ -615,37 +615,37 @@ class PathNodeValue(NodeValue):
         value (any): default value for this parameter
     '''
 
-    def __init__(self, type, value=None, package=None):
+    def __init__(self, type, value=None, dataroot=None):
         super().__init__(type, value=value)
         self.__filehash = None
-        self.__package = package
+        self.__dataroot = dataroot
 
     def getdict(self):
         return {
             **super().getdict(),
             "filehash": self.get(field="filehash"),
-            "package": self.get(field="package")
+            "dataroot": self.get(field="dataroot")
         }
 
     def _from_dict(self, manifest, keypath, version):
         super()._from_dict(manifest, keypath, version)
 
         self.set(manifest["filehash"], field="filehash")
-        self.set(manifest["package"], field="package")
+        self.set(manifest["dataroot"], field="dataroot")
 
     def get(self, field='value'):
         if field == 'filehash':
             return self.__filehash
-        if field == 'package':
-            return self.__package
+        if field == 'dataroot':
+            return self.__dataroot
         return super().get(field=field)
 
     def set(self, value, field='value'):
         if field == 'filehash':
             self.__filehash = NodeType.normalize(value, "str")
             return self
-        if field == 'package':
-            self.__package = NodeType.normalize(value, "str")
+        if field == 'dataroot':
+            self.__dataroot = NodeType.normalize(value, "str")
             return self
         return super().set(value, field=field)
 
@@ -666,7 +666,7 @@ class PathNodeValue(NodeValue):
             basename = str(pathlib.PurePosixPath(*path_paths[0:n]))
             endname = str(pathlib.PurePosixPath(*path_paths[n:]))
 
-            import_name = PathNodeValue.generate_hashed_path(basename, self.__package)
+            import_name = PathNodeValue.generate_hashed_path(basename, self.__dataroot)
             if import_name not in collected_paths:
                 continue
 
@@ -715,7 +715,7 @@ class PathNodeValue(NodeValue):
         raise FileNotFoundError(value)
 
     @staticmethod
-    def generate_hashed_path(path, package):
+    def generate_hashed_path(path, dataroot):
         '''
         Utility to map file to an unambiguous name based on its path.
 
@@ -724,7 +724,7 @@ class PathNodeValue(NodeValue):
 
         Args:
             path (str): path to directory or file
-            package (str): name of package this file belongs to
+            dataroot (str): name of dataroot this file belongs to
         '''
         path = pathlib.PurePosixPath(path)
         ext = ''.join(path.suffixes)
@@ -735,12 +735,12 @@ class PathNodeValue(NodeValue):
             barepath = pathlib.PurePosixPath(barepath.stem)
         filename = str(barepath.parts[-1])
 
-        if not package:
-            package = ''
+        if not dataroot:
+            dataroot = ''
         else:
-            package = f'{package}:'
+            dataroot = f'{dataroot}:'
 
-        path_to_hash = f'{package}{str(path.parent)}'
+        path_to_hash = f'{dataroot}{str(path.parent)}'
 
         pathhash = hashlib.sha1(path_to_hash.encode('utf-8')).hexdigest()
 
@@ -753,7 +753,7 @@ class PathNodeValue(NodeValue):
         The mapping looks like:
         path/to/file.ext => file_<hash('path/to')>.ext
         '''
-        return PathNodeValue.generate_hashed_path(self.get(), self.__package)
+        return PathNodeValue.generate_hashed_path(self.get(), self.__dataroot)
 
     def hash(self, function, **kwargs):
         """
@@ -828,7 +828,7 @@ class PathNodeValue(NodeValue):
 
     @property
     def fields(self):
-        return (*super().fields, "filehash", "package")
+        return (*super().fields, "filehash", "dataroot")
 
     @property
     def type(self):
@@ -843,8 +843,8 @@ class DirectoryNodeValue(PathNodeValue):
         value (any): default value for this parameter
     '''
 
-    def __init__(self, value=None, package=None):
-        super().__init__("dir", value=value, package=package)
+    def __init__(self, value=None, dataroot=None):
+        super().__init__("dir", value=value, dataroot=dataroot)
 
     def hash(self, function, **kwargs):
         """
@@ -871,8 +871,8 @@ class FileNodeValue(PathNodeValue):
         value (any): default value for this parameter
     '''
 
-    def __init__(self, value=None, package=None):
-        super().__init__("file", value=value, package=package)
+    def __init__(self, value=None, dataroot=None):
+        super().__init__("file", value=value, dataroot=dataroot)
         self.__date = None
         self.__author = []
 

--- a/siliconcompiler/schema_support/pathschema.py
+++ b/siliconcompiler/schema_support/pathschema.py
@@ -399,7 +399,7 @@ class PathSchema(PathSchemaBase):
         if dataroot and dataroot not in schema.getkeys("dataroot"):
             raise ValueError(f"{dataroot} is not a recognized dataroot")
 
-        with self._active(package=dataroot):
+        with self._active(dataroot=dataroot):
             yield
 
     def _get_active_dataroot(self, user_dataroot: str) -> str:
@@ -432,7 +432,7 @@ class PathSchema(PathSchemaBase):
 
         schema = self.__dataroot_section()
 
-        active_dataroot = schema._get_active("package")
+        active_dataroot = schema._get_active("dataroot")
         if active_dataroot:
             return active_dataroot
 

--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -29,7 +29,7 @@ class OpenROADSTAParameter(OpenROADTask):
         self.set_dataroot("siliconcompiler", "python://siliconcompiler")
         self.add_parameter("opensta_generic_sdc", "file", "generic opensta SDC file",
                            defvalue="tools/_common/sdc/sc_constraints.sdc",
-                           package="siliconcompiler")
+                           dataroot="siliconcompiler")
 
     def setup(self):
         super().setup()

--- a/siliconcompiler/tools/opensta/timing.py
+++ b/siliconcompiler/tools/opensta/timing.py
@@ -23,7 +23,7 @@ class TimingTaskBase(OpenSTATask):
         self.set_dataroot("siliconcompiler", "python://siliconcompiler")
         self.add_parameter("opensta_generic_sdc", "file", "generic opensta SDC file",
                            defvalue="tools/_common/sdc/sc_constraints.sdc",
-                           package="siliconcompiler")
+                           dataroot="siliconcompiler")
 
     def set_timing_mode(self, mode: str, step: str = None, index: str = None):
         return self.set("var", "timing_mode", mode, step=step, index=index)

--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -196,7 +196,7 @@ class ASICSynthesis(_ASICTask, YosysTask):
             "[file]",
             "Files used in synthesis to perform additional techmapping",
             "techmaps/lcu_kogge_stone.v",
-            package="yosys-techmaps")
+            dataroot="yosys-techmaps")
 
     def __init_hierarchy_parameter(self):
         self.add_parameter(

--- a/tests/data/defaults.json
+++ b/tests/data/defaults.json
@@ -17,7 +17,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.51.5",
+              "value": "0.52.0",
               "signature": null
             }
           }
@@ -250,7 +250,7 @@
                     "value": [],
                     "signature": [],
                     "filehash": [],
-                    "package": [],
+                    "dataroot": [],
                     "date": [],
                     "author": []
                   }
@@ -282,7 +282,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -1467,7 +1467,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -1500,7 +1500,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": []
+                        "dataroot": []
                       }
                     }
                   },
@@ -1530,7 +1530,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -1561,7 +1561,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -1722,7 +1722,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -1754,7 +1754,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": []
+                      "dataroot": []
                     }
                   }
                 },
@@ -1783,7 +1783,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -1814,7 +1814,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -1845,7 +1845,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -1927,7 +1927,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -1959,7 +1959,7 @@
                       "value": null,
                       "signature": null,
                       "filehash": null,
-                      "package": null
+                      "dataroot": null
                     }
                   }
                 },
@@ -2149,7 +2149,7 @@
                 "value": null,
                 "signature": null,
                 "filehash": null,
-                "package": null,
+                "dataroot": null,
                 "date": null,
                 "author": []
               }
@@ -2180,7 +2180,7 @@
                 "value": null,
                 "signature": null,
                 "filehash": null,
-                "package": null
+                "dataroot": null
               }
             }
           },
@@ -2311,7 +2311,7 @@
                 "value": "build",
                 "signature": null,
                 "filehash": null,
-                "package": null
+                "dataroot": null
               }
             }
           },
@@ -3067,7 +3067,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.51.5",
+              "value": "0.52.0",
               "signature": null
             }
           }
@@ -3300,7 +3300,7 @@
                     "value": [],
                     "signature": [],
                     "filehash": [],
-                    "package": [],
+                    "dataroot": [],
                     "date": [],
                     "author": []
                   }
@@ -3332,7 +3332,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -5205,7 +5205,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -5238,7 +5238,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": []
+                        "dataroot": []
                       }
                     }
                   },
@@ -5268,7 +5268,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -5299,7 +5299,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -5460,7 +5460,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -5492,7 +5492,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": []
+                      "dataroot": []
                     }
                   }
                 },
@@ -5521,7 +5521,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -5552,7 +5552,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -5583,7 +5583,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -5665,7 +5665,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -5697,7 +5697,7 @@
                       "value": null,
                       "signature": null,
                       "filehash": null,
-                      "package": null
+                      "dataroot": null
                     }
                   }
                 },
@@ -5887,7 +5887,7 @@
                 "value": null,
                 "signature": null,
                 "filehash": null,
-                "package": null,
+                "dataroot": null,
                 "date": null,
                 "author": []
               }
@@ -5918,7 +5918,7 @@
                 "value": null,
                 "signature": null,
                 "filehash": null,
-                "package": null
+                "dataroot": null
               }
             }
           },
@@ -6049,7 +6049,7 @@
                 "value": "build",
                 "signature": null,
                 "filehash": null,
-                "package": null
+                "dataroot": null
               }
             }
           },
@@ -6880,7 +6880,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.51.5",
+              "value": "0.52.0",
               "signature": null
             }
           }
@@ -7113,7 +7113,7 @@
                     "value": [],
                     "signature": [],
                     "filehash": [],
-                    "package": [],
+                    "dataroot": [],
                     "date": [],
                     "author": []
                   }
@@ -7145,7 +7145,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -9250,7 +9250,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -9283,7 +9283,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": []
+                        "dataroot": []
                       }
                     }
                   },
@@ -9313,7 +9313,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -9344,7 +9344,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -9505,7 +9505,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -9537,7 +9537,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": []
+                      "dataroot": []
                     }
                   }
                 },
@@ -9566,7 +9566,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -9597,7 +9597,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -9628,7 +9628,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -9710,7 +9710,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -9742,7 +9742,7 @@
                       "value": null,
                       "signature": null,
                       "filehash": null,
-                      "package": null
+                      "dataroot": null
                     }
                   }
                 },
@@ -9932,7 +9932,7 @@
                 "value": null,
                 "signature": null,
                 "filehash": null,
-                "package": null,
+                "dataroot": null,
                 "date": null,
                 "author": []
               }
@@ -9963,7 +9963,7 @@
                 "value": null,
                 "signature": null,
                 "filehash": null,
-                "package": null
+                "dataroot": null
               }
             }
           },
@@ -10094,7 +10094,7 @@
                 "value": "build",
                 "signature": null,
                 "filehash": null,
-                "package": null
+                "dataroot": null
               }
             }
           },
@@ -11601,7 +11601,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.51.5",
+              "value": "0.52.0",
               "signature": null
             }
           }
@@ -11834,7 +11834,7 @@
                     "value": [],
                     "signature": [],
                     "filehash": [],
-                    "package": [],
+                    "dataroot": [],
                     "date": [],
                     "author": []
                   }
@@ -11866,7 +11866,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -13051,7 +13051,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -13084,7 +13084,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": []
+                        "dataroot": []
                       }
                     }
                   },
@@ -13114,7 +13114,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -13145,7 +13145,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -13306,7 +13306,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -13338,7 +13338,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": []
+                      "dataroot": []
                     }
                   }
                 },
@@ -13367,7 +13367,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -13398,7 +13398,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -13429,7 +13429,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -13511,7 +13511,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -13543,7 +13543,7 @@
                       "value": null,
                       "signature": null,
                       "filehash": null,
-                      "package": null
+                      "dataroot": null
                     }
                   }
                 },
@@ -13733,7 +13733,7 @@
                 "value": null,
                 "signature": null,
                 "filehash": null,
-                "package": null,
+                "dataroot": null,
                 "date": null,
                 "author": []
               }
@@ -13764,7 +13764,7 @@
                 "value": null,
                 "signature": null,
                 "filehash": null,
-                "package": null
+                "dataroot": null
               }
             }
           },
@@ -13895,7 +13895,7 @@
                 "value": "build",
                 "signature": null,
                 "filehash": null,
-                "package": null
+                "dataroot": null
               }
             }
           },
@@ -14651,7 +14651,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.51.5",
+              "value": "0.52.0",
               "signature": null
             }
           }
@@ -14884,7 +14884,7 @@
                     "value": [],
                     "signature": [],
                     "filehash": [],
-                    "package": [],
+                    "dataroot": [],
                     "date": [],
                     "author": []
                   }
@@ -14916,7 +14916,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -16101,7 +16101,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -16134,7 +16134,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": []
+                        "dataroot": []
                       }
                     }
                   },
@@ -16164,7 +16164,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -16195,7 +16195,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -16356,7 +16356,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -16388,7 +16388,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": []
+                      "dataroot": []
                     }
                   }
                 },
@@ -16417,7 +16417,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -16448,7 +16448,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -16479,7 +16479,7 @@
                       "value": [],
                       "signature": [],
                       "filehash": [],
-                      "package": [],
+                      "dataroot": [],
                       "date": [],
                       "author": []
                     }
@@ -16561,7 +16561,7 @@
                         "value": [],
                         "signature": [],
                         "filehash": [],
-                        "package": [],
+                        "dataroot": [],
                         "date": [],
                         "author": []
                       }
@@ -16593,7 +16593,7 @@
                       "value": null,
                       "signature": null,
                       "filehash": null,
-                      "package": null
+                      "dataroot": null
                     }
                   }
                 },
@@ -16783,7 +16783,7 @@
                 "value": null,
                 "signature": null,
                 "filehash": null,
-                "package": null,
+                "dataroot": null,
                 "date": null,
                 "author": []
               }
@@ -16814,7 +16814,7 @@
                 "value": null,
                 "signature": null,
                 "filehash": null,
-                "package": null
+                "dataroot": null
               }
             }
           },
@@ -16945,7 +16945,7 @@
                 "value": "build",
                 "signature": null,
                 "filehash": null,
-                "package": null
+                "dataroot": null
               }
             }
           },
@@ -17778,7 +17778,7 @@
                     "value": [],
                     "signature": [],
                     "filehash": [],
-                    "package": [],
+                    "dataroot": [],
                     "date": [],
                     "author": []
                   }
@@ -17831,7 +17831,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": []
+                  "dataroot": []
                 }
               }
             },
@@ -17901,7 +17901,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": []
+                  "dataroot": []
                 }
               }
             },
@@ -18077,7 +18077,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18108,7 +18108,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18139,7 +18139,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18170,7 +18170,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18201,7 +18201,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18232,7 +18232,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18263,7 +18263,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18294,7 +18294,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18351,7 +18351,7 @@
                 "value": [],
                 "signature": [],
                 "filehash": [],
-                "package": [],
+                "dataroot": [],
                 "date": [],
                 "author": []
               }
@@ -18521,7 +18521,7 @@
                     "value": [],
                     "signature": [],
                     "filehash": [],
-                    "package": [],
+                    "dataroot": [],
                     "date": [],
                     "author": []
                   }
@@ -18632,7 +18632,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18663,7 +18663,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18694,7 +18694,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18725,7 +18725,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18756,7 +18756,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18787,7 +18787,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18818,7 +18818,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18849,7 +18849,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -18906,7 +18906,7 @@
                 "value": [],
                 "signature": [],
                 "filehash": [],
-                "package": [],
+                "dataroot": [],
                 "date": [],
                 "author": []
               }
@@ -19716,7 +19716,7 @@
                     "value": [],
                     "signature": [],
                     "filehash": [],
-                    "package": [],
+                    "dataroot": [],
                     "date": [],
                     "author": []
                   }
@@ -19827,7 +19827,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -19858,7 +19858,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -19889,7 +19889,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -19920,7 +19920,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -19951,7 +19951,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -19982,7 +19982,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -20013,7 +20013,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -20044,7 +20044,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -20101,7 +20101,7 @@
                 "value": [],
                 "signature": [],
                 "filehash": [],
-                "package": [],
+                "dataroot": [],
                 "date": [],
                 "author": []
               }
@@ -20343,7 +20343,7 @@
                     "value": [],
                     "signature": [],
                     "filehash": [],
-                    "package": [],
+                    "dataroot": [],
                     "date": [],
                     "author": []
                   }
@@ -20454,7 +20454,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -20485,7 +20485,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -20516,7 +20516,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -20547,7 +20547,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -20578,7 +20578,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -20609,7 +20609,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -20640,7 +20640,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -20671,7 +20671,7 @@
                   "value": [],
                   "signature": [],
                   "filehash": [],
-                  "package": [],
+                  "dataroot": [],
                   "date": [],
                   "author": []
                 }
@@ -20728,7 +20728,7 @@
                 "value": [],
                 "signature": [],
                 "filehash": [],
-                "package": [],
+                "dataroot": [],
                 "date": [],
                 "author": []
               }

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -590,7 +590,7 @@ def test_check_files_changed_package(project, monkeypatch, caplog):
         assert node.check_files_changed(
             node_other, now,
             [("library", "testdesign", "fileset", "rtl", "file", "verilog")]) is True
-    assert "[library,testdesign,fileset,rtl,file,verilog] (file package) in steptwo/0 has " \
+    assert "[library,testdesign,fileset,rtl,file,verilog] (file dataroot) in steptwo/0 has " \
         "been modified from previous run" in caplog.text
 
 

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -1413,7 +1413,7 @@ def test_find_files_with_package():
         f.write("test")
 
     assert schema.set("package", "file", ["test0.txt", "test1.txt"])
-    assert schema.set("package", "file", ["this_package", "this_package"], field="package")
+    assert schema.set("package", "file", ["this_package", "this_package"], field="dataroot")
 
     class Resolver:
         called = 0
@@ -1429,7 +1429,7 @@ def test_find_files_with_package():
         "that_package": resolve1.resolve,
     }
 
-    assert schema.find_files("package", "file", packages=package_map) == [
+    assert schema.find_files("package", "file", dataroots=package_map) == [
         os.path.abspath("package_path/test0.txt"),
         os.path.abspath("package_path/test1.txt"),
     ]
@@ -1449,7 +1449,7 @@ def test_find_files_with_package_not_found():
         f.write("test")
 
     assert schema.set("package", "file", ["test0.txt", "test1.txt"])
-    assert schema.set("package", "file", ["this_package", "this_package"], field="package")
+    assert schema.set("package", "file", ["this_package", "this_package"], field="dataroot")
 
     class Resolver:
         called = 0
@@ -1467,7 +1467,7 @@ def test_find_files_with_package_not_found():
 
     with pytest.raises(FileNotFoundError,
                        match=r"Could not find \"test1.txt\" in this_package \[package,file\]: .*"):
-        schema.find_files("package", "file", packages=package_map)
+        schema.find_files("package", "file", dataroots=package_map)
 
     assert resolve0.called == 2
     assert resolve1.called == 0
@@ -1484,10 +1484,10 @@ def test_find_files_with_package_missing():
         f.write("test")
 
     assert schema.set("package", "file", ["test0.txt", "test1.txt"])
-    assert schema.set("package", "file", ["this_package", "this_package"], field="package")
+    assert schema.set("package", "file", ["this_package", "this_package"], field="dataroot")
 
     with pytest.raises(ValueError, match=r"Resolver for this_package not provided"):
-        schema.find_files("package", "file", packages={})
+        schema.find_files("package", "file", dataroots={})
 
 
 def test_find_files_with_package_as_string():
@@ -1504,7 +1504,7 @@ def test_find_files_with_package_as_string():
         f.write("test")
 
     assert schema.set("package", "file", ["test0.txt", "test1.txt"])
-    assert schema.set("package", "file", ["this_package", "that_package"], field="package")
+    assert schema.set("package", "file", ["this_package", "that_package"], field="dataroot")
 
     class Resolver:
         called = 0
@@ -1519,7 +1519,7 @@ def test_find_files_with_package_as_string():
         "that_package": resolve.resolve,
     }
 
-    assert schema.find_files("package", "file", packages=package_map) == [
+    assert schema.find_files("package", "file", dataroots=package_map) == [
         os.path.abspath("package_path/test0.txt"),
         os.path.abspath("package_path/test1.txt"),
     ]
@@ -1538,14 +1538,14 @@ def test_find_files_with_package_as_invalid():
         f.write("test")
 
     assert schema.set("package", "file", "test0.txt")
-    assert schema.set("package", "file", "this_package", field="package")
+    assert schema.set("package", "file", "this_package", field="dataroot")
 
     package_map = {
         "this_package": 1
     }
 
     with pytest.raises(TypeError, match="Resolver for this_package is not a recognized type"):
-        schema.find_files("package", "file", packages=package_map)
+        schema.find_files("package", "file", dataroots=package_map)
 
 
 def test_find_files_with_collection_dir_not_found():
@@ -1983,11 +1983,11 @@ def test_active_package():
     schema = BaseSchema()
 
     assert schema._get_active(None) is None
-    with schema._active(package="testpack"):
+    with schema._active(dataroot="testpack"):
         assert schema._get_active(None) == {
-            "package": "testpack"
+            "dataroot": "testpack"
         }
-        assert schema._get_active("package") == "testpack"
+        assert schema._get_active("dataroot") == "testpack"
     assert schema._get_active(None) is None
 
 
@@ -1995,7 +1995,7 @@ def test_active_invalid_active():
     schema = BaseSchema()
 
     assert schema._get_active(None) is None
-    with schema._active(package="testpack"):
+    with schema._active(dataroot="testpack"):
         assert schema._get_active("package0") is None
     assert schema._get_active(None) is None
 
@@ -2004,27 +2004,27 @@ def test_active_compounded():
     schema = BaseSchema()
 
     assert schema._get_active(None) is None
-    with schema._active(package="testpack"):
+    with schema._active(dataroot="testpack"):
         assert schema._get_active(None) == {
-            "package": "testpack"
+            "dataroot": "testpack"
         }
 
         with schema._active(lock=True):
             assert schema._get_active(None) == {
-                "package": "testpack",
+                "dataroot": "testpack",
                 "lock": True
             }
             with schema._active(lock=False):
                 assert schema._get_active(None) == {
-                    "package": "testpack",
+                    "dataroot": "testpack",
                     "lock": False
                 }
             assert schema._get_active(None) == {
-                "package": "testpack",
+                "dataroot": "testpack",
                 "lock": True
             }
         assert schema._get_active(None) == {
-            "package": "testpack"
+            "dataroot": "testpack"
         }
 
     assert schema._get_active(None) is None
@@ -2038,43 +2038,43 @@ def test_active_compounded_depth():
 
     assert schema._get_active(None) is None
     assert schema1._get_active(None) is None
-    with schema._active(package="testpack"):
+    with schema._active(dataroot="testpack"):
         assert schema._get_active(None) == {
-            "package": "testpack"
+            "dataroot": "testpack"
         }
         assert schema1._get_active(None) == {
-            "package": "testpack"
+            "dataroot": "testpack"
         }
 
         with schema1._active(lock=True):
             assert schema._get_active(None) == {
-                "package": "testpack"
+                "dataroot": "testpack"
             }
             assert schema1._get_active(None) == {
-                "package": "testpack",
+                "dataroot": "testpack",
                 "lock": True
             }
             with schema._active(lock=False):
                 assert schema._get_active(None) == {
-                    "package": "testpack",
+                    "dataroot": "testpack",
                     "lock": False
                 }
                 assert schema1._get_active(None) == {
-                    "package": "testpack",
+                    "dataroot": "testpack",
                     "lock": False
                 }
             assert schema._get_active(None) == {
-                "package": "testpack"
+                "dataroot": "testpack"
             }
             assert schema1._get_active(None) == {
-                "package": "testpack",
+                "dataroot": "testpack",
                 "lock": True
             }
         assert schema._get_active(None) == {
-            "package": "testpack"
+            "dataroot": "testpack"
         }
         assert schema1._get_active(None) == {
-            "package": "testpack"
+            "dataroot": "testpack"
         }
 
     assert schema._get_active(None) is None
@@ -2087,17 +2087,17 @@ def test_active_compounded_set():
     EditableSchema(schema).insert("testfile", Parameter("file"))
     EditableSchema(schema).insert("testdir", Parameter("[dir]"))
 
-    with schema._active(package="testpack"):
+    with schema._active(dataroot="testpack"):
         assert schema.set("teststr", "thisstring")
         assert schema.get("teststr") == "thisstring"
 
         assert schema.set("testfile", "thisfile")
         assert schema.get("testfile") == "thisfile"
-        assert schema.get("testfile", field="package") == "testpack"
+        assert schema.get("testfile", field="dataroot") == "testpack"
 
         assert schema.set("testdir", "thisdir")
         assert schema.get("testdir") == ["thisdir"]
-        assert schema.get("testdir", field="package") == ["testpack"]
+        assert schema.get("testdir", field="dataroot") == ["testpack"]
 
         with schema._active(lock=True):
             assert schema.set("teststr", "thisnewstring")
@@ -2110,7 +2110,7 @@ def test_active_add():
     EditableSchema(schema).insert("teststr", Parameter("[str]"))
     EditableSchema(schema).insert("testdir", Parameter("[dir]"))
 
-    with schema._active(package="testpack"):
+    with schema._active(dataroot="testpack"):
         assert schema.add("teststr", "thisstring0")
         assert schema.get("teststr") == ["thisstring0"]
 
@@ -2119,12 +2119,12 @@ def test_active_add():
 
         assert schema.add("testdir", "thisdir0")
         assert schema.get("testdir") == ["thisdir0"]
-        assert schema.get("testdir", field="package") == ["testpack"]
+        assert schema.get("testdir", field="dataroot") == ["testpack"]
 
-        with schema._active(package="anotherpack"):
+        with schema._active(dataroot="anotherpack"):
             assert schema.add("testdir", "thisdir1")
             assert schema.get("testdir") == ["thisdir0", "thisdir1"]
-            assert schema.get("testdir", field="package") == [
+            assert schema.get("testdir", field="dataroot") == [
                 "testpack",
                 "anotherpack"]
 
@@ -2134,7 +2134,7 @@ def test_active_set_field():
     EditableSchema(schema).insert("teststr", Parameter("[str]"))
     EditableSchema(schema).insert("testdir", Parameter("[dir]"))
 
-    with schema._active(package="testpack"):
+    with schema._active(dataroot="testpack"):
         assert schema.add("teststr", "thisstring0")
         assert schema.set("teststr", True, field="lock")
 
@@ -2189,7 +2189,7 @@ def test_find_files_custom_class_package_resolution():
     custom = CustomFiles()
     schema = BaseSchema()
     EditableSchema(schema).insert("level-1", custom)
-    with schema._active(package="thispackage"):
+    with schema._active(dataroot="thispackage"):
         assert schema.set("level-1", "level0", "rootedfile", "thisfile.txt")
         assert schema.set("level-1", "level0", "level1", "unrootedfile", "thatfile.txt")
 
@@ -3161,7 +3161,7 @@ def test_hash_files_with_package():
         f.write("test")
 
     assert schema.set("package", "file", ["test0.txt", "test1.txt"])
-    assert schema.set("package", "file", ["this_package", "this_package"], field="package")
+    assert schema.set("package", "file", ["this_package", "this_package"], field="dataroot")
 
     class Resolver:
         called = 0
@@ -3177,7 +3177,7 @@ def test_hash_files_with_package():
         "that_package": resolve1.resolve,
     }
 
-    assert schema.hash_files("package", "file", packages=package_map) == [
+    assert schema.hash_files("package", "file", dataroots=package_map) == [
         "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
         "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
     ]
@@ -3197,7 +3197,7 @@ def test_hash_files_with_package_not_found():
         f.write("test")
 
     assert schema.set("package", "file", ["test0.txt", "test1.txt"])
-    assert schema.set("package", "file", ["this_package", "this_package"], field="package")
+    assert schema.set("package", "file", ["this_package", "this_package"], field="dataroot")
 
     class Resolver:
         called = 0
@@ -3216,7 +3216,7 @@ def test_hash_files_with_package_not_found():
     with pytest.raises(
             FileNotFoundError,
             match=r"Could not find \"test1.txt\" in this_package \[package,file\]: .*"):
-        schema.hash_files("package", "file", packages=package_map)
+        schema.hash_files("package", "file", dataroots=package_map)
 
     assert resolve0.called == 2
     assert resolve1.called == 0
@@ -3233,10 +3233,10 @@ def test_hash_files_with_package_missing():
         f.write("test")
 
     assert schema.set("package", "file", ["test0.txt", "test1.txt"])
-    assert schema.set("package", "file", ["this_package", "this_package"], field="package")
+    assert schema.set("package", "file", ["this_package", "this_package"], field="dataroot")
 
     with pytest.raises(ValueError, match=r"Resolver for this_package not provided"):
-        schema.hash_files("package", "file", packages={})
+        schema.hash_files("package", "file", dataroots={})
 
 
 def test_hash_files_with_package_as_string():
@@ -3253,7 +3253,7 @@ def test_hash_files_with_package_as_string():
         f.write("test")
 
     assert schema.set("package", "file", ["test0.txt", "test1.txt"])
-    assert schema.set("package", "file", ["this_package", "that_package"], field="package")
+    assert schema.set("package", "file", ["this_package", "that_package"], field="dataroot")
 
     class Resolver:
         called = 0
@@ -3268,7 +3268,7 @@ def test_hash_files_with_package_as_string():
         "that_package": resolve.resolve,
     }
 
-    assert schema.hash_files("package", "file", packages=package_map) == [
+    assert schema.hash_files("package", "file", dataroots=package_map) == [
         "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
         "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
     ]
@@ -3287,14 +3287,14 @@ def test_hash_files_with_package_as_invalid():
         f.write("test")
 
     assert schema.set("package", "file", "test0.txt")
-    assert schema.set("package", "file", "this_package", field="package")
+    assert schema.set("package", "file", "this_package", field="dataroot")
 
     package_map = {
         "this_package": 1
     }
 
     with pytest.raises(TypeError, match="Resolver for this_package is not a recognized type"):
-        schema.hash_files("package", "file", packages=package_map)
+        schema.hash_files("package", "file", dataroots=package_map)
 
 
 def test_hash_files_with_collection_dir_not_found():

--- a/tests/schema/test_parameter.py
+++ b/tests/schema/test_parameter.py
@@ -70,7 +70,7 @@ def test_default_init_file():
             'author': [],
             'date': None,
             'filehash': None,
-            'package': None,
+            "dataroot": None,
             'value': None,
             'signature': None}}}
     }
@@ -93,7 +93,7 @@ def test_default_init_dir():
         'hashalgo': 'sha256',
         'node': {'default': {'default': {
             'filehash': None,
-            'package': None,
+            "dataroot": None,
             'value': None,
             'signature': None}}}
     }
@@ -1005,7 +1005,7 @@ def test_immutable_returns():
     ("md5", "hashalgo", "md5"),
     ("notes are here", "notes", "notes are here"),
     ("1235", "filehash", "1235"),
-    ("12356", "package", "12356"),
+    ("12356", "dataroot", "12356"),
     ("12357", "date", "12357"),
     ("12358", "author", ["12358"]),
     ("12359", "signature", "12359"),
@@ -1054,8 +1054,8 @@ def test_normalize_fields_scalar_errors_dir():
 def test_normalize_fields_scalar_errors_int():
     param = Parameter("int")
 
-    with pytest.raises(ValueError, match='"package" is not a valid field'):
-        param.set("test", field="package")
+    with pytest.raises(ValueError, match='"dataroot" is not a valid field'):
+        param.set("test", field="dataroot")
 
     with pytest.raises(ValueError, match='"filehash" is not a valid field'):
         param.set("test", field="filehash")
@@ -1080,7 +1080,7 @@ def test_normalize_fields_scalar_errors_int():
     ("md5", "hashalgo", "md5"),
     ("notes are here", "notes", "notes are here"),
     ("1235", "filehash", ["1235"]),
-    ("12356", "package", ["12356"]),
+    ("12356", "dataroot", ["12356"]),
     ("12357", "date", ["12357"]),
     ("12358", "author", [["12358"]]),
     ("12359", "signature", ["12359"]),
@@ -1139,8 +1139,8 @@ def test_add_normalize_fields_list_errors_dir():
 def test_add_normalize_fields_list_errors_int():
     param = Parameter("[int]")
 
-    with pytest.raises(ValueError, match='"package" is not a valid field'):
-        param.add("test", field="package")
+    with pytest.raises(ValueError, match='"dataroot" is not a valid field'):
+        param.add("test", field="dataroot")
 
     with pytest.raises(ValueError, match='"filehash" is not a valid field'):
         param.add("test", field="filehash")
@@ -1755,7 +1755,7 @@ def test_defvalue_file_getdict():
                     'author': [],
                     'date': None,
                     'filehash': None,
-                    'package': None,
+                    "dataroot": None,
                     'signature': None,
                     'value': 'thisfile',
                 },
@@ -1794,7 +1794,7 @@ def test_defvalue_file_list_getdict():
                     'filehash': [
                         None,
                     ],
-                    'package': [
+                    "dataroot": [
                         None,
                     ],
                     'signature': [
@@ -1817,13 +1817,13 @@ def test_defvalue_file_list_getdict():
 
 
 def test_defvalue_file_package():
-    param = Parameter("file", defvalue="thisfile", package="thispackage")
+    param = Parameter("file", defvalue="thisfile", dataroot="thispackage")
     assert param.default.get() == "thisfile"
-    assert param.default.get(field="package") == "thispackage"
+    assert param.default.get(field="dataroot") == "thispackage"
 
 
 def test_defvalue_file_package_getdict():
-    param = Parameter("file", defvalue="thisfile", package="thispackage")
+    param = Parameter("file", defvalue="thisfile", dataroot="thispackage")
     assert param.getdict() == {
         'copy': False,
         'example': [],
@@ -1836,7 +1836,7 @@ def test_defvalue_file_package_getdict():
                     'author': [],
                     'date': None,
                     'filehash': None,
-                    'package': "thispackage",
+                    "dataroot": "thispackage",
                     'signature': None,
                     'value': 'thisfile',
                 },
@@ -1853,19 +1853,19 @@ def test_defvalue_file_package_getdict():
 
 
 def test_defvalue_file_list_package():
-    param = Parameter("[file]", defvalue="thisfile", package="thispackage")
+    param = Parameter("[file]", defvalue="thisfile", dataroot="thispackage")
     assert param.default.get() == ["thisfile"]
-    assert param.default.get(field="package") == ["thispackage"]
+    assert param.default.get(field="dataroot") == ["thispackage"]
 
 
 def test_defvalue_file_set_package():
-    param = Parameter("{file}", defvalue="thisfile", package="thispackage")
+    param = Parameter("{file}", defvalue="thisfile", dataroot="thispackage")
     assert param.default.get() == ["thisfile"]
-    assert param.default.get(field="package") == ["thispackage"]
+    assert param.default.get(field="dataroot") == ["thispackage"]
 
 
 def test_defvalue_file_list_package_getdict():
-    param = Parameter("[file]", defvalue="thisfile", package="thispackage")
+    param = Parameter("[file]", defvalue="thisfile", dataroot="thispackage")
     assert param.getdict() == {
         'copy': False,
         'example': [],
@@ -1882,7 +1882,7 @@ def test_defvalue_file_list_package_getdict():
                     'filehash': [
                         None,
                     ],
-                    'package': [
+                    "dataroot": [
                         'thispackage',
                     ],
                     'signature': [
@@ -1905,19 +1905,19 @@ def test_defvalue_file_list_package_getdict():
 
 
 def test_defvalue_dir_package():
-    param = Parameter("dir", defvalue="thisdir", package="thispackage")
+    param = Parameter("dir", defvalue="thisdir", dataroot="thispackage")
     assert param.default.get() == "thisdir"
-    assert param.default.get(field="package") == "thispackage"
+    assert param.default.get(field="dataroot") == "thispackage"
 
 
 def test_defvalue_dir_list_package():
-    param = Parameter("[dir]", defvalue="thisdir", package="thispackage")
+    param = Parameter("[dir]", defvalue="thisdir", dataroot="thispackage")
     assert param.default.get() == ["thisdir"]
-    assert param.default.get(field="package") == ["thispackage"]
+    assert param.default.get(field="dataroot") == ["thispackage"]
 
 
 def test_defvalue_dir_list_package_getdict():
-    param = Parameter("[dir]", defvalue="thisdir", package="thispackage")
+    param = Parameter("[dir]", defvalue="thisdir", dataroot="thispackage")
     assert param.getdict() == {
         'copy': False,
         'example': [],
@@ -1930,7 +1930,7 @@ def test_defvalue_dir_list_package_getdict():
                     'filehash': [
                         None,
                     ],
-                    'package': [
+                    "dataroot": [
                         'thispackage',
                     ],
                     'signature': [

--- a/tests/schema/test_parametervalue.py
+++ b/tests/schema/test_parametervalue.py
@@ -261,7 +261,7 @@ def test_directory_get_dict():
         "value": "test",
         "signature": None,
         "filehash": None,
-        "package": None
+        "dataroot": None
     }
 
 
@@ -280,13 +280,13 @@ def test_directory_from_dict():
         "value": "test",
         "signature": "testsig",
         "filehash": "121324",
-        "package": "datasource"
+        "dataroot": "datasource"
     }, [], None, "str")
 
     assert value.get() == "test"
     assert value.get(field='signature') == "testsig"
     assert value.get(field='filehash') == "121324"
-    assert value.get(field='package') == "datasource"
+    assert value.get(field='dataroot') == "datasource"
 
 
 def test_directory_fields():
@@ -295,7 +295,7 @@ def test_directory_fields():
         "value",
         "signature",
         "filehash",
-        "package")
+        "dataroot")
 
 
 def test_directory_type():
@@ -344,7 +344,7 @@ def test_file_get_dict():
         "value": "test",
         "signature": None,
         "filehash": None,
-        "package": None,
+        "dataroot": None,
         "date": None,
         "author": []
     }
@@ -365,7 +365,7 @@ def test_file_from_dict():
         "value": "test",
         "signature": "testsig",
         "filehash": "121324",
-        "package": "datasource",
+        "dataroot": "datasource",
         "date": "today",
         "author": ["test"]
     }, [], None, "str")
@@ -373,7 +373,7 @@ def test_file_from_dict():
     assert value.get() == "test"
     assert value.get(field='signature') == "testsig"
     assert value.get(field='filehash') == "121324"
-    assert value.get(field='package') == "datasource"
+    assert value.get(field="dataroot") == "datasource"
     assert value.get(field='date') == "today"
     assert value.get(field='author') == ["test"]
 
@@ -384,7 +384,7 @@ def test_file_fields():
         "value",
         "signature",
         "filehash",
-        "package",
+        "dataroot",
         "date",
         "author")
 
@@ -466,7 +466,7 @@ def test_nodelist_file_getdict_empty():
     param = NodeListValue(FileNodeValue())
 
     assert param.getdict() == {
-        'signature': [], 'value': [], 'author': [], 'date': [], 'filehash': [], 'package': []}
+        'signature': [], 'value': [], 'author': [], 'date': [], 'filehash': [], "dataroot": []}
 
 
 def test_nodelist_file_getdict_author():
@@ -481,13 +481,13 @@ def test_nodelist_file_getdict_author():
         'author': [],
         'date': [None],
         'filehash': ["hash"],
-        'package': [None]}
+        "dataroot": [None]}
 
 
 def test_nodelist_dir_getdict_empty():
     param = NodeListValue(DirectoryNodeValue())
 
-    assert param.getdict() == {'signature': [], 'value': [], 'filehash': [], 'package': []}
+    assert param.getdict() == {'signature': [], 'value': [], 'filehash': [], "dataroot": []}
 
 
 def test_nodelist_type():
@@ -499,9 +499,9 @@ def test_nodelist_type():
 def test_nodelist_fields():
     assert NodeListValue(NodeValue("str")).fields == (None, 'value', 'signature')
     assert NodeListValue(FileNodeValue()).fields == \
-        (None, 'value', 'signature', 'filehash', 'package', 'date', 'author')
+        (None, 'value', 'signature', 'filehash', "dataroot", 'date', 'author')
     assert NodeListValue(DirectoryNodeValue()).fields == \
-        (None, 'value', 'signature', 'filehash', 'package')
+        (None, 'value', 'signature', 'filehash', "dataroot")
 
 
 def test_nodelist_set_str_value():
@@ -754,7 +754,7 @@ def test_generate_hashed_path_package(package, expect):
 def test_get_hashed_filename_file(package, expect):
     value = FileNodeValue()
     value.set("this/is/the/path.txt.gz")
-    value.set(package, field="package")
+    value.set(package, field="dataroot")
     assert value.get_hashed_filename() == expect
 
 
@@ -767,7 +767,7 @@ def test_get_hashed_filename_file(package, expect):
 def test_get_hashed_filename_dir(package, expect):
     value = DirectoryNodeValue()
     value.set("this/is/the/path")
-    value.set(package, field="package")
+    value.set(package, field="dataroot")
     assert value.get_hashed_filename() == expect
 
 
@@ -962,7 +962,7 @@ def test_defvalue_file_getdict():
         'author': [],
         'date': None,
         'filehash': None,
-        'package': None,
+        "dataroot": None,
         'signature': None,
         'value': 'thisfile'
     }
@@ -983,7 +983,7 @@ def test_defvalue_file_list_getdict():
         'filehash': [
             None,
         ],
-        'package': [
+        "dataroot": [
             None,
         ],
         'signature': [
@@ -996,31 +996,31 @@ def test_defvalue_file_list_getdict():
 
 
 def test_defvalue_file_package():
-    value = FileNodeValue(value="thisfile", package="thispackage")
+    value = FileNodeValue(value="thisfile", dataroot="thispackage")
     assert value.get() == "thisfile"
-    assert value.get(field="package") == "thispackage"
+    assert value.get(field="dataroot") == "thispackage"
 
 
 def test_defvalue_file_package_getdict():
-    value = FileNodeValue(value="thisfile", package="thispackage")
+    value = FileNodeValue(value="thisfile", dataroot="thispackage")
     assert value.getdict() == {
         'author': [],
         'date': None,
         'filehash': None,
-        'package': "thispackage",
+        "dataroot": "thispackage",
         'signature': None,
         'value': 'thisfile',
     }
 
 
 def test_defvalue_file_list_package():
-    value = NodeListValue(FileNodeValue(value="thisfile", package="thispackage"))
+    value = NodeListValue(FileNodeValue(value="thisfile", dataroot="thispackage"))
     assert value.get() == ["thisfile"]
-    assert value.get(field="package") == ["thispackage"]
+    assert value.get(field="dataroot") == ["thispackage"]
 
 
 def test_defvalue_file_list_package_getdict():
-    value = NodeListValue(FileNodeValue(value="thisfile", package="thispackage"))
+    value = NodeListValue(FileNodeValue(value="thisfile", dataroot="thispackage"))
     assert value.getdict() == {
         'author': [],
         'date': [
@@ -1029,7 +1029,7 @@ def test_defvalue_file_list_package_getdict():
         'filehash': [
             None,
         ],
-        'package': [
+        "dataroot": [
             'thispackage',
         ],
         'signature': [
@@ -1042,24 +1042,24 @@ def test_defvalue_file_list_package_getdict():
 
 
 def test_defvalue_dir_package():
-    value = DirectoryNodeValue(value="thisdir", package="thispackage")
+    value = DirectoryNodeValue(value="thisdir", dataroot="thispackage")
     assert value.get() == "thisdir"
-    assert value.get(field="package") == "thispackage"
+    assert value.get(field="dataroot") == "thispackage"
 
 
 def test_defvalue_dir_list_package():
-    value = NodeListValue(DirectoryNodeValue(value="thisdir", package="thispackage"))
+    value = NodeListValue(DirectoryNodeValue(value="thisdir", dataroot="thispackage"))
     assert value.get() == ["thisdir"]
-    assert value.get(field="package") == ["thispackage"]
+    assert value.get(field="dataroot") == ["thispackage"]
 
 
 def test_defvalue_dir_list_package_getdict():
-    value = NodeListValue(DirectoryNodeValue(value="thisdir", package="thispackage"))
+    value = NodeListValue(DirectoryNodeValue(value="thisdir", dataroot="thispackage"))
     assert value.getdict() == {
         'filehash': [
             None,
         ],
-        'package': [
+        "dataroot": [
             'thispackage',
         ],
         'signature': [
@@ -1102,7 +1102,7 @@ def test_nodeset_file_getdict_empty():
     param = NodeSetValue(FileNodeValue())
 
     assert param.getdict() == {
-        'signature': [], 'value': [], 'author': [], 'date': [], 'filehash': [], 'package': []}
+        'signature': [], 'value': [], 'author': [], 'date': [], 'filehash': [], "dataroot": []}
 
 
 def test_nodeset_file_getdict_author():
@@ -1117,13 +1117,13 @@ def test_nodeset_file_getdict_author():
         'author': [],
         'date': [None],
         'filehash': ["hash"],
-        'package': [None]}
+        "dataroot": [None]}
 
 
 def test_nodeset_dir_getdict_empty():
     param = NodeSetValue(DirectoryNodeValue())
 
-    assert param.getdict() == {'signature': [], 'value': [], 'filehash': [], 'package': []}
+    assert param.getdict() == {'signature': [], 'value': [], 'filehash': [], "dataroot": []}
 
 
 def test_nodeset_type():
@@ -1135,9 +1135,9 @@ def test_nodeset_type():
 def test_nodeset_fields():
     assert NodeSetValue(NodeValue("str")).fields == (None, 'value', 'signature')
     assert NodeSetValue(FileNodeValue()).fields == \
-        (None, 'value', 'signature', 'filehash', 'package', 'date', 'author')
+        (None, 'value', 'signature', 'filehash', "dataroot", 'date', 'author')
     assert NodeSetValue(DirectoryNodeValue()).fields == \
-        (None, 'value', 'signature', 'filehash', 'package')
+        (None, 'value', 'signature', 'filehash', "dataroot")
 
 
 def test_nodeset_set_str_value():

--- a/tests/schema_support/test_filesetschema.py
+++ b/tests/schema_support/test_filesetschema.py
@@ -66,7 +66,7 @@ def test_add_file_with_fileset_with_dataroot():
         with d.active_fileset("rtl"):
             assert d.add_file(['one.v', 'two.v'], filetype='verilog')
     assert d.get('fileset', 'rtl', 'file', 'verilog') == ['one.v', 'two.v']
-    assert d.get('fileset', 'rtl', 'file', 'verilog', field='package') == ['root', 'root']
+    assert d.get('fileset', 'rtl', 'file', 'verilog', field='dataroot') == ['root', 'root']
 
 
 def test_add_file_with_fileset_with_dataroot_passed():
@@ -79,7 +79,7 @@ def test_add_file_with_fileset_with_dataroot_passed():
         with d.active_fileset("rtl"):
             assert d.add_file(['one.v', 'two.v'], filetype='verilog', dataroot="test")
     assert d.get('fileset', 'rtl', 'file', 'verilog') == ['one.v', 'two.v']
-    assert d.get('fileset', 'rtl', 'file', 'verilog', field='package') == ['test', 'test']
+    assert d.get('fileset', 'rtl', 'file', 'verilog', field='dataroot') == ['test', 'test']
 
 
 def test_add_file_with_filetype():

--- a/tests/schema_support/test_pathschema.py
+++ b/tests/schema_support/test_pathschema.py
@@ -66,7 +66,7 @@ def test_find_files():
     test = Test()
     test.set_dataroot("testsource", "file://.")
     param = test.set("file", "test.txt")
-    param.set("testsource", field="package")
+    param.set("testsource", field="dataroot")
 
     with open("test.txt", "w") as f:
         f.write("test")
@@ -84,7 +84,7 @@ def test_find_files_no_source():
 
     test = Test()
     param = test.set("file", "test.txt")
-    param.set("testsource", field="package")
+    param.set("testsource", field="dataroot")
 
     with pytest.raises(ValueError, match="Resolver for testsource not provided"):
         test.find_files("file")
@@ -101,7 +101,7 @@ def test_find_files_dir():
     test = Test()
     test.set_dataroot("testsource", "file://.")
     param = test.set("dir", "test")
-    param.set("testsource", field="package")
+    param.set("testsource", field="dataroot")
 
     os.makedirs("test", exist_ok=True)
 
@@ -190,7 +190,7 @@ def test_find_files_keypath():
     assert root.set("ref", "test")
     os.makedirs("test", exist_ok=True)
     param = test.set("file", "test.txt")
-    param.set("keyref", field="package")
+    param.set("keyref", field="dataroot")
 
     with open("test/test.txt", "w") as f:
         f.write("test")
@@ -335,9 +335,9 @@ def test_active_dataroot():
     assert schema._get_active(None) is None
     with schema.active_dataroot("testpack"):
         assert schema._get_active(None) == {
-            "package": "testpack"
+            "dataroot": "testpack"
         }
-        assert schema._get_active("package") == "testpack"
+        assert schema._get_active("dataroot") == "testpack"
     assert schema._get_active(None) is None
 
 
@@ -373,7 +373,7 @@ def test_simple_find_files():
     test = Test()
     test.set_dataroot("testsource", "file://.")
     param = test.set("file", "test.txt")
-    param.set("testsource", field="package")
+    param.set("testsource", field="dataroot")
 
     with open("test.txt", "w") as f:
         f.write("test")
@@ -391,7 +391,7 @@ def test_simple_find_files_no_source():
 
     test = Test()
     param = test.set("file", "test.txt")
-    param.set("testsource", field="package")
+    param.set("testsource", field="dataroot")
 
     with pytest.raises(ValueError, match="Resolver for testsource not provided"):
         test.find_files("file")
@@ -408,7 +408,7 @@ def test_simple_find_files_dir():
     test = Test()
     test.set_dataroot("testsource", "file://.")
     param = test.set("dir", "test")
-    param.set("testsource", field="package")
+    param.set("testsource", field="dataroot")
 
     os.makedirs("test", exist_ok=True)
 
@@ -635,8 +635,8 @@ def test_dataroot_section_above_active_at_base():
     schema_base.set_dataroot("testroot", __file__)
 
     with schema_base.active_dataroot("testroot"):
-        assert schema_base._get_active("package") == "testroot"
-        assert schema._get_active("package") == "testroot"
+        assert schema_base._get_active("dataroot") == "testroot"
+        assert schema._get_active("dataroot") == "testroot"
 
 
 def test_dataroot_section_above_active_at_leaf():
@@ -648,8 +648,8 @@ def test_dataroot_section_above_active_at_leaf():
     schema_base.set_dataroot("testroot", __file__)
 
     with schema.active_dataroot("testroot"):
-        assert schema_base._get_active("package") is None
-        assert schema._get_active("package") == "testroot"
+        assert schema_base._get_active("dataroot") is None
+        assert schema._get_active("dataroot") == "testroot"
 
 
 def test_find_files_dataroot_resolvers_no_roots():

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -749,7 +749,7 @@ def test_read_fileset(datadir):
         'heartbeat.v',
         'increment.v'
     ]
-    assert d.get("fileset", "rtl", "file", "verilog", field="package") == [
+    assert d.get("fileset", "rtl", "file", "verilog", field="dataroot") == [
         'flist-test-rtl-heartbeat.f-0',
         'flist-test-rtl-heartbeat.f-0'
     ]

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -254,7 +254,7 @@ def test_define_tool_parameter_with_defvalue_file():
     assert param.get(field="help") == "liberty file for synthesis"
     assert param.get(field="shorthelp") == "liberty file for synthesis"
     assert param.default.get() == "./this.lib"
-    assert param.default.get(field="package") == "sc"
+    assert param.default.get(field="dataroot") == "sc"
     assert param.get(field="copy") is False
 
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -245,7 +245,7 @@ def test_define_tool_parameter_with_defvalue_file():
         "file",
         "liberty file for synthesis",
         defvalue="./this.lib",
-        package="sc"
+        dataroot="sc"
     )
 
     assert lib.allkeys("tool") == set([('yosys', 'liberty')])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Renamed public field/parameter "package" to "dataroot" across schemas, parameters, active context, file resolution, hashing, and file-input handling; input-copy behavior now triggers on dataroot sources (e.g., python://).
  - Updated logging messages to reference "file dataroot" and aligned tool parameter references to use dataroot.
- Documentation
  - Updated examples and docs to use the "dataroot" terminology.
- Tests
  - Updated test suite expectations to reflect the "dataroot" field and APIs.
- Chores
  - Version bumped to 0.52.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->