### PR TITLE
add set_yosys_useslang method to fpga and asic tasks in yosys

### DIFF
--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -299,7 +299,8 @@ class ASICSynthesis(_ASICTask, YosysTask):
             "str",
             "lock locking port name")
 
-    def set_yosys_useslang(self, enable: bool, step: Optional[str] = None, index: Optional[str] = None):
+    def set_yosys_useslang(self, enable: bool,
+                           step: Optional[str] = None, index: Optional[str] = None):
         self.set("var", "use_slang", enable, step=step, index=index)
 
     def task(self):

--- a/siliconcompiler/tools/yosys/syn_fpga.py
+++ b/siliconcompiler/tools/yosys/syn_fpga.py
@@ -1,5 +1,7 @@
 import json
 
+from typing import Optional
+
 from siliconcompiler import sc_open
 
 from siliconcompiler.tools.yosys import YosysTask
@@ -26,7 +28,8 @@ class FPGASynthesis(YosysTask):
             "perform buffer insertion",
             True)
 
-    def set_yosys_useslang(self, enable: bool, step: Optional[str] = None, index: Optional[str] = None):
+    def set_yosys_useslang(self, enable: bool,
+                           step: Optional[str] = None, index: Optional[str] = None):
         self.set("var", "use_slang", enable, step=step, index=index)
 
     def task(self):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration method to control Yosys synthesis behavior with optional context parameters
  * New required configuration variables for ASIC and FPGA synthesis workflows to ensure proper synthesis setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->