### PR TITLE
no backtrace on KeyboardInt

### DIFF
--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -356,7 +356,7 @@ class SchedulerNode:
             self.__project._logger_console.setFormatter(formatter)
             self.logger.addHandler(self.__project._logger_console)
 
-    def halt(self, msg: Optional[str] = None) -> None:
+    def halt(self, msg: Optional[str] = None, errmsg: Optional[str] = None) -> None:
         """
         Stops the node's execution due to an error.
 
@@ -365,6 +365,7 @@ class SchedulerNode:
 
         Args:
             msg (str, optional): An error message to log.
+            errmsg (str, optional): An additional error message to log.
         """
         if msg:
             self.logger.error(msg)
@@ -375,7 +376,10 @@ class SchedulerNode:
         except FileNotFoundError:
             self.logger.error(f"Failed to write manifest for {self.__step}/{self.__index}.")
 
-        self.logger.error(f"Halting {self.__step}/{self.__index} due to errors.")
+        if errmsg:
+            self.logger.error(errmsg)
+        else:
+            self.logger.error(f"Halting {self.__step}/{self.__index} due to errors.")
         send_messages.send(self.__project, "fail", self.__step, self.__index)
         sys.exit(1)
 
@@ -867,6 +871,8 @@ class SchedulerNode:
 
             try:
                 self.execute()
+            except KeyboardInterrupt:
+                self.halt(errmsg=f"Execution interrupted for {self.__step}/{self.__index}")
             except Exception as e:
                 utils.print_traceback(self.logger, e)
                 self.halt()

--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -382,8 +382,8 @@ class SchedulerNode:
             else:
                 self.logger.error(f"Halting {self.__step}/{self.__index} due to errors.")
             send_messages.send(self.__project, "fail", self.__step, self.__index)
-        except:
-            # Catch everthing to avoid generating additional errors during error handling
+        except:  # noqa E722
+            # Catch everything to avoid generating additional errors during error handling
             pass
         sys.exit(1)
 

--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -367,20 +367,24 @@ class SchedulerNode:
             msg (str, optional): An error message to log.
             errmsg (str, optional): An additional error message to log.
         """
-        if msg:
-            self.logger.error(msg)
-
-        self.__record.set("status", NodeStatus.ERROR, step=self.__step, index=self.__index)
         try:
-            self.__project.write_manifest(self.__manifests["output"])
-        except FileNotFoundError:
-            self.logger.error(f"Failed to write manifest for {self.__step}/{self.__index}.")
+            if msg:
+                self.logger.error(msg)
 
-        if errmsg:
-            self.logger.error(errmsg)
-        else:
-            self.logger.error(f"Halting {self.__step}/{self.__index} due to errors.")
-        send_messages.send(self.__project, "fail", self.__step, self.__index)
+            self.__record.set("status", NodeStatus.ERROR, step=self.__step, index=self.__index)
+            try:
+                self.__project.write_manifest(self.__manifests["output"])
+            except FileNotFoundError:
+                self.logger.error(f"Failed to write manifest for {self.__step}/{self.__index}.")
+
+            if errmsg:
+                self.logger.error(errmsg)
+            else:
+                self.logger.error(f"Halting {self.__step}/{self.__index} due to errors.")
+            send_messages.send(self.__project, "fail", self.__step, self.__index)
+        except:
+            # Catch everthing to avoid generating additional errors during error handling
+            pass
         sys.exit(1)
 
     def setup(self) -> bool:

--- a/siliconcompiler/utils/multiprocessing.py
+++ b/siliconcompiler/utils/multiprocessing.py
@@ -199,41 +199,52 @@ class MPManager(metaclass=_ManagerSingleton):
 
         manager = MPManager()
 
-        # Remove all logger handlers to release file locks
-        for handler in list(manager.__logger.handlers):
-            manager.__logger.removeHandler(handler)
-            handler.close()
+        try:
+            # Remove all logger handlers to release file locks
+            for handler in list(manager.__logger.handlers):
+                manager.__logger.removeHandler(handler)
+                handler.close()
 
-        # Remove the log file if the run was successful
-        if not manager.__error:
-            try:
-                os.remove(manager.__logfile)
-            except:  # noqa E722
-                pass
+            # Remove the log file if the run was successful
+            if not manager.__error:
+                try:
+                    os.remove(manager.__logfile)
+                except:  # noqa E722
+                    pass
 
-        # Stop the dashboard service if it's running
-        if manager.__board:
-            try:
-                with manager.__board_lock:
+            # Stop the dashboard service if it's running
+            if manager.__board:
+                try:
+                    with manager.__board_lock:
+                        if manager.__board:
+                            manager.__board.stop()
+                            manager.__board = None
+                except RemoteError:
+                    # Try without the lock
                     if manager.__board:
                         manager.__board.stop()
                         manager.__board = None
-            except RemoteError:
-                # Try without the lock
-                if manager.__board:
-                    manager.__board.stop()
-                    manager.__board = None
 
-        if manager.__manager_server:
-            # Shut down the multiprocessing manager
-            MPManager.__address = None
-            manager.__manager.shutdown()
-
-        # Unregister cleanup function to prevent it from being called again
-        atexit.unregister(MPManager.stop)
-
-        # Delete singleton instance to allow for re-initialization
-        _ManagerSingleton.remove_cls(MPManager)
+            if manager.__manager_server:
+                # Shut down the multiprocessing manager
+                MPManager.__address = None
+                manager.__manager.shutdown()
+        except:
+            # Catch everything (incl. KeyboardInterrupt) so a signal arriving
+            # mid-cleanup cannot escape an atexit callback or leave the
+            # singleton half-torn-down.
+            pass
+        finally:
+            # Always run housekeeping, even if cleanup above was interrupted,
+            # so a re-entry to stop() is a no-op.
+            try:
+                atexit.unregister(MPManager.stop)
+            except:
+                pass
+            try:
+                _ManagerSingleton.remove_cls(MPManager)
+            except:
+                pass
 
     @staticmethod
     def error(msg: Optional[str] = None):

--- a/siliconcompiler/utils/multiprocessing.py
+++ b/siliconcompiler/utils/multiprocessing.py
@@ -229,7 +229,7 @@ class MPManager(metaclass=_ManagerSingleton):
                 # Shut down the multiprocessing manager
                 MPManager.__address = None
                 manager.__manager.shutdown()
-        except:
+        except:  # noqa E722
             # Catch everything (incl. KeyboardInterrupt) so a signal arriving
             # mid-cleanup cannot escape an atexit callback or leave the
             # singleton half-torn-down.
@@ -239,11 +239,11 @@ class MPManager(metaclass=_ManagerSingleton):
             # so a re-entry to stop() is a no-op.
             try:
                 atexit.unregister(MPManager.stop)
-            except:
+            except:  # noqa E722
                 pass
             try:
                 _ManagerSingleton.remove_cls(MPManager)
-            except:
+            except:  # noqa E722
                 pass
 
     @staticmethod

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -296,6 +296,20 @@ def test_halt_with_reason(project, monkeypatch, caplog):
     assert project.get("record", "status", step="steptwo", index="0") == NodeStatus.ERROR
     assert os.path.exists("build/testdesign/job0/steptwo/0/outputs/testdesign.pkg.json")
     assert "failed due to error" in caplog.text
+    assert "Halting steptwo/0 due to errors" in caplog.text
+
+
+def test_halt_with_errmsg_replaces_default(project, monkeypatch, caplog):
+    monkeypatch.setattr(project, "_Project__logger", logging.getLogger())
+    node = SchedulerNode(project, "steptwo", "0")
+    node.task.setup_work_directory(node.workdir)
+
+    with pytest.raises(SystemExit):
+        node.halt(errmsg="custom halting message")
+    assert project.get("record", "status", step="steptwo", index="0") == NodeStatus.ERROR
+    assert "custom halting message" in caplog.text
+    # errmsg replaces the default "Halting..." line.
+    assert "Halting steptwo/0 due to errors" not in caplog.text
 
 
 def test_setup(project):
@@ -1616,6 +1630,26 @@ def test_run_failed_to_execute(project, monkeypatch, caplog):
 
     assert "thiserrorisraised" in caplog.text
     assert "Halting stepone/0 due to errors" in caplog.text
+
+
+def test_run_keyboard_interrupt_during_execute(project, monkeypatch, caplog):
+    monkeypatch.setattr(project, "_Project__logger", logging.getLogger())
+    project.logger.setLevel(logging.INFO)
+
+    node = SchedulerNode(project, "stepone", "0")
+    node.task.setup_work_directory(node.workdir)
+
+    with patch("siliconcompiler.scheduler.SchedulerNode.execute") as call_exec:
+        call_exec.side_effect = KeyboardInterrupt()
+        with pytest.raises(SystemExit):
+            node.run()
+        call_exec.assert_called_once()
+
+    assert project.get("record", "status", step="stepone", index="0") == NodeStatus.ERROR
+
+    assert "Execution interrupted for stepone/0" in caplog.text
+    # The interrupt path passes errmsg=, which replaces the default "Halting..." line.
+    assert "Halting stepone/0 due to errors" not in caplog.text
 
 
 def test_run_failed_to_execute_initial_save_has_error(project):

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -312,6 +312,52 @@ def test_halt_with_errmsg_replaces_default(project, monkeypatch, caplog):
     assert "Halting steptwo/0 due to errors" not in caplog.text
 
 
+def test_halt_swallows_write_manifest_error(project, monkeypatch, caplog):
+    '''halt() must still call sys.exit(1) even if write_manifest raises an
+    unexpected (non-FileNotFoundError) exception.'''
+    monkeypatch.setattr(project, "_Project__logger", logging.getLogger())
+    node = SchedulerNode(project, "steptwo", "0")
+    node.task.setup_work_directory(node.workdir)
+
+    with patch.object(project, "write_manifest", side_effect=RuntimeError("disk on fire")):
+        with pytest.raises(SystemExit) as excinfo:
+            node.halt("kicking off halt")
+    assert excinfo.value.code == 1
+    # The exception inside halt must not propagate out.
+    assert project.get("record", "status", step="steptwo", index="0") == NodeStatus.ERROR
+    assert "kicking off halt" in caplog.text
+
+
+def test_halt_swallows_send_messages_error(project, monkeypatch, caplog):
+    '''halt() must still call sys.exit(1) if send_messages.send raises.'''
+    monkeypatch.setattr(project, "_Project__logger", logging.getLogger())
+    node = SchedulerNode(project, "steptwo", "0")
+    node.task.setup_work_directory(node.workdir)
+
+    with patch("siliconcompiler.scheduler.schedulernode.send_messages.send",
+               side_effect=RuntimeError("messaging broker down")):
+        with pytest.raises(SystemExit) as excinfo:
+            node.halt("kicking off halt")
+    assert excinfo.value.code == 1
+    assert project.get("record", "status", step="steptwo", index="0") == NodeStatus.ERROR
+    # The "Halting..." line should still have been logged before the suppressed exception.
+    assert "Halting steptwo/0 due to errors" in caplog.text
+
+
+def test_halt_swallows_record_set_error(project, monkeypatch):
+    '''halt() must still call sys.exit(1) if the very first internal call
+    (recording status) raises.'''
+    monkeypatch.setattr(project, "_Project__logger", logging.getLogger())
+    node = SchedulerNode(project, "steptwo", "0")
+    node.task.setup_work_directory(node.workdir)
+
+    with patch.object(node._SchedulerNode__record, "set",
+                      side_effect=RuntimeError("record blew up")):
+        with pytest.raises(SystemExit) as excinfo:
+            node.halt()
+    assert excinfo.value.code == 1
+
+
 def test_setup(project):
     node = SchedulerNode(project, "steptwo", "0")
 

--- a/tests/utils/test_multiprocessing.py
+++ b/tests/utils/test_multiprocessing.py
@@ -176,3 +176,66 @@ def test_stop_repeat():
     manager = MPManager()
     manager.stop()
     manager.stop()
+
+
+def _raise_kbi(*args, **kwargs):
+    raise KeyboardInterrupt()
+
+
+def test_stop_swallows_keyboard_interrupt_in_os_remove():
+    '''A KeyboardInterrupt raised by os.remove during atexit must not escape.'''
+    MPManager()
+    with patch("os.remove", side_effect=_raise_kbi):
+        # Must not raise.
+        MPManager.stop()
+    # Singleton fully cleaned up so a second stop() is a no-op.
+    assert _ManagerSingleton.has_cls(MPManager) is False
+    MPManager.stop()
+
+
+def test_stop_swallows_keyboard_interrupt_in_handler_close():
+    '''A KeyboardInterrupt raised while closing a logger handler must not escape.'''
+    manager = MPManager()
+
+    class KBIHandler(logging.Handler):
+        def close(self):
+            raise KeyboardInterrupt()
+
+    manager._MPManager__logger.addHandler(KBIHandler())
+
+    MPManager.stop()
+    assert _ManagerSingleton.has_cls(MPManager) is False
+
+
+def test_stop_swallows_keyboard_interrupt_in_board_stop():
+    '''A KeyboardInterrupt raised while stopping the dashboard must not escape.'''
+    MPManager().get_dashboard()
+
+    with patch("siliconcompiler.report.dashboard.cli.board.Board.stop",
+               side_effect=_raise_kbi):
+        MPManager.stop()
+    assert _ManagerSingleton.has_cls(MPManager) is False
+
+
+def test_stop_swallows_keyboard_interrupt_in_manager_shutdown():
+    '''A KeyboardInterrupt raised while shutting down the multiprocessing
+    manager must not escape.'''
+    manager = MPManager()
+    # Force the manager_server branch on so shutdown() is reached.
+    manager._MPManager__manager_server = True
+
+    with patch.object(manager._MPManager__manager, "shutdown",
+                      side_effect=_raise_kbi):
+        MPManager.stop()
+    assert _ManagerSingleton.has_cls(MPManager) is False
+
+
+def test_stop_runs_housekeeping_after_interrupt():
+    '''Even if cleanup is interrupted, atexit.unregister must still run so the
+    handler is not left registered for a second invocation.'''
+    MPManager()
+    with patch("os.remove", side_effect=_raise_kbi), \
+            patch("atexit.unregister") as unreg:
+        MPManager.stop()
+        unreg.assert_called_once_with(MPManager.stop)
+    assert _ManagerSingleton.has_cls(MPManager) is False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nodes now record ERROR and log interrupt-specific or custom halt messages without emitting duplicate default halt logs.
  * Shutdown/cleanup routines swallow interruptions during teardown so exit handlers complete reliably and don't fail on interrupts.

* **Tests**
  * Added and updated tests covering interrupt handling, custom halt-message logging, and cleanup behavior during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->