### PR TITLE
use threading to speed up require run checks on

### DIFF
--- a/siliconcompiler/scheduler/scheduler.py
+++ b/siliconcompiler/scheduler/scheduler.py
@@ -764,11 +764,11 @@ class Scheduler:
                     self.__logger.debug(f"  Result: {node} -> {runrequired}")
 
                     if runrequired is not None:
+                        runrequired.log(self.__logger)
+
                         if isinstance(runrequired, SchedulerFlowReset):
                             raise runrequired from None
 
-                        if not runrequired.silent():
-                            self.__logger.warning(runrequired.msg)
                         # This node must be run
                         self.__mark_pending(*node)
                     else:

--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -30,11 +30,7 @@ if TYPE_CHECKING:
     from siliconcompiler.schema_support.metric import MetricSchema
 
 
-class SchedulerFlowReset(Exception):
-    pass
-
-
-class SchedulerNodeReset(Exception):
+class _SchedulerReset(Exception):
     def __init__(self, msg: str, *args: object) -> None:
         super().__init__(msg, *args)
         self.__msg = msg
@@ -43,16 +39,25 @@ class SchedulerNodeReset(Exception):
     def msg(self) -> str:
         return self.__msg
 
-    def silent(self) -> bool:
-        return False
+    def log(self, logger: logging.Logger) -> None:
+        logger.debug(self.msg)
+
+
+class SchedulerFlowReset(_SchedulerReset):
+    pass
+
+
+class SchedulerNodeReset(_SchedulerReset):
+    def log(self, logger: logging.Logger) -> None:
+        logger.warning(self.msg)
 
 
 class SchedulerNodeResetSilent(SchedulerNodeReset):
     def __init__(self, msg: str, *args: object) -> None:
         super().__init__(msg, *args)
 
-    def silent(self) -> bool:
-        return True
+    def log(self, logger: logging.Logger) -> None:
+        _SchedulerReset.log(self, logger)
 
 
 class SchedulerNode:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Run-required checks now run in parallel, improving scheduler responsiveness on multi-core systems.

* **Bug Fixes & Error Handling**
  * Reset conditions are signaled more explicitly, giving clearer diagnostics and more robust replay behavior.

* **Public API**
  * Scheduler exposes new reset signaling types to surface run/reset conditions consistently.

* **Tests**
  * Tests updated to validate the new exception-driven reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->