### PR TITLE
Remove exclusive option from slurm

### DIFF
--- a/siliconcompiler/scheduler/slurm.py
+++ b/siliconcompiler/scheduler/slurm.py
@@ -245,7 +245,6 @@ class SlurmSchedulerNode(SchedulerNode):
                  os.stat(script_file).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
         schedule_cmd = ['srun',
-                        '--exclusive',
                         '--partition', partition,
                         '--chdir', self.project_cwd,
                         '--job-name', SlurmSchedulerNode.get_job_name(self.__job_hash,


### PR DESCRIPTION
@gadfort can we remove `--exclusive` from the default slurm arguments? 

This can create some issues for certain setups. I'm no expert in HPC or slurm, but I think there are two different setups. 

1. Many nodes with few resources 
2. Few nodes with many resources

I think the `--exclusive` make a lot of sense in the context of the first setup. But for the second one, it only causes issues and leads to waste of resources. I guess users can use the `scheduler, options` to set something as exclusive. 

Is it possible to remove it?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated job scheduling behavior to allow shared resource allocation instead of exclusive resource allocation, enabling more efficient utilization of compute resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->