### PR TITLE
Add input for mode SDCs

### DIFF
--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Set
 
 from siliconcompiler import sc_open
 from siliconcompiler import utils
@@ -1431,25 +1431,35 @@ class APRTask(OpenROADTask):
         if "power" in self.get("var", "reports"):
             self.add_required_key("var", "power_corner")
 
+    def _get_modes(self) -> Set[str]:
+        modes = set()
+        for scenario in self.project.constraint.timing.get_scenario().values():
+            mode = scenario.get_mode(self.step, self.index)
+            if mode:
+                modes.add(mode)
+        return modes
+
     def _add_pnr_inputs(self):
         if self.get("var", "load_sdcs"):
+            modes = self._get_modes()
             if f"{self.design_topmodule}.sdc" in self.get_files_from_input_nodes():
                 self.add_input_file(ext="sdc")
+            elif all(f"{self.design_topmodule}.{mode}.sdc" in self.get_files_from_input_nodes() for mode in modes):
+                for mode in modes:
+                    self.add_input_file(ext=f"{mode}.sdc")
             else:
                 for lib, fileset in self.project.get_filesets():
                     if lib.has_file(fileset=fileset, filetype="sdc"):
                         self.add_required_key(lib, "fileset", fileset, "file", "sdc")
 
-                modes = set()
                 for scenario in self.project.constraint.timing.get_scenario().values():
                     mode = scenario.get_mode(self.step, self.index)
                     if mode:
-                        modes.add(mode)
                         self.add_required_key(scenario, "mode")
                         mode_obj = self.project.constraint.timing.get_mode(mode)
                         self.add_required_key(mode_obj, "sdcfileset")
 
-                for mode in modes:
+                for mode in self._get_modes():
                     mode_obj = self.project.constraint.timing.get_mode(mode)
                     for lib, fileset in mode_obj.get_sdcfileset():
                         libobj = self.project.get_library(lib)

--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -1442,13 +1442,13 @@ class APRTask(OpenROADTask):
     def _add_pnr_inputs(self):
         if self.get("var", "load_sdcs"):
             modes = self._get_modes()
-            if f"{self.design_topmodule}.sdc" in self.get_files_from_input_nodes():
-                self.add_input_file(ext="sdc")
-            elif modes and \
+            if modes and \
                     all(f"{self.design_topmodule}.{mode}.sdc" in self.get_files_from_input_nodes()
                         for mode in modes):
                 for mode in modes:
                     self.add_input_file(ext=f"{mode}.sdc")
+            elif f"{self.design_topmodule}.sdc" in self.get_files_from_input_nodes():
+                self.add_input_file(ext="sdc")
             else:
                 for lib, fileset in self.project.get_filesets():
                     if lib.has_file(fileset=fileset, filetype="sdc"):

--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -1444,7 +1444,9 @@ class APRTask(OpenROADTask):
             modes = self._get_modes()
             if f"{self.design_topmodule}.sdc" in self.get_files_from_input_nodes():
                 self.add_input_file(ext="sdc")
-            elif all(f"{self.design_topmodule}.{mode}.sdc" in self.get_files_from_input_nodes() for mode in modes):
+            elif modes and \
+                    all(f"{self.design_topmodule}.{mode}.sdc" in self.get_files_from_input_nodes()
+                        for mode in modes):
                 for mode in modes:
                     self.add_input_file(ext=f"{mode}.sdc")
             else:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of mode-specific constraint files during place-and-route: when all per-mode constraint files are provided, the tool now registers them per mode; otherwise it falls back to using the generic constraint file or declares required constraint files. Internal logic for extracting timing modes was centralized for clearer processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->