### PR TITLE
add verbose flag to filler command in openroad

### DIFF
--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -734,7 +734,7 @@ proc sc_insert_fillers { } {
         }
     }
     if { $fillers != "" } {
-        filler_placement $fillers
+        filler_placement -verbose $fillers
     }
 
     check_placement -verbose


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Enabled verbose logging during filler cell placement, providing more detailed progress and diagnostics in console/output reports. This improves visibility into the placement step and subsequent checks without changing flow behavior or placement results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->