### PR TITLE
load all to avoid issues when using from / to

### DIFF
--- a/siliconcompiler/scheduler/scheduler.py
+++ b/siliconcompiler/scheduler/scheduler.py
@@ -558,7 +558,18 @@ class Scheduler:
         else:
             if self.__project.option.get_from():
                 from_nodes = self.__flow_runtime.get_entry_nodes()
-            load_nodes = self.__flow_load_runtime.get_nodes()
+            # Load every node that feeds something in the active runtime,
+            # not just nodes upstream of option.from. The original
+            # flow_load_runtime (to_steps=from_steps) silently dropped
+            # fork-sibling legs that re-converge downstream of from --
+            # their prior SUCCESS was never forwarded, so the join node
+            # would wait on a PENDING input forever.
+            runtime_steps = set(step for step, _ in self.__flow_runtime.get_nodes())
+            load_runtime = RuntimeFlowgraph(
+                self.__flow,
+                to_steps=runtime_steps,
+                prune_nodes=self.__project.option.get_prune())
+            load_nodes = load_runtime.get_nodes()
 
         # Collect previous run information
         for step, index in self.__flow.get_nodes():

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -104,6 +104,55 @@ class DupInputTask(Task):
         return 0
 
 
+class SeedTask(Task):
+    """Entry task that writes a seed.v file so downstream NOPTasks have
+    something to propagate."""
+
+    def tool(self) -> str:
+        return "seedtool"
+
+    def task(self) -> str:
+        return "seed"
+
+    def setup(self):
+        self.add_output_file("seed.v")
+
+    def run(self):
+        with open("outputs/seed.v", "w") as f:
+            f.write("// seed\n")
+        return 0
+
+
+@pytest.fixture
+def forkjoin_project(gcd_design):
+    """A fork/join flow used to exercise option.from after a fork:
+
+        entry --> A1 --> A2 --> joinstep
+              \\-> B1 --> B2 -/
+    """
+    project = Project(gcd_design)
+    project.add_fileset("rtl")
+    project.add_fileset("sdc")
+
+    flow = Flowgraph("forkjoin")
+    flow.node("entry", SeedTask())
+    flow.node("A1", NOPTask())
+    flow.node("A2", NOPTask())
+    flow.node("B1", NOPTask())
+    flow.node("B2", NOPTask())
+    flow.node("joinstep", NOPTask())
+
+    flow.edge("entry", "A1")
+    flow.edge("A1", "A2")
+    flow.edge("entry", "B1")
+    flow.edge("B1", "B2")
+    flow.edge("A2", "joinstep")
+    flow.edge("B2", "joinstep")
+
+    project.set_flow(flow)
+    return project
+
+
 class AdditionalFiles(Task):
     def __init__(self):
         super().__init__()
@@ -728,6 +777,52 @@ def test_rerun(gcd_nop_project):
         NodeStatus.SUCCESS
     assert gcd_nop_project.history("job0").get("record", "status", step="stepthree", index="0") == \
         NodeStatus.PENDING
+
+
+@pytest.mark.timeout(120)
+def test_rerun_from_after_fork_to_join(forkjoin_project):
+    """Re-running with option.from after a fork and option.to at the join
+    must forward the bypassed leg's prior SUCCESS so the join can launch.
+
+    Regression for a bug where __configure_collect_previous_information
+    only loaded prior manifests for nodes upstream of option.from,
+    silently dropping fork-sibling legs that re-converge downstream.
+    """
+    assert forkjoin_project.run()
+    for step in ("entry", "A1", "A2", "B1", "B2", "joinstep"):
+        assert forkjoin_project.history("job0").get(
+            "record", "status", step=step, index="0"
+        ) == NodeStatus.SUCCESS
+
+    forkjoin_project.set("option", "from", ["A1"])
+    forkjoin_project.set("option", "to", ["joinstep"])
+    assert forkjoin_project.run()
+
+    rec = forkjoin_project.history("job0")
+    # Bypassed leg keeps its prior SUCCESS so joinstep sees a satisfied dep.
+    assert rec.get("record", "status", step="B1", index="0") == NodeStatus.SUCCESS
+    assert rec.get("record", "status", step="B2", index="0") == NodeStatus.SUCCESS
+    # Active leg and join re-ran successfully.
+    assert rec.get("record", "status", step="A1", index="0") == NodeStatus.SUCCESS
+    assert rec.get("record", "status", step="A2", index="0") == NodeStatus.SUCCESS
+    assert rec.get("record", "status", step="joinstep", index="0") == NodeStatus.SUCCESS
+
+
+@pytest.mark.timeout(120)
+def test_rerun_from_after_fork_to_join_with_clean(forkjoin_project):
+    """Same scenario as test_rerun_from_after_fork_to_join but with
+    option.clean=True, which takes the other branch in
+    __configure_collect_previous_information."""
+    assert forkjoin_project.run()
+
+    forkjoin_project.set("option", "from", ["A1"])
+    forkjoin_project.set("option", "to", ["joinstep"])
+    forkjoin_project.set("option", "clean", True)
+    assert forkjoin_project.run()
+
+    rec = forkjoin_project.history("job0")
+    assert rec.get("record", "status", step="B2", index="0") == NodeStatus.SUCCESS
+    assert rec.get("record", "status", step="joinstep", index="0") == NodeStatus.SUCCESS
 
 
 @pytest.mark.timeout(60)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed scheduler re-run behavior when using the `from` option at or after fork steps with reconverging paths, ensuring downstream join nodes receive all required inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siliconcompiler/siliconcompiler/pull/4978?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->