### PR TITLE
add check for existing object in copy_* constraints

### DIFF
--- a/siliconcompiler/constraints/asic_component.py
+++ b/siliconcompiler/constraints/asic_component.py
@@ -384,7 +384,7 @@ class ASICComponentConstraints(BaseSchema):
         EditableSchema(constraint).rename(name)
         if insert:
             if self.valid(name):
-                raise ValueError(f"{name} is already in the defined")
+                raise ValueError(f"{name} already exists")
             self.add_component(constraint)
         return constraint
 

--- a/siliconcompiler/constraints/asic_pins.py
+++ b/siliconcompiler/constraints/asic_pins.py
@@ -495,7 +495,7 @@ class ASICPinConstraints(BaseSchema):
         EditableSchema(constraint).rename(name)
         if insert:
             if self.valid(name):
-                raise ValueError(f"{name} is already in the defined")
+                raise ValueError(f"{name} already exists")
             self.add_pinconstraint(constraint)
         return constraint
 

--- a/siliconcompiler/constraints/asic_timing.py
+++ b/siliconcompiler/constraints/asic_timing.py
@@ -517,7 +517,7 @@ class ASICTimingConstraintSchema(BaseSchema):
         EditableSchema(constraint).rename(name)
         if insert:
             if self.valid(name):
-                raise ValueError(f"{name} is already in the defined")
+                raise ValueError(f"{name} already exists")
             self.add_scenario(constraint)
         return constraint
 

--- a/tests/constraints/test_asic_component.py
+++ b/tests/constraints/test_asic_component.py
@@ -234,7 +234,7 @@ def test_timing_constraint_copy_component_samename():
     schema = ASICComponentConstraints()
 
     schema.make_component("macro0")
-    with pytest.raises(ValueError, match=r"^macro0 is already in the defined$"):
+    with pytest.raises(ValueError, match=r"^macro0 already exists$"):
         schema.copy_component("macro0", "macro0")
 
 

--- a/tests/constraints/test_asic_pins.py
+++ b/tests/constraints/test_asic_pins.py
@@ -310,7 +310,7 @@ def test_timing_constraint_copy_pinconstraint_samename():
     schema = ASICPinConstraints()
 
     schema.make_pinconstraint("pin0")
-    with pytest.raises(ValueError, match=r"^pin0 is already in the defined$"):
+    with pytest.raises(ValueError, match=r"^pin0 already exists$"):
         schema.copy_pinconstraint("pin0", "pin0")
 
 

--- a/tests/constraints/test_asic_timing.py
+++ b/tests/constraints/test_asic_timing.py
@@ -299,7 +299,7 @@ def test_timing_constraint_copy_scenario_samename():
     schema = ASICTimingConstraintSchema()
 
     schema.make_scenario("slow")
-    with pytest.raises(ValueError, match=r"^slow is already in the defined$"):
+    with pytest.raises(ValueError, match=r"^slow already exists$"):
         schema.copy_scenario("slow", "slow")
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where copying components, pin constraints, or timing scenarios to names that already exist would silently overwrite the original. Now raises an error to prevent accidental data loss.

* **Tests**
  * Added validation tests to verify that attempting to copy items with duplicate names properly raises errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->