### PR TITLE
Add drain period for manifest to propagate through nfs

### DIFF
--- a/siliconcompiler/scheduler/slurm.py
+++ b/siliconcompiler/scheduler/slurm.py
@@ -244,7 +244,7 @@ class SlurmSchedulerNode(SchedulerNode):
             if os.path.exists(log_file):
                 self.logger.error(f"Node log file: {log_file}")
             self.halt()
-        
+
         # Wait for manifest to propagate through network filesystem
         start = time.time()
         elapsed = 0


### PR DESCRIPTION
Closes #4423 


@gadfort This should wait for 2 seconds max, which should cover a really really slow network. In best case it won't wait at all. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slurm scheduler robustness: when job completion metadata is briefly delayed on shared storage, the scheduler now waits and retries for a short window with brief pauses before reporting an error, reducing spurious failures from transient filesystem latency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->