### PR TITLE
ensure filenotfound is handled during find_files

### DIFF
--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -939,7 +939,7 @@ class BaseSchema:
                         search_paths.append(dataroot_path())
                     except FileNotFoundError as e:
                         if not missing_ok:
-                            raise e from None
+                            raise FileNotFoundError(f"Dataroot {dataroot} not found: {e}") from e
                 else:
                     raise TypeError(f"Resolver for {dataroot} is not a recognized type: "
                                     f"{self.__format_key(*keypath)}")

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -1230,6 +1230,45 @@ def test_find_files_scalar_file_not_found():
         schema._find_files("file")
 
 
+def test_find_files_scalar_dataroot_not_found(monkeypatch):
+    schema = BaseSchema()
+    edit = EditableSchema(schema)
+    param = Parameter("file")
+    edit.insert("file", param)
+
+    def call_dataroot():
+        raise FileNotFoundError("this is not found")
+
+    def dataroot():
+        return {"test": call_dataroot}
+    monkeypatch.setattr(schema, "_find_files_dataroot_resolvers", dataroot)
+
+    assert schema.set("file", "test.txt")
+    assert schema.set("file", "test", field="dataroot")
+
+    with pytest.raises(FileNotFoundError, match=r"^Dataroot test not found: this is not found$"):
+        schema._find_files("file")
+
+
+def test_find_files_scalar_dataroot_not_found_allow(monkeypatch):
+    schema = BaseSchema()
+    edit = EditableSchema(schema)
+    param = Parameter("file")
+    edit.insert("file", param)
+
+    def call_dataroot():
+        raise FileNotFoundError("this is not found")
+
+    def dataroot():
+        return {"test": call_dataroot}
+    monkeypatch.setattr(schema, "_find_files_dataroot_resolvers", dataroot)
+
+    assert schema.set("file", "test.txt")
+    assert schema.set("file", "test", field="dataroot")
+
+    assert schema._find_files("file", missing_ok=True) is None
+
+
 def test_find_files_scalar_file_not_found_multiple_search():
     class CustomFiles(BaseSchema):
         def __init__(self):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for callable path resolvers so missing dataroots are handled according to configuration, avoiding unnecessary failures when non-fatal.

* **Tests**
  * Added tests verifying behavior when dataroot resolution fails and when missing-ok is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->