### PR TITLE
add option to assert pin placement in floorplan init

### DIFF
--- a/siliconcompiler/tools/openroad/init_floorplan.py
+++ b/siliconcompiler/tools/openroad/init_floorplan.py
@@ -113,7 +113,7 @@ class InitFloorplanTask(APRTask,
             self.add("var", "bumpmapfileset", fileset, step=step, index=index)
 
     def set_openroad_assertallpinsplaced(self, enable: bool,
-                                       step: Optional[str] = None, index: Optional[str] = None):
+                                         step: Optional[str] = None, index: Optional[str] = None):
         """
         Enables or disables an assertion that all pins are placed after floorplanning.
 

--- a/siliconcompiler/tools/openroad/init_floorplan.py
+++ b/siliconcompiler/tools/openroad/init_floorplan.py
@@ -25,6 +25,8 @@ class InitFloorplanTask(APRTask,
                            "remove buffers inserted by synthesis", defvalue=True)
         self.add_parameter("remove_dead_logic", "bool",
                            "remove logic which does not drive a primary output", defvalue=True)
+        self.add_parameter("assert_all_pins_placed", "bool",
+                           "assert that all pins are placed", defvalue=False)
 
         self.add_parameter("padringfileset", "[str]", "filesets to generate a padring")
         self.add_parameter("bumpmapfileset", "[str]", "filesets to generate a bumpmap")
@@ -110,6 +112,18 @@ class InitFloorplanTask(APRTask,
         else:
             self.add("var", "bumpmapfileset", fileset, step=step, index=index)
 
+    def set_openroad_assertallpinsplaced(self, enable: bool,
+                                       step: Optional[str] = None, index: Optional[str] = None):
+        """
+        Enables or disables an assertion that all pins are placed after floorplanning.
+
+        Args:
+            enable: True to assert that all pins are placed, False to disable this assertion.
+            step: The specific step to apply this configuration to.
+            index: The specific index to apply this configuration to.
+        """
+        self.set("var", "assert_all_pins_placed", enable, step=step, index=index)
+
     def task(self):
         return "init_floorplan"
 
@@ -145,6 +159,7 @@ class InitFloorplanTask(APRTask,
         self.add_required_key("var", "ifp_snap_strategy")
         self.add_required_key("var", "remove_synth_buffers")
         self.add_required_key("var", "remove_dead_logic")
+        self.add_required_key("var", "assert_all_pins_placed")
 
         if self.get("var", "padringfileset"):
             self.add_required_key("var", "padringfileset")

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_init_floorplan.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_init_floorplan.tcl
@@ -369,6 +369,13 @@ if { [sc_cfg_exists constraint pin] } {
 }
 
 ###############################
+# Check pin placement
+###############################
+if { [sc_cfg_tool_task_get var assert_all_pins_placed] } {
+    sc_design_assert_ios_fixed
+}
+
+###############################
 # Generate pad ring
 ###############################
 

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_init_floorplan.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_init_floorplan.tcl
@@ -369,13 +369,6 @@ if { [sc_cfg_exists constraint pin] } {
 }
 
 ###############################
-# Check pin placement
-###############################
-if { [sc_cfg_tool_task_get var assert_all_pins_placed] } {
-    sc_design_assert_ios_fixed
-}
-
-###############################
 # Generate pad ring
 ###############################
 
@@ -403,6 +396,13 @@ if { [llength [sc_cfg_tool_task_get var padringfileset]] > 0 } {
         }
         utl::error FLW 1 "Design contains unplaced IOs"
     }
+}
+
+###############################
+# Check pin placement
+###############################
+if { [sc_cfg_tool_task_get var assert_all_pins_placed] } {
+    sc_design_assert_ios_fixed
 }
 
 if { [sc_check_version 24 3 7421] } {

--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -292,6 +292,22 @@ proc sc_design_has_placeable_ios { } {
     return false
 }
 
+proc sc_design_assert_ios_fixed { } {
+    set unfixed_ios false
+    foreach bterm [[ord::get_db_block] getBTerms] {
+        if {
+            [$bterm getFirstPinPlacementStatus] != "FIRM" &&
+            [$bterm getFirstPinPlacementStatus] != "LOCKED"
+        } {
+            set unfixed_ios true
+            puts "IO terminal [$bterm getName] has not been placed."
+        }
+    }
+    if { $unfixed_ios } {
+        utl::error FLW 1 "Design has unfixed IOs. Please fix all IOs before proceeding."
+    }
+}
+
 ###########################
 # Check if net has placed bpins
 ###########################


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new boolean floorplanning option (default: disabled) to validate that all I/O pins are placed.
  * Exposed a user-facing setting to toggle this validation per run.
  * When enabled, the flow will report unplaced pins and halt the process to surface pin-placement issues early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->