### PR TITLE
add extract for bz2

### DIFF
--- a/siliconcompiler/package/https.py
+++ b/siliconcompiler/package/https.py
@@ -114,11 +114,16 @@ class HTTPResolver(RemoteResolver):
         except tarfile.ReadError:
             fileobj.seek(0)
             try:
-                with zipfile.ZipFile(fileobj) as zip_ref:
-                    zip_ref.extractall(path=self.cache_path)
-            except zipfile.BadZipFile:
-                raise TypeError(f"Could not extract file from {data_url}. "
-                                "File is not a valid tar.gz or zip archive.")
+                with tarfile.open(fileobj=fileobj, mode='r:bz2') as tar_ref:
+                    tar_ref.extractall(path=self.cache_path)
+            except tarfile.ReadError:
+                fileobj.seek(0)
+                try:
+                    with zipfile.ZipFile(fileobj) as zip_ref:
+                        zip_ref.extractall(path=self.cache_path)
+                except zipfile.BadZipFile:
+                    raise TypeError(f"Could not extract file from {data_url}. "
+                                    "File is not a valid tar.gz or zip archive.")
 
         # --- GitHub-specific directory flattening ---
         # GitHub archives often have a single top-level directory like 'repo-v1.0'.

--- a/siliconcompiler/tools/yosys/prepareLib.py
+++ b/siliconcompiler/tools/yosys/prepareLib.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Based on https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/84545863573a90bca3612298361adb35bf39e692/flow/util/markDontUse.py  # noqa E501
 
+import bz2
 import re
 import gzip
 import argparse  # argument parsing
@@ -12,10 +13,14 @@ def process_liberty_file(input_file, logger=None):
         logger.info(f"Opening file for replace: {input_file}")
     if input_file.endswith(".gz") or input_file.endswith(".GZ"):
         f = gzip.open(input_file, 'rt', encoding="utf-8")
+    elif input_file.endswith(".bz2") or input_file.endswith(".BZ2"):
+        f = bz2.open(input_file, 'rt', encoding="utf-8")
     else:
         f = open(input_file, encoding="utf-8")
-    content = f.read().encode("ascii", "ignore").decode("ascii")
-    f.close()
+    try:
+        content = f.read().encode("ascii", "ignore").decode("ascii")
+    finally:
+        f.close()
 
     # Yosys-abc throws an error if original_pin is found within the liberty file.
     # removing


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bz2-compressed archives in remote package extraction
  * Added support for reading bz2-compressed Liberty files in the Yosys toolchain

<!-- end of auto-generated comment: release notes by coderabbit.ai -->