### PR TITLE
fix builtin task IO checks

### DIFF
--- a/siliconcompiler/scheduler/scheduler.py
+++ b/siliconcompiler/scheduler/scheduler.py
@@ -367,72 +367,24 @@ class Scheduler:
 
     def __check_flowgraph_io(self) -> bool:
         """
-        Validate that every runtime node will receive its required input files and that no
-        input file is provided by more than one source.
+        Validate that every runtime node will receive its required input files.
 
-        Checks whether each node's required inputs are available either from upstream
-        tasks' declared outputs or from existing output directories, and logs errors
-        for missing or duplicated input sources.
+        The per-node validation is delegated to ``Task._validate_io`` so that
+        task subclasses (notably the builtin tasks, which select among their
+        upstream inputs at runtime) can implement their own fan-in semantics.
 
         Returns:
             bool: `True` if the flowgraph satisfies input/output requirements, `False` otherwise.
         """
-        nodes = self.__flow_runtime.get_nodes()
         error = False
 
-        manifest_name = os.path.basename(self.manifest)
-
-        for (step, index) in nodes:
-            # Get files we receive from input nodes.
-            in_nodes = self.__flow_runtime.get_node_inputs(step, index, record=self.__record)
-            all_inputs = set()
+        for (step, index) in self.__flow_runtime.get_nodes():
             tool = self.__flow.get(step, index, "tool")
             task = self.__flow.get(step, index, "task")
             task_class = self.__project.get("tool", tool, "task", task, field="schema")
-            requirements = task_class.get('input', step=step, index=index)
 
-            for in_step, in_index in in_nodes:
-                if (in_step, in_index) not in nodes:
-                    # If we're not running the input step, the required
-                    # inputs need to already be copied into the build
-                    # directory.
-                    in_step_out_dir = os.path.join(
-                        workdir(self.__project, step=in_step, index=in_index), 'outputs')
-
-                    if not os.path.isdir(in_step_out_dir):
-                        # This means this step hasn't been run, but that
-                        # will be flagged by a different check. No error
-                        # message here since it would be redundant.
-                        inputs = []
-                        continue
-
-                    inputs = [inp for inp in os.listdir(in_step_out_dir) if inp != manifest_name]
-                else:
-                    in_tool = self.__flow.get(in_step, in_index, "tool")
-                    in_task = self.__flow.get(in_step, in_index, "task")
-                    in_task_class = self.__project.get("tool", in_tool, "task", in_task,
-                                                       field="schema")
-
-                    with in_task_class.runtime(self.__tasks[(in_step, in_index)]) as task:
-                        inputs = task.get_output_files()
-
-                with task_class.runtime(self.__tasks[(step, index)]) as task:
-                    for inp in inputs:
-                        node_inp = task.compute_input_file_node_name(inp, in_step, in_index)
-                        if node_inp in requirements:
-                            inp = node_inp
-                        if inp not in requirements:
-                            continue
-                        if inp in all_inputs:
-                            self.__logger.error(f'Invalid flow: {step}/{index} '
-                                                f'receives {inp} from multiple input tasks')
-                            error = True
-                        all_inputs.add(inp)
-
-            for requirement in requirements:
-                if requirement not in all_inputs:
-                    self.__logger.error(f'Invalid flow: {step}/{index} will '
-                                        f'not receive required input {requirement}.')
+            with task_class.runtime(self.__tasks[(step, index)]) as task_obj:
+                if not task_obj._validate_io():
                     error = True
 
         return not error

--- a/siliconcompiler/scheduler/scheduler.py
+++ b/siliconcompiler/scheduler/scheduler.py
@@ -27,7 +27,7 @@ from siliconcompiler import utils
 from siliconcompiler.utils.logging import SCLoggerFormatter
 from siliconcompiler.utils.multiprocessing import MPManager
 from siliconcompiler.scheduler import send_messages, SCRuntimeError
-from siliconcompiler.utils.paths import collectiondir, jobdir, workdir
+from siliconcompiler.utils.paths import collectiondir, jobdir
 from siliconcompiler.utils.curation import collect
 
 if TYPE_CHECKING:

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -559,6 +559,7 @@ class Task(NamedSchema, PathSchema, DocsSchema):
         self.__schema_metric: Optional[MetricSchema] = None
         self.__schema_flow: Optional[Flowgraph] = None
         self.__schema_flow_runtime: Optional[RuntimeFlowgraph] = None
+        self.__io_runtime_flow: Optional[RuntimeFlowgraph] = None
         if self.__schema_full:
             self.__schema_record = self.__schema_full.get("record", field="schema")
             self.__schema_metric = self.__schema_full.get("metric", field="schema")
@@ -579,6 +580,17 @@ class Task(NamedSchema, PathSchema, DocsSchema):
             self.__schema_flow_runtime = RuntimeFlowgraph(
                 self.__schema_flow,
                 from_steps=set([step for step, _ in self.__schema_flow.get_entry_nodes()]),
+                prune_nodes=self.__schema_full.option.get_prune())
+
+            # Runtime view honoring option.from / option.to / option.prune,
+            # i.e. the subset of nodes that will actually run this invocation.
+            # Used by IO validation to distinguish running upstreams (whose
+            # outputs come from declared task outputs) from non-running ones
+            # (whose outputs must already exist on disk).
+            self.__io_runtime_flow = RuntimeFlowgraph(
+                self.__schema_flow,
+                from_steps=self.__schema_full.option.get_from(),
+                to_steps=self.__schema_full.option.get_to(),
                 prune_nodes=self.__schema_full.option.get_prune())
 
     @property
@@ -651,6 +663,17 @@ class Task(NamedSchema, PathSchema, DocsSchema):
     @property
     def schema_flowruntime(self) -> RuntimeFlowgraph:
         return self.__schema_flow_runtime
+
+    @property
+    def _io_runtime_flow(self) -> RuntimeFlowgraph:
+        """
+        Runtime view of the flow that honors the project's ``from`` / ``to``
+        / ``prune`` options — i.e. the nodes that will actually run this
+        invocation. Distinct from ``schema_flowruntime`` (which is the full
+        graph minus pruned nodes), used by IO validation so that nodes
+        outside the active run are treated as on-disk dependencies.
+        """
+        return self.__io_runtime_flow
 
     def get_logpath(self, log: str) -> str:
         """
@@ -1511,6 +1534,70 @@ class Task(NamedSchema, PathSchema, DocsSchema):
                 inputs.setdefault(output, []).append((in_step, in_index))
 
         return inputs
+
+    def _list_upstream_outputs(self, in_step: str, in_index: str) -> List[str]:
+        """
+        Returns the file names that an upstream node will provide to this task.
+
+        If the upstream is part of the active IO runtime, its declared output
+        files are returned. Otherwise its on-disk ``outputs/`` directory is
+        scanned (excluding the manifest), since that node will not be re-run.
+        """
+        if (in_step, in_index) not in set(self._io_runtime_flow.get_nodes()):
+            in_step_out_dir = os.path.join(
+                paths.workdir(self.project, step=in_step, index=in_index), 'outputs')
+            if not os.path.isdir(in_step_out_dir):
+                return []
+            manifest_name = f"{self.project.name}.pkg.json"
+            return [inp for inp in os.listdir(in_step_out_dir) if inp != manifest_name]
+
+        in_tool = self.schema_flow.get(in_step, in_index, "tool")
+        in_task = self.schema_flow.get(in_step, in_index, "task")
+        in_task_class = self.project.get("tool", in_tool, "task", in_task, field="schema")
+        return list(in_task_class.get("output", step=in_step, index=in_index))
+
+    def _validate_io(self) -> bool:
+        """
+        Validate that this node's required input files will be supplied by
+        upstream nodes (or already exist on disk for nodes outside the runtime
+        view).
+
+        The base implementation enforces standard fan-in semantics: every
+        declared input must be produced by some upstream, and the same input
+        coming from multiple upstreams is flagged. Subclasses with non-standard
+        fan-in (e.g. builtin tasks that pick a single upstream at runtime) may
+        override this.
+
+        Returns:
+            bool: True if requirements are satisfied; False otherwise.
+        """
+        in_nodes = self._io_runtime_flow.get_node_inputs(
+            self.step, self.index, record=self.schema_record)
+        requirements = self.get("input")
+        all_inputs: Set[str] = set()
+        error = False
+
+        for in_step, in_index in in_nodes:
+            for inp in self._list_upstream_outputs(in_step, in_index):
+                node_inp = self.compute_input_file_node_name(inp, in_step, in_index)
+                if node_inp in requirements:
+                    inp = node_inp
+                if inp not in requirements:
+                    continue
+                if inp in all_inputs:
+                    self.logger.error(
+                        f'Invalid flow: {self.step}/{self.index} '
+                        f'receives {inp} from multiple input tasks')
+                all_inputs.add(inp)
+
+        for requirement in requirements:
+            if requirement not in all_inputs:
+                self.logger.error(
+                    f'Invalid flow: {self.step}/{self.index} will '
+                    f'not receive required input {requirement}.')
+                error = True
+
+        return not error
 
     def compute_input_file_node_name(self, filename: str, step: str, index: str) -> str:
         """

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -1588,6 +1588,7 @@ class Task(NamedSchema, PathSchema, DocsSchema):
                     self.logger.error(
                         f'Invalid flow: {self.step}/{self.index} '
                         f'receives {inp} from multiple input tasks')
+                    error = True
                 all_inputs.add(inp)
 
         for requirement in requirements:

--- a/siliconcompiler/tools/builtin/__init__.py
+++ b/siliconcompiler/tools/builtin/__init__.py
@@ -33,6 +33,37 @@ class BuiltinTask(Task):
 
         return super().select_input_nodes()
 
+    def _validate_io(self):
+        """
+        Builtin tasks resolve their input fan-in at runtime: ``mux``,
+        ``minimum``, ``maximum``, and ``verify`` pick one upstream from many,
+        and ``join`` unions them. The same file arriving from multiple
+        upstreams is therefore expected, not an error. Validation only
+        requires that every declared input is produced by at least one
+        upstream node (or exists on disk for nodes outside the runtime view).
+        """
+        in_nodes = self._io_runtime_flow.get_node_inputs(
+            self.step, self.index, record=self.schema_record)
+        requirements = self.get("input")
+        received = set()
+
+        for in_step, in_index in in_nodes:
+            for inp in self._list_upstream_outputs(in_step, in_index):
+                node_inp = self.compute_input_file_node_name(inp, in_step, in_index)
+                if node_inp in requirements:
+                    inp = node_inp
+                if inp in requirements:
+                    received.add(inp)
+
+        error = False
+        for requirement in requirements:
+            if requirement not in received:
+                self.logger.error(
+                    f'Invalid flow: {self.step}/{self.index} will '
+                    f'not receive required input {requirement}.')
+                error = True
+        return not error
+
     def run(self):
         # Do nothing
         return 0

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -632,6 +632,10 @@ def test_check_task_classes_pass(basic_project, monkeypatch, caplog):
 
 
 def test_check_flowgraph_io_basic(basic_project, monkeypatch, caplog):
+    """Smoke integration test that the scheduler still walks nodes and reports
+    success when there are no IO requirements. Detailed validation behavior
+    lives with Task._validate_io and is tested in tests/test_tool.py and
+    tests/tools/test_builtin.py."""
     monkeypatch.setattr(basic_project, "_Project__logger", logging.getLogger())
     basic_project.logger.setLevel(logging.INFO)
 
@@ -641,7 +645,8 @@ def test_check_flowgraph_io_basic(basic_project, monkeypatch, caplog):
     assert caplog.text == ""
 
 
-def test_check_flowgraph_io_with_files(basic_project_no_flow, monkeypatch, caplog):
+def test_check_flowgraph_io_propagates_failure(basic_project_no_flow, monkeypatch, caplog):
+    """Scheduler-level smoke: a failing _validate_io result is surfaced."""
     flow = Flowgraph("testflow")
     flow.node("stepone", NOPTask())
     flow.node("steptwo", NOPTask())
@@ -654,154 +659,10 @@ def test_check_flowgraph_io_with_files(basic_project_no_flow, monkeypatch, caplo
     scheduler = Scheduler(basic_project_no_flow)
 
     nop = NOPTask.find_task(basic_project_no_flow)
-    nop.add_output_file("test.v", step="stepone", index="0")
-    nop.add_input_file("test.v", step="steptwo", index="0")
-
-    assert scheduler._Scheduler__check_flowgraph_io() is True
-    assert caplog.text == ""
-
-
-def test_check_flowgraph_io_with_files_join(basic_project_no_flow, monkeypatch, caplog):
-    flow = Flowgraph("testflow")
-    flow.node("stepone", NOPTask())
-    flow.node("steptwo", NOPTask())
-    flow.node("dojoin", NOPTask())
-    flow.node("postjoin", NOPTask())
-    flow.edge("stepone", "dojoin")
-    flow.edge("steptwo", "dojoin")
-    flow.edge("dojoin", "postjoin")
-    basic_project_no_flow.set_flow(flow)
-
-    monkeypatch.setattr(basic_project_no_flow, "_Project__logger", logging.getLogger())
-    basic_project_no_flow.logger.setLevel(logging.INFO)
-
-    scheduler = Scheduler(basic_project_no_flow)
-
-    nop = NOPTask.find_task(basic_project_no_flow)
-    nop.add_output_file("a.v", step="stepone", index="0")
-    nop.add_output_file("b.v", step="steptwo", index="0")
-    nop.add_input_file("a.v", step="dojoin", index="0")
-    nop.add_input_file("b.v", step="dojoin", index="0")
-    nop.add_output_file("a.v", step="dojoin", index="0")
-    nop.add_output_file("b.v", step="dojoin", index="0")
-    nop.add_input_file("a.v", step="postjoin", index="0")
-    nop.add_input_file("b.v", step="postjoin", index="0")
-
-    assert scheduler._Scheduler__check_flowgraph_io() is True
-    assert caplog.text == ""
-
-
-def test_check_flowgraph_io_with_files_join_extra_files(basic_project_no_flow, monkeypatch, caplog):
-    flow = Flowgraph("testflow")
-    flow.node("stepone", NOPTask())
-    flow.node("steptwo", NOPTask())
-    flow.node("dojoin", NOPTask())
-    flow.node("postjoin", NOPTask())
-    flow.edge("stepone", "dojoin")
-    flow.edge("steptwo", "dojoin")
-    flow.edge("dojoin", "postjoin")
-    basic_project_no_flow.set_flow(flow)
-
-    monkeypatch.setattr(basic_project_no_flow, "_Project__logger", logging.getLogger())
-    basic_project_no_flow.logger.setLevel(logging.INFO)
-
-    scheduler = Scheduler(basic_project_no_flow)
-
-    nop = NOPTask.find_task(basic_project_no_flow)
-    nop.add_output_file("a.v", step="stepone", index="0")
-    nop.add_output_file("common.v", step="stepone", index="0")
-    nop.add_output_file("b.v", step="steptwo", index="0")
-    nop.add_output_file("common.v", step="stepone", index="0")
-    nop.add_input_file("common.v", step="dojoin", index="0")
-    nop.add_output_file("common.v", step="dojoin", index="0")
-    nop.add_input_file("common.v", step="postjoin", index="0")
-
-    assert scheduler._Scheduler__check_flowgraph_io() is True
-    assert caplog.text == ""
-
-
-def test_check_flowgraph_io_with_files_missing_input(basic_project_no_flow, monkeypatch, caplog):
-    flow = Flowgraph("testflow")
-    flow.node("stepone", NOPTask())
-    flow.node("steptwo", NOPTask())
-    flow.edge("stepone", "steptwo")
-    basic_project_no_flow.set_flow(flow)
-
-    monkeypatch.setattr(basic_project_no_flow, "_Project__logger", logging.getLogger())
-    basic_project_no_flow.logger.setLevel(logging.INFO)
-
-    scheduler = Scheduler(basic_project_no_flow)
-
-    nop = NOPTask.find_task(basic_project_no_flow)
-    nop.add_output_file("test.v", step="stepone", index="0")
-    nop.add_input_file("test.v", step="steptwo", index="0")
     nop.add_input_file("missing.v", step="steptwo", index="0")
 
     assert scheduler._Scheduler__check_flowgraph_io() is False
     assert "Invalid flow: steptwo/0 will not receive required input missing.v" in caplog.text
-
-
-def test_check_flowgraph_io_with_files_valid_input(basic_project_no_flow):
-    flow = Flowgraph("testflow")
-    flow.node("stepone", NOPTask())
-    flow.node("steptwo", NOPTask())
-    flow.edge("stepone", "steptwo")
-    basic_project_no_flow.set_flow(flow)
-
-    scheduler = Scheduler(basic_project_no_flow)
-
-    nop = NOPTask.find_task(basic_project_no_flow)
-    nop.add_output_file("test.v", step="stepone", index="0")
-    nop.add_input_file("test.stepone0.v", step="steptwo", index="0")
-
-    assert scheduler._Scheduler__check_flowgraph_io() is True
-
-
-def test_check_flowgraph_io_with_files_valid_input_from(basic_project_no_flow):
-    flow = Flowgraph("testflow")
-    flow.node("stepone", NOPTask())
-    flow.node("steptwo", NOPTask())
-    flow.edge("stepone", "steptwo")
-    basic_project_no_flow.set_flow(flow)
-
-    basic_project_no_flow.option.add_from("steptwo")
-
-    os.makedirs(os.path.join(workdir(basic_project_no_flow, step="stepone", index="0"), 'outputs'),
-                exist_ok=True)
-    with open(os.path.join(workdir(basic_project_no_flow, step="stepone", index="0"), 'outputs',
-                           'test.v'), 'w') as f:
-        f.write("test")
-
-    scheduler = Scheduler(basic_project_no_flow)
-
-    nop = NOPTask.find_task(basic_project_no_flow)
-    nop.add_output_file("test.v", step="stepone", index="0")
-    nop.add_input_file("test.stepone0.v", step="steptwo", index="0")
-
-    assert scheduler._Scheduler__check_flowgraph_io() is True
-
-
-def test_check_flowgraph_io_with_files_multple_input(basic_project_no_flow, monkeypatch, caplog):
-    flow = Flowgraph("testflow")
-    flow.node("stepone", NOPTask(), index=0)
-    flow.node("stepone", NOPTask(), index=1)
-    flow.node("steptwo", NOPTask())
-    flow.edge("stepone", "steptwo", tail_index=0)
-    flow.edge("stepone", "steptwo", tail_index=1)
-    basic_project_no_flow.set_flow(flow)
-
-    monkeypatch.setattr(basic_project_no_flow, "_Project__logger", logging.getLogger())
-    basic_project_no_flow.logger.setLevel(logging.INFO)
-
-    scheduler = Scheduler(basic_project_no_flow)
-
-    nop = NOPTask.find_task(basic_project_no_flow)
-    nop.add_output_file("test.v", step="stepone", index="0")
-    nop.add_output_file("test.v", step="stepone", index="1")
-    nop.add_input_file("test.v", step="steptwo", index="0")
-
-    assert scheduler._Scheduler__check_flowgraph_io() is False
-    assert "Invalid flow: steptwo/0 receives test.v from multiple input tasks" in caplog.text
 
 
 @pytest.mark.timeout(60)

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -14,7 +14,7 @@ from siliconcompiler.scheduler import Scheduler, SCRuntimeError, SlurmSchedulerN
 from siliconcompiler.schema import EditableSchema, Parameter
 
 from siliconcompiler.tools.builtin.nop import NOPTask
-from siliconcompiler.utils.paths import jobdir, workdir
+from siliconcompiler.utils.paths import jobdir
 from siliconcompiler.tool import TaskExecutableNotReceived, TaskSkip, Task
 from siliconcompiler.utils.multiprocessing import MPManager
 

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -93,6 +93,17 @@ class SetupSkip(Task):
         raise TaskSkip("skipped")
 
 
+class DupInputTask(Task):
+    def tool(self) -> str:
+        return "testtool"
+
+    def task(self) -> str:
+        return "dupinput"
+
+    def run(self):
+        return 0
+
+
 class AdditionalFiles(Task):
     def __init__(self):
         super().__init__()
@@ -663,6 +674,34 @@ def test_check_flowgraph_io_propagates_failure(basic_project_no_flow, monkeypatc
 
     assert scheduler._Scheduler__check_flowgraph_io() is False
     assert "Invalid flow: steptwo/0 will not receive required input missing.v" in caplog.text
+
+
+def test_check_flowgraph_io_rejects_duplicate_input(basic_project_no_flow,
+                                                    monkeypatch, caplog):
+    """Non-builtin task with ambiguous fan-in (same input name from two
+    upstreams) must fail validation at the scheduler entrypoint."""
+    flow = Flowgraph("testflow")
+    flow.node("stepone", NOPTask(), index=0)
+    flow.node("stepone", NOPTask(), index=1)
+    flow.node("steptwo", DupInputTask())
+    flow.edge("stepone", "steptwo", tail_index=0)
+    flow.edge("stepone", "steptwo", tail_index=1)
+    basic_project_no_flow.set_flow(flow)
+
+    monkeypatch.setattr(basic_project_no_flow, "_Project__logger", logging.getLogger())
+    basic_project_no_flow.logger.setLevel(logging.INFO)
+
+    scheduler = Scheduler(basic_project_no_flow)
+
+    NOPTask.find_task(basic_project_no_flow).add_output_file(
+        "test.v", step="stepone", index="0")
+    NOPTask.find_task(basic_project_no_flow).add_output_file(
+        "test.v", step="stepone", index="1")
+    DupInputTask.find_task(basic_project_no_flow).add_input_file(
+        "test.v", step="steptwo", index="0")
+
+    assert scheduler._Scheduler__check_flowgraph_io() is False
+    assert "Invalid flow: steptwo/0 receives test.v from multiple input tasks" in caplog.text
 
 
 @pytest.mark.timeout(60)

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -4038,9 +4038,10 @@ def test_validate_io_input_from_disk(io_project):
     assert _validate_io(io_project, "steptwo", "0") is True
 
 
-def test_validate_io_duplicate_input_logs(io_project, caplog):
-    """For a non-builtin task, the same file from multiple upstreams logs (but
-    historically does not fail) the validation."""
+def test_validate_io_duplicate_input_fails(io_project, caplog):
+    """A non-builtin task with two upstreams providing the same input name has
+    ambiguous fan-in: the runtime can't decide which upstream's file is the
+    real one. The base validator must reject this flow, not just log it."""
     flow = Flowgraph("testflow")
     flow.node("stepone", NOPTask(), index=0)
     flow.node("stepone", NOPTask(), index=1)
@@ -4056,9 +4057,9 @@ def test_validate_io_duplicate_input_logs(io_project, caplog):
     nop.add_output_file("test.v", step="stepone", index="1")
     nop.add_input_file("test.v", step="steptwo", index="0")
 
-    # NOPTask is a BuiltinTask; the duplicate-input log message belongs to the
+    # NOPTask is a BuiltinTask; the duplicate-input rejection belongs to the
     # base Task implementation. Exercise the base directly.
     node = SchedulerNode(io_project, "steptwo", "0")
     with nop.runtime(node) as task_obj:
-        assert Task._validate_io(task_obj) is True
+        assert Task._validate_io(task_obj) is False
     assert "Invalid flow: steptwo/0 receives test.v from multiple input tasks" in caplog.text

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -3974,7 +3974,7 @@ def test_validate_io_with_files_join_extra_files(io_project, caplog):
     nop.add_output_file("a.v", step="stepone", index="0")
     nop.add_output_file("common.v", step="stepone", index="0")
     nop.add_output_file("b.v", step="steptwo", index="0")
-    nop.add_output_file("common.v", step="stepone", index="0")
+    nop.add_output_file("common.v", step="steptwo", index="0")
     nop.add_input_file("common.v", step="dojoin", index="0")
     nop.add_output_file("common.v", step="dojoin", index="0")
     nop.add_input_file("common.v", step="postjoin", index="0")

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -3874,3 +3874,191 @@ def test_open_task_get_show_workdir():
     task = OpenTask()
     assert hasattr(task, 'get_show_workdir')
     assert callable(task.get_show_workdir)
+
+
+# -- Task._validate_io ---------------------------------------------------------
+
+@pytest.fixture
+def io_project():
+    """Empty project with a design but no flow; tests build their own flow."""
+    design = Design("testdesign")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    proj = Project(design)
+    proj.add_fileset("rtl")
+    return proj
+
+
+def _validate_io(project, step, index):
+    """Helper: enter runtime context for (step, index) and call _validate_io."""
+    flow_name = project.option.get_flow()
+    flow = project.get_flow(flow_name)
+    tool = flow.get(step, index, "tool")
+    task = flow.get(step, index, "task")
+    task_class = project.get("tool", tool, "task", task, field="schema")
+    node = SchedulerNode(project, step, index)
+    with task_class.runtime(node) as task_obj:
+        return task_obj._validate_io()
+
+
+def test_validate_io_no_inputs_no_upstream(io_project, caplog):
+    flow = Flowgraph("testflow")
+    flow.node("stepone", NOPTask())
+    io_project.set_flow(flow)
+    io_project._Project__logger = logging.getLogger()
+    io_project.logger.setLevel(logging.INFO)
+
+    assert _validate_io(io_project, "stepone", "0") is True
+    assert caplog.text == ""
+
+
+def test_validate_io_with_files(io_project, caplog):
+    flow = Flowgraph("testflow")
+    flow.node("stepone", NOPTask())
+    flow.node("steptwo", NOPTask())
+    flow.edge("stepone", "steptwo")
+    io_project.set_flow(flow)
+    io_project._Project__logger = logging.getLogger()
+    io_project.logger.setLevel(logging.INFO)
+
+    nop = NOPTask.find_task(io_project)
+    nop.add_output_file("test.v", step="stepone", index="0")
+    nop.add_input_file("test.v", step="steptwo", index="0")
+
+    assert _validate_io(io_project, "steptwo", "0") is True
+    assert caplog.text == ""
+
+
+def test_validate_io_with_files_join(io_project, caplog):
+    flow = Flowgraph("testflow")
+    flow.node("stepone", NOPTask())
+    flow.node("steptwo", NOPTask())
+    flow.node("dojoin", NOPTask())
+    flow.node("postjoin", NOPTask())
+    flow.edge("stepone", "dojoin")
+    flow.edge("steptwo", "dojoin")
+    flow.edge("dojoin", "postjoin")
+    io_project.set_flow(flow)
+    io_project._Project__logger = logging.getLogger()
+    io_project.logger.setLevel(logging.INFO)
+
+    nop = NOPTask.find_task(io_project)
+    nop.add_output_file("a.v", step="stepone", index="0")
+    nop.add_output_file("b.v", step="steptwo", index="0")
+    nop.add_input_file("a.v", step="dojoin", index="0")
+    nop.add_input_file("b.v", step="dojoin", index="0")
+    nop.add_output_file("a.v", step="dojoin", index="0")
+    nop.add_output_file("b.v", step="dojoin", index="0")
+    nop.add_input_file("a.v", step="postjoin", index="0")
+    nop.add_input_file("b.v", step="postjoin", index="0")
+
+    assert _validate_io(io_project, "dojoin", "0") is True
+    assert _validate_io(io_project, "postjoin", "0") is True
+    assert caplog.text == ""
+
+
+def test_validate_io_with_files_join_extra_files(io_project, caplog):
+    flow = Flowgraph("testflow")
+    flow.node("stepone", NOPTask())
+    flow.node("steptwo", NOPTask())
+    flow.node("dojoin", NOPTask())
+    flow.node("postjoin", NOPTask())
+    flow.edge("stepone", "dojoin")
+    flow.edge("steptwo", "dojoin")
+    flow.edge("dojoin", "postjoin")
+    io_project.set_flow(flow)
+    io_project._Project__logger = logging.getLogger()
+    io_project.logger.setLevel(logging.INFO)
+
+    nop = NOPTask.find_task(io_project)
+    nop.add_output_file("a.v", step="stepone", index="0")
+    nop.add_output_file("common.v", step="stepone", index="0")
+    nop.add_output_file("b.v", step="steptwo", index="0")
+    nop.add_output_file("common.v", step="stepone", index="0")
+    nop.add_input_file("common.v", step="dojoin", index="0")
+    nop.add_output_file("common.v", step="dojoin", index="0")
+    nop.add_input_file("common.v", step="postjoin", index="0")
+
+    assert _validate_io(io_project, "dojoin", "0") is True
+    assert _validate_io(io_project, "postjoin", "0") is True
+    assert caplog.text == ""
+
+
+def test_validate_io_missing_input(io_project, caplog):
+    flow = Flowgraph("testflow")
+    flow.node("stepone", NOPTask())
+    flow.node("steptwo", NOPTask())
+    flow.edge("stepone", "steptwo")
+    io_project.set_flow(flow)
+    io_project._Project__logger = logging.getLogger()
+    io_project.logger.setLevel(logging.INFO)
+
+    nop = NOPTask.find_task(io_project)
+    nop.add_output_file("test.v", step="stepone", index="0")
+    nop.add_input_file("test.v", step="steptwo", index="0")
+    nop.add_input_file("missing.v", step="steptwo", index="0")
+
+    assert _validate_io(io_project, "steptwo", "0") is False
+    assert "Invalid flow: steptwo/0 will not receive required input missing.v" in caplog.text
+
+
+def test_validate_io_renamed_input(io_project):
+    flow = Flowgraph("testflow")
+    flow.node("stepone", NOPTask())
+    flow.node("steptwo", NOPTask())
+    flow.edge("stepone", "steptwo")
+    io_project.set_flow(flow)
+
+    nop = NOPTask.find_task(io_project)
+    nop.add_output_file("test.v", step="stepone", index="0")
+    nop.add_input_file("test.stepone0.v", step="steptwo", index="0")
+
+    assert _validate_io(io_project, "steptwo", "0") is True
+
+
+def test_validate_io_input_from_disk(io_project):
+    """Upstream is outside the runtime (option.from); inputs should be discovered on disk."""
+    from siliconcompiler.utils.paths import workdir as _workdir
+    flow = Flowgraph("testflow")
+    flow.node("stepone", NOPTask())
+    flow.node("steptwo", NOPTask())
+    flow.edge("stepone", "steptwo")
+    io_project.set_flow(flow)
+    io_project.option.add_from("steptwo")
+
+    out_dir = os.path.join(_workdir(io_project, step="stepone", index="0"), 'outputs')
+    os.makedirs(out_dir, exist_ok=True)
+    with open(os.path.join(out_dir, 'test.v'), 'w') as f:
+        f.write("test")
+
+    nop = NOPTask.find_task(io_project)
+    nop.add_output_file("test.v", step="stepone", index="0")
+    nop.add_input_file("test.stepone0.v", step="steptwo", index="0")
+
+    assert _validate_io(io_project, "steptwo", "0") is True
+
+
+def test_validate_io_duplicate_input_logs(io_project, caplog):
+    """For a non-builtin task, the same file from multiple upstreams logs (but
+    historically does not fail) the validation."""
+    flow = Flowgraph("testflow")
+    flow.node("stepone", NOPTask(), index=0)
+    flow.node("stepone", NOPTask(), index=1)
+    flow.node("steptwo", NOPTask())
+    flow.edge("stepone", "steptwo", tail_index=0)
+    flow.edge("stepone", "steptwo", tail_index=1)
+    io_project.set_flow(flow)
+    io_project._Project__logger = logging.getLogger()
+    io_project.logger.setLevel(logging.INFO)
+
+    nop = NOPTask.find_task(io_project)
+    nop.add_output_file("test.v", step="stepone", index="0")
+    nop.add_output_file("test.v", step="stepone", index="1")
+    nop.add_input_file("test.v", step="steptwo", index="0")
+
+    # NOPTask is a BuiltinTask; the duplicate-input log message belongs to the
+    # base Task implementation. Exercise the base directly.
+    node = SchedulerNode(io_project, "steptwo", "0")
+    with nop.runtime(node) as task_obj:
+        assert Task._validate_io(task_obj) is True
+    assert "Invalid flow: steptwo/0 receives test.v from multiple input tasks" in caplog.text

--- a/tests/tools/test_builtin.py
+++ b/tests/tools/test_builtin.py
@@ -1601,3 +1601,83 @@ def test_wait_serialize_tool_tasks_validates_serial_execution():
         (("end", "0"),))
 
     assert flow.validate()
+
+
+# Regression: builtin tasks select among (or union) their upstream inputs at
+# runtime, so the same file arriving from multiple upstreams is expected — not
+# an error. The base Task validator would log "receives X from multiple input
+# tasks" repeatedly here; BuiltinTask._validate_io must suppress that.
+@pytest.mark.parametrize("cls", [JoinTask, MinimumTask, MaximumTask, MuxTask])
+def test_validate_io_builtin_multiple_inputs_same_file(cls, monkeypatch, caplog):
+    design = Design("testdesign")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+
+    task_name = cls().task()
+
+    flow = Flowgraph("test")
+    flow.node("start", NOPTask(), index=0)
+    flow.node("start", NOPTask(), index=1)
+    flow.node("start", NOPTask(), index=2)
+    flow.node("end", cls())
+    flow.edge("start", "end", tail_index=0)
+    flow.edge("start", "end", tail_index=1)
+    flow.edge("start", "end", tail_index=2)
+
+    proj = Project(design)
+    proj.add_fileset("rtl")
+    proj.set_flow(flow)
+    monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
+    proj.logger.setLevel(logging.INFO)
+
+    nop = NOPTask.find_task(proj)
+    nop.add_output_file("result.v", step="start", index="0")
+    nop.add_output_file("result.v", step="start", index="1")
+    nop.add_output_file("result.v", step="start", index="2")
+
+    node = SchedulerNode(proj, "end", "0")
+    with node.runtime():
+        node.setup()
+
+    builtin_task = proj.get("tool", "builtin", "task", task_name, field="schema")
+    with builtin_task.runtime(node) as task_obj:
+        assert task_obj._validate_io() is True
+
+    assert "receives result.v from multiple input tasks" not in caplog.text
+    assert "will not receive required input" not in caplog.text
+
+
+# Builtins still flag genuinely-missing inputs.
+@pytest.mark.parametrize("cls", [JoinTask, MinimumTask, MaximumTask, MuxTask])
+def test_validate_io_builtin_missing_input(cls, monkeypatch, caplog):
+    design = Design("testdesign")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+
+    task_name = cls().task()
+
+    flow = Flowgraph("test")
+    flow.node("start", NOPTask())
+    flow.node("end", cls())
+    flow.edge("start", "end")
+
+    proj = Project(design)
+    proj.add_fileset("rtl")
+    proj.set_flow(flow)
+    monkeypatch.setattr(proj, "_Project__logger", logging.getLogger())
+    proj.logger.setLevel(logging.INFO)
+
+    NOPTask.find_task(proj).add_output_file("test.out", step="start", index="0")
+
+    node = SchedulerNode(proj, "end", "0")
+    with node.runtime():
+        node.setup()
+
+    # Force a requirement that no upstream actually produces.
+    proj.get("tool", "builtin", "task", task_name, field="schema").add_input_file(
+        "missing.v", step="end", index="0")
+
+    builtin_task = proj.get("tool", "builtin", "task", task_name, field="schema")
+    with builtin_task.runtime(node) as task_obj:
+        assert task_obj._validate_io() is False
+    assert "will not receive required input missing.v" in caplog.text


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-task I/O validation delegated to runtime view honoring from/to/prune; runtime flow view and helpers exposed to enumerate upstream outputs and validate inputs, with on-disk fallback for outside-view nodes.

* **Bug Fixes**
  * Flowgraph I/O check now fails when any task reports missing or ambiguous required inputs; duplicate-input and missing-input issues are detected and logged.

* **Tests**
  * Added comprehensive tests covering success, failure, disk-fallback, renames, joins, duplicate-inputs, and failure propagation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siliconcompiler/siliconcompiler/pull/4961)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->