### PR TITLE
add wildebeest plugin

### DIFF
--- a/siliconcompiler/tools/yosys/scripts/sc_synth_fpga.tcl
+++ b/siliconcompiler/tools/yosys/scripts/sc_synth_fpga.tcl
@@ -78,7 +78,7 @@ if { [string match {ice*} $sc_partname] } {
 } elseif {
     [sc_cfg_exists library $sc_designlib tool yosys fpga_config] &&
     [sc_cfg_get library $sc_designlib tool yosys fpga_config] != {} &&
-    [sc_load_plugin yosys-syn]
+    [sc_load_plugin wildebeest]
 } {
     set synth_fpga_args []
     if { [sc_cfg_tool_task_get var synth_opt_mode] != "none" } {

--- a/siliconcompiler/toolscripts/_tools.json
+++ b/siliconcompiler/toolscripts/_tools.json
@@ -155,6 +155,12 @@
     "docker-depends": "yosys",
     "auto-update": true
   },
+  "yosys-wildebeest": {
+    "git-url": "https://github.com/zeroasiccorp/wildebeest.git",
+    "git-commit": "33ae3483c7bf81c66ace088c98421f757e196172",
+    "docker-depends": "yosys",
+    "auto-update": true
+  },
   "surfer": {
     "git-url": "https://gitlab.com/surfer-project/surfer.git",
     "git-commit": "v0.3.0",

--- a/siliconcompiler/toolscripts/rhel9/install-yosys-wildebeest.sh
+++ b/siliconcompiler/toolscripts/rhel9/install-yosys-wildebeest.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+sudo yum install -y git
+
+mkdir -p deps
+cd deps
+
+python3 -m venv .yosys-wildebeest --clear
+. .yosys-wildebeest/bin/activate
+python3 -m pip install cmake==3.31.6
+
+git clone $(python3 ${src_path}/_tools.py --tool yosys-wildebeest --field git-url) yosys-wildebeest
+cd yosys-wildebeest
+git checkout $(python3 ${src_path}/_tools.py --tool yosys-wildebeest --field git-commit)
+
+cmake -S . -B build
+cmake --build build
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+cd build
+$SUDO_INSTALL make install
+
+cd -

--- a/siliconcompiler/toolscripts/ubuntu22/install-yosys-wildebeest.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-yosys-wildebeest.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+sudo apt-get update
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+python3 -m venv .yosys-wildebeest --clear
+. .yosys-wildebeest/bin/activate
+python3 -m pip install cmake==3.31.6
+
+git clone $(python3 ${src_path}/_tools.py --tool yosys-wildebeest --field git-url) yosys-wildebeest
+cd yosys-wildebeest
+git checkout $(python3 ${src_path}/_tools.py --tool yosys-wildebeest --field git-commit)
+
+cmake -S . -B build
+cmake --build build
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+cd build
+$SUDO_INSTALL make install
+
+cd -

--- a/siliconcompiler/toolscripts/ubuntu24/install-yosys-wildebeest.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-yosys-wildebeest.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+sudo apt-get update
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+python3 -m venv .yosys-wildebeest --clear
+. .yosys-wildebeest/bin/activate
+python3 -m pip install cmake==3.31.6
+
+git clone $(python3 ${src_path}/_tools.py --tool yosys-wildebeest --field git-url) yosys-wildebeest
+cd yosys-wildebeest
+git checkout $(python3 ${src_path}/_tools.py --tool yosys-wildebeest --field git-commit)
+
+cmake -S . -B build
+cmake --build build
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+cd build
+$SUDO_INSTALL make install
+
+cd -


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for an alternative FPGA synthesis backend (Wildebeest) when an FPGA config is provided.
  - Integrated the new backend into the tool catalog with auto-update and container dependency handling.

- Chores
  - Added automated installers for RHEL 9, Ubuntu 22, and Ubuntu 24 to build and install the new backend, including optional sudo usage and pinned CMake version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->