### PR TITLE
ensure getdict uses search and correctly handles param only dict

### DIFF
--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -689,6 +689,55 @@ def test_getdict_keypath():
     }
 
 
+def test_getdict_param_keypath():
+    schema = BaseSchema()
+    edit = EditableSchema(schema)
+    edit.insert("test0", "default", "test1", Parameter("str"))
+
+    schema.set("test0", "default", "test1", "thistest")
+
+    assert schema.getdict("test0", "default", "test1") == {
+        'example': [],
+        'help': None,
+        'lock': False,
+        'node': {
+            'default': {
+                'default': {
+                    'signature': None,
+                    'value': None,
+                },
+            },
+            'global': {
+                'global': {
+                    'signature': None,
+                    'value': "thistest",
+                },
+            },
+        },
+        'notes': None,
+        'pernode': 'never',
+        'require': False,
+        'scope': 'global',
+        'shorthelp': None,
+        'switch': [],
+        'type': 'str',
+    }
+
+
+def test_getdict_param_keypath_value_only():
+    schema = BaseSchema()
+    edit = EditableSchema(schema)
+    edit.insert("test0", "default", "test1", Parameter("str"))
+
+    schema.set("test0", "default", "test1", "thistest")
+
+    assert schema.getdict("test0", "default", "test1", values_only=True) == {
+        None: {
+            None: "thistest"
+        },
+    }
+
+
 def test_getdict_keypath_unmatched():
     schema = BaseSchema()
     edit = EditableSchema(schema)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema parameter resolution to correctly handle nested keypaths and metadata extraction across complex parameter structures.

* **Tests**
  * Added test coverage for parameter keypath handling in schema operations to ensure reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->