### PR TITLE
add logic to find the build dir abspath during issue generation

### DIFF
--- a/siliconcompiler/apps/sc_issue.py
+++ b/siliconcompiler/apps/sc_issue.py
@@ -158,7 +158,8 @@ To run a testcase, use:
 
         # Modify run environment to point to extracted files
         builddir_key = ['option', 'builddir']
-        new_builddir = os.path.abspath(os.path.join(test_dir, f"{os.path.basename(project.get(*builddir_key))}"))
+        new_builddir = os.path.abspath(
+            os.path.join(test_dir, f"{os.path.basename(project.get(*builddir_key))}"))
         project.logger.info(f"Changing [{','.join(builddir_key)}] to '{new_builddir}'")
         project.set(*builddir_key, new_builddir)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolves build directory detection so configured build directories are found and set as absolute paths relative to config files.
  * Ensures path updates use the correct absolute build directory when modifying run paths.

* **Style**
  * Clarified log message formatting to more clearly show the resolved build directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->