### PR TITLE
only build job information once in dashboard

### DIFF
--- a/siliconcompiler/report/dashboard/cli/board.py
+++ b/siliconcompiler/report/dashboard/cli/board.py
@@ -10,7 +10,7 @@ import os.path
 from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import List, Dict
+from typing import Any, List, Dict, Set, Tuple
 
 from rich import box
 from rich.theme import Theme
@@ -175,6 +175,26 @@ class LogBufferHandler(logging.Handler):
                     (SCColorLoggerFormatter.bold_red.replace("[", "\\["), "[bold red]")):
                 log_entry = log_entry.replace(color, replacement)
         self._parent.add_line(log_entry)
+
+
+@dataclass
+class _FlowTopology:
+    """
+    Cached topology data for a single (design, jobname) flow.
+
+    The recursive distance walk in `_get_job` is the most expensive piece of
+    every dashboard update, but its result depends only on the flowgraph
+    structure (plus which nodes are SKIPPED — see `signature`). Caching this
+    lets status-only updates avoid O(N^2) recomputation on every refresh.
+    """
+    nodes: List[Tuple[str, str]]
+    nodeorder: Dict[Tuple[str, str], Tuple[int, int]]
+    node_dists: Dict[Tuple[str, str], Dict[Tuple[str, str], int]]
+    flow_entry_nodes: Set[Tuple[str, str]]
+    flow_exit_nodes: Set[Tuple[str, str]]
+    check_flow_nodes: Set[Tuple[str, str]]
+    lowest_priority: int
+    signature: Any
 
 
 @dataclass
@@ -351,6 +371,11 @@ class Board:
 
         self._render_data = SessionData()
         self._render_data_lock = threading.Lock()
+
+        # Cache of flowgraph topology per project_id. The render thread is the
+        # only consumer of _get_job, and callers already serialize via
+        # _job_data_lock, so the cache itself does not need its own lock.
+        self._topology_cache: Dict[str, _FlowTopology] = {}
 
         self._log_handler_queue = manager.Queue()
 
@@ -1061,6 +1086,113 @@ class Board:
             self._board_info.data_modified = True
             self._render_event.set()
 
+    def _get_flow_topology(self, project, project_id):
+        """Compute (and cache) the topology-only parts of the flowgraph.
+
+        The recursive distance walk is the most expensive piece of `_get_job`
+        and depends only on the flowgraph structure plus the set of SKIPPED
+        nodes (since `get_node_inputs(record=...)` walks through skipped
+        nodes to their real predecessors). Caching by `project_id` lets
+        status-only updates skip the O(N^2) work entirely.
+
+        Returns None if the project has no configured flow.
+        """
+        flow = project.option.get_flow()
+        if not flow:
+            return None
+
+        check_flow = RuntimeFlowgraph(
+            project.get_flow(flow),
+            from_steps=project.option.get_from(),
+            to_steps=project.option.get_to(),
+            prune_nodes=project.option.get_prune())
+        runtime_flow = RuntimeFlowgraph(
+            project.get_flow(flow),
+            to_steps=project.option.get_to(),
+            prune_nodes=project.option.get_prune())
+        record = project.get("record", field='schema')
+
+        execnodes = runtime_flow.get_nodes()
+        check_flow_nodes = set(check_flow.get_nodes())
+
+        # Signature for cache invalidation. SKIPPED is the only status that
+        # changes which inputs a downstream node sees, so it's enough to
+        # invalidate on the SKIPPED set rather than re-running the heavier
+        # get_node_inputs probe for every node every call.
+        skipped = tuple(
+            sorted(
+                node for node in execnodes
+                if project.get("record", "status", step=node[0], index=node[1])
+                == NodeStatus.SKIPPED
+            )
+        )
+        signature = (
+            flow,
+            tuple(execnodes),
+            tuple(sorted(check_flow_nodes)),
+            tuple(project.option.get_from() or ()),
+            tuple(project.option.get_to() or ()),
+            tuple(project.option.get_prune() or ()),
+            skipped,
+        )
+
+        cached = self._topology_cache.get(project_id)
+        if cached is not None and cached.signature == signature:
+            return cached
+
+        nodes = []
+        nodeorder = {}
+        node_inputs = {}
+        node_outputs = {}
+
+        for n, nodeset in enumerate(runtime_flow.get_execution_order()):
+            for m, node in enumerate(nodeset):
+                if node not in execnodes:
+                    continue
+                nodes.append(node)
+                nodeorder[node] = (n, m)
+                node_inputs[node] = runtime_flow.get_node_inputs(*node, record=record)
+                for in_node in project.get_flow(flow).get_graph_node(node[0],
+                                                                     node[1]).get_input():
+                    node_outputs.setdefault(in_node, set()).add(node)
+
+        flow_entry_nodes = set(project.get_flow(flow).get_entry_nodes())
+        flow_exit_nodes = set(runtime_flow.get_exit_nodes())
+
+        def get_node_distance(node, search, level=1):
+            dists = {}
+            if node not in search:
+                return dists
+            for snode in search[node]:
+                dists[snode] = level
+                dists.update(get_node_distance(snode, search, level=level + 1))
+            return dists
+
+        node_dists = {}
+        for cnode in nodes:
+            # use 2x + 1 to give completed nodes sorting priority
+            node_dists[cnode] = {
+                node: 2 * level + 1
+                for node, level in get_node_distance(cnode, node_inputs).items()
+            }
+            node_dists[cnode].update({
+                node: 2 * level
+                for node, level in get_node_distance(cnode, node_outputs).items()
+            })
+
+        topology = _FlowTopology(
+            nodes=nodes,
+            nodeorder=nodeorder,
+            node_dists=node_dists,
+            flow_entry_nodes=flow_entry_nodes,
+            flow_exit_nodes=flow_exit_nodes,
+            check_flow_nodes=check_flow_nodes,
+            lowest_priority=3 * len(execnodes),
+            signature=signature,
+        )
+        self._topology_cache[project_id] = topology
+        return topology
+
     def _get_job(self, project, starttimes=None) -> JobData:
         """
         Parses a project object to extract detailed information about the flowgraph,
@@ -1080,88 +1212,45 @@ class Board:
         if not starttimes:
             starttimes = {}
 
+        design = project.option.get_design()
+        jobname = project.option.get_jobname()
+        project_id = f"{design}/{jobname}"
+
         nodes = []
         nodestatus = {}
         nodeorder = {}
         node_priority = {}
         flow_entry_nodes = set()
         flow_exit_nodes = set()
+        check_flow_nodes = set()
         try:
-            node_inputs = {}
-            node_outputs = {}
-            flow = project.option.get_flow()
-            if not flow:
+            topology = self._get_flow_topology(project, project_id)
+            if topology is None:
                 raise RuntimeError("dummy error")
 
-            check_flow = RuntimeFlowgraph(
-                project.get_flow(flow),
-                from_steps=project.option.get_from(),
-                to_steps=project.option.get_to(),
-                prune_nodes=project.option.get_prune())
-            runtime_flow = RuntimeFlowgraph(
-                project.get_flow(flow),
-                to_steps=project.option.get_to(),
-                prune_nodes=project.option.get_prune())
-            record = project.get("record", field='schema')
+            nodes = topology.nodes
+            nodeorder = topology.nodeorder
+            flow_entry_nodes = topology.flow_entry_nodes
+            flow_exit_nodes = topology.flow_exit_nodes
+            check_flow_nodes = topology.check_flow_nodes
 
-            execnodes = runtime_flow.get_nodes()
-            lowest_priority = 3 * len(execnodes)  # 2x + 1 is lowest computed, so 3x will be lower
-            for n, nodeset in enumerate(runtime_flow.get_execution_order()):
-                for m, node in enumerate(nodeset):
-                    if node not in execnodes:
-                        continue
-                    nodes.append(node)
-
-                    node_priority[node] = lowest_priority
-
-                    status = project.get("record", "status", step=node[0], index=node[1])
-                    if status is None:
-                        status = NodeStatus.PENDING
-                    nodestatus[node] = status
-                    nodeorder[node] = (n, m)
-
-                    node_inputs[node] = runtime_flow.get_node_inputs(*node, record=record)
-                    for in_node in project.get_flow(flow).get_graph_node(node[0],
-                                                                         node[1]).get_input():
-                        node_outputs.setdefault(in_node, set()).add(node)
-
-            flow_entry_nodes = set(
-                project.get_flow(flow).get_entry_nodes())
-            flow_exit_nodes = set(runtime_flow.get_exit_nodes())
+            for node in nodes:
+                node_priority[node] = topology.lowest_priority
+                status = project.get("record", "status", step=node[0], index=node[1])
+                if status is None:
+                    status = NodeStatus.PENDING
+                nodestatus[node] = status
 
             running_nodes = set([node for node in nodes if NodeStatus.is_running(nodestatus[node])])
             done_nodes = set([node for node in nodes if NodeStatus.is_done(nodestatus[node])])
             error_nodes = set([node for node in nodes if NodeStatus.is_error(nodestatus[node])])
 
-            def get_node_distance(node, search, level=1):
-                dists = {}
-
-                if node not in search:
-                    return dists
-
-                for snode in search[node]:
-                    dists[snode] = level
-                    dists.update(get_node_distance(snode, search, level=level+1))
-
-                return dists
-
-            # Compute relative node distances
-            node_dists = {}
-            for cnode in nodes:
-                # use 2x + 1 to give completed nodes sorting priority
-                node_dists[cnode] = {
-                    node: 2*level+1 for node, level in get_node_distance(cnode, node_inputs).items()
-                }
-                node_dists[cnode].update({
-                    node: 2*level for node, level in get_node_distance(cnode, node_outputs).items()
-                })
-
-            # Compute printing priority of nodes
+            # Compute printing priority of nodes (status-dependent; cheap)
             remaining_entry_nodes = flow_entry_nodes - done_nodes
             startnodes = running_nodes.union(remaining_entry_nodes)
             priority_node = {0: startnodes.union(error_nodes)}
             for node in nodes:
-                dists = node_dists[node]
+                dists = topology.node_dists[node]
                 levels = []
                 for snode in startnodes:
                     if snode not in dists:
@@ -1177,9 +1266,6 @@ class Board:
                     node_priority[node] = min(node_priority[node], level)
         except RuntimeError:
             pass
-
-        design = project.option.get_design()
-        jobname = project.option.get_jobname()
 
         job_data = JobData()
         job_data.jobname = jobname
@@ -1207,7 +1293,7 @@ class Board:
                 job_data.skipped += 1
                 continue
 
-            hide = (step, index) not in check_flow.get_nodes()
+            hide = (step, index) not in check_flow_nodes
             if not hide:
                 job_data.visible += 1
 

--- a/siliconcompiler/report/dashboard/cli/board.py
+++ b/siliconcompiler/report/dashboard/cli/board.py
@@ -1126,10 +1126,21 @@ class Board:
                 == NodeStatus.SKIPPED
             )
         )
+        # Edges of the static flow graph. Including these makes the cache
+        # invalidate when a user mutates flowgraph edges between calls (e.g.
+        # in a Jupyter session) — node-set equality alone wouldn't catch
+        # that. O(N + E) per signature build, far cheaper than the recursive
+        # distance walk it gates.
+        flow_obj = project.get_flow(flow)
+        edges = tuple(
+            (node, tuple(sorted(flow_obj.get_graph_node(node[0], node[1]).get_input())))
+            for node in sorted(execnodes)
+        )
         signature = (
             flow,
             tuple(execnodes),
             tuple(sorted(check_flow_nodes)),
+            edges,
             tuple(project.option.get_from() or ()),
             tuple(project.option.get_to() or ()),
             tuple(project.option.get_prune() or ()),

--- a/tests/report/dashboard/test_cli_dashboard.py
+++ b/tests/report/dashboard/test_cli_dashboard.py
@@ -23,6 +23,7 @@ from siliconcompiler.report.dashboard.cli.board import (
 )
 from siliconcompiler.report.dashboard.cli.keyboard import Keyboard
 from siliconcompiler import NodeStatus
+from siliconcompiler.flowgraph import RuntimeFlowgraph
 from siliconcompiler.utils.multiprocessing import MPManager
 
 
@@ -1686,37 +1687,50 @@ def test_get_job_topology_invalidated_by_skipped(mock_project, fake_console):
     assert first.signature != second.signature
 
 
-def test_get_job_topology_distance_walk_runs_once(mock_project, fake_console):
+def test_get_job_topology_distance_walk_runs_once(mock_project, fake_console,
+                                                  monkeypatch):
     """The recursive `get_node_distance` walk inside `_get_flow_topology`
     is the expensive piece we're trying to avoid. After the first call
-    seeds the cache, status-only refreshes must not call it again."""
+    seeds the cache, status-only refreshes must not call it again.
+
+    Uses `RuntimeFlowgraph.get_execution_order` as a miss-only sentinel:
+    it is invoked exclusively from the cache-miss branch of
+    `_get_flow_topology`, so its call count equals the number of real
+    rebuilds. We also pin object identity to catch in-place rebuilds that
+    a presence-only check (`project_id in _topology_cache`) would miss.
+    """
     dashboard = MPManager.get_dashboard()
+    real_get_exec_order = RuntimeFlowgraph.get_execution_order
+    exec_calls = []
 
-    real_get_flow_topology = dashboard._get_flow_topology
-    call_count = {"n": 0}
+    def counting(self, *args, **kwargs):
+        exec_calls.append(self)
+        return real_get_exec_order(self, *args, **kwargs)
 
-    def counting_topology(project, project_id):
-        # Count cache misses by detecting whether the project_id is already
-        # in the cache before the underlying call resolves it.
-        was_cached = project_id in dashboard._topology_cache
-        result = real_get_flow_topology(project, project_id)
-        if not was_cached:
-            call_count["n"] += 1
-        return result
+    monkeypatch.setattr(RuntimeFlowgraph, "get_execution_order", counting)
 
-    with patch.object(dashboard, "_get_flow_topology",
-                      side_effect=counting_topology):
-        dashboard._get_job(mock_project)
-        dashboard._get_job(mock_project)
-        mock_project.set("record", "status", "running",
-                         step="floorplan.init", index=0)
-        dashboard._get_job(mock_project)
-        mock_project.set("record", "status", "success",
-                         step="floorplan.init", index=0)
-        dashboard._get_job(mock_project)
+    # First call: cache miss — get_execution_order must be invoked.
+    dashboard._get_job(mock_project)
+    after_seed = len(exec_calls)
+    assert after_seed >= 1
+    seeded = dashboard._topology_cache["test_design/test_job"]
 
-    assert call_count["n"] == 1, (
-        f"Topology should be computed once; computed {call_count['n']} times"
+    # Status-only refreshes: cache hits — must reuse the same _FlowTopology
+    # object and must not invoke get_execution_order again.
+    dashboard._get_job(mock_project)
+    mock_project.set("record", "status", "running",
+                     step="floorplan.init", index=0)
+    dashboard._get_job(mock_project)
+    mock_project.set("record", "status", "success",
+                     step="floorplan.init", index=0)
+    dashboard._get_job(mock_project)
+
+    assert len(exec_calls) == after_seed, (
+        f"get_execution_order called {len(exec_calls)} times, expected "
+        f"{after_seed} (one per real topology rebuild)"
+    )
+    assert dashboard._topology_cache["test_design/test_job"] is seeded, (
+        "Topology object identity changed despite no structural change"
     )
 
 

--- a/tests/report/dashboard/test_cli_dashboard.py
+++ b/tests/report/dashboard/test_cli_dashboard.py
@@ -1643,6 +1643,150 @@ def test_get_job_with_status(mock_project, fake_console):
     assert len(job.nodes) == 18
 
 
+def test_get_job_topology_cached(mock_project, fake_console):
+    """Repeated _get_job calls on the same project must reuse the cached
+    flowgraph topology rather than re-running the recursive distance walk.
+
+    The cache key is the design/jobname pair; status changes that don't
+    introduce/remove SKIPPED nodes must hit the cache.
+    """
+    dashboard = MPManager.get_dashboard()
+
+    dashboard._get_job(mock_project)
+    project_id = "test_design/test_job"
+    assert project_id in dashboard._topology_cache
+    cached = dashboard._topology_cache[project_id]
+
+    # A status flip that is NOT skipped must reuse the cached topology
+    # (same object identity).
+    mock_project.set("record", "status", "success", step="route.global", index=0)
+    dashboard._get_job(mock_project)
+    assert dashboard._topology_cache[project_id] is cached
+
+    mock_project.set("record", "status", "error", step="write.views", index=0)
+    dashboard._get_job(mock_project)
+    assert dashboard._topology_cache[project_id] is cached
+
+
+def test_get_job_topology_invalidated_by_skipped(mock_project, fake_console):
+    """Introducing a SKIPPED node changes which inputs downstream nodes see
+    (RuntimeFlowgraph.get_node_inputs walks past skipped predecessors), so
+    the topology cache must be rebuilt when the SKIPPED set changes."""
+    dashboard = MPManager.get_dashboard()
+
+    dashboard._get_job(mock_project)
+    project_id = "test_design/test_job"
+    first = dashboard._topology_cache[project_id]
+
+    mock_project.set("record", "status", "skipped", step="route.detailed", index=0)
+    dashboard._get_job(mock_project)
+    second = dashboard._topology_cache[project_id]
+
+    assert second is not first
+    assert first.signature != second.signature
+
+
+def test_get_job_topology_distance_walk_runs_once(mock_project, fake_console):
+    """The recursive `get_node_distance` walk inside `_get_flow_topology`
+    is the expensive piece we're trying to avoid. After the first call
+    seeds the cache, status-only refreshes must not call it again."""
+    dashboard = MPManager.get_dashboard()
+
+    real_get_flow_topology = dashboard._get_flow_topology
+    call_count = {"n": 0}
+
+    def counting_topology(project, project_id):
+        # Count cache misses by detecting whether the project_id is already
+        # in the cache before the underlying call resolves it.
+        was_cached = project_id in dashboard._topology_cache
+        result = real_get_flow_topology(project, project_id)
+        if not was_cached:
+            call_count["n"] += 1
+        return result
+
+    with patch.object(dashboard, "_get_flow_topology",
+                      side_effect=counting_topology):
+        dashboard._get_job(mock_project)
+        dashboard._get_job(mock_project)
+        mock_project.set("record", "status", "running",
+                         step="floorplan.init", index=0)
+        dashboard._get_job(mock_project)
+        mock_project.set("record", "status", "success",
+                         step="floorplan.init", index=0)
+        dashboard._get_job(mock_project)
+
+    assert call_count["n"] == 1, (
+        f"Topology should be computed once; computed {call_count['n']} times"
+    )
+
+
+def test_get_job_status_counts_correct_with_cache(mock_project, fake_console):
+    """Status-derived counters (success/error/finished/visible) must update
+    on every call even when the topology cache is reused — they are
+    deliberately *not* part of the cache."""
+    dashboard = MPManager.get_dashboard()
+
+    job0 = dashboard._get_job(mock_project)
+    assert job0.success == 0
+    assert job0.finished == 0
+
+    mock_project.set("record", "status", "success", step="route.global", index=0)
+    job1 = dashboard._get_job(mock_project)
+    assert job1.success == 1
+    assert job1.finished == 1
+
+    mock_project.set("record", "status", "error", step="write.views", index=0)
+    job2 = dashboard._get_job(mock_project)
+    assert job2.error == 1
+    assert job2.success == 1
+    assert job2.finished == 2
+
+
+def test_get_job_priority_reflects_status_changes(mock_project, fake_console):
+    """node_priority is recomputed from cached node_dists on every call so
+    that running/error nodes float to the top of the display even though
+    the underlying topology was cached."""
+    dashboard = MPManager.get_dashboard()
+
+    # First call: nothing is running, nothing has errored, so entry nodes
+    # are the only priority-0 nodes.
+    job_initial = dashboard._get_job(mock_project)
+    initial_priorities = {
+        (node["step"], node["index"]): node["print"]["priority"]
+        for node in job_initial.nodes
+    }
+
+    # Pick a deep, non-entry node to set ERROR on; its priority should
+    # drop to 0 (errors are part of the priority-0 startnode set).
+    target = ("write.views", "0")
+    assert initial_priorities.get(target, 1) > 0
+
+    mock_project.set("record", "status", "error",
+                     step=target[0], index=target[1])
+    job_after = dashboard._get_job(mock_project)
+
+    after_priorities = {
+        (node["step"], node["index"]): node["print"]["priority"]
+        for node in job_after.nodes
+    }
+    assert after_priorities[target] == 0
+
+
+def test_get_job_separate_projects_use_separate_cache_entries(
+        mock_project, fake_console):
+    """The cache key is design/jobname; two distinct projects must each
+    get their own cached topology."""
+    dashboard = MPManager.get_dashboard()
+
+    dashboard._get_job(mock_project)
+    assert "test_design/test_job" in dashboard._topology_cache
+
+    mock_project.set('option', 'jobname', 'other_job')
+    dashboard._get_job(mock_project)
+    assert "test_design/other_job" in dashboard._topology_cache
+    assert "test_design/test_job" in dashboard._topology_cache
+
+
 def test_render_help_full_height(mock_project, fake_console):
     """Test rendering help display with full height (banner, authors, version, table)"""
     dashboard = MPManager.get_dashboard()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Dashboard refreshes now reuse a per-project precomputed flow topology to avoid expensive recomputation on status-only updates while preserving correct status, counts, and display priorities; cache invalidates when topology-relevant state (e.g., skipped nodes) changes.

* **Tests**
  * Added tests covering topology caching, cache invalidation, reduced recomputation, correct per-call status/priority updates, and cache isolation across projects.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siliconcompiler/siliconcompiler/pull/4970)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->