### PR TITLE
disable example that has not been updated

### DIFF
--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -69,6 +69,7 @@ def test_py_gcd_gf180():
 
 @pytest.mark.eda
 @pytest.mark.timeout(900)
+@pytest.mark.skip(reason="example not updated yet")
 def test_py_gcd_screenshot(monkeypatch):
     from gcd import gcd
     gcd.main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Temporarily skipped the example-based test for GCD screenshot with a clear reason (“example not updated yet”).
  * Prevents unnecessary test failures in CI while the example is being refreshed.
  * No impact on user-facing features or data; runtime behavior remains unchanged.
  * Improves test suite stability and clarity by explicitly marking the pending example update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->