### PR TITLE
remove keys that should not be going forward

### DIFF
--- a/siliconcompiler/remote/schema.py
+++ b/siliconcompiler/remote/schema.py
@@ -77,20 +77,6 @@ class ServerSchema(CommandLineSchema, BaseSchema):
                 help="""Flag determining whether to enable authenticated and encrypted jobs."""))
 
         schema.insert(
-            'option', 'loglevel',
-            Parameter(
-                '<info,warning,error,critical,debug>',
-                scope=Scope.JOB,
-                defvalue='info',
-                shorthelp="Logging level",
-                switch="-loglevel <str>",
-                example=[
-                        "cli: -loglevel info",
-                        "api: server.set('option', 'loglevel', 'info')"],
-                help="""
-                Provides explicit control over the level of debug logging printed."""))
-
-        schema.insert(
             'option', 'checkinterval',
             Parameter(
                 'int',

--- a/siliconcompiler/remote/server.py
+++ b/siliconcompiler/remote/server.py
@@ -20,7 +20,6 @@ from siliconcompiler import Project
 from siliconcompiler import NodeStatus as SCNodeStatus
 from siliconcompiler._metadata import version as sc_version
 
-from siliconcompiler.schema import utils as schema_utils
 from siliconcompiler.schema import __version__ as sc_schema_version
 
 from siliconcompiler.flowgraph import RuntimeFlowgraph

--- a/siliconcompiler/remote/server.py
+++ b/siliconcompiler/remote/server.py
@@ -73,7 +73,7 @@ class Server(ServerSchema):
     __version__ = '0.0.1'
 
     ####################
-    def __init__(self, loglevel="info"):
+    def __init__(self):
         '''
         Init method for Server object
         '''
@@ -86,7 +86,7 @@ class Server(ServerSchema):
         formatter = logging.Formatter('%(asctime)s | %(levelname)-8s | %(message)s')
         handler.setFormatter(formatter)
         self.logger.addHandler(handler)
-        self.logger.setLevel(schema_utils.translate_loglevel(loglevel))
+        self.logger.setLevel(logging.INFO)
 
         # Set up a dictionary to track running jobs.
         self.sc_jobs_lock = threading.Lock()

--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -16,7 +16,6 @@ from typing import List
 from siliconcompiler import utils, sc_open
 from siliconcompiler import NodeStatus
 from siliconcompiler.utils.logging import get_console_formatter, SCInRunLoggerFormatter
-from siliconcompiler.schema import utils as schema_utils
 
 from siliconcompiler.package import Resolver
 from siliconcompiler.schema_support.record import RecordTime, RecordTool

--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -307,10 +307,6 @@ class SchedulerNode:
         """
         self.__project._logger_console.setFormatter(
             get_console_formatter(self.__project, True, self.__step, self.__index))
-        self.logger.setLevel(
-            schema_utils.translate_loglevel(self.__project.get('option', 'loglevel',
-                                                               step=self.__step,
-                                                               index=self.__index)))
 
         if self.__queue:
             formatter = self.__project._logger_console.formatter
@@ -933,7 +929,6 @@ class SchedulerNode:
                 ret_code = self.__task.run_task(
                     self.__workdir,
                     self.__project.get('option', 'quiet', step=self.__step, index=self.__index),
-                    self.__project.get('option', 'loglevel', step=self.__step, index=self.__index),
                     self.__breakpoint,
                     self.__project.get('option', 'nice', step=self.__step, index=self.__index),
                     self.__project.get('option', 'timeout', step=self.__step, index=self.__index))

--- a/siliconcompiler/schema/utils.py
+++ b/siliconcompiler/schema/utils.py
@@ -40,9 +40,3 @@ def trim(docstring: str) -> str:
         trimmed.pop(0)
     # Return a single string:
     return '\n'.join(trimmed)
-
-
-def translate_loglevel(level: str) -> str:
-    if level == "quiet":
-        level = "error"
-    return level.upper()

--- a/siliconcompiler/schema_support/option.py
+++ b/siliconcompiler/schema_support/option.py
@@ -118,21 +118,6 @@ class OptionSchema(BaseSchema):
                 """))
 
         schema.insert(
-            'loglevel',
-            Parameter(
-                '<info,warning,error,critical,debug,quiet>',
-                pernode=PerNode.OPTIONAL,
-                scope=Scope.GLOBAL,
-                defvalue='info',
-                shorthelp="Option: logging level",
-                switch="-loglevel <str>",
-                example=[
-                    "cli: -loglevel info",
-                    "api: option.set('loglevel', 'info')"],
-                help="""
-                Provides explicit control over the level of debug logging printed."""))
-
-        schema.insert(
             'builddir',
             Parameter(
                 'dir',
@@ -363,20 +348,6 @@ class OptionSchema(BaseSchema):
                 Timeout value in seconds. The timeout value is compared
                 against the wall time tracked by the SC runtime to determine
                 if an operation should continue."""))
-
-        schema.insert(
-            'strict',
-            Parameter(
-                'bool',
-                shorthelp="Option: strict checking",
-                switch="-strict <bool>",
-                example=["cli: -strict true",
-                         "api: option.set('strict', True)"],
-                help="""
-                Enable additional strict checking in the SC Python API. When this
-                parameter is set to True, users must provide step and index keyword
-                arguments when reading from parameters with the pernode field set to
-                'optional'."""))
 
         # job scheduler
         schema.insert(

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -850,7 +850,7 @@ class Task(NamedSchema, PathSchema, DocsSchema):
                                       f'{TERMINATE_TIMEOUT} seconds. Terminating...')
                 terminate_process(proc.pid, timeout=TERMINATE_TIMEOUT)
 
-    def run_task(self, workdir, quiet, loglevel, breakpoint, nice, timeout):
+    def run_task(self, workdir, quiet, breakpoint, nice, timeout):
         """
         Executes the task's main process.
 
@@ -861,7 +861,6 @@ class Task(NamedSchema, PathSchema, DocsSchema):
         Args:
             workdir (str): The path to the node's working directory.
             quiet (bool): If True, suppresses execution output.
-            loglevel (str): The logging level.
             breakpoint (bool): If True, attempts to run with a breakpoint.
             nice (int): The POSIX nice level for the process.
             timeout (int): The execution timeout in seconds.
@@ -885,9 +884,6 @@ class Task(NamedSchema, PathSchema, DocsSchema):
 
         stdout_print = self.__logger.info
         stderr_print = self.__logger.error
-        if loglevel == "quiet":
-            stdout_print = self.__logger.error
-            stderr_print = self.__logger.error
 
         def read_stdio(stdout_reader, stderr_reader):
             """Helper to read and print stdout/stderr streams."""
@@ -2360,22 +2356,6 @@ def schema_task(schema):
             """)))
 
     schema.insert(
-        'var', 'default',
-        Parameter(
-            '[str]',
-            scope=Scope.JOB,
-            pernode=PerNode.OPTIONAL,
-            shorthelp="Task: script variables",
-            switch="-tool_task_var 'tool task key <str>'",
-            example=[
-                "cli: -tool_task_var 'openroad cts myvar 42'",
-                "api: task.set('tool', 'openroad', 'task', 'cts', 'var', 'myvar', '42')"],
-            help=trim("""
-            Task script variables specified as key value pairs. Variable
-            names and value types must match the name and type of task and reference
-            script consuming the variable.""")))
-
-    schema.insert(
         'env', 'default',
         Parameter(
             'str',
@@ -2390,43 +2370,6 @@ def schema_task(schema):
             Environment variables to set for individual tasks. Keys and values
             should be set in accordance with the task's documentation. Most
             tasks do not require extra environment variables to function.""")))
-
-    schema.insert(
-        'file', 'default', Parameter(
-            '[file]',
-            scope=Scope.JOB,
-            pernode=PerNode.OPTIONAL,
-            copy=True,
-            shorthelp="Task: custom setup files",
-            switch="-tool_task_file 'tool task key <file>'",
-            example=[
-                "cli: -tool_task_file 'openroad floorplan macroplace macroplace.tcl'",
-                "api: task.set('tool', 'openroad', 'task', 'floorplan', 'file', 'macroplace', "
-                "'macroplace.tcl')"],
-            help=trim("""
-            Paths to user supplied files mapped to keys. Keys and filetypes must
-            match what's expected by the task/reference script consuming the
-            file.
-            """)))
-
-    schema.insert(
-        'dir', 'default',
-        Parameter(
-            '[dir]',
-            scope=Scope.JOB,
-            pernode=PerNode.OPTIONAL,
-            copy=True,
-            shorthelp="Task: custom setup directories",
-            switch="-tool_task_dir 'tool task key <dir>'",
-            example=[
-                "cli: -tool_task_dir 'verilator compile cincludes include'",
-                "api: task.set('tool', 'verilator', 'task', 'compile', 'dir', 'cincludes', "
-                "'include')"],
-            help=trim("""
-            Paths to user supplied directories mapped to keys. Keys must match
-            what's expected by the task/reference script consuming the
-            directory.
-            """)))
 
     # Definitions of inputs, outputs, requirements
     schema.insert(

--- a/siliconcompiler/utils/logging.py
+++ b/siliconcompiler/utils/logging.py
@@ -133,27 +133,13 @@ class SCColorLoggerFormatter(logging.Formatter):
 
 
 def get_console_formatter(project, in_run, step, index):
-    loglevel = project.get('option', 'loglevel',
-                           step=step, index=index)
-
-    if loglevel == 'quiet':
-        base_format = SCBlankLoggerFormatter()
-    elif in_run:
-        if loglevel == 'debug':
-            base_format = SCDebugInRunLoggerFormatter(
-                project,
-                project.get('option', 'jobname'),
-                step, index)
-        else:
-            base_format = SCInRunLoggerFormatter(
-                project,
-                project.get('option', 'jobname'),
-                step, index)
+    if in_run:
+        base_format = SCInRunLoggerFormatter(
+            project,
+            project.get('option', 'jobname'),
+            step, index)
     else:
-        if loglevel == 'debug':
-            base_format = SCDebugLoggerFormatter()
-        else:
-            base_format = SCLoggerFormatter()
+        base_format = SCLoggerFormatter()
 
     support_color = SCColorLoggerFormatter.supports_color(sys.stdout)
     if support_color:

--- a/tests/data/defaults.json
+++ b/tests/data/defaults.json
@@ -1604,33 +1604,6 @@
                   }
                 }
               },
-              "var": {
-                "default": {
-                  "type": "[str]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_var 'tool task key <str>'"
-                  ],
-                  "shorthelp": "Task: script variables",
-                  "example": [
-                    "cli: -tool_task_var 'openroad cts myvar 42'",
-                    "api: task.set('tool', 'openroad', 'task', 'cts', 'var', 'myvar', '42')"
-                  ],
-                  "help": "Task script variables specified as key value pairs. Variable\nnames and value types must match the name and type of task and reference\nscript consuming the variable.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": []
-                      }
-                    }
-                  }
-                }
-              },
               "env": {
                 "default": {
                   "type": "str",
@@ -1656,70 +1629,6 @@
                       }
                     }
                   }
-                }
-              },
-              "file": {
-                "default": {
-                  "type": "[file]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_file 'tool task key <file>'"
-                  ],
-                  "shorthelp": "Task: custom setup files",
-                  "example": [
-                    "cli: -tool_task_file 'openroad floorplan macroplace macroplace.tcl'",
-                    "api: task.set('tool', 'openroad', 'task', 'floorplan', 'file', 'macroplace', 'macroplace.tcl')"
-                  ],
-                  "help": "Paths to user supplied files mapped to keys. Keys and filetypes must\nmatch what's expected by the task/reference script consuming the\nfile.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": [],
-                        "filehash": [],
-                        "dataroot": [],
-                        "date": [],
-                        "author": []
-                      }
-                    }
-                  },
-                  "hashalgo": "sha256",
-                  "copy": true
-                }
-              },
-              "dir": {
-                "default": {
-                  "type": "[dir]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_dir 'tool task key <dir>'"
-                  ],
-                  "shorthelp": "Task: custom setup directories",
-                  "example": [
-                    "cli: -tool_task_dir 'verilator compile cincludes include'",
-                    "api: task.set('tool', 'verilator', 'task', 'compile', 'dir', 'cincludes', 'include')"
-                  ],
-                  "help": "Paths to user supplied directories mapped to keys. Keys must match\nwhat's expected by the task/reference script consuming the\ndirectory.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": [],
-                        "filehash": [],
-                        "dataroot": []
-                      }
-                    }
-                  },
-                  "hashalgo": "sha256",
-                  "copy": true
                 }
               },
               "input": {
@@ -2264,31 +2173,6 @@
             }
           }
         },
-        "loglevel": {
-          "type": "<critical,debug,error,info,quiet,warning>",
-          "require": false,
-          "scope": "global",
-          "lock": false,
-          "switch": [
-            "-loglevel <str>"
-          ],
-          "shorthelp": "Option: logging level",
-          "example": [
-            "cli: -loglevel info",
-            "api: option.set('loglevel', 'info')"
-          ],
-          "help": "\n                Provides explicit control over the level of debug logging printed.",
-          "notes": null,
-          "pernode": "optional",
-          "node": {
-            "default": {
-              "default": {
-                "value": "info",
-                "signature": null
-              }
-            }
-          }
-        },
         "builddir": {
           "type": "dir",
           "require": false,
@@ -2668,31 +2552,6 @@
             }
           },
           "unit": "s"
-        },
-        "strict": {
-          "type": "bool",
-          "require": false,
-          "scope": "global",
-          "lock": false,
-          "switch": [
-            "-strict <bool>"
-          ],
-          "shorthelp": "Option: strict checking",
-          "example": [
-            "cli: -strict true",
-            "api: option.set('strict', True)"
-          ],
-          "help": "\n                Enable additional strict checking in the SC Python API. When this\n                parameter is set to True, users must provide step and index keyword\n                arguments when reading from parameters with the pernode field set to\n                'optional'.",
-          "notes": null,
-          "pernode": "never",
-          "node": {
-            "default": {
-              "default": {
-                "value": false,
-                "signature": null
-              }
-            }
-          }
         },
         "scheduler": {
           "name": {
@@ -5342,33 +5201,6 @@
                   }
                 }
               },
-              "var": {
-                "default": {
-                  "type": "[str]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_var 'tool task key <str>'"
-                  ],
-                  "shorthelp": "Task: script variables",
-                  "example": [
-                    "cli: -tool_task_var 'openroad cts myvar 42'",
-                    "api: task.set('tool', 'openroad', 'task', 'cts', 'var', 'myvar', '42')"
-                  ],
-                  "help": "Task script variables specified as key value pairs. Variable\nnames and value types must match the name and type of task and reference\nscript consuming the variable.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": []
-                      }
-                    }
-                  }
-                }
-              },
               "env": {
                 "default": {
                   "type": "str",
@@ -5394,70 +5226,6 @@
                       }
                     }
                   }
-                }
-              },
-              "file": {
-                "default": {
-                  "type": "[file]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_file 'tool task key <file>'"
-                  ],
-                  "shorthelp": "Task: custom setup files",
-                  "example": [
-                    "cli: -tool_task_file 'openroad floorplan macroplace macroplace.tcl'",
-                    "api: task.set('tool', 'openroad', 'task', 'floorplan', 'file', 'macroplace', 'macroplace.tcl')"
-                  ],
-                  "help": "Paths to user supplied files mapped to keys. Keys and filetypes must\nmatch what's expected by the task/reference script consuming the\nfile.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": [],
-                        "filehash": [],
-                        "dataroot": [],
-                        "date": [],
-                        "author": []
-                      }
-                    }
-                  },
-                  "hashalgo": "sha256",
-                  "copy": true
-                }
-              },
-              "dir": {
-                "default": {
-                  "type": "[dir]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_dir 'tool task key <dir>'"
-                  ],
-                  "shorthelp": "Task: custom setup directories",
-                  "example": [
-                    "cli: -tool_task_dir 'verilator compile cincludes include'",
-                    "api: task.set('tool', 'verilator', 'task', 'compile', 'dir', 'cincludes', 'include')"
-                  ],
-                  "help": "Paths to user supplied directories mapped to keys. Keys must match\nwhat's expected by the task/reference script consuming the\ndirectory.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": [],
-                        "filehash": [],
-                        "dataroot": []
-                      }
-                    }
-                  },
-                  "hashalgo": "sha256",
-                  "copy": true
                 }
               },
               "input": {
@@ -6002,31 +5770,6 @@
             }
           }
         },
-        "loglevel": {
-          "type": "<critical,debug,error,info,quiet,warning>",
-          "require": false,
-          "scope": "global",
-          "lock": false,
-          "switch": [
-            "-loglevel <str>"
-          ],
-          "shorthelp": "Option: logging level",
-          "example": [
-            "cli: -loglevel info",
-            "api: option.set('loglevel', 'info')"
-          ],
-          "help": "\n                Provides explicit control over the level of debug logging printed.",
-          "notes": null,
-          "pernode": "optional",
-          "node": {
-            "default": {
-              "default": {
-                "value": "info",
-                "signature": null
-              }
-            }
-          }
-        },
         "builddir": {
           "type": "dir",
           "require": false,
@@ -6406,31 +6149,6 @@
             }
           },
           "unit": "s"
-        },
-        "strict": {
-          "type": "bool",
-          "require": false,
-          "scope": "global",
-          "lock": false,
-          "switch": [
-            "-strict <bool>"
-          ],
-          "shorthelp": "Option: strict checking",
-          "example": [
-            "cli: -strict true",
-            "api: option.set('strict', True)"
-          ],
-          "help": "\n                Enable additional strict checking in the SC Python API. When this\n                parameter is set to True, users must provide step and index keyword\n                arguments when reading from parameters with the pernode field set to\n                'optional'.",
-          "notes": null,
-          "pernode": "never",
-          "node": {
-            "default": {
-              "default": {
-                "value": false,
-                "signature": null
-              }
-            }
-          }
         },
         "scheduler": {
           "name": {
@@ -9387,33 +9105,6 @@
                   }
                 }
               },
-              "var": {
-                "default": {
-                  "type": "[str]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_var 'tool task key <str>'"
-                  ],
-                  "shorthelp": "Task: script variables",
-                  "example": [
-                    "cli: -tool_task_var 'openroad cts myvar 42'",
-                    "api: task.set('tool', 'openroad', 'task', 'cts', 'var', 'myvar', '42')"
-                  ],
-                  "help": "Task script variables specified as key value pairs. Variable\nnames and value types must match the name and type of task and reference\nscript consuming the variable.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": []
-                      }
-                    }
-                  }
-                }
-              },
               "env": {
                 "default": {
                   "type": "str",
@@ -9439,70 +9130,6 @@
                       }
                     }
                   }
-                }
-              },
-              "file": {
-                "default": {
-                  "type": "[file]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_file 'tool task key <file>'"
-                  ],
-                  "shorthelp": "Task: custom setup files",
-                  "example": [
-                    "cli: -tool_task_file 'openroad floorplan macroplace macroplace.tcl'",
-                    "api: task.set('tool', 'openroad', 'task', 'floorplan', 'file', 'macroplace', 'macroplace.tcl')"
-                  ],
-                  "help": "Paths to user supplied files mapped to keys. Keys and filetypes must\nmatch what's expected by the task/reference script consuming the\nfile.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": [],
-                        "filehash": [],
-                        "dataroot": [],
-                        "date": [],
-                        "author": []
-                      }
-                    }
-                  },
-                  "hashalgo": "sha256",
-                  "copy": true
-                }
-              },
-              "dir": {
-                "default": {
-                  "type": "[dir]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_dir 'tool task key <dir>'"
-                  ],
-                  "shorthelp": "Task: custom setup directories",
-                  "example": [
-                    "cli: -tool_task_dir 'verilator compile cincludes include'",
-                    "api: task.set('tool', 'verilator', 'task', 'compile', 'dir', 'cincludes', 'include')"
-                  ],
-                  "help": "Paths to user supplied directories mapped to keys. Keys must match\nwhat's expected by the task/reference script consuming the\ndirectory.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": [],
-                        "filehash": [],
-                        "dataroot": []
-                      }
-                    }
-                  },
-                  "hashalgo": "sha256",
-                  "copy": true
                 }
               },
               "input": {
@@ -10047,31 +9674,6 @@
             }
           }
         },
-        "loglevel": {
-          "type": "<critical,debug,error,info,quiet,warning>",
-          "require": false,
-          "scope": "global",
-          "lock": false,
-          "switch": [
-            "-loglevel <str>"
-          ],
-          "shorthelp": "Option: logging level",
-          "example": [
-            "cli: -loglevel info",
-            "api: option.set('loglevel', 'info')"
-          ],
-          "help": "\n                Provides explicit control over the level of debug logging printed.",
-          "notes": null,
-          "pernode": "optional",
-          "node": {
-            "default": {
-              "default": {
-                "value": "info",
-                "signature": null
-              }
-            }
-          }
-        },
         "builddir": {
           "type": "dir",
           "require": false,
@@ -10451,31 +10053,6 @@
             }
           },
           "unit": "s"
-        },
-        "strict": {
-          "type": "bool",
-          "require": false,
-          "scope": "global",
-          "lock": false,
-          "switch": [
-            "-strict <bool>"
-          ],
-          "shorthelp": "Option: strict checking",
-          "example": [
-            "cli: -strict true",
-            "api: option.set('strict', True)"
-          ],
-          "help": "\n                Enable additional strict checking in the SC Python API. When this\n                parameter is set to True, users must provide step and index keyword\n                arguments when reading from parameters with the pernode field set to\n                'optional'.",
-          "notes": null,
-          "pernode": "never",
-          "node": {
-            "default": {
-              "default": {
-                "value": false,
-                "signature": null
-              }
-            }
-          }
         },
         "scheduler": {
           "name": {
@@ -13188,33 +12765,6 @@
                   }
                 }
               },
-              "var": {
-                "default": {
-                  "type": "[str]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_var 'tool task key <str>'"
-                  ],
-                  "shorthelp": "Task: script variables",
-                  "example": [
-                    "cli: -tool_task_var 'openroad cts myvar 42'",
-                    "api: task.set('tool', 'openroad', 'task', 'cts', 'var', 'myvar', '42')"
-                  ],
-                  "help": "Task script variables specified as key value pairs. Variable\nnames and value types must match the name and type of task and reference\nscript consuming the variable.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": []
-                      }
-                    }
-                  }
-                }
-              },
               "env": {
                 "default": {
                   "type": "str",
@@ -13240,70 +12790,6 @@
                       }
                     }
                   }
-                }
-              },
-              "file": {
-                "default": {
-                  "type": "[file]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_file 'tool task key <file>'"
-                  ],
-                  "shorthelp": "Task: custom setup files",
-                  "example": [
-                    "cli: -tool_task_file 'openroad floorplan macroplace macroplace.tcl'",
-                    "api: task.set('tool', 'openroad', 'task', 'floorplan', 'file', 'macroplace', 'macroplace.tcl')"
-                  ],
-                  "help": "Paths to user supplied files mapped to keys. Keys and filetypes must\nmatch what's expected by the task/reference script consuming the\nfile.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": [],
-                        "filehash": [],
-                        "dataroot": [],
-                        "date": [],
-                        "author": []
-                      }
-                    }
-                  },
-                  "hashalgo": "sha256",
-                  "copy": true
-                }
-              },
-              "dir": {
-                "default": {
-                  "type": "[dir]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_dir 'tool task key <dir>'"
-                  ],
-                  "shorthelp": "Task: custom setup directories",
-                  "example": [
-                    "cli: -tool_task_dir 'verilator compile cincludes include'",
-                    "api: task.set('tool', 'verilator', 'task', 'compile', 'dir', 'cincludes', 'include')"
-                  ],
-                  "help": "Paths to user supplied directories mapped to keys. Keys must match\nwhat's expected by the task/reference script consuming the\ndirectory.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": [],
-                        "filehash": [],
-                        "dataroot": []
-                      }
-                    }
-                  },
-                  "hashalgo": "sha256",
-                  "copy": true
                 }
               },
               "input": {
@@ -13848,31 +13334,6 @@
             }
           }
         },
-        "loglevel": {
-          "type": "<critical,debug,error,info,quiet,warning>",
-          "require": false,
-          "scope": "global",
-          "lock": false,
-          "switch": [
-            "-loglevel <str>"
-          ],
-          "shorthelp": "Option: logging level",
-          "example": [
-            "cli: -loglevel info",
-            "api: option.set('loglevel', 'info')"
-          ],
-          "help": "\n                Provides explicit control over the level of debug logging printed.",
-          "notes": null,
-          "pernode": "optional",
-          "node": {
-            "default": {
-              "default": {
-                "value": "info",
-                "signature": null
-              }
-            }
-          }
-        },
         "builddir": {
           "type": "dir",
           "require": false,
@@ -14252,31 +13713,6 @@
             }
           },
           "unit": "s"
-        },
-        "strict": {
-          "type": "bool",
-          "require": false,
-          "scope": "global",
-          "lock": false,
-          "switch": [
-            "-strict <bool>"
-          ],
-          "shorthelp": "Option: strict checking",
-          "example": [
-            "cli: -strict true",
-            "api: option.set('strict', True)"
-          ],
-          "help": "\n                Enable additional strict checking in the SC Python API. When this\n                parameter is set to True, users must provide step and index keyword\n                arguments when reading from parameters with the pernode field set to\n                'optional'.",
-          "notes": null,
-          "pernode": "never",
-          "node": {
-            "default": {
-              "default": {
-                "value": false,
-                "signature": null
-              }
-            }
-          }
         },
         "scheduler": {
           "name": {
@@ -16238,33 +15674,6 @@
                   }
                 }
               },
-              "var": {
-                "default": {
-                  "type": "[str]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_var 'tool task key <str>'"
-                  ],
-                  "shorthelp": "Task: script variables",
-                  "example": [
-                    "cli: -tool_task_var 'openroad cts myvar 42'",
-                    "api: task.set('tool', 'openroad', 'task', 'cts', 'var', 'myvar', '42')"
-                  ],
-                  "help": "Task script variables specified as key value pairs. Variable\nnames and value types must match the name and type of task and reference\nscript consuming the variable.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": []
-                      }
-                    }
-                  }
-                }
-              },
               "env": {
                 "default": {
                   "type": "str",
@@ -16290,70 +15699,6 @@
                       }
                     }
                   }
-                }
-              },
-              "file": {
-                "default": {
-                  "type": "[file]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_file 'tool task key <file>'"
-                  ],
-                  "shorthelp": "Task: custom setup files",
-                  "example": [
-                    "cli: -tool_task_file 'openroad floorplan macroplace macroplace.tcl'",
-                    "api: task.set('tool', 'openroad', 'task', 'floorplan', 'file', 'macroplace', 'macroplace.tcl')"
-                  ],
-                  "help": "Paths to user supplied files mapped to keys. Keys and filetypes must\nmatch what's expected by the task/reference script consuming the\nfile.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": [],
-                        "filehash": [],
-                        "dataroot": [],
-                        "date": [],
-                        "author": []
-                      }
-                    }
-                  },
-                  "hashalgo": "sha256",
-                  "copy": true
-                }
-              },
-              "dir": {
-                "default": {
-                  "type": "[dir]",
-                  "require": false,
-                  "scope": "job",
-                  "lock": false,
-                  "switch": [
-                    "-tool_task_dir 'tool task key <dir>'"
-                  ],
-                  "shorthelp": "Task: custom setup directories",
-                  "example": [
-                    "cli: -tool_task_dir 'verilator compile cincludes include'",
-                    "api: task.set('tool', 'verilator', 'task', 'compile', 'dir', 'cincludes', 'include')"
-                  ],
-                  "help": "Paths to user supplied directories mapped to keys. Keys must match\nwhat's expected by the task/reference script consuming the\ndirectory.",
-                  "notes": null,
-                  "pernode": "optional",
-                  "node": {
-                    "default": {
-                      "default": {
-                        "value": [],
-                        "signature": [],
-                        "filehash": [],
-                        "dataroot": []
-                      }
-                    }
-                  },
-                  "hashalgo": "sha256",
-                  "copy": true
                 }
               },
               "input": {
@@ -16898,31 +16243,6 @@
             }
           }
         },
-        "loglevel": {
-          "type": "<critical,debug,error,info,quiet,warning>",
-          "require": false,
-          "scope": "global",
-          "lock": false,
-          "switch": [
-            "-loglevel <str>"
-          ],
-          "shorthelp": "Option: logging level",
-          "example": [
-            "cli: -loglevel info",
-            "api: option.set('loglevel', 'info')"
-          ],
-          "help": "\n                Provides explicit control over the level of debug logging printed.",
-          "notes": null,
-          "pernode": "optional",
-          "node": {
-            "default": {
-              "default": {
-                "value": "info",
-                "signature": null
-              }
-            }
-          }
-        },
         "builddir": {
           "type": "dir",
           "require": false,
@@ -17302,31 +16622,6 @@
             }
           },
           "unit": "s"
-        },
-        "strict": {
-          "type": "bool",
-          "require": false,
-          "scope": "global",
-          "lock": false,
-          "switch": [
-            "-strict <bool>"
-          ],
-          "shorthelp": "Option: strict checking",
-          "example": [
-            "cli: -strict true",
-            "api: option.set('strict', True)"
-          ],
-          "help": "\n                Enable additional strict checking in the SC Python API. When this\n                parameter is set to True, users must provide step and index keyword\n                arguments when reading from parameters with the pernode field set to\n                'optional'.",
-          "notes": null,
-          "pernode": "never",
-          "node": {
-            "default": {
-              "default": {
-                "value": false,
-                "signature": null
-              }
-            }
-          }
         },
         "scheduler": {
           "name": {

--- a/tests/schema/test_schema_utils.py
+++ b/tests/schema/test_schema_utils.py
@@ -1,6 +1,3 @@
-import logging
-import pytest
-
 from siliconcompiler.schema.utils import trim
 
 

--- a/tests/schema/test_schema_utils.py
+++ b/tests/schema/test_schema_utils.py
@@ -1,18 +1,7 @@
 import logging
 import pytest
 
-from siliconcompiler.schema.utils import translate_loglevel, trim
-
-
-@pytest.mark.parametrize("level,check", [
-    ("debug", logging.DEBUG),
-    ("info", logging.INFO),
-    ("warning", logging.WARNING),
-    ("error", logging.ERROR),
-    ("quiet", logging.ERROR)
-])
-def test_translate_loglevel(level, check):
-    assert translate_loglevel(level) == logging.getLevelName(check)
+from siliconcompiler.schema.utils import trim
 
 
 def test_trim_none():

--- a/tests/schema_support/test_cmdlineschema.py
+++ b/tests/schema_support/test_cmdlineschema.py
@@ -24,8 +24,6 @@ def schema():
             schema.insert("test4", Parameter("bool", switch=["-test_bool <bool>"],
                                              pernode=PerNode.OPTIONAL))
             schema.insert("option", "cfg", Parameter("[file]", switch=["-cfg <file>"]))
-            schema.insert("option", "loglevel", Parameter("str", switch=["-loglevel <str>"],
-                                                          pernode=PerNode.OPTIONAL))
             schema.insert("test5", Parameter(
                 "int",
                 switch=["-O<int>"]))

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1398,7 +1398,7 @@ def test_select_input_nodes_entry_has_input(running_node):
 def test_task_add_parameter():
     task = Task()
 
-    with pytest.raises(KeyError, match=r"\[var\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[var\] is not a valid keypath'$"):
         task.getkeys("var")
 
     assert isinstance(task.add_parameter("teststr", "str", "long form help"), Parameter)

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1082,7 +1082,7 @@ def test_run_task(running_node, exitcode, monkeypatch):
     assert running_node.project.get("metric", "memory", step="running", index="0") is None
 
     with running_node.task.runtime(running_node) as runtool:
-        assert runtool.run_task('.', False, "info", False, None, None) == exitcode
+        assert runtool.run_task('.', False, False, None, None) == exitcode
 
     assert running_node.project.get("record", "toolargs", step="running", index="0") == ""
     assert running_node.project.get("record", "toolexitcode", step="running", index="0") == exitcode
@@ -1103,7 +1103,7 @@ def test_run_task_failed_popen(running_node, monkeypatch):
 
     with running_node.task.runtime(running_node) as runtool:
         with pytest.raises(TaskError, match="^Unable to start found/exe: something bad happened$"):
-            runtool.run_task('.', False, "info", False, None, None)
+            runtool.run_task('.', False, False, None, None)
 
 
 @pytest.mark.parametrize("nice", [-5, 0, 5])
@@ -1136,7 +1136,7 @@ def test_run_task_nice(running_node, nice, monkeypatch):
     monkeypatch.setattr(running_node.task, 'get_exe', dummy_get_exe)
 
     with running_node.task.runtime(running_node) as runtool:
-        assert runtool.run_task('.', False, "info", False, nice, None) == 0
+        assert runtool.run_task('.', False, False, nice, None) == 0
 
 
 def test_run_task_timeout(running_node, monkeypatch, patch_psutil):
@@ -1165,7 +1165,7 @@ def test_run_task_timeout(running_node, monkeypatch, patch_psutil):
 
     with running_node.task.runtime(running_node) as runtool:
         with pytest.raises(TaskTimeout, match="^$"):
-            runtool.run_task('.', False, "info", False, None, 2)
+            runtool.run_task('.', False, False, None, 2)
 
 
 def test_run_task_memory_limit(running_node, monkeypatch, patch_psutil, caplog):
@@ -1195,7 +1195,7 @@ def test_run_task_memory_limit(running_node, monkeypatch, patch_psutil, caplog):
     monkeypatch.setattr(running_node.task, 'get_exe', dummy_get_exe)
 
     with running_node.task.runtime(running_node) as runtool:
-        assert runtool.run_task('.', False, "info", False, None, None) == 0
+        assert runtool.run_task('.', False, False, None, None) == 0
 
     assert "Current system memory usage is 91.2%" in caplog.text
 
@@ -1232,7 +1232,7 @@ def test_run_task_exceptions_loop(running_node, monkeypatch, patch_psutil, error
     monkeypatch.setattr(running_node.task, 'get_exe', dummy_get_exe)
 
     with running_node.task.runtime(running_node) as runtool:
-        assert runtool.run_task('.', False, "info", False, None, None) == 0
+        assert runtool.run_task('.', False, False, None, None) == 0
 
 
 def test_run_task_contl_c(running_node, monkeypatch, patch_psutil, caplog):
@@ -1270,7 +1270,7 @@ def test_run_task_contl_c(running_node, monkeypatch, patch_psutil, caplog):
 
     with running_node.task.runtime(running_node) as runtool:
         with pytest.raises(TaskError, match="^$"):
-            runtool.run_task('.', False, "info", False, None, None)
+            runtool.run_task('.', False, False, None, None)
 
     assert "Received ctrl-c." in caplog.text
 
@@ -1285,7 +1285,7 @@ def test_run_task_breakpoint_valid(running_node, monkeypatch):
     with running_node.task.runtime(running_node) as runtool:
         with patch("pty.spawn", autospec=True) as spawn:
             spawn.return_value = 1
-            assert runtool.run_task('.', False, "info", True, None, None) == 1
+            assert runtool.run_task('.', False, True, None, None) == 1
             spawn.assert_called_once()
             spawn.assert_called_with(["found/exe"], ANY)
 
@@ -1313,7 +1313,7 @@ def test_run_task_breakpoint_not_used(running_node, monkeypatch):
     with running_node.task.runtime(running_node) as runtool:
         with patch("pty.spawn", autospec=True) as spawn:
             spawn.return_value = 1
-            assert runtool.run_task('.', False, "info", True, None, None) == 1
+            assert runtool.run_task('.', False, True, None, None) == 1
             spawn.assert_not_called()
 
 
@@ -1334,7 +1334,7 @@ def test_run_task_run(running_node):
 
     with running_node.task.runtime(running_node) as runtool:
         assert isinstance(runtool, RunTool)
-        assert runtool.run_task('.', False, "info", True, None, None) == 1
+        assert runtool.run_task('.', False, True, None, None) == 1
         assert runtool.call_count == 1
 
 
@@ -1355,7 +1355,7 @@ def test_run_task_run_error(running_node):
 
     with running_node.task.runtime(running_node) as runtool:
         with pytest.raises(ValueError, match="^run error$"):
-            runtool.run_task('.', False, "info", True, None, None)
+            runtool.run_task('.', False, True, None, None)
         assert runtool.call_count == 1
 
 
@@ -1380,7 +1380,7 @@ def test_run_task_run_failed_resource(running_node, monkeypatch):
     assert isinstance(running_node.task, RunTool)
 
     with running_node.task.runtime(running_node) as runtool:
-        assert runtool.run_task('.', False, "info", True, None, None) == 1
+        assert runtool.run_task('.', False, True, None, None) == 1
         assert runtool.call_count == 1
 
 
@@ -1398,7 +1398,8 @@ def test_select_input_nodes_entry_has_input(running_node):
 def test_task_add_parameter():
     task = Task()
 
-    assert task.getkeys("var") == tuple()
+    with pytest.raises(KeyError, match=r"\[var\] is not a valid keypath"):
+        task.getkeys("var")
 
     assert isinstance(task.add_parameter("teststr", "str", "long form help"), Parameter)
     assert isinstance(task.add_parameter("testbool", "bool", "long form help"), Parameter)


### PR DESCRIPTION
Removes the following keys:
option,strict <- no longer needed
option,loglevel <- can be handled cleanly with the logger API
tool,task,file <- no longer needed
tool,task,dir <- no longer needed
tool,task,var <- handled via the tool parameter API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Streamlined, consistent console logging behavior.

- Refactor
  - Removed configurable log level; server now logs at INFO.
  - Dropped -loglevel CLI flag and “strict” option.
  - Simplified task configuration by removing per-task var/file/dir parameters.
  - Unified console formatter selection for clearer output.

- Chores
  - Cleaned up default schema by removing deprecated options (e.g., loglevel, strict, verbose).

- Tests
  - Updated test suite to reflect removed options and adjusted interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->