### PR TITLE
disable failing daily test until it can be debugged

### DIFF
--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -119,7 +119,8 @@ def test_py_gcd_ihp130():
 
 @pytest.mark.eda
 @pytest.mark.ready
-@pytest.mark.timeout(1800)
+@pytest.mark.timeout(1200)
+@pytest.mark.skip(reason="does not complete synthesis")
 def test_py_gcd_hls():
     from gcd import gcd_hls
     gcd_hls.main()

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -119,7 +119,7 @@ def test_py_gcd_ihp130():
 
 @pytest.mark.eda
 @pytest.mark.ready
-@pytest.mark.timeout(1200)
+@pytest.mark.timeout(1800)
 def test_py_gcd_hls():
     from gcd import gcd_hls
     gcd_hls.main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite configuration; a hardware-synthesis GCD test is now skipped during execution.
  * All other tests remain unchanged and continue to run as before.
  * No impact on application behavior, performance, or user experience.
  * No new features or bug fixes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->