### PR TITLE
allow sc-issue without -cfg

### DIFF
--- a/siliconcompiler/apps/sc_issue.py
+++ b/siliconcompiler/apps/sc_issue.py
@@ -20,15 +20,21 @@ Restricted SC app that generates a sharable testcase from a
 failed flow or runs an issue generated with this program.
 
 To generate a testcase, use:
+    sc-issue <design>.pkg.json
+
+    or with explicit flag:
     sc-issue -cfg <stepdir>/outputs/<design>.pkg.json
 
     or include a different step/index than what the cfg_file is pointing to:
-    sc-issue -cfg <otherdir>/outputs/<design>.pkg.json -arg_step <step> -arg_index <index>
+    sc-issue <design>.pkg.json -arg_step <step> -arg_index <index>
 
     or include specific libraries while excluding others:
-    sc-issue -cfg <stepdir>/outputs/<design>.pkg.json -exclude_libraries -add_library sram -add_library gpio
+    sc-issue <design>.pkg.json -exclude_libraries -add_library sram -add_library gpio
 
 To run a testcase, use:
+    sc-issue -run sc_issue_<...>.tar.gz
+
+    or with explicit flag:
     sc-issue -run -file sc_issue_<...>.tar.gz
 -----------------------------------------------------------
 """  # noqa E501
@@ -67,14 +73,22 @@ To run a testcase, use:
     issue = IssueProject.create_cmdline(
         progname,
         description=description,
-        switchlist=switchlist)
+        switchlist=switchlist,
+        use_sources=True)
 
     if not issue.get("cmdarg", "run"):
-        if not issue.get("cmdarg", "cfg"):
-            issue.logger.error('-cfg must be provided')
-            return 1
-
+        # Generate mode
         cfg_path = issue.get("cmdarg", "cfg")
+
+        # If no -cfg provided, check for positional argument
+        if not cfg_path:
+            input_files = issue.get("cmdarg", "input")
+            if input_files and len(input_files) > 0:
+                cfg_path = input_files[0]
+
+        if not cfg_path:
+            issue.logger.error('-cfg must be provided or pass manifest as positional argument')
+            return 1
         try:
             project: Project = Project.from_manifest(filepath=cfg_path)
         except FileNotFoundError:
@@ -85,7 +99,7 @@ To run a testcase, use:
         builddir = project.option.get_builddir()
         if isinstance(builddir, str) and not os.path.isabs(builddir):
             builddirname = os.path.basename(builddir)
-            fullpath = os.path.dirname(os.path.abspath(issue.get("cmdarg", "cfg")))
+            fullpath = os.path.dirname(os.path.abspath(cfg_path))
             while True:
                 if os.path.basename(fullpath) == builddirname:
                     project.option.set_builddir(fullpath)
@@ -121,9 +135,17 @@ To run a testcase, use:
 
         return 0
     else:
+        # Run mode
         file: Optional[str] = issue.get("cmdarg", "file")
+
+        # If no -file provided, check for positional argument
         if not file:
-            raise ValueError('-file must be provided')
+            input_files = issue.get("cmdarg", "input")
+            if input_files and len(input_files) > 0:
+                file = input_files[0]
+
+        if not file:
+            raise ValueError('-file must be provided or pass testcase file as positional argument')
 
         test_dir = os.path.basename(file)[0:-7]
         with tarfile.open(file, 'r:gz') as f:

--- a/tests/apps/test_sc_issue.py
+++ b/tests/apps/test_sc_issue.py
@@ -63,10 +63,57 @@ def test_sc_issue_generate_success(flags,
 
 
 @pytest.mark.timeout(90)
-def test_sc_issue_fail_on_no_cfg(monkeypatch, project):
+def test_sc_issue_generate_positional_with_args(monkeypatch, project):
+    '''Test sc-issue app with positional argument and additional flags.'''
     monkeypatch.setattr('sys.argv', ['sc-issue',
-                                     'build/heartbeat/job0/steptwo/0/outputs/heartbeat.pkg.json'])
-    assert sc_issue.main() == 1
+                                     'build/heartbeat/job0/steptwo/0/outputs/heartbeat.pkg.json',
+                                     '-arg_step', 'stepone', '-arg_index', '0'])
+    with patch("siliconcompiler.utils.issue.datetime") as time:
+        time.fromtimestamp = datetime.fromtimestamp
+        time.now.return_value = datetime(2020, 3, 11, 14, 12, 13, tzinfo=timezone.utc)
+        assert sc_issue.main() == 0
+        time.now.assert_called()
+
+    assert os.path.isfile('sc_issue_heartbeat_job0_stepone_0_20200311-141213.tar.gz')
+
+
+@pytest.mark.timeout(90)
+@pytest.mark.parametrize('positional_path,flags,args', [
+    ('build/heartbeat/job0/stepone/0/outputs/heartbeat.pkg.json',
+     [],
+     ("stepone", "0", None,
+      {"include_libraries": True, "include_specific_libraries": [], "hash_files": False})),
+    ('build/heartbeat/job0/steptwo/0/outputs/heartbeat.pkg.json',
+     ['-arg_step', 'stepone', '-arg_index', '0'],
+     ("stepone", "0", None,
+      {"include_libraries": True, "include_specific_libraries": [], "hash_files": False})),
+    ('build/heartbeat/job0/heartbeat.pkg.json',
+     ['-arg_step', 'steptwo', '-arg_index', '0', '-hash_files'],
+     ("steptwo", "0", None,
+      {"include_libraries": True, "include_specific_libraries": [], "hash_files": True})),
+    ('build/heartbeat/job0/heartbeat.pkg.json',
+     ['-arg_step', 'steptwo', '-arg_index', '0', '-exclude_libraries'],
+     ("steptwo", "0", None,
+      {"include_libraries": False, "include_specific_libraries": [], "hash_files": False})),
+    ('build/heartbeat/job0/heartbeat.pkg.json',
+     ['-arg_step', 'steptwo', '-arg_index', '0', '-exclude_libraries',
+      '-add_library', 'test0', '-add_library', 'test1'],
+     ("steptwo", "0", None,
+      {"include_libraries": False, "include_specific_libraries": ["test0", "test1"],
+       "hash_files": False}))
+])
+def test_sc_issue_generate_positional_call(positional_path,
+                                           flags,
+                                           args,
+                                           monkeypatch,
+                                           project):
+    '''Test sc-issue app with positional arguments and various flag combinations.'''
+
+    monkeypatch.setattr('sys.argv', ['sc-issue', positional_path] + flags)
+    with patch("siliconcompiler.apps.sc_issue.generate_testcase") as generate_testcase:
+        assert sc_issue.main() == 0
+        arg_step, arg_index, outfile, kwargs = args
+        generate_testcase.assert_called_once_with(ANY, arg_step, arg_index, outfile, **kwargs)
 
 
 @pytest.mark.timeout(90)
@@ -154,12 +201,46 @@ def test_sc_issue_run(monkeypatch, project):
 
 
 @pytest.mark.timeout(90)
-def test_sc_issue_run_without_file(monkeypatch, project):
-    '''Test sc-issue app fails when -run is used without -file.'''
+def test_sc_issue_run_positional(monkeypatch, project):
+    '''Test sc-issue app run with positional argument instead of -file flag.'''
+
+    # First generate a testcase with the -cfg flag to have a file to run
+    monkeypatch.setattr('sys.argv', ['sc-issue',
+                                     '-cfg',
+                                     'build/heartbeat/job0/stepone/0/outputs/heartbeat.pkg.json',
+                                     '-file',
+                                     'sc_issue_positional.tar.gz'])
+    assert sc_issue.main() == 0
+    assert os.path.isfile("sc_issue_positional.tar.gz")
+
+    # Now run the testcase using positional argument (before the -run flag)
+    monkeypatch.setattr('sys.argv', ['sc-issue', 'sc_issue_positional.tar.gz', '-run'])
+    assert sc_issue.main() == 0
+
+
+@pytest.mark.timeout(90)
+def test_sc_issue_run_without_file_error(monkeypatch, project):
+    '''Test sc-issue app fails when -run is used without -file or positional argument.'''
 
     monkeypatch.setattr('sys.argv', ['sc-issue', '-run'])
-    with pytest.raises(ValueError, match=r'-file must be provided'):
+    with pytest.raises(ValueError,
+                       match=r'-file must be provided|pass testcase file as positional argument'):
         sc_issue.main()
+
+
+@pytest.mark.timeout(90)
+def test_sc_issue_generate_positional_with_file(monkeypatch, project):
+    '''Test sc-issue app with positional argument and output file flag.'''
+    monkeypatch.setattr('sys.argv', ['sc-issue',
+                                     'build/heartbeat/job0/stepone/0/outputs/heartbeat.pkg.json',
+                                     '-file', 'custom_output.tar.gz'])
+    with patch("siliconcompiler.utils.issue.datetime") as time:
+        time.fromtimestamp = datetime.fromtimestamp
+        time.now.return_value = datetime(2020, 3, 11, 14, 12, 13, tzinfo=timezone.utc)
+        assert sc_issue.main() == 0
+        time.now.assert_called()
+
+    assert os.path.isfile('custom_output.tar.gz')
 
 
 @pytest.mark.timeout(90)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `sc-issue` CLI now accepts configuration/testcase paths as positional arguments in generate and run modes, simplifying command invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->