### PR TITLE
only show log with non-zero size in dashboard

### DIFF
--- a/siliconcompiler/report/dashboard/cli/board.py
+++ b/siliconcompiler/report/dashboard/cli/board.py
@@ -692,9 +692,13 @@ class Board:
             log_file = None
             if layout.job_board_show_log:
                 for log in node["log"]:
-                    if os.path.exists(log) and os.path.getsize(log):
-                        log_file = "[bright_black]{}[/]".format(log)
-                        break
+                    try:
+                        if os.path.getsize(log) > 0:
+                            log_file = "[bright_black]{}[/]".format(log)
+                            break
+                    except OSError:
+                        # File doesn't exist or inaccessible
+                        continue
 
             if node["time"]["duration"] is not None:
                 duration = f'{node["time"]["duration"]:.1f}s'

--- a/siliconcompiler/report/dashboard/cli/board.py
+++ b/siliconcompiler/report/dashboard/cli/board.py
@@ -692,7 +692,7 @@ class Board:
             log_file = None
             if layout.job_board_show_log:
                 for log in node["log"]:
-                    if os.path.exists(log):
+                    if os.path.exists(log) and os.path.getsize(log):
                         log_file = "[bright_black]{}[/]".format(log)
                         break
 


### PR DESCRIPTION
Closes #4259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Job dashboard can display a secondary log per node when present.

- Bug Fixes
  - Empty log files are ignored and no longer show as valid logs.
  - Log indicators now appear only for existing, non-empty files; inaccessible files are skipped gracefully.

- Tests
  - Added tests validating dashboard rendering with and without secondary logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->