### PR TITLE
Put limits on what python version can be used with Cocotb.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ optimizer = [
     "google-vizier[jax] == 0.1.21; python_version >= '3.10'"
 ]
 cocotb = [
-    "cocotb >= 2.0.1, < 2.1.0"
+    "cocotb >= 2.0.1, < 2.1.0; python_version >= '3.7' and python_version <= '3.13'"
 ]
 
 [tool.setuptools]

--- a/tests/examples/test_adder_cocotb.py
+++ b/tests/examples/test_adder_cocotb.py
@@ -7,6 +7,9 @@ import os.path
 @pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_make_sim_icarus_no_trace():
+    pytest.importorskip("cocotb", reason="Cocotb is required for this test")
+    pytest.importorskip("cocotb_tools", reason="Cocotb tools are required for this test")
+
     from adder_cocotb import make
     make.sim_icarus(trace=False)
 
@@ -18,6 +21,9 @@ def test_py_make_sim_icarus_no_trace():
 @pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_make_sim_icarus_vcd():
+    pytest.importorskip("cocotb", reason="Cocotb is required for this test")
+    pytest.importorskip("cocotb_tools", reason="Cocotb tools are required for this test")
+
     from adder_cocotb import make
     make.sim_icarus(trace=True)
 
@@ -29,6 +35,9 @@ def test_py_make_sim_icarus_vcd():
 @pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_make_sim_verilator_no_trace():
+    pytest.importorskip("cocotb", reason="Cocotb is required for this test")
+    pytest.importorskip("cocotb_tools", reason="Cocotb tools are required for this test")
+
     from adder_cocotb import make
     make.sim_verilator(trace=False, trace_type="vcd")
 
@@ -40,6 +49,9 @@ def test_py_make_sim_verilator_no_trace():
 @pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_make_sim_verilator_vcd():
+    pytest.importorskip("cocotb", reason="Cocotb is required for this test")
+    pytest.importorskip("cocotb_tools", reason="Cocotb tools are required for this test")
+
     from adder_cocotb import make
     make.sim_verilator(trace=True, trace_type="vcd")
 
@@ -51,6 +63,9 @@ def test_py_make_sim_verilator_vcd():
 @pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_make_sim_verilator_fst():
+    pytest.importorskip("cocotb", reason="Cocotb is required for this test")
+    pytest.importorskip("cocotb_tools", reason="Cocotb tools are required for this test")
+
     from adder_cocotb import make
     make.sim_verilator(trace=True, trace_type="fst")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened an optional dependency constraint to explicitly target Python 3.7–3.13.

* **Tests**
  * Tests now detect missing optional test tooling and skip gracefully instead of failing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->