### PR TITLE
make clear thread count is 1 for builtins

### DIFF
--- a/siliconcompiler/tools/builtin/__init__.py
+++ b/siliconcompiler/tools/builtin/__init__.py
@@ -21,6 +21,8 @@ class BuiltinTask(Task):
 
         self._set_io_files()
 
+        self.set_threads(1)
+
     def _set_io_files(self):
         files = sorted(list(self.get_files_from_input_nodes().keys()))
         self.add_input_file(files)

--- a/siliconcompiler/tools/builtin/filter.py
+++ b/siliconcompiler/tools/builtin/filter.py
@@ -50,6 +50,8 @@ class FilterTask(Task):
     def setup(self):
         super().setup()
 
+        self.set_threads(1)
+
         flow = self.project.get("flowgraph", self.project.option.get_flow(), field="schema")
         graph_node = flow.get_graph_node(self.step, self.index)
 

--- a/siliconcompiler/tools/builtin/importfiles.py
+++ b/siliconcompiler/tools/builtin/importfiles.py
@@ -92,6 +92,8 @@ class ImportFilesTask(Task):
         """
         super().setup()
 
+        self.set_threads(1)
+
         if (self.step, self.index) not in self.schema_flow.get_entry_nodes():
             raise ValueError("task must be an entry node")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Builtin tasks now enforce sequential, single-threaded execution for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->