### PR TITLE
add check for file not found in timestamp checking

### DIFF
--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -564,8 +564,11 @@ class SchedulerNode:
                     files = [files]
 
                 for check_file in files:
-                    if get_file_time(check_file) > previous_time:
-                        gen_warning(key, "timestamp")
+                    try:
+                        if get_file_time(check_file) > previous_time:
+                            gen_warning(key, "timestamp")
+                    except FileNotFoundError as e:
+                        gen_warning(key, f"file not found: {e.filename or e.filename2}")
 
     def get_check_changed_keys(self) -> Tuple[Set[Tuple[str, ...]], Set[Tuple[str, ...]]]:
         """

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -901,7 +901,8 @@ def test_check_files_changed_directory_invalid_symlink(project):
     node = SchedulerNode(project, "steptwo", "0")
     with node.runtime():
         with pytest.raises(SchedulerNodeReset,
-                           match=r"^\[library,testdesign,fileset,rtl,idir\] \(file not found: .*/testdir/invalid_link\.txt\) "
+                           match=r"^\[library,testdesign,fileset,rtl,idir\] "
+                                 r"\(file not found: .*/testdir/invalid_link\.txt\) "
                                  r"in steptwo/0 has been modified from previous run$"):
             node.check_files_changed(
                 node, now, [("library", "testdesign", "fileset", "rtl", "idir")])

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -886,8 +886,6 @@ def test_check_files_changed_hash_directory_symlink(project):
 @pytest.mark.skipif(sys.platform == "win32", reason="Symlinks are not supported on Windows")
 def test_check_files_changed_directory_invalid_symlink(project):
     """Test that get_file_time fails when a directory contains an invalid symlink."""
-    now = time.time() - 1
-
     # Create a directory with a valid file and an invalid symlink inside
     os.makedirs("testdir", exist_ok=True)
     with open("testdir/validfile.txt", "w") as f:
@@ -895,6 +893,9 @@ def test_check_files_changed_directory_invalid_symlink(project):
 
     # Create an invalid symlink inside the directory
     os.symlink("nonexistent_target.txt", "testdir/invalid_link.txt")
+
+    # Set now to be later than the file mtimes to deterministically test the invalid symlink path
+    now = os.path.getmtime("testdir/validfile.txt") + 1
 
     project.set("library", "testdesign", "fileset", "rtl", "idir", "testdir")
 

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -883,6 +883,30 @@ def test_check_files_changed_hash_directory_symlink(project):
                 node_other, now, [("library", "testdesign", "fileset", "rtl", "idir")])
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Symlinks are not supported on Windows")
+def test_check_files_changed_directory_invalid_symlink(project):
+    """Test that get_file_time fails when a directory contains an invalid symlink."""
+    now = time.time() - 1
+
+    # Create a directory with a valid file and an invalid symlink inside
+    os.makedirs("testdir", exist_ok=True)
+    with open("testdir/validfile.txt", "w") as f:
+        f.write("test")
+
+    # Create an invalid symlink inside the directory
+    os.symlink("nonexistent_target.txt", "testdir/invalid_link.txt")
+
+    project.set("library", "testdesign", "fileset", "rtl", "idir", "testdir")
+
+    node = SchedulerNode(project, "steptwo", "0")
+    with node.runtime():
+        with pytest.raises(SchedulerNodeReset,
+                           match=r"^\[library,testdesign,fileset,rtl,idir\] \(file not found: .*/testdir/invalid_link\.txt\) "
+                                 r"in steptwo/0 has been modified from previous run$"):
+            node.check_files_changed(
+                node, now, [("library", "testdesign", "fileset", "rtl", "idir")])
+
+
 def test_requires_run_breakpoint(project):
     assert project.set("option", "breakpoint", True, step="steptwo")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File-change detection now gracefully handles missing or inaccessible files, emitting clearer "file not found" diagnostics and triggering the appropriate reset behavior instead of aborting.

* **Tests**
  * Added a test for a directory containing a broken symlink (skipped on Windows) to validate clear error reporting and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->