### PR TITLE
Img2stream DRC check

### DIFF
--- a/siliconcompiler/flows/img2streamflow.py
+++ b/siliconcompiler/flows/img2streamflow.py
@@ -1,0 +1,27 @@
+from siliconcompiler import Flowgraph
+
+from siliconcompiler.tools.klayout import img2stream
+from siliconcompiler.tools.klayout import drc
+
+
+class Img2StreamFlow(Flowgraph):
+    '''An image-to-stream flow with DRC verification.
+
+    This flow converts an image file (PNG/JPG) to a GDSII or OASIS stream
+    using KLayout, then runs a design rule check on the resulting layout.
+    '''
+    def __init__(self, name: str = "img2streamflow", run_drc: bool = True):
+        super().__init__(name)
+
+        self.node('image', img2stream.Img2StreamTask())
+
+        if run_drc:
+            self.node('drc', drc.DRCTask())
+
+            self.edge('image', 'drc')
+
+
+##################################################
+if __name__ == "__main__":
+    flow = Img2StreamFlow()
+    flow.write_flowgraph(f"{flow.name}.png")

--- a/siliconcompiler/tools/klayout/__init__.py
+++ b/siliconcompiler/tools/klayout/__init__.py
@@ -172,8 +172,9 @@ class KLayoutTask(ASICTask):
             self.set_refdir("scripts")
 
         self.set_environmentalvariable('PYTHONUNBUFFERED', '1')
-        # Always use offscreen — klayout -z is batch-only and never needs a real display.
-        self.set_environmentalvariable('QT_QPA_PLATFORM', 'offscreen')
+        if self.project.option.get_nodisplay():
+            # Tells QT to use the offscreen platform if nodisplay is used
+            self.set_environmentalvariable('QT_QPA_PLATFORM', 'offscreen')
 
         self.add_regex("warnings", r'(WARNING|warning)')
         self.add_regex("errors", r'ERROR')

--- a/siliconcompiler/tools/klayout/__init__.py
+++ b/siliconcompiler/tools/klayout/__init__.py
@@ -172,9 +172,8 @@ class KLayoutTask(ASICTask):
             self.set_refdir("scripts")
 
         self.set_environmentalvariable('PYTHONUNBUFFERED', '1')
-        if self.project.option.get_nodisplay():
-            # Tells QT to use the offscreen platform if nodisplay is used
-            self.set_environmentalvariable('QT_QPA_PLATFORM', 'offscreen')
+        # Always use offscreen — klayout -z is batch-only and never needs a real display.
+        self.set_environmentalvariable('QT_QPA_PLATFORM', 'offscreen')
 
         self.add_regex("warnings", r'(WARNING|warning)')
         self.add_regex("errors", r'ERROR')

--- a/siliconcompiler/tools/klayout/__init__.py
+++ b/siliconcompiler/tools/klayout/__init__.py
@@ -172,8 +172,10 @@ class KLayoutTask(ASICTask):
             self.set_refdir("scripts")
 
         self.set_environmentalvariable('PYTHONUNBUFFERED', '1')
-        # Always use offscreen — klayout -z is batch-only and never needs a real display.
-        self.set_environmentalvariable('QT_QPA_PLATFORM', 'offscreen')
+
+        if self.project.option.get_nodisplay():
+            # Tells QT to use the offscreen platform if nodisplay is used
+            self.set_environmentalvariable('QT_QPA_PLATFORM', 'offscreen')
 
         self.add_regex("warnings", r'(WARNING|warning)')
         self.add_regex("errors", r'ERROR')

--- a/siliconcompiler/tools/klayout/img2stream.py
+++ b/siliconcompiler/tools/klayout/img2stream.py
@@ -20,6 +20,8 @@ class Img2StreamTask(KLayoutTask):
         self.add_parameter("timestamp", "bool", "Export GDSII with timestamps", defvalue=True)
         self.add_parameter("outline_layer", "(int,int)",
                            "Layer/datatype to use for the OUTLINE boundary rectangle")
+        self.add_parameter("fill_exclusion_layer", "(int,int)",
+                           "Layer/datatype to use for the FILL EXCLUSION boundary rectangle")
 
     def set_klayout_timestamp(self, enable: bool,
                               step: Optional[str] = None,
@@ -110,6 +112,20 @@ class Img2StreamTask(KLayoutTask):
             index (str, optional): The specific index to apply this configuration to.
         """
         self.set("var", "outline_layer", (layer, purpose), step=step, index=index)
+
+    def set_klayout_fill_exclusion_layer(self, layer: int, purpose: int = 0,
+                                         step: Optional[str] = None,
+                                         index: Optional[str] = None):
+        """
+        Sets the layer/datatype for the FILL EXCLUSION boundary rectangle added to the stream.
+
+        Args:
+            layer (int): The GDS layer number for the FILL EXCLUSION shape.
+            purpose (int, optional): The GDS datatype for the FILL EXCLUSION shape.
+            step (str, optional): The specific step to apply this configuration to.
+            index (str, optional): The specific index to apply this configuration to.
+        """
+        self.set("var", "fill_exclusion_layer", (layer, purpose), step=step, index=index)
 
     def set_klayout_invert(self, invert: bool,
                            step: Optional[str] = None,

--- a/siliconcompiler/tools/klayout/img2stream.py
+++ b/siliconcompiler/tools/klayout/img2stream.py
@@ -18,6 +18,8 @@ class Img2StreamTask(KLayoutTask):
         self.add_parameter("invert", "bool", "Invert the polarity of the image", defvalue=False)
         self.add_parameter("darkissolid", "bool", "Treat dark colors as a solid", defvalue=True)
         self.add_parameter("timestamp", "bool", "Export GDSII with timestamps", defvalue=True)
+        self.add_parameter("outline_layer", "(int,int)",
+                           "Layer/datatype to use for the OUTLINE boundary rectangle")
 
     def set_klayout_timestamp(self, enable: bool,
                               step: Optional[str] = None,
@@ -94,6 +96,20 @@ class Img2StreamTask(KLayoutTask):
             index (str, optional): The specific index to apply this configuration to.
         """
         self.set("var", "layer", (layer, purpose), step=step, index=index)
+
+    def set_klayout_outline_layer(self, layer: int, purpose: int = 0,
+                                  step: Optional[str] = None,
+                                  index: Optional[str] = None):
+        """
+        Sets the layer/datatype for the OUTLINE boundary rectangle added to the stream.
+
+        Args:
+            layer (int): The GDS layer number for the OUTLINE shape.
+            purpose (int, optional): The GDS datatype for the OUTLINE shape.
+            step (str, optional): The specific step to apply this configuration to.
+            index (str, optional): The specific index to apply this configuration to.
+        """
+        self.set("var", "outline_layer", (layer, purpose), step=step, index=index)
 
     def set_klayout_invert(self, invert: bool,
                            step: Optional[str] = None,

--- a/siliconcompiler/tools/klayout/img2stream.py
+++ b/siliconcompiler/tools/klayout/img2stream.py
@@ -8,7 +8,7 @@ class Img2StreamTask(KLayoutTask):
 
         self.add_parameter("stream", "<gds,oas>", "Extension to use for stream generation",
                            defvalue="gds")
-        self.add_parameter("imageformat", "<png,jpg>", "Image format for input files",
+        self.add_parameter("imageformat", "<png>", "Image format for input files",
                            defvalue="png")
         self.add_parameter("minsize", "float", "Minimum shape size for image processing",
                            units="um")

--- a/siliconcompiler/tools/klayout/img2stream.py
+++ b/siliconcompiler/tools/klayout/img2stream.py
@@ -8,7 +8,7 @@ class Img2StreamTask(KLayoutTask):
 
         self.add_parameter("stream", "<gds,oas>", "Extension to use for stream generation",
                            defvalue="gds")
-        self.add_parameter("imageformat", "<png>", "Image format for input files",
+        self.add_parameter("imageformat", "<png,jpg>", "Image format for input files",
                            defvalue="png")
         self.add_parameter("minsize", "float", "Minimum shape size for image processing",
                            units="um")

--- a/siliconcompiler/tools/klayout/img2stream.py
+++ b/siliconcompiler/tools/klayout/img2stream.py
@@ -155,6 +155,9 @@ class Img2StreamTask(KLayoutTask):
         self.add_required_key("var", "darkissolid")
         self.add_required_key("var", "timestamp")
 
+        if self.get("var", "outline_layer"):
+            self.add_required_key("var", "outline_layer")
+
         self.add_output_file(ext=f"{default_stream}.gz")
 
         if f"{self.design_topmodule}.{imageformat}" in self.get_files_from_input_nodes():

--- a/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
+++ b/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
@@ -195,12 +195,8 @@ def main():
     sc_timestamps = schema.get('tool', 'klayout', 'task', "image2stream", 'var', 'timestamp',
                                step=sc_step, index=sc_index)
 
-    outline_layer = None
-    if schema.valid('tool', 'klayout', 'task', 'image2stream', 'var', 'outline_layer') and \
-            schema.get('tool', 'klayout', 'task', 'image2stream', 'var', 'outline_layer',
-                       step=sc_step, index=sc_index):
-        outline_layer = schema.get('tool', 'klayout', 'task', 'image2stream', 'var',
-                                   'outline_layer', step=sc_step, index=sc_index)
+    outline_layer = schema.get('tool', 'klayout', 'task', 'image2stream', 'var',
+                               'outline_layer', step=sc_step, index=sc_index)
 
     in_image = f"inputs/{design}.{format}"
     if not os.path.exists(in_image):

--- a/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
+++ b/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
@@ -30,25 +30,28 @@ def png_to_gds(
     :param dark_is_solid: Base logic - If True, dark pixels become GDS shapes.
     :param invert: Explicitly inverts the final polarity of the image.
     """
-    from PIL import Image as PILImage  # noqa E402
     from klayout_utils import get_write_options  # noqa E402
 
-    # 1. Load image with PIL — handles RGBA correctly (pya.Image drops the alpha channel)
+    # 1. Load image via pya.PixelBuffer (headless, no display required).
+    # pixel() returns ARGB as a packed uint32; composite over white so transparent→light.
     print(f"Loading {image_path}...")
 
-    pil_img = PILImage.open(image_path)
-
-    orig_w, orig_h = pil_img.size
+    if not image_path.lower().endswith('.png'):
+        raise ValueError(f"Only PNG images are supported; got: {image_path}")
+    img_buf = pya.PixelBuffer.read_png(image_path)
+    orig_w = img_buf.width()
+    orig_h = img_buf.height()
     if orig_w == 0 or orig_h == 0:
         raise ValueError("Image is empty. Ensure it's a valid image.")
 
-    # Convert to grayscale; composite RGBA over white so transparent→light, opaque→dark.
-    if pil_img.mode == 'RGBA':
-        _, _, _, alpha = pil_img.split()
-        gray_img = PILImage.new('L', pil_img.size, 255)
-        gray_img.paste(pil_img.convert('L'), mask=alpha)
-    else:
-        gray_img = pil_img.convert('L')
+    def _gray(x, y):
+        argb = img_buf.pixel(x, y)
+        a = (argb >> 24) & 0xFF
+        r = (argb >> 16) & 0xFF
+        g = (argb >> 8) & 0xFF
+        b = argb & 0xFF
+        gray = (299 * r + 587 * g + 114 * b) // 1000
+        return (a * gray + (255 - a) * 255) // 255
 
     # 2. Calculate pixel sizing and enforce minimum shape constraints
     raw_pixel_size = target_width_um / orig_w
@@ -73,7 +76,6 @@ def png_to_gds(
     region = pya.Region()
     pixel_size_dbu = int(pixel_size_um / layout.dbu)
 
-    gray_pixels = gray_img.load()
     threshold = 128  # midpoint of [0, 255]
 
     print("Generating GDS shapes...")
@@ -86,7 +88,7 @@ def png_to_gds(
             # Nearest-neighbor mapping back to original X coordinate
             x_orig = int(x_new * orig_w / new_w)
 
-            val = gray_pixels[x_orig, y_orig]
+            val = _gray(x_orig, y_orig)
 
             # Base binarization logic
             if dark_is_solid:

--- a/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
+++ b/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
@@ -145,8 +145,8 @@ def png_to_gds(
     # 5. Insert the optimized region into the cell and save
     top_cell.shapes(layer).insert(region)
 
-    bounds = pya.Box(0, 0, new_w * pixel_size_dbu, new_h * pixel_size_dbu)
     for boundary_layer in (outline_layer, fill_exclusion_layer):
+        bounds = pya.Box(0, 0, new_w * pixel_size_dbu, new_h * pixel_size_dbu)
         if boundary_layer is not None:
             top_cell.shapes(layout.layer(boundary_layer[0], boundary_layer[1])).insert(bounds)
 

--- a/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
+++ b/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
@@ -32,13 +32,11 @@ def png_to_gds(
     """
     from klayout_utils import get_write_options  # noqa E402
 
-    # 1. Load image via pya.PixelBuffer (headless, no display required).
+    # 1. Load image via QImage (supports PNG, JPEG, etc.) into a PixelBuffer.
     # pixel() returns ARGB as a packed uint32; composite over white so transparent→light.
     print(f"Loading {image_path}...")
 
-    if not image_path.lower().endswith('.png'):
-        raise ValueError(f"Only PNG images are supported; got: {image_path}")
-    img_buf = pya.PixelBuffer.read_png(image_path)
+    img_buf = pya.PixelBuffer.from_qimage(pya.QImage(image_path))
     orig_w = img_buf.width()
     orig_h = img_buf.height()
     if orig_w == 0 or orig_h == 0:

--- a/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
+++ b/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
@@ -17,7 +17,8 @@ def png_to_gds(
     dark_is_solid: bool = True,
     invert: bool = False,
     timestamps: bool = True,
-    outline_layer: Optional[Tuple[int, int]] = None
+    outline_layer: Optional[Tuple[int, int]] = None,
+    fill_exclusion_layer: Optional[Tuple[int, int]] = None,
 ):
     """
     Converts a PNG image to a GDSII layout using KLayout's native API.
@@ -29,6 +30,8 @@ def png_to_gds(
     :param layer_num: The GDS layer number to draw the shapes on.
     :param dark_is_solid: Base logic - If True, dark pixels become GDS shapes.
     :param invert: Explicitly inverts the final polarity of the image.
+    :param outline_layer: Optional GDS layer for the outline.
+    :param fill_exclusion_layer: Optional GDS layer for fill exclusion.
     """
     from klayout_utils import get_write_options  # noqa E402
 
@@ -142,10 +145,10 @@ def png_to_gds(
     # 5. Insert the optimized region into the cell and save
     top_cell.shapes(layer).insert(region)
 
-    if outline_layer is not None:
-        ol = layout.layer(outline_layer[0], outline_layer[1])
-        outline_box = pya.Box(0, 0, new_w * pixel_size_dbu, new_h * pixel_size_dbu)
-        top_cell.shapes(ol).insert(outline_box)
+    bounds = pya.Box(0, 0, new_w * pixel_size_dbu, new_h * pixel_size_dbu)
+    for boundary_layer in (outline_layer, fill_exclusion_layer):
+        if boundary_layer is not None:
+            top_cell.shapes(layout.layer(boundary_layer[0], boundary_layer[1])).insert(bounds)
 
     layout.write(output_gds, get_write_options(output_gds, timestamps))
     print(f"GDS saved to {output_gds}")
@@ -197,6 +200,8 @@ def main():
 
     outline_layer = schema.get('tool', 'klayout', 'task', 'image2stream', 'var',
                                'outline_layer', step=sc_step, index=sc_index)
+    fill_exclusion_layer = schema.get('tool', 'klayout', 'task', 'image2stream', 'var',
+                                      'fill_exclusion_layer', step=sc_step, index=sc_index)
 
     in_image = f"inputs/{design}.{format}"
     if not os.path.exists(in_image):
@@ -216,7 +221,8 @@ def main():
         dark_is_solid=darkissolid,
         invert=invert,
         timestamps=sc_timestamps,
-        outline_layer=outline_layer
+        outline_layer=outline_layer,
+        fill_exclusion_layer=fill_exclusion_layer,
     )
 
 

--- a/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
+++ b/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
@@ -1,4 +1,6 @@
 import sys
+
+from typing import Optional
 from typing import Tuple
 import pya
 import os.path
@@ -14,7 +16,8 @@ def png_to_gds(
     layer_num: Tuple[int, int] = (1, 0),
     dark_is_solid: bool = True,
     invert: bool = False,
-    timestamps: bool = True
+    timestamps: bool = True,
+    outline_layer: Optional[Tuple[int, int]] = None
 ):
     """
     Converts a PNG image to a GDSII layout using KLayout's native API.
@@ -140,6 +143,12 @@ def png_to_gds(
 
     # 5. Insert the optimized region into the cell and save
     top_cell.shapes(layer).insert(region)
+
+    if outline_layer is not None:
+        ol = layout.layer(outline_layer[0], outline_layer[1])
+        outline_box = pya.Box(0, 0, new_w * pixel_size_dbu, new_h * pixel_size_dbu)
+        top_cell.shapes(ol).insert(outline_box)
+
     layout.write(output_gds, get_write_options(output_gds, timestamps))
     print(f"GDS saved to {output_gds}")
 
@@ -188,6 +197,13 @@ def main():
     sc_timestamps = schema.get('tool', 'klayout', 'task', "image2stream", 'var', 'timestamp',
                                step=sc_step, index=sc_index)
 
+    outline_layer = None
+    if schema.valid('tool', 'klayout', 'task', 'image2stream', 'var', 'outline_layer') and \
+            schema.get('tool', 'klayout', 'task', 'image2stream', 'var', 'outline_layer',
+                       step=sc_step, index=sc_index):
+        outline_layer = schema.get('tool', 'klayout', 'task', 'image2stream', 'var',
+                                   'outline_layer', step=sc_step, index=sc_index)
+
     in_image = f"inputs/{design}.{format}"
     if not os.path.exists(in_image):
         for fileset in schema.get("option", "fileset"):
@@ -205,7 +221,8 @@ def main():
         layer_num=layer,
         dark_is_solid=darkissolid,
         invert=invert,
-        timestamps=sc_timestamps
+        timestamps=sc_timestamps,
+        outline_layer=outline_layer
     )
 
 

--- a/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
+++ b/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
@@ -35,10 +35,8 @@ def png_to_gds(
 
     # 1. Load image with PIL — handles RGBA correctly (pya.Image drops the alpha channel)
     print(f"Loading {image_path}...")
-    try:
-        pil_img = PILImage.open(image_path)
-    except Exception as e:
-        raise ValueError(f"Image could not be loaded: {e}")
+
+    pil_img = PILImage.open(image_path)
 
     orig_w, orig_h = pil_img.size
     if orig_w == 0 or orig_h == 0:

--- a/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
+++ b/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
@@ -17,7 +17,7 @@ def png_to_gds(
     timestamps: bool = True
 ):
     """
-    Converts a PNG image to a GDSII layout using only KLayout's native API.
+    Converts a PNG image to a GDSII layout using KLayout's native API.
 
     :param image_path: Path to the input PNG image.
     :param output_gds: Path to the output GDS file.
@@ -27,17 +27,27 @@ def png_to_gds(
     :param dark_is_solid: Base logic - If True, dark pixels become GDS shapes.
     :param invert: Explicitly inverts the final polarity of the image.
     """
+    from PIL import Image as PILImage  # noqa E402
     from klayout_utils import get_write_options  # noqa E402
 
-    # 1. Open the image using KLayout's native Image class
+    # 1. Load image with PIL — handles RGBA correctly (pya.Image drops the alpha channel)
     print(f"Loading {image_path}...")
-    img = pya.Image(image_path)
+    try:
+        pil_img = PILImage.open(image_path)
+    except Exception as e:
+        raise ValueError(f"Image could not be loaded: {e}")
 
-    if img.is_empty():
-        raise ValueError("Image could not be loaded or is empty. Ensure it's a valid image.")
+    orig_w, orig_h = pil_img.size
+    if orig_w == 0 or orig_h == 0:
+        raise ValueError("Image is empty. Ensure it's a valid image.")
 
-    orig_w = img.width()
-    orig_h = img.height()
+    # Convert to grayscale; composite RGBA over white so transparent→light, opaque→dark.
+    if pil_img.mode == 'RGBA':
+        _, _, _, alpha = pil_img.split()
+        gray_img = PILImage.new('L', pil_img.size, 255)
+        gray_img.paste(pil_img.convert('L'), mask=alpha)
+    else:
+        gray_img = pil_img.convert('L')
 
     # 2. Calculate pixel sizing and enforce minimum shape constraints
     raw_pixel_size = target_width_um / orig_w
@@ -62,12 +72,8 @@ def png_to_gds(
     region = pya.Region()
     pixel_size_dbu = int(pixel_size_um / layout.dbu)
 
-    # KLayout image properties
-    is_color = img.is_color()
-
-    # We set our binarization threshold at the 50% mark of the image's max value.
-    # We fallback to 0.5 if max_value() returns 0 for any reason.
-    threshold = (img.max_value / 2.0) if img.max_value > 0 else 0.5
+    gray_pixels = gray_img.load()
+    threshold = 128  # midpoint of [0, 255]
 
     print("Generating GDS shapes...")
     # 4. Iterate through the target grid and sample the image
@@ -79,16 +85,7 @@ def png_to_gds(
             # Nearest-neighbor mapping back to original X coordinate
             x_orig = int(x_new * orig_w / new_w)
 
-            # Extract grayscale value from the native pya.Image
-            if is_color:
-                # Components: 0=R, 1=G, 2=B
-                r = img.get_pixel(x_orig, y_orig, 0)
-                g = img.get_pixel(x_orig, y_orig, 1)
-                b = img.get_pixel(x_orig, y_orig, 2)
-                # Standard luminance conversion
-                val = 0.299 * r + 0.587 * g + 0.114 * b
-            else:
-                val = img.get_pixel(x_orig, y_orig)
+            val = gray_pixels[x_orig, y_orig]
 
             # Base binarization logic
             if dark_is_solid:
@@ -164,11 +161,11 @@ def main():
     schema = get_schema(manifest='sc_manifest.json')
 
     # Extract info from manifest
-    sc_step = schema.get('arg', 'step')
-    sc_index = schema.get('arg', 'index')
+    sc_step: str = schema.get('arg', 'step')
+    sc_index: str = schema.get('arg', 'index')
 
     design_name = schema.get('option', 'design')
-    fileset = schema.get("option", "fileset")[0]
+    fileset: str = schema.get("option", "fileset")[0]
     design = schema.get("library", design_name, "fileset", fileset, "topmodule")
     if not design:
         design = design_name

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -301,6 +301,7 @@ def test_img2stream():
 
     # test optional outline layer path
     task.set_klayout_outline_layer(189)  # prBoundary
+    task.set_klayout_fill_exclusion_layer(170)  # NoMetFiller
 
     task.set_klayout_invert(True)
     task.set_klayout_timestamp(False)
@@ -313,7 +314,7 @@ def test_img2stream():
 
     with open(gds, 'rb') as gds_file:
         data = gds_file.read()
-        assert hashlib.md5(data).hexdigest() == "3357e0cd3cc9f3b32fba4ccf394bc156"
+        assert hashlib.md5(data).hexdigest() == "e23055c16b50e65ae297cabb00fc8669"
 
     assert proj.history("job0").get('metric', 'drcs', step='drc', index='0') == 0
 

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -279,7 +279,9 @@ def test_convert_drc(setup_pdk_test, datadir):
 @pytest.mark.eda
 @pytest.mark.quick
 @pytest.mark.timeout(300)
-def test_img2stream():
+def test_img2stream(monkeypatch):
+    # pya.PixelBuffer.read_png triggers Qt platform init; offscreen avoids needing a display.
+    monkeypatch.setenv('QT_QPA_PLATFORM', 'offscreen')
     design = Design("testdesign")
     design.set_dataroot("sc", "python://siliconcompiler")
     with design.active_fileset("image"):
@@ -299,10 +301,10 @@ def test_img2stream():
     task.set_klayout_minsize(100.0)
     task.set_klayout_targetwidth(1500.0)
     task.set_klayout_layer(157)
-    
+
     # test optional outline layer path
     task.set_klayout_outline_layer(189)  # prBoundary
-    
+
     task.set_klayout_invert(True)
     task.set_klayout_timestamp(False)
 

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -314,7 +314,7 @@ def test_img2stream():
 
     with open(gds, 'rb') as gds_file:
         data = gds_file.read()
-        assert hashlib.md5(data).hexdigest() == "e23055c16b50e65ae297cabb00fc8669"
+        assert hashlib.md5(data).hexdigest() == "98e5472b73430afa2952ec8393cdef2a"
 
     assert proj.history("job0").get('metric', 'drcs', step='drc', index='0') == 0
 

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -279,9 +279,7 @@ def test_convert_drc(setup_pdk_test, datadir):
 @pytest.mark.eda
 @pytest.mark.quick
 @pytest.mark.timeout(300)
-def test_img2stream(monkeypatch):
-    # pya.PixelBuffer.read_png triggers Qt platform init; offscreen avoids needing a display.
-    monkeypatch.setenv('QT_QPA_PLATFORM', 'offscreen')
+def test_img2stream():
     design = Design("testdesign")
     design.set_dataroot("sc", "python://siliconcompiler")
     with design.active_fileset("image"):
@@ -292,7 +290,6 @@ def test_img2stream(monkeypatch):
     proj.add_fileset("image")
 
     ihp130_demo(proj)
-    proj.option.set_nodashboard(True)
 
     proj.set_flow(Img2StreamFlow())
 
@@ -313,7 +310,10 @@ def test_img2stream(monkeypatch):
     assert proj.run()
 
     gds = proj.find_result("gds", step="image")
-    assert os.path.isfile(gds)
+
+    with open(gds, 'rb') as gds_file:
+        data = gds_file.read()
+        assert hashlib.md5(data).hexdigest() == "3357e0cd3cc9f3b32fba4ccf394bc156"
 
     assert proj.history("job0").get('metric', 'drcs', step='drc', index='0') == 0
 

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -290,7 +290,6 @@ def test_img2stream():
     proj.add_fileset("image")
 
     ihp130_demo(proj)
-    proj.option.set_nodisplay(True)
 
     proj.set_flow(Img2StreamFlow())
 

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -11,9 +11,10 @@ from siliconcompiler.tools.klayout import convert_drc_db
 from siliconcompiler.tools.klayout import merge
 from siliconcompiler.tools.klayout import img2stream
 
-from siliconcompiler.targets import freepdk45_demo
+from siliconcompiler.targets import freepdk45_demo, ihp130_demo
 
 from siliconcompiler import ASIC, Flowgraph, Design
+from siliconcompiler.flows.img2streamflow import Img2StreamFlow
 from siliconcompiler.scheduler import SchedulerNode
 from siliconcompiler.tools.klayout.export import ExportTask
 from siliconcompiler.tools.klayout import KLayoutLibrary
@@ -287,28 +288,30 @@ def test_img2stream():
 
     proj = ASIC(design)
     proj.add_fileset("image")
-    freepdk45_demo(proj)
 
-    flow = Flowgraph("testflow")
-    flow.node('image', img2stream.Img2StreamTask())
-    proj.set_flow(flow)
+    ihp130_demo(proj)
+    proj.option.set_nodashboard(True)
+
+    proj.set_flow(Img2StreamFlow())
 
     task = img2stream.Img2StreamTask.find_task(proj)
-    task.set_klayout_minsize(5.0)
-    task.set_klayout_targetwidth(200.0)
-    task.set_klayout_layer(1)
+    # 15 x 15 logo
+    task.set_klayout_minsize(100.0)
+    task.set_klayout_targetwidth(1500.0)
+    task.set_klayout_layer(157)
     task.set_klayout_invert(True)
     task.set_klayout_timestamp(False)
+
+    drc.DRCTask.find_task(proj).set_klayout_drcname("drc")
 
     assert proj.run()
 
     gds = proj.find_result("gds", step="image")
     assert os.path.isfile(gds)
 
-    with open(gds, 'rb') as gds_file:
-        data = gds_file.read()
-        assert hashlib.md5(data).hexdigest() == "994037d33d3c704e78bfca1f16b8b2cf"
+    assert proj.history("job0").get('metric', 'drcs', step='drc', index='0') == 0
 
+    print(gds)
 
 def test_klayout_parameter_operations():
     task = operations.OperationsTask()

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -299,6 +299,10 @@ def test_img2stream():
     task.set_klayout_minsize(100.0)
     task.set_klayout_targetwidth(1500.0)
     task.set_klayout_layer(157)
+    
+    # test optional outline layer path
+    task.set_klayout_outline_layer(189)  # prBoundary
+    
     task.set_klayout_invert(True)
     task.set_klayout_timestamp(False)
 

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -311,7 +311,6 @@ def test_img2stream():
 
     assert proj.history("job0").get('metric', 'drcs', step='drc', index='0') == 0
 
-    print(gds)
 
 def test_klayout_parameter_operations():
     task = operations.OperationsTask()

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -290,6 +290,7 @@ def test_img2stream():
     proj.add_fileset("image")
 
     ihp130_demo(proj)
+    proj.option.set_nodisplay(True)
 
     proj.set_flow(Img2StreamFlow())
 


### PR DESCRIPTION
- Adds an Img2StreamFlow, which runs klayout drc after converting an image to GDS
- Convert to grayscale earlier and uses PIL to preserve alpha channel contents
- Adds an outline layer option, as required by some DRC decks
- Switches the test from freepdk45 -> ihp130 to enable klayout DRC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New image-to-stream conversion workflow with an optional verification (DRC) step.
  * Option to add an outline layer that inserts a boundary rectangle around the converted image.

* **Improvements**
  * Improved image loading and headless RGBA handling, robust grayscale sampling, and fixed-midpoint binarization.
  * Headless display mode forced to offscreen to improve non-GUI runs.

* **Tests**
  * Tests updated to exercise the new workflow and assert DRC metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->