### PR TITLE
Added pre/post scripts to vivado steps

### DIFF
--- a/siliconcompiler/tools/vivado/scripts/sc_bitstream.tcl
+++ b/siliconcompiler/tools/vivado/scripts/sc_bitstream.tcl
@@ -1,17 +1,13 @@
 open_checkpoint "inputs/${sc_topmodule}.dcp"
 
-if { [sc_cfg_tool_task_exists prescript] } {
-    foreach sc_pre_script [sc_cfg_tool_task_get prescript] {
-        puts "Sourcing pre script: ${sc_pre_script}"
-        source $sc_pre_script
-    }
+foreach sc_pre_script [sc_cfg_tool_task_get prescript] {
+    puts "Sourcing pre script: ${sc_pre_script}"
+    source $sc_pre_script
 }
 
 write_bitstream -force -file "outputs/${sc_topmodule}.bit"
 
-if { [sc_cfg_tool_task_exists postscript] } {
-    foreach sc_post_script [sc_cfg_tool_task_get postscript] {
-        puts "Sourcing post script: ${sc_post_script}"
-        source $sc_post_script
-    }
+foreach sc_post_script [sc_cfg_tool_task_get postscript] {
+    puts "Sourcing post script: ${sc_post_script}"
+    source $sc_post_script
 }

--- a/siliconcompiler/tools/vivado/scripts/sc_place.tcl
+++ b/siliconcompiler/tools/vivado/scripts/sc_place.tcl
@@ -1,17 +1,13 @@
 open_checkpoint "inputs/${sc_topmodule}.dcp"
 
-if { [sc_cfg_tool_task_exists prescript] } {
-    foreach sc_pre_script [sc_cfg_tool_task_get prescript] {
-        puts "Sourcing pre script: ${sc_pre_script}"
-        source $sc_pre_script
-    }
+foreach sc_pre_script [sc_cfg_tool_task_get prescript] {
+    puts "Sourcing pre script: ${sc_pre_script}"
+    source $sc_pre_script
 }
 
 place_design
 
-if { [sc_cfg_tool_task_exists postscript] } {
-    foreach sc_post_script [sc_cfg_tool_task_get postscript] {
-        puts "Sourcing post script: ${sc_post_script}"
-        source $sc_post_script
-    }
+foreach sc_post_script [sc_cfg_tool_task_get postscript] {
+    puts "Sourcing post script: ${sc_post_script}"
+    source $sc_post_script
 }

--- a/siliconcompiler/tools/vivado/scripts/sc_route.tcl
+++ b/siliconcompiler/tools/vivado/scripts/sc_route.tcl
@@ -1,19 +1,15 @@
 open_checkpoint "inputs/${sc_topmodule}.dcp"
 
-if { [sc_cfg_tool_task_exists prescript] } {
-    foreach sc_pre_script [sc_cfg_tool_task_get prescript] {
-        puts "Sourcing pre script: ${sc_pre_script}"
-        source $sc_pre_script
-    }
+foreach sc_pre_script [sc_cfg_tool_task_get prescript] {
+    puts "Sourcing pre script: ${sc_pre_script}"
+    source $sc_pre_script
 }
 
 phys_opt_design
 power_opt_design
 route_design
 
-if { [sc_cfg_tool_task_exists postscript] } {
-    foreach sc_post_script [sc_cfg_tool_task_get postscript] {
-        puts "Sourcing post script: ${sc_post_script}"
-        source $sc_post_script
-    }
+foreach sc_post_script [sc_cfg_tool_task_get postscript] {
+    puts "Sourcing post script: ${sc_post_script}"
+    source $sc_post_script
 }

--- a/siliconcompiler/tools/vivado/scripts/sc_syn_fpga.tcl
+++ b/siliconcompiler/tools/vivado/scripts/sc_syn_fpga.tcl
@@ -3,11 +3,9 @@ create_project $sc_topmodule -force
 set_property part $sc_partname [current_project]
 set_property target_language Verilog [current_project]
 
-if { [sc_cfg_tool_task_exists prescript] } {
-    foreach sc_pre_script [sc_cfg_tool_task_get prescript] {
-        puts "Sourcing pre script: ${sc_pre_script}"
-        source $sc_pre_script
-    }
+foreach sc_pre_script [sc_cfg_tool_task_get prescript] {
+    puts "Sourcing pre script: ${sc_pre_script}"
+    source $sc_pre_script
 }
 
 # add imported files
@@ -36,9 +34,7 @@ synth_design -top $sc_topmodule {*}$synth_args
 
 opt_design
 
-if { [sc_cfg_tool_task_exists postscript] } {
-    foreach sc_post_script [sc_cfg_tool_task_get postscript] {
-        puts "Sourcing post script: ${sc_post_script}"
-        source $sc_post_script
-    }
+foreach sc_post_script [sc_cfg_tool_task_get postscript] {
+    puts "Sourcing post script: ${sc_post_script}"
+    source $sc_post_script
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom pre- and post-script hooks in Vivado workflows. User scripts can now run immediately before and after key stages—synthesis, placement, routing, and bitstream generation—and each hook prints a sourcing message when executed. These hooks enable lightweight, conditional customization of the build flow without changing core tool behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->