### PR TITLE
Update write_sdf, _liberty to opensta 3.0+ and add eda test

### DIFF
--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -201,7 +201,7 @@ if { $opensta_timing_mode == "asic" } {
 if { [sc_cfg_tool_task_get var write_sdf] } {
     foreach corner $sc_scenarios {
         puts "Writing SDF for $corner"
-        write_sdf -corner $corner \
+        write_sdf -scene $corner \
             -include_typ \
             "outputs/${sc_topmodule}.${corner}.sdf"
     }
@@ -215,7 +215,7 @@ if { [sc_cfg_tool_task_get var write_liberty] } {
     foreach corner $sc_scenarios {
         puts "Writing liberty model for $corner"
         write_timing_model -library_name "${sc_topmodule}_${corner}" \
-            -corner $corner \
+            -scene $corner \
             "outputs/${sc_topmodule}.${corner}.lib"
     }
 }

--- a/tests/tools/test_opensta.py
+++ b/tests/tools/test_opensta.py
@@ -6,6 +6,7 @@ import os.path
 from siliconcompiler.scheduler import SchedulerNode
 from siliconcompiler import ASIC, Design, Flowgraph
 from siliconcompiler.tools.opensta import timing
+from siliconcompiler.utils.paths import workdir
 
 from siliconcompiler.targets import freepdk45_demo
 
@@ -83,6 +84,39 @@ def test_opensta_sdf(datadir):
     # Check that the setup and hold slacks are the expected values.
     assert proj.history("job0").get('metric', 'setupslack', step='opensta', index='0') == -0.890
     assert proj.history("job0").get('metric', 'holdslack', step='opensta', index='0') == 0.020
+
+
+@pytest.mark.eda
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_opensta_write_lib_sdf(datadir):
+    design = Design("testdesign")
+    design.set_dataroot("root", datadir)
+    with design.active_dataroot("root"), design.active_fileset("rtl"):
+        design.set_topmodule("foo")
+        design.add_file(os.path.join("lec", "foo.vg"))
+    with design.active_dataroot("root"), design.active_fileset("sdc"):
+        design.add_file(os.path.join("lec", "foo.sdc"))
+    proj = ASIC(design)
+    proj.add_fileset(["rtl", "sdc"])
+    freepdk45_demo(proj)
+
+    flow = Flowgraph("timing")
+    flow.node("opensta", timing.TimingTask())
+    proj.set_flow(flow)
+
+    timing.TimingTask.find_task(proj).set_opensta_writesdf(True)
+    timing.TimingTask.find_task(proj).set_opensta_writeliberty(True)
+
+    # Check that OpenSTA ran successfully
+    assert proj.run()
+
+    # Check that sdf, liberty outputs are generated
+    out_dir = os.path.join(
+        workdir(proj.history("job0"), step="opensta", index="0"), "outputs"
+    )
+    assert os.path.exists(os.path.join(out_dir, "foo.typical.sdf"))
+    assert os.path.exists(os.path.join(out_dir, "foo.typical.lib"))
 
 
 def test_opensta_parameter_top_n_paths():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated timing artifact export commands to use corrected parameter syntax, ensuring SDF file and liberty timing model generation work properly with current tool versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->