### PR TITLE
update nextpnr

### DIFF
--- a/siliconcompiler/toolscripts/_tools.json
+++ b/siliconcompiler/toolscripts/_tools.json
@@ -81,12 +81,12 @@
   },
   "icepack": {
     "git-url": "https://github.com/YosysHQ/icestorm.git",
-    "git-commit": "7fbf8c0afbcf7665c45499b090409859b1815184",
+    "git-commit": "v1.1",
     "auto-update": false
   },
   "nextpnr": {
     "git-url": "https://github.com/YosysHQ/nextpnr.git",
-    "git-commit": "nextpnr-0.7",
+    "git-commit": "nextpnr-0.9",
     "docker-depends": "icepack"
   },
   "chisel": {

--- a/siliconcompiler/toolscripts/ubuntu20/install-nextpnr.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-nextpnr.sh
@@ -6,23 +6,21 @@ sudo apt-get update
 
 sudo apt-get install -y build-essential clang bison flex libreadline-dev \
                         gawk tcl-dev libffi-dev git mercurial graphviz   \
-                        xdot pkg-config python python3 libftdi-dev \
-                        qt5-default python3-dev libboost-all-dev cmake libeigen3-dev
+                        xdot pkg-config python3 libftdi-dev \
+                        qtbase5-dev python3-dev libboost-all-dev cmake libeigen3-dev
 
 sudo apt-get install -y git
 
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
-USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
-if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
-    SUDO_INSTALL=sudo
-else
-    SUDO_INSTALL=""
-fi
-
 mkdir -p deps
 cd deps
+
+python3 -m venv .nextpnr --clear
+. .nextpnr/bin/activate
+python3 -m pip install --upgrade pip
+python3 -m pip install cmake==3.28.4
 
 git clone $(python3 ${src_path}/_tools.py --tool nextpnr --field git-url) nextpnr
 cd nextpnr
@@ -33,7 +31,17 @@ if [ ! -z ${PREFIX} ]; then
     args=-DCMAKE_INSTALL_PREFIX="$PREFIX"
 fi
 
-cmake -DARCH=ice40 $args .
-make -j$(nproc)
+cmake -S . -B build -DARCH=ice40 $args
+cmake --build build
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+cd build
 $SUDO_INSTALL make install
+
 cd -

--- a/siliconcompiler/toolscripts/ubuntu22/install-nextpnr.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-nextpnr.sh
@@ -9,21 +9,18 @@ sudo apt-get install -y build-essential clang bison flex libreadline-dev \
                         xdot pkg-config python3 libftdi-dev \
                         qtbase5-dev python3-dev libboost-all-dev cmake libeigen3-dev
 
-
 sudo apt-get install -y git
 
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
-USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
-if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
-    SUDO_INSTALL=sudo
-else
-    SUDO_INSTALL=""
-fi
-
 mkdir -p deps
 cd deps
+
+python3 -m venv .nextpnr --clear
+. .nextpnr/bin/activate
+python3 -m pip install --upgrade pip
+python3 -m pip install cmake==3.28.4
 
 git clone $(python3 ${src_path}/_tools.py --tool nextpnr --field git-url) nextpnr
 cd nextpnr
@@ -34,7 +31,17 @@ if [ ! -z ${PREFIX} ]; then
     args=-DCMAKE_INSTALL_PREFIX="$PREFIX"
 fi
 
-cmake -DARCH=ice40 $args .
-make -j$(nproc)
+cmake -S . -B build -DARCH=ice40 $args
+cmake --build build
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+cd build
 $SUDO_INSTALL make install
+
 cd -

--- a/siliconcompiler/toolscripts/ubuntu24/install-nextpnr.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-nextpnr.sh
@@ -14,15 +14,13 @@ sudo apt-get install -y git
 # Get directory of script
 src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 
-USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
-if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
-    SUDO_INSTALL=sudo
-else
-    SUDO_INSTALL=""
-fi
-
 mkdir -p deps
 cd deps
+
+python3 -m venv .nextpnr --clear
+. .nextpnr/bin/activate
+python3 -m pip install --upgrade pip
+python3 -m pip install cmake==3.28.4
 
 git clone $(python3 ${src_path}/_tools.py --tool nextpnr --field git-url) nextpnr
 cd nextpnr
@@ -33,7 +31,17 @@ if [ ! -z ${PREFIX} ]; then
     args=-DCMAKE_INSTALL_PREFIX="$PREFIX"
 fi
 
-cmake -DARCH=ice40 $args .
-make -j$(nproc)
+cmake -S . -B build -DARCH=ice40 $args
+cmake --build build
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+cd build
 $SUDO_INSTALL make install
+
 cd -


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Updated bundled FPGA tools: nextpnr 0.9 and icepack v1.1 for improved compatibility and fixes.
- Refactor
  - Installer on Ubuntu 20/22/24 now uses out-of-source CMake builds for cleaner, isolated build and install steps.
- Chores
  - Switch to Python 3-only tooling with a virtual environment, pinned cmake, preserved PATH during sudo installs, and streamlined build/install flow for more repeatable, reliable installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->