### PR TITLE
avoid calling relatively slow reset during show

### DIFF
--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -1451,6 +1451,10 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         task.set_showfiletype(filetype)
         task.set_shownode(jobname=sc_jobname, nodestep=sc_step, nodeindex=sc_index)
 
+        # Avoid call to reset params
+        # This is safe because proj is a copy and is not returned from this function
+        proj.__reset_job_params = lambda: None
+
         # run show flow
         proj.run()
         if screenshot:

--- a/tests/apps/test_sc_show.py
+++ b/tests/apps/test_sc_show.py
@@ -776,3 +776,80 @@ def test_sc_show_nonexistent_file_with_design(monkeypatch):
         assert sc_show.main() == 0
         show.assert_called_once_with(nonexistent_file, extension=None, screenshot=False, tool=None,
                                      open=False)
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_does_not_call_reset_job_params(monkeypatch, make_manifests, asic_gcd):
+    '''Test that Project.show() does not call __reset_job_params.'''
+    make_manifests(asic_gcd)
+
+    # Patch __reset_job_params to verify it's not called
+    with patch.object(asic_gcd, '_Project__reset_job_params') as mock_reset:
+        try:
+            asic_gcd.show()
+        except Exception:
+            # show() might fail due to missing files, that's OK
+            pass
+
+        # Verify __reset_job_params was not called on the original project
+        mock_reset.assert_not_called()
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_preserves_job_parameters(monkeypatch, make_manifests, asic_gcd):
+    '''Test that job-scoped parameters are preserved after show().'''
+    make_manifests(asic_gcd)
+
+    # Set job-scoped parameters that would normally be reset
+    asic_gcd.set("arg", "step", "custom_step")
+    asic_gcd.set("arg", "index", "42")
+
+    # Call show - since it overrides __reset_job_params with a no-op,
+    # the original project's parameters should still be there
+    try:
+        asic_gcd.show()
+    except Exception:
+        # show() might fail, but that's OK for this test
+        pass
+
+    # Verify job parameters are still set (not reset)
+    # Note: show() creates a copy of the project, so the original should be unaffected
+    assert asic_gcd.get("arg", "step") == "custom_step"
+    assert asic_gcd.get("arg", "index") == "42"
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_with_screenshot_does_not_reset_params(monkeypatch, make_manifests, asic_gcd):
+    '''Test that __reset_job_params is not called when using screenshot mode.'''
+    make_manifests(asic_gcd)
+
+    # Set job-scoped parameters
+    asic_gcd.set("arg", "step", "screenshot_step")
+
+    with patch.object(asic_gcd, '_Project__reset_job_params') as mock_reset:
+        try:
+            asic_gcd.show(screenshot=True)
+        except Exception:
+            pass
+
+        # Verify __reset_job_params was not called
+        mock_reset.assert_not_called()
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_with_file_does_not_reset_params(monkeypatch, make_manifests, asic_gcd):
+    '''Test that __reset_job_params is not called when showing a specific file.'''
+    make_manifests(asic_gcd)
+
+    # Set job-scoped parameters
+    asic_gcd.set("arg", "index", "99")
+
+    with patch.object(asic_gcd, '_Project__reset_job_params') as mock_reset:
+        try:
+            # Try to show a file that might not exist
+            asic_gcd.show(filename="/tmp/test.gds")
+        except Exception:
+            pass
+
+        # Verify __reset_job_params was not called
+        mock_reset.assert_not_called()

--- a/tests/apps/test_sc_show.py
+++ b/tests/apps/test_sc_show.py
@@ -5,6 +5,7 @@ import os.path
 
 from unittest.mock import patch
 
+from siliconcompiler import Project
 from siliconcompiler.apps import sc_show
 from siliconcompiler.utils.paths import workdir, jobdir
 
@@ -779,77 +780,130 @@ def test_sc_show_nonexistent_file_with_design(monkeypatch):
 
 
 @pytest.mark.timeout(90)
-def test_sc_show_does_not_call_reset_job_params(monkeypatch, make_manifests, asic_gcd):
-    '''Test that Project.show() does not call __reset_job_params.'''
+def _capture_show_run(monkeypatch):
+    '''Patch Project.copy and Project.run so we can capture the copy that
+    show() builds and skip the actual flow execution. Returns a dict that
+    will be populated with 'copy' and 'run_self' once show() runs.'''
+    captured = {}
+    real_copy = Project.copy
+
+    def spy_copy(self, *args, **kwargs):
+        proj = real_copy(self, *args, **kwargs)
+        captured['copy'] = proj
+        return proj
+
+    def fake_run(self):
+        captured['run_self'] = self
+
+    monkeypatch.setattr(Project, 'copy', spy_copy)
+    monkeypatch.setattr(Project, 'run', fake_run)
+    return captured
+
+
+def test_sc_show_does_not_call_reset_job_params(monkeypatch, make_manifests, asic_gcd, tmp_path):
+    '''show() must override __reset_job_params on the copied project before run().'''
     make_manifests(asic_gcd)
 
-    # Patch __reset_job_params to verify it's not called
-    with patch.object(asic_gcd, '_Project__reset_job_params') as mock_reset:
-        try:
-            asic_gcd.show()
-        except Exception:
-            # show() might fail due to missing files, that's OK
-            pass
+    gds_file = tmp_path / "layout.gds"
+    gds_file.write_text("dummy")
 
-        # Verify __reset_job_params was not called on the original project
-        mock_reset.assert_not_called()
+    captured = _capture_show_run(monkeypatch)
+
+    asic_gcd.show(filename=str(gds_file))
+
+    proj = captured.get('copy')
+    assert proj is not None, 'show() did not reach proj = self.copy()'
+    assert captured.get('run_self') is proj, 'show() did not call proj.run()'
+    # The override must live on the copy as an instance attribute that shadows
+    # the bound method, and it must be a no-op.
+    assert '_Project__reset_job_params' in proj.__dict__
+    assert proj._Project__reset_job_params() is None
 
 
 @pytest.mark.timeout(90)
-def test_sc_show_preserves_job_parameters(monkeypatch, make_manifests, asic_gcd):
-    '''Test that job-scoped parameters are preserved after show().'''
+def test_sc_show_preserves_job_parameters(monkeypatch, make_manifests, asic_gcd, tmp_path):
+    '''When run() invokes __reset_job_params on the copy, the override makes it a no-op.'''
     make_manifests(asic_gcd)
 
-    # Set job-scoped parameters that would normally be reset
     asic_gcd.set("arg", "step", "custom_step")
     asic_gcd.set("arg", "index", "42")
 
-    # Call show - since it overrides __reset_job_params with a no-op,
-    # the original project's parameters should still be there
-    try:
-        asic_gcd.show()
-    except Exception:
-        # show() might fail, but that's OK for this test
-        pass
+    gds_file = tmp_path / "layout.gds"
+    gds_file.write_text("dummy")
 
-    # Verify job parameters are still set (not reset)
-    # Note: show() creates a copy of the project, so the original should be unaffected
+    captured = {}
+    real_copy = Project.copy
+    reset_called = []
+
+    def spy_copy(self, *args, **kwargs):
+        proj = real_copy(self, *args, **kwargs)
+        captured['copy'] = proj
+        return proj
+
+    def fake_run(self):
+        captured['run_self'] = self
+        # Mirror what real run() does at the end so the override actually matters.
+        result = self._Project__reset_job_params()
+        reset_called.append(result)
+
+    monkeypatch.setattr(Project, 'copy', spy_copy)
+    monkeypatch.setattr(Project, 'run', fake_run)
+
+    asic_gcd.show(filename=str(gds_file))
+
+    proj = captured.get('copy')
+    assert proj is not None
+    assert captured.get('run_self') is proj
+    # The reset call inside run() must hit the no-op lambda, not the real method.
+    assert reset_called == [None]
+    assert '_Project__reset_job_params' in proj.__dict__
+    # Original's args are unaffected because the copy is independent.
     assert asic_gcd.get("arg", "step") == "custom_step"
     assert asic_gcd.get("arg", "index") == "42"
 
 
 @pytest.mark.timeout(90)
-def test_sc_show_with_screenshot_does_not_reset_params(monkeypatch, make_manifests, asic_gcd):
-    '''Test that __reset_job_params is not called when using screenshot mode.'''
+def test_sc_show_with_screenshot_does_not_reset_params(monkeypatch, make_manifests,
+                                                       asic_gcd, tmp_path):
+    '''The reset override is installed on the copy in screenshot mode too.'''
     make_manifests(asic_gcd)
 
-    # Set job-scoped parameters
     asic_gcd.set("arg", "step", "screenshot_step")
 
-    with patch.object(asic_gcd, '_Project__reset_job_params') as mock_reset:
-        try:
-            asic_gcd.show(screenshot=True)
-        except Exception:
-            pass
+    gds_file = tmp_path / "layout.gds"
+    gds_file.write_text("dummy")
 
-        # Verify __reset_job_params was not called
-        mock_reset.assert_not_called()
+    captured = _capture_show_run(monkeypatch)
+
+    asic_gcd.show(filename=str(gds_file), screenshot=True)
+
+    proj = captured.get('copy')
+    assert proj is not None
+    assert captured.get('run_self') is proj
+    assert '_Project__reset_job_params' in proj.__dict__
+    assert proj._Project__reset_job_params() is None
+    # Original project's job arg is untouched.
+    assert asic_gcd.get("arg", "step") == "screenshot_step"
 
 
 @pytest.mark.timeout(90)
-def test_sc_show_with_file_does_not_reset_params(monkeypatch, make_manifests, asic_gcd):
-    '''Test that __reset_job_params is not called when showing a specific file.'''
+def test_sc_show_with_file_does_not_reset_params(monkeypatch, make_manifests,
+                                                 asic_gcd, tmp_path):
+    '''The reset override is installed on the copy when showing a specific file.'''
     make_manifests(asic_gcd)
 
-    # Set job-scoped parameters
     asic_gcd.set("arg", "index", "99")
 
-    with patch.object(asic_gcd, '_Project__reset_job_params') as mock_reset:
-        try:
-            # Try to show a file that might not exist
-            asic_gcd.show(filename="/tmp/test.gds")
-        except Exception:
-            pass
+    gds_file = tmp_path / "specific.gds"
+    gds_file.write_text("dummy")
 
-        # Verify __reset_job_params was not called
-        mock_reset.assert_not_called()
+    captured = _capture_show_run(monkeypatch)
+
+    asic_gcd.show(filename=str(gds_file))
+
+    proj = captured.get('copy')
+    assert proj is not None
+    assert captured.get('run_self') is proj
+    assert '_Project__reset_job_params' in proj.__dict__
+    assert proj._Project__reset_job_params() is None
+    assert asic_gcd.get("arg", "index") == "99"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `show()` method to preserve job-scoped parameters during execution instead of resetting them unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->