### PR TITLE
tighten pytest.raises checks

### DIFF
--- a/tests/apps/test_sc_dashboard.py
+++ b/tests/apps/test_sc_dashboard.py
@@ -54,7 +54,7 @@ def test_dashboard_graph_cfg_file_not_found(monkeypatch):
     monkeypatch.setattr('sys.argv', [
         'sc-dashboard', '-cfg', 'test.json', '-graph_cfg', 'testing.json'])
 
-    with pytest.raises(ValueError, match="not a valid file path: testing.json"):
+    with pytest.raises(ValueError, match="^not a valid file path: testing.json$"):
         sc_dashboard.main()
 
 
@@ -103,8 +103,8 @@ def test_dashboard_graph_cfg_names_invalid(monkeypatch):
         'sc-dashboard', '-cfg', 'test.json', '-graph_cfg', 'testfile opt test.json'])
 
     with pytest.raises(ValueError,
-                       match='graph_cfg accepts a max of 2 values, you supplied 3 in '
-                             '"-graph_cfg \\[\'testfile\', \'opt\', \'test.json\'\\]"'):
+                       match=r'^graph_cfg accepts a max of 2 values, you supplied 3 in '
+                             r'"-graph_cfg \[\'testfile\', \'opt\', \'test\.json\'\]"$'):
         sc_dashboard.main()
 
 

--- a/tests/constraints/test_asic_component.py
+++ b/tests/constraints/test_asic_component.py
@@ -48,9 +48,9 @@ def test_set_get_placement(component_constraint):
     component_constraint.set_placement(5, 15)  # Test integers
     assert component_constraint.get_placement() == (5, 15)
 
-    with pytest.raises(TypeError, match="x must be a number"):
+    with pytest.raises(TypeError, match="^x must be a number$"):
         component_constraint.set_placement("a", 1.0)
-    with pytest.raises(TypeError, match="y must be a number"):
+    with pytest.raises(TypeError, match="^y must be a number$"):
         component_constraint.set_placement(1.0, "b")
 
 
@@ -69,9 +69,9 @@ def test_set_get_partname(component_constraint):
     component_constraint.set_partname("my_cell")
     assert component_constraint.get_partname() == "my_cell"
 
-    with pytest.raises(ValueError, match="a partname is required"):
+    with pytest.raises(ValueError, match="^a partname is required$"):
         component_constraint.set_partname("")
-    with pytest.raises(ValueError, match="a partname is required"):
+    with pytest.raises(ValueError, match="^a partname is required$"):
         component_constraint.set_partname(None)
 
 
@@ -92,13 +92,13 @@ def test_set_get_halo(component_constraint):
     component_constraint.set_halo(0, 0)  # Test zero halo
     assert component_constraint.get_halo() == (0, 0)
 
-    with pytest.raises(TypeError, match="x must be a number"):
+    with pytest.raises(TypeError, match="^x must be a number$"):
         component_constraint.set_halo("a", 1.0)
-    with pytest.raises(TypeError, match="y must be a number"):
+    with pytest.raises(TypeError, match="^y must be a number$"):
         component_constraint.set_halo(1.0, "b")
-    with pytest.raises(ValueError, match="x must be a positive number"):
+    with pytest.raises(ValueError, match="^x must be a positive number$"):
         component_constraint.set_halo(-1.0, 1.0)
-    with pytest.raises(ValueError, match="y must be a positive number"):
+    with pytest.raises(ValueError, match="^y must be a positive number$"):
         component_constraint.set_halo(1.0, -1.0)
 
 
@@ -152,12 +152,12 @@ def test_add_component(component_constraints_collection):
     assert component_constraints_collection.get_component("new_comp") is updated_comp
 
     # Test adding invalid type
-    with pytest.raises(TypeError, match="component must be a component constraint object"):
+    with pytest.raises(TypeError, match="^component must be a component constraint object$"):
         component_constraints_collection.add_component("not_a_component")
 
     # Test adding component without a name
     no_name_comp = ASICComponentConstraint()
-    with pytest.raises(ValueError, match="component constraint must have a name"):
+    with pytest.raises(ValueError, match="^component constraint must have a name$"):
         component_constraints_collection.add_component(no_name_comp)
 
 
@@ -179,7 +179,7 @@ def test_get_component(component_constraints_collection):
     assert all_components["comp2"] is comp2
 
     # Get non-existent
-    with pytest.raises(LookupError, match="non_existent_comp is not defined"):
+    with pytest.raises(LookupError, match="^non_existent_comp is not defined$"):
         component_constraints_collection.get_component("non_existent_comp")
 
 
@@ -191,13 +191,13 @@ def test_make_component(component_constraints_collection):
     assert component_constraints_collection.get_component("made_comp") is new_comp
 
     # Test creating existing
-    with pytest.raises(LookupError, match="made_comp constraint already exists"):
+    with pytest.raises(LookupError, match="^made_comp constraint already exists$"):
         component_constraints_collection.make_component("made_comp")
 
     # Test empty name
-    with pytest.raises(ValueError, match="component name is required"):
+    with pytest.raises(ValueError, match="^component name is required$"):
         component_constraints_collection.make_component("")
-    with pytest.raises(ValueError, match="component name is required"):
+    with pytest.raises(ValueError, match="^component name is required$"):
         component_constraints_collection.make_component(None)
 
 
@@ -208,14 +208,14 @@ def test_remove_component(component_constraints_collection):
 
     # Remove existing
     assert component_constraints_collection.remove_component("to_remove_comp") is True
-    with pytest.raises(LookupError, match="to_remove_comp is not defined"):
+    with pytest.raises(LookupError, match="^to_remove_comp is not defined$"):
         component_constraints_collection.get_component("to_remove_comp")
 
     # Remove non-existent
     assert component_constraints_collection.remove_component("non_existent_comp") is False
 
     # Test empty name
-    with pytest.raises(ValueError, match="component name is required"):
+    with pytest.raises(ValueError, match="^component name is required$"):
         component_constraints_collection.remove_component("")
-    with pytest.raises(ValueError, match="component name is required"):
+    with pytest.raises(ValueError, match="^component name is required$"):
         component_constraints_collection.remove_component(None)

--- a/tests/constraints/test_asic_floorplan.py
+++ b/tests/constraints/test_asic_floorplan.py
@@ -23,17 +23,17 @@ def test_key_params(key):
 
 
 def test_aspectratio_illegal():
-    with pytest.raises(TypeError, match="aspectratio must be a number"):
+    with pytest.raises(TypeError, match="^aspectratio must be a number$"):
         ASICAreaConstraint().set_aspectratio("abc")
 
 
 def test_aspectratio_negative():
-    with pytest.raises(ValueError, match="aspectratio cannot be zero or negative"):
+    with pytest.raises(ValueError, match="^aspectratio cannot be zero or negative$"):
         ASICAreaConstraint().set_aspectratio(-1)
 
 
 def test_aspectratio_zero():
-    with pytest.raises(ValueError, match="aspectratio cannot be zero or negative"):
+    with pytest.raises(ValueError, match="^aspectratio cannot be zero or negative$"):
         ASICAreaConstraint().set_aspectratio(0)
 
 
@@ -57,12 +57,12 @@ def test_aspectratio_step_index():
 
 
 def test_coremargin_illegal():
-    with pytest.raises(TypeError, match="coremargin must be a number"):
+    with pytest.raises(TypeError, match="^coremargin must be a number$"):
         ASICAreaConstraint().set_coremargin("abc")
 
 
 def test_coremargin_negative():
-    with pytest.raises(ValueError, match="coremargin cannot be negative"):
+    with pytest.raises(ValueError, match="^coremargin cannot be negative$"):
         ASICAreaConstraint().set_coremargin(-1)
 
 
@@ -83,22 +83,22 @@ def test_coremargin_step_index():
 
 
 def test_density_illegal():
-    with pytest.raises(TypeError, match="density must be a number"):
+    with pytest.raises(TypeError, match="^density must be a number$"):
         ASICAreaConstraint().set_density("abc")
 
 
 def test_density_negative():
-    with pytest.raises(ValueError, match=r"density must be between \(0, 100\]"):
+    with pytest.raises(ValueError, match=r"^density must be between \(0, 100\]$"):
         ASICAreaConstraint().set_density(-1)
 
 
 def test_density_zero():
-    with pytest.raises(ValueError, match=r"density must be between \(0, 100\]"):
+    with pytest.raises(ValueError, match=r"^density must be between \(0, 100\]$"):
         ASICAreaConstraint().set_density(0)
 
 
 def test_density_gt_100():
-    with pytest.raises(ValueError, match=r"density must be between \(0, 100\]"):
+    with pytest.raises(ValueError, match=r"^density must be between \(0, 100\]$"):
         ASICAreaConstraint().set_density(101)
 
 
@@ -134,69 +134,69 @@ def test_density_aspectratio_coremargin_step_index():
 
 
 def test_corearea_rectangle_illegal_height():
-    with pytest.raises(TypeError, match="height must be a number"):
+    with pytest.raises(TypeError, match="^height must be a number$"):
         ASICAreaConstraint().set_corearea_rectangle("abc", "abc", "abc")
 
 
 def test_corearea_rectangle_illegal_width():
-    with pytest.raises(TypeError, match="width must be a number"):
+    with pytest.raises(TypeError, match="^width must be a number$"):
         ASICAreaConstraint().set_corearea_rectangle(100.0, "abc", "abc")
 
 
 def test_corearea_rectangle_illegal_margin():
-    with pytest.raises(TypeError, match="coremargin must be a number or a tuple of two numbers"):
+    with pytest.raises(TypeError, match="^coremargin must be a number or a tuple of two numbers$"):
         ASICAreaConstraint().set_corearea_rectangle(100.0, 100.0, "abc")
 
 
 def test_corearea_rectangle_illegal_negative_height():
-    with pytest.raises(ValueError, match="height must be greater than zero"):
+    with pytest.raises(ValueError, match="^height must be greater than zero$"):
         ASICAreaConstraint().set_corearea_rectangle(-100.0, 100.0, 2.0)
 
 
 def test_corearea_rectangle_illegal_negative_width():
-    with pytest.raises(ValueError, match="width must be greater than zero"):
+    with pytest.raises(ValueError, match="^width must be greater than zero$"):
         ASICAreaConstraint().set_corearea_rectangle(100.0, -100.0, 2.0)
 
 
 def test_corearea_rectangle_illegal_negative_margin():
-    with pytest.raises(ValueError, match="x margin cannot be negative"):
+    with pytest.raises(ValueError, match="^x margin cannot be negative$"):
         ASICAreaConstraint().set_corearea_rectangle(100.0, 100.0, -2.0)
 
 
 def test_corearea_rectangle_illegal_negative_xmargin():
-    with pytest.raises(ValueError, match="x margin cannot be negative"):
+    with pytest.raises(ValueError, match="^x margin cannot be negative$"):
         ASICAreaConstraint().set_corearea_rectangle(100.0, 100.0, (-2.0, 2))
 
 
 def test_corearea_rectangle_illegal_extra_margin():
-    with pytest.raises(ValueError, match="coremargin must be a number or a tuple of two numbers"):
+    with pytest.raises(ValueError, match="^coremargin must be a number or a tuple of two numbers$"):
         ASICAreaConstraint().set_corearea_rectangle(100.0, 100.0, (2.0, 2, 2.0))
 
 
 def test_corearea_rectangle_illegal_negative_ymargin():
-    with pytest.raises(ValueError, match="y margin cannot be negative"):
+    with pytest.raises(ValueError, match="^y margin cannot be negative$"):
         ASICAreaConstraint().set_corearea_rectangle(100.0, 100.0, (2, -2.0))
 
 
 def test_corearea_rectangle_illegal_zero_height():
-    with pytest.raises(ValueError, match="height must be greater than zero"):
+    with pytest.raises(ValueError, match="^height must be greater than zero$"):
         ASICAreaConstraint().set_corearea_rectangle(0.0, 100.0, 2.0)
 
 
 def test_corearea_rectangle_illegal_zero_width():
-    with pytest.raises(ValueError, match="width must be greater than zero"):
+    with pytest.raises(ValueError, match="^width must be greater than zero$"):
         ASICAreaConstraint().set_corearea_rectangle(100.0, 0, 2.0)
 
 
 def test_corearea_rectangle_illegal_extra_xmargin():
     with pytest.raises(ValueError,
-                       match="x margin is greater than or equal to the die width"):
+                       match="^x margin is greater than or equal to the die width$"):
         ASICAreaConstraint().set_corearea_rectangle(100.0, 100.0, (50.0, 2))
 
 
 def test_corearea_rectangle_illegal_extra_ymargin():
     with pytest.raises(ValueError,
-                       match="y margin is greater than or equal to the die height"):
+                       match="^y margin is greater than or equal to the die height$"):
         ASICAreaConstraint().set_corearea_rectangle(100.0, 100.0, (2, 50.0))
 
 
@@ -225,22 +225,22 @@ def test_corearea_rectangle_step_index():
 
 
 def test_diearea_rectangle_illegal_height():
-    with pytest.raises(TypeError, match="height must be a number"):
+    with pytest.raises(TypeError, match="^height must be a number$"):
         ASICAreaConstraint().set_diearea_rectangle("abc", "abc", "abc")
 
 
 def test_diearea_rectangle_illegal_width():
-    with pytest.raises(TypeError, match="width must be a number"):
+    with pytest.raises(TypeError, match="^width must be a number$"):
         ASICAreaConstraint().set_diearea_rectangle(100.0, "abc", "abc")
 
 
 def test_diearea_rectangle_illegal_negative_height():
-    with pytest.raises(ValueError, match="height must be greater than zero"):
+    with pytest.raises(ValueError, match="^height must be greater than zero$"):
         ASICAreaConstraint().set_diearea_rectangle(-100.0, 100.0, 2.0)
 
 
 def test_diearea_rectangle_illegal_negative_width():
-    with pytest.raises(ValueError, match="width must be greater than zero"):
+    with pytest.raises(ValueError, match="^width must be greater than zero$"):
         ASICAreaConstraint().set_diearea_rectangle(100.0, -100.0, 2.0)
 
 

--- a/tests/constraints/test_asic_pins.py
+++ b/tests/constraints/test_asic_pins.py
@@ -49,11 +49,11 @@ def test_set_get_width(pin_constraint):
     pin_constraint.set_width(5)  # Test integer
     assert pin_constraint.get_width() == 5
 
-    with pytest.raises(TypeError, match="width must be a number"):
+    with pytest.raises(TypeError, match="^width must be a number$"):
         pin_constraint.set_width("abc")
-    with pytest.raises(ValueError, match="width must be a positive value"):
+    with pytest.raises(ValueError, match="^width must be a positive value$"):
         pin_constraint.set_width(0)
-    with pytest.raises(ValueError, match="width must be a positive value"):
+    with pytest.raises(ValueError, match="^width must be a positive value$"):
         pin_constraint.set_width(-1.0)
 
 
@@ -74,11 +74,11 @@ def test_set_get_length(pin_constraint):
     pin_constraint.set_length(15)  # Test integer
     assert pin_constraint.get_length() == 15
 
-    with pytest.raises(TypeError, match="length must be a number"):
+    with pytest.raises(TypeError, match="^length must be a number$"):
         pin_constraint.set_length([1])
-    with pytest.raises(ValueError, match="length must be a positive value"):
+    with pytest.raises(ValueError, match="^length must be a positive value$"):
         pin_constraint.set_length(0.0)
-    with pytest.raises(ValueError, match="length must be a positive value"):
+    with pytest.raises(ValueError, match="^length must be a positive value$"):
         pin_constraint.set_length(-5)
 
 
@@ -99,9 +99,9 @@ def test_set_get_placement(pin_constraint):
     pin_constraint.set_placement(10, 20)  # Test integers
     assert pin_constraint.get_placement() == (10, 20)
 
-    with pytest.raises(TypeError, match="x must be a number"):
+    with pytest.raises(TypeError, match="^x must be a number$"):
         pin_constraint.set_placement("a", 1.0)
-    with pytest.raises(TypeError, match="y must be a number"):
+    with pytest.raises(TypeError, match="^y must be a number$"):
         pin_constraint.set_placement(1.0, "b")
 
 
@@ -164,13 +164,13 @@ def test_set_get_side(pin_constraint):
     pin_constraint.set_side("west")
     assert pin_constraint.get_side() == 1
 
-    with pytest.raises(TypeError, match="side must be an integer"):
+    with pytest.raises(TypeError, match="^side must be an integer$"):
         pin_constraint.set_side(3.5)
-    with pytest.raises(ValueError, match="side must be a positive integer"):
+    with pytest.raises(ValueError, match="^side must be a positive integer$"):
         pin_constraint.set_side(0)
-    with pytest.raises(ValueError, match="side must be a positive integer"):
+    with pytest.raises(ValueError, match="^side must be a positive integer$"):
         pin_constraint.set_side(-1)
-    with pytest.raises(ValueError, match="not a recognized side"):
+    with pytest.raises(ValueError, match="^invalid is a not a recognized side$"):
         pin_constraint.set_side("invalid")
 
 
@@ -228,12 +228,12 @@ def test_add_pinconstraint(pin_constraints_collection):
     assert pin_constraints_collection.get_pinconstraint("new_pin") is updated_pin
 
     # Test adding invalid type
-    with pytest.raises(TypeError, match="pin must be a pin constraint object"):
+    with pytest.raises(TypeError, match="^pin must be a pin constraint object$"):
         pin_constraints_collection.add_pinconstraint("not_a_pin")
 
     # Test adding pin without a name
     no_name_pin = ASICPinConstraint()
-    with pytest.raises(ValueError, match="pin constraint must have a name"):
+    with pytest.raises(ValueError, match="^pin constraint must have a name$"):
         pin_constraints_collection.add_pinconstraint(no_name_pin)
 
 
@@ -255,7 +255,7 @@ def test_get_pinconstraint(pin_constraints_collection):
     assert all_pins["pin2"] is pin2
 
     # Get non-existent
-    with pytest.raises(LookupError, match="non_existent_pin is not defined"):
+    with pytest.raises(LookupError, match="^non_existent_pin is not defined$"):
         pin_constraints_collection.get_pinconstraint("non_existent_pin")
 
 
@@ -267,13 +267,13 @@ def test_make_pinconstraint(pin_constraints_collection):
     assert pin_constraints_collection.get_pinconstraint("made_pin") is new_pin
 
     # Test creating existing
-    with pytest.raises(LookupError, match="made_pin constraint already exists"):
+    with pytest.raises(LookupError, match="^made_pin constraint already exists$"):
         pin_constraints_collection.make_pinconstraint("made_pin")
 
     # Test empty name
-    with pytest.raises(ValueError, match="pin name is required"):
+    with pytest.raises(ValueError, match="^pin name is required$"):
         pin_constraints_collection.make_pinconstraint("")
-    with pytest.raises(ValueError, match="pin name is required"):
+    with pytest.raises(ValueError, match="^pin name is required$"):
         pin_constraints_collection.make_pinconstraint(None)
 
 
@@ -284,14 +284,14 @@ def test_remove_pinconstraint(pin_constraints_collection):
 
     # Remove existing
     assert pin_constraints_collection.remove_pinconstraint("to_remove_pin") is True
-    with pytest.raises(LookupError, match="to_remove_pin is not defined"):
+    with pytest.raises(LookupError, match="^to_remove_pin is not defined$"):
         pin_constraints_collection.get_pinconstraint("to_remove_pin")
 
     # Remove non-existent
     assert pin_constraints_collection.remove_pinconstraint("non_existent_pin") is False
 
     # Test empty name
-    with pytest.raises(ValueError, match="pin name is required"):
+    with pytest.raises(ValueError, match="^pin name is required$"):
         pin_constraints_collection.remove_pinconstraint("")
-    with pytest.raises(ValueError, match="pin name is required"):
+    with pytest.raises(ValueError, match="^pin name is required$"):
         pin_constraints_collection.remove_pinconstraint(None)

--- a/tests/constraints/test_asic_timing.py
+++ b/tests/constraints/test_asic_timing.py
@@ -38,7 +38,7 @@ def test_timing_scanario_pin_voltage():
 
 def test_timing_scanario_pin_voltage_missing():
     scene = ASICTimingScenarioSchema()
-    with pytest.raises(LookupError, match="VDD does not have voltage"):
+    with pytest.raises(LookupError, match="^VDD does not have voltage$"):
         scene.get_pin_voltage("VDD")
 
 
@@ -142,12 +142,12 @@ def test_timing_scanario_check_clobber_step_index():
 
 
 def test_timing_scanario_sdcfileset_invalid_type_design():
-    with pytest.raises(TypeError, match="design must be a design object or string"):
+    with pytest.raises(TypeError, match="^design must be a design object or string$"):
         ASICTimingScenarioSchema().add_sdcfileset(1.0, "fileset")
 
 
 def test_timing_scanario_sdcfileset_invalid_type_fileset():
-    with pytest.raises(TypeError, match="fileset must be a string"):
+    with pytest.raises(TypeError, match="^fileset must be a string$"):
         ASICTimingScenarioSchema().add_sdcfileset("test", 1.0)
 
 
@@ -209,17 +209,17 @@ def test_timing_constraint_get_scenarios_empty():
 
 
 def test_timing_constraint_get_scenarios_missing():
-    with pytest.raises(LookupError, match="notfound is not defined"):
+    with pytest.raises(LookupError, match="^notfound is not defined$"):
         ASICTimingConstraintSchema().get_scenario("notfound")
 
 
 def test_timing_constraint_add_scenario_invalid_type():
-    with pytest.raises(TypeError, match="scenario must be a timing scenario object"):
+    with pytest.raises(TypeError, match="^scenario must be a timing scenario object$"):
         ASICTimingConstraintSchema().add_scenario(ASICTimingConstraintSchema())
 
 
 def test_timing_constraint_add_scenario_unnamed():
-    with pytest.raises(ValueError, match="scenario must have a name"):
+    with pytest.raises(ValueError, match="^scenario must have a name$"):
         ASICTimingConstraintSchema().add_scenario(ASICTimingScenarioSchema())
 
 
@@ -247,7 +247,7 @@ def test_timing_constraint_get_scenario():
 
 
 def test_timing_constraint_make_scenario_illegal():
-    with pytest.raises(ValueError, match="scenario name is required"):
+    with pytest.raises(ValueError, match="^scenario name is required$"):
         ASICTimingConstraintSchema().make_scenario(None)
 
 
@@ -255,7 +255,7 @@ def test_timing_constraint_make_scenario_exists():
     schema = ASICTimingConstraintSchema()
 
     schema.add_scenario(ASICTimingScenarioSchema("slow"))
-    with pytest.raises(LookupError, match="slow scenario already exists"):
+    with pytest.raises(LookupError, match="^slow scenario already exists$"):
         schema.make_scenario("slow")
 
 
@@ -269,7 +269,7 @@ def test_timing_constraint_make_scenario():
 
 
 def test_timing_constraint_remove_scenario_illegal():
-    with pytest.raises(ValueError, match="scenario name is required"):
+    with pytest.raises(ValueError, match="^scenario name is required$"):
         ASICTimingConstraintSchema().remove_scenario(None)
 
 

--- a/tests/package/test_github.py
+++ b/tests/package/test_github.py
@@ -8,8 +8,8 @@ from siliconcompiler import Project
 
 def test_init_incorrect():
     with pytest.raises(ValueError,
-                       match="'github://this' is not in the proper form: github://"
-                             "<owner>/<repository>/<version>/<artifact>"):
+                       match="^'github://this' is not in the proper form: github://"
+                             "<owner>/<repository>/<version>/<artifact>$"):
         GithubResolver("github", Project(), "github://this", "main")
 
 

--- a/tests/package/test_https.py
+++ b/tests/package/test_https.py
@@ -58,5 +58,7 @@ def test_dependency_path_download_http_failed():
         "main"
     )
 
-    with pytest.raises(FileNotFoundError, match="Failed to download sc-data data source."):
+    with pytest.raises(FileNotFoundError,
+                       match=r"^Failed to download sc-data data source from "
+                             r"https://.*\.tar\.gz\. Status code: 400$"):
         resolver.resolve()

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -82,12 +82,13 @@ def test_init_with_env_project():
 
 def test_resolve():
     resolver = Resolver("testpath", Project("testproj"), "source://this")
-    with pytest.raises(NotImplementedError, match="child class must implement this"):
+    with pytest.raises(NotImplementedError, match="^child class must implement this$"):
         resolver.resolve()
 
 
 def test_find_resolver_not_found():
-    with pytest.raises(ValueError, match="Source URI 'nosupport://help.me/file' is not supported"):
+    with pytest.raises(ValueError,
+                       match="^Source URI 'nosupport://help.me/file' is not supported$"):
         Resolver.find_resolver("nosupport://help.me/file")
 
 
@@ -283,7 +284,7 @@ def test_get_path_not_found():
     proj = Project("testproj")
 
     resolver = AlwaysOld("alwaysmissing", proj, "notused", "notused")
-    with pytest.raises(FileNotFoundError, match="Unable to locate 'alwaysmissing' at .*path"):
+    with pytest.raises(FileNotFoundError, match="^Unable to locate 'alwaysmissing' at .*path$"):
         resolver.get_path()
 
 
@@ -300,17 +301,17 @@ def test_remote_init():
 
 def test_remote_init_no_ref():
     with pytest.raises(ValueError,
-                       match=r"A reference \(e.g., version, commit\) is required for thisname"):
+                       match=r"^A reference \(e.g., version, commit\) is required for thisname$"):
         RemoteResolver("thisname", Project("testproj"), "https://filepath")
 
 
 def test_remote_child_impl():
     resolver = RemoteResolver("thisname", Project("testproj"), "https://filepath", "ref")
 
-    with pytest.raises(NotImplementedError, match="child class must implement this"):
+    with pytest.raises(NotImplementedError, match="^child class must implement this$"):
         resolver.resolve_remote()
 
-    with pytest.raises(NotImplementedError, match="child class must implement this"):
+    with pytest.raises(NotImplementedError, match="^child class must implement this$"):
         resolver.check_cache()
 
 
@@ -499,8 +500,8 @@ def test_remote_lock_within_lock_thread():
         assert os.path.exists(resolver0.lock_file)
         assert not os.path.exists(resolver0.sc_lock_file)
 
-        with pytest.raises(RuntimeError, match="Failed to access .*. "
-                                               "Another thread is currently holding the lock."):
+        with pytest.raises(RuntimeError, match=r"^Failed to access .*\. "
+                                               r"Another thread is currently holding the lock.$"):
             with resolver1.lock():
                 assert False, "should not get here"
 
@@ -578,8 +579,8 @@ def test_remote_lock_within_lock_file(monkeypatch):
         def dummy_lock(*args, **kwargs):
             return False
         monkeypatch.setattr(dut_ipl, "acquire", dummy_lock)
-        with pytest.raises(RuntimeError, match="Failed to access .*. .* is still locked. "
-                           "If this is a mistake, please delete the lock file."):
+        with pytest.raises(RuntimeError, match=r"^Failed to access .*\. .*\.lock is still locked. "
+                           r"If this is a mistake, please delete the lock file\.$"):
             with resolver1.lock():
                 pass
 
@@ -620,8 +621,8 @@ def test_remote_lock_failed():
     with patch("fasteners.InterProcessLock.acquire") as acquire:
         acquire.return_value = False
         with pytest.raises(RuntimeError,
-                           match="Failed to access .*.lock is still locked. "
-                           "If this is a mistake, please delete the lock file."):
+                           match=r"^Failed to access .*\. .*\.lock is still locked\. "
+                           r"If this is a mistake, please delete the lock file\.$"):
             with resolver.lock():
                 assert False, "Should not gain lock"
             acquire.assert_called_once()
@@ -665,7 +666,7 @@ def test_remote_lock_revert_to_file_failed():
         resolver.sc_lock_file.touch()
 
         with pytest.raises(RuntimeError,
-                           match="Failed to access .*. Lock .* still exists"):
+                           match=r"^Failed to access .*\. Lock .* still exists\.$"):
             with resolver.lock():
                 pass
 
@@ -714,7 +715,7 @@ def test_keypath_resolver():
 def test_keypath_resolver_no_root():
     resolver = KeyPathResolver("thisname", None, "key://option,dir,testdir")
     with pytest.raises(RuntimeError,
-                       match="A root schema has not been defined for 'thisname'"):
+                       match="^A root schema has not been defined for 'thisname'$"):
         resolver.resolve()
 
 

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -501,7 +501,7 @@ def test_remote_lock_within_lock_thread():
         assert not os.path.exists(resolver0.sc_lock_file)
 
         with pytest.raises(RuntimeError, match=r"^Failed to access .*\. "
-                                               r"Another thread is currently holding the lock.$"):
+                                               r"Another thread is currently holding the lock\.$"):
             with resolver1.lock():
                 assert False, "should not get here"
 

--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -66,7 +66,7 @@ def test_server_not_authenticated(gcd_nop_project, scserver, scserver_users,
     gcd_nop_project.set('option', 'credentials', tmp_creds)
 
     # Run remote build. It should fail, so catch the expected exception.
-    with pytest.raises(RuntimeError, match="Server responded with 403: Authentication error."):
+    with pytest.raises(RuntimeError, match="^Server responded with 403: Authentication error.$"):
         gcd_nop_project.run()
 
 

--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -66,7 +66,8 @@ def test_server_not_authenticated(gcd_nop_project, scserver, scserver_users,
     gcd_nop_project.set('option', 'credentials', tmp_creds)
 
     # Run remote build. It should fail, so catch the expected exception.
-    with pytest.raises(RuntimeError, match="^Server responded with 403: Authentication error.$"):
+    with pytest.raises(RuntimeError,
+                       match=r"^Server responded with 403: Authentication error\.$"):
         gcd_nop_project.run()
 
 

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -67,20 +67,20 @@ def basic_project_no_flow():
 
 
 def test_init_no_flow():
-    with pytest.raises(ValueError, match="flow must be specified"):
+    with pytest.raises(ValueError, match="^flow must be specified$"):
         Scheduler(Project(Design("testdesign")))
 
 
 def test_init_flow_not_defined(basic_project):
     basic_project.set("option", "flow", "testflow")
-    with pytest.raises(ValueError, match="flow is not defined"):
+    with pytest.raises(ValueError, match="^flow is not defined$"):
         Scheduler(basic_project)
 
 
 def test_init_flow_not_valid(basic_project):
     with patch("siliconcompiler.flowgraph.Flowgraph.validate") as call:
         call.return_value = False
-        with pytest.raises(ValueError, match="test flowgraph contains errors and cannot be run."):
+        with pytest.raises(ValueError, match="^test flowgraph contains errors and cannot be run.$"):
             Scheduler(basic_project)
 
 
@@ -89,7 +89,7 @@ def test_init_flow_runtime_not_valid(basic_project):
          patch("siliconcompiler.flowgraph.RuntimeFlowgraph.validate") as call1:
         call0.return_value = True
         call1.return_value = False
-        with pytest.raises(ValueError, match="test flowgraph contains errors and cannot be run."):
+        with pytest.raises(ValueError, match="^test flowgraph contains errors and cannot be run.$"):
             Scheduler(basic_project)
 
 
@@ -339,7 +339,7 @@ def test_check_manifest_fail(basic_project):
     with patch("siliconcompiler.scheduler.Scheduler.check_manifest",
                autospec=True) as call:
         call.return_value = False
-        with pytest.raises(RuntimeError, match='check_manifest\\(\\) failed'):
+        with pytest.raises(RuntimeError, match='^check_manifest\\(\\) failed$'):
             scheduler.run()
         call.assert_called_once()
 

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -80,7 +80,8 @@ def test_init_flow_not_defined(basic_project):
 def test_init_flow_not_valid(basic_project):
     with patch("siliconcompiler.flowgraph.Flowgraph.validate") as call:
         call.return_value = False
-        with pytest.raises(ValueError, match="^test flowgraph contains errors and cannot be run.$"):
+        with pytest.raises(ValueError,
+                           match=r"^test flowgraph contains errors and cannot be run\.$"):
             Scheduler(basic_project)
 
 
@@ -89,7 +90,8 @@ def test_init_flow_runtime_not_valid(basic_project):
          patch("siliconcompiler.flowgraph.RuntimeFlowgraph.validate") as call1:
         call0.return_value = True
         call1.return_value = False
-        with pytest.raises(ValueError, match="^test flowgraph contains errors and cannot be run.$"):
+        with pytest.raises(ValueError,
+                           match=r"^test flowgraph contains errors and cannot be run\.$"):
             Scheduler(basic_project)
 
 

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -61,27 +61,27 @@ def echo_project():
 
 
 def test_init_invalid_step(project):
-    with pytest.raises(TypeError, match="step must be a string with a value"):
+    with pytest.raises(TypeError, match="^step must be a string with a value$"):
         SchedulerNode(project, None, "0")
 
 
 def test_init_invalid_step_empty(project):
-    with pytest.raises(TypeError, match="step must be a string with a value"):
+    with pytest.raises(TypeError, match="^step must be a string with a value$"):
         SchedulerNode(project, "", "0")
 
 
 def test_init_invalid_index(project):
-    with pytest.raises(TypeError, match="index must be a string with a value"):
+    with pytest.raises(TypeError, match="^index must be a string with a value$"):
         SchedulerNode(project, "step", None)
 
 
 def test_init_invalid_index_int(project):
-    with pytest.raises(TypeError, match="index must be a string with a value"):
+    with pytest.raises(TypeError, match="^index must be a string with a value$"):
         SchedulerNode(project, "step", 0)
 
 
 def test_init_invalid_index_empty(project):
-    with pytest.raises(TypeError, match="index must be a string with a value"):
+    with pytest.raises(TypeError, match="^index must be a string with a value$"):
         SchedulerNode(project, "step", "")
 
 
@@ -212,7 +212,7 @@ def test_get_log(project, type, expect_name):
 
 def test_get_log_invalid(project):
     node = SchedulerNode(project, "steptwo", "0")
-    with pytest.raises(ValueError, match="invalid is not a log"):
+    with pytest.raises(ValueError, match="^invalid is not a log$"):
         node.get_log("invalid")
 
 
@@ -254,7 +254,7 @@ def test_setup_error(project, monkeypatch, caplog):
     monkeypatch.setattr(node.task, "setup", dummy_setup)
 
     with node.runtime():
-        with pytest.raises(ValueError, match="Find this"):
+        with pytest.raises(ValueError, match="^Find this$"):
             node.setup()
     assert "Failed to run setup() for steptwo/0 with builtin/nop" in caplog.text
 
@@ -269,8 +269,8 @@ def test_setup_with_return(project, monkeypatch, caplog):
 
     with node.runtime():
         with pytest.raises(RuntimeError,
-                           match=r"setup\(\) returned a value, but should not have: "
-                           "This should not be there"):
+                           match=r"^setup\(\) returned a value, but should not have: "
+                           "This should not be there$"):
             node.setup()
     assert "Failed to run setup() for steptwo/0 with builtin/nop" in caplog.text
 
@@ -324,7 +324,7 @@ def test_get_check_changed_keys_with_invalid_require(project):
 
     node = SchedulerNode(project, "steptwo", "0")
     with node.runtime():
-        with pytest.raises(KeyError, match="\\[this,key\\] not found"):
+        with pytest.raises(KeyError, match="^'\\[this,key\\] not found'$"):
             node.get_check_changed_keys()
 
 
@@ -1665,7 +1665,7 @@ def test_check_previous_run_status_flow_different_name_vs_original(project):
 
     # Comparing nodes with different flow names should raise SchedulerFlowReset
     with node.runtime(), node_new.runtime():
-        with pytest.raises(SchedulerFlowReset, match="Flow name changed, require full reset"):
+        with pytest.raises(SchedulerFlowReset, match="^Flow name changed, require full reset$"):
             node.check_previous_run_status(node_new)
 
 

--- a/tests/scheduler/test_taskscheduler.py
+++ b/tests/scheduler/test_taskscheduler.py
@@ -83,7 +83,7 @@ def test_get_nodes_with_complete(large_flow, make_tasks):
 
 
 def test_register_callback_invalid():
-    with pytest.raises(ValueError, match="pre_run0 is not a valid callback"):
+    with pytest.raises(ValueError, match="^pre_run0 is not a valid callback$"):
         TaskScheduler.register_callback("pre_run0", lambda: None)
 
 
@@ -187,5 +187,5 @@ def test_check(large_flow, make_tasks):
 def test_check_invalid(large_flow, make_tasks):
     scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
 
-    with pytest.raises(RuntimeError, match="These final steps could not be reached: jointhree"):
+    with pytest.raises(RuntimeError, match="^These final steps could not be reached: jointhree$"):
         scheduler.check()

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -96,7 +96,7 @@ def test_get_invalid_key():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0,test2\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test2\] is not a valid keypath'$"):
         schema.get("test0", "test2")
 
 
@@ -105,7 +105,7 @@ def test_get_invalid_key_depth():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0,test1,test2\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test1,test2\] is not a valid keypath'$"):
         schema.get("test0", "test1", "test2")
 
 
@@ -114,7 +114,7 @@ def test_get_invalid_key_from_child():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0,test2\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test2\] is not a valid keypath'$"):
         schema.get("test0", field="schema").get("test2")
 
 
@@ -160,7 +160,7 @@ def test_set_invalid_key():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0,test2\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test2\] is not a valid keypath'$"):
         schema.set("test0", "test2", "hello")
 
 
@@ -169,7 +169,7 @@ def test_set_invalid_key_from_child():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0,test2\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test2\] is not a valid keypath'$"):
         schema.get("test0", field="schema").set("test2", "hello")
 
 
@@ -178,7 +178,7 @@ def test_add_invalid_key():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0,test2\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test2\] is not a valid keypath'$"):
         schema.add("test0", "test2", "hello")
 
 
@@ -187,7 +187,7 @@ def test_add_invalid_key_from_child():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0,test2\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test2\] is not a valid keypath'$"):
         schema.get("test0", field="schema").add("test2", "hello")
 
 
@@ -196,7 +196,7 @@ def test_set_partial_key():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0\] is not a valid keypath'$"):
         schema.set("test0", "hello")
 
 
@@ -205,7 +205,7 @@ def test_set_partial_key_from_child():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", "test2", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0,test1\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test1\] is not a valid keypath'$"):
         schema.get("test0", field="schema").set("test1", "hello")
 
 
@@ -214,7 +214,7 @@ def test_get_empty_key():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[\] is not a valid keypath'$"):
         schema.get()
 
 
@@ -231,7 +231,7 @@ def test_set_empty_key_no_value():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"keypath and value is required"):
+    with pytest.raises(KeyError, match=r"^'keypath and value is required'$"):
         schema.set()
 
 
@@ -240,7 +240,7 @@ def test_set_empty_key_with_value():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"keypath and value is required"):
+    with pytest.raises(KeyError, match=r"^'keypath and value is required'$"):
         schema.set("hello")
 
 
@@ -249,7 +249,7 @@ def test_add_empty_key_no_value():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"keypath and value is required"):
+    with pytest.raises(KeyError, match=r"^'keypath and value is required'$"):
         schema.add()
 
 
@@ -258,7 +258,7 @@ def test_add_empty_key_with_value():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"keypath and value is required"):
+    with pytest.raises(KeyError, match=r"^'keypath and value is required'$"):
         schema.add("hello")
 
 
@@ -267,7 +267,7 @@ def test_add_partial_key():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0\] is not a valid keypath'$"):
         schema.add("test0", "hello")
 
 
@@ -276,7 +276,7 @@ def test_add_partial_key_form_child():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", "test2", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0,test1\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test1\] is not a valid keypath'$"):
         schema.get("test0", field="schema").add("test1", "hello")
 
 
@@ -285,7 +285,7 @@ def test_unset_invalid_key():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0,test3\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test3\] is not a valid keypath'$"):
         schema.unset("test0", "test3")
 
 
@@ -294,7 +294,7 @@ def test_unset_invalid_key_from_child():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", "test2", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0,test3\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test3\] is not a valid keypath'$"):
         schema.get("test0", field="schema").unset("test3")
 
 
@@ -344,7 +344,7 @@ def test_remove_invalid_key():
     edit = EditableSchema(schema)
     edit.insert("test0", "default", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test1,test1\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test1,test1\] is not a valid keypath'$"):
         schema.remove("test1", "test1")
 
 
@@ -353,7 +353,7 @@ def test_remove_invalid_key_from_child():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", "default", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test0,test0,test1\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test0,test1\] is not a valid keypath'$"):
         schema.get("test0", field="schema").remove("test0", "test1")
 
 
@@ -416,7 +416,7 @@ def test_insert_locked_default():
 
     assert schema.set("test0", "test1", "test2", "hello")
     assert schema.set("test0", "test1", "default", True, field="lock")
-    with pytest.raises(KeyError, match=r"\[test0,test1,test3\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test1,test3\] is not a valid keypath'$"):
         assert schema.set("test0", "test1", "test3", "hello")
     assert schema.set("test0", "test1", "default", False, field="lock")
     assert schema.set("test0", "test1", "test3", "hello")
@@ -779,15 +779,15 @@ def test_getkeys_unmatched():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test1\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test1\] is not a valid keypath'$"):
         schema.getkeys("test1")
-    with pytest.raises(KeyError, match=r"\[test0,test0\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test0,test0\] is not a valid keypath'$"):
         schema.getkeys("test0", "test0")
     assert schema.getkeys("test0", "test1") == tuple()
 
 
 def test_from_manifest_no_args():
-    with pytest.raises(RuntimeError, match="filepath or dictionary is required"):
+    with pytest.raises(RuntimeError, match="^filepath or dictionary is required$"):
         BaseSchema.from_manifest()
 
 
@@ -844,7 +844,7 @@ def test_write_manifest_gz_no_gzip(monkeypatch):
     edit.insert("test0", "test1", Parameter("str"))
 
     assert not os.path.isfile("test.json.gz")
-    with pytest.raises(RuntimeError, match="gzip is not available"):
+    with pytest.raises(RuntimeError, match="^gzip is not available$"):
         schema.write_manifest("test.json.gz")
     assert not os.path.isfile("test.json.gz")
 
@@ -1100,7 +1100,7 @@ def test_getschema_invalid():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(KeyError, match=r"\[test\] is not a valid keypath"):
+    with pytest.raises(KeyError, match=r"^'\[test\] is not a valid keypath'$"):
         schema.get("test", field='schema')
 
 
@@ -1109,11 +1109,11 @@ def test_getschema_parameter():
     edit = EditableSchema(schema)
     edit.insert("test0", "test1", Parameter("str"))
 
-    with pytest.raises(ValueError, match=r"\[test0,test1\] is a complete keypath"):
+    with pytest.raises(ValueError, match=r"^\[test0,test1\] is a complete keypath$"):
         schema.get("test0", "test1", field='schema')
 
 
-@pytest.mark.parametrize("error", (ValueError, RuntimeError, KeyError))
+@pytest.mark.parametrize("error", (ValueError, RuntimeError))
 def test_forward_exception_with_key_get(error, monkeypatch):
     schema = BaseSchema()
     edit = EditableSchema(schema)
@@ -1125,12 +1125,12 @@ def test_forward_exception_with_key_get(error, monkeypatch):
     monkeypatch.setattr(param, 'get', dummy_get)
 
     with pytest.raises(error,
-                       match=r"error while accessing \[test0,test1\]: "
-                             r"this is an error from the param"):
+                       match=r"^error while accessing \[test0,test1\]: "
+                             r"this is an error from the param$"):
         schema.get("test0", "test1")
 
 
-@pytest.mark.parametrize("error", (ValueError, RuntimeError, KeyError))
+@pytest.mark.parametrize("error", (ValueError, RuntimeError))
 def test_forward_exception_with_key_set(error, monkeypatch):
     schema = BaseSchema()
     edit = EditableSchema(schema)
@@ -1142,12 +1142,12 @@ def test_forward_exception_with_key_set(error, monkeypatch):
     monkeypatch.setattr(param, 'set', dummy_set)
 
     with pytest.raises(error,
-                       match=r"error while setting \[test0,test1\]: "
-                             r"this is an error from the param"):
+                       match=r"^error while setting \[test0,test1\]: "
+                             r"this is an error from the param$"):
         schema.set("test0", "test1", "value")
 
 
-@pytest.mark.parametrize("error", (ValueError, RuntimeError, KeyError))
+@pytest.mark.parametrize("error", (ValueError, RuntimeError))
 def test_forward_exception_with_key_add(error, monkeypatch):
     schema = BaseSchema()
     edit = EditableSchema(schema)
@@ -1159,12 +1159,12 @@ def test_forward_exception_with_key_add(error, monkeypatch):
     monkeypatch.setattr(param, 'add', dummy_add)
 
     with pytest.raises(error,
-                       match=r"error while adding to \[test0,test1\]: "
-                             r"this is an error from the param"):
+                       match=r"^error while adding to \[test0,test1\]: "
+                             r"this is an error from the param$"):
         schema.add("test0", "test1", "value")
 
 
-@pytest.mark.parametrize("error", (ValueError, RuntimeError, KeyError))
+@pytest.mark.parametrize("error", (ValueError, RuntimeError))
 def test_forward_exception_with_key_unset(error, monkeypatch):
     schema = BaseSchema()
     edit = EditableSchema(schema)
@@ -1176,8 +1176,8 @@ def test_forward_exception_with_key_unset(error, monkeypatch):
     monkeypatch.setattr(param, 'unset', dummy_unset)
 
     with pytest.raises(error,
-                       match=r"error while unsetting \[test0,test1\]: "
-                             r"this is an error from the param"):
+                       match=r"^error while unsetting \[test0,test1\]: "
+                             r"this is an error from the param$"):
         schema.unset("test0", "test1")
 
 
@@ -1187,7 +1187,7 @@ def test_find_files_non_path():
     param = Parameter("str")
     edit.insert("var", param)
 
-    with pytest.raises(TypeError, match=r"Cannot find files on \[var\], must be a path type"):
+    with pytest.raises(TypeError, match=r"^Cannot find files on \[var\], must be a path type$"):
         schema.find_files("var")
 
 
@@ -1226,7 +1226,7 @@ def test_find_files_scalar_file_not_found():
 
     assert schema.set("file", "test.txt")
 
-    with pytest.raises(FileNotFoundError, match=r"Could not find \"test.txt\" \[file\]: .*"):
+    with pytest.raises(FileNotFoundError, match=r"^Could not find \"test.txt\" \[file\]: .*$"):
         schema.find_files("file")
 
 
@@ -1245,7 +1245,7 @@ def test_find_files_scalar_file_not_found_multiple_search():
 
     with pytest.raises(
             FileNotFoundError,
-            match=r"Could not find \"test.txt\" \[file\]: .*, .*, .*"):
+            match=r"^Could not find \"test.txt\" \[file\]: .*, .*, .*$"):
         schema.find_files("file")
 
 
@@ -1257,7 +1257,7 @@ def test_find_files_scalar_dir_not_found():
 
     assert schema.set("directory", "test")
 
-    with pytest.raises(FileNotFoundError, match=r"Could not find \"test\" \[directory\]: .*"):
+    with pytest.raises(FileNotFoundError, match=r"^Could not find \"test\" \[directory\]: .*$"):
         schema.find_files("directory")
 
 
@@ -1331,7 +1331,7 @@ def test_find_files_list_file_not_found():
 
     assert schema.set("file", ["test0.txt", "test1.txt"])
 
-    with pytest.raises(FileNotFoundError, match=r"Could not find \"test1.txt\" \[file\]: .*"):
+    with pytest.raises(FileNotFoundError, match=r"^Could not find \"test1.txt\" \[file\]: .*$"):
         schema.find_files("file")
 
 
@@ -1345,7 +1345,7 @@ def test_find_files_list_dir_not_found():
 
     assert schema.set("directory", ["test0", "test1"])
 
-    with pytest.raises(FileNotFoundError, match=r"Could not find \"test1\" \[directory\]: .*"):
+    with pytest.raises(FileNotFoundError, match=r"^Could not find \"test1\" \[directory\]: .*$"):
         schema.find_files("directory")
 
 
@@ -1466,7 +1466,8 @@ def test_find_files_with_package_not_found():
     }
 
     with pytest.raises(FileNotFoundError,
-                       match=r"Could not find \"test1.txt\" in this_package \[package,file\]: .*"):
+                       match=r"^Could not find \"test1.txt\" in this_package "
+                             r"\[package,file\]: .*$"):
         schema.find_files("package", "file", dataroots=package_map)
 
     assert resolve0.called == 2
@@ -1486,7 +1487,8 @@ def test_find_files_with_package_missing():
     assert schema.set("package", "file", ["test0.txt", "test1.txt"])
     assert schema.set("package", "file", ["this_package", "this_package"], field="dataroot")
 
-    with pytest.raises(ValueError, match=r"Resolver for this_package not provided"):
+    with pytest.raises(ValueError, match=r"^Resolver for this_package not "
+                                         r"provided: \[package,file\]$"):
         schema.find_files("package", "file", dataroots={})
 
 
@@ -1544,7 +1546,8 @@ def test_find_files_with_package_as_invalid():
         "this_package": 1
     }
 
-    with pytest.raises(TypeError, match="Resolver for this_package is not a recognized type"):
+    with pytest.raises(TypeError, match=r"^Resolver for this_package is not a recognized "
+                                        r"type: \[package,file\]$"):
         schema.find_files("package", "file", dataroots=package_map)
 
 
@@ -2877,7 +2880,7 @@ def test___load_schema_class_forward_import_fails(error):
         import_module.side_effect = raises
 
         BaseSchema._BaseSchema__load_schema_class.cache_clear()
-        with pytest.raises(error, match="match this"):
+        with pytest.raises(error, match="^match this$"):
             BaseSchema._BaseSchema__load_schema_class("test/Class")
         import_module.assert_called_once()
 
@@ -2903,7 +2906,7 @@ def test___load_schema_class_class_invalid_class_type():
         import_module.return_value = Test
 
         BaseSchema._BaseSchema__load_schema_class.cache_clear()
-        with pytest.raises(TypeError, match="Class must be a BaseSchema type"):
+        with pytest.raises(TypeError, match="^Class must be a BaseSchema type$"):
             BaseSchema._BaseSchema__load_schema_class("test/Class")
         import_module.assert_called_once_with("test")
 
@@ -2950,7 +2953,7 @@ def test_hash_files_non_path():
     param = Parameter("str")
     edit.insert("var", param)
 
-    with pytest.raises(TypeError, match=r"Cannot find files on \[var\], must be a path type"):
+    with pytest.raises(TypeError, match=r"^Cannot find files on \[var\], must be a path type$"):
         schema.hash_files("var")
 
 
@@ -2992,7 +2995,7 @@ def test_hash_files_scalar_file_not_found():
 
     assert schema.set("file", "test.txt")
 
-    with pytest.raises(FileNotFoundError, match=r"Could not find \"test.txt\" \[file\]: .*"):
+    with pytest.raises(FileNotFoundError, match=r"^Could not find \"test.txt\" \[file\]: .*$"):
         schema.hash_files("file")
 
 
@@ -3004,7 +3007,7 @@ def test_hash_files_scalar_dir_not_found():
 
     assert schema.set("directory", "test")
 
-    with pytest.raises(FileNotFoundError, match=r"Could not find \"test\" \[directory\]: .*"):
+    with pytest.raises(FileNotFoundError, match=r"^Could not find \"test\" \[directory\]: .*$"):
         schema.hash_files("directory")
 
 
@@ -3080,7 +3083,7 @@ def test_hash_files_list_file_not_found():
 
     assert schema.set("file", ["test0.txt", "test1.txt"])
 
-    with pytest.raises(FileNotFoundError, match=r"Could not find \"test1.txt\" \[file\]: .*"):
+    with pytest.raises(FileNotFoundError, match=r"^Could not find \"test1.txt\" \[file\]: .*$"):
         schema.hash_files("file")
 
 
@@ -3094,7 +3097,7 @@ def test_hash_files_list_dir_not_found():
 
     assert schema.set("directory", ["test0", "test1"])
 
-    with pytest.raises(FileNotFoundError, match=r"Could not find \"test1\" \[directory\]: .*"):
+    with pytest.raises(FileNotFoundError, match=r"^Could not find \"test1\" \[directory\]: .*$"):
         schema.hash_files("directory")
 
 
@@ -3219,7 +3222,7 @@ def test_hash_files_with_package_not_found():
 
     with pytest.raises(
             FileNotFoundError,
-            match=r"Could not find \"test1.txt\" in this_package \[package,file\]: .*"):
+            match=r"^Could not find \"test1.txt\" in this_package \[package,file\]: .*$"):
         schema.hash_files("package", "file", dataroots=package_map)
 
     assert resolve0.called == 2
@@ -3239,7 +3242,8 @@ def test_hash_files_with_package_missing():
     assert schema.set("package", "file", ["test0.txt", "test1.txt"])
     assert schema.set("package", "file", ["this_package", "this_package"], field="dataroot")
 
-    with pytest.raises(ValueError, match=r"Resolver for this_package not provided"):
+    with pytest.raises(ValueError, match=r"^Resolver for this_package not provided: "
+                                         r"\[package,file\]$"):
         schema.hash_files("package", "file", dataroots={})
 
 
@@ -3297,7 +3301,9 @@ def test_hash_files_with_package_as_invalid():
         "this_package": 1
     }
 
-    with pytest.raises(TypeError, match="Resolver for this_package is not a recognized type"):
+    with pytest.raises(TypeError,
+                       match=r"^Resolver for this_package is not a recognized "
+                             r"type: \[package,file\]$"):
         schema.hash_files("package", "file", dataroots=package_map)
 
 

--- a/tests/schema/test_editableschema.py
+++ b/tests/schema/test_editableschema.py
@@ -26,7 +26,7 @@ def test_insert_duplicate():
     edit = EditableSchema(schema)
     edit.insert("test", BaseSchema())
     with pytest.raises(KeyError,
-                       match=r"\[test\] is already defined"):
+                       match=r"^'\[test\] is already defined'$"):
         edit.insert("test", BaseSchema())
 
 
@@ -88,7 +88,8 @@ def test_insert_illegal_type():
 
     edit = EditableSchema(schema)
     with pytest.raises(ValueError,
-                       match=r"Value \(<class 'str'>\) must be schema type: Parameter, BaseSchema"):
+                       match=r"^Value \(<class 'str'>\) must be schema type: "
+                             r"Parameter, BaseSchema$"):
         edit.insert("test", "123456")
 
 
@@ -181,7 +182,7 @@ def test_remove_unknown():
 
     edit = EditableSchema(schema)
     with pytest.raises(KeyError,
-                       match=r"\[test\] cannot be found"):
+                       match=r"^'\[test\] cannot be found'$"):
         edit.remove("test")
 
 
@@ -192,7 +193,7 @@ def test_insert_no_path():
 
     edit = EditableSchema(schema)
     with pytest.raises(ValueError,
-                       match=r"A keypath is required"):
+                       match=r"^A keypath is required$"):
         edit.insert(BaseSchema())
 
 
@@ -203,7 +204,7 @@ def test_remove_no_path():
 
     edit = EditableSchema(schema)
     with pytest.raises(ValueError,
-                       match=r"A keypath is required"):
+                       match=r"^A keypath is required$"):
         edit.remove()
 
 
@@ -214,7 +215,7 @@ def test_insert_invalid_keypath():
 
     edit = EditableSchema(schema)
     with pytest.raises(ValueError,
-                       match=r"Keypath must only be strings"):
+                       match=r"^Keypath must only be strings$"):
         edit.insert("test", 1, BaseSchema())
 
 
@@ -225,7 +226,7 @@ def test_remove_invalid_keypath():
 
     edit = EditableSchema(schema)
     with pytest.raises(ValueError,
-                       match=r"Keypath must only be strings"):
+                       match=r"^Keypath must only be strings$"):
         edit.remove("test", 1)
 
 
@@ -236,7 +237,7 @@ def test_search_no_path():
 
     edit = EditableSchema(schema)
     with pytest.raises(ValueError,
-                       match=r"A keypath is required"):
+                       match=r"^A keypath is required$"):
         edit.search()
 
 
@@ -247,7 +248,7 @@ def test_search_invalid_keypath():
 
     edit = EditableSchema(schema)
     with pytest.raises(ValueError,
-                       match=r"Keypath must only be strings"):
+                       match=r"^Keypath must only be strings$"):
         edit.search("test", 1)
 
 

--- a/tests/schema/test_journal.py
+++ b/tests/schema/test_journal.py
@@ -79,8 +79,8 @@ def test_access():
 
 
 def test_access_invalid():
-    with pytest.raises(TypeError, match="schema must be a BaseSchema, not "
-                       "<class 'siliconcompiler.schema.parameter.Parameter'>"):
+    with pytest.raises(TypeError, match=r"^schema must be a BaseSchema, not "
+                       r"<class 'siliconcompiler\.schema\.parameter\.Parameter'>$"):
         Journal.access(Parameter("str"))
 
 
@@ -304,8 +304,8 @@ def test_replay_invalid_schema_type():
     assert "remove" in journal.get_types()
     journal.record("remove", ["test0", "test1"])
 
-    with pytest.raises(TypeError, match="schema must be a BaseSchema, not "
-                       "<class 'siliconcompiler.schema.parameter.Parameter'>"):
+    with pytest.raises(TypeError, match="^schema must be a BaseSchema, not "
+                       "<class 'siliconcompiler.schema.parameter.Parameter'>$"):
         journal.replay(Parameter("str"))
 
 
@@ -369,7 +369,7 @@ def test_replay_invalid_type():
         "index": None
     }]
 
-    with pytest.raises(ValueError, match="Unknown record type notanoption"):
+    with pytest.raises(ValueError, match="^Unknown record type notanoption$"):
         journal.replay(BaseSchema())
 
 
@@ -378,7 +378,7 @@ def test_replay_empty():
 
 
 def test_add_invalid_type():
-    with pytest.raises(ValueError, match="invalid is not a valid type"):
+    with pytest.raises(ValueError, match="^invalid is not a valid type$"):
         Journal().add_type("invalid")
 
 
@@ -386,7 +386,7 @@ def test_remove_invalid_type():
     Journal().remove_type("invalid")
 
 
-@pytest.mark.parametrize("error", (ValueError, RuntimeError, KeyError))
+@pytest.mark.parametrize("error", (ValueError, RuntimeError))
 def test_forward_exception_with_key_set_replay(error, monkeypatch):
     schema = BaseSchema()
     edit = EditableSchema(schema)
@@ -410,12 +410,12 @@ def test_forward_exception_with_key_set_replay(error, monkeypatch):
     ]
 
     with pytest.raises(error,
-                       match=r"error while setting \[test0,test1\]: "
-                             r"this is an error from the param"):
+                       match=r"^error while setting \[test0,test1\]: "
+                             r"this is an error from the param$"):
         journal.replay(schema)
 
 
-@pytest.mark.parametrize("error", (ValueError, RuntimeError, KeyError))
+@pytest.mark.parametrize("error", (ValueError, RuntimeError))
 def test_forward_exception_with_key_add_replay(error, monkeypatch):
     schema = BaseSchema()
     edit = EditableSchema(schema)
@@ -439,8 +439,8 @@ def test_forward_exception_with_key_add_replay(error, monkeypatch):
     ]
 
     with pytest.raises(error,
-                       match=r"error while adding to \[test0,test1\]: "
-                             r"this is an error from the param"):
+                       match=r"^error while adding to \[test0,test1\]: "
+                             r"this is an error from the param$"):
         journal.replay(schema)
 
 

--- a/tests/schema/test_namedschema.py
+++ b/tests/schema/test_namedschema.py
@@ -22,24 +22,24 @@ def test_set_name_repeat():
     assert schema.name is None
     schema.set_name("myname")
     assert schema.name == "myname"
-    with pytest.raises(RuntimeError, match="Cannot call set_name more than once."):
+    with pytest.raises(RuntimeError, match="^Cannot call set_name more than once.$"):
         schema.set_name("myname")
 
 
 def test_set_name_with_name():
     schema = NamedSchema("myname")
     assert schema.name == "myname"
-    with pytest.raises(RuntimeError, match="Cannot call set_name more than once."):
+    with pytest.raises(RuntimeError, match="^Cannot call set_name more than once.$"):
         schema.set_name("myname")
 
 
 def test_set_name_with_invalid_name():
-    with pytest.raises(ValueError, match=r"Named schema object cannot contains: \."):
+    with pytest.raises(ValueError, match=r"^Named schema object cannot contains: \.$"):
         NamedSchema("myname.this")
 
 
 def test_type():
-    with pytest.raises(NotImplementedError, match="Must be implemented by the child classes."):
+    with pytest.raises(NotImplementedError, match="^Must be implemented by the child classes.$"):
         NamedSchema().type()
 
 
@@ -142,7 +142,7 @@ def test_inserting_name():
 
 
 def test_from_manifest_no_args():
-    with pytest.raises(RuntimeError, match="filepath or dictionary is required"):
+    with pytest.raises(RuntimeError, match="^filepath or dictionary is required$"):
         NamedSchema.from_manifest(name="name")
 
 

--- a/tests/schema/test_namedschema.py
+++ b/tests/schema/test_namedschema.py
@@ -22,14 +22,14 @@ def test_set_name_repeat():
     assert schema.name is None
     schema.set_name("myname")
     assert schema.name == "myname"
-    with pytest.raises(RuntimeError, match="^Cannot call set_name more than once.$"):
+    with pytest.raises(RuntimeError, match=r"^Cannot call set_name more than once\.$"):
         schema.set_name("myname")
 
 
 def test_set_name_with_name():
     schema = NamedSchema("myname")
     assert schema.name == "myname"
-    with pytest.raises(RuntimeError, match="^Cannot call set_name more than once.$"):
+    with pytest.raises(RuntimeError, match=r"^Cannot call set_name more than once\.$"):
         schema.set_name("myname")
 
 
@@ -39,7 +39,8 @@ def test_set_name_with_invalid_name():
 
 
 def test_type():
-    with pytest.raises(NotImplementedError, match="^Must be implemented by the child classes.$"):
+    with pytest.raises(NotImplementedError,
+                       match=r"^Must be implemented by the child classes\.$"):
         NamedSchema().type()
 
 

--- a/tests/schema/test_parameter.py
+++ b/tests/schema/test_parameter.py
@@ -102,7 +102,7 @@ def test_default_init_dir():
 def test_get_invalid_field():
     param = Parameter("str")
 
-    with pytest.raises(ValueError, match='"invalidfield" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"invalidfield\" is not a valid field$"):
         param.get(field='invalidfield')
 
 
@@ -296,7 +296,7 @@ def test_get_fields_enum():
 def test_set_add_illegal():
     param = Parameter("<test0,test1>")
 
-    with pytest.raises(ValueError, match="add can only be used on lists or sets"):
+    with pytest.raises(ValueError, match="^add can only be used on lists or sets$"):
         param.add("test0")
 
 
@@ -322,7 +322,7 @@ def test_add_fields_enum():
     assert param.add("test3", field="example")
     assert param.get(field='example') == ["test3"]
 
-    with pytest.raises(ValueError, match='"invalid" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"invalid\" is not a valid field$"):
         param.add("test3", field="invalid")
 
 
@@ -642,7 +642,7 @@ def test_pernode_mandatory_get():
 def test_pernode_mandatory_set():
     param = Parameter("str", pernode=PerNode.REQUIRED)
 
-    with pytest.raises(KeyError, match="'step and index are required'"):
+    with pytest.raises(KeyError, match="^'step and index are required'$"):
         param.set("foo")
 
     param.set("foo", step="test", index="0")
@@ -652,7 +652,7 @@ def test_pernode_mandatory_set():
 def test_pernode_mandatory_add():
     param = Parameter("[str]", pernode=PerNode.REQUIRED)
 
-    with pytest.raises(KeyError, match="'step and index are required'"):
+    with pytest.raises(KeyError, match="^'step and index are required'$"):
         param.add("foo")
 
     param.add("foo", step="test", index="0")
@@ -1031,33 +1031,33 @@ def test_normalize_fields_scalar(value, field, expect):
 def test_normalize_fields_scalar_errors_file():
     param = Parameter("file")
 
-    with pytest.raises(ValueError, match="invalid is not a member of: global, job, scratch"):
+    with pytest.raises(ValueError, match="^invalid is not a member of: global, job, scratch$"):
         param.set("invalid", field='scope')
 
-    with pytest.raises(ValueError, match="invalid is not a member of: never, optional, required"):
+    with pytest.raises(ValueError, match="^invalid is not a member of: never, optional, required$"):
         param.set("invalid", field='pernode')
 
-    with pytest.raises(ValueError, match='"invalid" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"invalid\" is not a valid field$"):
         param.set("test", field="invalid")
 
 
 def test_normalize_fields_scalar_errors_dir():
     param = Parameter("dir")
 
-    with pytest.raises(ValueError, match='"date" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"date\" is not a valid field$"):
         param.set("test", field="date")
 
-    with pytest.raises(ValueError, match='"author" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"author\" is not a valid field$"):
         param.set("test", field="author")
 
 
 def test_normalize_fields_scalar_errors_int():
     param = Parameter("int")
 
-    with pytest.raises(ValueError, match='"dataroot" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"dataroot\" is not a valid field$"):
         param.set("test", field="dataroot")
 
-    with pytest.raises(ValueError, match='"filehash" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"filehash\" is not a valid field$"):
         param.set("test", field="filehash")
 
 
@@ -1109,50 +1109,50 @@ def test_normalize_fields_list(value, field, expect):
 def test_normalize_fields_list_errors():
     param = Parameter("[file]")
 
-    with pytest.raises(ValueError, match="invalid is not a member of: global, job, scratch"):
+    with pytest.raises(ValueError, match="^invalid is not a member of: global, job, scratch$"):
         param.set("invalid", field='scope')
 
-    with pytest.raises(ValueError, match="invalid is not a member of: never, optional, required"):
+    with pytest.raises(ValueError, match="^invalid is not a member of: never, optional, required$"):
         param.set("invalid", field='pernode')
 
-    with pytest.raises(ValueError, match='"invalid" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"invalid\" is not a valid field$"):
         param.set("test", field="invalid")
 
 
 def test_add_normalize_fields_list_errors_file():
     param = Parameter("[file]")
 
-    with pytest.raises(ValueError, match='"invalid" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"invalid\" is not a valid field$"):
         param.add("test", field="invalid")
 
 
 def test_add_normalize_fields_list_errors_dir():
     param = Parameter("[dir]")
 
-    with pytest.raises(ValueError, match='"date" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"date\" is not a valid field$"):
         param.add("test", field="date")
 
-    with pytest.raises(ValueError, match='"author" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"author\" is not a valid field$"):
         param.add("test", field="author")
 
 
 def test_add_normalize_fields_list_errors_int():
     param = Parameter("[int]")
 
-    with pytest.raises(ValueError, match='"dataroot" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"dataroot\" is not a valid field$"):
         param.add("test", field="dataroot")
 
-    with pytest.raises(ValueError, match='"filehash" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"filehash\" is not a valid field$"):
         param.add("test", field="filehash")
 
-    with pytest.raises(ValueError, match='"hashalgo" is not a valid field'):
+    with pytest.raises(ValueError, match="^\"hashalgo\" is not a valid field$"):
         param.add("test", field="hashalgo")
 
 
 def test_add_on_scalar():
     param = Parameter("int")
 
-    with pytest.raises(ValueError, match="add can only be used on lists"):
+    with pytest.raises(ValueError, match="^add can only be used on lists or sets$"):
         param.add("test")
 
 
@@ -1204,10 +1204,10 @@ def test_unlock():
 def test_step_index_required():
     param = Parameter("int", pernode=PerNode.REQUIRED)
 
-    with pytest.raises(KeyError, match='step and index are required'):
+    with pytest.raises(KeyError, match="^'step and index are required'$"):
         param.get()
 
-    with pytest.raises(KeyError, match='step and index are required'):
+    with pytest.raises(KeyError, match="^'step and index are required'$"):
         param.get(step="type")
 
     assert param.get(step="type", index="0") is None
@@ -1216,10 +1216,10 @@ def test_step_index_required():
 def test_step_index_never():
     param = Parameter("int", pernode=PerNode.NEVER)
 
-    with pytest.raises(KeyError, match='use of step and index are not valid'):
+    with pytest.raises(KeyError, match="^'use of step and index are not valid'$"):
         param.get(step="type", index="0")
 
-    with pytest.raises(KeyError, match='use of step and index are not valid'):
+    with pytest.raises(KeyError, match="^'use of step and index are not valid'$"):
         param.get(step="type")
 
     assert param.get() is None
@@ -1229,16 +1229,16 @@ def test_step_index_optional():
     param = Parameter("int", pernode=PerNode.OPTIONAL)
 
     with pytest.raises(KeyError,
-                       match='step and index are only valid for: value, signature'):
+                       match="^'step and index are only valid for: value, signature'$"):
         param.get(step="type", index="0", field="type")
 
-    with pytest.raises(KeyError, match='step is required if index is provided'):
+    with pytest.raises(KeyError, match="^'step is required if index is provided'$"):
         param.get(index="0")
 
-    with pytest.raises(KeyError, match='illegal step name: default is reserved'):
+    with pytest.raises(KeyError, match="^'illegal step name: default is reserved'$"):
         param.get(step="default", index="0")
 
-    with pytest.raises(KeyError, match='illegal index name: default is reserved'):
+    with pytest.raises(KeyError, match="^'illegal index name: default is reserved'$"):
         param.get(step="test", index="default")
 
 
@@ -1485,7 +1485,7 @@ def test_add_commandline_arguments_none():
 def test_add_commandline_arguments_invalid():
     param = Parameter("str", switch=["-testing:this"])
 
-    with pytest.raises(ValueError, match="unable to process switch information: -testing:this"):
+    with pytest.raises(ValueError, match="^unable to process switch information: -testing:this$"):
         param.add_commandline_arguments(argparse.ArgumentParser(), "test")
 
 
@@ -1616,16 +1616,16 @@ def test_parse_commandline_arguments_pernode_required():
     assert param.parse_commandline_arguments("step index 1", "key", "path") == \
         (("key", "path"), "step", "index", "1")
 
-    with pytest.raises(ValueError, match='Invalid value "step 1" for switch -test <int>: '
-                       'Requires step and index before final value'):
+    with pytest.raises(ValueError, match="^Invalid value \"step 1\" for switch -test <int>: "
+                       'Requires step and index before final value$'):
         param.parse_commandline_arguments("step 1", "key", "path")
 
-    with pytest.raises(ValueError, match='Invalid value "1" for switch -test <int>: '
-                       'Requires step and index before final value'):
+    with pytest.raises(ValueError, match="^Invalid value \"1\" for switch -test <int>: "
+                       'Requires step and index before final value$'):
         param.parse_commandline_arguments("1", "key", "path")
 
-    with pytest.raises(ValueError, match='Invalid value "step index 1 1" for switch -test <int>: '
-                       'Requires step and index before final value'):
+    with pytest.raises(ValueError, match="^Invalid value \"step index 1 1\" for switch -test "
+                       '<int>: Requires step and index before final value$'):
         param.parse_commandline_arguments("step index 1 1", "key", "path")
 
 
@@ -1640,7 +1640,7 @@ def test_add_commandline_arguments_with_quotes():
 def test_add_commandline_arguments_with_quote_mismatch():
     param = Parameter("str", switch=["-test '<str>"], pernode=PerNode.OPTIONAL)
 
-    with pytest.raises(ValueError, match="unable to process switch information: -test '<str>"):
+    with pytest.raises(ValueError, match="^unable to process switch information: -test '<str>$"):
         param.add_commandline_arguments(argparse.ArgumentParser(),
                                         "key", "path", switchlist="-test")
 
@@ -1683,8 +1683,8 @@ def test_parse_commandline_arguments_pernode_optional():
     assert param.parse_commandline_arguments("1", "key", "path") == \
         (("key", "path"), None, None, "1")
 
-    with pytest.raises(ValueError, match='Invalid value "step index 1 1" for switch -test <int>: '
-                       'Too many arguments'):
+    with pytest.raises(ValueError, match="^Invalid value \"step index 1 1\" for switch -test "
+                       '<int>: Too many arguments$'):
         param.parse_commandline_arguments("step index 1 1", "key", "path")
 
 
@@ -1728,11 +1728,12 @@ def test_parse_commandline_arguments_default_keys():
     assert param.parse_commandline_arguments("path \"1\"", "key", "default") == \
         (("key", "path"), None, None, "1")
 
-    with pytest.raises(ValueError, match='Invalid value "step index 1 1" for switch -test <int>'):
+    with pytest.raises(ValueError,
+                       match="^Invalid value \"step index 1 1\" for switch -test <int>$"):
         param.parse_commandline_arguments("step index 1 1", "key", "default")
 
     with pytest.raises(ValueError,
-                       match='Invalid value "test "step index 1"" for switch -test <int>'):
+                       match="^Invalid value \"test \"step index 1\"\" for switch -test <int>$"):
         param.parse_commandline_arguments("test \"step index 1\"", "key", "default", "default")
 
 

--- a/tests/schema/test_parametertype.py
+++ b/tests/schema/test_parametertype.py
@@ -17,7 +17,7 @@ def test_node_enum_type_eq():
 
 
 def test_node_enum_type_empty():
-    with pytest.raises(ValueError, match="enum cannot be empty set"):
+    with pytest.raises(ValueError, match="^enum cannot be empty set$"):
         NodeEnumType()
 
 
@@ -100,7 +100,7 @@ def test_encode(type, expect):
 
 
 def test_encode_invalid():
-    with pytest.raises(ValueError, match="1 not a recognized type"):
+    with pytest.raises(ValueError, match="^1 not a recognized type$"):
         NodeType.encode(1)
 
 
@@ -221,7 +221,7 @@ def test_to_tcl(type, value, expect):
 
 
 def test_to_tcl_unsupported():
-    with pytest.raises(TypeError, match="invalid is not a supported type"):
+    with pytest.raises(TypeError, match="^invalid is not a supported type$"):
         NodeType.to_tcl(12, "invalid")
 
 
@@ -231,10 +231,10 @@ def test_normalize_value_enum():
     assert NodeType.normalize("test1", enum) == "test1"
     assert NodeType.normalize("test2", enum) == "test2"
 
-    with pytest.raises(ValueError, match="test3 is not a member of: test0, test1, test2"):
+    with pytest.raises(ValueError, match="^test3 is not a member of: test0, test1, test2$"):
         NodeType.normalize("test3", enum)
 
-    with pytest.raises(ValueError, match="enum must be a string, not a <class 'int'>"):
+    with pytest.raises(ValueError, match="^enum must be a string, not a <class 'int'>$"):
         NodeType.normalize(1, enum)
 
 
@@ -243,7 +243,7 @@ def test_normalize_value_file():
     assert NodeType.normalize("./test1", "file") == "test1"
     assert NodeType.normalize(Path("./test2"), "file") == "test2"
 
-    with pytest.raises(ValueError, match="file must be a string or Path, not <class 'int'>"):
+    with pytest.raises(ValueError, match="^file must be a string or Path, not <class 'int'>$"):
         NodeType.normalize(1, "file")
 
 
@@ -252,7 +252,7 @@ def test_normalize_value_dir():
     assert NodeType.normalize("./test1", "dir") == "test1"
     assert NodeType.normalize(Path("./test2"), "dir") == "test2"
 
-    with pytest.raises(ValueError, match="dir must be a string or Path, not <class 'int'>"):
+    with pytest.raises(ValueError, match="^dir must be a string or Path, not <class 'int'>$"):
         NodeType.normalize(1, "dir")
 
 
@@ -262,47 +262,47 @@ def test_normalize_value_nodetype():
 
 
 def test_normalize_invalid_type():
-    with pytest.raises(ValueError, match="Invalid type specifier: invalid"):
+    with pytest.raises(ValueError, match="^Invalid type specifier: invalid$"):
         NodeType.normalize('1235', 'invalid')
 
 
 def test_normalize_invalid_int():
-    with pytest.raises(ValueError, match="\"a\" unable to convert to int"):
+    with pytest.raises(ValueError, match="^\"a\" unable to convert to int$"):
         NodeType.normalize('a', 'int')
 
 
 def test_normalize_invalid_list_entry():
-    with pytest.raises(ValueError, match="\"a\" unable to convert to int"):
+    with pytest.raises(ValueError, match="^\"a\" unable to convert to int$"):
         NodeType.normalize(['a'], ['int'])
 
 
 def test_normalize_invalid_float():
-    with pytest.raises(ValueError, match="\"a\" unable to convert to float"):
+    with pytest.raises(ValueError, match="^\"a\" unable to convert to float$"):
         NodeType.normalize('a', 'float')
 
 
 def test_normalize_invalid_bool():
-    with pytest.raises(ValueError, match="\"a\" unable to convert to boolean"):
+    with pytest.raises(ValueError, match="^\"a\" unable to convert to boolean$"):
         NodeType.normalize('a', 'bool')
 
 
 def test_normalize_invalid_tuple():
-    with pytest.raises(ValueError, match=r"\(a\) does not have 2 entries"):
+    with pytest.raises(ValueError, match=r"^\(a\) does not have 2 entries$"):
         NodeType.normalize('(a)', ("int", "str"))
-    with pytest.raises(ValueError, match=r"\(a\) does not have 2 entries"):
+    with pytest.raises(ValueError, match=r"^\(a\) does not have 2 entries$"):
         NodeType.normalize('a', ("int", "str"))
-    with pytest.raises(ValueError, match=r"\(a\) \(<class 'set'>\) cannot be converted to tuple"):
+    with pytest.raises(ValueError, match=r"^\(a\) \(<class 'set'>\) cannot be converted to tuple$"):
         NodeType.normalize(set(['a']), ("int", "str"))
-    with pytest.raises(ValueError, match=r"\(1\) \(<class 'int'>\) cannot be converted to tuple"):
+    with pytest.raises(ValueError, match=r"^\(1\) \(<class 'int'>\) cannot be converted to tuple$"):
         NodeType.normalize(1, ("int", "str"))
 
 
 def test_normalize_invalid_str():
-    with pytest.raises(ValueError, match=r'"<class \'list\'>" unable to convert to str'):
+    with pytest.raises(ValueError, match=r'^"<class \'list\'>" unable to convert to str$'):
         NodeType.normalize(list(['a', 'b']), 'str')
-    with pytest.raises(ValueError, match=r'"<class \'set\'>" unable to convert to str'):
+    with pytest.raises(ValueError, match=r'^"<class \'set\'>" unable to convert to str$'):
         NodeType.normalize(set(['a', 'b']), 'str')
-    with pytest.raises(ValueError, match=r'"<class \'tuple\'>" unable to convert to str'):
+    with pytest.raises(ValueError, match=r'^"<class \'tuple\'>" unable to convert to str$'):
         NodeType.normalize(tuple(['a', 'b']), 'str')
 
 
@@ -322,7 +322,7 @@ def test_str(sctype):
 
 
 def test_str_invalid():
-    with pytest.raises(ValueError, match="<class 'int'> not a recognized type"):
+    with pytest.raises(ValueError, match="^<class 'int'> not a recognized type$"):
         str(NodeType(int))
 
 

--- a/tests/schema/test_parametervalue.py
+++ b/tests/schema/test_parametervalue.py
@@ -64,7 +64,7 @@ def test_sign_no_module(monkeypatch):
 
     value = NodeValue("str")
     value.set("signthis")
-    with pytest.raises(RuntimeError, match="encoding not available"):
+    with pytest.raises(RuntimeError, match="^encoding not available$"):
         value.sign(person="testing", key="123456", salt="0147258")
 
 
@@ -106,7 +106,7 @@ def test_verify_signature_no_module(monkeypatch):
     monkeypatch.setattr(parametervalue, "_has_sign", False)
     assert not parametervalue._has_sign
 
-    with pytest.raises(RuntimeError, match="encoding not available"):
+    with pytest.raises(RuntimeError, match="^encoding not available$"):
         value.verify_signature(person="testing", key="123456")
 
 
@@ -114,7 +114,7 @@ def test_verify_no_signature():
     value = NodeValue("str")
     value.set("signthis")
 
-    with pytest.raises(ValueError, match="no signature available"):
+    with pytest.raises(ValueError, match="^no signature available$"):
         value.verify_signature(person="testing", key="123456")
 
 
@@ -123,7 +123,7 @@ def test_verify_signature_person_mismatch():
     value.set("signthis")
     value.sign(person="testing", key="123456", salt="0147258")
 
-    with pytest.raises(ValueError, match="testing1 does not match signing person: testing"):
+    with pytest.raises(ValueError, match="^testing1 does not match signing person: testing$"):
         value.verify_signature(person="testing1", key="123456")
 
 
@@ -153,10 +153,10 @@ def test_value_get_dict():
 def test_value_get_set_invalid():
     value = NodeValue("str")
 
-    with pytest.raises(ValueError, match="invalid is not a valid field"):
+    with pytest.raises(ValueError, match="^invalid is not a valid field$"):
         value.get(field="invalid")
 
-    with pytest.raises(ValueError, match="invalid is not a valid field"):
+    with pytest.raises(ValueError, match="^invalid is not a valid field$"):
         value.set("test", field="invalid")
 
 
@@ -312,10 +312,10 @@ def test_directory_get_dict():
 def test_directory_get_set_invalid():
     value = DirectoryNodeValue()
 
-    with pytest.raises(ValueError, match="invalid is not a valid field"):
+    with pytest.raises(ValueError, match="^invalid is not a valid field$"):
         value.get(field="invalid")
 
-    with pytest.raises(ValueError, match="invalid is not a valid field"):
+    with pytest.raises(ValueError, match="^invalid is not a valid field$"):
         value.set("test", field="invalid")
 
 
@@ -353,13 +353,13 @@ def test_directory_resolve_path():
 
     value.set("testdir")
 
-    with pytest.raises(FileNotFoundError, match="testdir"):
+    with pytest.raises(FileNotFoundError, match="^testdir$"):
         assert value.resolve_path()
 
     os.makedirs("testdir", exist_ok=True)
     assert value.resolve_path() == os.path.abspath("testdir")
 
-    with pytest.raises(FileNotFoundError, match="testdir"):
+    with pytest.raises(FileNotFoundError, match="^testdir$"):
         assert value.resolve_path(search=[])
 
     assert value.resolve_path(search=["nothere", "notthere", "."]) == \
@@ -397,10 +397,10 @@ def test_file_get_dict():
 def test_file_get_set_invalid():
     value = FileNodeValue()
 
-    with pytest.raises(ValueError, match="invalid is not a valid field"):
+    with pytest.raises(ValueError, match="^invalid is not a valid field$"):
         value.get(field="invalid")
 
-    with pytest.raises(ValueError, match="invalid is not a valid field"):
+    with pytest.raises(ValueError, match="^invalid is not a valid field$"):
         value.set("test", field="invalid")
 
 
@@ -444,14 +444,14 @@ def test_file_resolve_path():
 
     value.set("test.txt")
 
-    with pytest.raises(FileNotFoundError, match="test.txt"):
+    with pytest.raises(FileNotFoundError, match="^test.txt$"):
         assert value.resolve_path()
 
     with open("test.txt", "w") as f:
         f.write("test")
     assert value.resolve_path() == os.path.abspath("test.txt")
 
-    with pytest.raises(FileNotFoundError, match="test.txt"):
+    with pytest.raises(FileNotFoundError, match="^test.txt$"):
         assert value.resolve_path(search=[])
 
     assert value.resolve_path(search=["nothere", "notthere", "."]) == \
@@ -601,7 +601,7 @@ def test_nodelist_set_str_signature():
         'signature': ["test3", "test4"],
         'value': ["test1", "test2"]}
 
-    with pytest.raises(ValueError, match="set on signature field must match number of value"):
+    with pytest.raises(ValueError, match="^set on signature field must match number of values$"):
         param.set(["test3"], field='signature')
 
 
@@ -630,7 +630,7 @@ def test_nodelist_add_str_non_value():
         'signature': [None, None],
         'value': ["test1", "test2"]}
 
-    with pytest.raises(ValueError, match="cannot add to signature field"):
+    with pytest.raises(ValueError, match="^cannot add to signature field$"):
         param.add(["test0", "test4", "test1"], field='signature')
 
 
@@ -669,7 +669,7 @@ def test_file_hash_invalid_algoritm():
     param.set('foo.txt')
 
     with pytest.raises(RuntimeError,
-                       match="Unable to hash file due to missing hash function: md56"):
+                       match="^Unable to hash file due to missing hash function: md56$"):
         param.hash('md56')
 
 
@@ -742,14 +742,14 @@ def test_directory_hash_invalid_algoritm():
     param.set('foo.txt')
 
     with pytest.raises(RuntimeError,
-                       match="Unable to hash directory due to missing hash function: md56"):
+                       match="^Unable to hash directory due to missing hash function: md56$"):
         param.hash('md56')
 
 
 def test_file_add_to_parent_field():
     param = FileNodeValue()
 
-    with pytest.raises(ValueError, match="cannot add to signature field"):
+    with pytest.raises(ValueError, match="^cannot add to signature field$"):
         param.add("notthis", field="signature")
 
 
@@ -826,7 +826,7 @@ def test_directory_resolve_path_collected_empty():
 
     value.set("one/two/three/four/testdir")
 
-    with pytest.raises(FileNotFoundError, match="one/two/three/four/testdir"):
+    with pytest.raises(FileNotFoundError, match="^one/two/three/four/testdir$"):
         value.resolve_path(collection_dir=coll_dir)
 
 
@@ -880,7 +880,7 @@ def test_directory_resolve_path_collected_dir_not_found():
 
     value.set("one/two/three/four/testdir")
 
-    with pytest.raises(FileNotFoundError, match="one/two/three/four/testdir"):
+    with pytest.raises(FileNotFoundError, match="^one/two/three/four/testdir$"):
         value.resolve_path(collection_dir=coll_dir)
 
 
@@ -899,7 +899,7 @@ def test_directory_resolve_path_collected_not_found():
 
     value.set("one/two/three/four/testdir0")
 
-    with pytest.raises(FileNotFoundError, match="one/two/three/four/testdir0"):
+    with pytest.raises(FileNotFoundError, match="^one/two/three/four/testdir0$"):
         value.resolve_path(collection_dir=coll_dir)
 
 
@@ -1249,7 +1249,7 @@ def test_nodeset_set_str_signature():
         'signature': ["test3", "test4"],
         'value': ["test1", "test2"]}
 
-    with pytest.raises(ValueError, match="set on signature field must match number of value"):
+    with pytest.raises(ValueError, match="^set on signature field must match number of values$"):
         param.set(["test3"], field='signature')
 
 
@@ -1279,7 +1279,7 @@ def test_nodeset_add_str_non_value():
         'value': ["test1", "test2"]}
 
     with pytest.raises(ValueError,
-                       match="cannot add to signature field"):
+                       match="^cannot add to signature field$"):
         param.add(["test0", "test4", "test1"], field='signature')
 
 

--- a/tests/schema_support/test_cmdlineschema.py
+++ b/tests/schema_support/test_cmdlineschema.py
@@ -61,7 +61,7 @@ def test_list(schema, monkeypatch):
 
 
 def test_invalid_argument_in_switchlist(schema):
-    with pytest.raises(ValueError, match="-invalid is/are not a valid commandline arguments"):
+    with pytest.raises(ValueError, match="^-invalid is/are not a valid commandline arguments$"):
         schema().create_cmdline("testprog", switchlist=["-invalid"])
 
 
@@ -199,7 +199,7 @@ def test_add_cmdarg_with_no_switch(schema):
 
 def test_add_cmdarg_with_missing_switch(schema):
     schema = schema()
-    with pytest.raises(ValueError, match="switch is required"):
+    with pytest.raises(ValueError, match="^switch is required$"):
         schema._add_commandline_argument("string", "str", "help string", "")
 
 
@@ -220,7 +220,7 @@ def test_wrong_cfg_read_fail(schema, monkeypatch):
             "BaseSchema": BaseSchema,
             "testschema": TestSchema
         }
-        with pytest.raises(TypeError, match="Schema is not a commandline class"):
+        with pytest.raises(TypeError, match="^Schema is not a commandline class$"):
             schema.create_cmdline("testprog", use_cfg=True)
 
 

--- a/tests/schema_support/test_dependencyschema.py
+++ b/tests/schema_support/test_dependencyschema.py
@@ -19,8 +19,8 @@ def test_add_dep_invalid():
     schema = DependencySchema()
 
     with pytest.raises(TypeError,
-                       match="Cannot add an object of type: <class "
-                       "'siliconcompiler.schema.baseschema.BaseSchema'>"):
+                       match=r"^Cannot add an object of type: <class "
+                       r"'siliconcompiler\.schema\.baseschema\.BaseSchema'>$"):
         schema.add_dep(BaseSchema())
 
 
@@ -86,14 +86,14 @@ def test_add_dep_no_clobber():
 def test_add_dep_unnamed():
     schema = DependencySchema()
 
-    with pytest.raises(ValueError, match="Cannot add an unnamed dependency"):
+    with pytest.raises(ValueError, match="^Cannot add an unnamed dependency$"):
         schema.add_dep(NamedSchema())
 
 
 def test_get_dep_not_found():
     schema = DependencySchema()
 
-    with pytest.raises(KeyError, match="notthere is not an imported module"):
+    with pytest.raises(KeyError, match="^'notthere is not an imported module'$"):
         schema.get_dep("notthere")
 
 
@@ -262,7 +262,7 @@ def test_get_dep_hier_with_non_dep():
     assert schema.get_dep("level0-0.level0-1") is dep01
 
     with pytest.raises(KeyError,
-                       match="level0-1.notthis does not contain dependency information"):
+                       match=r"^'level0-1\.notthis does not contain dependency information'$"):
         schema.get_dep("level0-0.level0-1.notthis")
 
 
@@ -313,7 +313,9 @@ def test_write_depgraph_no_graphviz_exe():
             raise graphviz.ExecutableNotFound("args")
         render.side_effect = raise_error
 
-        with pytest.raises(RuntimeError, match="Unable to save flowgraph: failed to execute"):
+        with pytest.raises(RuntimeError,
+                           match="^Unable to save flowgraph: failed to execute 'a', make sure the "
+                                 "Graphviz executables are on your systems' PATH$"):
             schema.write_depgraph("test.png")
         render.assert_called_once()
 
@@ -463,7 +465,7 @@ def test_populate_deps_missing():
     assert schema.add_dep(dep01)
 
     check = Test.from_manifest(name="test", cfg=schema.getdict())
-    with pytest.raises(ValueError, match="level0-0 not available in map"):
+    with pytest.raises(ValueError, match="^level0-0 not available in map$"):
         check._populate_deps({})
 
 

--- a/tests/schema_support/test_filesetschema.py
+++ b/tests/schema_support/test_filesetschema.py
@@ -29,7 +29,7 @@ def test_add_file_single():
 def test_add_file_none():
     d = FileSetSchema()
 
-    with pytest.raises(ValueError, match="add_file cannot process None"):
+    with pytest.raises(ValueError, match="^add_file cannot process None$"):
         d.add_file(None, "rtl")
 
 
@@ -99,7 +99,7 @@ def test_add_file_default_to_ext():
 def test_add_file_invalid_fileset():
     d = FileSetSchema()
 
-    with pytest.raises(ValueError, match="fileset key must be a string"):
+    with pytest.raises(ValueError, match="^fileset key must be a string$"):
         d.add_file('tb.ver', 3)
 
 
@@ -166,18 +166,18 @@ def test_get_file_filetype_vhdl():
 
 
 def test_get_file_one_invalid_fileset():
-    with pytest.raises(ValueError, match="fileset key must be a string"):
+    with pytest.raises(ValueError, match="^fileset key must be a string$"):
         FileSetSchema().get_file(fileset=4)
 
 
 def test_active_fileset_invalid_none():
-    with pytest.raises(TypeError, match="fileset must a string"):
+    with pytest.raises(TypeError, match="^fileset must a string$"):
         with FileSetSchema().active_fileset(None):
             pass
 
 
 def test_active_fileset_invalid_empty():
-    with pytest.raises(ValueError, match="fileset cannot be an empty string"):
+    with pytest.raises(ValueError, match="^fileset cannot be an empty string$"):
         with FileSetSchema().active_fileset(""):
             pass
 
@@ -236,7 +236,7 @@ def test_copy_fileset_fail_overwrite():
     with schema.active_fileset("rtl"):
         assert schema.add_file("top.v")
 
-    with pytest.raises(ValueError, match="rtl already exists"):
+    with pytest.raises(ValueError, match="^rtl already exists$"):
         schema.copy_fileset("rtl", "rtl")
 
 
@@ -373,5 +373,5 @@ def test_has_file_filetype_vhdl():
 
 
 def test_has_file_one_invalid_fileset():
-    with pytest.raises(ValueError, match="fileset key must be a string"):
+    with pytest.raises(ValueError, match="^fileset key must be a string$"):
         FileSetSchema().has_file(fileset=4)

--- a/tests/schema_support/test_metric.py
+++ b/tests/schema_support/test_metric.py
@@ -81,7 +81,7 @@ def test_record_unit_covert():
 def test_record_unit_mismatch():
     schema = MetricSchema()
     with pytest.raises(ValueError,
-                       match="errors does not have a unit, but ms was supplied"):
+                       match="^errors does not have a unit, but ms was supplied$"):
         schema.record("teststep", "testindex", "errors", 5, unit='ms')
 
 

--- a/tests/schema_support/test_pathschema.py
+++ b/tests/schema_support/test_pathschema.py
@@ -86,7 +86,8 @@ def test_find_files_no_source():
     param = test.set("file", "test.txt")
     param.set("testsource", field="dataroot")
 
-    with pytest.raises(ValueError, match="Resolver for testsource not provided"):
+    with pytest.raises(ValueError,
+                       match=r"^Resolver for testsource not provided: \[file\]$"):
         test.find_files("file")
 
 
@@ -206,7 +207,7 @@ def test_get_dataroot():
 
 def test_get_dataroot_not_found():
     schema = PathSchema()
-    with pytest.raises(ValueError, match="testsource is not a recognized source"):
+    with pytest.raises(ValueError, match="^testsource is not a recognized source$"):
         schema.get_dataroot("testsource")
 
 
@@ -345,7 +346,7 @@ def test_active_dataroot_missing():
     schema = PathSchema()
 
     assert schema._get_active(None) is None
-    with pytest.raises(ValueError, match="testpack is not a recognized dataroot"):
+    with pytest.raises(ValueError, match="^testpack is not a recognized dataroot$"):
         with schema.active_dataroot("testpack"):
             pass
     assert schema._get_active(None) is None
@@ -356,7 +357,7 @@ def test_active_dataroot_no_root():
     EditableSchema(schema).remove("dataroot")
 
     assert schema._get_active(None) is None
-    with pytest.raises(ValueError, match="testpack is not a recognized dataroot"):
+    with pytest.raises(ValueError, match="^testpack is not a recognized dataroot$"):
         with schema.active_dataroot("testpack"):
             pass
     assert schema._get_active(None) is None
@@ -393,7 +394,8 @@ def test_simple_find_files_no_source():
     param = test.set("file", "test.txt")
     param.set("testsource", field="dataroot")
 
-    with pytest.raises(ValueError, match="Resolver for testsource not provided"):
+    with pytest.raises(ValueError,
+                       match=r"^Resolver for testsource not provided: \[file\]$"):
         test.find_files("file")
 
 
@@ -596,8 +598,8 @@ def test_get_active_dataroot_multiple_defined():
     schema.set_dataroot("defined1", "file://")
 
     with pytest.raises(ValueError,
-                       match="dataroot must be specified, multiple are defined: "
-                             "defined0, defined1"):
+                       match="^dataroot must be specified, multiple are defined: "
+                             "defined0, defined1$"):
         schema._get_active_dataroot(None)
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2133,7 +2133,7 @@ def test_run_with_empty_flowgraph():
 
     # Should handle empty flow gracefully
     with pytest.raises(ValueError,
-                       match="^emptyflow flowgraph contains errors and cannot be run.$"):
+                       match=r"^emptyflow flowgraph contains errors and cannot be run\.$"):
         proj.run()
 
 

--- a/tests/tools/test_builtin.py
+++ b/tests/tools/test_builtin.py
@@ -272,7 +272,7 @@ def test_verify_fail(minmax_project, caplog):
 
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
-        with pytest.raises(ValueError, match="end/0 fails 'errors' metric: 1042==1041"):
+        with pytest.raises(ValueError, match="^end/0 fails 'errors' metric: 1042==1041$"):
             node.task.select_input_nodes()
 
     assert "Running builtin task 'verify'" in caplog.text
@@ -297,7 +297,7 @@ def test_verify_fail_two(minmax_project, caplog):
 
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
-        with pytest.raises(ValueError, match="end/0 fails 'warnings' metric: 0==1"):
+        with pytest.raises(ValueError, match="^end/0 fails 'warnings' metric: 0==1$"):
             node.task.select_input_nodes()
 
     assert "Running builtin task 'verify'" in caplog.text
@@ -308,7 +308,7 @@ def test_verify_input_fail(minmax_project):
 
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
-        with pytest.raises(ValueError, match="end/0 receives 2 inputs, but only supports one"):
+        with pytest.raises(ValueError, match="^end/0 receives 2 inputs, but only supports one$"):
             node.task.setup()
 
 

--- a/tests/tools/test_slang.py
+++ b/tests/tools/test_slang.py
@@ -25,7 +25,7 @@ def test_version_fail(task, monkeypatch):
             return 10
 
     monkeypatch.setattr(pyslang, "VersionInfo", Version)
-    with pytest.raises(RuntimeError, match="incorrect pyslang version: 8.9.10"):
+    with pytest.raises(RuntimeError, match="^incorrect pyslang version: 8.9.10$"):
         task()
 
 

--- a/tests/utils/test_curation.py
+++ b/tests/utils/test_curation.py
@@ -29,7 +29,7 @@ class FauxTask1(Task):
 
 @pytest.mark.parametrize("arg", [None, Design(), "string"])
 def test_collect_notproject(arg):
-    with pytest.raises(TypeError, match="project must be a Project"):
+    with pytest.raises(TypeError, match="^project must be a Project$"):
         collect(arg)
 
 
@@ -273,7 +273,8 @@ def test_collect_file_whitelist_error():
 
     proj = Project(design)
 
-    with pytest.raises(RuntimeError, match=".* is not on the approved collection list"):
+    with pytest.raises(RuntimeError,
+                       match=r"^.* is not on the approved collection list\.$"):
         collect(proj, whitelist=[os.path.abspath('not_test_folder')])
 
     assert len(os.listdir(collectiondir(proj))) == 0
@@ -299,12 +300,12 @@ def test_collect_file_whitelist_pass():
 
 @pytest.mark.parametrize("arg", [None, Design(), "string"])
 def test_archive_notproject(arg):
-    with pytest.raises(TypeError, match="project must be a Project"):
+    with pytest.raises(TypeError, match="^project must be a Project$"):
         archive(arg)
 
 
 def test_archive_no_jobs():
-    with pytest.raises(ValueError, match="no history to archive"):
+    with pytest.raises(ValueError, match="^no history to archive$"):
         archive(Project())
 
 

--- a/tests/utils/test_paths.py
+++ b/tests/utils/test_paths.py
@@ -15,7 +15,7 @@ def test_builddir():
 
 @pytest.mark.parametrize("arg", [None, Design(), "string"])
 def test_builddir_notproject(arg):
-    with pytest.raises(TypeError, match="project must be a Project type"):
+    with pytest.raises(TypeError, match="^project must be a Project type$"):
         builddir(arg)
 
 
@@ -34,7 +34,7 @@ def test_builddir_diff_build():
 
 
 def test_jobdir_no_name():
-    with pytest.raises(ValueError, match="name has not been set"):
+    with pytest.raises(ValueError, match="^name has not been set$"):
         jobdir(Project())
 
 
@@ -45,7 +45,7 @@ def test_jobdir():
 
 @pytest.mark.parametrize("arg", [None, Design(), "string"])
 def test_jobdir_notproject(arg):
-    with pytest.raises(TypeError, match="project must be a Project type"):
+    with pytest.raises(TypeError, match="^project must be a Project type$"):
         jobdir(arg)
 
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -71,7 +71,7 @@ def test_safecompare(a, op, b, expect):
 
 
 def test_safecompare_invalid_operator():
-    with pytest.raises(ValueError, match="Illegal comparison operation !"):
+    with pytest.raises(ValueError, match="^Illegal comparison operation !$"):
         safecompare(1, "!", 2)
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Standardized error messages for clarity and consistency across failure cases.
  - HTTP download failures now report the full source URL and HTTP status code.

- Tests
  - Tightened exception-message assertions across the test suite to require exact full-string matches (anchored regexes, proper quoting/escaping).
  - Many tests updated to align with the standardized, more precise error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->