### PR TITLE
check if pins are actually in the die

### DIFF
--- a/siliconcompiler/tools/openroad/scripts/apr/sc_init_floorplan.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_init_floorplan.tcl
@@ -349,6 +349,12 @@ if { [sc_cfg_exists constraint pin] } {
             utl::error FLW 1 "Shape $shape on pin $pin is not supported."
         }
 
+        if { ![sc_is_inside_die $x_loc $y_loc] } {
+            utl::warn FLW 1 "Pin $pin has a placement location of ($x_loc, $y_loc)\
+                which is outside the die area."
+            incr pin_errors
+        }
+
         if {
             [catch {
                 place_pin -pin_name $pin \
@@ -399,6 +405,12 @@ if { [sc_cfg_exists constraint pin] } {
                         set x_loc [expr { ($i + 1) * $spacing }]
                         set y_loc [lindex [ord::get_die_area] 1]
                     }
+                }
+
+                if { ![sc_is_inside_die $x_loc $y_loc] } {
+                    utl::warn FLW 1 "Pin $name has a placement location of ($x_loc, $y_loc)\
+                        which is outside the die area."
+                    incr pin_errors
                 }
 
                 if {

--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -942,10 +942,10 @@ proc sc_is_inside_die { x y } {
 
     set die_area [[ord::get_db_block] getDieArea]
     if {
-        $x < [die_area xMin] ||
-        $x > [die_area xMax] ||
-        $y < [die_area yMin] ||
-        $y > [die_area yMax]
+        $x < [$die_area xMin] ||
+        $x > [$die_area xMax] ||
+        $y < [$die_area yMin] ||
+        $y > [$die_area yMax]
     } {
         return false
     }

--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -935,3 +935,19 @@ proc sc_is_scene_enabled { scene check } {
         return false
     }
 }
+
+proc sc_is_inside_die { x y } {
+    set x [ord::microns_to_dbu $x]
+    set y [ord::microns_to_dbu $y]
+
+    set die_area [[ord::get_db_block] getDieArea]
+    if {
+        $x < [die_area xMin] ||
+        $x > [die_area xMax] ||
+        $y < [die_area yMin] ||
+        $y > [die_area yMax]
+    } {
+        return false
+    }
+    return true
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Floorplan initialization now validates pin coordinates against the die boundary to prevent placements outside the chip area.
  * Out-of-bound pin attempts now emit warnings and increment an error counter, improving detection and debugging of invalid pin locations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siliconcompiler/siliconcompiler/pull/4959)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->