### PR TITLE
add protection for attributes during serialization attempting to access parent

### DIFF
--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -54,7 +54,10 @@ class BaseSchema:
         '''
         Returns true if the object is the root of the schema
         '''
-        return self.__parent is None
+        try:
+            return self.__parent is None
+        except AttributeError:
+            return True
 
     @property
     def _keypath(self) -> Tuple[str, ...]:
@@ -63,7 +66,13 @@ class BaseSchema:
         '''
         if self.__is_root:
             return tuple()
-        return tuple([*self.__parent._keypath, self.__key])
+        try:
+            parentpath = self.__parent._keypath
+            key = self.__key
+        except AttributeError:
+            # Guard against partially setup parents during serialization
+            return tuple()
+        return tuple([*parentpath, key])
 
     @staticmethod
     @cache

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -2303,6 +2303,17 @@ def test_find_files_custom_class_package_resolution():
     assert custom.calls == 2
 
 
+def test_is_root_bad_level_parent():
+    schema = BaseSchema()
+    edit = EditableSchema(schema)
+    edit.insert("test0", "test1", "test2", Parameter("str"))
+    assert schema._BaseSchema__is_root is True
+    middle = schema.get("test0", field="schema")
+    assert middle._BaseSchema__is_root is False
+    del middle._BaseSchema__parent
+    assert middle._BaseSchema__is_root is True
+
+
 def test_keypath_root():
     assert BaseSchema()._keypath == tuple()
 
@@ -2314,6 +2325,28 @@ def test_keypath_with_levels():
     assert schema._keypath == tuple()
     assert schema.get("test0", field="schema")._keypath == ("test0",)
     assert schema.get("test0", "test1", field="schema")._keypath == ("test0", "test1")
+
+
+def test_keypath_with_bad_level_parent():
+    schema = BaseSchema()
+    edit = EditableSchema(schema)
+    edit.insert("test0", "test1", "test2", Parameter("str"))
+    assert schema._keypath == tuple()
+    middle = schema.get("test0", field="schema")
+    del middle._BaseSchema__parent
+    assert middle._keypath == tuple()
+    assert schema.get("test0", "test1", field="schema")._keypath == ("test1",)
+
+
+def test_keypath_with_bad_level_key():
+    schema = BaseSchema()
+    edit = EditableSchema(schema)
+    edit.insert("test0", "test1", "test2", Parameter("str"))
+    assert schema._keypath == tuple()
+    middle = schema.get("test0", field="schema")
+    del middle._BaseSchema__key
+    assert middle._keypath == tuple()
+    assert schema.get("test0", "test1", field="schema")._keypath == ("test1",)
 
 
 def test_keypath_with_default_unset():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced schema operation robustness to gracefully handle edge cases when internal parent or key references are missing, invalid, or tampered with during operations.

* **Tests**
  * Added comprehensive tests validating schema state transitions, root node detection accuracy, and keypath resolution behavior in edge case scenarios involving missing, modified, or removed internal references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->