### PR TITLE
fix collection to avoid getting the same time twice

### DIFF
--- a/siliconcompiler/utils/curation.py
+++ b/siliconcompiler/utils/curation.py
@@ -129,10 +129,9 @@ def collect(project: "Project",
 
     try:
         path_filter = FilterDirectories(project)
+        collected_dirs = set()
         for key, step, index in sorted(dirs.keys()):
             abs_paths = find_files(*key, step=step, index=index)
-
-            new_paths = set()
 
             if not isinstance(abs_paths, (list, tuple, set)):
                 abs_paths = [abs_paths]
@@ -149,14 +148,14 @@ def collect(project: "Project",
                     continue
 
                 imported = False
-                for new_path in new_paths:
-                    if abs_path.startswith(new_path):
+                for collected in collected_dirs:
+                    if abs_path == collected or abs_path.startswith(collected + os.sep):
                         imported = True
                         break
                 if imported:
                     continue
 
-                new_paths.add(abs_path)
+                collected_dirs.add(abs_path)
 
                 import_path = os.path.join(directory, value.get_hashed_filename())
                 if os.path.exists(import_path):
@@ -186,6 +185,16 @@ def collect(project: "Project",
 
                 if abs_path.startswith(directory):
                     # File already imported in directory
+                    continue
+
+                # Skip files that live inside a directory that was already collected;
+                # they are reachable via the collected directory's search path.
+                contained = False
+                for collected in collected_dirs:
+                    if abs_path.startswith(collected + os.sep):
+                        contained = True
+                        break
+                if contained:
                     continue
 
                 import_path = os.path.join(directory, value.get_hashed_filename())

--- a/tests/utils/test_curation.py
+++ b/tests/utils/test_curation.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from siliconcompiler import Project, Design, Flowgraph, Task
 from siliconcompiler.utils.curation import collect, archive
 from siliconcompiler.utils.paths import collectiondir
+from siliconcompiler.schema.parametervalue import PathNodeValue
 
 
 class FauxTask0(Task):
@@ -186,6 +187,95 @@ def test_collect_subdirectory():
     assert os.listdir(os.path.join(path, "subdir")) == ['test.v']
     assert design.get_file(fileset="rtl",
                            filetype="verilog")[0].startswith(collectiondir(proj))
+
+
+def test_collect_script_inside_refdir_not_duplicated():
+    """A script that lives inside a refdir should be collected only via the refdir,
+    not also as a separate hashed file. Regression test for sc-issue duplicating
+    OpenROAD scripts that are already part of the collected refdir.
+
+    Mimics the sc-issue path: collect() is called with an explicit ``directory``
+    that differs from ``collectiondir(project)``, so the script's refdir search
+    path (which uses ``collectiondir(project)`` internally) resolves to the
+    original filesystem location rather than the destination collection dir."""
+
+    os.makedirs('scripts/apr', exist_ok=True)
+    with open('scripts/apr/sc_test.tcl', 'w') as f:
+        f.write('# entry script')
+    with open('scripts/helper.tcl', 'w') as f:
+        f.write('# helper')
+
+    design = Design("testdesign")
+    design.set_topmodule("top", fileset="rtl")
+    proj = Project(design)
+    proj.add_fileset("rtl")
+
+    flow = Flowgraph("testflow")
+    flow.node("step", FauxTask0())
+    proj.set_flow(flow)
+
+    task = FauxTask0.find_task(proj)
+    task.set_refdir("scripts")
+    task.set_script("apr/sc_test.tcl")
+
+    proj.set("tool", "tool0", "task", "task0", "refdir", True, field="copy")
+    proj.set("tool", "tool0", "task", "task0", "script", True, field="copy")
+
+    # Collect into a directory that is NOT the project's normal collectiondir,
+    # to match how sc-issue redirects collection into a temporary issue dir.
+    custom_collect_dir = os.path.abspath("issue_collect")
+    collect(proj, directory=custom_collect_dir)
+
+    collected = os.listdir(custom_collect_dir)
+    # Only the refdir should land in the collection — the script lives inside it.
+    assert len(collected) == 1, \
+        f"Expected only refdir to be collected, got: {collected}"
+
+    refdir_collected = os.path.join(custom_collect_dir, collected[0])
+    assert os.path.isdir(refdir_collected)
+    assert os.path.isfile(os.path.join(refdir_collected, "apr", "sc_test.tcl"))
+
+    # The script's standalone hashed name must NOT have been copied separately.
+    script_hashed = PathNodeValue.generate_hashed_path("apr/sc_test.tcl", None)
+    assert not os.path.exists(os.path.join(custom_collect_dir, script_hashed)), \
+        "Script was copied separately even though it lives inside the collected refdir"
+
+
+def test_collect_overlapping_refdirs_dedup_across_keys():
+    """If two refdir entries point to a parent and child directory, only the parent
+    should be copied. Verifies the dedup set is shared across keys."""
+
+    os.makedirs('parent/child', exist_ok=True)
+    with open('parent/top.txt', 'w') as f:
+        f.write('top')
+    with open('parent/child/inner.txt', 'w') as f:
+        f.write('inner')
+
+    design = Design("testdesign")
+    design.set_topmodule("top", fileset="rtl")
+    proj = Project(design)
+    proj.add_fileset("rtl")
+
+    flow = Flowgraph("testflow")
+    flow.node("step", FauxTask0())
+    proj.set_flow(flow)
+
+    task = FauxTask0.find_task(proj)
+    task.set_refdir("parent")
+    task.add("refdir", "parent/child")
+
+    proj.set("tool", "tool0", "task", "task0", "refdir", True, field="copy")
+
+    collect(proj)
+
+    # Only the parent dir should be present in the collection
+    collected = os.listdir(collectiondir(proj))
+    assert len(collected) == 1, \
+        f"Expected only parent refdir, got: {collected}"
+
+    child_hashed = PathNodeValue.generate_hashed_path("parent/child", None)
+    assert not os.path.exists(os.path.join(collectiondir(proj), child_hashed)), \
+        "Child refdir was copied separately even though parent already covers it"
 
 
 def test_collect_file_with_false():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory collection to prevent redundant copying when files are nested within previously collected directories.
  * Fixed deduplication for overlapping directory references, ensuring parent directories are collected without duplicate child entries.

* **Tests**
  * Added regression tests verifying correct handling of script files within configured directories and overlapping directory deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->