### PR TITLE
add job killing when memory exceeds 99% utilization

### DIFF
--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -79,11 +79,13 @@ class TaskOutOfMemoryError(TaskError):
 
     Args:
         memory_percent (float): The percentage of system memory usage at the time of the error.
+        available_mb (float): The available system memory in megabytes at the time of the error.
     '''
 
-    def __init__(self, *args, memory_percent=None, **kwargs):
+    def __init__(self, *args, memory_percent=None, available_mb=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.memory_percent = memory_percent
+        self.available_mb = available_mb
 
 
 class TaskExecutableNotFound(TaskError):
@@ -146,7 +148,7 @@ class Task(NamedSchema, PathSchema, DocsSchema):
     __IO_POLL_INTERVAL: float = 0.1
     __MEM_POLL_INTERVAL: float = 0.5
     __MEMORY_WARN_LIMIT: int = 90
-    __MEMORY_KILL_LIMIT: int = 99
+    __MEMORY_KILL_LIMIT_MB: int = 256
 
     def __init__(self):
         super().__init__()
@@ -935,11 +937,13 @@ class Task(NamedSchema, PathSchema, DocsSchema):
             pass
         return None
 
-    def __check_memory_limit(self, warn_limit: int, kill_limit: int) -> int:
+    def __check_memory_limit(self, warn_limit: int, kill_limit_mb: int) -> int:
         try:
             memory_usage = psutil.virtual_memory()
-            if memory_usage.percent > kill_limit:
-                raise TaskOutOfMemoryError(memory_percent=memory_usage.percent)
+            available_mb = memory_usage.available / (1024 * 1024)
+            if available_mb < kill_limit_mb:
+                raise TaskOutOfMemoryError(memory_percent=memory_usage.percent,
+                                           available_mb=available_mb)
             if memory_usage.percent > warn_limit:
                 self.logger.warning(
                     'Current system memory usage is '
@@ -1101,7 +1105,7 @@ class Task(NamedSchema, PathSchema, DocsSchema):
                                 next_collection = curr_time + Task.__MEM_POLL_INTERVAL
 
                                 memory_warn_limit = self.__check_memory_limit(
-                                    memory_warn_limit, Task.__MEMORY_KILL_LIMIT)
+                                    memory_warn_limit, Task.__MEMORY_KILL_LIMIT_MB)
 
                             read_stdio(stdout_reader, stderr_reader)
 
@@ -1121,7 +1125,8 @@ class Task(NamedSchema, PathSchema, DocsSchema):
                         raise
                     except TaskOutOfMemoryError as e:
                         self.logger.error('Task ran out of memory with '
-                                          f'{e.memory_percent:.1f}% system memory usage')
+                                          f'{e.memory_percent:.1f}% system memory usage '
+                                          f'({e.available_mb:.1f} MB available)')
                         self.__terminate_exe(proc)
                         raise
 

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -74,6 +74,18 @@ class TaskTimeout(TaskError):
         self.timeout = timeout
 
 
+class TaskOutOfMemoryError(TaskError):
+    '''Error indicating that a task has run out of memory during execution.
+
+    Args:
+        memory_percent (float): The percentage of system memory usage at the time of the error.
+    '''
+
+    def __init__(self, *args, memory_percent=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.memory_percent = memory_percent
+
+
 class TaskExecutableNotFound(TaskError):
     '''Error indicating that the required tool executable could not be found.'''
     pass
@@ -134,6 +146,7 @@ class Task(NamedSchema, PathSchema, DocsSchema):
     __IO_POLL_INTERVAL: float = 0.1
     __MEM_POLL_INTERVAL: float = 0.5
     __MEMORY_WARN_LIMIT: int = 90
+    __MEMORY_KILL_LIMIT: int = 99
 
     def __init__(self):
         super().__init__()
@@ -922,9 +935,11 @@ class Task(NamedSchema, PathSchema, DocsSchema):
             pass
         return None
 
-    def __check_memory_limit(self, warn_limit: int) -> int:
+    def __check_memory_limit(self, warn_limit: int, kill_limit: int) -> int:
         try:
             memory_usage = psutil.virtual_memory()
+            if memory_usage.percent > kill_limit:
+                raise TaskOutOfMemoryError(memory_percent=memory_usage.percent)
             if memory_usage.percent > warn_limit:
                 self.logger.warning(
                     'Current system memory usage is '
@@ -1085,7 +1100,8 @@ class Task(NamedSchema, PathSchema, DocsSchema):
                                     max_mem_bytes = max(max_mem_bytes, proc_mem_bytes)
                                 next_collection = curr_time + Task.__MEM_POLL_INTERVAL
 
-                                memory_warn_limit = self.__check_memory_limit(memory_warn_limit)
+                                memory_warn_limit = self.__check_memory_limit(
+                                    memory_warn_limit, Task.__MEMORY_KILL_LIMIT)
 
                             read_stdio(stdout_reader, stderr_reader)
 
@@ -1101,6 +1117,11 @@ class Task(NamedSchema, PathSchema, DocsSchema):
                         raise TaskError
                     except TaskTimeout as e:
                         self.logger.error(f'Task timed out after {e.timeout:.1f} seconds')
+                        self.__terminate_exe(proc)
+                        raise
+                    except TaskOutOfMemoryError as e:
+                        self.logger.error('Task ran out of memory with '
+                                          f'{e.memory_percent:.1f}% system memory usage')
                         self.__terminate_exe(proc)
                         raise
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1394,6 +1394,7 @@ def test_run_task_memory_limit_kill(running_node, monkeypatch, caplog):
         # Return memory usage above kill limit (99%)
         class Memory:
             percent = 99.5
+            available = 100 * 1024 * 1024  # 100 MiB
         return Memory
 
     monkeypatch.setattr(imported_subprocess, 'Popen', dummy_popen)
@@ -1403,14 +1404,16 @@ def test_run_task_memory_limit_kill(running_node, monkeypatch, caplog):
         return "found/exe"
     monkeypatch.setattr(running_node.task, 'get_exe', dummy_get_exe)
 
-    with patch("siliconcompiler.tool.Task._Task__terminate_exe", autospec=True) as mock_terminate_exe:
+    with patch("siliconcompiler.tool.Task._Task__terminate_exe",
+               autospec=True) as mock_terminate_exe:
         with running_node.task.runtime(running_node) as runtool:
             with pytest.raises(TaskOutOfMemoryError, match=r"^$"):
                 runtool.run_task('.', False, False, None, None)
         mock_terminate_exe.assert_called_once()
 
     # Verify error message about memory is logged
-    assert "Task ran out of memory with 99.5% system memory usage" in caplog.text
+    assert "Task ran out of memory with 99.5% system memory usage (100.0 MB available)" \
+        in caplog.text
 
 
 @pytest.mark.parametrize("error", [PermissionError, imported_psutil.Error])

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -20,7 +20,8 @@ from siliconcompiler import Task
 from siliconcompiler import Design, Project
 from siliconcompiler.schema import BaseSchema, EditableSchema, Parameter, SafeSchema
 from siliconcompiler.schema.parameter import PerNode, Scope
-from siliconcompiler.tool import TaskExecutableNotFound, TaskError, TaskTimeout
+from siliconcompiler.tool import TaskExecutableNotFound, TaskError, TaskTimeout, \
+    TaskOutOfMemoryError
 from siliconcompiler.flowgraph import RuntimeFlowgraph
 from siliconcompiler.scheduler import SchedulerNode
 from siliconcompiler.utils.multiprocessing import MPManager
@@ -1368,6 +1369,91 @@ def test_run_task_memory_limit(running_node, monkeypatch, patch_psutil, caplog):
         assert runtool.run_task('.', False, False, None, None) == 0
 
     assert "Current system memory usage is 91.2%" in caplog.text
+
+
+def test_run_task_memory_limit_kill(running_node, monkeypatch, caplog):
+    """Verify process is killed when memory limit is exceeded and terminate/kill are called."""
+    assert running_node.project.set("tool", "builtin", 'task', 'nop', "format", "json")
+
+    # Mock process with tracking for terminate() and kill() calls
+    class TrackingPopen:
+        returncode = 0
+        pid = 1
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            pass
+
+    # Create a mock for psutil.Process to track calls
+    class MockProcess:
+        instances = []
+
+        def __init__(self, pid):
+            self.pid = pid
+            self.terminate_called = False
+            self.kill_called = False
+            MockProcess.instances.append(self)
+
+        def terminate(self):
+            self.terminate_called = True
+
+        def kill(self):
+            self.kill_called = True
+
+        def memory_full_info(self):
+            class Memory:
+                uss = 2
+            return Memory
+
+        def children(self, recursive=True):
+            return []
+
+        def wait(self, timeout=None):
+            pass
+
+    def dummy_psutil_process(pid):
+        return MockProcess(pid)
+
+    def dummy_popen(*args, **kwargs):
+        assert args == (["found/exe"],)
+        return TrackingPopen()
+
+    def dummy_wait_procs(children, timeout=None):
+        # Return empty alive list - all processes terminated/killed
+        return None, []
+
+    def dummy_virtual_memory():
+        # Return memory usage above kill limit (99%)
+        class Memory:
+            percent = 99.5
+        return Memory
+
+    monkeypatch.setattr(imported_subprocess, 'Popen', dummy_popen)
+    monkeypatch.setattr(imported_psutil, 'Process', dummy_psutil_process)
+    monkeypatch.setattr(imported_psutil, 'wait_procs', dummy_wait_procs)
+    monkeypatch.setattr(imported_psutil, 'virtual_memory', dummy_virtual_memory)
+
+    def dummy_get_exe(*args, **kwargs):
+        return "found/exe"
+    monkeypatch.setattr(running_node.task, 'get_exe', dummy_get_exe)
+
+    with running_node.task.runtime(running_node) as runtool:
+        with pytest.raises(TaskOutOfMemoryError, match=r"^$"):
+            runtool.run_task('.', False, False, None, None)
+
+    # Verify error message about memory is logged
+    assert "Task ran out of memory with 99.5% system memory usage" in caplog.text
+    # Verify process termination messages are logged
+    assert "Waiting for builtin/nop to exit" in caplog.text
+
+    # Verify that terminate() was called on the process created during termination
+    # The MockProcess instances include: one created during __terminate_exe
+    assert len(MockProcess.instances) > 0, "MockProcess should have been instantiated"
+    # The last instance created (during __terminate_exe) should have terminate() called
+    terminate_process = MockProcess.instances[-1]
+    assert terminate_process.terminate_called, "Process terminate() should have been called"
 
 
 @pytest.mark.parametrize("error", [PermissionError, imported_psutil.Error])

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1386,43 +1386,9 @@ def test_run_task_memory_limit_kill(running_node, monkeypatch, caplog):
         def wait(self, timeout=None):
             pass
 
-    # Create a mock for psutil.Process to track calls
-    class MockProcess:
-        instances = []
-
-        def __init__(self, pid):
-            self.pid = pid
-            self.terminate_called = False
-            self.kill_called = False
-            MockProcess.instances.append(self)
-
-        def terminate(self):
-            self.terminate_called = True
-
-        def kill(self):
-            self.kill_called = True
-
-        def memory_full_info(self):
-            class Memory:
-                uss = 2
-            return Memory
-
-        def children(self, recursive=True):
-            return []
-
-        def wait(self, timeout=None):
-            pass
-
-    def dummy_psutil_process(pid):
-        return MockProcess(pid)
-
     def dummy_popen(*args, **kwargs):
         assert args == (["found/exe"],)
         return TrackingPopen()
-
-    def dummy_wait_procs(children, timeout=None):
-        # Return empty alive list - all processes terminated/killed
-        return None, []
 
     def dummy_virtual_memory():
         # Return memory usage above kill limit (99%)
@@ -1431,29 +1397,20 @@ def test_run_task_memory_limit_kill(running_node, monkeypatch, caplog):
         return Memory
 
     monkeypatch.setattr(imported_subprocess, 'Popen', dummy_popen)
-    monkeypatch.setattr(imported_psutil, 'Process', dummy_psutil_process)
-    monkeypatch.setattr(imported_psutil, 'wait_procs', dummy_wait_procs)
     monkeypatch.setattr(imported_psutil, 'virtual_memory', dummy_virtual_memory)
 
     def dummy_get_exe(*args, **kwargs):
         return "found/exe"
     monkeypatch.setattr(running_node.task, 'get_exe', dummy_get_exe)
 
-    with running_node.task.runtime(running_node) as runtool:
-        with pytest.raises(TaskOutOfMemoryError, match=r"^$"):
-            runtool.run_task('.', False, False, None, None)
+    with patch("siliconcompiler.tool.Task._Task__terminate_exe", autospec=True) as mock_terminate_exe:
+        with running_node.task.runtime(running_node) as runtool:
+            with pytest.raises(TaskOutOfMemoryError, match=r"^$"):
+                runtool.run_task('.', False, False, None, None)
+        mock_terminate_exe.assert_called_once()
 
     # Verify error message about memory is logged
     assert "Task ran out of memory with 99.5% system memory usage" in caplog.text
-    # Verify process termination messages are logged
-    assert "Waiting for builtin/nop to exit" in caplog.text
-
-    # Verify that terminate() was called on the process created during termination
-    # The MockProcess instances include: one created during __terminate_exe
-    assert len(MockProcess.instances) > 0, "MockProcess should have been instantiated"
-    # The last instance created (during __terminate_exe) should have terminate() called
-    terminate_process = MockProcess.instances[-1]
-    assert terminate_process.terminate_called, "Process terminate() should have been called"
 
 
 @pytest.mark.parametrize("error", [PermissionError, imported_psutil.Error])

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -98,6 +98,7 @@ def patch_psutil(monkeypatch):
     def drummy_virtual_memory():
         class Memory:
             percent = 91.21
+            available = 1024 * 1024 * 1024
         return Memory
 
     monkeypatch.setattr(imported_psutil, 'virtual_memory', drummy_virtual_memory)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks now detect low-system-memory conditions and forcibly terminate subprocesses when a strict kill threshold is reached, logging a clear out-of-memory error that includes observed usage percent and available MB.
  * Improved resource management to prevent runaway processes from consuming excessive system memory.

* **Tests**
  * Added tests validating memory-limit enforcement, termination behavior, and the out-of-memory logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->