### PR TITLE
cleanup step directory when all indexes are removed

### DIFF
--- a/siliconcompiler/scheduler/scheduler.py
+++ b/siliconcompiler/scheduler/scheduler.py
@@ -560,7 +560,7 @@ class Scheduler:
                 with self.__tasks[(step, index)].runtime():
                     self.__tasks[(step, index)].clean_directory()
                     parent_dir = os.path.dirname(self.__tasks[(step, index)].workdir)
-                    if len(os.listdir(parent_dir)) == 0:
+                    if os.path.exists(parent_dir) and len(os.listdir(parent_dir)) == 0:
                         # Step directory is empty so safe to remove
                         os.rmdir(parent_dir)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleaner build-directory cleanup: when a build step is removed, empty parent directories are now also removed when safe, reducing leftover empty folders and improving temporary file cleanup and disk space organization during builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->