### PR TITLE
add catch to sc-show

### DIFF
--- a/siliconcompiler/apps/sc_show.py
+++ b/siliconcompiler/apps/sc_show.py
@@ -211,16 +211,20 @@ def main():
                                f"\"{project.option.get_builddir()}\", using \"build\" instead")
         project.option.set_builddir('build')
 
-    success = project.show(filename,
-                           extension=show.get("cmdarg", "extension"),
-                           screenshot=show.get("cmdarg", "screenshot"),
-                           tool=show.get("cmdarg", "tool"),
-                           open=show.get("cmdarg", "open"))
+    try:
+        success = project.show(filename,
+                               extension=show.get("cmdarg", "extension"),
+                               screenshot=show.get("cmdarg", "screenshot"),
+                               tool=show.get("cmdarg", "tool"),
+                               open=show.get("cmdarg", "open"))
 
-    if success and os.path.isfile(success) and show.get("cmdarg", "screenshot"):
-        project.logger.info(f'Screenshot file: {success}')
+        if success and os.path.isfile(success) and show.get("cmdarg", "screenshot"):
+            project.logger.info(f'Screenshot file: {success}')
 
-    return 0
+        return 0
+    except Exception as e:
+        project.logger.debug(f"Error during show: {e}", exc_info=True)
+        return 1
 
 
 #########################

--- a/tests/apps/test_sc_show.py
+++ b/tests/apps/test_sc_show.py
@@ -582,6 +582,7 @@ def test_sc_show_exception_with_screenshot(monkeypatch, make_manifests, asic_gcd
     with patch('siliconcompiler.Project.show') as show:
         show.side_effect = Exception("Screenshot generation failed")
         assert sc_show.main() == 1
+        show.assert_called_once()
 
 
 @pytest.mark.timeout(90)
@@ -593,6 +594,7 @@ def test_sc_show_exception_with_tool(monkeypatch, make_manifests, asic_gcd):
     with patch('siliconcompiler.Project.show') as show:
         show.side_effect = RuntimeError("Tool execution failed")
         assert sc_show.main() == 1
+        show.assert_called_once()
 
 
 @pytest.mark.timeout(90)

--- a/tests/apps/test_sc_show.py
+++ b/tests/apps/test_sc_show.py
@@ -550,6 +550,52 @@ def test_sc_show_tool_with_all_parameters(monkeypatch, make_manifests, asic_gcd,
 
 
 @pytest.mark.timeout(90)
+def test_sc_show_exception_handling(monkeypatch, make_manifests, asic_gcd):
+    '''Test sc-show app catches exceptions from project.show and returns non-zero exit code.'''
+    make_manifests(asic_gcd)
+
+    monkeypatch.setattr('sys.argv', ['sc-show', '-design', 'gcd'])
+    with patch('siliconcompiler.Project.show') as show:
+        show.side_effect = RuntimeError("Test error")
+        assert sc_show.main() == 1
+        show.assert_called_once_with(None, extension=None, screenshot=False, tool=None, open=False)
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_exception_with_file(monkeypatch, make_manifests, asic_gcd):
+    '''Test sc-show app catches exceptions when showing a file.'''
+    make_manifests(asic_gcd)
+
+    monkeypatch.setattr('sys.argv', ['sc-show', 'build/gcd/job0/write.gds/0/outputs/gcd.gds'])
+    with patch('siliconcompiler.Project.show') as show:
+        show.side_effect = OSError("File not found")
+        assert sc_show.main() == 1
+        show.assert_called_once()
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_exception_with_screenshot(monkeypatch, make_manifests, asic_gcd):
+    '''Test sc-show app catches exceptions when generating screenshot.'''
+    make_manifests(asic_gcd)
+
+    monkeypatch.setattr('sys.argv', ['sc-show', '-design', 'gcd', '-screenshot'])
+    with patch('siliconcompiler.Project.show') as show:
+        show.side_effect = Exception("Screenshot generation failed")
+        assert sc_show.main() == 1
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_exception_with_tool(monkeypatch, make_manifests, asic_gcd):
+    '''Test sc-show app catches exceptions when using a specific tool.'''
+    make_manifests(asic_gcd)
+
+    monkeypatch.setattr('sys.argv', ['sc-show', '-design', 'gcd', '-tool', 'klayout'])
+    with patch('siliconcompiler.Project.show') as show:
+        show.side_effect = RuntimeError("Tool execution failed")
+        assert sc_show.main() == 1
+
+
+@pytest.mark.timeout(90)
 def test_sc_show_with_tool_task_format(monkeypatch, make_manifests, asic_gcd):
     '''Test sc-show app with tool/task format.'''
     make_manifests(asic_gcd)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * sc-show now correctly reports failures with a non-zero exit code when errors occur, and logs debug information including tracebacks to aid diagnosis.
* **Tests**
  * Added tests covering sc-show error handling across multiple invocation modes to ensure failures are detected and reported consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->