### PR TITLE
add range support for int/float schema types

### DIFF
--- a/docs/reference_manual/schema.rst
+++ b/docs/reference_manual/schema.rst
@@ -37,7 +37,7 @@ Parameter Fields
 
     pernode
         Enables/disables setting of value on a per node basis.
-        Allowed values are 'never', 'option', or 'required'.
+        Allowed values are 'never', 'optional', or 'required'.
 
     require
         Boolean value dictating whether the parameter is required for a run.
@@ -57,8 +57,11 @@ Parameter Fields
         The parameter type.
         Supported types include Python compatible types ('int', 'float', 'str', and 'bool') and two custom file types ('file' and 'dir').
         The 'file' and 'dir' type specify that the parameter is a 'regular' file or directory as described by Posix.
-        Enums can be specified using the `<`  and `>` (eg. <input,output> specifies an enum that has the possible values of input and output.)
-        All types can be specified as a Python compatible list type by enclosing the type value in brackets. (ie. [str] specifies that the parameter is a list of strings).
+        Enums can be specified using the ``<``  and ``>`` (eg. <input,output> specifies an enum that has the possible values of input and output.)
+        Numeric types ('int' and 'float') can be restricted to a set of values or ranges using the ``<`` and ``>`` syntax (eg. ``int<0-10>`` specifies an integer that must be between 0 and 10 inclusive, ``float<0.0-1.0,2.0>`` specifies a float that is either between 0.0 and 1.0 or equal to 2.0).
+        Open-ended ranges are supported using the ``<<-XX>`` and ``<XX->>`` syntax (eg. ``int<0->>`` specifies an integer greater than or equal to 0, ``int<<-10>`` specifies an integer less than or equal to 10).
+        All types can be specified as a Python compatible list type by enclosing the type value in brackets.
+        (ie. [str] specifies that the parameter is a list of strings).
         Types can also be specified as tuples, using the Python-like parentheses syntax (eg. [(float,float)] specifies a list of 2-float tuples).
         Additionally types can also be specified as sets, using the Python-like curly brackets syntax (eg. {str} specifies a set of strings).
         Input arguments and return values of the set/get/add core methods are encoded as native Python types.

--- a/docs/reference_manual/schema.rst
+++ b/docs/reference_manual/schema.rst
@@ -58,8 +58,8 @@ Parameter Fields
         Supported types include Python compatible types ('int', 'float', 'str', and 'bool') and two custom file types ('file' and 'dir').
         The 'file' and 'dir' type specify that the parameter is a 'regular' file or directory as described by Posix.
         Enums can be specified using the ``<``  and ``>`` (eg. <input,output> specifies an enum that has the possible values of input and output.)
-        Numeric types ('int' and 'float') can be restricted to a set of values or ranges using the ``<`` and ``>`` syntax (eg. ``int<0-10>`` specifies an integer that must be between 0 and 10 inclusive, ``float<0.0-1.0,2.0>`` specifies a float that is either between 0.0 and 1.0 or equal to 2.0).
-        Open-ended ranges are supported using the ``<<-XX>`` and ``<XX->>`` syntax (eg. ``int<0->>`` specifies an integer greater than or equal to 0, ``int<<-10>`` specifies an integer less than or equal to 10).
+        Numeric types ('int' and 'float') can be restricted to a set of values or ranges using the ``<`` and ``>`` syntax (eg. ``int<0..10>`` specifies an integer that must be between 0 and 10 inclusive, ``float<0.0..1.0,2.0>`` specifies a float that is either between 0.0 and 1.0 or equal to 2.0).
+        Open-ended ranges are supported using the ``<..XX>`` and ``<XX..>`` syntax (eg. ``int<0..>`` specifies an integer greater than or equal to 0, ``int<..10>`` specifies an integer less than or equal to 10).
         All types can be specified as a Python compatible list type by enclosing the type value in brackets.
         (ie. [str] specifies that the parameter is a list of strings).
         Types can also be specified as tuples, using the Python-like parentheses syntax (eg. [(float,float)] specifies a list of 2-float tuples).

--- a/siliconcompiler/checklist.py
+++ b/siliconcompiler/checklist.py
@@ -397,7 +397,7 @@ class Checklist(NamedSchema):
                         error = True
                         continue
 
-                    if job_data.get("metric", metric, field='type') == 'int':
+                    if job_data.get("metric", metric, field='type').startswith('int'):
                         goal = int(m.group(3))
                         number_format = 'd'
                     else:

--- a/siliconcompiler/constraints/asic_floorplan.py
+++ b/siliconcompiler/constraints/asic_floorplan.py
@@ -54,7 +54,7 @@ class ASICAreaConstraint(BaseSchema):
         schema.insert(
             'coremargin',
             Parameter(
-                'float',
+                'float<0->>',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
                 unit='um',
@@ -68,7 +68,7 @@ class ASICAreaConstraint(BaseSchema):
 
         schema.insert(
             'density', Parameter(
-                'float',
+                'float<0.0-100.0>',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
                 shorthelp="Constraint: layout density",
@@ -83,7 +83,7 @@ class ASICAreaConstraint(BaseSchema):
 
         schema.insert(
             'aspectratio', Parameter(
-                'float',
+                'float<0.0->>',
                 pernode=PerNode.OPTIONAL,
                 defvalue=1.0,
                 scope=Scope.GLOBAL,

--- a/siliconcompiler/constraints/asic_floorplan.py
+++ b/siliconcompiler/constraints/asic_floorplan.py
@@ -54,7 +54,7 @@ class ASICAreaConstraint(BaseSchema):
         schema.insert(
             'coremargin',
             Parameter(
-                'float<0->>',
+                'float<0..>',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
                 unit='um',
@@ -68,7 +68,7 @@ class ASICAreaConstraint(BaseSchema):
 
         schema.insert(
             'density', Parameter(
-                'float<0.0-100.0>',
+                'float<0.0..100.0>',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
                 shorthelp="Constraint: layout density",
@@ -83,7 +83,7 @@ class ASICAreaConstraint(BaseSchema):
 
         schema.insert(
             'aspectratio', Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 pernode=PerNode.OPTIONAL,
                 defvalue=1.0,
                 scope=Scope.GLOBAL,

--- a/siliconcompiler/constraints/asic_pins.py
+++ b/siliconcompiler/constraints/asic_pins.py
@@ -39,7 +39,7 @@ class ASICPinConstraint(NamedSchema):
         schema.insert(
             'width',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 unit='um',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
@@ -56,7 +56,7 @@ class ASICPinConstraint(NamedSchema):
         schema.insert(
             'length',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 unit='um',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
@@ -101,7 +101,7 @@ class ASICPinConstraint(NamedSchema):
         schema.insert(
             'side',
             Parameter(
-                'int<1->>',
+                'int<1..>',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
                 shorthelp="Constraint: pin side",
@@ -117,7 +117,7 @@ class ASICPinConstraint(NamedSchema):
         schema.insert(
             'order',
             Parameter(
-                'int<0->>',
+                'int<0..>',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
                 shorthelp="Constraint: pin order",

--- a/siliconcompiler/constraints/asic_pins.py
+++ b/siliconcompiler/constraints/asic_pins.py
@@ -39,7 +39,7 @@ class ASICPinConstraint(NamedSchema):
         schema.insert(
             'width',
             Parameter(
-                'float',
+                'float<0.0->>',
                 unit='um',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
@@ -56,7 +56,7 @@ class ASICPinConstraint(NamedSchema):
         schema.insert(
             'length',
             Parameter(
-                'float',
+                'float<0.0->>',
                 unit='um',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
@@ -101,7 +101,7 @@ class ASICPinConstraint(NamedSchema):
         schema.insert(
             'side',
             Parameter(
-                'int',
+                'int<1->>',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
                 shorthelp="Constraint: pin side",
@@ -117,7 +117,7 @@ class ASICPinConstraint(NamedSchema):
         schema.insert(
             'order',
             Parameter(
-                'int',
+                'int<0->>',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
                 shorthelp="Constraint: pin order",

--- a/siliconcompiler/flowgraph.py
+++ b/siliconcompiler/flowgraph.py
@@ -1807,7 +1807,7 @@ def schema_flowgraph(schema: FlowgraphNodeSchema):
     edit.insert(
         'weight', metric,
         Parameter(
-            'float<0.0->>',
+            'float<0.0..>',
             scope=Scope.GLOBAL,
             defvalue=0.0,
             shorthelp="Flowgraph: Metric weights",

--- a/siliconcompiler/flowgraph.py
+++ b/siliconcompiler/flowgraph.py
@@ -1807,7 +1807,7 @@ def schema_flowgraph(schema: FlowgraphNodeSchema):
     edit.insert(
         'weight', metric,
         Parameter(
-            'float',
+            'float<0.0->>',
             scope=Scope.GLOBAL,
             defvalue=0.0,
             shorthelp="Flowgraph: Metric weights",

--- a/siliconcompiler/fpga.py
+++ b/siliconcompiler/fpga.py
@@ -99,7 +99,7 @@ class FPGADevice(ToolLibrarySchema):
         schema.insert(
             "fpga", 'lutsize',
             Parameter(
-                'int',
+                'int<1->>',
                 scope=Scope.GLOBAL,
                 shorthelp="FPGA: lutsize",
                 switch="-fpga_lutsize 'partname <int>'",

--- a/siliconcompiler/fpga.py
+++ b/siliconcompiler/fpga.py
@@ -99,7 +99,7 @@ class FPGADevice(ToolLibrarySchema):
         schema.insert(
             "fpga", 'lutsize',
             Parameter(
-                'int<1->>',
+                'int<1..>',
                 scope=Scope.GLOBAL,
                 shorthelp="FPGA: lutsize",
                 switch="-fpga_lutsize 'partname <int>'",

--- a/siliconcompiler/metrics/asic.py
+++ b/siliconcompiler/metrics/asic.py
@@ -17,7 +17,7 @@ class ASICMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int',
+                    'int<0->>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: total {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -37,7 +37,7 @@ class ASICMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'float',
+                    'float<0.0->>',
                     unit='um^2',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
@@ -52,7 +52,7 @@ class ASICMetricsSchema(MetricSchema):
         schema.insert(
             'utilization',
             Parameter(
-                'float',
+                'float<0.0->>',
                 unit='%',
                 scope=Scope.JOB,
                 shorthelp="Metric: area utilization",
@@ -68,7 +68,7 @@ class ASICMetricsSchema(MetricSchema):
         schema.insert(
             'logicdepth',
             Parameter(
-                'int',
+                'int<0->>',
                 scope=Scope.JOB,
                 shorthelp="Metric: logic depth",
                 switch="-metric_logicdepth 'step index <int>'",
@@ -132,7 +132,7 @@ class ASICMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int',
+                    'int<0->>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -173,7 +173,7 @@ class ASICMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'float',
+                    'float<0.0->>',
                     unit='Hz',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
@@ -198,7 +198,7 @@ class ASICMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int',
+                    'int<0->>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -213,7 +213,7 @@ class ASICMetricsSchema(MetricSchema):
         schema.insert(
             'wirelength',
             Parameter(
-                'float',
+                'float<0.0->>',
                 unit='um',
                 scope=Scope.JOB,
                 shorthelp="Metric: wirelength",

--- a/siliconcompiler/metrics/asic.py
+++ b/siliconcompiler/metrics/asic.py
@@ -17,7 +17,7 @@ class ASICMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int<0->>',
+                    'int<0..>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: total {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -37,7 +37,7 @@ class ASICMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'float<0.0->>',
+                    'float<0.0..>',
                     unit='um^2',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
@@ -52,7 +52,7 @@ class ASICMetricsSchema(MetricSchema):
         schema.insert(
             'utilization',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 unit='%',
                 scope=Scope.JOB,
                 shorthelp="Metric: area utilization",
@@ -68,7 +68,7 @@ class ASICMetricsSchema(MetricSchema):
         schema.insert(
             'logicdepth',
             Parameter(
-                'int<0->>',
+                'int<0..>',
                 scope=Scope.JOB,
                 shorthelp="Metric: logic depth",
                 switch="-metric_logicdepth 'step index <int>'",
@@ -132,7 +132,7 @@ class ASICMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int<0->>',
+                    'int<0..>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -173,7 +173,7 @@ class ASICMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'float<0.0->>',
+                    'float<0.0..>',
                     unit='Hz',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
@@ -198,7 +198,7 @@ class ASICMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int<0->>',
+                    'int<0..>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -213,7 +213,7 @@ class ASICMetricsSchema(MetricSchema):
         schema.insert(
             'wirelength',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 unit='um',
                 scope=Scope.JOB,
                 shorthelp="Metric: wirelength",

--- a/siliconcompiler/metrics/fpga.py
+++ b/siliconcompiler/metrics/fpga.py
@@ -15,7 +15,7 @@ class FPGAMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int<0->>',
+                    'int<0..>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: total {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -33,7 +33,7 @@ class FPGAMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int<0->>',
+                    'int<0..>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {description}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -51,7 +51,7 @@ class FPGAMetricsSchema(MetricSchema):
         schema.insert(
             'utilization',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 unit='%',
                 scope=Scope.JOB,
                 shorthelp="Metric: area utilization",
@@ -67,7 +67,7 @@ class FPGAMetricsSchema(MetricSchema):
         schema.insert(
             'logicdepth',
             Parameter(
-                'int<0->>',
+                'int<0..>',
                 scope=Scope.JOB,
                 shorthelp="Metric: logic depth",
                 switch="-metric_logicdepth 'step index <int>'",
@@ -112,7 +112,7 @@ class FPGAMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int<0->>',
+                    'int<0..>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -153,7 +153,7 @@ class FPGAMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'float<0.0->>',
+                    'float<0.0..>',
                     unit='Hz',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
@@ -174,7 +174,7 @@ class FPGAMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int<0->>',
+                    'int<0..>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -189,7 +189,7 @@ class FPGAMetricsSchema(MetricSchema):
         schema.insert(
             'wirelength',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 scope=Scope.JOB,
                 shorthelp="Metric: wirelength",
                 switch="-metric_wirelength 'step index <float>'",

--- a/siliconcompiler/metrics/fpga.py
+++ b/siliconcompiler/metrics/fpga.py
@@ -15,7 +15,7 @@ class FPGAMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int',
+                    'int<0->>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: total {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -33,7 +33,7 @@ class FPGAMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int',
+                    'int<0->>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {description}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -51,7 +51,7 @@ class FPGAMetricsSchema(MetricSchema):
         schema.insert(
             'utilization',
             Parameter(
-                'float',
+                'float<0.0->>',
                 unit='%',
                 scope=Scope.JOB,
                 shorthelp="Metric: area utilization",
@@ -67,7 +67,7 @@ class FPGAMetricsSchema(MetricSchema):
         schema.insert(
             'logicdepth',
             Parameter(
-                'int',
+                'int<0->>',
                 scope=Scope.JOB,
                 shorthelp="Metric: logic depth",
                 switch="-metric_logicdepth 'step index <int>'",
@@ -112,7 +112,7 @@ class FPGAMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int',
+                    'int<0->>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -153,7 +153,7 @@ class FPGAMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'float',
+                    'float<0.0->>',
                     unit='Hz',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
@@ -174,7 +174,7 @@ class FPGAMetricsSchema(MetricSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int',
+                    'int<0->>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -189,7 +189,7 @@ class FPGAMetricsSchema(MetricSchema):
         schema.insert(
             'wirelength',
             Parameter(
-                'float',
+                'float<0.0->>',
                 scope=Scope.JOB,
                 shorthelp="Metric: wirelength",
                 switch="-metric_wirelength 'step index <float>'",

--- a/siliconcompiler/pdk.py
+++ b/siliconcompiler/pdk.py
@@ -49,7 +49,7 @@ class PDK(ToolLibrarySchema):
         schema.insert(
             "pdk", 'node',
             Parameter(
-                'float',
+                'float<0.0->>',
                 scope=Scope.GLOBAL,
                 unit='nm',
                 shorthelp="PDK: process node",
@@ -116,7 +116,7 @@ class PDK(ToolLibrarySchema):
         schema.insert(
             "pdk", 'wafersize',
             Parameter(
-                'float',
+                'float<0.0->>',
                 scope=Scope.GLOBAL,
                 unit='mm',
                 shorthelp="PDK: wafer size",
@@ -133,7 +133,7 @@ class PDK(ToolLibrarySchema):
         schema.insert(
             "pdk", 'unitcost',
             Parameter(
-                'float',
+                'float<0.0->>',
                 scope=Scope.GLOBAL,
                 unit='USD',
                 shorthelp="PDK: unit cost",
@@ -147,7 +147,7 @@ class PDK(ToolLibrarySchema):
         schema.insert(
             "pdk", 'd0',
             Parameter(
-                'float',
+                'float<0.0->>',
                 scope=Scope.GLOBAL,
                 shorthelp="PDK: process defect density",
                 switch="-pdk_d0 'pdkname <float>'",
@@ -181,7 +181,7 @@ class PDK(ToolLibrarySchema):
         schema.insert(
             "pdk", 'edgemargin',
             Parameter(
-                'float',
+                'float<0.0->>',
                 scope=Scope.GLOBAL,
                 unit='mm',
                 shorthelp="PDK: wafer edge keep-out margin",

--- a/siliconcompiler/pdk.py
+++ b/siliconcompiler/pdk.py
@@ -49,7 +49,7 @@ class PDK(ToolLibrarySchema):
         schema.insert(
             "pdk", 'node',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 scope=Scope.GLOBAL,
                 unit='nm',
                 shorthelp="PDK: process node",
@@ -116,7 +116,7 @@ class PDK(ToolLibrarySchema):
         schema.insert(
             "pdk", 'wafersize',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 scope=Scope.GLOBAL,
                 unit='mm',
                 shorthelp="PDK: wafer size",
@@ -133,7 +133,7 @@ class PDK(ToolLibrarySchema):
         schema.insert(
             "pdk", 'unitcost',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 scope=Scope.GLOBAL,
                 unit='USD',
                 shorthelp="PDK: unit cost",
@@ -147,7 +147,7 @@ class PDK(ToolLibrarySchema):
         schema.insert(
             "pdk", 'd0',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 scope=Scope.GLOBAL,
                 shorthelp="PDK: process defect density",
                 switch="-pdk_d0 'pdkname <float>'",
@@ -181,7 +181,7 @@ class PDK(ToolLibrarySchema):
         schema.insert(
             "pdk", 'edgemargin',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 scope=Scope.GLOBAL,
                 unit='mm',
                 shorthelp="PDK: wafer edge keep-out margin",

--- a/siliconcompiler/remote/schema.py
+++ b/siliconcompiler/remote/schema.py
@@ -27,7 +27,7 @@ class ServerSchema(CommandLineSchema, BaseSchema):
         schema.insert(
             'option', 'port',
             Parameter(
-                'int<1-65535>',
+                'int<1..65535>',
                 scope=Scope.GLOBAL,
                 defvalue=8080,
                 require='all',
@@ -79,7 +79,7 @@ class ServerSchema(CommandLineSchema, BaseSchema):
         schema.insert(
             'option', 'checkinterval',
             Parameter(
-                'int<1->>',
+                'int<1..>',
                 defvalue=30,
                 shorthelp="Interval for client",
                 switch="-checkinterval <int>",

--- a/siliconcompiler/remote/schema.py
+++ b/siliconcompiler/remote/schema.py
@@ -27,7 +27,7 @@ class ServerSchema(CommandLineSchema, BaseSchema):
         schema.insert(
             'option', 'port',
             Parameter(
-                'int',
+                'int<1-65535>',
                 scope=Scope.GLOBAL,
                 defvalue=8080,
                 require='all',
@@ -79,7 +79,7 @@ class ServerSchema(CommandLineSchema, BaseSchema):
         schema.insert(
             'option', 'checkinterval',
             Parameter(
-                'int',
+                'int<1->>',
                 defvalue=30,
                 shorthelp="Interval for client",
                 switch="-checkinterval <int>",

--- a/siliconcompiler/schema/CHANGELOG.md
+++ b/siliconcompiler/schema/CHANGELOG.md
@@ -12,10 +12,10 @@ from the code diffs, not the commit messages). Dates are the git commit dates of
 the version bump. Version numbering was not strictly linear during early
 development, so a few dates are non-monotonic relative to the semver ordering.
 
-## 0.56.0 — 2026-07-06
+## 0.56.0 — 2026-07-07
 - Added value ranges/limits to numeric schema types via a new `NodeRangeType`
-  and `int<...>`/`float<...>` type syntax (e.g. `int<0-100>`, `float<0.0-1.0>`,
-  open-ended `int<0->`); `str<...>` is treated as an enum. Ranges are validated
+  and `int<...>`/`float<...>` type syntax (e.g. `int<0..100>`, `float<0.0..1.0>`,
+  open-ended `int<0..>`); `str<...>` is treated as an enum. Ranges are validated
   on set and encoded into the serialized type string.
 
 ## 0.55.0 — 2026-07-01

--- a/siliconcompiler/schema/CHANGELOG.md
+++ b/siliconcompiler/schema/CHANGELOG.md
@@ -12,6 +12,12 @@ from the code diffs, not the commit messages). Dates are the git commit dates of
 the version bump. Version numbering was not strictly linear during early
 development, so a few dates are non-monotonic relative to the semver ordering.
 
+## 0.56.0 — 2026-07-06
+- Added value ranges/limits to numeric schema types via a new `NodeRangeType`
+  and `int<...>`/`float<...>` type syntax (e.g. `int<0-100>`, `float<0.0-1.0>`,
+  open-ended `int<0->`); `str<...>` is treated as an enum. Ranges are validated
+  on set and encoded into the serialized type string.
+
 ## 0.55.0 — 2026-07-01
 - Changed the global-value key from `'global'` to `'*'` to avoid name conflicts,
   with legacy read support for older manifests.

--- a/siliconcompiler/schema/_metadata.py
+++ b/siliconcompiler/schema/_metadata.py
@@ -1,2 +1,2 @@
 # Version number following semver standard.
-version = '0.55.0'
+version = '0.56.0'

--- a/siliconcompiler/schema/parametertype.py
+++ b/siliconcompiler/schema/parametertype.py
@@ -16,7 +16,7 @@ class NodeType:
     __enum = re.compile(r"^<(.*)>$")
     __rangetype = re.compile(r"^(int|float|str)<(.*)>$")
     __rangenumber = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
-    __rangevalues = re.compile(f"^({__rangenumber}|<)-({__rangenumber}|>)$")
+    __rangevalues = re.compile(rf"^({__rangenumber})?\.\.({__rangenumber})?$")
     __basetypes = re.compile(r"^(<(.*)>|int(<(.*)>)?|float(<(.*)>)?|str(<(.*)>)?|bool|file|dir)$")
 
     def __init__(self, sctype):
@@ -62,13 +62,9 @@ class NodeType:
                     match = NodeType.__rangevalues.match(part)
                     if match:
                         start, end = match.groups()
-                        if start == "<":
-                            start = None
-                        else:
+                        if start is not None:
                             start = normlizer(start)
-                        if end == ">":
-                            end = None
-                        else:
+                        if end is not None:
                             end = normlizer(end)
                         range_parts.append((start, end))
                     else:
@@ -336,7 +332,7 @@ class NodeType:
             valid = []
             for minval, maxval in sctype.values:
                 if minval != maxval:
-                    valid.append(f"{minval if minval is not None else ''}-"
+                    valid.append(f"{minval if minval is not None else ''}.."
                                  f"{maxval if maxval is not None else ''}")
                 else:
                     valid.append(f"{minval}")
@@ -417,8 +413,8 @@ class NodeRangeType:
         values = []
         for minval, maxval in self.__values:
             if minval != maxval:
-                values.append(f"{minval if minval is not None else '<'}-"
-                              f"{maxval if maxval is not None else '>'}")
+                values.append(f"{minval if minval is not None else ''}.."
+                              f"{maxval if maxval is not None else ''}")
             else:
                 values.append(f"{minval}")
         return f"{self.__base}<{','.join(values)}>"

--- a/siliconcompiler/schema/parametertype.py
+++ b/siliconcompiler/schema/parametertype.py
@@ -14,7 +14,10 @@ class NodeType:
     __tuple = re.compile(r"^\((.*)\)$")
     __set = re.compile(r"^\{(.*)\}$")
     __enum = re.compile(r"^<(.*)>$")
-    __basetypes = re.compile(r"^(<(.*)>|int|float|str|bool|file|dir)$")
+    __rangetype = re.compile(r"^(int|float|str)<(.*)>$")
+    __rangenumber = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+    __rangevalues = re.compile(f"^({__rangenumber}|<)-({__rangenumber}|>)$")
+    __basetypes = re.compile(r"^(<(.*)>|int(<(.*)>)?|float(<(.*)>)?|str(<(.*)>)?|bool|file|dir)$")
 
     def __init__(self, sctype):
         if isinstance(sctype, NodeType):
@@ -46,6 +49,32 @@ class NodeType:
         if NodeType.__basetypes.match(sctype):
             if NodeType.__enum.match(sctype):
                 return NodeEnumType(*sctype[1:-1].split(","))
+            range_groups = NodeType.__rangetype.match(sctype)
+            if range_groups:
+                basetype, rangespec = range_groups.groups()
+                if basetype == "str":
+                    return NodeEnumType(*rangespec.split(","))
+                if basetype not in ("int", "float"):
+                    raise ValueError(f"Invalid range base type: {basetype}")
+                range_parts = []
+                normlizer = int if basetype == "int" else float
+                for part in rangespec.split(","):
+                    match = NodeType.__rangevalues.match(part)
+                    if match:
+                        start, end = match.groups()
+                        if start == "<":
+                            start = None
+                        else:
+                            start = normlizer(start)
+                        if end == ">":
+                            end = None
+                        else:
+                            end = normlizer(end)
+                        range_parts.append((start, end))
+                    else:
+                        part = normlizer(part)
+                        range_parts.append((part, part))
+                return NodeRangeType(basetype, *range_parts)
             return sctype
         if NodeType.__list.match(sctype):
             return [NodeType.parse(sctype[1:-1])]
@@ -82,7 +111,7 @@ class NodeType:
         if isinstance(sctype, set):
             return f"{{{','.join([NodeType.encode(sct) for sct in sctype])}}}"
 
-        if isinstance(sctype, NodeEnumType):
+        if isinstance(sctype, (NodeEnumType, NodeRangeType)):
             return str(sctype)
 
         if isinstance(sctype, str):
@@ -95,7 +124,7 @@ class NodeType:
         """
         Check if the type contains a specific type.
         """
-        if check in (list, tuple, set, NodeEnumType):
+        if check in (list, tuple, set, NodeEnumType, NodeRangeType):
             if isinstance(value, check):
                 return True
         if isinstance(value, list):
@@ -104,6 +133,8 @@ class NodeType:
             return NodeType.contains(list(value)[0], check)
         if isinstance(value, tuple):
             return any([NodeType.contains(v, check) for v in value])
+        if isinstance(value, NodeRangeType):
+            return value.base == check
         return value == check
 
     @staticmethod
@@ -112,6 +143,9 @@ class NodeType:
         Recursive helper function for converting Python values to safe TCL
         values, based on the SC type string.
         '''
+
+        if isinstance(sctype, NodeRangeType):
+            sctype = sctype.base
 
         if isinstance(sctype, list):
             if value is None:
@@ -150,6 +184,7 @@ class NodeType:
                                 .replace('$', '\\$')    # escape '$' to avoid variable substitution
                                 .replace('"', '\\"'))   # escape '"' to avoid string terminating
             return '"' + escaped_val + '"'
+
         if sctype == 'bool':
             return 'true' if value else 'false'
 
@@ -287,6 +322,26 @@ class NodeType:
             else:
                 raise ValueError(f"enum must be a string, not a {type(value)}")
 
+        if isinstance(sctype, NodeRangeType):
+            value = NodeType.normalize(value, sctype.base)
+            for minval, maxval in sctype.values:
+                if minval is None:
+                    if value <= maxval:
+                        return value
+                elif maxval is None:
+                    if value >= minval:
+                        return value
+                elif minval <= value <= maxval:
+                    return value
+            valid = []
+            for minval, maxval in sctype.values:
+                if minval != maxval:
+                    valid.append(f"{minval if minval is not None else ''}-"
+                                 f"{maxval if maxval is not None else ''}")
+                else:
+                    valid.append(f"{minval}")
+            raise ValueError(f'{value} is not in range: {", ".join(valid)}')
+
         raise ValueError(f'Invalid type specifier: {sctype}')
 
 
@@ -315,11 +370,75 @@ class NodeEnumType:
         return str(self)
 
     def __hash__(self):
-        return hash(tuple(self.__values))
+        return hash(tuple(sorted(self.__values)))
 
     @property
     def values(self):
         '''
         Returns a set of the legal values for this enum.
+        '''
+        return self.__values
+
+
+class NodeRangeType:
+    """
+    Numeric range type for schema data values.
+
+    Args:
+        base (str): numeric base type, either 'int' or 'float'.
+        *values: one or more range tuples of (min, max). A bound of None
+            indicates an open-ended range on that side (e.g. (0, None) means
+            the value must be >= 0). A fully unbounded (None, None) range is
+            not allowed.
+    """
+
+    def __init__(self, base, *values):
+        if not values:
+            raise ValueError("range cannot be empty set")
+        for v0, v1 in values:
+            if v0 is None and v1 is None:
+                raise ValueError("range cannot be fully unbounded")
+        self.__base = base
+        values = [
+            (min([v0, v1]), max([v0, v1])) if v0 is not None and v1 is not None else (v0, v1)
+            for v0, v1 in set(values)]
+        self.__values = sorted(values,
+                               key=lambda v: (float('-inf') if v[0] is None else v[0],
+                                              float('inf') if v[1] is None else v[1]))
+
+    def __eq__(self, other):
+        if isinstance(other, NodeRangeType):
+            if self.__base != other.__base:
+                return False
+            return self.__values == other.__values
+        return False
+
+    def __str__(self):
+        values = []
+        for minval, maxval in self.__values:
+            if minval != maxval:
+                values.append(f"{minval if minval is not None else '<'}-"
+                              f"{maxval if maxval is not None else '>'}")
+            else:
+                values.append(f"{minval}")
+        return f"{self.__base}<{','.join(values)}>"
+
+    def __repr__(self):
+        return str(self)
+
+    def __hash__(self):
+        return hash(tuple([self.__base, *self.__values]))
+
+    @property
+    def base(self):
+        '''
+        Returns the base for this range.
+        '''
+        return self.__base
+
+    @property
+    def values(self):
+        '''
+        Returns a set of the legal values for this range.
         '''
         return self.__values

--- a/siliconcompiler/schema_support/metric.py
+++ b/siliconcompiler/schema_support/metric.py
@@ -37,7 +37,7 @@ class MetricSchema(BaseSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int',
+                    'int<0->>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: total {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -51,7 +51,7 @@ class MetricSchema(BaseSchema):
         schema.insert(
             'memory',
             Parameter(
-                'float',
+                'float<0.0->>',
                 unit='B',
                 scope=Scope.JOB,
                 shorthelp="Metric: memory",
@@ -67,7 +67,7 @@ class MetricSchema(BaseSchema):
         schema.insert(
             'exetime',
             Parameter(
-                'float',
+                'float<0.0->>',
                 unit='s',
                 scope=Scope.JOB,
                 shorthelp="Metric: exetime",
@@ -86,7 +86,7 @@ class MetricSchema(BaseSchema):
         schema.insert(
             'tasktime',
             Parameter(
-                'float',
+                'float<0.0->>',
                 unit='s',
                 scope=Scope.JOB,
                 shorthelp="Metric: tasktime",
@@ -103,7 +103,7 @@ class MetricSchema(BaseSchema):
         schema.insert(
             'totaltime',
             Parameter(
-                'float',
+                'float<0.0->>',
                 unit='s',
                 scope=Scope.JOB,
                 shorthelp="Metric: totaltime",

--- a/siliconcompiler/schema_support/metric.py
+++ b/siliconcompiler/schema_support/metric.py
@@ -37,7 +37,7 @@ class MetricSchema(BaseSchema):
             schema.insert(
                 item,
                 Parameter(
-                    'int<0->>',
+                    'int<0..>',
                     scope=Scope.JOB,
                     shorthelp=f"Metric: total {item}",
                     switch=f"-metric_{item} 'step index <int>'",
@@ -51,7 +51,7 @@ class MetricSchema(BaseSchema):
         schema.insert(
             'memory',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 unit='B',
                 scope=Scope.JOB,
                 shorthelp="Metric: memory",
@@ -67,7 +67,7 @@ class MetricSchema(BaseSchema):
         schema.insert(
             'exetime',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 unit='s',
                 scope=Scope.JOB,
                 shorthelp="Metric: exetime",
@@ -86,7 +86,7 @@ class MetricSchema(BaseSchema):
         schema.insert(
             'tasktime',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 unit='s',
                 scope=Scope.JOB,
                 shorthelp="Metric: tasktime",
@@ -103,7 +103,7 @@ class MetricSchema(BaseSchema):
         schema.insert(
             'totaltime',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 unit='s',
                 scope=Scope.JOB,
                 shorthelp="Metric: totaltime",

--- a/siliconcompiler/schema_support/option.py
+++ b/siliconcompiler/schema_support/option.py
@@ -45,7 +45,7 @@ class SchedulerSchema(BaseSchema):
         schema.insert(
             'cores',
             Parameter(
-                'int',
+                'int<1->>',
                 scope=Scope.GLOBAL,
                 pernode=PerNode.OPTIONAL,
                 shorthelp="Option: Scheduler core constraint",
@@ -169,7 +169,7 @@ class SchedulerSchema(BaseSchema):
         schema.insert(
             'maxnodes',
             Parameter(
-                'int',
+                'int<1->>',
                 scope=Scope.GLOBAL,
                 shorthelp="Option: maximum concurrent nodes",
                 switch="-maxnodes <int>",
@@ -182,7 +182,7 @@ class SchedulerSchema(BaseSchema):
         schema.insert(
             'maxthreads',
             Parameter(
-                'int',
+                'int<1->>',
                 scope=Scope.GLOBAL,
                 shorthelp="Option: maximum number of threads to assign a task",
                 example=["api: option.set('maxthreads', 4)"],
@@ -494,7 +494,7 @@ class OptionSchema(BaseSchema):
         schema.insert(
             'nice',
             Parameter(
-                'int',
+                'int<-20-19>',
                 scope=Scope.GLOBAL,
                 pernode=PerNode.OPTIONAL,
                 shorthelp="Option: tool scheduling priority",
@@ -523,7 +523,7 @@ class OptionSchema(BaseSchema):
         schema.insert(
             'optmode',
             Parameter(
-                'int',
+                'int<0->>',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
                 defvalue=0,
@@ -763,7 +763,7 @@ class OptionSchema(BaseSchema):
         schema.insert(
             'timeout',
             Parameter(
-                'float',
+                'float<0.0->>',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
                 unit='s',

--- a/siliconcompiler/schema_support/option.py
+++ b/siliconcompiler/schema_support/option.py
@@ -45,7 +45,7 @@ class SchedulerSchema(BaseSchema):
         schema.insert(
             'cores',
             Parameter(
-                'int<1->>',
+                'int<1..>',
                 scope=Scope.GLOBAL,
                 pernode=PerNode.OPTIONAL,
                 shorthelp="Option: Scheduler core constraint",
@@ -169,7 +169,7 @@ class SchedulerSchema(BaseSchema):
         schema.insert(
             'maxnodes',
             Parameter(
-                'int<1->>',
+                'int<1..>',
                 scope=Scope.GLOBAL,
                 shorthelp="Option: maximum concurrent nodes",
                 switch="-maxnodes <int>",
@@ -182,7 +182,7 @@ class SchedulerSchema(BaseSchema):
         schema.insert(
             'maxthreads',
             Parameter(
-                'int<1->>',
+                'int<1..>',
                 scope=Scope.GLOBAL,
                 shorthelp="Option: maximum number of threads to assign a task",
                 example=["api: option.set('maxthreads', 4)"],
@@ -494,7 +494,7 @@ class OptionSchema(BaseSchema):
         schema.insert(
             'nice',
             Parameter(
-                'int<-20-19>',
+                'int<-20..19>',
                 scope=Scope.GLOBAL,
                 pernode=PerNode.OPTIONAL,
                 shorthelp="Option: tool scheduling priority",
@@ -523,7 +523,7 @@ class OptionSchema(BaseSchema):
         schema.insert(
             'optmode',
             Parameter(
-                'int<0->>',
+                'int<0..>',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
                 defvalue=0,
@@ -763,7 +763,7 @@ class OptionSchema(BaseSchema):
         schema.insert(
             'timeout',
             Parameter(
-                'float<0.0->>',
+                'float<0.0..>',
                 pernode=PerNode.OPTIONAL,
                 scope=Scope.GLOBAL,
                 unit='s',

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -3454,7 +3454,7 @@ def schema_task(schema):
     schema.insert(
         'threads',
         Parameter(
-            'int<1->>',
+            'int<1..>',
             scope=Scope.JOB,
             pernode=PerNode.OPTIONAL,
             shorthelp="Task: thread parallelism",

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -36,7 +36,7 @@ from pathlib import Path
 
 from siliconcompiler.schema import BaseSchema, NamedSchema, DocsSchema, LazyLoad
 from siliconcompiler.schema import EditableSchema, Parameter, PerNode, Scope
-from siliconcompiler.schema.parametertype import NodeType
+from siliconcompiler.schema.parametertype import NodeType, NodeEnumType
 from siliconcompiler.schema.utils import trim
 
 from siliconcompiler import utils, NodeStatus, Flowgraph
@@ -2391,8 +2391,8 @@ class Task(NamedSchema, PathSchema, DocsSchema):
                 help_str = param.get(field="help")
 
                 val_type = param.get(field="type")
-                if "<" in val_type:
-                    encode_type = NodeType.parse(val_type)
+                encode_type = NodeType.parse(val_type)
+                if NodeType.contains(encode_type, NodeEnumType):
                     try:
                         if val_type.startswith('['):
                             allowed = list(encode_type)[0].values
@@ -3454,7 +3454,7 @@ def schema_task(schema):
     schema.insert(
         'threads',
         Parameter(
-            'int',
+            'int<1->>',
             scope=Scope.JOB,
             pernode=PerNode.OPTIONAL,
             shorthelp="Task: thread parallelism",

--- a/siliconcompiler/tools/bambu/__init__.py
+++ b/siliconcompiler/tools/bambu/__init__.py
@@ -30,7 +30,7 @@ class BambuStdCellLibrary(StdCellLibrary):
 
         self.define_tool_parameter("bambu", "device", "str",
                                    "name of the target device for bambu.")
-        self.define_tool_parameter("bambu", "clock_multiplier", "float",
+        self.define_tool_parameter("bambu", "clock_multiplier", "float<0.0->>",
                                    "scalar facto to convert from library units to ns.")
 
     def set_bambu_device_name(self, name):

--- a/siliconcompiler/tools/bambu/__init__.py
+++ b/siliconcompiler/tools/bambu/__init__.py
@@ -30,7 +30,7 @@ class BambuStdCellLibrary(StdCellLibrary):
 
         self.define_tool_parameter("bambu", "device", "str",
                                    "name of the target device for bambu.")
-        self.define_tool_parameter("bambu", "clock_multiplier", "float<0.0->>",
+        self.define_tool_parameter("bambu", "clock_multiplier", "float<0.0..>",
                                    "scalar facto to convert from library units to ns.")
 
     def set_bambu_device_name(self, name):

--- a/siliconcompiler/tools/bambu/convert.py
+++ b/siliconcompiler/tools/bambu/convert.py
@@ -16,7 +16,7 @@ class ConvertTask(ASICTask, Task):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("memorychannels", "int", "Number of memory channels available",
+        self.add_parameter("memorychannels", "int<1->>", "Number of memory channels available",
                            defvalue=1)
 
     def set_bambu_memorychannels(self, channels: int,

--- a/siliconcompiler/tools/bambu/convert.py
+++ b/siliconcompiler/tools/bambu/convert.py
@@ -16,7 +16,7 @@ class ConvertTask(ASICTask, Task):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("memorychannels", "int<1->>", "Number of memory channels available",
+        self.add_parameter("memorychannels", "int<1..>", "Number of memory channels available",
                            defvalue=1)
 
     def set_bambu_memorychannels(self, channels: int,

--- a/siliconcompiler/tools/builtin/verify.py
+++ b/siliconcompiler/tools/builtin/verify.py
@@ -57,7 +57,7 @@ class VerifyTask(BuiltinTask):
                 raise ValueError(
                     f"Missing metric for {metric} in {step}/{index}")
 
-            goal = NodeType.normalize(goal, metric_param.get(field='type'))
+            goal = NodeType.normalize(goal, NodeType.parse(metric_param.get(field='type')))
             if not utils.safecompare(value, op, goal):
                 raise ValueError(f"{self.step}/{self.index} fails '{metric}' "
                                  f"metric: {value}{op}{goal}")

--- a/siliconcompiler/tools/klayout/__init__.py
+++ b/siliconcompiler/tools/klayout/__init__.py
@@ -31,7 +31,7 @@ class KLayoutPDK(PDK):
     def __init__(self):
         super().__init__()
 
-        self.define_tool_parameter("klayout", "units", "float",
+        self.define_tool_parameter("klayout", "units", "float<0.0->>",
                                    "The stream units for KLayout.")
         self.define_tool_parameter("klayout", "hide_layers", "{str}",
                                    "A list of layer names to initially hide when "

--- a/siliconcompiler/tools/klayout/__init__.py
+++ b/siliconcompiler/tools/klayout/__init__.py
@@ -31,7 +31,7 @@ class KLayoutPDK(PDK):
     def __init__(self):
         super().__init__()
 
-        self.define_tool_parameter("klayout", "units", "float<0.0->>",
+        self.define_tool_parameter("klayout", "units", "float<0.0..>",
                                    "The stream units for KLayout.")
         self.define_tool_parameter("klayout", "hide_layers", "{str}",
                                    "A list of layer names to initially hide when "

--- a/siliconcompiler/tools/klayout/screenshot.py
+++ b/siliconcompiler/tools/klayout/screenshot.py
@@ -11,17 +11,17 @@ class ScreenshotParams(Task):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("show_resolution", "(int,int)",
+        self.add_parameter("show_resolution", "(int<1->>,int<1->>)",
                            "Horizontal and vertical resolution in pixels",
                            defvalue=(4096, 4096), unit="px")
-        self.add_parameter("show_bins", "(int,int)",
+        self.add_parameter("show_bins", "(int<1->>,int<1->>)",
                            "If greater than 1, splits the image into multiple segments along "
                            "x-axis and y-axis", defvalue=(1, 1))
-        self.add_parameter("show_margin", "float",
+        self.add_parameter("show_margin", "float<0.0->>",
                            "Margin around design in microns", defvalue=10, unit="um")
-        self.add_parameter("show_linewidth", "int",
+        self.add_parameter("show_linewidth", "int<0->>",
                            "Width of lines in detailed screenshots", defvalue=0, unit="px")
-        self.add_parameter("show_oversampling", "int",
+        self.add_parameter("show_oversampling", "int<1-3>",
                            "Image oversampling used in detailed screenshots", defvalue=2)
 
     def set_klayout_bins(self, xbins: int, ybins: int,

--- a/siliconcompiler/tools/klayout/screenshot.py
+++ b/siliconcompiler/tools/klayout/screenshot.py
@@ -11,17 +11,17 @@ class ScreenshotParams(Task):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("show_resolution", "(int<1->>,int<1->>)",
+        self.add_parameter("show_resolution", "(int<1..>,int<1..>)",
                            "Horizontal and vertical resolution in pixels",
                            defvalue=(4096, 4096), unit="px")
-        self.add_parameter("show_bins", "(int<1->>,int<1->>)",
+        self.add_parameter("show_bins", "(int<1..>,int<1..>)",
                            "If greater than 1, splits the image into multiple segments along "
                            "x-axis and y-axis", defvalue=(1, 1))
-        self.add_parameter("show_margin", "float<0.0->>",
+        self.add_parameter("show_margin", "float<0.0..>",
                            "Margin around design in microns", defvalue=10, unit="um")
-        self.add_parameter("show_linewidth", "int<0->>",
+        self.add_parameter("show_linewidth", "int<0..>",
                            "Width of lines in detailed screenshots", defvalue=0, unit="px")
-        self.add_parameter("show_oversampling", "int<1-3>",
+        self.add_parameter("show_oversampling", "int<1..3>",
                            "Image oversampling used in detailed screenshots", defvalue=2)
 
     def set_klayout_bins(self, xbins: int, ybins: int,

--- a/siliconcompiler/tools/montage/tile.py
+++ b/siliconcompiler/tools/montage/tile.py
@@ -14,7 +14,7 @@ class TileTask(ImageMagickTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("bins", "(int<1->>,int<1->>)",
+        self.add_parameter("bins", "(int<1..>,int<1..>)",
                            "Number of bins along the (x, y)-axis. If left unset, the grid size is "
                            "auto-detected from the incoming tile images.")
 

--- a/siliconcompiler/tools/montage/tile.py
+++ b/siliconcompiler/tools/montage/tile.py
@@ -14,7 +14,7 @@ class TileTask(ImageMagickTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("bins", "(int,int)",
+        self.add_parameter("bins", "(int<1->>,int<1->>)",
                            "Number of bins along the (x, y)-axis. If left unset, the grid size is "
                            "auto-detected from the incoming tile images.")
 

--- a/siliconcompiler/tools/openroad/__init__.py
+++ b/siliconcompiler/tools/openroad/__init__.py
@@ -183,13 +183,13 @@ class OpenROADStdCellLibrary(StdCellLibrary):
         self.define_tool_parameter("openroad", "tielow_cell", "(str,str)",
                                    "A tuple specifying the tie-low cell name and its output port.")
 
-        self.define_tool_parameter("openroad", "place_density", "float",
+        self.define_tool_parameter("openroad", "place_density", "float<0.0-1.0>",
                                    "The target placement density for the design.")
 
-        self.define_tool_parameter("openroad", "global_cell_padding", "int",
+        self.define_tool_parameter("openroad", "global_cell_padding", "int<0->>",
                                    "Padding to be applied to cells during global placement.",
                                    defvalue=0)
-        self.define_tool_parameter("openroad", "detailed_cell_padding", "int",
+        self.define_tool_parameter("openroad", "detailed_cell_padding", "int<0->>",
                                    "Padding to be applied to cells during detailed placement.",
                                    defvalue=0)
 
@@ -366,7 +366,7 @@ class OpenROADTask(ASICTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("debug_level", "{(str,str,int)}",
+        self.add_parameter("debug_level", "{(str,str,int<0->>)}",
                            'list of "tool key level" to enable debugging of OpenROAD')
 
     def add_openroad_debuglevel(self, tool: str, category: str, level: int,

--- a/siliconcompiler/tools/openroad/__init__.py
+++ b/siliconcompiler/tools/openroad/__init__.py
@@ -183,13 +183,13 @@ class OpenROADStdCellLibrary(StdCellLibrary):
         self.define_tool_parameter("openroad", "tielow_cell", "(str,str)",
                                    "A tuple specifying the tie-low cell name and its output port.")
 
-        self.define_tool_parameter("openroad", "place_density", "float<0.0-1.0>",
+        self.define_tool_parameter("openroad", "place_density", "float<0.0..1.0>",
                                    "The target placement density for the design.")
 
-        self.define_tool_parameter("openroad", "global_cell_padding", "int<0->>",
+        self.define_tool_parameter("openroad", "global_cell_padding", "int<0..>",
                                    "Padding to be applied to cells during global placement.",
                                    defvalue=0)
-        self.define_tool_parameter("openroad", "detailed_cell_padding", "int<0->>",
+        self.define_tool_parameter("openroad", "detailed_cell_padding", "int<0..>",
                                    "Padding to be applied to cells during detailed placement.",
                                    defvalue=0)
 
@@ -366,7 +366,7 @@ class OpenROADTask(ASICTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("debug_level", "{(str,str,int<0->>)}",
+        self.add_parameter("debug_level", "{(str,str,int<0..>)}",
                            'list of "tool key level" to enable debugging of OpenROAD')
 
     def add_openroad_debuglevel(self, tool: str, category: str, level: int,

--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -25,7 +25,7 @@ class OpenROADSTAParameter(OpenROADTask):
                            "timing derating factor to use for hold corners", defvalue=0.0)
         self.add_parameter("sta_late_timing_derate", "float",
                            "timing derating factor to use for setup corners", defvalue=0.0)
-        self.add_parameter("sta_top_n_paths", "int",
+        self.add_parameter("sta_top_n_paths", "int<1->>",
                            "number of paths to report timing for", defvalue=10)
         self.add_parameter("sta_define_path_groups", "bool",
                            "if true will generate path groups for timing reporting", defvalue=True)
@@ -277,7 +277,7 @@ class OpenROADGPLParameter(OpenROADTask):
         self.add_parameter("gpl_enable_skip_initial_place", "bool",
                            "true/false, when enabled a global placement skips the initial "
                            "placement, before the main global placement pass.", defvalue=False)
-        self.add_parameter("gpl_uniform_placement_adjustment", "float",
+        self.add_parameter("gpl_uniform_placement_adjustment", "float<0-0.99>",
                            "percent of remaining area density to apply above uniform density "
                            "(0.00 - 0.99)", defvalue=0.0)
         self.add_parameter("gpl_timing_driven", "bool",
@@ -287,9 +287,9 @@ class OpenROADGPLParameter(OpenROADTask):
                            "true/false, when true global placement will consider the routability "
                            "of the design", defvalue=True)
 
-        self.add_parameter("place_density", "float",
+        self.add_parameter("place_density", "float<0.0-1.0>",
                            "global placement density (0.0 - 1.0)")
-        self.add_parameter("pad_global_place", "int",
+        self.add_parameter("pad_global_place", "int<0->>",
                            "global placement cell padding in number of sites", defvalue=0)
 
     def set_openroad_gplskipio(self, enable: bool,
@@ -397,10 +397,10 @@ class OpenROADRSZDRVParameter(OpenROADTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("rsz_cap_margin", "float",
+        self.add_parameter("rsz_cap_margin", "float<0.0-100.0>",
                            "specifies the amount of margin to apply to max capacitance repairs in "
                            "percent (0 - 100)", defvalue=0.0)
-        self.add_parameter("rsz_slew_margin", "float",
+        self.add_parameter("rsz_slew_margin", "float<0.0-100.0>",
                            "specifies the amount of margin to apply to max slew repairs in percent "
                            "(0 - 100)", defvalue=0.0)
 
@@ -453,10 +453,10 @@ class OpenROADRSZTimingParameter(OpenROADTask):
                            "true/false, skip pin swap optimization", defvalue=True)
         self.add_parameter("rsz_skip_gate_cloning", "bool",
                            "true/false, skip gate cloning optimization", defvalue=True)
-        self.add_parameter("rsz_repair_tns", "float",
+        self.add_parameter("rsz_repair_tns", "float<0.0-100.0>",
                            "percentage of violating nets to attempt to repair (0 - 100)",
                            defvalue=100)
-        self.add_parameter("rsz_recover_power", "float",
+        self.add_parameter("rsz_recover_power", "float<0.0-100.0>",
                            "percentage of paths to attempt to recover power (0 - 100)",
                            defvalue=100)
 
@@ -550,9 +550,9 @@ class OpenROADDPLParameter(OpenROADTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("pad_detail_place", "int",
+        self.add_parameter("pad_detail_place", "int<0->>",
                            "detailed placement cell padding in number of sites", defvalue=0)
-        self.add_parameter("dpl_max_displacement", "(float,float)",
+        self.add_parameter("dpl_max_displacement", "(float<0.0->>,float<0.0->>)",
                            "maximum cell movement in detailed placement in microns, 0 will result "
                            "in the tool default maximum displacement", defvalue=(0, 0))
 
@@ -627,7 +627,7 @@ class OpenROADDPOParameter(OpenROADTask):
         self.add_parameter("dpo_enable", "bool",
                            "true/false, when true the detailed placement optimization will be "
                            "performed", defvalue=True)
-        self.add_parameter("dpo_max_displacement", "(float,float)",
+        self.add_parameter("dpo_max_displacement", "(float<0.0->>,float<0.0->>)",
                            "maximum cell movement in detailed placement optimization in microns, "
                            "0 will result in the tool default maximum displacement", unit="um",
                            defvalue=(5, 5))
@@ -671,13 +671,13 @@ class OpenROADCTSParameter(OpenROADTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("cts_distance_between_buffers", "float",
+        self.add_parameter("cts_distance_between_buffers", "float<0.0->>",
                            "maximum distance between buffers during clock tree synthesis in "
                            "microns", defvalue=100, unit="um")
-        self.add_parameter("cts_cluster_diameter", "float",
+        self.add_parameter("cts_cluster_diameter", "float<0.0->>",
                            "clustering distance to use during clock tree synthesis in microns",
                            defvalue=100, unit="um")
-        self.add_parameter("cts_cluster_size", "int",
+        self.add_parameter("cts_cluster_size", "int<1->>",
                            "number of instances in a cluster to use during clock tree synthesis",
                            defvalue=30)
         self.add_parameter("cts_balance_levels", "bool",
@@ -763,7 +763,7 @@ class OpenROADGRTGeneralParameter(OpenROADTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("grt_macro_extension", "int",
+        self.add_parameter("grt_macro_extension", "int<0->>",
                            "macro extension distance in number of gcells, this can be useful when "
                            "the detailed router needs additional space to avoid DRCs", defvalue=0)
         self.add_parameter("grt_signal_min_layer", "str",
@@ -868,7 +868,7 @@ class OpenROADGRTParameter(OpenROADGRTGeneralParameter):
         self.add_parameter("grt_allow_congestion", "bool",
                            "true/false, when true allow global routing to finish with congestion",
                            defvalue=False)
-        self.add_parameter("grt_overflow_iter", "int",
+        self.add_parameter("grt_overflow_iter", "int<1->>",
                            "maximum number of iterations to use in global routing when attempting "
                            "to solve overflow", defvalue=100)
 
@@ -910,10 +910,11 @@ class OpenROADANTParameter(OpenROADTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("ant_iterations", "int",
+        self.add_parameter("ant_iterations", "int<1->>",
                            "maximum number of repair iterations to use during antenna repairs",
                            defvalue=3)
-        self.add_parameter("ant_margin", "float", "adds a margin to the antenna ratios (0 - 100)",
+        self.add_parameter("ant_margin", "float<0.0-100.0>",
+                           "adds a margin to the antenna ratios (0 - 100)",
                            defvalue=0)
 
     def set_openroad_antiterations(self, iterations: int,
@@ -1053,9 +1054,9 @@ class OpenROADDRTParameter(_OpenROADDRTCommonParameter):
         self.add_parameter("drt_repair_pdn_vias", "str",
                            "layer to repair PDN vias on")
 
-        self.add_parameter("drt_report_interval", "int",
+        self.add_parameter("drt_report_interval", "int<1-64>",
                            "reporting interval in steps for generating a DRC report.", defvalue=5)
-        self.add_parameter("drt_end_iteration", "int",
+        self.add_parameter("drt_end_iteration", "int<1-64>",
                            "end iteration for detailed routing")
 
     def set_openroad_drtdisableviagen(self, disable: bool,
@@ -1215,7 +1216,7 @@ class APRTask(OpenROADTask):
         self.add_parameter("ord_enable_images", "bool",
                            "true/false, enable generating images of the design at the end "
                            "of the task", defvalue=True)
-        self.add_parameter("ord_heatmap_bins", "(int,int)",
+        self.add_parameter("ord_heatmap_bins", "(int<1->>,int<1->>)",
                            "number of (X, Y) bins to use for heatmap image generation",
                            defvalue=(16, 16))
 

--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -25,7 +25,7 @@ class OpenROADSTAParameter(OpenROADTask):
                            "timing derating factor to use for hold corners", defvalue=0.0)
         self.add_parameter("sta_late_timing_derate", "float",
                            "timing derating factor to use for setup corners", defvalue=0.0)
-        self.add_parameter("sta_top_n_paths", "int<1->>",
+        self.add_parameter("sta_top_n_paths", "int<1..>",
                            "number of paths to report timing for", defvalue=10)
         self.add_parameter("sta_define_path_groups", "bool",
                            "if true will generate path groups for timing reporting", defvalue=True)
@@ -277,7 +277,7 @@ class OpenROADGPLParameter(OpenROADTask):
         self.add_parameter("gpl_enable_skip_initial_place", "bool",
                            "true/false, when enabled a global placement skips the initial "
                            "placement, before the main global placement pass.", defvalue=False)
-        self.add_parameter("gpl_uniform_placement_adjustment", "float<0-0.99>",
+        self.add_parameter("gpl_uniform_placement_adjustment", "float<0..0.99>",
                            "percent of remaining area density to apply above uniform density "
                            "(0.00 - 0.99)", defvalue=0.0)
         self.add_parameter("gpl_timing_driven", "bool",
@@ -287,9 +287,9 @@ class OpenROADGPLParameter(OpenROADTask):
                            "true/false, when true global placement will consider the routability "
                            "of the design", defvalue=True)
 
-        self.add_parameter("place_density", "float<0.0-1.0>",
+        self.add_parameter("place_density", "float<0.0..1.0>",
                            "global placement density (0.0 - 1.0)")
-        self.add_parameter("pad_global_place", "int<0->>",
+        self.add_parameter("pad_global_place", "int<0..>",
                            "global placement cell padding in number of sites", defvalue=0)
 
     def set_openroad_gplskipio(self, enable: bool,
@@ -397,10 +397,10 @@ class OpenROADRSZDRVParameter(OpenROADTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("rsz_cap_margin", "float<0.0-100.0>",
+        self.add_parameter("rsz_cap_margin", "float<0.0..100.0>",
                            "specifies the amount of margin to apply to max capacitance repairs in "
                            "percent (0 - 100)", defvalue=0.0)
-        self.add_parameter("rsz_slew_margin", "float<0.0-100.0>",
+        self.add_parameter("rsz_slew_margin", "float<0.0..100.0>",
                            "specifies the amount of margin to apply to max slew repairs in percent "
                            "(0 - 100)", defvalue=0.0)
 
@@ -453,10 +453,10 @@ class OpenROADRSZTimingParameter(OpenROADTask):
                            "true/false, skip pin swap optimization", defvalue=True)
         self.add_parameter("rsz_skip_gate_cloning", "bool",
                            "true/false, skip gate cloning optimization", defvalue=True)
-        self.add_parameter("rsz_repair_tns", "float<0.0-100.0>",
+        self.add_parameter("rsz_repair_tns", "float<0.0..100.0>",
                            "percentage of violating nets to attempt to repair (0 - 100)",
                            defvalue=100)
-        self.add_parameter("rsz_recover_power", "float<0.0-100.0>",
+        self.add_parameter("rsz_recover_power", "float<0.0..100.0>",
                            "percentage of paths to attempt to recover power (0 - 100)",
                            defvalue=100)
 
@@ -550,9 +550,9 @@ class OpenROADDPLParameter(OpenROADTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("pad_detail_place", "int<0->>",
+        self.add_parameter("pad_detail_place", "int<0..>",
                            "detailed placement cell padding in number of sites", defvalue=0)
-        self.add_parameter("dpl_max_displacement", "(float<0.0->>,float<0.0->>)",
+        self.add_parameter("dpl_max_displacement", "(float<0.0..>,float<0.0..>)",
                            "maximum cell movement in detailed placement in microns, 0 will result "
                            "in the tool default maximum displacement", defvalue=(0, 0))
 
@@ -627,7 +627,7 @@ class OpenROADDPOParameter(OpenROADTask):
         self.add_parameter("dpo_enable", "bool",
                            "true/false, when true the detailed placement optimization will be "
                            "performed", defvalue=True)
-        self.add_parameter("dpo_max_displacement", "(float<0.0->>,float<0.0->>)",
+        self.add_parameter("dpo_max_displacement", "(float<0.0..>,float<0.0..>)",
                            "maximum cell movement in detailed placement optimization in microns, "
                            "0 will result in the tool default maximum displacement", unit="um",
                            defvalue=(5, 5))
@@ -671,13 +671,13 @@ class OpenROADCTSParameter(OpenROADTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("cts_distance_between_buffers", "float<0.0->>",
+        self.add_parameter("cts_distance_between_buffers", "float<0.0..>",
                            "maximum distance between buffers during clock tree synthesis in "
                            "microns", defvalue=100, unit="um")
-        self.add_parameter("cts_cluster_diameter", "float<0.0->>",
+        self.add_parameter("cts_cluster_diameter", "float<0.0..>",
                            "clustering distance to use during clock tree synthesis in microns",
                            defvalue=100, unit="um")
-        self.add_parameter("cts_cluster_size", "int<1->>",
+        self.add_parameter("cts_cluster_size", "int<1..>",
                            "number of instances in a cluster to use during clock tree synthesis",
                            defvalue=30)
         self.add_parameter("cts_balance_levels", "bool",
@@ -763,7 +763,7 @@ class OpenROADGRTGeneralParameter(OpenROADTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("grt_macro_extension", "int<0->>",
+        self.add_parameter("grt_macro_extension", "int<0..>",
                            "macro extension distance in number of gcells, this can be useful when "
                            "the detailed router needs additional space to avoid DRCs", defvalue=0)
         self.add_parameter("grt_signal_min_layer", "str",
@@ -868,7 +868,7 @@ class OpenROADGRTParameter(OpenROADGRTGeneralParameter):
         self.add_parameter("grt_allow_congestion", "bool",
                            "true/false, when true allow global routing to finish with congestion",
                            defvalue=False)
-        self.add_parameter("grt_overflow_iter", "int<1->>",
+        self.add_parameter("grt_overflow_iter", "int<1..>",
                            "maximum number of iterations to use in global routing when attempting "
                            "to solve overflow", defvalue=100)
 
@@ -910,10 +910,10 @@ class OpenROADANTParameter(OpenROADTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("ant_iterations", "int<1->>",
+        self.add_parameter("ant_iterations", "int<1..>",
                            "maximum number of repair iterations to use during antenna repairs",
                            defvalue=3)
-        self.add_parameter("ant_margin", "float<0.0-100.0>",
+        self.add_parameter("ant_margin", "float<0.0..100.0>",
                            "adds a margin to the antenna ratios (0 - 100)",
                            defvalue=0)
 
@@ -1054,9 +1054,9 @@ class OpenROADDRTParameter(_OpenROADDRTCommonParameter):
         self.add_parameter("drt_repair_pdn_vias", "str",
                            "layer to repair PDN vias on")
 
-        self.add_parameter("drt_report_interval", "int<1-64>",
+        self.add_parameter("drt_report_interval", "int<1..64>",
                            "reporting interval in steps for generating a DRC report.", defvalue=5)
-        self.add_parameter("drt_end_iteration", "int<1-64>",
+        self.add_parameter("drt_end_iteration", "int<1..64>",
                            "end iteration for detailed routing")
 
     def set_openroad_drtdisableviagen(self, disable: bool,
@@ -1216,7 +1216,7 @@ class APRTask(OpenROADTask):
         self.add_parameter("ord_enable_images", "bool",
                            "true/false, enable generating images of the design at the end "
                            "of the task", defvalue=True)
-        self.add_parameter("ord_heatmap_bins", "(int<1->>,int<1->>)",
+        self.add_parameter("ord_heatmap_bins", "(int<1..>,int<1..>)",
                            "number of (X, Y) bins to use for heatmap image generation",
                            defvalue=(16, 16))
 

--- a/siliconcompiler/tools/openroad/macro_placement.py
+++ b/siliconcompiler/tools/openroad/macro_placement.py
@@ -19,26 +19,25 @@ class MacroPlacementTask(APRTask, OpenROADSTAParameter, OpenROADGPLParameter):
                            "flag to enable or disable the creation of blockages during "
                            "macro placement", defvalue=False)
 
-        self.add_parameter("macro_place_halo", "(float,float)",
+        self.add_parameter("macro_place_halo", "(float<0.0->>,float<0.0->>)",
                            "macro halo to use when performing automated macro placement "
                            "([x, y] in microns)", unit="um")
-
-        self.add_parameter("mpl_min_instances", "int",
+        self.add_parameter("mpl_min_instances", "int<1->>",
                            "minimum number of instances to use while clustering for "
                            "macro placement")
-        self.add_parameter("mpl_max_instances", "int",
+        self.add_parameter("mpl_max_instances", "int<1->>",
                            "maximum number of instances to use while clustering for "
                            "macro placement")
-        self.add_parameter("mpl_min_macros", "int",
+        self.add_parameter("mpl_min_macros", "int<1->>",
                            "minimum number of macros to use while clustering for macro placement")
-        self.add_parameter("mpl_max_macros", "int",
+        self.add_parameter("mpl_max_macros", "int<1->>",
                            "maximum number of macros to use while clustering for macro placement")
-        self.add_parameter("mpl_max_levels", "int",
+        self.add_parameter("mpl_max_levels", "int<1->>",
                            "maximum depth of physical hierarchical tree")
-        self.add_parameter("mpl_min_aspect_ratio", "float",
+        self.add_parameter("mpl_min_aspect_ratio", "float<0.0->>",
                            "Specifies the minimum aspect ratio of its width to height of a "
                            "standard cell cluster")
-        self.add_parameter("mpl_fence", "(float,float,float,float)",
+        self.add_parameter("mpl_fence", "(float<0.0->>,float<0.0->>,float<0.0->>,float<0.0->>)",
                            "Defines the global fence bounding box coordinates (llx, lly, urx, ury)",
                            unit="um")
         self.add_parameter("mpl_bus_planning", "bool",
@@ -47,30 +46,30 @@ class MacroPlacementTask(APRTask, OpenROADSTAParameter, OpenROADGPLParameter):
                            "Specifies the target dead space percentage, which influences the "
                            "utilization of standard cell clusters")
 
-        self.add_parameter("mpl_area_weight", "float",
+        self.add_parameter("mpl_area_weight", "float<0.0->>",
                            "Weight for the area of current floorplan")
-        self.add_parameter("mpl_outline_weight", "float",
+        self.add_parameter("mpl_outline_weight", "float<0.0->>",
                            "Weight for violating the fixed outline constraint, meaning that all "
                            "clusters should be placed within the shape of their parent cluster")
-        self.add_parameter("mpl_wirelength_weight", "float",
+        self.add_parameter("mpl_wirelength_weight", "float<0.0->>",
                            "Weight for half-perimeter wirelength")
-        self.add_parameter("mpl_guidance_weight", "float",
+        self.add_parameter("mpl_guidance_weight", "float<0.0->>",
                            "Weight for guidance cost or clusters being placed near specified "
                            "regions if users provide such constraints")
-        self.add_parameter("mpl_fence_weight", "float",
+        self.add_parameter("mpl_fence_weight", "float<0.0->>",
                            "Weight for fence cost, or how far the macro is from zero fence "
                            "violation")
-        self.add_parameter("mpl_boundary_weight", "float",
+        self.add_parameter("mpl_boundary_weight", "float<0.0->>",
                            "Weight for the boundary, or how far the hard macro clusters are from "
                            "boundaries. Note that mixed macro clusters are not pushed, thus not "
                            "considered in this cost.")
-        self.add_parameter("mpl_blockage_weight", "float",
+        self.add_parameter("mpl_blockage_weight", "float<0.0->>",
                            "Weight for the boundary, or how far the hard macro clusters are from "
                            "boundaries")
-        self.add_parameter("mpl_notch_weight", "float",
+        self.add_parameter("mpl_notch_weight", "float<0.0->>",
                            "Weight for the notch, or the existence of dead space that cannot be "
                            "used for placement & routing")
-        self.add_parameter("mpl_macro_blockage_weight", "float",
+        self.add_parameter("mpl_macro_blockage_weight", "float<0.0->>",
                            "Weight for macro blockage, or the overlapping instances of the macro")
 
     def add_openroad_mplconstraints(self, constraints: Union[str, List[str]],

--- a/siliconcompiler/tools/openroad/macro_placement.py
+++ b/siliconcompiler/tools/openroad/macro_placement.py
@@ -19,25 +19,25 @@ class MacroPlacementTask(APRTask, OpenROADSTAParameter, OpenROADGPLParameter):
                            "flag to enable or disable the creation of blockages during "
                            "macro placement", defvalue=False)
 
-        self.add_parameter("macro_place_halo", "(float<0.0->>,float<0.0->>)",
+        self.add_parameter("macro_place_halo", "(float<0.0..>,float<0.0..>)",
                            "macro halo to use when performing automated macro placement "
                            "([x, y] in microns)", unit="um")
-        self.add_parameter("mpl_min_instances", "int<1->>",
+        self.add_parameter("mpl_min_instances", "int<1..>",
                            "minimum number of instances to use while clustering for "
                            "macro placement")
-        self.add_parameter("mpl_max_instances", "int<1->>",
+        self.add_parameter("mpl_max_instances", "int<1..>",
                            "maximum number of instances to use while clustering for "
                            "macro placement")
-        self.add_parameter("mpl_min_macros", "int<1->>",
+        self.add_parameter("mpl_min_macros", "int<1..>",
                            "minimum number of macros to use while clustering for macro placement")
-        self.add_parameter("mpl_max_macros", "int<1->>",
+        self.add_parameter("mpl_max_macros", "int<1..>",
                            "maximum number of macros to use while clustering for macro placement")
-        self.add_parameter("mpl_max_levels", "int<1->>",
+        self.add_parameter("mpl_max_levels", "int<1..>",
                            "maximum depth of physical hierarchical tree")
-        self.add_parameter("mpl_min_aspect_ratio", "float<0.0->>",
+        self.add_parameter("mpl_min_aspect_ratio", "float<0.0..>",
                            "Specifies the minimum aspect ratio of its width to height of a "
                            "standard cell cluster")
-        self.add_parameter("mpl_fence", "(float<0.0->>,float<0.0->>,float<0.0->>,float<0.0->>)",
+        self.add_parameter("mpl_fence", "(float<0.0..>,float<0.0..>,float<0.0..>,float<0.0..>)",
                            "Defines the global fence bounding box coordinates (llx, lly, urx, ury)",
                            unit="um")
         self.add_parameter("mpl_bus_planning", "bool",
@@ -46,30 +46,30 @@ class MacroPlacementTask(APRTask, OpenROADSTAParameter, OpenROADGPLParameter):
                            "Specifies the target dead space percentage, which influences the "
                            "utilization of standard cell clusters")
 
-        self.add_parameter("mpl_area_weight", "float<0.0->>",
+        self.add_parameter("mpl_area_weight", "float<0.0..>",
                            "Weight for the area of current floorplan")
-        self.add_parameter("mpl_outline_weight", "float<0.0->>",
+        self.add_parameter("mpl_outline_weight", "float<0.0..>",
                            "Weight for violating the fixed outline constraint, meaning that all "
                            "clusters should be placed within the shape of their parent cluster")
-        self.add_parameter("mpl_wirelength_weight", "float<0.0->>",
+        self.add_parameter("mpl_wirelength_weight", "float<0.0..>",
                            "Weight for half-perimeter wirelength")
-        self.add_parameter("mpl_guidance_weight", "float<0.0->>",
+        self.add_parameter("mpl_guidance_weight", "float<0.0..>",
                            "Weight for guidance cost or clusters being placed near specified "
                            "regions if users provide such constraints")
-        self.add_parameter("mpl_fence_weight", "float<0.0->>",
+        self.add_parameter("mpl_fence_weight", "float<0.0..>",
                            "Weight for fence cost, or how far the macro is from zero fence "
                            "violation")
-        self.add_parameter("mpl_boundary_weight", "float<0.0->>",
+        self.add_parameter("mpl_boundary_weight", "float<0.0..>",
                            "Weight for the boundary, or how far the hard macro clusters are from "
                            "boundaries. Note that mixed macro clusters are not pushed, thus not "
                            "considered in this cost.")
-        self.add_parameter("mpl_blockage_weight", "float<0.0->>",
+        self.add_parameter("mpl_blockage_weight", "float<0.0..>",
                            "Weight for the boundary, or how far the hard macro clusters are from "
                            "boundaries")
-        self.add_parameter("mpl_notch_weight", "float<0.0->>",
+        self.add_parameter("mpl_notch_weight", "float<0.0..>",
                            "Weight for the notch, or the existence of dead space that cannot be "
                            "used for placement & routing")
-        self.add_parameter("mpl_macro_blockage_weight", "float<0.0->>",
+        self.add_parameter("mpl_macro_blockage_weight", "float<0.0..>",
                            "Weight for macro blockage, or the overlapping instances of the macro")
 
     def add_openroad_mplconstraints(self, constraints: Union[str, List[str]],

--- a/siliconcompiler/tools/openroad/power_grid.py
+++ b/siliconcompiler/tools/openroad/power_grid.py
@@ -13,7 +13,7 @@ class PowerGridTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("fixed_pin_keepout", "float",
+        self.add_parameter("fixed_pin_keepout", "float<0.0->>",
                            "if > 0, applies a blockage in multiples of the routing pitch to each "
                            "fixed pin to ensure there is room for routing.", defvalue=0)
         self.add_parameter("psm_allow_missing_terminal_nets", "[str]",

--- a/siliconcompiler/tools/openroad/power_grid.py
+++ b/siliconcompiler/tools/openroad/power_grid.py
@@ -13,7 +13,7 @@ class PowerGridTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("fixed_pin_keepout", "float<0.0->>",
+        self.add_parameter("fixed_pin_keepout", "float<0.0..>",
                            "if > 0, applies a blockage in multiples of the routing pitch to each "
                            "fixed pin to ensure there is room for routing.", defvalue=0)
         self.add_parameter("psm_allow_missing_terminal_nets", "[str]",

--- a/siliconcompiler/tools/openroad/power_grid_analysis.py
+++ b/siliconcompiler/tools/openroad/power_grid_analysis.py
@@ -16,7 +16,7 @@ class PowerGridAnalysisTask(APRTask, OpenROADPSMParameter, OpenROADSTAParameter)
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("source_disconnection_rate", "float",
+        self.add_parameter("source_disconnection_rate", "float<0.0-100.0>",
                            "Fraction (0.0-100.0) of power source bumps to simulate "
                            "disconnected/failing bumps.",
                            defvalue=0.0)
@@ -31,11 +31,11 @@ class PowerGridAnalysisTask(APRTask, OpenROADPSMParameter, OpenROADSTAParameter)
         self.add_parameter("net", "{str}",
                            "Set of specific power/ground nets to analyze (e.g., VDD, VSS).")
 
-        self.add_parameter("heatmap_grid", "(float,float)",
+        self.add_parameter("heatmap_grid", "(float<0.0->>,float<0.0->>)",
                            "Resolution of the IR drop heatmap grid (x_step, y_step).",
                            defvalue=(10, 10), units="um")
 
-        self.add_parameter("external_resistance", "float",
+        self.add_parameter("external_resistance", "float<0.0->>",
                            "Resistance value to add to the power grid model to account for "
                            "external factors (e.g., package, PCB).",
                            defvalue=0, units="ohm")

--- a/siliconcompiler/tools/openroad/power_grid_analysis.py
+++ b/siliconcompiler/tools/openroad/power_grid_analysis.py
@@ -16,7 +16,7 @@ class PowerGridAnalysisTask(APRTask, OpenROADPSMParameter, OpenROADSTAParameter)
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("source_disconnection_rate", "float<0.0-100.0>",
+        self.add_parameter("source_disconnection_rate", "float<0.0..100.0>",
                            "Fraction (0.0-100.0) of power source bumps to simulate "
                            "disconnected/failing bumps.",
                            defvalue=0.0)
@@ -31,11 +31,11 @@ class PowerGridAnalysisTask(APRTask, OpenROADPSMParameter, OpenROADSTAParameter)
         self.add_parameter("net", "{str}",
                            "Set of specific power/ground nets to analyze (e.g., VDD, VSS).")
 
-        self.add_parameter("heatmap_grid", "(float<0.0->>,float<0.0->>)",
+        self.add_parameter("heatmap_grid", "(float<0.0..>,float<0.0..>)",
                            "Resolution of the IR drop heatmap grid (x_step, y_step).",
                            defvalue=(10, 10), units="um")
 
-        self.add_parameter("external_resistance", "float<0.0->>",
+        self.add_parameter("external_resistance", "float<0.0..>",
                            "Resistance value to add to the power grid model to account for "
                            "external factors (e.g., package, PCB).",
                            defvalue=0, units="ohm")

--- a/siliconcompiler/tools/openroad/rcx_bench.py
+++ b/siliconcompiler/tools/openroad/rcx_bench.py
@@ -11,7 +11,7 @@ class ORXBenchTask(OpenROADTask):
         super().__init__()
 
         self.add_parameter("max_layer", "str", "Maximum layer to generate extraction bench for")
-        self.add_parameter("bench_length", "float", "Length of bench wires",
+        self.add_parameter("bench_length", "float<0.0->>", "Length of bench wires",
                            defvalue=100, units="um")
 
     def set_openroad_benchmaxlayer(self, layer: str,

--- a/siliconcompiler/tools/openroad/rcx_bench.py
+++ b/siliconcompiler/tools/openroad/rcx_bench.py
@@ -11,7 +11,7 @@ class ORXBenchTask(OpenROADTask):
         super().__init__()
 
         self.add_parameter("max_layer", "str", "Maximum layer to generate extraction bench for")
-        self.add_parameter("bench_length", "float<0.0->>", "Length of bench wires",
+        self.add_parameter("bench_length", "float<0.0..>", "Length of bench wires",
                            defvalue=100, units="um")
 
     def set_openroad_benchmaxlayer(self, layer: str,

--- a/siliconcompiler/tools/openroad/repair_design.py
+++ b/siliconcompiler/tools/openroad/repair_design.py
@@ -11,7 +11,7 @@ class RepairDesignTask(APRTask, OpenROADSTAParameter, OpenROADRSZDRVParameter):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("ifp_tie_separation", "float",
+        self.add_parameter("ifp_tie_separation", "float<0.0->>",
                            "maximum distance between tie high/low cells in microns",
                            defvalue=0, unit="um")
 

--- a/siliconcompiler/tools/openroad/repair_design.py
+++ b/siliconcompiler/tools/openroad/repair_design.py
@@ -11,7 +11,7 @@ class RepairDesignTask(APRTask, OpenROADSTAParameter, OpenROADRSZDRVParameter):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("ifp_tie_separation", "float<0.0->>",
+        self.add_parameter("ifp_tie_separation", "float<0.0..>",
                            "maximum distance between tie high/low cells in microns",
                            defvalue=0, unit="um")
 

--- a/siliconcompiler/tools/openroad/screenshot.py
+++ b/siliconcompiler/tools/openroad/screenshot.py
@@ -11,7 +11,7 @@ class ScreenshotTask(ScreenshotTask, ShowTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("show_vertical_resolution", "int",
+        self.add_parameter("show_vertical_resolution", "int<1->>",
                            "Vertical resolution of the screenshot image",
                            defvalue=1024)
         self.add_parameter("include_report_images", "bool",

--- a/siliconcompiler/tools/openroad/screenshot.py
+++ b/siliconcompiler/tools/openroad/screenshot.py
@@ -11,7 +11,7 @@ class ScreenshotTask(ScreenshotTask, ShowTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("show_vertical_resolution", "int<1->>",
+        self.add_parameter("show_vertical_resolution", "int<1..>",
                            "Vertical resolution of the screenshot image",
                            defvalue=1024)
         self.add_parameter("include_report_images", "bool",

--- a/siliconcompiler/tools/openroad/write_data.py
+++ b/siliconcompiler/tools/openroad/write_data.py
@@ -14,7 +14,7 @@ class WriteViewsTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
         self.add_parameter("ord_abstract_lef_bloat_layers", "bool",
                            "true/false, fill all layers when writing the abstract lef",
                            defvalue=True)
-        self.add_parameter("ord_abstract_lef_bloat_factor", "int",
+        self.add_parameter("ord_abstract_lef_bloat_factor", "int<1->>",
                            "Factor to apply when writing the abstract lef", defvalue=10)
 
         self.add_parameter("write_cdl", "bool",

--- a/siliconcompiler/tools/openroad/write_data.py
+++ b/siliconcompiler/tools/openroad/write_data.py
@@ -14,7 +14,7 @@ class WriteViewsTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
         self.add_parameter("ord_abstract_lef_bloat_layers", "bool",
                            "true/false, fill all layers when writing the abstract lef",
                            defvalue=True)
-        self.add_parameter("ord_abstract_lef_bloat_factor", "int<1->>",
+        self.add_parameter("ord_abstract_lef_bloat_factor", "int<1..>",
                            "Factor to apply when writing the abstract lef", defvalue=10)
 
         self.add_parameter("write_cdl", "bool",

--- a/siliconcompiler/tools/opensta/timing.py
+++ b/siliconcompiler/tools/opensta/timing.py
@@ -18,7 +18,7 @@ class TimingTaskBase(OpenSTATask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("top_n_paths", "int", "number of paths to report timing for",
+        self.add_parameter("top_n_paths", "int<1->>", "number of paths to report timing for",
                            defvalue=10)
         self.add_parameter("unique_path_groups_per_clock", "bool",
                            "if true will generate separate path groups per clock", defvalue=False)

--- a/siliconcompiler/tools/opensta/timing.py
+++ b/siliconcompiler/tools/opensta/timing.py
@@ -18,7 +18,7 @@ class TimingTaskBase(OpenSTATask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("top_n_paths", "int<1->>", "number of paths to report timing for",
+        self.add_parameter("top_n_paths", "int<1..>", "number of paths to report timing for",
                            defvalue=10)
         self.add_parameter("unique_path_groups_per_clock", "bool",
                            "if true will generate separate path groups per clock", defvalue=False)

--- a/siliconcompiler/tools/verilator/compile.py
+++ b/siliconcompiler/tools/verilator/compile.py
@@ -33,7 +33,7 @@ class CompileTask(VerilatorTask):
         self.add_parameter("ldflags", "[str]",
                            "flags to provide to the linker invoked by Verilator")
 
-        self.add_parameter("pins_bv", "int",
+        self.add_parameter("pins_bv", "int<1->>",
                            "controls datatypes used to represent SystemC inputs/outputs. "
                            "See --pins-bv in Verilator docs for more info")
 

--- a/siliconcompiler/tools/verilator/compile.py
+++ b/siliconcompiler/tools/verilator/compile.py
@@ -33,7 +33,7 @@ class CompileTask(VerilatorTask):
         self.add_parameter("ldflags", "[str]",
                            "flags to provide to the linker invoked by Verilator")
 
-        self.add_parameter("pins_bv", "int<1->>",
+        self.add_parameter("pins_bv", "int<1..>",
                            "controls datatypes used to represent SystemC inputs/outputs. "
                            "See --pins-bv in Verilator docs for more info")
 

--- a/siliconcompiler/tools/vpr/__init__.py
+++ b/siliconcompiler/tools/vpr/__init__.py
@@ -46,7 +46,7 @@ class VPRFPGA(FPGADevice):
 
         self.define_tool_parameter("vpr", "devicecode", "str",
                                    "The name or code for the target FPGA device.")
-        self.define_tool_parameter("vpr", "channelwidth", "int",
+        self.define_tool_parameter("vpr", "channelwidth", "int<1->>",
                                    "The channel width to be used during routing.")
 
         self.define_tool_parameter("vpr", "registers", "{str}",
@@ -200,7 +200,8 @@ class VPRTask(Task):
         self.add_parameter("enable_images", "bool",
                            "true/false generate images of the design at the end of the task",
                            defvalue=True)
-        self.add_parameter("timing_paths", "int", "number of timing paths to report", defvalue=20)
+        self.add_parameter("timing_paths", "int<1->>", "number of timing paths to report",
+                           defvalue=20)
         self.add_parameter("timing_report_type",
                            "<netlist,aggregated,detailed,debug>",
                            "level of detail for timing reports: vpr --timing_report_detail",

--- a/siliconcompiler/tools/vpr/__init__.py
+++ b/siliconcompiler/tools/vpr/__init__.py
@@ -46,7 +46,7 @@ class VPRFPGA(FPGADevice):
 
         self.define_tool_parameter("vpr", "devicecode", "str",
                                    "The name or code for the target FPGA device.")
-        self.define_tool_parameter("vpr", "channelwidth", "int<1->>",
+        self.define_tool_parameter("vpr", "channelwidth", "int<1..>",
                                    "The channel width to be used during routing.")
 
         self.define_tool_parameter("vpr", "registers", "{str}",
@@ -200,7 +200,7 @@ class VPRTask(Task):
         self.add_parameter("enable_images", "bool",
                            "true/false generate images of the design at the end of the task",
                            defvalue=True)
-        self.add_parameter("timing_paths", "int<1->>", "number of timing paths to report",
+        self.add_parameter("timing_paths", "int<1..>", "number of timing paths to report",
                            defvalue=20)
         self.add_parameter("timing_report_type",
                            "<netlist,aggregated,detailed,debug>",

--- a/siliconcompiler/tools/vpr/route.py
+++ b/siliconcompiler/tools/vpr/route.py
@@ -11,7 +11,7 @@ class RouteTask(VPRTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("max_router_iterations", "int",
+        self.add_parameter("max_router_iterations", "int<1->>",
                            "set maximum number of routing iterations", defvalue=50)
         self.add_parameter("gen_post_implementation_netlist", "bool",
                            "set to true to have VPR generate a post-implementation netlist",

--- a/siliconcompiler/tools/vpr/route.py
+++ b/siliconcompiler/tools/vpr/route.py
@@ -11,7 +11,7 @@ class RouteTask(VPRTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("max_router_iterations", "int<1->>",
+        self.add_parameter("max_router_iterations", "int<1..>",
                            "set maximum number of routing iterations", defvalue=50)
         self.add_parameter("gen_post_implementation_netlist", "bool",
                            "set to true to have VPR generate a post-implementation netlist",

--- a/siliconcompiler/tools/yosys/lec_asic.py
+++ b/siliconcompiler/tools/yosys/lec_asic.py
@@ -13,7 +13,7 @@ class ASICLECTask(_ASICTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("induction_steps", "int",
+        self.add_parameter("induction_steps", "int<1->>",
                            "Number of induction steps for yosys equivalence checking", defvalue=10)
 
     def set_yosys_inductionsteps(self, steps: int,

--- a/siliconcompiler/tools/yosys/lec_asic.py
+++ b/siliconcompiler/tools/yosys/lec_asic.py
@@ -13,7 +13,7 @@ class ASICLECTask(_ASICTask):
     def __init__(self):
         super().__init__()
 
-        self.add_parameter("induction_steps", "int<1->>",
+        self.add_parameter("induction_steps", "int<1..>",
                            "Number of induction steps for yosys equivalence checking", defvalue=10)
 
     def set_yosys_inductionsteps(self, steps: int,

--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -278,7 +278,7 @@ class ASICSynthesis(_ASICTask, YosysTask):
             True)
         self.add_parameter(
             "hier_threshold",
-            "int<1->>",
+            "int<1..>",
             "Instance limit for the number of cells in a module to preserve.",
             1000)
         self.add_parameter(
@@ -303,18 +303,18 @@ class ASICSynthesis(_ASICTask, YosysTask):
             copy=False)
         self.add_parameter(
             "abc_clock_period",
-            "float<0.0->>",
+            "float<0.0..>",
             "Clock period to use for synthesis in ps, if more than one clock is specified, the "
             "smallest period is used.",
             unit="ps")
         self.add_parameter(
             "abc_constraint_load",
-            "float<0.0->>",
+            "float<0.0..>",
             "Capacitive load for the abc techmapping in fF, if not specified it will not be used.",
             unit="fF")
         self.add_parameter(
             "abc_clock_derating",
-            "float<0.0->>",
+            "float<0.0..>",
             "Derating to apply to the clock period for abc synthesis",
             defvalue=0
         )
@@ -327,7 +327,7 @@ class ASICSynthesis(_ASICTask, YosysTask):
             False)
         self.add_parameter(
             "min_clockgate_fanout",
-            "int<1->>",
+            "int<1..>",
             "Minimum clockgate fanout.",
             8)
 

--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -278,7 +278,7 @@ class ASICSynthesis(_ASICTask, YosysTask):
             True)
         self.add_parameter(
             "hier_threshold",
-            "int",
+            "int<1->>",
             "Instance limit for the number of cells in a module to preserve.",
             1000)
         self.add_parameter(
@@ -303,18 +303,18 @@ class ASICSynthesis(_ASICTask, YosysTask):
             copy=False)
         self.add_parameter(
             "abc_clock_period",
-            "float",
+            "float<0.0->>",
             "Clock period to use for synthesis in ps, if more than one clock is specified, the "
             "smallest period is used.",
             unit="ps")
         self.add_parameter(
             "abc_constraint_load",
-            "float",
+            "float<0.0->>",
             "Capacitive load for the abc techmapping in fF, if not specified it will not be used.",
             unit="fF")
         self.add_parameter(
             "abc_clock_derating",
-            "float",
+            "float<0.0->>",
             "Derating to apply to the clock period for abc synthesis",
             defvalue=0
         )
@@ -327,7 +327,7 @@ class ASICSynthesis(_ASICTask, YosysTask):
             False)
         self.add_parameter(
             "min_clockgate_fanout",
-            "int",
+            "int<1->>",
             "Minimum clockgate fanout.",
             8)
 

--- a/tests/constraints/test_asic_pins.py
+++ b/tests/constraints/test_asic_pins.py
@@ -188,10 +188,8 @@ def test_set_get_order(pin_constraint):
     """Test setting and getting pin order."""
     pin_constraint.set_order(5)
     assert pin_constraint.get_order() == 5
-    pin_constraint.set_order(0)  # Order can be 0 or negative based on context, no validation here
+    pin_constraint.set_order(0)
     assert pin_constraint.get_order() == 0
-    pin_constraint.set_order(-2)
-    assert pin_constraint.get_order() == -2
 
 
 def test_set_get_order_step_index():

--- a/tests/data/defaults.json
+++ b/tests/data/defaults.json
@@ -367,7 +367,7 @@
               },
               "weight": {
                 "default": {
-                  "type": "float<0.0->>",
+                  "type": "float<0.0..>",
                   "require": false,
                   "scope": "global",
                   "lock": false,
@@ -534,7 +534,7 @@
       },
       "metric": {
         "errors": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -559,7 +559,7 @@
           }
         },
         "warnings": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -584,7 +584,7 @@
           }
         },
         "memory": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -610,7 +610,7 @@
           "unit": "B"
         },
         "exetime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -636,7 +636,7 @@
           "unit": "s"
         },
         "tasktime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -662,7 +662,7 @@
           "unit": "s"
         },
         "totaltime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -1990,7 +1990,7 @@
                 "copy": true
               },
               "threads": {
-                "type": "int<1->>",
+                "type": "int<1..>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -2110,7 +2110,7 @@
           "copy": false
         },
         "nice": {
-          "type": "int<-20-19>",
+          "type": "int<-20..19>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -2160,7 +2160,7 @@
           }
         },
         "optmode": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -2541,7 +2541,7 @@
           }
         },
         "timeout": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -2734,7 +2734,7 @@
             }
           },
           "cores": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -2910,7 +2910,7 @@
             }
           },
           "maxnodes": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -2935,7 +2935,7 @@
             }
           },
           "maxthreads": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -3339,7 +3339,7 @@
               },
               "weight": {
                 "default": {
-                  "type": "float<0.0->>",
+                  "type": "float<0.0..>",
                   "require": false,
                   "scope": "global",
                   "lock": false,
@@ -3506,7 +3506,7 @@
       },
       "metric": {
         "errors": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3531,7 +3531,7 @@
           }
         },
         "warnings": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3556,7 +3556,7 @@
           }
         },
         "memory": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3582,7 +3582,7 @@
           "unit": "B"
         },
         "exetime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3608,7 +3608,7 @@
           "unit": "s"
         },
         "tasktime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3634,7 +3634,7 @@
           "unit": "s"
         },
         "totaltime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3660,7 +3660,7 @@
           "unit": "s"
         },
         "unconstrained": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3685,7 +3685,7 @@
           }
         },
         "luts": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3710,7 +3710,7 @@
           }
         },
         "dsps": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3735,7 +3735,7 @@
           }
         },
         "brams": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3760,7 +3760,7 @@
           }
         },
         "utilization": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3786,7 +3786,7 @@
           "unit": "%"
         },
         "logicdepth": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3889,7 +3889,7 @@
           "unit": "mw"
         },
         "holdpaths": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3914,7 +3914,7 @@
           }
         },
         "setuppaths": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4147,7 +4147,7 @@
           "unit": "ns"
         },
         "fmax": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4173,7 +4173,7 @@
           "unit": "Hz"
         },
         "macros": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4198,7 +4198,7 @@
           }
         },
         "cells": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4223,7 +4223,7 @@
           }
         },
         "registers": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4248,7 +4248,7 @@
           }
         },
         "pins": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4273,7 +4273,7 @@
           }
         },
         "nets": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4298,7 +4298,7 @@
           }
         },
         "wirelength": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -5650,7 +5650,7 @@
                 "copy": true
               },
               "threads": {
-                "type": "int<1->>",
+                "type": "int<1..>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -5770,7 +5770,7 @@
           "copy": false
         },
         "nice": {
-          "type": "int<-20-19>",
+          "type": "int<-20..19>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -5820,7 +5820,7 @@
           }
         },
         "optmode": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -6201,7 +6201,7 @@
           }
         },
         "timeout": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -6394,7 +6394,7 @@
             }
           },
           "cores": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -6570,7 +6570,7 @@
             }
           },
           "maxnodes": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -6595,7 +6595,7 @@
             }
           },
           "maxthreads": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -7109,7 +7109,7 @@
               },
               "weight": {
                 "default": {
-                  "type": "float<0.0->>",
+                  "type": "float<0.0..>",
                   "require": false,
                   "scope": "global",
                   "lock": false,
@@ -7276,7 +7276,7 @@
       },
       "metric": {
         "errors": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7301,7 +7301,7 @@
           }
         },
         "warnings": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7326,7 +7326,7 @@
           }
         },
         "memory": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7352,7 +7352,7 @@
           "unit": "B"
         },
         "exetime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7378,7 +7378,7 @@
           "unit": "s"
         },
         "tasktime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7404,7 +7404,7 @@
           "unit": "s"
         },
         "totaltime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7430,7 +7430,7 @@
           "unit": "s"
         },
         "drvs": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7455,7 +7455,7 @@
           }
         },
         "drcs": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7480,7 +7480,7 @@
           }
         },
         "unconstrained": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7505,7 +7505,7 @@
           }
         },
         "cellarea": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7531,7 +7531,7 @@
           "unit": "um^2"
         },
         "totalarea": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7557,7 +7557,7 @@
           "unit": "um^2"
         },
         "macroarea": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7583,7 +7583,7 @@
           "unit": "um^2"
         },
         "padcellarea": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7609,7 +7609,7 @@
           "unit": "um^2"
         },
         "stdcellarea": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7635,7 +7635,7 @@
           "unit": "um^2"
         },
         "utilization": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7661,7 +7661,7 @@
           "unit": "%"
         },
         "logicdepth": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7790,7 +7790,7 @@
           "unit": "mv"
         },
         "holdpaths": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7815,7 +7815,7 @@
           }
         },
         "setuppaths": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8048,7 +8048,7 @@
           "unit": "ns"
         },
         "fmax": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8074,7 +8074,7 @@
           "unit": "Hz"
         },
         "macros": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8099,7 +8099,7 @@
           }
         },
         "cells": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8124,7 +8124,7 @@
           }
         },
         "registers": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8149,7 +8149,7 @@
           }
         },
         "buffers": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8174,7 +8174,7 @@
           }
         },
         "inverters": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8199,7 +8199,7 @@
           }
         },
         "transistors": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8224,7 +8224,7 @@
           }
         },
         "pins": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8249,7 +8249,7 @@
           }
         },
         "nets": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8274,7 +8274,7 @@
           }
         },
         "vias": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8299,7 +8299,7 @@
           }
         },
         "wirelength": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -9652,7 +9652,7 @@
                 "copy": true
               },
               "threads": {
-                "type": "int<1->>",
+                "type": "int<1..>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -9772,7 +9772,7 @@
           "copy": false
         },
         "nice": {
-          "type": "int<-20-19>",
+          "type": "int<-20..19>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -9822,7 +9822,7 @@
           }
         },
         "optmode": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -10203,7 +10203,7 @@
           }
         },
         "timeout": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -10396,7 +10396,7 @@
             }
           },
           "cores": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -10572,7 +10572,7 @@
             }
           },
           "maxnodes": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -10597,7 +10597,7 @@
             }
           },
           "maxthreads": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -10982,7 +10982,7 @@
               "unit": "um"
             },
             "width": {
-              "type": "float<0.0->>",
+              "type": "float<0.0..>",
               "require": false,
               "scope": "global",
               "lock": false,
@@ -11005,7 +11005,7 @@
               "unit": "um"
             },
             "length": {
-              "type": "float<0.0->>",
+              "type": "float<0.0..>",
               "require": false,
               "scope": "global",
               "lock": false,
@@ -11072,7 +11072,7 @@
               }
             },
             "side": {
-              "type": "int<1->>",
+              "type": "int<1..>",
               "require": false,
               "scope": "global",
               "lock": false,
@@ -11094,7 +11094,7 @@
               }
             },
             "order": {
-              "type": "int<0->>",
+              "type": "int<0..>",
               "require": false,
               "scope": "global",
               "lock": false,
@@ -11177,7 +11177,7 @@
             "unit": "um"
           },
           "coremargin": {
-            "type": "float<0.0->>",
+            "type": "float<0.0..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -11202,7 +11202,7 @@
             "unit": "um"
           },
           "density": {
-            "type": "float<0.0-100.0>",
+            "type": "float<0.0..100.0>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -11226,7 +11226,7 @@
             }
           },
           "aspectratio": {
-            "type": "float<0.0->>",
+            "type": "float<0.0..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -11765,7 +11765,7 @@
               },
               "weight": {
                 "default": {
-                  "type": "float<0.0->>",
+                  "type": "float<0.0..>",
                   "require": false,
                   "scope": "global",
                   "lock": false,
@@ -11932,7 +11932,7 @@
       },
       "metric": {
         "errors": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -11957,7 +11957,7 @@
           }
         },
         "warnings": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -11982,7 +11982,7 @@
           }
         },
         "memory": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -12008,7 +12008,7 @@
           "unit": "B"
         },
         "exetime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -12034,7 +12034,7 @@
           "unit": "s"
         },
         "tasktime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -12060,7 +12060,7 @@
           "unit": "s"
         },
         "totaltime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -13388,7 +13388,7 @@
                 "copy": true
               },
               "threads": {
-                "type": "int<1->>",
+                "type": "int<1..>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -13508,7 +13508,7 @@
           "copy": false
         },
         "nice": {
-          "type": "int<-20-19>",
+          "type": "int<-20..19>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -13558,7 +13558,7 @@
           }
         },
         "optmode": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -13939,7 +13939,7 @@
           }
         },
         "timeout": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -14132,7 +14132,7 @@
             }
           },
           "cores": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -14308,7 +14308,7 @@
             }
           },
           "maxnodes": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -14333,7 +14333,7 @@
             }
           },
           "maxthreads": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -14737,7 +14737,7 @@
               },
               "weight": {
                 "default": {
-                  "type": "float<0.0->>",
+                  "type": "float<0.0..>",
                   "require": false,
                   "scope": "global",
                   "lock": false,
@@ -14904,7 +14904,7 @@
       },
       "metric": {
         "errors": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -14929,7 +14929,7 @@
           }
         },
         "warnings": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -14954,7 +14954,7 @@
           }
         },
         "memory": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -14980,7 +14980,7 @@
           "unit": "B"
         },
         "exetime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -15006,7 +15006,7 @@
           "unit": "s"
         },
         "tasktime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -15032,7 +15032,7 @@
           "unit": "s"
         },
         "totaltime": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -16360,7 +16360,7 @@
                 "copy": true
               },
               "threads": {
-                "type": "int<1->>",
+                "type": "int<1..>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -16480,7 +16480,7 @@
           "copy": false
         },
         "nice": {
-          "type": "int<-20-19>",
+          "type": "int<-20..19>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -16530,7 +16530,7 @@
           }
         },
         "optmode": {
-          "type": "int<0->>",
+          "type": "int<0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -16911,7 +16911,7 @@
           }
         },
         "timeout": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -17104,7 +17104,7 @@
             }
           },
           "cores": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -17280,7 +17280,7 @@
             }
           },
           "maxnodes": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -17305,7 +17305,7 @@
             }
           },
           "maxthreads": {
-            "type": "int<1->>",
+            "type": "int<1..>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -18903,7 +18903,7 @@
           }
         },
         "node": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -19004,7 +19004,7 @@
           }
         },
         "wafersize": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -19030,7 +19030,7 @@
           "unit": "mm"
         },
         "unitcost": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -19056,7 +19056,7 @@
           "unit": "USD"
         },
         "d0": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -19107,7 +19107,7 @@
           "unit": "mm"
         },
         "edgemargin": {
-          "type": "float<0.0->>",
+          "type": "float<0.0..>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -20312,7 +20312,7 @@
           }
         },
         "lutsize": {
-          "type": "int<1->>",
+          "type": "int<1..>",
           "require": false,
           "scope": "global",
           "lock": false,

--- a/tests/data/defaults.json
+++ b/tests/data/defaults.json
@@ -17,7 +17,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.55.0",
+              "value": "0.56.0",
               "signature": null
             }
           }
@@ -367,7 +367,7 @@
               },
               "weight": {
                 "default": {
-                  "type": "float",
+                  "type": "float<0.0->>",
                   "require": false,
                   "scope": "global",
                   "lock": false,
@@ -534,7 +534,7 @@
       },
       "metric": {
         "errors": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -559,7 +559,7 @@
           }
         },
         "warnings": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -584,7 +584,7 @@
           }
         },
         "memory": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -610,7 +610,7 @@
           "unit": "B"
         },
         "exetime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -636,7 +636,7 @@
           "unit": "s"
         },
         "tasktime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -662,7 +662,7 @@
           "unit": "s"
         },
         "totaltime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -1990,7 +1990,7 @@
                 "copy": true
               },
               "threads": {
-                "type": "int",
+                "type": "int<1->>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -2110,7 +2110,7 @@
           "copy": false
         },
         "nice": {
-          "type": "int",
+          "type": "int<-20-19>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -2160,7 +2160,7 @@
           }
         },
         "optmode": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -2541,7 +2541,7 @@
           }
         },
         "timeout": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -2734,7 +2734,7 @@
             }
           },
           "cores": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -2910,7 +2910,7 @@
             }
           },
           "maxnodes": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -2935,7 +2935,7 @@
             }
           },
           "maxthreads": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -2989,7 +2989,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.55.0",
+              "value": "0.56.0",
               "signature": null
             }
           }
@@ -3339,7 +3339,7 @@
               },
               "weight": {
                 "default": {
-                  "type": "float",
+                  "type": "float<0.0->>",
                   "require": false,
                   "scope": "global",
                   "lock": false,
@@ -3506,7 +3506,7 @@
       },
       "metric": {
         "errors": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3531,7 +3531,7 @@
           }
         },
         "warnings": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3556,7 +3556,7 @@
           }
         },
         "memory": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3582,7 +3582,7 @@
           "unit": "B"
         },
         "exetime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3608,7 +3608,7 @@
           "unit": "s"
         },
         "tasktime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3634,7 +3634,7 @@
           "unit": "s"
         },
         "totaltime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3660,7 +3660,7 @@
           "unit": "s"
         },
         "unconstrained": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3685,7 +3685,7 @@
           }
         },
         "luts": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3710,7 +3710,7 @@
           }
         },
         "dsps": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3735,7 +3735,7 @@
           }
         },
         "brams": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3760,7 +3760,7 @@
           }
         },
         "utilization": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3786,7 +3786,7 @@
           "unit": "%"
         },
         "logicdepth": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3889,7 +3889,7 @@
           "unit": "mw"
         },
         "holdpaths": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -3914,7 +3914,7 @@
           }
         },
         "setuppaths": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4147,7 +4147,7 @@
           "unit": "ns"
         },
         "fmax": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4173,7 +4173,7 @@
           "unit": "Hz"
         },
         "macros": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4198,7 +4198,7 @@
           }
         },
         "cells": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4223,7 +4223,7 @@
           }
         },
         "registers": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4248,7 +4248,7 @@
           }
         },
         "pins": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4273,7 +4273,7 @@
           }
         },
         "nets": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -4298,7 +4298,7 @@
           }
         },
         "wirelength": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -5650,7 +5650,7 @@
                 "copy": true
               },
               "threads": {
-                "type": "int",
+                "type": "int<1->>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -5770,7 +5770,7 @@
           "copy": false
         },
         "nice": {
-          "type": "int",
+          "type": "int<-20-19>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -5820,7 +5820,7 @@
           }
         },
         "optmode": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -6201,7 +6201,7 @@
           }
         },
         "timeout": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -6394,7 +6394,7 @@
             }
           },
           "cores": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -6570,7 +6570,7 @@
             }
           },
           "maxnodes": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -6595,7 +6595,7 @@
             }
           },
           "maxthreads": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -6759,7 +6759,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.55.0",
+              "value": "0.56.0",
               "signature": null
             }
           }
@@ -7109,7 +7109,7 @@
               },
               "weight": {
                 "default": {
-                  "type": "float",
+                  "type": "float<0.0->>",
                   "require": false,
                   "scope": "global",
                   "lock": false,
@@ -7276,7 +7276,7 @@
       },
       "metric": {
         "errors": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7301,7 +7301,7 @@
           }
         },
         "warnings": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7326,7 +7326,7 @@
           }
         },
         "memory": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7352,7 +7352,7 @@
           "unit": "B"
         },
         "exetime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7378,7 +7378,7 @@
           "unit": "s"
         },
         "tasktime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7404,7 +7404,7 @@
           "unit": "s"
         },
         "totaltime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7430,7 +7430,7 @@
           "unit": "s"
         },
         "drvs": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7455,7 +7455,7 @@
           }
         },
         "drcs": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7480,7 +7480,7 @@
           }
         },
         "unconstrained": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7505,7 +7505,7 @@
           }
         },
         "cellarea": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7531,7 +7531,7 @@
           "unit": "um^2"
         },
         "totalarea": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7557,7 +7557,7 @@
           "unit": "um^2"
         },
         "macroarea": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7583,7 +7583,7 @@
           "unit": "um^2"
         },
         "padcellarea": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7609,7 +7609,7 @@
           "unit": "um^2"
         },
         "stdcellarea": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7635,7 +7635,7 @@
           "unit": "um^2"
         },
         "utilization": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7661,7 +7661,7 @@
           "unit": "%"
         },
         "logicdepth": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7790,7 +7790,7 @@
           "unit": "mv"
         },
         "holdpaths": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -7815,7 +7815,7 @@
           }
         },
         "setuppaths": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8048,7 +8048,7 @@
           "unit": "ns"
         },
         "fmax": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8074,7 +8074,7 @@
           "unit": "Hz"
         },
         "macros": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8099,7 +8099,7 @@
           }
         },
         "cells": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8124,7 +8124,7 @@
           }
         },
         "registers": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8149,7 +8149,7 @@
           }
         },
         "buffers": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8174,7 +8174,7 @@
           }
         },
         "inverters": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8199,7 +8199,7 @@
           }
         },
         "transistors": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8224,7 +8224,7 @@
           }
         },
         "pins": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8249,7 +8249,7 @@
           }
         },
         "nets": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8274,7 +8274,7 @@
           }
         },
         "vias": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -8299,7 +8299,7 @@
           }
         },
         "wirelength": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -9652,7 +9652,7 @@
                 "copy": true
               },
               "threads": {
-                "type": "int",
+                "type": "int<1->>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -9772,7 +9772,7 @@
           "copy": false
         },
         "nice": {
-          "type": "int",
+          "type": "int<-20-19>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -9822,7 +9822,7 @@
           }
         },
         "optmode": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -10203,7 +10203,7 @@
           }
         },
         "timeout": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -10396,7 +10396,7 @@
             }
           },
           "cores": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -10572,7 +10572,7 @@
             }
           },
           "maxnodes": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -10597,7 +10597,7 @@
             }
           },
           "maxthreads": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -10982,7 +10982,7 @@
               "unit": "um"
             },
             "width": {
-              "type": "float",
+              "type": "float<0.0->>",
               "require": false,
               "scope": "global",
               "lock": false,
@@ -11005,7 +11005,7 @@
               "unit": "um"
             },
             "length": {
-              "type": "float",
+              "type": "float<0.0->>",
               "require": false,
               "scope": "global",
               "lock": false,
@@ -11072,7 +11072,7 @@
               }
             },
             "side": {
-              "type": "int",
+              "type": "int<1->>",
               "require": false,
               "scope": "global",
               "lock": false,
@@ -11094,7 +11094,7 @@
               }
             },
             "order": {
-              "type": "int",
+              "type": "int<0->>",
               "require": false,
               "scope": "global",
               "lock": false,
@@ -11177,7 +11177,7 @@
             "unit": "um"
           },
           "coremargin": {
-            "type": "float",
+            "type": "float<0.0->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -11202,7 +11202,7 @@
             "unit": "um"
           },
           "density": {
-            "type": "float",
+            "type": "float<0.0-100.0>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -11226,7 +11226,7 @@
             }
           },
           "aspectratio": {
-            "type": "float",
+            "type": "float<0.0->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -11415,7 +11415,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.55.0",
+              "value": "0.56.0",
               "signature": null
             }
           }
@@ -11765,7 +11765,7 @@
               },
               "weight": {
                 "default": {
-                  "type": "float",
+                  "type": "float<0.0->>",
                   "require": false,
                   "scope": "global",
                   "lock": false,
@@ -11932,7 +11932,7 @@
       },
       "metric": {
         "errors": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -11957,7 +11957,7 @@
           }
         },
         "warnings": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -11982,7 +11982,7 @@
           }
         },
         "memory": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -12008,7 +12008,7 @@
           "unit": "B"
         },
         "exetime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -12034,7 +12034,7 @@
           "unit": "s"
         },
         "tasktime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -12060,7 +12060,7 @@
           "unit": "s"
         },
         "totaltime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -13388,7 +13388,7 @@
                 "copy": true
               },
               "threads": {
-                "type": "int",
+                "type": "int<1->>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -13508,7 +13508,7 @@
           "copy": false
         },
         "nice": {
-          "type": "int",
+          "type": "int<-20-19>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -13558,7 +13558,7 @@
           }
         },
         "optmode": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -13939,7 +13939,7 @@
           }
         },
         "timeout": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -14132,7 +14132,7 @@
             }
           },
           "cores": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -14308,7 +14308,7 @@
             }
           },
           "maxnodes": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -14333,7 +14333,7 @@
             }
           },
           "maxthreads": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -14387,7 +14387,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.55.0",
+              "value": "0.56.0",
               "signature": null
             }
           }
@@ -14737,7 +14737,7 @@
               },
               "weight": {
                 "default": {
-                  "type": "float",
+                  "type": "float<0.0->>",
                   "require": false,
                   "scope": "global",
                   "lock": false,
@@ -14904,7 +14904,7 @@
       },
       "metric": {
         "errors": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -14929,7 +14929,7 @@
           }
         },
         "warnings": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -14954,7 +14954,7 @@
           }
         },
         "memory": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -14980,7 +14980,7 @@
           "unit": "B"
         },
         "exetime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -15006,7 +15006,7 @@
           "unit": "s"
         },
         "tasktime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -15032,7 +15032,7 @@
           "unit": "s"
         },
         "totaltime": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "job",
           "lock": false,
@@ -16360,7 +16360,7 @@
                 "copy": true
               },
               "threads": {
-                "type": "int",
+                "type": "int<1->>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -16480,7 +16480,7 @@
           "copy": false
         },
         "nice": {
-          "type": "int",
+          "type": "int<-20-19>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -16530,7 +16530,7 @@
           }
         },
         "optmode": {
-          "type": "int",
+          "type": "int<0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -16911,7 +16911,7 @@
           }
         },
         "timeout": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -17104,7 +17104,7 @@
             }
           },
           "cores": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -17280,7 +17280,7 @@
             }
           },
           "maxnodes": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -17305,7 +17305,7 @@
             }
           },
           "maxthreads": {
-            "type": "int",
+            "type": "int<1->>",
             "require": false,
             "scope": "global",
             "lock": false,
@@ -18903,7 +18903,7 @@
           }
         },
         "node": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -19004,7 +19004,7 @@
           }
         },
         "wafersize": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -19030,7 +19030,7 @@
           "unit": "mm"
         },
         "unitcost": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -19056,7 +19056,7 @@
           "unit": "USD"
         },
         "d0": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -19107,7 +19107,7 @@
           "unit": "mm"
         },
         "edgemargin": {
-          "type": "float",
+          "type": "float<0.0->>",
           "require": false,
           "scope": "global",
           "lock": false,
@@ -20312,7 +20312,7 @@
           }
         },
         "lutsize": {
-          "type": "int",
+          "type": "int<1->>",
           "require": false,
           "scope": "global",
           "lock": false,

--- a/tests/schema/test_parametertype.py
+++ b/tests/schema/test_parametertype.py
@@ -188,11 +188,11 @@ def test_encode_invalid():
         (NodeType("(str,float)"), (1, 2.5), ("1", 2.5)),
         ("str<one,two,three>", "one", "one"),
         ("int<0,2,5>", "2", 2),
-        ("int<0-5>", "2", 2),
-        ("int<0,2,5-9>", "8", 8),
+        ("int<0..5>", "2", 2),
+        ("int<0,2,5..9>", "8", 8),
         ("float<0,2.1,5>", "2.1", 2.1),
-        ("float<0-5>", "2.5", 2.5),
-        ("float<0,2,5-9>", "8.7", 8.7),
+        ("float<0..5>", "2.5", 2.5),
+        ("float<0,2,5..9>", "8.7", 8.7),
     ])
 def test_normalize(type, value, expect):
     norm = NodeType.normalize(value, NodeType.parse(type))
@@ -211,7 +211,7 @@ def test_normalize(type, value, expect):
         ("str", "test$next[0]", "\"test\\$next\\[0]\""),
         ("str", "test\\next", "\"test\\\\next\""),
         ("int", 1, "1"),
-        ("int<0-5>", 1, "1"),
+        ("int<0..5>", 1, "1"),
         ("float", 1e5, "100000"),
         ("float", 10.5e-6, "1.05e-05"),
         ("float", 100.555555555e-12, "1.00555556e-10"),
@@ -268,7 +268,7 @@ def test_normalize_value_int_range():
     assert NodeType.normalize("6", range) == 6
     assert NodeType.normalize("7", range) == 7
 
-    with pytest.raises(ValueError, match=r"^8 is not in range: 0, 2, 5-7$"):
+    with pytest.raises(ValueError, match=r"^8 is not in range: 0, 2, 5\.\.7$"):
         NodeType.normalize("8", range)
 
 
@@ -288,7 +288,7 @@ def test_normalize_value_float_range():
     assert NodeType.normalize("6", range) == 6
     assert NodeType.normalize("7", range) == 7
 
-    with pytest.raises(ValueError, match=r"^8\.0 is not in range: 0, 2\.2, 5-7$"):
+    with pytest.raises(ValueError, match=r"^8\.0 is not in range: 0, 2\.2, 5\.\.7$"):
         NodeType.normalize("8", range)
 
 
@@ -364,18 +364,18 @@ def test_normalize_invalid_str():
     "str",
     "bool",
     "int<0,2,5>",
-    "int<0-5>",
-    "int<<-5>",
-    "int<-5->>",
-    "int<<--5,5->>",
-    "float<<--5.0,5.0->>",
+    "int<0..5>",
+    "int<..-5>",
+    "int<-5..>",
+    "int<..-5,5..>",
+    "float<..-5.0,5.0..>",
     "[str]",
     "[int]",
     "(str,int)",
     "(str,int,bool,float,<hello,world>)",
     "[(str,int)]",
     "[<hello,world>]",
-    "[int<0,2,5-9>]",
+    "[int<0,2,5..9>]",
     "{(str,int,int,str)}",
 ])
 def test_str(sctype):
@@ -388,8 +388,8 @@ def test_str_enum():
 
 
 def test_str_floatrange():
-    assert str(NodeType("float<0,2.1,5-9>")) == "float<0.0,2.1,5.0-9.0>"
-    assert str(NodeType("[float<0,2.1,5-9>]")) == "[float<0.0,2.1,5.0-9.0>]"
+    assert str(NodeType("float<0,2.1,5..9>")) == "float<0.0,2.1,5.0..9.0>"
+    assert str(NodeType("[float<0,2.1,5..9>]")) == "[float<0.0,2.1,5.0..9.0>]"
 
 
 def test_str_invalid():
@@ -424,7 +424,7 @@ def test_str_invalid():
     ("{(str,int)}", set, True),
     ("{(str,int)}", "str", True),
     ("{(str,int)}", "int", True),
-    ("{(str,int<0-5>)}", "int", True),
+    ("{(str,int<0..5>)}", "int", True),
     ("{(str,int)}", tuple, True),
     ("{(str,int)}", list, False),
     ("{(str,int)}", set, True),
@@ -443,7 +443,7 @@ def test_contains(sctype, check, expect):
 
 def test_parse_negative_float_range():
     # Range from -0.5 to 0.5
-    parsed = NodeType.parse("float<-0.5-0.5>")
+    parsed = NodeType.parse("float<-0.5..0.5>")
     assert isinstance(parsed, NodeRangeType)
     assert parsed.base == "float"
     assert parsed.values == [(-0.5, 0.5)]
@@ -451,7 +451,7 @@ def test_parse_negative_float_range():
 
 def test_parse_outoforder_float_range():
     # Range from -0.5 to 0.5
-    parsed = NodeType.parse("float<0.5--0.5>")
+    parsed = NodeType.parse("float<0.5..-0.5>")
     assert isinstance(parsed, NodeRangeType)
     assert parsed.base == "float"
     assert parsed.values == [(-0.5, 0.5)]
@@ -459,22 +459,22 @@ def test_parse_outoforder_float_range():
 
 def test_parse_scientific_notation_range():
     # Range from 1e-5 to 1e-2
-    parsed = NodeType.parse("float<1e-5-1e-2>")
+    parsed = NodeType.parse("float<1e-5..1e-2>")
     assert isinstance(parsed, NodeRangeType)
     assert parsed.base == "float"
     assert parsed.values == [(1e-5, 1e-2)]
-    assert str(parsed) == "float<1e-05-0.01>"
+    assert str(parsed) == "float<1e-05..0.01>"
 
 
 def test_parse_mixed_ranges_and_values():
     # Mixed single values and ranges with negatives
-    parsed = NodeType.parse("int<-10,-5,0-5>")
+    parsed = NodeType.parse("int<-10,-5,0..5>")
     assert isinstance(parsed, NodeRangeType)
     assert parsed.values == [(-10, -10), (-5, -5), (0, 5)]
 
 
 def test_normalize_negative_range():
-    rnge = NodeType.parse("int<-10-10>")
+    rnge = NodeType.parse("int<-10..10>")
     assert NodeType.normalize("-5", rnge) == -5
     assert NodeType.normalize("10", rnge) == 10
     assert NodeType.normalize("-10", rnge) == -10
@@ -483,8 +483,8 @@ def test_normalize_negative_range():
 
 
 def test_parse_open_range_high():
-    # int<0->
-    rnge = NodeType.parse("int<0->>")
+    # int<0..>
+    rnge = NodeType.parse("int<0..>")
     assert isinstance(rnge, NodeRangeType)
     assert rnge.values == [(0, None)]
 
@@ -495,8 +495,8 @@ def test_parse_open_range_high():
 
 
 def test_parse_open_negative_range_high():
-    # int<-10->
-    rnge = NodeType.parse("int<-10->>")
+    # int<-10..>
+    rnge = NodeType.parse("int<-10..>")
     assert isinstance(rnge, NodeRangeType)
     assert rnge.values == [(-10, None)]
 
@@ -507,8 +507,8 @@ def test_parse_open_negative_range_high():
 
 
 def test_parse_open_range_low():
-    # int<-5>
-    rnge = NodeType.parse("int<<--5>")
+    # int<..-5>
+    rnge = NodeType.parse("int<..-5>")
     assert isinstance(rnge, NodeRangeType)
     assert rnge.values == [(None, -5)]
 
@@ -519,8 +519,8 @@ def test_parse_open_range_low():
 
 
 def test_parse_open_negative_range_low():
-    # int<--5>
-    rnge = NodeType.parse("int<<--5>")
+    # int<..-5>
+    rnge = NodeType.parse("int<..-5>")
     assert isinstance(rnge, NodeRangeType)
     assert rnge.values == [(None, -5)]
 
@@ -531,8 +531,8 @@ def test_parse_open_negative_range_low():
 
 
 def test_parse_negative_range():
-    # int<-10--5>
-    rnge = NodeType.parse("int<-10--5>")
+    # int<-10..-5>
+    rnge = NodeType.parse("int<-10..-5>")
     assert isinstance(rnge, NodeRangeType)
     assert rnge.values == [(-10, -5)]
 
@@ -545,9 +545,9 @@ def test_parse_negative_range():
 
 
 @pytest.mark.parametrize("range_str,expect", [
-    ("int<-10--5>", [(-10, -5)]),
-    ("int<-20--15,<--5>", [(None, -5), (-20, -15)]),
-    ("float<-2.5-1.5,<-0.5>", [(None, 0.5), (-2.5, 1.5)]),
+    ("int<-10..-5>", [(-10, -5)]),
+    ("int<-20..-15,..-5>", [(None, -5), (-20, -15)]),
+    ("float<-2.5..1.5,..-0.5>", [(None, -0.5), (-2.5, 1.5)]),
 ])
 def test_parse_range(range_str, expect):
     rnge = NodeType.parse(range_str)
@@ -556,8 +556,127 @@ def test_parse_range(range_str, expect):
 
 
 def test_range_eq():
-    r0 = NodeType.parse("int<-10--5>")
-    r1 = NodeType.parse("float<-10--5>")
+    r0 = NodeType.parse("int<-10..-5>")
+    r1 = NodeType.parse("float<-10..-5>")
 
     assert r0 == NodeRangeType("int", (-10, -5))
     assert r0 != r1
+
+
+@pytest.mark.parametrize("range_str,expect", [
+    # Leading decimal point
+    ("float<.5..1.5>", [(0.5, 1.5)]),
+    ("float<-.5...5>", [(-0.5, 0.5)]),
+    # Trailing decimal point
+    ("float<1...2.>", [(1.0, 2.0)]),
+    ("float<5.>", [(5.0, 5.0)]),
+    # Explicit positive sign
+    ("float<+1..+2>", [(1.0, 2.0)]),
+    # Scientific notation, both cases
+    ("float<1E5..2E5>", [(1e5, 2e5)]),
+    ("float<1e-5..1e-2>", [(1e-5, 1e-2)]),
+    ("float<1E-5..1e-2>", [(1e-5, 1e-2)]),
+    ("float<+1.5e3..+2.5e3>", [(1.5e3, 2.5e3)]),
+    # Mix of scientific notation single values and ranges
+    ("float<1e-5,2e-3..4e-2>", [(1e-5, 1e-5), (0.002, 0.04)]),
+])
+def test_parse_float_range_formats(range_str, expect):
+    """Well-formed floating point range specifiers should parse correctly."""
+    parsed = NodeType.parse(range_str)
+    assert isinstance(parsed, NodeRangeType)
+    assert parsed.base == "float"
+    assert parsed.values == expect
+
+
+@pytest.mark.parametrize("range_str,expect", [
+    ("int<+0,+2,+5..+9>", [(0, 0), (2, 2), (5, 9)]),
+    ("int<+5..+9>", [(5, 9)]),
+])
+def test_parse_int_range_formats(range_str, expect):
+    """Well-formed integer range specifiers should parse correctly."""
+    parsed = NodeType.parse(range_str)
+    assert isinstance(parsed, NodeRangeType)
+    assert parsed.base == "int"
+    assert parsed.values == expect
+
+
+@pytest.mark.parametrize("range_str,match", [
+    # Float value in an int range
+    ("int<1.5..2>", r"^invalid literal for int\(\) with base 10: '1\.5'$"),
+    ("int<1.5>", r"^invalid literal for int\(\) with base 10: '1\.5'$"),
+    ("int<0..2.5>", r"^invalid literal for int\(\) with base 10: '2\.5'$"),
+    # Dash used instead of '..' as the range separator
+    ("int<5-7>", r"^invalid literal for int\(\) with base 10: '5-7'$"),
+    ("float<5-7>", r"^could not convert string to float: '5-7'$"),
+    # Non-numeric garbage
+    ("float<abc..2>", r"^could not convert string to float: 'abc\.\.2'$"),
+    ("int<abc>", r"^invalid literal for int\(\) with base 10: 'abc'$"),
+    # Empty range specifier
+    ("int<>", r"^invalid literal for int\(\) with base 10: ''$"),
+    ("float<>", r"^could not convert string to float: ''$"),
+    # Too many dots / malformed decimals
+    ("float<1..2..3>", r"^could not convert string to float: '1\.\.2\.\.3'$"),
+    ("int<1.2.3>", r"^invalid literal for int\(\) with base 10: '1\.2\.3'$"),
+    # Interior whitespace is not stripped by the range regex
+    ("int< 0 .. 5 >", r"^invalid literal for int\(\) with base 10: ' 0 \.\. 5 '$"),
+])
+def test_parse_invalid_range(range_str, match):
+    """Poorly formatted numbers inside a range must raise a ValueError."""
+    with pytest.raises(ValueError, match=match):
+        NodeType.parse(range_str)
+
+
+@pytest.mark.parametrize("range_str", [
+    "int<..>",
+    "float<..>",
+    "int<..,0..5>",
+    "float<1..2,..>",
+])
+def test_parse_fully_unbounded_range(range_str):
+    """A range with both ends open (<..>) is not a valid, bounded range."""
+    with pytest.raises(ValueError, match=r"^range cannot be fully unbounded$"):
+        NodeType.parse(range_str)
+
+
+def test_parse_bare_unbounded_enum():
+    """A bare <..> with no base type is parsed as an enum, not a range."""
+    parsed = NodeType.parse("<..>")
+    assert isinstance(parsed, NodeEnumType)
+    assert parsed.values == set([".."])
+
+
+def test_noderange_empty():
+    with pytest.raises(ValueError, match=r"^range cannot be empty set$"):
+        NodeRangeType("int")
+
+
+def test_noderange_fully_unbounded():
+    with pytest.raises(ValueError, match=r"^range cannot be fully unbounded$"):
+        NodeRangeType("int", (None, None))
+
+
+@pytest.mark.parametrize("range_str,value,expect", [
+    ("float<0.0..1.0>", "0.5", 0.5),
+    ("float<0.0..1.0>", ".5", 0.5),
+    ("float<0.0..1.0>", "5e-1", 0.5),
+    ("float<-1.5..1.5>", "-1.5", -1.5),
+    ("float<0.0..1.0>", 0.5, 0.5),
+])
+def test_normalize_float_range_values(range_str, value, expect):
+    """Well-formed floats normalize against a float range."""
+    assert NodeType.normalize(value, NodeType.parse(range_str)) == expect
+
+
+@pytest.mark.parametrize("range_str,value,match", [
+    # Malformed value fails base conversion before the range check
+    ("float<0.0..1.0>", "abc", r"^\"abc\" unable to convert to float$"),
+    ("int<0..10>", "1.5", r"^\"1\.5\" unable to convert to int$"),
+    ("int<0..10>", "5.0", r"^\"5\.0\" unable to convert to int$"),
+    # Well-formed but out of range
+    ("float<0.0..1.0>", "1.5", r"^1\.5 is not in range: 0\.0\.\.1\.0$"),
+    ("float<0.0..1.0>", "-0.1", r"^-0\.1 is not in range: 0\.0\.\.1\.0$"),
+])
+def test_normalize_float_range_invalid(range_str, value, match):
+    """Poorly formatted or out-of-range values raise on normalize."""
+    with pytest.raises(ValueError, match=match):
+        NodeType.normalize(value, NodeType.parse(range_str))

--- a/tests/tools/test_builtin.py
+++ b/tests/tools/test_builtin.py
@@ -7,6 +7,7 @@ import os.path
 from unittest.mock import patch
 
 from siliconcompiler import Flowgraph, Design, Project
+from siliconcompiler.schema import EditableSchema, Parameter, PerNode
 from siliconcompiler.scheduler import SchedulerNode
 from siliconcompiler.tools.builtin.nop import NOPTask
 from siliconcompiler.tools.builtin.join import JoinTask
@@ -27,6 +28,8 @@ def minmax_project(project_logger):
             design.set_topmodule("top")
 
         proj = Project(design)
+        EditableSchema(proj).insert("metric", "metric0", Parameter("int", pernode=PerNode.REQUIRED))
+        EditableSchema(proj).insert("metric", "metric1", Parameter("int", pernode=PerNode.REQUIRED))
 
         flow = Flowgraph("test")
 
@@ -36,11 +39,11 @@ def minmax_project(project_logger):
             flow.edge("start", "end", tail_index=n)
 
             # errors / warnings is always present so safe to use here
-            flow.set("start", str(n), "weight", "errors", 1.0)
-            flow.set("start", str(n), "goal", "warnings", 0.0)
+            flow.set("start", str(n), "weight", "metric0", 1.0)
+            flow.set("start", str(n), "goal", "metric1", 0.0)
 
-            proj.set("metric", "errors", 1000 - n * 1 + 42.0, step="start", index=n)
-            proj.set("metric", "warnings", 0, step="start", index=n)
+            proj.set("metric", "metric0", 1000 - n * 1 + 42.0, step="start", index=n)
+            proj.set("metric", "metric1", 0, step="start", index=n)
 
         project_logger(proj)
         proj.logger.setLevel(logging.INFO)
@@ -240,25 +243,25 @@ def test_minimum_winner_failed(minmax_project, caplog):
 
 def test_minimum_winner_goal_negative(minmax_project, caplog):
     project = minmax_project(MinimumTask)
-    project.set("metric", "warnings", -1, step="start", index="9")
+    project.set("metric", "metric1", -1, step="start", index="9")
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
         assert node.task.select_input_nodes() == [('start', '8')]
 
     assert "Running builtin task 'minimum'" in caplog.text
-    assert "Step start/9 failed because it didn't meet goals for 'warnings' metric." in caplog.text
+    assert "Step start/9 failed because it didn't meet goals for 'metric1' metric." in caplog.text
     assert "Selected 'start/8' with score 0.000" in caplog.text
 
 
 def test_minimum_winner_goal_positive(minmax_project, caplog):
     project = minmax_project(MinimumTask)
-    project.set("metric", "warnings", 1, step="start", index="9")
+    project.set("metric", "metric1", 1, step="start", index="9")
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
         assert node.task.select_input_nodes() == [('start', '8')]
 
     assert "Running builtin task 'minimum'" in caplog.text
-    assert "Step start/9 failed because it didn't meet goals for 'warnings' metric." in caplog.text
+    assert "Step start/9 failed because it didn't meet goals for 'metric1' metric." in caplog.text
     assert "Selected 'start/8' with score 0.000" in caplog.text
 
 
@@ -275,31 +278,31 @@ def test_maximum_winner_failed(minmax_project, caplog):
 
 def test_maximum_winner_goal_negative(minmax_project, caplog):
     project = minmax_project(MaximumTask)
-    project.set("metric", "warnings", -1, step="start", index="0")
+    project.set("metric", "metric1", -1, step="start", index="0")
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
         assert node.task.select_input_nodes() == [('start', '1')]
 
     assert "Running builtin task 'maximum'" in caplog.text
-    assert "Step start/0 failed because it didn't meet goals for 'warnings' metric." in caplog.text
+    assert "Step start/0 failed because it didn't meet goals for 'metric1' metric." in caplog.text
     assert "Selected 'start/1' with score 1.000" in caplog.text
 
 
 def test_maximum_winner_goal_positive(minmax_project, caplog):
     project = minmax_project(MaximumTask)
-    project.set("metric", "warnings", 1, step="start", index="0")
+    project.set("metric", "metric1", 1, step="start", index="0")
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
         assert node.task.select_input_nodes() == [('start', '1')]
 
     assert "Running builtin task 'maximum'" in caplog.text
-    assert "Step start/0 failed because it didn't meet goals for 'warnings' metric." in caplog.text
+    assert "Step start/0 failed because it didn't meet goals for 'metric1' metric." in caplog.text
     assert "Selected 'start/1' with score 1.000" in caplog.text
 
 
 def test_mux_minimum(minmax_project, caplog):
     project = minmax_project(MuxTask)
-    project.set('flowgraph', "test", 'end', '0', 'args', 'minimum(errors)')
+    project.set('flowgraph', "test", 'end', '0', 'args', 'minimum(metric0)')
 
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
@@ -310,7 +313,7 @@ def test_mux_minimum(minmax_project, caplog):
 
 def test_mux_maximum(minmax_project, caplog):
     project = minmax_project(MuxTask)
-    project.set('flowgraph', "test", 'end', '0', 'args', 'maximum(errors)')
+    project.set('flowgraph', "test", 'end', '0', 'args', 'maximum(metric0)')
 
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
@@ -322,10 +325,10 @@ def test_mux_maximum(minmax_project, caplog):
 def test_mux_two_metrics(minmax_project, caplog):
     project = minmax_project(MuxTask)
     for index in project.getkeys("flowgraph", "test", "start"):
-        project.set("metric", "errors", 100 - int(index), step="start", index=index)
-        project.set("metric", "warnings", int(index) % 3, step="start", index=index)
-    project.set('flowgraph', "test", 'end', '0', 'args', 'maximum(warnings)')
-    project.add('flowgraph', "test", 'end', '0', 'args', 'minimum(errors)')
+        project.set("metric", "metric0", 100 - int(index), step="start", index=index)
+        project.set("metric", "metric1", int(index) % 3, step="start", index=index)
+    project.set('flowgraph', "test", 'end', '0', 'args', 'maximum(metric1)')
+    project.add('flowgraph', "test", 'end', '0', 'args', 'minimum(metric0)')
 
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
@@ -336,7 +339,7 @@ def test_mux_two_metrics(minmax_project, caplog):
 
 def test_verify_pass(minmax_project, caplog):
     project = minmax_project(VerifyTask, parallel=1)
-    project.set('flowgraph', "test", 'end', '0', 'args', 'errors==1042')
+    project.set('flowgraph', "test", 'end', '0', 'args', 'metric0==1042')
 
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
@@ -347,11 +350,11 @@ def test_verify_pass(minmax_project, caplog):
 
 def test_verify_fail(minmax_project, caplog):
     project = minmax_project(VerifyTask, parallel=1)
-    project.set('flowgraph', "test", 'end', '0', 'args', 'errors==1041')
+    project.set('flowgraph', "test", 'end', '0', 'args', 'metric0==1041')
 
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
-        with pytest.raises(ValueError, match=r"^end/0 fails 'errors' metric: 1042==1041$"):
+        with pytest.raises(ValueError, match=r"^end/0 fails 'metric0' metric: 1042==1041$"):
             node.task.select_input_nodes()
 
     assert "Running builtin task 'verify'" in caplog.text
@@ -359,8 +362,8 @@ def test_verify_fail(minmax_project, caplog):
 
 def test_verify_pass_two(minmax_project, caplog):
     project = minmax_project(VerifyTask, parallel=1)
-    project.set('flowgraph', "test", 'end', '0', 'args', 'errors==1042')
-    project.add('flowgraph', "test", 'end', '0', 'args', 'warnings==0')
+    project.set('flowgraph', "test", 'end', '0', 'args', 'metric0==1042')
+    project.add('flowgraph', "test", 'end', '0', 'args', 'metric1==0')
 
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
@@ -371,12 +374,12 @@ def test_verify_pass_two(minmax_project, caplog):
 
 def test_verify_fail_two(minmax_project, caplog):
     project = minmax_project(VerifyTask, parallel=1)
-    project.set('flowgraph', "test", 'end', '0', 'args', 'errors==1042')
-    project.add('flowgraph', "test", 'end', '0', 'args', 'warnings==1')
+    project.set('flowgraph', "test", 'end', '0', 'args', 'metric0==1042')
+    project.add('flowgraph', "test", 'end', '0', 'args', 'metric1==1')
 
     node = SchedulerNode(project, "end", "0")
     with node.runtime():
-        with pytest.raises(ValueError, match=r"^end/0 fails 'warnings' metric: 0==1$"):
+        with pytest.raises(ValueError, match=r"^end/0 fails 'metric1' metric: 0==1$"):
             node.task.select_input_nodes()
 
     assert "Running builtin task 'verify'" in caplog.text
@@ -477,10 +480,12 @@ def test_setup_copies_inputs_verify():
     flow.edge("start", "end")
 
     proj = Project(design)
+    EditableSchema(proj).insert("metric", "metric0", Parameter("float"))
+    EditableSchema(proj).insert("metric", "metric1", Parameter("float"))
     proj.add_fileset("rtl")
     proj.set_flow(flow)
     NOPTask.find_task(proj).add_output_file("test.out", step="start", index="0")
-    proj.set('flowgraph', "test", 'end', '0', 'args', 'errors==1042')
+    proj.set('flowgraph', "test", 'end', '0', 'args', 'metric0==1042')
 
     assert proj.get("tool", "builtin", "task", task_name, "input", step="end", index="0") == []
     assert proj.get("tool", "builtin", "task", task_name, "output", step="end", index="0") == []
@@ -513,6 +518,8 @@ def test_setup_copies_inputs_multiple(cls):
     flow.edge("otherstart", "end")
 
     proj = Project(design)
+    EditableSchema(proj).insert("metric", "metric0", Parameter("float"))
+    EditableSchema(proj).insert("metric", "metric1", Parameter("float"))
     proj.add_fileset("rtl")
     proj.set_flow(flow)
     NOPTask.find_task(proj).add_output_file("test.out", step="start", index="0")


### PR DESCRIPTION
Ranges supported:
- enumerated list: int/float `<1,2,3,4>`
- ranges: `<1..4>` (ranges are inclusive)
- mixed: `<1,2,4..9,11>`
- openended ranges: `<..9>` negative inf to 9, `<-8..>` -8 to inf.

Adds:
- schema range checking to ensure values are values

Notes:
- this is a step towards implementing hyper parameter optimization (this allows the values to be extracted from the schema instead of needing to be specified by the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added range-based schema type support with `int<...>`/`float<...>` validation (bounded and open-ended intervals) and `str<...>` treated as enum, including correct string/TCL handling.
* **Behavior / Validation**
  * Tightened numeric validation across tools, constraints, PDK, metrics, scheduler, flowgraph weights, and remote/server options to enforce non-negative and minimum-1 domains.
  * Improved metric integer/float detection during metric goal formatting.
* **Documentation**
  * Updated schema reference wording/examples and added a release entry for the new range syntax.
* **Tests**
  * Expanded unit tests for parsing, normalization, containment, equality, and encoded output for range types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->