### PR TITLE
adjust how active is handled to avoid excessive copying of schema objects during active calls

### DIFF
--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -2007,7 +2007,7 @@ def test_active_empty():
 
     assert schema._get_active(None) is None
     with schema._active():
-        assert schema._get_active(None) == {}
+        assert schema._get_active(None) is None
     assert schema._get_active(None) is None
 
 
@@ -2103,7 +2103,7 @@ def test_active_compounded_depth():
                 }
                 assert schema1._get_active(None) == {
                     "dataroot": "testpack",
-                    "lock": False
+                    "lock": True
                 }
             assert schema._get_active(None) == {
                 "dataroot": "testpack"


### PR DESCRIPTION
In testing this represents a 70% runtime reduction during run initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Bug Fixes**
  * Improved schema activation state propagation to correctly handle nested hierarchies, ensuring consistent behavior when using multiple activation contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->