### PR TITLE
ensure syncmanager has fallback when address is deleted while setting  up Sync

### DIFF
--- a/siliconcompiler/utils/multiprocessing.py
+++ b/siliconcompiler/utils/multiprocessing.py
@@ -125,6 +125,7 @@ class MPManager(metaclass=_ManagerSingleton):
                 self.__manager.connect()
                 self.__manager_server = False
             except FileNotFoundError:  # error when address has been deleted by previous server
+                self.__logger.warning("Manager address file not found; falling back to server mode")
                 is_server = True  # fall back to create new manager
         if is_server:
             self.__manager = SyncManager(authkey=MPManager.__authkey)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multiprocessing startup to reconnect to an existing session when available and otherwise start a new one.
  - Added detection of server vs. client mode so instances set role correctly.
  - Logged and recovered cleanly if a previous address file is missing, preventing startup failures.
  - Kept dashboard behavior unchanged while making initialization more fault-tolerant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->