### PR TITLE
cleanup cache when failures occur to avoid leaving bad data behind

### DIFF
--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -16,6 +16,7 @@ import logging
 import os
 import random
 import re
+import shutil
 import time
 import threading
 import uuid
@@ -543,7 +544,17 @@ class RemoteResolver(Resolver):
             if self.check_cache():
                 return self.cache_path
 
-            self.resolve_remote()
+            try:
+                self.resolve_remote()
+            except BaseException as e:
+                # Exception occurred, so need to cleanup
+                try:
+                    shutil.rmtree(self.cache_path)
+                except BaseException as cleane:
+                    self.logger.error(f"Exception occurred during cleanup: {cleane} "
+                                      f"({cleane.__class__.__name__})")
+                raise e from None
+
             self.set_changed()
             return self.cache_path
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package resolution error handling to automatically attempt cleanup of temporary cache directories when remote resolution fails; original errors are propagated and cleanup failures are logged.

* **Tests**
  * Added tests covering error propagation, cache cleanup attempts, and logging when cleanup itself fails during package resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->