### PR TITLE
Use [scheduler,options] in slurm

### DIFF
--- a/siliconcompiler/scheduler/slurm.py
+++ b/siliconcompiler/scheduler/slurm.py
@@ -209,8 +209,7 @@ class SlurmSchedulerNode(SchedulerNode):
         self._init_run_logger()
 
         # Determine which cluster parititon to use.
-        partition = self.project.get('option', 'scheduler', 'queue',
-                                     step=self.step, index=self.index)
+        partition = self.project.option.scheduler.get_queue(step=self.step, index=self.index)
         if not partition:
             partition = SlurmSchedulerNode.get_slurm_partition()
 
@@ -254,14 +253,12 @@ class SlurmSchedulerNode(SchedulerNode):
                         '--output', log_file]
 
         # Only delay the starting time if the 'defer' Schema option is specified.
-        defer_time = self.project.get('option', 'scheduler', 'defer',
-                                      step=self.step, index=self.index)
+        defer_time = self.project.option.scheduler.get_defer(step=self.step, index=self.index)
         if defer_time:
             schedule_cmd.extend(['--begin', defer_time])
 
-        # Forward additional options
-        options = self.project.get('option', 'scheduler', 'options',
-                                   step=self.step, index=self.index)
+        # Forward additional user options
+        options = self.project.option.scheduler.get_options(step=self.step, index=self.index)
         if options:
             schedule_cmd.extend(options)
 


### PR DESCRIPTION
@gadfort I noticed `[option, scheduler, options]` were omitted for slurm. This should take care of it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slurm scheduler now forwards user-defined scheduler options to srun, allowing additional Slurm flags/settings when launching jobs.
  * Queue/partition selection now respects configured scheduler queue values so jobs use the intended partition when set.
  * Deferred start times are now applied to job launches (adds a scheduled/begin time when configured).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->