### PR TITLE
disable DEF loading until fixed in OpenROAD

### DIFF
--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -1464,10 +1464,12 @@ class APRTask(OpenROADTask):
             self.add_input_file(ext="odb")
             load_tech = False
         elif f"{self.design_topmodule}.def.gz" in self.get_files_from_input_nodes():
-            self.add_input_file(ext="def.gz")
+            if not self.get("var", "enablehier"):
+                self.add_input_file(ext="def.gz")
             load_vg = self.get("var", "enablehier")
         elif f"{self.design_topmodule}.def" in self.get_files_from_input_nodes():
-            self.add_input_file(ext="def")
+            if not self.get("var", "enablehier"):
+                self.add_input_file(ext="def")
             load_vg = self.get("var", "enablehier")
         else:
             load_vg = True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved hierarchical mode handling in the physical design flow by refining how design files are processed based on hierarchy settings, ensuring more efficient input management when hierarchical mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->