### PR TITLE
remove testing on macos 13 as it is no longer available

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -25,12 +25,10 @@ jobs:
       matrix:
         python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-latest", "ubuntu-24.04-arm", "windows-latest", "macos-latest"]
-        # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
+        # Python 3.9 is not on macos-latest (macos-14-arm64)
         # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
         exclude:
           - { python: "3.9", os: "macos-latest" }
-        include:
-          - { python: "3.9", os: "macos-13" }
 
     steps:
       - uses: actions/checkout@v5
@@ -47,12 +45,6 @@ jobs:
           choco install -y graphviz
           New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
           git config --system core.longpaths true
-
-      - name: Install Dependencies (macos-13)
-        if: matrix.os == 'macos-13'
-        run: |
-          # || true is needed to avoid failure on brew link error with python3.12
-          brew install graphviz || true
 
       - name: Install Dependencies (macos)
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -67,10 +67,12 @@ jobs:
         platform:
           - os: ubuntu-22.04
             arch: x86_64
-          - os: macos-13
+          - os: macos-latest
             arch: x86_64
           - os: windows-latest
             arch: x86_64
+        exclude:
+          - { python-version: "3.9", platform: {os: "macos-latest", arch: "x86_64"} }
 
     steps:
     - uses: actions/checkout@v5
@@ -101,7 +103,7 @@ jobs:
         xcopy /E klayout-${{ needs.klayout_cache.outputs.version }}-win64 "C:\Program Files (x86)\KLayout\"
 
     - name: Setup env (macOS)
-      if: matrix.platform.os == 'macos-13'
+      if: matrix.platform.os == 'macos-latest'
       run: |
         # || true is needed to avoid failure on brew link error with python3.12
         brew install graphviz || true


### PR DESCRIPTION
https://github.com/siliconcompiler/siliconcompiler/actions/runs/19279378829

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use the latest macOS platform version for testing and building.
  * Adjusted Python 3.9 compatibility handling for the updated macOS infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->