### PR TITLE
ensure cache downlaods are readonly by default

### DIFF
--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -546,6 +546,11 @@ class RemoteResolver(Resolver):
             except BaseException:
                 # Exception occurred, so need to cleanup
                 try:
+                    # Make writable first, in case cache was partially made read-only
+                    try:
+                        self._make_writable(self.cache_path)
+                    except OSError as e:
+                        self.logger.warning(f"Could not make cache writable before cleanup: {e}")
                     shutil.rmtree(self.cache_path)
                 except BaseException as cleane:
                     self.logger.error(f"Exception occurred during cleanup: {cleane} "
@@ -586,6 +591,31 @@ class RemoteResolver(Resolver):
             # Remove write permissions from the directory itself
             current_mode = os.stat(path).st_mode
             new_mode = current_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+            os.chmod(path, new_mode)
+
+    def _make_writable(self, path: Union[str, Path]) -> None:
+        """
+        Recursively makes all files and directories in the given path writable.
+
+        This is used before deletion to ensure that read-only cached files can be
+        properly removed when necessary (e.g., for corrupted cache cleanup).
+
+        Args:
+            path: The path to make writable (file or directory).
+        """
+        path = Path(path)
+        if path.is_file():
+            # Add owner write permission, preserve everything else
+            current_mode = os.stat(path).st_mode
+            new_mode = current_mode | stat.S_IWUSR
+            os.chmod(path, new_mode)
+        elif path.is_dir():
+            # Process all contents recursively
+            for item in path.iterdir():
+                self._make_writable(item)
+            # Add owner write permission to the directory itself
+            current_mode = os.stat(path).st_mode
+            new_mode = current_mode | stat.S_IWUSR
             os.chmod(path, new_mode)
 
     def _get_auth_token(self, prefix: List[str]) -> str:

--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -579,6 +579,9 @@ class RemoteResolver(Resolver):
             path: The path to make read-only (file or directory).
         """
         path = Path(path)
+        # Skip symlinks to avoid following them outside the cache
+        if path.is_symlink():
+            return
         if path.is_file():
             # Remove write permissions, preserve everything else (especially execute bit)
             current_mode = os.stat(path).st_mode
@@ -604,6 +607,9 @@ class RemoteResolver(Resolver):
             path: The path to make writable (file or directory).
         """
         path = Path(path)
+        # Skip symlinks to avoid following them outside the cache
+        if path.is_symlink():
+            return
         if path.is_file():
             # Add owner write permission, preserve everything else
             current_mode = os.stat(path).st_mode

--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -18,6 +18,7 @@ import random
 import re
 import site
 import shutil
+import stat
 import time
 import threading
 import uuid
@@ -551,8 +552,41 @@ class RemoteResolver(Resolver):
                                       f"({cleane.__class__.__name__})")
                 raise
 
+            # Make all cached files read-only to prevent accidental modifications
+            try:
+                self._make_readonly(self.cache_path)
+            except OSError as e:
+                self.logger.warning(f"Could not make cache read-only: {e}")
+
             self.set_changed()
             return self.cache_path
+
+    def _make_readonly(self, path: Union[str, Path]) -> None:
+        """
+        Recursively makes all files and directories in the given path read-only.
+
+        This prevents accidental modification of cached remote data by removing write
+        permissions while preserving executable bits and read access. Note: git does
+        not track full file permissions (only the executable bit), so this operation
+        will not create a dirty warning in git repositories.
+
+        Args:
+            path: The path to make read-only (file or directory).
+        """
+        path = Path(path)
+        if path.is_file():
+            # Remove write permissions, preserve everything else (especially execute bit)
+            current_mode = os.stat(path).st_mode
+            new_mode = current_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+            os.chmod(path, new_mode)
+        elif path.is_dir():
+            # Process all contents recursively
+            for item in path.iterdir():
+                self._make_readonly(item)
+            # Remove write permissions from the directory itself
+            current_mode = os.stat(path).st_mode
+            new_mode = current_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+            os.chmod(path, new_mode)
 
     def _get_auth_token(self, prefix: List[str]) -> str:
         """

--- a/siliconcompiler/package/git.py
+++ b/siliconcompiler/package/git.py
@@ -72,6 +72,11 @@ class GitResolver(RemoteResolver):
                 return True
             except GitCommandError:
                 self.logger.warning('Deleting corrupted cache data.')
+                # Make writable first, in case cache was previously made read-only
+                try:
+                    self._make_writable(self.cache_path)
+                except OSError as e:
+                    self.logger.warning(f"Could not make cache writable before deletion: {e}")
                 shutil.rmtree(self.cache_path)
                 return False
         return False

--- a/tests/package/test_git.py
+++ b/tests/package/test_git.py
@@ -86,6 +86,9 @@ def test_dirty_warning(monkeypatch, caplog, tmp_path):
 
     assert Path(resolver.cache_path).exists()
 
+    # Make cache writable to simulate a dirty repository (it's now read-only by default)
+    resolver._make_writable(resolver.cache_path)
+
     file = Path(resolver.cache_path).joinpath('file.txt')
     file.touch()
 

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -1072,6 +1072,8 @@ def test_make_readonly_single_file(tmp_path):
     # Create a test file
     test_file = tmp_path / "test.txt"
     test_file.write_text("content")
+    # Set explicit initial permissions (0o644) to avoid umask variability
+    os.chmod(test_file, 0o644)
 
     # Verify it's writable initially
     assert os.access(test_file, os.W_OK)
@@ -1392,33 +1394,42 @@ def test_make_readonly_string_path(tmp_path):
     assert not (mode & stat.S_IWUSR)
 
 
-def test_make_readonly_error_handling(tmp_path, monkeypatch):
-    """Test error handling when chmod fails."""
-    # Create a test file
-    test_file = tmp_path / "test.txt"
-    test_file.write_text("content")
+def test_make_readonly_error_handling(tmp_path, monkeypatch, caplog):
+    """Test error handling when chmod fails in resolve() flow."""
+    import logging
+
+    # Create a mock remote resolver that succeeds initially
+    class TestResolver(RemoteResolver):
+        def check_cache(self):
+            return False  # Cache is invalid, will fetch
+
+        def resolve_remote(self):
+            # Create a test file to simulate successful download
+            (Path(self.cache_path) / "test.txt").parent.mkdir(parents=True, exist_ok=True)
+            (Path(self.cache_path) / "test.txt").write_text("content")
+
+    # Create project with logging
+    project = Project("testproj")
+    monkeypatch.setattr(project, "_Project__logger", logging.getLogger())
+    project.logger.setLevel(logging.WARNING)
+    caplog.set_level(logging.WARNING)
+
+    resolver = TestResolver("test", project, "https://example.com", "v1.0")
 
     # Mock os.chmod to simulate permission error
-    original_chmod = os.chmod
-    call_count = {"count": 0}
-
     def mock_chmod(path, mode, **kwargs):
-        call_count["count"] += 1
-        if call_count["count"] > 1:  # Fail on second call (after walking)
-            raise PermissionError("Permission denied")
-        return original_chmod(path, mode)
+        raise PermissionError("Permission denied")
 
     monkeypatch.setattr("os.chmod", mock_chmod)
 
-    # Make it read-only - should log warning but not raise
-    project = Project("testproj")
-    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    # resolve() should catch the chmod error and log warning
+    # (the cache won't be made read-only, but resolve succeeds)
+    result = resolver.resolve()
 
-    # This should not raise an exception
-    try:
-        resolver._make_readonly(test_file)
-    except PermissionError:
-        pytest.fail("_make_readonly should not raise PermissionError")
+    # Verify that the cache path exists (resolve succeeded)
+    assert Path(result).exists()
+    # Verify that warning was logged about chmod failure
+    assert "Could not make cache read-only" in caplog.text
 
 
 # ============================================================================

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -1,6 +1,7 @@
 import contextlib
 import logging
 import pytest
+import shutil
 
 import os.path
 
@@ -1418,3 +1419,101 @@ def test_make_readonly_error_handling(tmp_path, monkeypatch):
         resolver._make_readonly(test_file)
     except PermissionError:
         pytest.fail("_make_readonly should not raise PermissionError")
+
+
+# ============================================================================
+# Tests for _make_writable() method (for cache cleanup/deletion)
+# ============================================================================
+
+def test_make_writable_single_file(tmp_path):
+    """Test making a read-only file writable."""
+    import stat
+
+    # Create a read-only file
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("content")
+    test_file.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)  # 444
+
+    # Verify it's read-only
+    assert not os.access(test_file, os.W_OK)
+
+    # Make it writable
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_writable(test_file)
+
+    # Verify owner can now write
+    assert os.access(test_file, os.W_OK)
+
+
+def test_make_writable_directory(tmp_path):
+    """Test making a read-only directory writable."""
+    # Create a directory with read-only files
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    file1 = cache_dir / "file1.txt"
+    file1.write_text("content1")
+
+    # Make everything read-only
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_readonly(cache_dir)
+
+    # Verify it's read-only
+    assert not os.access(file1, os.W_OK)
+    assert not os.access(cache_dir, os.W_OK)
+
+    # Make writable
+    resolver._make_writable(cache_dir)
+
+    # Verify owner can write
+    assert os.access(file1, os.W_OK)
+    assert os.access(cache_dir, os.W_OK)
+
+
+def test_make_readonly_then_delete(tmp_path):
+    """Test that we can delete a read-only cache after making it writable."""
+    # Create a read-only cache directory
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "file1.txt").write_text("content1")
+    (cache_dir / "subdir").mkdir()
+    (cache_dir / "subdir" / "file2.txt").write_text("content2")
+
+    # Make it read-only
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_readonly(cache_dir)
+
+    # Verify it's read-only
+    assert not os.access(cache_dir / "file1.txt", os.W_OK)
+    assert not os.access(cache_dir / "subdir", os.W_OK)
+
+    # Make writable and delete (should not raise)
+    resolver._make_writable(cache_dir)
+    shutil.rmtree(cache_dir)
+
+    # Verify deletion succeeded
+    assert not cache_dir.exists()
+
+
+def test_make_writable_preserves_read_and_exec(tmp_path):
+    """Test that making writable preserves existing read and execute permissions."""
+    import stat
+
+    # Create an executable file that's read-only
+    exec_file = tmp_path / "script.sh"
+    exec_file.write_text("#!/bin/bash\necho hello")
+    exec_file.chmod(stat.S_IRUSR | stat.S_IXUSR)  # r-x --- --- (500)
+
+    # Make writable
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_writable(exec_file)
+
+    # Verify it's still executable
+    assert os.access(exec_file, os.X_OK)
+    # Verify it's now writable
+    assert os.access(exec_file, os.W_OK)
+    # Verify it's still readable
+    assert os.access(exec_file, os.R_OK)

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -2,6 +2,7 @@ import contextlib
 import logging
 import pytest
 import shutil
+import sys
 
 import os.path
 
@@ -1186,6 +1187,8 @@ def test_make_readonly_nested_directories(tmp_path):
 
 def test_make_readonly_empty_directory(tmp_path):
     """Test making an empty directory read-only."""
+    import stat
+
     # Create an empty directory
     cache_dir = tmp_path / "empty_cache"
     cache_dir.mkdir()
@@ -1199,8 +1202,9 @@ def test_make_readonly_empty_directory(tmp_path):
     assert os.access(cache_dir, os.R_OK)
     assert os.access(cache_dir, os.X_OK)
 
-    # Verify it's not writable
-    assert not os.access(cache_dir, os.W_OK)
+    # Verify it's not writable by checking stat mode bits
+    mode = os.stat(cache_dir).st_mode
+    assert not (mode & stat.S_IWUSR)
 
 
 def test_make_readonly_preserves_read_access(tmp_path):
@@ -1228,7 +1232,7 @@ def test_make_readonly_preserves_read_access(tmp_path):
 
 
 def test_make_readonly_preserves_executable_bit_file(tmp_path):
-    """Test that making read-only preserves the executable bit on files."""
+    """Test that making read-only preserves the executable bit on files (Unix only)."""
     import stat
 
     # Create an executable file
@@ -1238,20 +1242,24 @@ def test_make_readonly_preserves_executable_bit_file(tmp_path):
                     stat.S_IRGRP | stat.S_IXGRP |
                     stat.S_IROTH | stat.S_IXOTH)  # 755
 
-    # Verify it's executable initially
-    assert os.access(test_file, os.X_OK)
-
     # Make it read-only
     project = Project("testproj")
     resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
     resolver._make_readonly(test_file)
 
-    # Verify it's still executable
-    assert os.access(test_file, os.X_OK)
-    # Verify it's not writable
-    assert not os.access(test_file, os.W_OK)
-    # Verify it's readable
-    assert os.access(test_file, os.R_OK)
+    # Verify core behavior: write bits removed
+    mode = os.stat(test_file).st_mode
+    assert not (mode & stat.S_IWUSR)
+    assert not (mode & stat.S_IWGRP)
+    assert not (mode & stat.S_IWOTH)
+
+    # Unix-specific: verify execute bits preserved
+    if sys.platform != "win32":
+        assert os.access(test_file, os.X_OK)
+        # Check exact permissions
+        assert mode & stat.S_IXUSR
+        assert mode & stat.S_IXGRP
+        assert mode & stat.S_IXOTH
 
     # Check exact permissions (555)
     mode = os.stat(test_file).st_mode
@@ -1335,13 +1343,12 @@ def test_make_readonly_directory_with_mixed_permissions(tmp_path):
 
 
 def test_make_readonly_directory_preserves_execute_bit(tmp_path):
-    """Test that making directories read-only preserves execute bit."""
+    """Test that making directories read-only preserves execute bit (Unix only)."""
     import stat
 
     # Create a directory structure
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()
-    # Make cache_dir writable for setting it up, but will have initial permissions
 
     subdir = cache_dir / "subdir"
     subdir.mkdir()
@@ -1352,28 +1359,23 @@ def test_make_readonly_directory_preserves_execute_bit(tmp_path):
                  stat.S_IRGRP | stat.S_IXGRP |
                  stat.S_IROTH | stat.S_IXOTH)
 
-    # Verify execute bit initially
-    assert os.access(subdir, os.X_OK)
-
     # Make read-only
     project = Project("testproj")
     resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
     resolver._make_readonly(cache_dir)
 
-    # Verify subdir still has execute bit (555 instead of 755)
-    assert os.access(subdir, os.X_OK)
-    # Verify not writable
-    assert not os.access(subdir, os.W_OK)
-    # Verify readable
-    assert os.access(subdir, os.R_OK)
-
+    # Core behavior: verify write bits removed
     mode = os.stat(subdir).st_mode
-    assert mode & stat.S_IXUSR
-    assert mode & stat.S_IXGRP
-    assert mode & stat.S_IXOTH
     assert not (mode & stat.S_IWUSR)
     assert not (mode & stat.S_IWGRP)
     assert not (mode & stat.S_IWOTH)
+
+    # Unix-specific: verify execute bits preserved (555 instead of 755)
+    if sys.platform != "win32":
+        assert os.access(subdir, os.X_OK)
+        assert mode & stat.S_IXUSR
+        assert mode & stat.S_IXGRP
+        assert mode & stat.S_IXOTH
 
 
 def test_make_readonly_string_path(tmp_path):
@@ -1459,6 +1461,8 @@ def test_make_writable_single_file(tmp_path):
 
 def test_make_writable_directory(tmp_path):
     """Test making a read-only directory writable."""
+    import stat
+
     # Create a directory with read-only files
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()
@@ -1470,20 +1474,26 @@ def test_make_writable_directory(tmp_path):
     resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
     resolver._make_readonly(cache_dir)
 
-    # Verify it's read-only
-    assert not os.access(file1, os.W_OK)
-    assert not os.access(cache_dir, os.W_OK)
+    # Verify it's read-only via stat mode
+    mode_file = os.stat(file1).st_mode
+    mode_dir = os.stat(cache_dir).st_mode
+    assert not (mode_file & stat.S_IWUSR)
+    assert not (mode_dir & stat.S_IWUSR)
 
     # Make writable
     resolver._make_writable(cache_dir)
 
-    # Verify owner can write
-    assert os.access(file1, os.W_OK)
-    assert os.access(cache_dir, os.W_OK)
+    # Verify owner can write via stat mode
+    mode_file = os.stat(file1).st_mode
+    mode_dir = os.stat(cache_dir).st_mode
+    assert mode_file & stat.S_IWUSR
+    assert mode_dir & stat.S_IWUSR
 
 
 def test_make_readonly_then_delete(tmp_path):
     """Test that we can delete a read-only cache after making it writable."""
+    import stat
+
     # Create a read-only cache directory
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()
@@ -1496,9 +1506,11 @@ def test_make_readonly_then_delete(tmp_path):
     resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
     resolver._make_readonly(cache_dir)
 
-    # Verify it's read-only
-    assert not os.access(cache_dir / "file1.txt", os.W_OK)
-    assert not os.access(cache_dir / "subdir", os.W_OK)
+    # Verify it's read-only via stat mode
+    mode_file1 = os.stat(cache_dir / "file1.txt").st_mode
+    mode_subdir = os.stat(cache_dir / "subdir").st_mode
+    assert not (mode_file1 & stat.S_IWUSR)
+    assert not (mode_subdir & stat.S_IWUSR)
 
     # Make writable and delete (should not raise)
     resolver._make_writable(cache_dir)

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -1058,3 +1058,363 @@ def test_reset_cache_none():
     with patch("siliconcompiler.package.Resolver._Resolver__get_root_id") as root:
         Resolver.reset_cache(None)
         root.assert_not_called()
+
+
+# ============================================================================
+# Tests for _make_readonly() method
+# ============================================================================
+
+def test_make_readonly_single_file(tmp_path):
+    """Test making a single file read-only."""
+    import stat
+
+    # Create a test file
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("content")
+
+    # Verify it's writable initially
+    assert os.access(test_file, os.W_OK)
+
+    # Make it read-only
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_readonly(test_file)
+
+    # Verify it's read-only
+    assert not os.access(test_file, os.W_OK)
+    assert os.access(test_file, os.R_OK)
+
+    # Check exact permissions (444)
+    mode = os.stat(test_file).st_mode
+    assert mode & stat.S_IRUSR
+    assert mode & stat.S_IRGRP
+    assert mode & stat.S_IROTH
+    assert not (mode & stat.S_IWUSR)
+    assert not (mode & stat.S_IWGRP)
+    assert not (mode & stat.S_IWOTH)
+
+
+def test_make_readonly_single_file_path_object(tmp_path):
+    """Test making a single file read-only using Path object."""
+    import stat
+
+    # Create a test file
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("content")
+
+    # Make it read-only using Path object
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_readonly(Path(test_file))
+
+    # Verify it's read-only
+    assert not os.access(test_file, os.W_OK)
+
+    # Check exact permissions
+    mode = os.stat(test_file).st_mode
+    assert not (mode & stat.S_IWUSR)
+    assert not (mode & stat.S_IWGRP)
+    assert not (mode & stat.S_IWOTH)
+
+
+def test_make_readonly_directory_simple(tmp_path):
+    """Test making a directory with files read-only."""
+    # Create a directory with files
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "file1.txt").write_text("content1")
+    (cache_dir / "file2.txt").write_text("content2")
+
+    # Verify files are writable initially
+    assert os.access(cache_dir / "file1.txt", os.W_OK)
+    assert os.access(cache_dir / "file2.txt", os.W_OK)
+
+    # Make directory and contents read-only
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_readonly(cache_dir)
+
+    # Verify all files are read-only
+    assert not os.access(cache_dir / "file1.txt", os.W_OK)
+    assert not os.access(cache_dir / "file2.txt", os.W_OK)
+
+    # Verify we can still read files
+    assert os.access(cache_dir / "file1.txt", os.R_OK)
+    assert os.access(cache_dir / "file2.txt", os.R_OK)
+
+    # Verify we can still traverse the directory
+    assert os.access(cache_dir, os.X_OK)
+
+
+def test_make_readonly_nested_directories(tmp_path):
+    """Test making nested directories with files read-only."""
+    # Create nested directory structure
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "file1.txt").write_text("root")
+
+    subdir1 = cache_dir / "subdir1"
+    subdir1.mkdir()
+    (subdir1 / "file2.txt").write_text("sub1")
+
+    subdir2 = subdir1 / "subdir2"
+    subdir2.mkdir()
+    (subdir2 / "file3.txt").write_text("sub2")
+
+    subdir3 = subdir2 / "subdir3"
+    subdir3.mkdir()
+    (subdir3 / "file4.txt").write_text("sub3")
+
+    # Make entire tree read-only
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_readonly(cache_dir)
+
+    # Verify all files are read-only
+    for fpath in cache_dir.rglob("*.txt"):
+        assert not os.access(fpath, os.W_OK), f"{fpath} should be read-only"
+        assert os.access(fpath, os.R_OK), f"{fpath} should be readable"
+
+    # Verify all directories are readable and traversable
+    for dpath in [cache_dir, subdir1, subdir2, subdir3]:
+        assert os.access(dpath, os.R_OK), f"{dpath} should be readable"
+        assert os.access(dpath, os.X_OK), f"{dpath} should be traversable"
+
+
+def test_make_readonly_empty_directory(tmp_path):
+    """Test making an empty directory read-only."""
+    # Create an empty directory
+    cache_dir = tmp_path / "empty_cache"
+    cache_dir.mkdir()
+
+    # Make it read-only
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_readonly(cache_dir)
+
+    # Verify directory is readable and still traversable
+    assert os.access(cache_dir, os.R_OK)
+    assert os.access(cache_dir, os.X_OK)
+
+    # Verify it's not writable
+    assert not os.access(cache_dir, os.W_OK)
+
+
+def test_make_readonly_preserves_read_access(tmp_path):
+    """Test that making read-only only removes write permissions, preserving others."""
+    import stat
+
+    # Create a file with restrictive permissions initially
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("content")
+    # Make it only readable by owner (400)
+    test_file.chmod(stat.S_IRUSR)
+
+    # Make it read-only (this should only remove write bits, not add read bits)
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_readonly(test_file)
+
+    # Verify owner can still read
+    mode = os.stat(test_file).st_mode
+    assert mode & stat.S_IRUSR
+    # Verify none can write (since the original file had no write bits anyway)
+    assert not (mode & stat.S_IWUSR)
+    assert not (mode & stat.S_IWGRP)
+    assert not (mode & stat.S_IWOTH)
+
+
+def test_make_readonly_preserves_executable_bit_file(tmp_path):
+    """Test that making read-only preserves the executable bit on files."""
+    import stat
+
+    # Create an executable file
+    test_file = tmp_path / "script.sh"
+    test_file.write_text("#!/bin/bash\necho hello")
+    test_file.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+                    stat.S_IRGRP | stat.S_IXGRP |
+                    stat.S_IROTH | stat.S_IXOTH)  # 755
+
+    # Verify it's executable initially
+    assert os.access(test_file, os.X_OK)
+
+    # Make it read-only
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_readonly(test_file)
+
+    # Verify it's still executable
+    assert os.access(test_file, os.X_OK)
+    # Verify it's not writable
+    assert not os.access(test_file, os.W_OK)
+    # Verify it's readable
+    assert os.access(test_file, os.R_OK)
+
+    # Check exact permissions (555)
+    mode = os.stat(test_file).st_mode
+    assert mode & stat.S_IRUSR
+    assert mode & stat.S_IXUSR
+    assert mode & stat.S_IRGRP
+    assert mode & stat.S_IXGRP
+    assert mode & stat.S_IROTH
+    assert mode & stat.S_IXOTH
+    assert not (mode & stat.S_IWUSR)
+    assert not (mode & stat.S_IWGRP)
+    assert not (mode & stat.S_IWOTH)
+
+
+def test_make_readonly_removes_write_preserves_exec(tmp_path):
+    """Test that making read-only removes write but preserves read and execute."""
+    import stat
+
+    # Create a file with write permission (644)
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("content")
+    test_file.chmod(stat.S_IRUSR | stat.S_IWUSR |
+                    stat.S_IRGRP |
+                    stat.S_IROTH)  # 644
+
+    # Make it read-only
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_readonly(test_file)
+
+    # Verify permissions changed from 644 to 444
+    mode = os.stat(test_file).st_mode
+    assert mode & stat.S_IRUSR
+    assert mode & stat.S_IRGRP
+    assert mode & stat.S_IROTH
+    assert not (mode & stat.S_IWUSR)
+    assert not (mode & stat.S_IWGRP)
+    assert not (mode & stat.S_IWOTH)
+    # Verify no execute bit
+    assert not (mode & stat.S_IXUSR)
+    assert not (mode & stat.S_IXGRP)
+    assert not (mode & stat.S_IXOTH)
+
+
+def test_make_readonly_directory_with_mixed_permissions(tmp_path):
+    """Test making directory read-only removes write permissions while preserving read/exec."""
+    import stat
+
+    # Create a directory with files having different permissions
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+
+    file1 = cache_dir / "file1.txt"
+    file1.write_text("content1")
+    file1.chmod(stat.S_IRUSR | stat.S_IWUSR)  # rw- --- ---
+
+    file2 = cache_dir / "file2.txt"
+    file2.write_text("content2")
+    file2.chmod(stat.S_IRUSR | stat.S_IRGRP)  # r-- r-- ---
+
+    # Make directory and contents read-only
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_readonly(cache_dir)
+
+    # Verify all files have write permissions removed
+    for fpath in [file1, file2]:
+        mode = os.stat(fpath).st_mode
+        assert not (mode & stat.S_IWUSR), f"{fpath}: owner should not be able to write"
+        assert not (mode & stat.S_IWGRP), f"{fpath}: group should not be able to write"
+        assert not (mode & stat.S_IWOTH), f"{fpath}: others should not be able to write"
+
+    # Verify file1 preserved its original read permission (owner only)
+    mode1 = os.stat(file1).st_mode
+    assert mode1 & stat.S_IRUSR, "file1: owner should be able to read"
+
+    # Verify file2 preserved its original read permissions (owner and group)
+    mode2 = os.stat(file2).st_mode
+    assert mode2 & stat.S_IRUSR, "file2: owner should be able to read"
+    assert mode2 & stat.S_IRGRP, "file2: group should be able to read"
+
+
+def test_make_readonly_directory_preserves_execute_bit(tmp_path):
+    """Test that making directories read-only preserves execute bit."""
+    import stat
+
+    # Create a directory structure
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    # Make cache_dir writable for setting it up, but will have initial permissions
+
+    subdir = cache_dir / "subdir"
+    subdir.mkdir()
+    (cache_dir / "test.txt").write_text("content")
+
+    # Set directory with specific permissions (755)
+    subdir.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+                 stat.S_IRGRP | stat.S_IXGRP |
+                 stat.S_IROTH | stat.S_IXOTH)
+
+    # Verify execute bit initially
+    assert os.access(subdir, os.X_OK)
+
+    # Make read-only
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_readonly(cache_dir)
+
+    # Verify subdir still has execute bit (555 instead of 755)
+    assert os.access(subdir, os.X_OK)
+    # Verify not writable
+    assert not os.access(subdir, os.W_OK)
+    # Verify readable
+    assert os.access(subdir, os.R_OK)
+
+    mode = os.stat(subdir).st_mode
+    assert mode & stat.S_IXUSR
+    assert mode & stat.S_IXGRP
+    assert mode & stat.S_IXOTH
+    assert not (mode & stat.S_IWUSR)
+    assert not (mode & stat.S_IWGRP)
+    assert not (mode & stat.S_IWOTH)
+
+
+def test_make_readonly_string_path(tmp_path):
+    """Test making files read-only using string path instead of Path object."""
+    import stat
+
+    # Create a test file
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("content")
+
+    # Make it read-only using string path
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+    resolver._make_readonly(str(test_file))
+
+    # Verify it's read-only
+    mode = os.stat(test_file).st_mode
+    assert not (mode & stat.S_IWUSR)
+
+
+def test_make_readonly_error_handling(tmp_path, monkeypatch):
+    """Test error handling when chmod fails."""
+    # Create a test file
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("content")
+
+    # Mock os.chmod to simulate permission error
+    original_chmod = os.chmod
+    call_count = {"count": 0}
+
+    def mock_chmod(path, mode, **kwargs):
+        call_count["count"] += 1
+        if call_count["count"] > 1:  # Fail on second call (after walking)
+            raise PermissionError("Permission denied")
+        return original_chmod(path, mode)
+
+    monkeypatch.setattr("os.chmod", mock_chmod)
+
+    # Make it read-only - should log warning but not raise
+    project = Project("testproj")
+    resolver = RemoteResolver("test", project, "https://example.com", "v1.0")
+
+    # This should not raise an exception
+    try:
+        resolver._make_readonly(test_file)
+    except PermissionError:
+        pytest.fail("_make_readonly should not raise PermissionError")

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -1257,21 +1257,15 @@ def test_make_readonly_preserves_executable_bit_file(tmp_path):
     if sys.platform != "win32":
         assert os.access(test_file, os.X_OK)
         # Check exact permissions
+        assert mode & stat.S_IRUSR
         assert mode & stat.S_IXUSR
+        assert mode & stat.S_IRGRP
         assert mode & stat.S_IXGRP
+        assert mode & stat.S_IROTH
         assert mode & stat.S_IXOTH
-
-    # Check exact permissions (555)
-    mode = os.stat(test_file).st_mode
-    assert mode & stat.S_IRUSR
-    assert mode & stat.S_IXUSR
-    assert mode & stat.S_IRGRP
-    assert mode & stat.S_IXGRP
-    assert mode & stat.S_IROTH
-    assert mode & stat.S_IXOTH
-    assert not (mode & stat.S_IWUSR)
-    assert not (mode & stat.S_IWGRP)
-    assert not (mode & stat.S_IWOTH)
+        assert not (mode & stat.S_IWUSR)
+        assert not (mode & stat.S_IWGRP)
+        assert not (mode & stat.S_IWOTH)
 
 
 def test_make_readonly_removes_write_preserves_exec(tmp_path):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote packages downloaded to cache are now made read-only (write bits removed) while preserving read/execute access.

* **Bug Fixes**
  * Cache cleanup and repository-replacement flows now attempt to restore writable permissions before removal; failures are logged as warnings to avoid interrupting cleanup.

* **Tests**
  * Added comprehensive tests for read-only/writable transitions, nested directories, executable-bit preservation, and permission-error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->