### PR TITLE
 add gate for logicdepth

### DIFF
--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -1186,6 +1186,7 @@ class APRTask(OpenROADTask):
             "drv_violations",
             "fmax",
             "power",
+            "logicdepth",
             "check_setup",
             "report_buffers",
             "placement_density",

--- a/siliconcompiler/tools/openroad/antenna_repair.py
+++ b/siliconcompiler/tools/openroad/antenna_repair.py
@@ -61,6 +61,7 @@ class AntennaRepairTask(APRTask, OpenROADSTAParameter, OpenROADGRTParameter, Ope
             'power',
             'drv_violations',
             'fmax',
+            "logicdepth",
 
             # Images
             'placement_density',

--- a/siliconcompiler/tools/openroad/clock_tree_synthesis.py
+++ b/siliconcompiler/tools/openroad/clock_tree_synthesis.py
@@ -27,6 +27,7 @@ class CTSTask(APRTask, OpenROADSTAParameter, OpenROADDPLParameter, OpenROADCTSPa
             'drv_violations',
             'fmax',
             'report_buffers',
+            "logicdepth",
 
             # Images
             'placement_density',

--- a/siliconcompiler/tools/openroad/detailed_placement.py
+++ b/siliconcompiler/tools/openroad/detailed_placement.py
@@ -25,6 +25,7 @@ class DetailedPlacementTask(APRTask, OpenROADSTAParameter, OpenROADDPLParameter,
             'power',
             'drv_violations',
             'fmax',
+            "logicdepth",
 
             # Images
             'placement_density',

--- a/siliconcompiler/tools/openroad/detailed_route.py
+++ b/siliconcompiler/tools/openroad/detailed_route.py
@@ -27,6 +27,7 @@ class DetailedRouteTask(APRTask, OpenROADSTAParameter, OpenROADDRTPinAccessParam
             'power',
             'drv_violations',
             'fmax',
+            "logicdepth",
 
             # Images
             'placement_density',

--- a/siliconcompiler/tools/openroad/fillercell_insertion.py
+++ b/siliconcompiler/tools/openroad/fillercell_insertion.py
@@ -25,6 +25,7 @@ class FillCellTask(APRTask, OpenROADSTAParameter, OpenROADDPLParameter, OpenROAD
             'power',
             'drv_violations',
             'fmax',
+            "logicdepth",
 
             # Images
             'placement_density',

--- a/siliconcompiler/tools/openroad/fillmetal_insertion.py
+++ b/siliconcompiler/tools/openroad/fillmetal_insertion.py
@@ -44,6 +44,7 @@ class FillMetalTask(APRTask, OpenROADSTAParameter):
             'clock_skew',
             'drv_violations',
             'fmax',
+            "logicdepth",
 
             # Images
             'placement_density',

--- a/siliconcompiler/tools/openroad/global_placement.py
+++ b/siliconcompiler/tools/openroad/global_placement.py
@@ -105,6 +105,7 @@ class GlobalPlacementTask(APRTask, OpenROADSTAParameter, OpenROADGPLParameter,
             'power',
             'fmax',
             'report_buffers',
+            "logicdepth",
 
             # Images
             'placement_density',

--- a/siliconcompiler/tools/openroad/global_route.py
+++ b/siliconcompiler/tools/openroad/global_route.py
@@ -46,6 +46,7 @@ class GlobalRouteTask(APRTask, OpenROADSTAParameter, OpenROADGRTParameter,
             'power',
             'drv_violations',
             'fmax',
+            "logicdepth",
 
             # Images
             'placement_density',

--- a/siliconcompiler/tools/openroad/init_floorplan.py
+++ b/siliconcompiler/tools/openroad/init_floorplan.py
@@ -186,7 +186,8 @@ class InitFloorplanTask(APRTask,
             'check_setup',
             'setup',
             'unconstrained',
-            'power'
+            'power',
+            "logicdepth"
         ])
 
         self.add_required_key("var", "ifp_snap_strategy")

--- a/siliconcompiler/tools/openroad/metrics.py
+++ b/siliconcompiler/tools/openroad/metrics.py
@@ -22,6 +22,7 @@ class MetricsTask(APRTask, OpenROADSTAParameter):
             'power',
             'drv_violations',
             'fmax',
+            "logicdepth",
 
             # Images
             'placement_density',

--- a/siliconcompiler/tools/openroad/pin_placement.py
+++ b/siliconcompiler/tools/openroad/pin_placement.py
@@ -21,6 +21,7 @@ class PinPlacementTask(APRTask, OpenROADSTAParameter, OpenROADGPLParameter, Open
         self._set_reports([
             'setup',
             'unconstrained',
+            "logicdepth",
 
             # Images
             'placement_density',

--- a/siliconcompiler/tools/openroad/repair_design.py
+++ b/siliconcompiler/tools/openroad/repair_design.py
@@ -76,6 +76,7 @@ class RepairDesignTask(APRTask, OpenROADSTAParameter, OpenROADRSZDRVParameter):
             'drv_violations',
             'fmax',
             'report_buffers',
+            "logicdepth",
 
             # Images
             'placement_density',

--- a/siliconcompiler/tools/openroad/repair_timing.py
+++ b/siliconcompiler/tools/openroad/repair_timing.py
@@ -92,6 +92,7 @@ class RepairTimingTask(APRTask, OpenROADSTAParameter, OpenROADDPLParameter,
             'drv_violations',
             'fmax',
             'report_buffers',
+            "logicdepth",
 
             # Images
             'placement_density',

--- a/siliconcompiler/tools/openroad/scripts/common/reports.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/reports.tcl
@@ -217,13 +217,15 @@ if { ![sc_check_version 26 1 0] } {
     utl::metric_int "design__inverters" $invs
 }
 
-# get number of unconstrained endpoints
-with_output_to_variable endpoints {check_setup -unconstrained_endpoints}
-set unconstrained_endpoints [regexp -all -inline {[0-9]+} $endpoints]
-if { $unconstrained_endpoints == "" } {
-    set unconstrained_endpoints 0
+if { [sc_cfg_tool_task_check_in_list unconstrained var reports] } {
+    # get number of unconstrained endpoints
+    with_output_to_variable endpoints {check_setup -unconstrained_endpoints}
+    set unconstrained_endpoints [regexp -all -inline {[0-9]+} $endpoints]
+    if { $unconstrained_endpoints == "" } {
+        set unconstrained_endpoints 0
+    }
+    utl::metric_int "timing__unconstrained" $unconstrained_endpoints
 }
-utl::metric_int "timing__unconstrained" $unconstrained_endpoints
 
 # Write markers
 foreach markerdb [[ord::get_db_block] getMarkerCategories] {

--- a/siliconcompiler/tools/openroad/scripts/common/reports.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/reports.tcl
@@ -149,7 +149,9 @@ if { [llength [all_clocks]] > 0 } {
 }
 
 # get logic depth of design
-utl::metric_int "design__logic__depth" [sc_count_logic_depth]
+if { [sc_cfg_tool_task_check_in_list logicdepth var reports] } {
+    utl::metric_int "design__logic__depth" [sc_count_logic_depth]
+}
 
 if { [sc_cfg_tool_task_check_in_list power var reports] } {
     puts "$PREFIX power"

--- a/siliconcompiler/tools/openroad/write_data.py
+++ b/siliconcompiler/tools/openroad/write_data.py
@@ -128,6 +128,7 @@ class WriteViewsTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
             'power',
             'drv_violations',
             'fmax',
+            "logicdepth",
 
             # Images
             'placement_density',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "logic depth" as a configurable report/metric across OpenROAD-based design tasks, available throughout the compilation flow.
* **Bug Fixes**
  * Reporting now emits logic-depth and unconstrained-endpoint metrics only when their respective report types are enabled, avoiding unnecessary metric outputs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siliconcompiler/siliconcompiler/pull/4958)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->