### PR TITLE
add keypath to dataroot messages

### DIFF
--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -135,6 +135,15 @@ class Resolver:
         return self.__name
 
     @property
+    def display_name(self) -> str:
+        """A user-friendly display name for the resolver."""
+        if self.__schema:
+            keypath = self.__schema._keypath
+            if keypath:
+                return f"{self.name} [{','.join(keypath)}]"
+        return self.name
+
+    @property
     def root(self) -> Optional[Union["Project", "BaseSchema"]]:
         """The root object (e.g., Project) providing context."""
         return self.__root
@@ -296,12 +305,12 @@ class Resolver:
 
         path = self.resolve()
         if not os.path.exists(path):
-            raise FileNotFoundError(f"Unable to locate '{self.name}' at {path}")
+            raise FileNotFoundError(f"Unable to locate '{self.display_name}' at {path}")
 
         if self.changed:
-            self.logger.info(f'Saved {self.name} data to {path}')
+            self.logger.info(f'Saved {self.display_name} data to {path}')
         else:
-            self.logger.info(f'Found {self.name} data at {path}')
+            self.logger.info(f'Found {self.display_name} data at {path}')
 
         Resolver.set_cache(self.__root, self.cache_id, path)
         return str(path)
@@ -828,7 +837,7 @@ class KeyPathResolver(Resolver):
             RuntimeError: If the resolver does not have a root project object defined.
         """
         if not self.root:
-            raise RuntimeError(f"A root schema has not been defined for '{self.name}'")
+            raise RuntimeError(f"A root schema has not been defined for '{self.display_name}'")
 
         key = self.urlpath.split(",")
         if self.root.get(*key, field='pernode').is_never():

--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -98,7 +98,6 @@ class Resolver:
         settings.set("resolvers", "file", FileResolver)
         settings.set("resolvers", "key", KeyPathResolver)
         settings.set("resolvers", "python", PythonPathResolver)
-        settings.set("resolvers", "dataroot", DatarootResolver)
 
         for resolver in get_plugins("path_resolver"):
             for scheme, res in resolver().items():

--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -52,7 +52,7 @@ class Resolver:
 
     Attributes:
         name (str): The name of the data package being resolved.
-        root (object): The root object (typically a Project) providing context,
+        schema (object): The root object (typically a Project) providing context,
             such as environment variables and the working directory.
         source (str): The URI or path specifying the data source.
         reference (str): A version, commit hash, or tag for remote sources.
@@ -60,14 +60,15 @@ class Resolver:
     __STORAGE: Final[str] = "__Resolver_cache_id"
 
     def __init__(self, name: str,
-                 root: Optional[Union["Project", "BaseSchema"]],
+                 schema: Optional[Union["Project", "BaseSchema"]],
                  source: str,
                  reference: Optional[str] = None):
         """
         Initializes the Resolver.
         """
         self.__name = name
-        self.__root = root
+        self.__schema = schema
+        self.__root = None if schema is None else schema._parent(root=True)
         self.__source = source
         self.__reference = reference
         self.__changed = False
@@ -97,6 +98,7 @@ class Resolver:
         settings.set("resolvers", "file", FileResolver)
         settings.set("resolvers", "key", KeyPathResolver)
         settings.set("resolvers", "python", PythonPathResolver)
+        settings.set("resolvers", "dataroot", DatarootResolver)
 
         for resolver in get_plugins("path_resolver"):
             for scheme, res in resolver().items():
@@ -147,6 +149,11 @@ class Resolver:
     def root(self) -> Optional[Union["Project", "BaseSchema"]]:
         """The root object (e.g., Project) providing context."""
         return self.__root
+
+    @property
+    def schema(self) -> Optional["BaseSchema"]:
+        """The schema object (e.g., Project) providing context."""
+        return self.__schema
 
     @property
     def logger(self) -> logging.Logger:
@@ -343,13 +350,13 @@ class RemoteResolver(Resolver):
     multiple SC instances try to download the same resource simultaneously.
     """
     def __init__(self, name: str,
-                 root: Optional[Union["Project", "BaseSchema"]],
+                 schema: Optional[Union["Project", "BaseSchema"]],
                  source: str,
                  reference: Optional[str] = None):
         if reference is None:
             raise ValueError(f'A reference (e.g., version, commit) is required for {name}')
 
-        super().__init__(name, root, source, reference)
+        super().__init__(name, schema, source, reference)
 
         # Wait a maximum of 10 minutes for other processes to finish
         self.__max_lock_wait: int = 60 * 10
@@ -675,13 +682,13 @@ class FileResolver(Resolver):
     It normalizes the source string to a `file://` URI.
     """
 
-    def __init__(self, name: str, root: "Project", source: str, reference: Optional[str] = None):
+    def __init__(self, name: str, schema: "Project", source: str, reference: Optional[str] = None):
         if source.startswith("file://"):
             source = source[7:]
         if source[0] != "$" and not os.path.isabs(source):
-            source = os.path.join(cwdirsafe(root), source)
+            source = os.path.join(cwdirsafe(schema._parent(root=True)), source)
 
-        super().__init__(name, root, f"file://{source}", None)
+        super().__init__(name, schema, f"file://{source}", None)
 
     @property
     def urlpath(self) -> str:
@@ -706,8 +713,8 @@ class PythonPathResolver(Resolver):
     determine if a package is installed in "editable" mode.
     """
 
-    def __init__(self, name: str, root: "Project", source: str, reference: Optional[str] = None):
-        super().__init__(name, root, source, None)
+    def __init__(self, name: str, schema: "Project", source: str, reference: Optional[str] = None):
+        super().__init__(name, schema, source, None)
 
     @staticmethod
     @functools.lru_cache(maxsize=1)
@@ -823,8 +830,8 @@ class KeyPathResolver(Resolver):
     `find_files` method of the root project object to locate the corresponding file.
     """
 
-    def __init__(self, name: str, root: "Project", source: str, reference: Optional[str] = None):
-        super().__init__(name, root, source, None)
+    def __init__(self, name: str, schema: "Project", source: str, reference: Optional[str] = None):
+        super().__init__(name, schema, source, None)
 
     def resolve(self) -> str:
         """

--- a/siliconcompiler/package/git.py
+++ b/siliconcompiler/package/git.py
@@ -47,11 +47,11 @@ class GitResolver(RemoteResolver):
     for SSH-based URLs.
     """
 
-    def __init__(self, name: str, root: "Project", source: str, reference: Optional[str] = None):
+    def __init__(self, name: str, schema: "Project", source: str, reference: Optional[str] = None):
         """
         Initializes the GitResolver.
         """
-        super().__init__(name, root, source, reference)
+        super().__init__(name, schema, source, reference)
 
     def check_cache(self) -> bool:
         """
@@ -177,7 +177,7 @@ class GitResolver(RemoteResolver):
         """
         try:
             path = self.git_path
-            self.logger.info(f'Cloning {self.name} data from {path}')
+            self.logger.info(f'Cloning {self.display_name} data from {path}')
             repo = Repo.clone_from(path, self.cache_path,
                                    recurse_submodules=self.include_submodules)
 

--- a/siliconcompiler/package/github.py
+++ b/siliconcompiler/package/github.py
@@ -49,11 +49,11 @@ class GithubResolver(HTTPResolver):
     a GitHub token must be provided via environment variables.
     """
 
-    def __init__(self, name: str, root: "Project", source: str, reference: Optional[str] = None):
+    def __init__(self, name: str, schema: "Project", source: str, reference: Optional[str] = None):
         """
         Initializes the GithubResolver.
         """
-        super().__init__(name, root, source, reference)
+        super().__init__(name, schema, source, reference)
 
         self.__url = None
 

--- a/siliconcompiler/package/https.py
+++ b/siliconcompiler/package/https.py
@@ -121,11 +121,11 @@ class HTTPResolver(RemoteResolver):
             if auth_token:
                 headers['Authorization'] = f'token {auth_token}'
 
-        self.logger.info(f'Downloading {self.name} data from {data_url}')
+        self.logger.info(f'Downloading {self.display_name} data from {data_url}')
 
         response = requests.get(data_url, stream=True, headers=headers)
         if not response.ok:
-            raise FileNotFoundError(f'Failed to download {self.name} data source from {data_url}. '
+            raise FileNotFoundError(f'Failed to download {self.display_name} data source from {data_url}. '
                                     f'Status code: {response.status_code}')
 
         os.makedirs(self.cache_path, exist_ok=True)

--- a/siliconcompiler/package/https.py
+++ b/siliconcompiler/package/https.py
@@ -125,8 +125,8 @@ class HTTPResolver(RemoteResolver):
 
         response = requests.get(data_url, stream=True, headers=headers)
         if not response.ok:
-            raise FileNotFoundError(f'Failed to download {self.display_name} data source from {data_url}. '
-                                    f'Status code: {response.status_code}')
+            raise FileNotFoundError(f'Failed to download {self.display_name} data source from '
+                                    f'{data_url}. Status code: {response.status_code}')
 
         os.makedirs(self.cache_path, exist_ok=True)
 

--- a/siliconcompiler/package/scp.py
+++ b/siliconcompiler/package/scp.py
@@ -36,11 +36,11 @@ class SCPResolver(RemoteResolver):
     This class copies a directory from a remote server using SCP
     """
 
-    def __init__(self, name: str, root: "Project", source: str, reference: Optional[str] = None):
+    def __init__(self, name: str, schema: "Project", source: str, reference: Optional[str] = None):
         """
         Initializes the SCPResolver.
         """
-        super().__init__(name, root, source, reference)
+        super().__init__(name, schema, source, reference)
 
         self.__host = None
         self.__host_path = None

--- a/siliconcompiler/schema_support/pathschema.py
+++ b/siliconcompiler/schema_support/pathschema.py
@@ -390,7 +390,7 @@ class PathSchema(PathSchemaBase):
         tag: Optional[str] = BaseSchema.get(schema, "dataroot", name, "tag")
 
         resolver = Resolver.find_resolver(path)
-        return resolver(name, schema._parent(root=True), path, tag).get_path()
+        return resolver(name, self, path, tag).get_path()
 
     def _find_files_dataroot_resolvers(self, resolvers: bool = False) \
             -> Dict[str, Union[str, Callable]]:
@@ -411,7 +411,7 @@ class PathSchema(PathSchemaBase):
             path = BaseSchema.get(schema, "dataroot", dataroot, "path")
             tag = BaseSchema.get(schema, "dataroot", dataroot, "tag")
             resolver = Resolver.find_resolver(path)
-            resolver_obj = resolver(dataroot, schema_root, path, tag)
+            resolver_obj = resolver(dataroot, self, path, tag)
             if resolvers:
                 resolver_map[dataroot] = resolver_obj
             else:

--- a/siliconcompiler/schema_support/pathschema.py
+++ b/siliconcompiler/schema_support/pathschema.py
@@ -400,7 +400,6 @@ class PathSchema(PathSchemaBase):
         Returns:
             dictionary of str to resolver mapping
         """
-        schema_root = self._parent(root=True)
         schema = self.__dataroot_section()
 
         if not schema.valid("dataroot"):

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -18,6 +18,7 @@ from siliconcompiler.package import FileResolver, PythonPathResolver, KeyPathRes
 from siliconcompiler.package import InterProcessLock as dut_ipl
 
 from siliconcompiler import Project, Design
+from siliconcompiler.schema import BaseSchema
 
 
 def test_init():
@@ -229,7 +230,7 @@ def test_file_env_var_with_scheme():
 
 
 def test_file_env_var_start_with_root():
-    class Project:
+    class Project(BaseSchema):
         __cwd = "thiscwd"
 
         def valid(*_args, **_kwargs):  # keep interface, silence linters

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -90,6 +90,70 @@ def test_resolve():
         resolver.resolve()
 
 
+def test_display_name_with_schema():
+    """Test display_name returns name when schema exists but has empty keypath."""
+    project = Project("testproj")
+    resolver = Resolver("mydata", project, "source://this")
+
+    # For root-level schemas with empty keypath, display_name should be just the name
+    display = resolver.display_name
+    assert display == "mydata"
+
+
+def test_display_name_without_schema():
+    """Test display_name returns just the name when no schema is provided."""
+    resolver = Resolver("mydata", None, "source://this")
+
+    # display_name should be just the name without keypath
+    assert resolver.display_name == "mydata"
+
+
+def test_display_name_with_nested_schema():
+    """Test display_name includes keypath when schema is nested."""
+    design = Design("testdesign")
+    with design.active_fileset("rtl"):
+        design.add_idir(".")
+
+    project = Project(design)
+
+    # Get a nested design schema from the project
+    library_design = project.get("library", "testdesign", field="schema")
+    resolver = Resolver("packagedata", library_design, "source://this")
+
+    # display_name should include the keypath in brackets
+    display = resolver.display_name
+    assert display == "packagedata [library,testdesign]"
+
+
+def test_display_name_consistency():
+    """Test that display_name is consistent across multiple calls."""
+    project = Project("testproj")
+    resolver = Resolver("data", project, "source://path")
+
+    # Multiple calls should return the same value
+    display1 = resolver.display_name
+    display2 = resolver.display_name
+    assert display1 == display2
+
+
+def test_display_name_format_with_keypath():
+    """Test that display_name follows the expected format when keypath exists."""
+    design = Design("testdesign")
+    with design.active_fileset("rtl"):
+        design.add_idir(".")
+
+    project = Project(design)
+    library_design = project.get("library", "testdesign", field="schema")
+
+    resolver = Resolver("myresolver", library_design, "source://this")
+
+    # Format should be: "name [keypath,...]"
+    display = resolver.display_name
+    # Should have brackets and the name at the start
+    assert display.startswith("myresolver [")
+    assert display.endswith("]")
+
+
 def test_find_resolver_not_found():
     with pytest.raises(ValueError,
                        match=r"^Source URI 'nosupport://help.me/file' is not supported$"):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a human-friendly resolver identifier that appends schema keypath when available.

* **Improvements**
  * Error messages and logs now use the new display identifiers for clearer resolver reporting.
  * Resolver initialization and path-base handling now use the schema context for more consistent resolution behavior across sources and remotes.
  * Log messages standardized to reference display identifiers.

* **Tests**
  * Added unit tests covering display-name formatting and behavior across schema scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->