### PR TITLE
fix error message in smake for no file

### DIFF
--- a/siliconcompiler/apps/smake.py
+++ b/siliconcompiler/apps/smake.py
@@ -204,12 +204,16 @@ To run a target with arguments, use:
         sys.path.insert(0, dir)
 
         # --- Process the source file to discover targets ---
+        # If the user is only asking for help, allow the file to be missing so
+        # `smake --help` still prints usage information.
+        help_requested = any(arg in sys.argv for arg in ('--help', '-h'))
         make_args, default_arg, module_help = {}, None, None
         try:
             make_args, default_arg, module_help = __process_file(source_file, dir)
         except FileNotFoundError as e:
-            print(f"Error: Unable to process source file {source_file}: {e}")
-            return 1
+            if not help_requested:
+                print(f"Error: Unable to process source file {source_file}: {e}")
+                return 1
 
         if module_help:
             description += f"\n\n{module_help}\n\n"

--- a/siliconcompiler/apps/smake.py
+++ b/siliconcompiler/apps/smake.py
@@ -53,7 +53,7 @@ def __process_file(path: Union[Path, str], dir: str) -> Tuple[Dict, Optional[str
             - str or None: The docstring of the loaded module, if any.
     """
     if not os.path.exists(path):
-        return {}, None, None
+        raise FileNotFoundError(f"Specified file '{path}' does not exist.")
 
     mod_name, _ = os.path.splitext(os.path.basename(path))
 
@@ -204,8 +204,12 @@ To run a target with arguments, use:
         sys.path.insert(0, dir)
 
         # --- Process the source file to discover targets ---
-        make_args, default_arg, module_help = __process_file(source_file, dir) \
-            if source_file else ({}, None, None)
+        make_args, default_arg, module_help = {}, None, None
+        try:
+            make_args, default_arg, module_help = __process_file(source_file, dir)
+        except FileNotFoundError as e:
+            print(f"Error: Unable to process source file {source_file}: {e}")
+            return 1
 
         if module_help:
             description += f"\n\n{module_help}\n\n"

--- a/tests/apps/test_smake.py
+++ b/tests/apps/test_smake.py
@@ -35,7 +35,9 @@ def test_smake_default_missing(monkeypatch, capfd):
 
     monkeypatch.setattr('sys.argv', ['smake'])
     assert smake.main() == 1
-    assert "Error: Unable to load makefile 'make.py'" in capfd.readouterr().out
+    output = capfd.readouterr().out
+    assert "Error: Unable to process source file make.py" in output
+    assert "does not exist" in output
 
 
 def test_smake_default_dir_missing(monkeypatch, capfd):
@@ -44,6 +46,17 @@ def test_smake_default_dir_missing(monkeypatch, capfd):
     monkeypatch.setattr('sys.argv', ['smake', '-C', 'testdir'])
     assert smake.main() == 1
     assert "Unable to change directory to testdir" in capfd.readouterr().out
+
+
+def test_smake_file_missing(monkeypatch, capfd, datadir):
+    '''Test smake fails when the file specified with -f does not exist.'''
+
+    monkeypatch.setattr('sys.argv', [
+        'smake', '-C', datadir, '-f', 'does_not_exist.py', 'asic'])
+    assert smake.main() == 1
+    output = capfd.readouterr().out
+    assert "Error: Unable to process source file does_not_exist.py" in output
+    assert "does not exist" in output
 
 
 @pytest.mark.parametrize('target', ('target0', 'target1'))

--- a/tests/apps/test_smake.py
+++ b/tests/apps/test_smake.py
@@ -118,6 +118,21 @@ def test_smake_help(monkeypatch, capfd, datadir):
     assert "LINT HELP" in output.out
 
 
+def test_smake_help_no_file(monkeypatch, capfd, tmp_path):
+    '''Test that smake --help works even when the source file is missing.'''
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr('sys.argv', ['smake', '--help'])
+    with pytest.raises(SystemExit) as exc:
+        smake.main()
+    assert exc.value.code == 0
+    output = capfd.readouterr().out
+    # The usage line should still be printed.
+    assert "usage:" in output.lower()
+    # The file-not-found error should NOT appear when only help was requested.
+    assert "Error: Unable to process source file" not in output
+
+
 def test_smake_file(monkeypatch, capfd, datadir):
     '''Test smake with -f'''
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing source files: the app now reports the specific missing file and exits with a non-zero status. Requesting help (via --help/-h) will still display usage/help without treating missing source files as an error.

* **Tests**
  * Updated and added tests to verify the new error message, exit codes, and that help output is shown without missing-file errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siliconcompiler/siliconcompiler/pull/4974)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->