### PR TITLE
use self instead of None to avoid issues on restore

### DIFF
--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -767,7 +767,7 @@ class BaseSchema:
         """
 
         parent = self.__parent
-        self.__parent = None
+        self.__parent = self
         schema_copy = copy.deepcopy(self)
         self.__parent = parent
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced object copy functionality to properly maintain parent-child relationships and improve instance traversal accuracy during duplication operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->