### PR TITLE
add lef output to img2stream

### DIFF
--- a/siliconcompiler/tools/klayout/img2stream.py
+++ b/siliconcompiler/tools/klayout/img2stream.py
@@ -175,6 +175,7 @@ class Img2StreamTask(KLayoutTask):
             self.add_required_key("var", "outline_layer")
 
         self.add_output_file(ext=f"{default_stream}.gz")
+        self.add_output_file(ext="lef")
 
         if f"{self.design_topmodule}.{imageformat}" in self.get_files_from_input_nodes():
             self.add_input_file(ext=imageformat)
@@ -183,3 +184,11 @@ class Img2StreamTask(KLayoutTask):
                 if lib.has_file(fileset=fileset, filetype=imageformat):
                     self.add_required_key(lib, "fileset", fileset, "file", imageformat)
                     break
+
+        sc_stream_order = [default_stream, *[s for s in ("gds", "oas") if s != default_stream]]
+        for s in sc_stream_order:
+            if self.pdk.valid("pdk", "layermapfileset", "klayout", "def", s):
+                self.add_required_key(self.pdk, "pdk", "layermapfileset", "klayout", "def", s)
+                for fileset in self.pdk.get("pdk", "layermapfileset", "klayout", "def", s):
+                    self.add_required_key(self.pdk, "fileset", fileset, "file", "layermap")
+                break

--- a/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
+++ b/siliconcompiler/tools/klayout/scripts/klayout_img2stream.py
@@ -167,6 +167,7 @@ def main():
         technology,
         get_schema
     )
+    from klayout_stream2lef import to_lef, parse_layermap
 
     schema = get_schema(manifest='sc_manifest.json')
 
@@ -210,11 +211,14 @@ def main():
                 in_image = schema.get("library", design_name, "fileset", fileset, "file", format)[0]
                 break
 
+    sc_tech = technology(design, schema)
+
+    output_gds = f"outputs/{design}.{stream}.gz"
     png_to_gds(
         name=design,
         image_path=in_image,
-        output_gds=f"outputs/{design}.{stream}.gz",
-        technology=technology(design, schema),
+        output_gds=output_gds,
+        technology=sc_tech,
         target_width_um=targetwidth,
         min_shape_um=minsize,
         layer_num=layer,
@@ -223,6 +227,27 @@ def main():
         timestamps=sc_timestamps,
         outline_layer=outline_layer,
         fill_exclusion_layer=fill_exclusion_layer,
+    )
+
+    # Generate a LEF macro for the streamed image
+    load_options = sc_tech.load_layout_options
+    map_file = load_options.lefdef_config.map_file
+    if not map_file:
+        print("[ERROR] No layermap file specified in technology. Cannot proceed with LEF export.")
+        sys.exit(1)
+
+    layers = {}
+    for layer_name, layer_purpose, stream_number, datatype in parse_layermap(map_file):
+        if layer_name == "NAME":
+            layer_name = layer_purpose.split("/")[0]
+        layers.setdefault(layer_name, set()).add((stream_number, datatype))
+
+    to_lef(
+        output_gds,
+        f"outputs/{design}.lef",
+        layers,
+        set(),
+        "COVER",
     )
 
 

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -297,11 +297,11 @@ def test_img2stream():
     # 15 x 15 logo
     task.set_klayout_minsize(100.0)
     task.set_klayout_targetwidth(1500.0)
-    task.set_klayout_layer(157)
+    task.set_klayout_layer(134)
 
     # test optional outline layer path
     task.set_klayout_outline_layer(189)  # prBoundary
-    task.set_klayout_fill_exclusion_layer(170)  # NoMetFiller
+    task.set_klayout_fill_exclusion_layer(134, 4)  # NoMetFiller
 
     task.set_klayout_invert(True)
     task.set_klayout_timestamp(False)
@@ -311,10 +311,29 @@ def test_img2stream():
     assert proj.run()
 
     gds = proj.find_result("gds", step="image")
+    lef = proj.find_result("lef", step="image")
+    assert os.path.isfile(gds)
+    assert os.path.isfile(lef)
 
     with open(gds, 'rb') as gds_file:
         data = gds_file.read()
-        assert hashlib.md5(data).hexdigest() == "98e5472b73430afa2952ec8393cdef2a"
+        assert hashlib.md5(data).hexdigest() == "0c8a1f81af4a731ecb4f86f3f4bac591"
+
+    with open(lef, 'r') as lef_file:
+        assert lef_file.read() == """MACRO logo
+  CLASS COVER ;
+  ORIGIN 0.0000 0.0000 ;
+  FOREIGN logo -0.0000 -0.0000 ;
+  SIZE 1500.0000 BY 1400.0000 ;
+  SYMMETRY X Y R90 ;
+  OBS
+    LAYER TopMetal2 ;
+      POLYGON 0.0000 0.0000 0.0000 1400.0000 1500.0000 1400.0000 1500.0000 0.0000 ;
+    LAYER DIEAREA ;
+      POLYGON 0.0000 0.0000 0.0000 1400.0000 1500.0000 1400.0000 1500.0000 0.0000 ;
+  END
+END logo
+"""
 
     assert proj.history("job0").get('metric', 'drcs', step='drc', index='0') == 0
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Klayout img2stream tool now generates LEF macro output alongside GDS/OAS streams.
  * LEF generation is determined by available PDK layermap configuration.

* **Tests**
  * Updated tests to validate both GDS and LEF artifact generation and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->