### PR TITLE
fix icarus typo in parameter

### DIFF
--- a/siliconcompiler/tools/icarus/compile.py
+++ b/siliconcompiler/tools/icarus/compile.py
@@ -8,7 +8,7 @@ class CompileTask(Task):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("verilog_genration", "<1995,2001,2001-noconfig,2005,2005-sv,2009,2012>",
+        self.add_parameter("verilog_generation", "<1995,2001,2001-noconfig,2005,2005-sv,2009,2012>",
                            'Select Verilog language generation for Icarus to use. Legal values are '
                            '"1995", "2001", "2001-noconfig", "2005", "2005-sv", "2009", or "2012". '
                            'See the corresponding "-g" flags in the Icarus manual for more "'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected a typo in a public configuration parameter: use verilog_generation instead of verilog_genration.
  - Ensures the parameter is recognized consistently across the toolchain.
  - Note: Update any scripts or configurations referencing the old key to the corrected name to avoid failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->