### PR TITLE
ensure list and sets return the default values when possible

### DIFF
--- a/siliconcompiler/schema/parametervalue.py
+++ b/siliconcompiler/schema/parametervalue.py
@@ -185,7 +185,13 @@ class NodeListValue:
         '''
         Returns a copy of the values stored in the list
         '''
-        return self.__values.copy()
+        if self.__values:
+            return self.__values.copy()
+        else:
+            if self.__base.has_value:
+                return [self.__base]
+            else:
+                return []
 
     def copy(self) -> "NodeListValue":
         """
@@ -385,7 +391,13 @@ class NodeSetValue:
         '''
         Returns a copy of the values stored in the list
         '''
-        return self.__values.copy()
+        if self.__values:
+            return self.__values.copy()
+        else:
+            if self.__base.has_value:
+                return [self.__base]
+            else:
+                return []
 
     def copy(self) -> "NodeSetValue":
         """

--- a/tests/schema/test_parametervalue.py
+++ b/tests/schema/test_parametervalue.py
@@ -645,6 +645,20 @@ def test_nodelist_copy():
     assert param.getdict() == check_param.getdict()
 
 
+def test_nodelist_values():
+    value = NodeListValue(NodeValue("str", value="thisvalue"))
+    assert value.values[0].get() == "thisvalue"
+    value.set(["test"])
+    assert value.values[0].get() == "test"
+
+
+def test_nodelist_values_nodefault():
+    value = NodeListValue(NodeValue("str"))
+    assert value.values == []
+    value.set(["test"])
+    assert value.values[0].get() == "test"
+
+
 def test_nodelist_set_type():
     value = NodeListValue(NodeValue("str"))
     value.set(["test"])
@@ -1317,6 +1331,20 @@ def test_nodeset_copy():
 
     assert param is not check_param
     assert param.getdict() == check_param.getdict()
+
+
+def test_nodeset_values():
+    value = NodeSetValue(NodeValue("str", value="thisvalue"))
+    assert value.values[0].get() == "thisvalue"
+    value.set(["test"])
+    assert value.values[0].get() == "test"
+
+
+def test_nodeset_values_nodefault():
+    value = NodeSetValue(NodeValue("str"))
+    assert value.values == []
+    value.set(["test"])
+    assert value.values[0].get() == "test"
 
 
 def test_nodeset_set_type():


### PR DESCRIPTION
Closes #4427

Issue was the default value was not getting returned causing collection to miss the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parameter value containers now correctly fall back to base values when no explicit values are defined, ensuring consistent behavior across list and set value types.

* **Tests**
  * Added tests for parameter value retrieval, modification operations, and default value fallback scenarios to ensure correct behavior in various configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->