### PR TITLE
add warning about slang not being loaded when requested and fix fpga match ordering

### DIFF
--- a/siliconcompiler/tools/yosys/scripts/sc_synth_asic.tcl
+++ b/siliconcompiler/tools/yosys/scripts/sc_synth_asic.tcl
@@ -82,7 +82,7 @@ if { ![file exists $input_verilog] } {
 
 set use_slang false
 if { [sc_cfg_tool_task_get var use_slang] } {
-    if { ! [sc_load_plugin slang] } {
+    if { ![sc_load_plugin slang] } {
         puts "WARNING: Unable to load slang plugin reverting back to yosys read_verilog"
     } else {
         set use_slang true

--- a/siliconcompiler/tools/yosys/scripts/sc_synth_fpga.tcl
+++ b/siliconcompiler/tools/yosys/scripts/sc_synth_fpga.tcl
@@ -32,7 +32,7 @@ if { ![file exists $input_verilog] } {
 
 set use_slang false
 if { [sc_cfg_tool_task_get var use_slang] } {
-    if { ! [sc_load_plugin slang] } {
+    if { ![sc_load_plugin slang] } {
         puts "WARNING: Unable to load slang plugin reverting back to yosys read_verilog"
     } else {
         set use_slang true
@@ -86,9 +86,7 @@ if {
     [sc_cfg_exists library $sc_designlib tool yosys fpga_config] &&
     [sc_cfg_get library $sc_designlib tool yosys fpga_config] != {} &&
     [sc_load_plugin wildebeest]
-} elseif { [string match {ice*} $sc_partname] } {
-    yosys synth_ice40 -top $sc_topmodule
-} else {
+} {
     set synth_fpga_args []
     if { [sc_cfg_tool_task_get var synth_opt_mode] != "none" } {
         lappend synth_fpga_args \
@@ -103,6 +101,8 @@ if {
         -show_config \
         -top $sc_topmodule \
         {*}$synth_fpga_args
+} elseif { [string match {ice*} $sc_partname] } {
+    yosys synth_ice40 -top $sc_topmodule
 } else {
     set sc_syn_feature_set [sc_cfg_get library $sc_designlib tool yosys feature_set]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an explicit configuration flag to opt into the alternate parsing/synthesis path, with robust plugin load checks and clear warnings on failure; system now automatically falls back to the standard flow when the plugin is unavailable.
  * Reordered and clarified FPGA synthesis branching so target selection evaluates the FPGA-configured path before device-specific branches, improving predictability and reliability of synthesis flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->