### PR TITLE
fix ordering of show tools and add web option to openroad

### DIFF
--- a/siliconcompiler/apps/sc_show.py
+++ b/siliconcompiler/apps/sc_show.py
@@ -94,28 +94,49 @@ def main():
 
     # Handle --list option
     if show.get("cmdarg", "list"):
+        # Warn if other CLI flags are set (they will be ignored)
+        ignored_flags = []
+        try:
+            if show.get("cmdarg", "design"):
+                ignored_flags.append("-design")
+        except KeyError:
+            pass
+        if show.get("cmdarg", "cfg"):
+            ignored_flags.append("-cfg")
+        if show.get("cmdarg", "extension"):
+            ignored_flags.append("-ext")
+        if show.get("cmdarg", "tool"):
+            ignored_flags.append("-tool")
+        if show.get("cmdarg", "input"):
+            ignored_flags.append("input files")
+        if ignored_flags:
+            show.logger.warning(f"Ignoring {', '.join(ignored_flags)} when using -list")
+
         task_cls = ScreenshotTask if show.get("cmdarg", "screenshot") else ShowTask
         task_type = "Screenshot" if show.get("cmdarg", "screenshot") else "Show"
 
         tasks = task_cls.get_task(None)
-        if tasks:
-            print(f"Registered {task_type} Tools (in order):")
-            print("=" * 70)
-            count = 0
-            for task_cls_item in tasks:
-                try:
-                    task_inst = task_cls_item()
-                    tool_name = task_inst.tool()
-                    task_name = task_inst.task()
-                    exts = task_inst.get_supported_show_extentions()
-                    ext_str = ', '.join(sorted(exts)) if exts else 'none'
-                    count += 1
-                    print(f"{count}. {tool_name}/{task_name}")
-                    print(f"   Extensions: {ext_str}")
-                except NotImplementedError:
-                    # Skip abstract tasks
-                    pass
-            print("=" * 70)
+        if not tasks:
+            print(f"No registered {task_type} tools found")
+            return 0
+
+        print(f"Registered {task_type} Tools (in order):")
+        print("=" * 70)
+        count = 0
+        for task_cls_item in tasks:
+            try:
+                task_inst = task_cls_item()
+                tool_name = task_inst.tool()
+                task_name = task_inst.task()
+                exts = task_inst.get_supported_show_extentions()
+                ext_str = ', '.join(sorted(exts)) if exts else 'none'
+                count += 1
+                print(f"{count}. {tool_name}/{task_name}")
+                print(f"   Extensions: {ext_str}")
+            except NotImplementedError:
+                # Skip abstract tasks
+                pass
+        print("=" * 70)
         return 0
 
     manifest = None

--- a/siliconcompiler/apps/sc_show.py
+++ b/siliconcompiler/apps/sc_show.py
@@ -3,7 +3,7 @@ import sys
 
 import os.path
 
-from siliconcompiler import Project, Design
+from siliconcompiler import Project, Design, ShowTask, ScreenshotTask
 from siliconcompiler.apps._common import pick_manifest
 
 
@@ -53,6 +53,12 @@ def main():
 
     sc-show build/adder/job0/route/1/outputs/adder.def
     (displays build/adder/job0/route/1/outputs/adder.def)
+
+    sc-show -list
+    (lists all registered show tools and their supported extensions)
+
+    sc-show -list -screenshot
+    (lists all registered screenshot tools and their supported extensions)
     """
 
     class ShowProject(Project):
@@ -68,6 +74,9 @@ def main():
                 "screenshot", "bool", "Generate a screenshot and exit.")
             self._add_commandline_argument(
                 "tool", "str", "Tool to use for showing the file.")
+            self._add_commandline_argument(
+                "list", "bool",
+                "List all registered show/screenshot tools and their supported extensions.")
 
     show = ShowProject.create_cmdline(
         progname,
@@ -80,7 +89,34 @@ def main():
             '-cfg',
             '-ext',
             '-screenshot',
-            '-tool'])
+            '-tool',
+            '-list'])
+
+    # Handle --list option
+    if show.get("cmdarg", "list"):
+        task_cls = ScreenshotTask if show.get("cmdarg", "screenshot") else ShowTask
+        task_type = "Screenshot" if show.get("cmdarg", "screenshot") else "Show"
+
+        tasks = task_cls.get_task(None)
+        if tasks:
+            print(f"Registered {task_type} Tools (in order):")
+            print("=" * 70)
+            count = 0
+            for task_cls_item in tasks:
+                try:
+                    task_inst = task_cls_item()
+                    tool_name = task_inst.tool()
+                    task_name = task_inst.task()
+                    exts = task_inst.get_supported_show_extentions()
+                    ext_str = ', '.join(sorted(exts)) if exts else 'none'
+                    count += 1
+                    print(f"{count}. {tool_name}/{task_name}")
+                    print(f"   Extensions: {ext_str}")
+                except NotImplementedError:
+                    # Skip abstract tasks
+                    pass
+            print("=" * 70)
+        return 0
 
     manifest = None
     filename = None

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -1347,6 +1347,12 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
                     exts = cls().get_supported_show_extentions()
                     # Sort extensions within each task for consistency
                     for ext in sorted(exts):
+                        # If a specific tool is requested, verify the extension resolves to that tool
+                        if tool:
+                            resolved_task = tool_cls.get_task(ext, tool=tool)
+                            if resolved_task is None:
+                                # This extension is not supported by the requested tool
+                                continue
                         search_exts.append((cls, ext))
                 except NotImplementedError:
                     pass

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -1339,23 +1339,31 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
                 if sc_index:
                     search_nodes = [node for node in search_nodes if node[1] == sc_index]
 
-            exts = set()
+            # Build ordered list of (task_class, extension) pairs respecting tool order
+            # This preserves the registration order so higher-priority tools are tried first
+            search_exts = []
             for cls in tool_cls.get_task(None, tool=tool):
                 try:
-                    exts.update(cls().get_supported_show_extentions())
+                    exts = cls().get_supported_show_extentions()
+                    # Sort extensions within each task for consistency
+                    for ext in sorted(exts):
+                        search_exts.append((cls, ext))
                 except NotImplementedError:
                     pass
-            # Sort extensions for consistent search order
-            exts = sorted(exts)
 
             if extension:
-                if extension not in exts:
+                # Validate that requested extension is supported
+                all_exts = [ext for _, ext in search_exts]
+                if extension not in all_exts:
                     self.logger.error(f"Extension '{extension}' not supported by "
-                                      f"registered showtools: {', '.join(exts)}")
+                                      f"registered showtools: {', '.join(sorted(set(all_exts)))}")
                     return None
-                exts = [extension]
+                # Search for the specific extension only, respecting tool order
+                search_exts = [(cls, ext) for cls, ext in search_exts if ext == extension]
 
-            for ext in exts:
+            # Search for files in tool-ordered sequence
+            # This ensures that earlier-registered (higher-priority) tools are tried first
+            for task_cls, ext in search_exts:
                 for step, index in search_nodes:
                     filename = search_obj.find_result(ext,
                                                       step=step,

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -1347,7 +1347,8 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
                     exts = cls().get_supported_show_extentions()
                     # Sort extensions within each task for consistency
                     for ext in sorted(exts):
-                        # If a specific tool is requested, verify the extension resolves to that tool
+                        # If a specific tool is requested, verify the extension resolves
+                        # to that tool
                         if tool:
                             resolved_task = tool_cls.get_task(ext, tool=tool)
                             if resolved_task is None:

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -2226,35 +2226,43 @@ class ShowTask(Task):
         Private helper to discover and populate all available show/screenshot tasks.
 
         This method recursively finds all subclasses and also loads tasks from
-        any installed plugins.
+        any installed plugins. Tasks are registered in a stable order:
+        1. Core siliconcompiler tasks (sorted by module path)
+        2. Plugin-provided tasks (in plugin load order)
+
+        This ensures that later-registered extensions take precedence over
+        earlier core tasks when multiple tools support the same extension.
         """
         cls.__check_task(None)
 
         if MPManager.get_transient_settings().get_category(cls.__name__):
             return  # Already populated
 
-        def recurse(searchcls: Type["ShowTask"]):
-            subclss = set()
+        def recurse(searchcls: Type["ShowTask"]) -> list:
+            subclss = []
             if not cls.__check_task(searchcls):
                 return subclss
 
-            subclss.add(searchcls)
-            for subcls in searchcls.__subclasses__():
-                subclss.update(recurse(subcls))
+            subclss.append(searchcls)
+            # Process subclasses in a deterministic order (sorted by name)
+            for subcls in sorted(searchcls.__subclasses__(), key=lambda c: c.__name__):
+                subclss.extend(recurse(subcls))
 
             return subclss
 
         classes = recurse(cls)
 
-        # Support non-SC defined tasks from plugins
+        # Sort core classes by module path for stable ordering
+        # Ensures consistent discovery order across runs
+        core_classes = sorted(classes, key=lambda c: (c.__module__, c.__name__))
+
+        # Register core tasks first
+        for c in core_classes:
+            cls.register_task(c)
+
+        # Support non-SC defined tasks from plugins (these override core tasks)
         for plugin in utils.get_plugins('showtask'):
             plugin()
-
-        if not classes:
-            return
-
-        for c in classes:
-            cls.register_task(c)
 
     @classmethod
     def get_task(cls: Type[TShowTask], ext: Optional[str], tool: Optional[str] = None) -> \

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -2244,8 +2244,8 @@ class ShowTask(Task):
                 return subclss
 
             subclss.append(searchcls)
-            # Process subclasses in a deterministic order (sorted by name)
-            for subcls in sorted(searchcls.__subclasses__(), key=lambda c: c.__name__):
+            # Iterate over subclasses (final sort by module path happens below)
+            for subcls in searchcls.__subclasses__():
                 subclss.extend(recurse(subcls))
 
             return subclss
@@ -2344,7 +2344,8 @@ class ShowTask(Task):
                 return result
 
         # 3. Fallback to Automatic Discovery
-        for task_cls in tasks:
+        # Iterate in reverse so later-registered tasks (e.g., plugins) take precedence
+        for task_cls in reversed(tasks):
             try:
                 task_inst = task_cls()
                 if ext in task_inst.get_supported_show_extentions():

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -2261,7 +2261,12 @@ class ShowTask(Task):
             cls.register_task(c)
 
         # Support non-SC defined tasks from plugins (these override core tasks)
-        for plugin in utils.get_plugins('showtask'):
+        # Sort plugins deterministically for consistent ordering
+        plugins = sorted(
+            utils.get_plugins('showtask'),
+            key=lambda p: (p.__module__, p.__name__)
+        )
+        for plugin in plugins:
             plugin()
 
     @classmethod

--- a/siliconcompiler/tools/openroad/show.py
+++ b/siliconcompiler/tools/openroad/show.py
@@ -88,6 +88,30 @@ class ShowTask(BaseShowTask, APRTask, OpenROADSTAParameter):
         return options
 
 
+class WebTask(ShowTask):
+    '''
+    Open with webviewer
+    '''
+
+    def task(self) -> str:
+        return "web"
+
+    def setup(self):
+        super().setup()
+
+        # Set minimum version
+        self.add_version(">=26Q2-565", clobber=True)
+
+    def runtime_options(self):
+        options = super().runtime_options()
+        try:
+            options.remove("-gui")
+        except ValueError:
+            pass
+        options.append("-web")
+        return options
+
+
 class Show3DBloxTask(BaseShowTask, OpenROADTask):
     '''
     Show a 3D view of the design in openroad

--- a/siliconcompiler/utils/showtools.py
+++ b/siliconcompiler/utils/showtools.py
@@ -7,6 +7,7 @@ from siliconcompiler.tools.klayout.screenshot import ScreenshotTask as KlayoutSc
 
 from siliconcompiler.tools.openroad.show import ShowTask as OpenROADShow
 from siliconcompiler.tools.openroad.show import Show3DBloxTask as OpenROADShow3DBlox
+from siliconcompiler.tools.openroad.show import WebTask as OpenROADWeb
 from siliconcompiler.tools.openroad.screenshot import ScreenshotTask as OpenROADScreenshot
 
 from siliconcompiler.tools.graphviz.show import ShowTask as GraphvizShow
@@ -20,16 +21,30 @@ from siliconcompiler.tools.surfer.show import ShowTask as SurferShow
 
 
 def showtasks():
+    """
+    Registers show and screenshot tasks in a stable order.
+
+    Registration order:
+    1. Core siliconcompiler tools (KLayout, OpenROAD variants, Graphviz, VPR)
+    2. Optional tools based on system availability (Surfer or GTKWave for VCD)
+
+    Later registrations take precedence when multiple tools support the same extension.
+    """
+    # Register Show tasks - core tools first
     ShowTask.register_task(KlayoutShow)
     ShowTask.register_task(OpenROADShow)
+    ShowTask.register_task(OpenROADWeb)
     ShowTask.register_task(OpenROADShow3DBlox)
     ShowTask.register_task(GraphvizShow)
     ShowTask.register_task(VPRShow)
+
+    # Register VCD viewer - prefer surfer if available, otherwise fall back to gtkwave
     if which('surfer') is not None:
         ShowTask.register_task(SurferShow)
     else:
         ShowTask.register_task(GTKWaveShow)
 
+    # Register Screenshot tasks - same order as Show tasks
     ScreenshotTask.register_task(KlayoutScreenshot)
     ScreenshotTask.register_task(OpenROADScreenshot)
     ScreenshotTask.register_task(GraphvizScreenshot)

--- a/tests/apps/test_sc_show.py
+++ b/tests/apps/test_sc_show.py
@@ -199,6 +199,197 @@ def test_sc_show_with_empty_tool(monkeypatch, make_manifests, asic_gcd):
         show.assert_called_once_with(None, extension=None, screenshot=False, tool='')
 
 
+# Mock task classes for testing
+class MockShowTask1:
+    """Mock show task for testing."""
+    def tool(self):
+        return "tool1"
+
+    def task(self):
+        return "task1"
+
+    def get_supported_show_extentions(self):
+        return ["ext1", "ext2"]
+
+
+class MockShowTask2:
+    """Mock show task for testing."""
+    def tool(self):
+        return "tool2"
+
+    def task(self):
+        return "task2"
+
+    def get_supported_show_extentions(self):
+        return ["ext3"]
+
+
+class MockScreenshotTask1:
+    """Mock screenshot task for testing."""
+    def tool(self):
+        return "tool1"
+
+    def task(self):
+        return "screenshot1"
+
+    def get_supported_show_extentions(self):
+        return ["ext1", "ext2"]
+
+
+class MockScreenshotTask2:
+    """Mock screenshot task for testing."""
+    def tool(self):
+        return "tool2"
+
+    def task(self):
+        return "screenshot2"
+
+    def get_supported_show_extentions(self):
+        return ["ext3"]
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_list_show_tools(monkeypatch, capsys):
+    '''Test sc-show -list to display show tools.'''
+    monkeypatch.setattr('sys.argv', ['sc-show', '-list'])
+
+    mock_tasks = [MockShowTask1, MockShowTask2]
+
+    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task:
+        mock_get_task.return_value = mock_tasks
+        assert sc_show.main() == 0
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # Verify header and structure
+    assert "Registered Show Tools (in order):" in output
+    assert "=" * 70 in output
+
+    # Verify tools are listed with their extensions
+    assert "1. tool1/task1" in output
+    assert "Extensions: ext1, ext2" in output
+    assert "2. tool2/task2" in output
+    assert "Extensions: ext3" in output
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_list_screenshot_tools(monkeypatch, capsys):
+    '''Test sc-show -list -screenshot to display screenshot tools.'''
+    monkeypatch.setattr('sys.argv', ['sc-show', '-list', '-screenshot'])
+
+    mock_tasks = [MockScreenshotTask1, MockScreenshotTask2]
+
+    with patch('siliconcompiler.apps.sc_show.ScreenshotTask.get_task') as mock_get_task:
+        mock_get_task.return_value = mock_tasks
+        assert sc_show.main() == 0
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # Verify header and structure
+    assert "Registered Screenshot Tools (in order):" in output
+    assert "=" * 70 in output
+
+    # Verify tools are listed with their extensions
+    assert "1. tool1/screenshot1" in output
+    assert "Extensions: ext1, ext2" in output
+    assert "2. tool2/screenshot2" in output
+    assert "Extensions: ext3" in output
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_list_empty_tools(monkeypatch, capsys):
+    '''Test sc-show -list when no tools are registered.'''
+    monkeypatch.setattr('sys.argv', ['sc-show', '-list'])
+
+    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task:
+        mock_get_task.return_value = None
+        assert sc_show.main() == 0
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # When no tasks, should still return 0 with no output
+    assert "Registered Show Tools (in order):" not in output
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_list_single_tool(monkeypatch, capsys):
+    '''Test sc-show -list with a single tool.'''
+    monkeypatch.setattr('sys.argv', ['sc-show', '-list'])
+
+    mock_tasks = [MockShowTask1]
+
+    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task:
+        mock_get_task.return_value = mock_tasks
+        assert sc_show.main() == 0
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # Verify correct numbering starts at 1
+    assert "1. tool1/task1" in output
+    assert "2. tool" not in output  # Should not have a second tool
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_list_sorted_extensions(monkeypatch, capsys):
+    '''Test sc-show -list displays extensions in sorted order.'''
+    monkeypatch.setattr('sys.argv', ['sc-show', '-list'])
+
+    class MockTaskWithUnsortedExts:
+        def tool(self):
+            return "tool"
+
+        def task(self):
+            return "task"
+
+        def get_supported_show_extentions(self):
+            # Return unsorted extensions
+            return ["zed", "abc", "mno"]
+
+    mock_tasks = [MockTaskWithUnsortedExts]
+
+    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task:
+        mock_get_task.return_value = mock_tasks
+        assert sc_show.main() == 0
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # Verify extensions are sorted alphabetically
+    assert "Extensions: abc, mno, zed" in output
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_list_no_extensions(monkeypatch, capsys):
+    '''Test sc-show -list with a tool that has no supported extensions.'''
+    monkeypatch.setattr('sys.argv', ['sc-show', '-list'])
+
+    class MockTaskNoExts:
+        def tool(self):
+            return "tool"
+
+        def task(self):
+            return "task"
+
+        def get_supported_show_extentions(self):
+            return []
+
+    mock_tasks = [MockTaskNoExts]
+
+    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task:
+        mock_get_task.return_value = mock_tasks
+        assert sc_show.main() == 0
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # Verify "none" is shown for no extensions
+    assert "Extensions: none" in output
+
+
 @pytest.mark.timeout(90)
 def test_sc_show_tool_with_all_parameters(monkeypatch, make_manifests, asic_gcd, capsys):
     '''Test sc-show app with tool and multiple other parameters.'''

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2585,3 +2585,553 @@ def test_write_depgraph_extra_edges_merged_into_existing_node():
     call = _capture_wdg(proj)
     graph = call.args[2]
     assert "extra_child" in graph["test"]
+
+
+# ============================================================================
+# Tests for Project.show() method
+# ============================================================================
+
+class MockShowTask(Task):
+    """Mock ShowTask for testing."""
+    def __init__(self, name="mock_tool", extensions=None):
+        super().__init__()
+        self._name = name
+        self._extensions = extensions or {'gds', 'def', 'lef'}
+
+    def tool(self):
+        return self._name
+
+    def task(self):
+        return "show"
+
+    def get_supported_show_extentions(self):
+        return self._extensions
+
+    def set_showfilepath(self, filepath):
+        """Mock method for setting show filepath."""
+        pass
+
+    def set_showfiletype(self, filetype):
+        """Mock method for setting show filetype."""
+        pass
+
+    def set_shownode(self, **kwargs):
+        """Mock method for setting show node."""
+        pass
+
+    @staticmethod
+    def find_task(proj):
+        """Mock find_task to return a mock task instance."""
+        return MockShowTask()
+
+
+class MockScreenshotTask(Task):
+    """Mock ScreenshotTask for testing."""
+    def __init__(self, name="mock_tool", extensions=None):
+        super().__init__()
+        self._name = name
+        self._extensions = extensions or {'gds', 'def'}
+
+    def tool(self):
+        return self._name
+
+    def task(self):
+        return "screenshot"
+
+    def get_supported_show_extentions(self):
+        return self._extensions
+
+    def set_showfilepath(self, filepath):
+        """Mock method for setting show filepath."""
+        pass
+
+    def set_showfiletype(self, filetype):
+        """Mock method for setting show filetype."""
+        pass
+
+    def set_shownode(self, **kwargs):
+        """Mock method for setting show node."""
+        pass
+
+    @staticmethod
+    def find_task(proj):
+        """Mock find_task to return a mock task instance."""
+        return MockScreenshotTask()
+
+
+def test_show_with_explicit_filename(monkeypatch):
+    """Test show() with explicit filename."""
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    proj = Project(design)
+    proj.add_fileset("rtl")
+
+    # Mock os.path functions
+    monkeypatch.setattr("os.path.exists", lambda x: x == "/path/to/design.gds")
+    monkeypatch.setattr("os.path.abspath", lambda x: x)
+
+    # Create a mock task instance
+    mock_show_task = MockShowTask()
+
+    # Mock ShowTask.get_task
+    monkeypatch.setattr("siliconcompiler.project.ShowTask.get_task",
+                        lambda ext=None, tool=None: mock_show_task)
+
+    # Mock project.run() to avoid execution
+    run_called = []
+    monkeypatch.setattr(Project, "run", lambda self: run_called.append(True) or self)
+
+    # Mock get_file_ext
+    monkeypatch.setattr("siliconcompiler.project.get_file_ext", lambda x: "gds")
+
+    # Mock ShowFlow to avoid graph construction issues
+    monkeypatch.setattr("siliconcompiler.project.ShowFlow", lambda task: Flowgraph("show_flow"))
+
+    result = proj.show("/path/to/design.gds")
+    # Result is None for show() (non-screenshot mode)
+    assert result is None
+    assert run_called  # Verify run was called
+
+
+def test_show_with_filename_not_exists(monkeypatch):
+    """Test show() with non-existent file."""
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    proj = Project(design)
+
+    # Mock os.path.exists to return False
+    monkeypatch.setattr("os.path.exists", lambda x: False)
+    monkeypatch.setattr("os.path.abspath", lambda x: x)
+
+    result = proj.show("/nonexistent/file.gds")
+    assert result is None
+
+
+def test_show_auto_find_no_layout(monkeypatch):
+    """Test show() with auto-find when no layout exists."""
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    proj = Project(design)
+    proj.add_fileset("rtl")
+    proj.option.set_flow("default")
+
+    # No history, so search_obj will be self
+    # Mock find_result to return None (no layout found)
+    monkeypatch.setattr(Project, "find_result", lambda self, *args, **kwargs: None)
+
+    # Mock get_task to return mock tasks
+    mock_show_task = MockShowTask()
+    monkeypatch.setattr("siliconcompiler.project.ShowTask.get_task",
+                        lambda ext=None, tool=None: [mock_show_task.__class__])
+
+    result = proj.show()
+    assert result is None
+
+
+def test_show_auto_find_with_layout(monkeypatch):
+    """Test show() with auto-find when layout exists."""
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    proj = Project(design)
+    proj.add_fileset("rtl")
+    proj.option.set_flow("default")
+
+    flow = Flowgraph("default")
+    from siliconcompiler import Task
+
+    class MockFlowTask(Task):
+        def tool(self):
+            return "mock_tool"
+
+        def task(self):
+            return "mock_step"
+
+    # Mock the flow
+    monkeypatch.setattr(proj, "get_flow", lambda name=None: flow)
+
+    # Mock get_execution_order to return flow nodes
+    monkeypatch.setattr(Flowgraph, "get_execution_order",
+                        lambda self, reverse=False: [[("mock_step", "0")]])
+
+    # Mock find_result to return a file
+    monkeypatch.setattr(Project, "find_result",
+                        lambda self, ext, step=None, index=None: "/path/to/design.gds")
+
+    # Mock ShowTask.get_task with proper behavior
+    def mock_get_task(ext=None, tool=None):
+        if ext is None:
+            # When called with None, return list of task classes
+            return [MockShowTask]
+        else:
+            # When called with specific extension, return instance
+            return MockShowTask()
+    monkeypatch.setattr("siliconcompiler.project.ShowTask.get_task", mock_get_task)
+
+    # Mock get_file_ext
+    monkeypatch.setattr("siliconcompiler.project.get_file_ext", lambda x: "gds")
+
+    # Mock os.path functions
+    monkeypatch.setattr("os.path.exists", lambda x: True)
+    monkeypatch.setattr("os.path.abspath", lambda x: x)
+
+    # Mock run
+    run_called = []
+    monkeypatch.setattr(Project, "run", lambda self: run_called.append(True) or self)
+
+    # Mock ShowFlow
+    monkeypatch.setattr("siliconcompiler.project.ShowFlow", lambda task: Flowgraph("show_flow"))
+
+    result = proj.show()
+    assert result is None
+    assert run_called  # Verify run was called
+
+
+def test_show_with_extension_filter(monkeypatch):
+    """Test show() with extension filtering."""
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    proj = Project(design)
+    proj.add_fileset("rtl")
+    proj.option.set_flow("default")
+
+    # Mock the flow
+    monkeypatch.setattr(proj, "get_flow", lambda name=None: Flowgraph("default"))
+
+    # Mock get_execution_order
+    monkeypatch.setattr(Flowgraph, "get_execution_order",
+                        lambda self, reverse=False: [[("mock_step", "0")]])
+
+    # Mock find_result to return a file
+    monkeypatch.setattr(Project, "find_result",
+                        lambda self, ext, step=None, index=None: "/path/to/design.def"
+                        if ext == "def" else None)
+
+    # Mock ShowTask with proper behavior
+    def mock_get_task(ext=None, tool=None):
+        if ext is None:
+            # When called with None, return list of task classes
+            return [MockShowTask]
+        else:
+            # When called with specific extension, return instance
+            return MockShowTask()
+    monkeypatch.setattr("siliconcompiler.project.ShowTask.get_task", mock_get_task)
+
+    # Mock get_file_ext
+    monkeypatch.setattr("siliconcompiler.project.get_file_ext", lambda x: "def")
+
+    # Mock os.path functions
+    monkeypatch.setattr("os.path.exists", lambda x: True)
+    monkeypatch.setattr("os.path.abspath", lambda x: x)
+
+    # Mock run
+    run_called = []
+    monkeypatch.setattr(Project, "run", lambda self: run_called.append(True) or self)
+
+    # Mock ShowFlow
+    monkeypatch.setattr("siliconcompiler.project.ShowFlow", lambda task: Flowgraph("show_flow"))
+
+    # Request only 'def' extension
+    result = proj.show(extension="def")
+    assert result is None
+    assert run_called
+
+
+def test_show_with_unsupported_extension(monkeypatch):
+    """Test show() with unsupported extension."""
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    proj = Project(design)
+    proj.add_fileset("rtl")
+    proj.option.set_flow("default")
+
+    # Mock get_execution_order
+    monkeypatch.setattr(proj, "get_flow", lambda name=None: Flowgraph("default"))
+    monkeypatch.setattr(Flowgraph, "get_execution_order",
+                        lambda self, reverse=False: [[("mock_step", "0")]])
+
+    # Create a mock task class with limited extensions
+    class LimitedMockShowTask(MockShowTask):
+        def __init__(self):
+            super().__init__(extensions={'gds'})
+
+    # Mock ShowTask with proper behavior
+    def mock_get_task(ext=None, tool=None):
+        if ext is None:
+            # When called with None, return list of task classes with limited extensions
+            return [LimitedMockShowTask]
+        else:
+            # When called with specific extension, return None (not supported)
+            return None
+    monkeypatch.setattr("siliconcompiler.project.ShowTask.get_task", mock_get_task)
+
+    # Request unsupported extension
+    result = proj.show(extension="xyz")
+    assert result is None
+
+
+def test_show_screenshot_mode(monkeypatch):
+    """Test show() with screenshot=True."""
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    proj = Project(design)
+
+    # Mock os.path functions
+    monkeypatch.setattr("os.path.exists", lambda x: x == "/path/to/design.gds")
+    monkeypatch.setattr("os.path.abspath", lambda x: x)
+
+    # Create a mock task instance
+    mock_screenshot_task = MockScreenshotTask()
+
+    # Mock ScreenshotTask.get_task
+    monkeypatch.setattr("siliconcompiler.project.ScreenshotTask.get_task",
+                        lambda ext=None, tool=None: mock_screenshot_task)
+
+    # Mock get_file_ext
+    monkeypatch.setattr("siliconcompiler.project.get_file_ext", lambda x: "gds")
+
+    # Mock run
+    run_called = []
+    monkeypatch.setattr(Project, "run", lambda self: run_called.append(True) or self)
+
+    # Mock find_result for screenshot mode return
+    monkeypatch.setattr(Project, "find_result",
+                        lambda self, ext, step=None, index=None: "/path/to/screenshot.png"
+                        if ext == "png" else None)
+
+    # Mock ShowFlow to avoid graph construction issues
+    monkeypatch.setattr("siliconcompiler.project.ShowFlow", lambda task: Flowgraph("show_flow"))
+
+    result = proj.show("/path/to/design.gds", screenshot=True)
+    # Screenshot mode returns the PNG path
+    assert result == "/path/to/screenshot.png"
+    assert run_called
+
+
+def test_show_with_tool_parameter(monkeypatch):
+    """Test show() with specific tool specified."""
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    proj = Project(design)
+
+    # Mock os.path functions
+    monkeypatch.setattr("os.path.exists", lambda x: x == "/path/to/design.gds")
+    monkeypatch.setattr("os.path.abspath", lambda x: x)
+
+    # Mock ShowTask.get_task - verify it's called with tool parameter
+    get_task_calls = []
+
+    def mock_get_task(ext=None, tool=None):
+        get_task_calls.append({"ext": ext, "tool": tool})
+        return MockShowTask("specified_tool")
+
+    monkeypatch.setattr("siliconcompiler.project.ShowTask.get_task", mock_get_task)
+
+    # Mock get_file_ext
+    monkeypatch.setattr("siliconcompiler.project.get_file_ext", lambda x: "gds")
+
+    # Mock run
+    monkeypatch.setattr(Project, "run", lambda self: self)
+
+    # Mock ShowFlow
+    monkeypatch.setattr("siliconcompiler.project.ShowFlow", lambda task: Flowgraph("show_flow"))
+
+    result = proj.show("/path/to/design.gds", tool="specified_tool")
+    assert result is None
+    # Verify get_task was called with the tool parameter
+    assert len(get_task_calls) > 0
+    assert get_task_calls[0]["tool"] == "specified_tool"
+
+
+def test_show_tool_not_found_for_extension(monkeypatch):
+    """Test show() when no tool supports the file extension."""
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    proj = Project(design)
+
+    # Mock os.path functions
+    monkeypatch.setattr("os.path.exists", lambda x: x == "/path/to/design.unknown")
+    monkeypatch.setattr("os.path.abspath", lambda x: x)
+
+    # Mock get_file_ext
+    monkeypatch.setattr("siliconcompiler.project.get_file_ext", lambda x: "unknown")
+
+    # Mock ShowTask.get_task to return None (no tool supports this extension)
+    monkeypatch.setattr("siliconcompiler.project.ShowTask.get_task",
+                        lambda ext=None, tool=None: None)
+
+    result = proj.show("/path/to/design.unknown")
+    assert result is None
+
+
+def test_show_auto_find_preserves_tool_order(monkeypatch):
+    """Test that auto-find respects tool registration order."""
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    proj = Project(design)
+    proj.add_fileset("rtl")
+    proj.option.set_flow("default")
+
+    # Mock the flow
+    monkeypatch.setattr(proj, "get_flow", lambda name=None: Flowgraph("default"))
+
+    # Mock get_execution_order
+    monkeypatch.setattr(Flowgraph, "get_execution_order",
+                        lambda self, reverse=False: [[("mock_step", "0")]])
+
+    # Track which tools were checked and in what order
+    tool_check_order = []
+
+    def track_find_result(self, ext, step=None, index=None):
+        tool_check_order.append(ext)
+        return "/path/to/design." + ext if ext in ['gds', 'def'] else None
+
+    monkeypatch.setattr(Project, "find_result", track_find_result)
+
+    # Create multiple mock task classes to simulate registration order
+    tool1 = MockShowTask("tool1", extensions={'gds'})
+    tool2 = MockShowTask("tool2", extensions={'def'})
+
+    # Mock get_task with proper behavior
+    def mock_get_task(ext=None, tool=None):
+        if ext is None:
+            # When called with None, return list of task classes in order
+            return [type(tool1), type(tool2)]
+        else:
+            # When called with specific extension, return instance
+            return MockShowTask()
+    monkeypatch.setattr("siliconcompiler.project.ShowTask.get_task", mock_get_task)
+
+    # Mock get_file_ext
+    monkeypatch.setattr("siliconcompiler.project.get_file_ext", lambda x: x.split('.')[-1])
+
+    # Mock os.path functions
+    monkeypatch.setattr("os.path.exists", lambda x: True)
+    monkeypatch.setattr("os.path.abspath", lambda x: x)
+
+    # Mock run
+    monkeypatch.setattr(Project, "run", lambda self: self)
+
+    # Mock ShowFlow
+    monkeypatch.setattr("siliconcompiler.project.ShowFlow", lambda task: Flowgraph("show_flow"))
+
+    result = proj.show()
+    assert result is None
+    # Extensions should be checked in order from task registration
+    assert 'gds' in tool_check_order or 'def' in tool_check_order
+
+
+def test_show_with_history(monkeypatch):
+    """Test show() uses history when available."""
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    proj = Project(design)
+    proj.add_fileset("rtl")
+    proj.option.set_flow("default")
+
+    # Record history
+    proj._record_history()
+
+    # Mock the flow for the history project
+    history_proj = proj.history("job0")
+    monkeypatch.setattr(history_proj, "get_flow", lambda name=None: Flowgraph("default"))
+
+    # Mock get_execution_order
+    monkeypatch.setattr(Flowgraph, "get_execution_order",
+                        lambda self, reverse=False: [[("mock_step", "0")]])
+
+    # Mock find_result
+    monkeypatch.setattr(Project, "find_result",
+                        lambda self, ext, step=None, index=None: "/path/to/design.gds")
+
+    # Mock ShowTask.get_task with proper behavior
+    def mock_get_task(ext=None, tool=None):
+        if ext is None:
+            # When called with None, return list of task classes
+            return [MockShowTask]
+        else:
+            # When called with specific extension, return instance
+            return MockShowTask()
+    monkeypatch.setattr("siliconcompiler.project.ShowTask.get_task", mock_get_task)
+
+    # Mock get_file_ext
+    monkeypatch.setattr("siliconcompiler.project.get_file_ext", lambda x: "gds")
+
+    # Mock os.path functions
+    monkeypatch.setattr("os.path.exists", lambda x: True)
+    monkeypatch.setattr("os.path.abspath", lambda x: x)
+
+    # Mock run
+    monkeypatch.setattr(Project, "run", lambda self: self)
+
+    # Mock ShowFlow
+    monkeypatch.setattr("siliconcompiler.project.ShowFlow", lambda task: Flowgraph("show_flow"))
+
+    result = proj.show()
+    assert result is None
+
+
+def test_show_handles_search_with_step_index_filter(monkeypatch):
+    """Test show() filters search nodes by step/index arguments."""
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    proj = Project(design)
+    proj.add_fileset("rtl")
+    proj.option.set_flow("default")
+    proj.set("arg", "step", "route")
+    proj.set("arg", "index", "0")
+
+    # Mock the flow
+    monkeypatch.setattr(proj, "get_flow", lambda name=None: Flowgraph("default"))
+
+    # Mock get_execution_order
+    monkeypatch.setattr(Flowgraph, "get_execution_order",
+                        lambda self, reverse=False: [[("place", "0"), ("route", "0")]])
+
+    # Track which steps are searched
+    searched_steps = []
+
+    def track_find_result(self, ext, step=None, index=None):
+        searched_steps.append((step, index))
+        return "/path/to/design.gds" if step == "route" else None
+
+    monkeypatch.setattr(Project, "find_result", track_find_result)
+
+    # Mock ShowTask.get_task with proper behavior
+    def mock_get_task(ext=None, tool=None):
+        if ext is None:
+            # When called with None, return list of task classes
+            return [MockShowTask]
+        else:
+            # When called with specific extension, return instance
+            return MockShowTask()
+    monkeypatch.setattr("siliconcompiler.project.ShowTask.get_task", mock_get_task)
+
+    # Mock get_file_ext
+    monkeypatch.setattr("siliconcompiler.project.get_file_ext", lambda x: "gds")
+
+    # Mock os.path functions
+    monkeypatch.setattr("os.path.exists", lambda x: True)
+    monkeypatch.setattr("os.path.abspath", lambda x: x)
+
+    # Mock run
+    monkeypatch.setattr(Project, "run", lambda self: self)
+
+    # Mock ShowFlow
+    monkeypatch.setattr("siliconcompiler.project.ShowFlow", lambda task: Flowgraph("show_flow"))
+
+    result = proj.show()
+    assert result is None
+    # Should only search for 'route' step since arg.step='route'
+    assert all(step == "route" for step, _ in searched_steps)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2993,22 +2993,38 @@ def test_show_auto_find_preserves_tool_order(monkeypatch):
 
     def track_find_result(self, ext, step=None, index=None):
         tool_check_order.append(ext)
-        return "/path/to/design." + ext if ext in ['gds', 'def'] else None
+        # Return file for 'def' only on second call to allow both extensions to be tried
+        return "/path/to/design.def" if ext == 'def' else None
 
     monkeypatch.setattr(Project, "find_result", track_find_result)
 
-    # Create multiple mock task classes to simulate registration order
-    tool1 = MockShowTask("tool1", extensions={'gds'})
-    tool2 = MockShowTask("tool2", extensions={'def'})
+    # Create two distinct mock task classes to properly test tool ordering
+    class Tool1Task(MockShowTask):
+        def tool(self):
+            return "tool1"
+
+        def get_supported_show_extentions(self):
+            return {'gds'}
+
+    class Tool2Task(MockShowTask):
+        def tool(self):
+            return "tool2"
+
+        def get_supported_show_extentions(self):
+            return {'def'}
 
     # Mock get_task with proper behavior
     def mock_get_task(ext=None, tool=None):
         if ext is None:
             # When called with None, return list of task classes in order
-            return [type(tool1), type(tool2)]
+            return [Tool1Task, Tool2Task]
         else:
-            # When called with specific extension, return instance
-            return MockShowTask()
+            # When called with specific extension, return instance based on extension
+            if ext == 'gds':
+                return Tool1Task()
+            elif ext == 'def':
+                return Tool2Task()
+            return None
     monkeypatch.setattr("siliconcompiler.project.ShowTask.get_task", mock_get_task)
 
     # Mock get_file_ext
@@ -3026,8 +3042,10 @@ def test_show_auto_find_preserves_tool_order(monkeypatch):
 
     result = proj.show()
     assert result is None
-    # Extensions should be checked in order from task registration
-    assert 'gds' in tool_check_order or 'def' in tool_check_order
+    # Extensions should be checked in order from task registration: gds first (tool1),
+    # then def (tool2)
+    assert tool_check_order == ['gds', 'def'], \
+        f"Expected tool order ['gds', 'def'] but got {tool_check_order}"
 
 
 def test_show_with_history(monkeypatch):

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -2401,9 +2401,16 @@ def test_show_register_task():
 
 
 def test_show_get_task_show_called():
-    with patch("siliconcompiler.utils.showtools.showtasks") as showtasks:
+    # Create a mock plugin function with proper attributes for sorting
+    mock_plugin = MagicMock()
+    mock_plugin.__module__ = 'test_module'
+    mock_plugin.__name__ = 'test_plugin'
+    
+    # Mock get_plugins to return the mock plugin that will be called
+    with patch("siliconcompiler.tool.utils.get_plugins", return_value=[mock_plugin]):
         ShowTask.get_task("test_extension")
-        showtasks.assert_called_once()
+        # Verify the plugin was called (this is what the test is checking)
+        mock_plugin.assert_called_once()
 
 
 @pytest.mark.parametrize("cls", [ShowTask, ScreenshotTask])

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -2405,7 +2405,7 @@ def test_show_get_task_show_called():
     mock_plugin = MagicMock()
     mock_plugin.__module__ = 'test_module'
     mock_plugin.__name__ = 'test_plugin'
-    
+
     # Mock get_plugins to return the mock plugin that will be called
     with patch("siliconcompiler.tool.utils.get_plugins", return_value=[mock_plugin]):
         ShowTask.get_task("test_extension")

--- a/tests/utils/test_showtools.py
+++ b/tests/utils/test_showtools.py
@@ -221,25 +221,26 @@ def test_extension_search_order_stable():
     assert exts_2 == exts_3, "Extension search order changed between calls"
 
 
-@pytest.mark.quick
-@pytest.mark.timeout(300)
 def test_later_registration_takes_precedence():
     """Test that later-registered tasks take precedence for supported extensions."""
     from siliconcompiler.tools.klayout.show import ShowTask as KlayoutShow
     from siliconcompiler.tools.openroad.show import ShowTask as OpenROADShow
 
+    # Clear the transient settings to ensure fresh registration state for this test
+    # (In practice, they share the same singleton, so we test the behavior as-is)
+
     # Register klayout first
     ShowTask.register_task(KlayoutShow)
     task_1 = ShowTask.get_task("def")
+    assert isinstance(task_1, KlayoutShow), "First registration should return KlayoutShow for 'def'"
 
-    # Register openroad after
+    # Register openroad after (openroad also supports 'def')
     ShowTask.register_task(OpenROADShow)
     task_2 = ShowTask.get_task("def")
-
-    # When both support 'def', OpenROAD (registered later) should take precedence
-    # This relies on the iteration order through tasks
-    assert isinstance(task_1, (KlayoutShow, OpenROADShow))
-    assert isinstance(task_2, (KlayoutShow, OpenROADShow))
+    # Later registration (OpenROAD) should take precedence via reversed iteration
+    from siliconcompiler.tools.openroad.show import ShowTask as OpenROADShowClass
+    assert isinstance(task_2, OpenROADShowClass), \
+        f"Later-registered OpenROAD should take precedence, but got {type(task_2).__name__}"
 
 
 @pytest.mark.quick

--- a/tests/utils/test_showtools.py
+++ b/tests/utils/test_showtools.py
@@ -221,13 +221,22 @@ def test_extension_search_order_stable():
     assert exts_2 == exts_3, "Extension search order changed between calls"
 
 
-def test_later_registration_takes_precedence():
+def test_later_registration_takes_precedence(monkeypatch):
     """Test that later-registered tasks take precedence for supported extensions."""
     from siliconcompiler.tools.klayout.show import ShowTask as KlayoutShow
     from siliconcompiler.tools.openroad.show import ShowTask as OpenROADShow
+    from siliconcompiler.utils.multiprocessing import MPManager
 
-    # Clear the transient settings to ensure fresh registration state for this test
-    # (In practice, they share the same singleton, so we test the behavior as-is)
+    # Isolate registry by clearing the transient settings category for this test
+    # This ensures the test exercises registration precedence logic deterministically
+    # without being affected by previous test runs
+    settings = MPManager.get_transient_settings()
+
+    # Clear the ShowTask category if it exists
+    try:
+        del settings._settings[ShowTask.__name__]
+    except (AttributeError, KeyError):
+        pass
 
     # Register klayout first
     ShowTask.register_task(KlayoutShow)

--- a/tests/utils/test_showtools.py
+++ b/tests/utils/test_showtools.py
@@ -153,3 +153,130 @@ def test_screenshot_dot(datadir, gcd_design):
     assert isinstance(ScreenshotTask.get_task("dot"), GraphvizScreenshot)
     file = proj.show(os.path.join(datadir, 'mkDotProduct_nt_Int32.dot'), screenshot=True)
     assert os.path.isfile(file)
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_show_tasks_stable_ordering():
+    """Test that ShowTask returns tasks in a stable order across multiple calls."""
+    # Get tasks multiple times to ensure stable ordering
+    tasks_1 = ShowTask.get_task(None)
+    tasks_2 = ShowTask.get_task(None)
+    tasks_3 = ShowTask.get_task(None)
+
+    # Convert to task class names for comparison
+    names_1 = [(t.__module__, t.__name__) for t in tasks_1]
+    names_2 = [(t.__module__, t.__name__) for t in tasks_2]
+    names_3 = [(t.__module__, t.__name__) for t in tasks_3]
+
+    # All three calls should return tasks in the same order
+    assert names_1 == names_2, "ShowTask order changed between calls"
+    assert names_2 == names_3, "ShowTask order changed between calls"
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_screenshot_tasks_stable_ordering():
+    """Test that ScreenshotTask returns tasks in a stable order across multiple calls."""
+    # Get tasks multiple times to ensure stable ordering
+    tasks_1 = ScreenshotTask.get_task(None)
+    tasks_2 = ScreenshotTask.get_task(None)
+    tasks_3 = ScreenshotTask.get_task(None)
+
+    # Convert to task class names for comparison
+    names_1 = [(t.__module__, t.__name__) for t in tasks_1]
+    names_2 = [(t.__module__, t.__name__) for t in tasks_2]
+    names_3 = [(t.__module__, t.__name__) for t in tasks_3]
+
+    # All three calls should return tasks in the same order
+    assert names_1 == names_2, "ScreenshotTask order changed between calls"
+    assert names_2 == names_3, "ScreenshotTask order changed between calls"
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_extension_search_order_stable():
+    """Test that extension search order is stable when gathering supported extensions."""
+    # Get all tasks
+    tasks = ShowTask.get_task(None)
+
+    # Collect extensions multiple times
+    exts_1 = []
+    exts_2 = []
+    exts_3 = []
+
+    for ext_list in [exts_1, exts_2, exts_3]:
+        seen = set()
+        for cls in tasks:
+            try:
+                for ext in sorted(cls().get_supported_show_extentions()):
+                    if ext not in seen:
+                        ext_list.append(ext)
+                        seen.add(ext)
+            except NotImplementedError:
+                pass
+
+    # All three collections should be identical
+    assert exts_1 == exts_2, "Extension search order changed between calls"
+    assert exts_2 == exts_3, "Extension search order changed between calls"
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_later_registration_takes_precedence():
+    """Test that later-registered tasks take precedence for supported extensions."""
+    from siliconcompiler.tools.klayout.show import ShowTask as KlayoutShow
+    from siliconcompiler.tools.openroad.show import ShowTask as OpenROADShow
+
+    # Register klayout first
+    ShowTask.register_task(KlayoutShow)
+    task_1 = ShowTask.get_task("def")
+
+    # Register openroad after
+    ShowTask.register_task(OpenROADShow)
+    task_2 = ShowTask.get_task("def")
+
+    # When both support 'def', OpenROAD (registered later) should take precedence
+    # This relies on the iteration order through tasks
+    assert isinstance(task_1, (KlayoutShow, OpenROADShow))
+    assert isinstance(task_2, (KlayoutShow, OpenROADShow))
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_show_task_core_tools_ordered():
+    """Test that core siliconcompiler tools are registered in a stable order."""
+    # Get all registered tasks
+    all_tasks = ShowTask.get_task(None)
+
+    # Find indices of known core tools by checking instances
+    task_indices = {}
+    for idx, task_cls in enumerate(all_tasks):
+        try:
+            task_inst = task_cls()
+            task_indices[task_inst.tool()] = idx
+        except NotImplementedError:
+            pass
+
+    # Verify core tools are all present
+    assert 'klayout' in task_indices, "KLayout should be registered"
+    assert 'openroad' in task_indices, "OpenROAD should be registered"
+    assert 'graphviz' in task_indices, "Graphviz should be registered"
+
+    # Store the indices for comparison
+    prev_order = (task_indices['klayout'], task_indices['openroad'], task_indices['graphviz'])
+
+    # Get tasks again and verify order hasn't changed
+    all_tasks_2 = ShowTask.get_task(None)
+    task_indices_2 = {}
+    for idx, task_cls in enumerate(all_tasks_2):
+        try:
+            task_inst = task_cls()
+            task_indices_2[task_inst.tool()] = idx
+        except NotImplementedError:
+            pass
+
+    curr_order = (task_indices_2['klayout'], task_indices_2['openroad'], task_indices_2['graphviz'])
+
+    assert prev_order == curr_order, \
+        f"Core tool registration order should be stable: {prev_order} vs {curr_order}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-list` CLI to list registered visualization tools and extensions; `-list -screenshot` lists screenshot-capable tasks
  * Added a web-specific OpenROAD visualization task

* **Improvements**
  * Deterministic discovery/registration order and selection precedence for show tools
  * Project show/search now preserves tool priority when resolving extensions

* **Tests**
  * Expanded tests for listing, discovery determinism, extension resolution, and project show scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->