### PR TITLE
add register count for clocks

### DIFF
--- a/siliconcompiler/tools/openroad/scripts/common/reports.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/reports.tcl
@@ -112,8 +112,9 @@ if { [sc_cfg_tool_task_check_in_list fmax var reports] } {
             continue
         }
         set fmax [expr { 1.0 / $min_period }]
+        set regs [llength [all_registers -clock $clk]]
         utl::metric_float "timing__fmax__clock:${clk_name}" $fmax
-        puts "$clk_name fmax = [format %.2f [expr { $fmax / 1e6 }]] MHz"
+        puts "$clk_name fmax = [format %.2f [expr { $fmax / 1e6 }]] MHz (registers: $regs)"
         set fmax_metric [expr { max($fmax_metric, $fmax) }]
     }
     if { $fmax_metric == 0 } {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fmax reporting now displays the number of registers for each clock domain, providing additional diagnostic information in the per-clock output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->