### PR TITLE
Icarus Verilog compilation output extension rename

### DIFF
--- a/siliconcompiler/tools/icarus/compile.py
+++ b/siliconcompiler/tools/icarus/compile.py
@@ -32,7 +32,7 @@ class CompileTask(Task):
 
         self.set_threads()
 
-        self.add_output_file(ext="vpp")
+        self.add_output_file(ext="vvp")
 
         self.add_required_key("option", "design")
         self.add_required_key("option", "fileset")
@@ -63,7 +63,7 @@ class CompileTask(Task):
     def runtime_options(self):
         options = super().runtime_options()
 
-        options.extend(["-o", f"outputs/{self.design_topmodule}.vpp"])
+        options.extend(["-o", f"outputs/{self.design_topmodule}.vvp"])
         options.extend(["-s", self.design_topmodule])
 
         verilog_gen = self.get("var", "verilog_generation")

--- a/tests/tools/test_icarus.py
+++ b/tests/tools/test_icarus.py
@@ -22,8 +22,8 @@ def test_compile(gcd_design):
     assert proj.run()
 
     # check that compilation succeeded
-    assert proj.find_result('vpp', step='compile') == \
-        os.path.abspath("build/gcd/job0/compile/0/outputs/gcd.vpp")
+    assert proj.find_result('vvp', step='compile') == \
+        os.path.abspath("build/gcd/job0/compile/0/outputs/gcd.vvp")
 
 
 @pytest.mark.eda
@@ -55,7 +55,7 @@ def test_runtime_args(heartbeat_design):
     with node.runtime():
         assert node.setup() is True
         assert node.task.get_runtime_arguments() == [
-            '-o', 'outputs/heartbeat.vpp',
+            '-o', 'outputs/heartbeat.vvp',
             '-s', 'heartbeat',
             '-Pheartbeat.N=8',
             '-DSILICONCOMPILER_TRACE_FILE="reports/heartbeat.vcd"',


### PR DESCRIPTION
Fixes small typo in the file extensions of files compiled by icarus for the "Verilog Virtual Processor"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Icarus Verilog compilation output extension to .vvp so produced artifacts are compatible with standard vvp runners; no user action required.

* **Tests**
  * Updated test expectations to reflect the .vvp output and adjusted runtime argument handling to match the produced artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->