### PR TITLE
add regfile to targets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "PyGithub >= 2.8.0, < 2.10.0",
     "urllib3 >= 1.26.0", # Required for PyGithub
 
-    "lambdapdk >= 0.2.11",
+    "lambdapdk >= 0.2.12",
 
     "fasteners >= 0.20",
     "pandas >= 1.1.5",

--- a/siliconcompiler/targets/asap7_demo.py
+++ b/siliconcompiler/targets/asap7_demo.py
@@ -5,7 +5,8 @@ from siliconcompiler.flows import asicflow, synflow
 from lambdapdk.asap7.libs.asap7sc7p5t import ASAP7SC7p5RVT, ASAP7SC7p5SLVT, ASAP7SC7p5LVT
 from lambdapdk.asap7.libs.fakeram7 import FakeRAM7Lambdalib_SinglePort, \
     FakeRAM7Lambdalib_DoublePort, \
-    FakeRAM7Lambdalib_TrueDoublePort
+    FakeRAM7Lambdalib_TrueDoublePort, \
+    FakeRAM7Lambdalib_SinglePortRegfile
 from lambdapdk.asap7.libs.fakeio7 import FakeIO7Lambdalib_IO
 
 
@@ -102,6 +103,7 @@ def asap7_demo(
     # under a common, standardized naming convention. These are 'fake' libraries
     # for demonstration and academic purposes.
     FakeRAM7Lambdalib_SinglePort.alias(project)
+    FakeRAM7Lambdalib_SinglePortRegfile.alias(project)
     FakeRAM7Lambdalib_DoublePort.alias(project)
     FakeRAM7Lambdalib_TrueDoublePort.alias(project)
     FakeIO7Lambdalib_IO.alias(project)

--- a/siliconcompiler/targets/freepdk45_demo.py
+++ b/siliconcompiler/targets/freepdk45_demo.py
@@ -3,7 +3,8 @@ from siliconcompiler import ASIC
 from siliconcompiler.flows import asicflow, synflow
 
 from lambdapdk.freepdk45.libs.nangate45 import Nangate45
-from lambdapdk.freepdk45.libs.fakeram45 import FakeRAM45Lambdalib_SinglePort
+from lambdapdk.freepdk45.libs.fakeram45 import FakeRAM45Lambdalib_SinglePort, \
+    FakeRAM45Lambdalib_SinglePortRegfile
 
 
 ####################################################
@@ -75,3 +76,4 @@ def freepdk45_demo(
     # Makes the fake SRAM library available to the flow under a common,
     # standardized naming convention.
     FakeRAM45Lambdalib_SinglePort.alias(project)
+    FakeRAM45Lambdalib_SinglePortRegfile.alias(project)

--- a/siliconcompiler/targets/gf180_demo.py
+++ b/siliconcompiler/targets/gf180_demo.py
@@ -4,7 +4,8 @@ from siliconcompiler.flows import asicflow, synflow
 
 from lambdapdk.gf180 import GF180_5LM_1TM_9K_9t
 from lambdapdk.gf180.libs.gf180mcu import GF180_MCU_9T_5LMLibrary
-from lambdapdk.gf180.libs.gf180sram import GF180Lambdalib_SinglePort
+from lambdapdk.gf180.libs.gf180sram import GF180Lambdalib_SinglePort, \
+    GF180Lambdalib_SinglePortRegfile
 from lambdapdk.gf180.libs.gf180io import GF180Lambdalib_IO_5LM
 
 
@@ -94,4 +95,5 @@ def gf180_demo(
     # Makes specialized libraries like SRAM and IO cells available to the flow
     # under a common, standardized naming convention.
     GF180Lambdalib_SinglePort.alias(project)
+    GF180Lambdalib_SinglePortRegfile.alias(project)
     GF180Lambdalib_IO_5LM.alias(project)

--- a/siliconcompiler/targets/ihp130_demo.py
+++ b/siliconcompiler/targets/ihp130_demo.py
@@ -3,7 +3,8 @@ from siliconcompiler import ASIC
 from siliconcompiler.flows import asicflow, synflow
 
 from lambdapdk.ihp130.libs.sg13g2_stdcell import IHP130StdCell_1p2
-from lambdapdk.ihp130.libs.sg13g2_sram import IHP130Lambdalib_SinglePort
+from lambdapdk.ihp130.libs.sg13g2_sram import IHP130Lambdalib_SinglePort, \
+    IHP130Lambdalib_SinglePortRegfile
 from lambdapdk.ihp130.libs.sg13g2_io import IHP130LambdaLib_IO_1p2
 
 
@@ -93,4 +94,5 @@ def ihp130_demo(
     # Makes specialized libraries like SRAM and IO cells available to the flow
     # under a common, standardized naming convention.
     IHP130Lambdalib_SinglePort.alias(project)
+    IHP130Lambdalib_SinglePortRegfile.alias(project)
     IHP130LambdaLib_IO_1p2.alias(project)

--- a/siliconcompiler/targets/skywater130_demo.py
+++ b/siliconcompiler/targets/skywater130_demo.py
@@ -4,7 +4,8 @@ from siliconcompiler import ASIC
 from siliconcompiler.flows import asicflow, synflow
 
 from lambdapdk.sky130.libs.sky130sc import Sky130_SCHDLibrary
-from lambdapdk.sky130.libs.sky130sram import Sky130Lambdalib_SinglePort
+from lambdapdk.sky130.libs.sky130sram import Sky130Lambdalib_SinglePort, \
+    Sky130Lambdalib_SinglePortRegfile
 from lambdapdk.sky130.libs.sky130io import Sky130LambdaLib_IO
 
 
@@ -92,4 +93,5 @@ def skywater130_demo(
     # Makes specialized libraries like SRAM and IO cells available to the flow
     # under a common, standardized naming convention.
     Sky130Lambdalib_SinglePort.alias(project)
+    Sky130Lambdalib_SinglePortRegfile.alias(project)
     Sky130LambdaLib_IO.alias(project)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added register-file-backed SRAM library support to ASAP7, FreePDK45, GF180, IHP130, and Skywater130 demo targets.

* **Chores**
  * Updated platform dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->