### PR TITLE
version 0.37.6

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,21 @@ The changes in each SiliconCompiler release version are described below. Commit
 version shown in (). Where applicable, the contributors that suggested a given
 feature are shown in [].
 
+SiliconCompiler 0.37.6 (2026-04-15)
+=========================================
+
+**Minor:**
+
+ * Switched to marking cached downloads as readonly to avoid accidental overwrites.
+ * Added utility app to cleanup caches with `python3 -m siliconcompiler.apps.utils.cleanup`.
+ * Updated targets to map regfiles from lambdalib.
+ * Added `scp` based file path resolver to allow files to be copied between machines.
+
+ * Tools:
+
+  * openroad: Added option to check that all pins are placed and remove blockages created during macro placement.
+
+
 SiliconCompiler 0.37.5 (2026-04-08)
 =========================================
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: SiliconCompiler 0.37.6

* **New Features**
  * Introduced cleanup utility app for SiliconCompiler management.
  * Added file transfer capability between machines using scp-based resolver.
  * OpenROAD: New option to verify pin placement and remove blockages during macro placement.

* **Improvements**
  * Cached downloads now marked read-only to prevent accidental overwrites.
  * Enhanced target support with regfile mapping from lambdalib.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->