### PR TITLE
fix openroad hier

### DIFF
--- a/siliconcompiler/tools/openroad/init_floorplan.py
+++ b/siliconcompiler/tools/openroad/init_floorplan.py
@@ -198,12 +198,21 @@ class InitFloorplanTask(APRTask,
 
         self.set_script("apr/sc_init_floorplan.tcl")
 
-        if f"{self.design_topmodule}.vg.gz" in self.get_files_from_input_nodes():
-            self.add_input_file(ext="vg.gz")
-        elif f"{self.design_topmodule}.vg" in self.get_files_from_input_nodes():
-            self.add_input_file(ext="vg")
+        load_vg = False
+        if self.get("var", "enablehier"):
+            inputs = self.get_files_from_input_nodes()
+            if f"{self.design_topmodule}.def.gz" not in inputs and f"{self.design_topmodule}.def" not in inputs:
+                load_vg = True
         else:
-            pass
+            load_vg = True
+
+        if load_vg:
+            if f"{self.design_topmodule}.vg.gz" in self.get_files_from_input_nodes():
+                self.add_input_file(ext="vg.gz")
+            elif f"{self.design_topmodule}.vg" in self.get_files_from_input_nodes():
+                self.add_input_file(ext="vg")
+            else:
+                pass
 
         self._set_reports([
             'check_setup',

--- a/siliconcompiler/tools/openroad/init_floorplan.py
+++ b/siliconcompiler/tools/openroad/init_floorplan.py
@@ -201,7 +201,8 @@ class InitFloorplanTask(APRTask,
         load_vg = False
         if self.get("var", "enablehier"):
             inputs = self.get_files_from_input_nodes()
-            if f"{self.design_topmodule}.def.gz" not in inputs and f"{self.design_topmodule}.def" not in inputs:
+            if f"{self.design_topmodule}.def.gz" not in inputs and \
+                    f"{self.design_topmodule}.def" not in inputs:
                 load_vg = True
         else:
             load_vg = True

--- a/siliconcompiler/tools/openroad/scripts/common/read_input_files.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/read_input_files.tcl
@@ -42,7 +42,11 @@ if { [file exists "inputs/${sc_topmodule}.odb"] || [file exists "inputs/${sc_top
     } {
         set def_args []
         # Read verilog if available and hier is enabled
-        if { [sc_cfg_tool_task_get var enablehier] && [file exists $verilog_file] } {
+        if {
+            [sc_cfg_tool_task_exists var enablehier] &&
+            [sc_cfg_tool_task_get var enablehier] &&
+            [file exists $verilog_file]
+        } {
             puts "Reading netlist verilog: ${verilog_file}"
             read_verilog $verilog_file
             link_design -hier $sc_topmodule


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Smarter decision to load Verilog/volume-geometry inputs: now depends on hierarchical mode and which design input files are present, avoiding redundant file loading.
  * Safer hierarchical-mode checks: the flow verifies the hierarchical flag exists and is enabled before using it to control reading/linking, preventing unexpected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->