### PR TITLE
dont draw bterms if there are too many

### DIFF
--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -463,6 +463,10 @@ proc sc_image_setup_default { } {
     gui::set_display_controls "Nets/*" visible true
     gui::set_display_controls "Instances/*" visible true
     gui::set_display_controls "Shape Types/*" visible true
+    if { [llength [[ord::get_db_block] getBTerms]] > 10000 } {
+        # Avoid performance issues with too many IOs
+        gui::set_display_controls "Shape Types/Pins" visible false
+    }
     gui::set_display_controls "Misc/Instances/*" visible true
     gui::set_display_controls "Misc/Instances/Pin Names" visible false
     gui::set_display_controls "Misc/Scale bar" visible true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Shape Types and Pins visibility is automatically disabled in the GUI for designs exceeding 10,000 boundary terminals. All other visibility settings remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->