### PR TITLE
fix manifest find

### DIFF
--- a/siliconcompiler/apps/_common.py
+++ b/siliconcompiler/apps/_common.py
@@ -118,6 +118,15 @@ def pick_manifest_from_file(cliproject: Project, src_file: Optional[str], all_ma
         return None
 
     src_dir = os.path.abspath(os.path.dirname(src_file))
+
+    # Check the source file's directory directly for a manifest. This handles
+    # files referenced by absolute paths or outside the cwd's build tree, where
+    # _get_manifests() would not have discovered them.
+    if os.path.isdir(src_dir):
+        for entry in os.listdir(src_dir):
+            if entry.endswith('.pkg.json'):
+                return os.path.join(src_dir, entry)
+
     # Iterate through all discovered manifests to find one in the same directory.
     for _, jobs in all_manifests.items():
         for _, nodes in jobs.items():

--- a/tests/apps/test_common.py
+++ b/tests/apps/test_common.py
@@ -358,6 +358,54 @@ def test_pick_manifest_from_file_in_outputs(asic_gcd, make_manifests, tmp_path):
     assert outputs_dir in result
 
 
+def test_pick_manifest_from_file_direct_outside_cwd(asic_gcd, tmp_path):
+    '''Manifest sits next to the source file but outside the cwd build tree.
+
+    Simulates passing an absolute path like
+    build/<design>/<jobname>/<step>/<index>/outputs/foo.vg
+    where the manifest <design>.pkg.json is in the same directory but cannot
+    be discovered by walking cwd.
+    '''
+    outputs_dir = tmp_path / "outputs"
+    outputs_dir.mkdir()
+
+    manifest = outputs_dir / "gcd.pkg.json"
+    manifest.write_text("nothing")
+
+    src_file = outputs_dir / "gcd.vg"
+    src_file.write_text("module gcd; endmodule")
+
+    # Empty all_manifests: the discovery scan would not find anything, so the
+    # only way this resolves is via the direct-directory check.
+    result = _common.pick_manifest_from_file(asic_gcd, str(src_file), {})
+
+    assert result == str(manifest)
+
+
+def test_pick_manifest_from_file_direct_inputs_dir(asic_gcd, tmp_path):
+    '''Same as above but for files placed in an inputs/ directory.'''
+    inputs_dir = tmp_path / "inputs"
+    inputs_dir.mkdir()
+
+    manifest = inputs_dir / "gcd.pkg.json"
+    manifest.write_text("nothing")
+
+    src_file = inputs_dir / "gcd.v"
+    src_file.write_text("module gcd; endmodule")
+
+    result = _common.pick_manifest_from_file(asic_gcd, str(src_file), {})
+
+    assert result == str(manifest)
+
+
+def test_pick_manifest_from_file_direct_no_manifest(asic_gcd, tmp_path):
+    '''No .pkg.json next to the source file and no discovered manifests.'''
+    src_file = tmp_path / "stray.vg"
+    src_file.write_text("module stray; endmodule")
+
+    assert _common.pick_manifest_from_file(asic_gcd, str(src_file), {}) is None
+
+
 @pytest.mark.timeout(90)
 def test_pick_manifest_jobname_inference(asic_gcd, monkeypatch):
     '''Test jobname inference when only one job exists.'''


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced manifest file resolution to handle absolute file paths and directories located outside the standard build tree structure, enabling successful discovery in additional edge-case scenarios.

* **Tests**
  * Added test coverage for manifest resolution when external discovery mechanisms are unavailable, validating both successful resolution and proper handling of missing manifest files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->