### PR TITLE
add preferred indicator to sc-show -list

### DIFF
--- a/siliconcompiler/apps/sc_show.py
+++ b/siliconcompiler/apps/sc_show.py
@@ -63,6 +63,12 @@ def main():
     sc-show -list -open
     (lists all registered open tools and their supported extensions)
 
+    sc-show -list -tool klayout
+    (lists only klayout show tasks and their supported extensions)
+
+    sc-show -list -tool openroad/show
+    (lists only the openroad/show task and its supported extensions)
+
     sc-show -design adder -open
     (opens build/adder/job0/write.gds/0/outputs/adder.gds in an interactive open tool)
     """
@@ -109,7 +115,8 @@ def main():
 
     # Handle --list option
     if show.get("cmdarg", "list"):
-        # Warn if other CLI flags are set (they will be ignored)
+        # Warn if other CLI flags are set (they will be ignored).
+        # -tool is honored as a filter, so it's not in this list.
         ignored_flags = []
         try:
             if show.get("cmdarg", "design"):
@@ -120,8 +127,6 @@ def main():
             ignored_flags.append("-cfg")
         if show.get("cmdarg", "extension"):
             ignored_flags.append("-ext")
-        if show.get("cmdarg", "tool"):
-            ignored_flags.append("-tool")
         if show.get("cmdarg", "input"):
             ignored_flags.append("input files")
         if ignored_flags:
@@ -137,21 +142,69 @@ def main():
             task_cls = ShowTask
             task_type = "Show"
 
+        tool_filter = show.get("cmdarg", "tool")
+
         tasks = task_cls.get_task(None)
         if not tasks:
             print(f"No registered {task_type} tools found")
             return 0
 
-        print(f"Registered {task_type} Tools (in order):")
+        # When -tool is provided, restrict the listing (and preference
+        # resolution) to that tool/task spec.
+        if tool_filter:
+            spec_parts = tool_filter.split('/')
+            spec_tool = spec_parts[0]
+            spec_task = spec_parts[1] if len(spec_parts) > 1 else None
+
+            def matches_filter(inst) -> bool:
+                if inst.tool() != spec_tool:
+                    return False
+                if spec_task is not None and inst.task() != spec_task:
+                    return False
+                return True
+
+            filtered = []
+            for task_cls_item in tasks:
+                try:
+                    if matches_filter(task_cls_item()):
+                        filtered.append(task_cls_item)
+                except NotImplementedError:
+                    pass
+            if not filtered:
+                print(f"No registered {task_type} tools matched -tool '{tool_filter}'")
+                return 0
+            tasks = filtered
+
+        ext_map = task_cls.get_extension_map(tool=tool_filter)
+
+        header = f"Registered {task_type} Tools (in order)"
+        if tool_filter:
+            header += f" matching '{tool_filter}'"
+        header += ":"
+        print(header)
         print("=" * 70)
         count = 0
+        has_preferred = False
         for task_cls_item in tasks:
             try:
                 task_inst = task_cls_item()
                 tool_name = task_inst.tool()
                 task_name = task_inst.task()
                 exts = task_inst.get_supported_task_extentions()
-                ext_str = ', '.join(sorted(exts)) if exts else 'none'
+                if exts:
+                    formatted = []
+                    for ext in sorted(exts):
+                        preferred = ext_map.get(ext)
+                        if (preferred is not None
+                                and preferred.tool() == tool_name
+                                and preferred.task() == task_name):
+                            formatted.append(f"{ext}*")
+                            has_preferred = True
+                        else:
+                            formatted.append(ext)
+                    ext_str = ', '.join(formatted)
+                else:
+                    ext_str = 'none'
                 count += 1
                 print(f"{count}. {tool_name}/{task_name}")
                 print(f"   Extensions: {ext_str}")
@@ -159,6 +212,8 @@ def main():
                 # Skip abstract tasks
                 pass
         print("=" * 70)
+        if has_preferred:
+            print("* indicates the preferred tool for that extension")
         return 0
 
     manifest = None

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -1354,38 +1354,29 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
                 if sc_index:
                     search_nodes = [node for node in search_nodes if node[1] == sc_index]
 
-            # Build ordered list of (task_class, extension) pairs respecting tool order
-            # This preserves the registration order so higher-priority tools are tried first
+            # Use the shared extension map so the preferred tool for each
+            # extension matches what sc-show -list reports.
+            ext_map = tool_cls.get_extension_map(tool=tool)
+
+            # Build an ordered list of extensions, preserving tool registration
+            # order so higher-priority tools are tried first.
             search_exts = []
-            for cls in tool_cls.get_task(None, tool=tool):
+            for cls in tool_cls.get_task(None):
                 try:
-                    exts = cls().get_supported_task_extentions()
-                    # Sort extensions within each task for consistency
-                    for ext in sorted(exts):
-                        # If a specific tool is requested, verify the extension resolves
-                        # to that tool
-                        if tool:
-                            resolved_task = tool_cls.get_task(ext, tool=tool)
-                            if resolved_task is None:
-                                # This extension is not supported by the requested tool
-                                continue
-                        search_exts.append((cls, ext))
+                    for ext in sorted(cls().get_supported_task_extentions()):
+                        if ext in ext_map and ext not in search_exts:
+                            search_exts.append(ext)
                 except NotImplementedError:
                     pass
 
             if extension:
-                # Validate that requested extension is supported
-                all_exts = [ext for _, ext in search_exts]
-                if extension not in all_exts:
+                if extension not in search_exts:
                     self.logger.error(f"Extension '{extension}' not supported by "
-                                      f"registered showtools: {', '.join(sorted(set(all_exts)))}")
+                                      f"registered showtools: {', '.join(sorted(search_exts))}")
                     return None
-                # Search for the specific extension only, respecting tool order
-                search_exts = [(cls, ext) for cls, ext in search_exts if ext == extension]
+                search_exts = [extension]
 
-            # Search for files in tool-ordered sequence
-            # This ensures that earlier-registered (higher-priority) tools are tried first
-            for task_cls, ext in search_exts:
+            for ext in search_exts:
                 for step, index in search_nodes:
                     filename = search_obj.find_result(ext,
                                                       step=step,

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -1355,19 +1355,10 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
                     search_nodes = [node for node in search_nodes if node[1] == sc_index]
 
             # Use the shared extension map so the preferred tool for each
-            # extension matches what sc-show -list reports.
+            # extension matches what sc-show -list reports. The map preserves
+            # registration order, so higher-priority tools are tried first.
             ext_map = tool_cls.get_extension_map(tool=tool)
-
-            # Build an ordered list of extensions, preserving tool registration
-            # order so higher-priority tools are tried first.
-            search_exts = []
-            for cls in tool_cls.get_task(None):
-                try:
-                    for ext in sorted(cls().get_supported_task_extentions()):
-                        if ext in ext_map and ext not in search_exts:
-                            search_exts.append(ext)
-                except NotImplementedError:
-                    pass
+            search_exts = list(ext_map.keys())
 
             if extension:
                 if extension not in search_exts:

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -2810,10 +2810,13 @@ class OpenTask(Task):
 
         Args:
             ext (str): The file extension to find a viewer for.
-            tool (str, optional): The name of the specific showtool to use for displaying the file.
-                Format can be "tool" to select any task from that tool, or "tool/task" to select
-                a specific task from that tool. If not provided, the tool is selected based on
-                the user's preference or automatic discovery.
+            tool (str, optional): A tool/task hint, not a strict filter. Format
+                can be ``"tool"`` to prefer any task from that tool, or
+                ``"tool/task"`` to prefer a specific task. If the hint cannot be
+                resolved for ``ext`` (e.g. the named tool doesn't support that
+                extension), resolution falls back to the user-settings
+                preference and then to automatic discovery, so a non-None
+                result does not guarantee the returned task matches the hint.
 
         Returns:
             An instance of a compatible ShowTask subclass, or None if
@@ -2904,10 +2907,17 @@ class OpenTask(Task):
         "which tool handles extension X" and is shared by ``sc-show -list``
         and :meth:`Project.show` to keep their behavior consistent.
 
+        Key insertion order is deterministic: extensions appear in the order
+        they are first encountered while iterating registered tasks in
+        registration order (within a task, the order returned by
+        :meth:`get_supported_task_extentions`).
+
         Args:
-            tool (str, optional): Tool spec in ``"tool"`` or ``"tool/task"``
-                form. When provided, only extensions resolvable to that
-                tool/task are included.
+            tool (str, optional): A tool/task preference hint in ``"tool"`` or
+                ``"tool/task"`` form, forwarded to :meth:`get_task`. It biases
+                the preferred task per extension but is not a strict filter:
+                extensions the hint cannot resolve still appear in the map
+                with whichever task :meth:`get_task` falls back to.
 
         Returns:
             A dictionary mapping each supported extension to the preferred
@@ -2920,15 +2930,19 @@ class OpenTask(Task):
         if not tasks:
             return {}
 
-        all_exts: Set[str] = set()
+        ordered_exts: List[str] = []
+        seen: Set[str] = set()
         for task_cls in tasks:
             try:
-                all_exts.update(task_cls().get_supported_task_extentions())
+                for ext in task_cls().get_supported_task_extentions():
+                    if ext not in seen:
+                        seen.add(ext)
+                        ordered_exts.append(ext)
             except NotImplementedError:
                 continue
 
         ext_map: Dict[str, TOpenTask] = {}
-        for ext in all_exts:
+        for ext in ordered_exts:
             preferred = cls.get_task(ext, tool=tool)
             if preferred is not None:
                 ext_map[ext] = preferred

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -2892,6 +2892,48 @@ class OpenTask(Task):
 
         return None
 
+    @classmethod
+    def get_extension_map(cls: Type[TOpenTask],
+                          tool: Optional[str] = None) -> Dict[str, TOpenTask]:
+        """
+        Returns a mapping of supported file extensions to the preferred task.
+
+        For every extension declared by any registered task of this class, the
+        returned dict contains the task instance that :meth:`get_task` would
+        pick for that extension. This is the single source of truth for
+        "which tool handles extension X" and is shared by ``sc-show -list``
+        and :meth:`Project.show` to keep their behavior consistent.
+
+        Args:
+            tool (str, optional): Tool spec in ``"tool"`` or ``"tool/task"``
+                form. When provided, only extensions resolvable to that
+                tool/task are included.
+
+        Returns:
+            A dictionary mapping each supported extension to the preferred
+            task instance for that extension.
+        """
+        cls.__check_task(None)
+        cls.__populate_tasks()
+
+        tasks = cls.get_task(None)
+        if not tasks:
+            return {}
+
+        all_exts: Set[str] = set()
+        for task_cls in tasks:
+            try:
+                all_exts.update(task_cls().get_supported_task_extentions())
+            except NotImplementedError:
+                continue
+
+        ext_map: Dict[str, TOpenTask] = {}
+        for ext in all_exts:
+            preferred = cls.get_task(ext, tool=tool)
+            if preferred is not None:
+                ext_map[ext] = preferred
+        return ext_map
+
 
 class ShowTask(OpenTask):
     """

--- a/siliconcompiler/utils/showtools.py
+++ b/siliconcompiler/utils/showtools.py
@@ -36,8 +36,8 @@ def showtasks():
 
     # Register Show tasks - core tools first
     ShowTask.register_task(KlayoutShow)
-    ShowTask.register_task(OpenROADShow)
     ShowTask.register_task(OpenROADWeb)
+    ShowTask.register_task(OpenROADShow)
     ShowTask.register_task(OpenROADShow3DBlox)
     ShowTask.register_task(GraphvizShow)
     ShowTask.register_task(VPRShow)

--- a/tests/apps/test_sc_show.py
+++ b/tests/apps/test_sc_show.py
@@ -370,9 +370,14 @@ def test_sc_show_list_show_tools(monkeypatch, capsys):
     monkeypatch.setattr('sys.argv', ['sc-show', '-list'])
 
     mock_tasks = [MockShowTask1, MockShowTask2]
+    # MockShowTask1 is preferred for ext1; MockShowTask2 is preferred for ext3.
+    # ext2 has no preferred entry (simulates an extension with no resolvable preference).
+    mock_ext_map = {"ext1": MockShowTask1(), "ext3": MockShowTask2()}
 
-    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task:
+    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task, \
+            patch('siliconcompiler.apps.sc_show.ShowTask.get_extension_map') as mock_ext:
         mock_get_task.return_value = mock_tasks
+        mock_ext.return_value = mock_ext_map
         assert sc_show.main() == 0
 
     captured = capsys.readouterr()
@@ -382,11 +387,12 @@ def test_sc_show_list_show_tools(monkeypatch, capsys):
     assert "Registered Show Tools (in order):" in output
     assert "=" * 70 in output
 
-    # Verify tools are listed with their extensions
+    # Verify tools are listed with their extensions, with preferred ones starred
     assert "1. tool1/task1" in output
-    assert "Extensions: ext1, ext2" in output
+    assert "Extensions: ext1*, ext2" in output
     assert "2. tool2/task2" in output
-    assert "Extensions: ext3" in output
+    assert "Extensions: ext3*" in output
+    assert "* indicates the preferred tool for that extension" in output
 
 
 @pytest.mark.timeout(90)
@@ -395,9 +401,16 @@ def test_sc_show_list_screenshot_tools(monkeypatch, capsys):
     monkeypatch.setattr('sys.argv', ['sc-show', '-list', '-screenshot'])
 
     mock_tasks = [MockScreenshotTask1, MockScreenshotTask2]
+    mock_ext_map = {
+        "ext1": MockScreenshotTask1(),
+        "ext2": MockScreenshotTask1(),
+        "ext3": MockScreenshotTask2(),
+    }
 
-    with patch('siliconcompiler.apps.sc_show.ScreenshotTask.get_task') as mock_get_task:
+    with patch('siliconcompiler.apps.sc_show.ScreenshotTask.get_task') as mock_get_task, \
+            patch('siliconcompiler.apps.sc_show.ScreenshotTask.get_extension_map') as mock_ext:
         mock_get_task.return_value = mock_tasks
+        mock_ext.return_value = mock_ext_map
         assert sc_show.main() == 0
 
     captured = capsys.readouterr()
@@ -407,11 +420,11 @@ def test_sc_show_list_screenshot_tools(monkeypatch, capsys):
     assert "Registered Screenshot Tools (in order):" in output
     assert "=" * 70 in output
 
-    # Verify tools are listed with their extensions
+    # Verify tools are listed with their extensions, with preferred ones starred
     assert "1. tool1/screenshot1" in output
-    assert "Extensions: ext1, ext2" in output
+    assert "Extensions: ext1*, ext2*" in output
     assert "2. tool2/screenshot2" in output
-    assert "Extensions: ext3" in output
+    assert "Extensions: ext3*" in output
 
 
 @pytest.mark.timeout(90)
@@ -420,9 +433,16 @@ def test_sc_show_list_open_tools(monkeypatch, capsys):
     monkeypatch.setattr('sys.argv', ['sc-show', '-list', '-open'])
 
     mock_tasks = [MockOpenTask1, MockOpenTask2]
+    mock_ext_map = {
+        "ext1": MockOpenTask1(),
+        "ext2": MockOpenTask1(),
+        "ext3": MockOpenTask2(),
+    }
 
-    with patch('siliconcompiler.apps.sc_show.OpenTask.get_task') as mock_get_task:
+    with patch('siliconcompiler.apps.sc_show.OpenTask.get_task') as mock_get_task, \
+            patch('siliconcompiler.apps.sc_show.OpenTask.get_extension_map') as mock_ext:
         mock_get_task.return_value = mock_tasks
+        mock_ext.return_value = mock_ext_map
         assert sc_show.main() == 0
 
     captured = capsys.readouterr()
@@ -432,11 +452,107 @@ def test_sc_show_list_open_tools(monkeypatch, capsys):
     assert "Registered Open Tools (in order):" in output
     assert "=" * 70 in output
 
-    # Verify tools are listed with their extensions
+    # Verify tools are listed with their extensions, with preferred ones starred
     assert "1. tool1/open1" in output
-    assert "Extensions: ext1, ext2" in output
+    assert "Extensions: ext1*, ext2*" in output
     assert "2. tool2/open2" in output
-    assert "Extensions: ext3" in output
+    assert "Extensions: ext3*" in output
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_list_with_tool_filter(monkeypatch, capsys):
+    '''Test sc-show -list -tool filters to only matching tools.'''
+    monkeypatch.setattr('sys.argv', ['sc-show', '-list', '-tool', 'tool2'])
+
+    mock_tasks = [MockShowTask1, MockShowTask2]
+    # When filtering to tool2, only its extensions resolve.
+    mock_ext_map = {"ext3": MockShowTask2()}
+
+    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task, \
+            patch('siliconcompiler.apps.sc_show.ShowTask.get_extension_map') as mock_ext:
+        mock_get_task.return_value = mock_tasks
+        mock_ext.return_value = mock_ext_map
+        assert sc_show.main() == 0
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    # Header reflects the active filter and only tool2 is listed.
+    assert "Registered Show Tools (in order) matching 'tool2':" in output
+    assert "1. tool2/task2" in output
+    assert "Extensions: ext3*" in output
+    # tool1 was filtered out entirely.
+    assert "tool1/task1" not in output
+    # The asterisk legend is printed (extension was starred).
+    assert "* indicates the preferred tool for that extension" in output
+    # get_extension_map must be called with the tool filter.
+    mock_ext.assert_called_once_with(tool='tool2')
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_list_with_tool_task_filter(monkeypatch, capsys):
+    '''Test sc-show -list -tool tool/task filters to a specific task.'''
+    monkeypatch.setattr('sys.argv', ['sc-show', '-list', '-tool', 'tool1/task1'])
+
+    mock_tasks = [MockShowTask1, MockShowTask2]
+    mock_ext_map = {"ext1": MockShowTask1(), "ext2": MockShowTask1()}
+
+    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task, \
+            patch('siliconcompiler.apps.sc_show.ShowTask.get_extension_map') as mock_ext:
+        mock_get_task.return_value = mock_tasks
+        mock_ext.return_value = mock_ext_map
+        assert sc_show.main() == 0
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    assert "Registered Show Tools (in order) matching 'tool1/task1':" in output
+    assert "1. tool1/task1" in output
+    assert "Extensions: ext1*, ext2*" in output
+    assert "tool2/task2" not in output
+    mock_ext.assert_called_once_with(tool='tool1/task1')
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_list_with_tool_filter_no_match(monkeypatch, capsys):
+    '''Test sc-show -list -tool with a non-matching tool prints a clear message.'''
+    monkeypatch.setattr('sys.argv', ['sc-show', '-list', '-tool', 'nonesuch'])
+
+    mock_tasks = [MockShowTask1, MockShowTask2]
+
+    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task:
+        mock_get_task.return_value = mock_tasks
+        assert sc_show.main() == 0
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    assert "No registered Show tools matched -tool 'nonesuch'" in output
+    # Nothing else should be listed.
+    assert "1. tool" not in output
+
+
+@pytest.mark.timeout(90)
+def test_sc_show_list_with_tool_filter_not_in_ignored_warning(monkeypatch, capsys):
+    '''-tool is honored with -list, so it must not appear in the ignored-flags warning.'''
+    monkeypatch.setattr('sys.argv', ['sc-show', '-list', '-tool', 'tool1', '-ext', 'ext1'])
+
+    mock_tasks = [MockShowTask1]
+    mock_ext_map = {"ext1": MockShowTask1(), "ext2": MockShowTask1()}
+
+    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task, \
+            patch('siliconcompiler.apps.sc_show.ShowTask.get_extension_map') as mock_ext:
+        mock_get_task.return_value = mock_tasks
+        mock_ext.return_value = mock_ext_map
+        assert sc_show.main() == 0
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+
+    # -ext should still be warned as ignored, but -tool should not.
+    assert "-ext" in combined
+    assert "-tool" not in combined.split("Ignoring", 1)[-1].split("\n")[0] \
+        if "Ignoring" in combined else True
 
 
 @pytest.mark.timeout(90)
@@ -461,9 +577,12 @@ def test_sc_show_list_single_tool(monkeypatch, capsys):
     monkeypatch.setattr('sys.argv', ['sc-show', '-list'])
 
     mock_tasks = [MockShowTask1]
+    mock_ext_map = {"ext1": MockShowTask1(), "ext2": MockShowTask1()}
 
-    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task:
+    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task, \
+            patch('siliconcompiler.apps.sc_show.ShowTask.get_extension_map') as mock_ext:
         mock_get_task.return_value = mock_tasks
+        mock_ext.return_value = mock_ext_map
         assert sc_show.main() == 0
 
     captured = capsys.readouterr()
@@ -492,8 +611,11 @@ def test_sc_show_list_sorted_extensions(monkeypatch, capsys):
 
     mock_tasks = [MockTaskWithUnsortedExts]
 
-    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task:
+    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task, \
+            patch('siliconcompiler.apps.sc_show.ShowTask.get_extension_map') as mock_ext:
         mock_get_task.return_value = mock_tasks
+        # No preferred mapping for any of these extensions
+        mock_ext.return_value = {}
         assert sc_show.main() == 0
 
     captured = capsys.readouterr()
@@ -520,8 +642,10 @@ def test_sc_show_list_no_extensions(monkeypatch, capsys):
 
     mock_tasks = [MockTaskNoExts]
 
-    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task:
+    with patch('siliconcompiler.apps.sc_show.ShowTask.get_task') as mock_get_task, \
+            patch('siliconcompiler.apps.sc_show.ShowTask.get_extension_map') as mock_ext:
         mock_get_task.return_value = mock_tasks
+        mock_ext.return_value = {}
         assert sc_show.main() == 0
 
     captured = capsys.readouterr()

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -3599,7 +3599,9 @@ def test_get_extension_map_single_tool():
 
 
 def test_get_extension_map_collects_all_extensions():
-    """All extensions across all registered tasks are present as keys."""
+    """All extensions across all registered tasks are present as keys, in
+    deterministic registration order (within a task, in the order returned by
+    get_supported_task_extentions)."""
 
     class ToolMulti(ShowTask):
         def tool(self):
@@ -3622,7 +3624,9 @@ def test_get_extension_map_collects_all_extensions():
 
         ext_map = ShowTask.get_extension_map()
 
-        assert set(ext_map.keys()) == {"ext", "a", "b", "c"}
+        # Order: ToolA registered first (its "ext"), then ToolMulti (a, b, c
+        # in the order it returns them).
+        assert list(ext_map.keys()) == ["ext", "a", "b", "c"]
 
 
 def test_get_extension_map_conflict_uses_last_registered():
@@ -3832,6 +3836,11 @@ def test_get_extension_map_matches_get_task_resolution():
         mock_settings_cls.return_value = mock_settings
 
         ext_map = ShowTask.get_extension_map()
+
+        # Deterministic order: ToolP registered first contributes "one" and
+        # "two" (its first appearance dedupes "two"), then ToolQ contributes
+        # "three".
+        assert list(ext_map.keys()) == ["one", "two", "three"]
 
         for ext, preferred in ext_map.items():
             resolved = ShowTask.get_task(ext)

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -3570,6 +3570,276 @@ def test_get_task_tool_task_format_priority_over_preference():
         assert isinstance(task, ToolITask2)
 
 
+def test_get_extension_map_empty():
+    """get_extension_map returns {} when no tasks are discovered."""
+    # Patch get_task to simulate "no registered tasks". (Real isolation is
+    # hard because subclasses defined elsewhere in the test file get
+    # auto-discovered by __populate_tasks.)
+    with patch.object(ShowTask, 'get_task', return_value=None):
+        assert ShowTask.get_extension_map() == {}
+
+    with patch.object(ShowTask, 'get_task', return_value=[]):
+        assert ShowTask.get_extension_map() == {}
+
+
+def test_get_extension_map_single_tool():
+    """Each ext from the registered tool maps to that tool's instance."""
+    ShowTask.register_task(ToolA)
+
+    with patch('siliconcompiler.utils.multiprocessing.MPManager.get_settings') \
+            as mock_settings_cls:
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = None
+        mock_settings_cls.return_value = mock_settings
+
+        ext_map = ShowTask.get_extension_map()
+
+        assert set(ext_map.keys()) == {"ext"}
+        assert isinstance(ext_map["ext"], ToolA)
+
+
+def test_get_extension_map_collects_all_extensions():
+    """All extensions across all registered tasks are present as keys."""
+
+    class ToolMulti(ShowTask):
+        def tool(self):
+            return "toolmulti"
+
+        def task(self):
+            return "show"
+
+        def get_supported_task_extentions(self):
+            return ["a", "b", "c"]
+
+    ShowTask.register_task(ToolA)
+    ShowTask.register_task(ToolMulti)
+
+    with patch('siliconcompiler.utils.multiprocessing.MPManager.get_settings') \
+            as mock_settings_cls:
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = None
+        mock_settings_cls.return_value = mock_settings
+
+        ext_map = ShowTask.get_extension_map()
+
+        assert set(ext_map.keys()) == {"ext", "a", "b", "c"}
+
+
+def test_get_extension_map_conflict_uses_last_registered():
+    """When two tools share an extension, the later-registered wins by default."""
+    ShowTask.register_task(ToolA)
+    ShowTask.register_task(ToolB)
+
+    with patch('siliconcompiler.utils.multiprocessing.MPManager.get_settings') \
+            as mock_settings_cls:
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = None
+        mock_settings_cls.return_value = mock_settings
+
+        ext_map = ShowTask.get_extension_map()
+
+        # ToolA and ToolB both register "ext"; later-registered (ToolB) wins.
+        assert "ext" in ext_map
+        assert isinstance(ext_map["ext"], ToolB)
+
+
+def test_get_extension_map_respects_user_preference():
+    """User preference selects the preferred tool for a contested extension."""
+    ShowTask.register_task(ToolA)
+    ShowTask.register_task(ToolB)
+
+    with patch('siliconcompiler.utils.multiprocessing.MPManager.get_settings') \
+            as mock_settings_cls:
+        mock_settings = MagicMock()
+
+        def get_side_effect(category, key, default=None):
+            if category == "showtask" and key == "ext":
+                return "toola"
+            return default
+
+        mock_settings.get.side_effect = get_side_effect
+        mock_settings_cls.return_value = mock_settings
+
+        ext_map = ShowTask.get_extension_map()
+
+        assert isinstance(ext_map["ext"], ToolA)
+
+
+def test_get_extension_map_tool_filter_matches_get_task():
+    """tool= behavior in get_extension_map mirrors get_task: it's a hint, not a strict filter.
+
+    For extensions the requested tool supports, the requested tool is preferred.
+    For extensions it does not, get_task falls back to whatever tool can handle
+    them, and get_extension_map reflects that same fallback. This matches how
+    Project.show resolves a tool for the eventual file extension.
+    """
+
+    class ToolOnlyXyz(ShowTask):
+        def tool(self):
+            return "xyztool"
+
+        def task(self):
+            return "show"
+
+        def get_supported_task_extentions(self):
+            return ["xyz"]
+
+    ShowTask.register_task(ToolA)
+    ShowTask.register_task(ToolOnlyXyz)
+
+    with patch('siliconcompiler.utils.multiprocessing.MPManager.get_settings') \
+            as mock_settings_cls:
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = None
+        mock_settings_cls.return_value = mock_settings
+
+        ext_map = ShowTask.get_extension_map(tool="toola")
+
+        # ToolA wins for "ext" because the requested tool actually supports it.
+        assert isinstance(ext_map["ext"], ToolA)
+        # "xyz" still falls back to ToolOnlyXyz — matching get_task's behavior
+        # when the requested tool can't handle the extension.
+        assert isinstance(ext_map["xyz"], ToolOnlyXyz)
+
+        # Every entry must equal what get_task would return for that ext.
+        for ext, preferred in ext_map.items():
+            assert type(ShowTask.get_task(ext, tool="toola")) is type(preferred)
+
+
+def test_get_extension_map_skips_not_implemented():
+    """Tasks that don't implement get_supported_task_extentions are ignored."""
+
+    class AbstractTool(ShowTask):
+        def tool(self):
+            return "abstracttool"
+
+        def task(self):
+            return "show"
+        # No get_supported_task_extentions implementation → NotImplementedError
+
+    ShowTask.register_task(ToolA)
+    ShowTask.register_task(AbstractTool)
+
+    with patch('siliconcompiler.utils.multiprocessing.MPManager.get_settings') \
+            as mock_settings_cls:
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = None
+        mock_settings_cls.return_value = mock_settings
+
+        ext_map = ShowTask.get_extension_map()
+
+        # Only ToolA's extensions appear; AbstractTool is silently skipped.
+        assert set(ext_map.keys()) == {"ext"}
+
+
+@pytest.mark.parametrize("cls,expected_tool_cls", [
+    (OpenTask, "open"),
+    (ShowTask, "show"),
+    (ScreenshotTask, "screenshot"),
+])
+def test_get_extension_map_isolated_per_base_class(cls, expected_tool_cls):
+    """Each base class returns only tasks registered to that class hierarchy."""
+
+    class _OpenOnly(OpenTask):
+        def tool(self):
+            return "opentool"
+
+        def get_supported_task_extentions(self):
+            return ["o"]
+
+    class _ShowOnly(ShowTask):
+        def tool(self):
+            return "showtool"
+
+        def get_supported_task_extentions(self):
+            return ["s"]
+
+    class _ScreenshotOnly(ScreenshotTask):
+        def tool(self):
+            return "screenshottool"
+
+        def get_supported_task_extentions(self):
+            return ["p"]
+
+    OpenTask.register_task(_OpenOnly)
+    ShowTask.register_task(_ShowOnly)
+    ScreenshotTask.register_task(_ScreenshotOnly)
+
+    with patch('siliconcompiler.utils.multiprocessing.MPManager.get_settings') \
+            as mock_settings_cls:
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = None
+        mock_settings_cls.return_value = mock_settings
+
+        ext_map = cls.get_extension_map()
+
+        if cls is OpenTask:
+            # OpenTask sees all (Open/Show/Screenshot are all OpenTasks),
+            # but get_task only returns those that are NOT subclasses of
+            # Show/Screenshot, so only _OpenOnly's "o" is present.
+            assert "o" in ext_map
+            assert "s" not in ext_map
+            assert "p" not in ext_map
+        elif cls is ShowTask:
+            # ShowTask filters out ScreenshotTask subclasses.
+            assert "s" in ext_map
+            assert "o" not in ext_map
+            assert "p" not in ext_map
+        else:
+            # ScreenshotTask only
+            assert "p" in ext_map
+            assert "s" not in ext_map
+            assert "o" not in ext_map
+
+
+def test_get_extension_map_matches_get_task_resolution():
+    """get_extension_map[ext] must equal get_task(ext) for every supported ext."""
+
+    class ToolP(ShowTask):
+        def tool(self):
+            return "toolp"
+
+        def task(self):
+            return "show"
+
+        def get_supported_task_extentions(self):
+            return ["one", "two"]
+
+    class ToolQ(ShowTask):
+        def tool(self):
+            return "toolq"
+
+        def task(self):
+            return "show"
+
+        def get_supported_task_extentions(self):
+            return ["two", "three"]
+
+    ShowTask.register_task(ToolP)
+    ShowTask.register_task(ToolQ)
+
+    with patch('siliconcompiler.utils.multiprocessing.MPManager.get_settings') \
+            as mock_settings_cls:
+        mock_settings = MagicMock()
+
+        def get_side_effect(category, key, default=None):
+            # Prefer ToolP for the contested "two"
+            if category == "showtask" and key == "two":
+                return "toolp"
+            return default
+
+        mock_settings.get.side_effect = get_side_effect
+        mock_settings_cls.return_value = mock_settings
+
+        ext_map = ShowTask.get_extension_map()
+
+        for ext, preferred in ext_map.items():
+            resolved = ShowTask.get_task(ext)
+            assert type(resolved) is type(preferred), \
+                f"ext={ext}: map gave {type(preferred).__name__}, " \
+                f"get_task gave {type(resolved).__name__}"
+
+
 def test_task_py_logging_output_different_files(gcd_design):
     # Create a project instance
     project = Project(gcd_design)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `sc-show -list` now honors the `-tool` filter (including tool/task form), showing only matching tools and their supported extensions; preferred tool/task pairs are marked with `*` and a legend is shown.

* **Documentation**
  * `-list` help text updated with explicit examples for filtering specific tools.

* **Improvements**
  * Auto-layout file discovery now follows the same extension preference ordering shown by `sc-show -list`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siliconcompiler/siliconcompiler/pull/4980?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->