### PR TITLE
Add support for verilog testbenches with Verilator

### DIFF
--- a/examples/heartbeat/make.py
+++ b/examples/heartbeat/make.py
@@ -187,7 +187,7 @@ def asic(pdk: str = "freepdk45", N: str = None):
     project.snapshot()
 
 
-def sim(N: str = None, tool: str = "verilator", tb_type: str = "cc"):
+def sim(N: str = None, tool: str = "verilator", tb_type: str = "v"):
     """Runs a simulation of the Heartbeat design.
 
     After the simulation completes, it attempts to open the generated
@@ -199,8 +199,7 @@ def sim(N: str = None, tool: str = "verilator", tb_type: str = "cc"):
         tool (str, optional): The simulation tool to use ('verilator' or
             'icarus'). Defaults to "verilator".
         tb_type (str, optional): The file extension of the testbench ('cc' or
-            'v'). Only used for tools which can work with multiple testbench
-            types. Defaults to "cc".
+            'v'). Defaults to "v".
     """
     # Create a project instance tailored for simulation.
     project = Sim()
@@ -210,15 +209,14 @@ def sim(N: str = None, tool: str = "verilator", tb_type: str = "cc"):
     project.set_design(hb)
 
     # Add the tool-specific testbench and the RTL design files.
-    tb_fileset = f"testbench.{tool}.{tb_type}" if tool == "verilator" else f"testbench.{tool}"
-    project.add_fileset(tb_fileset)
+    project.add_fileset(f"testbench.{tool}.{tb_type}")
     project.add_fileset("rtl")
     # Set the appropriate design verification flow.
     project.set_flow(DVFlow(tool=tool))
 
     # Optionally override the 'N' parameter for the testbench.
     if N is not None:
-        hb.set_param("N", N, fileset=tb_fileset)
+        hb.set_param("N", N, fileset=f"testbench.{tool}.{tb_type}")
 
     if tool == "verilator":
         # Add trace to verilator

--- a/examples/heartbeat/make.py
+++ b/examples/heartbeat/make.py
@@ -48,15 +48,21 @@ class HeartbeatDesign(Design):
                 self.set_param("N", "8")  # Default parameter value
 
             # Testbench for Icarus Verilog
-            with self.active_fileset("testbench.icarus"):
+            with self.active_fileset("testbench.icarus.v"):
                 self.set_topmodule("heartbeat_tb")
                 self.add_file("testbench.v")
                 self.set_param("N", "8")
 
             # C++ Testbench for Verilator
-            with self.active_fileset("testbench.verilator"):
+            with self.active_fileset("testbench.verilator.cc"):
                 self.set_topmodule("heartbeat")
                 self.add_file("testbench.cc")
+                self.set_param("N", "8")
+
+            # Verilog Testbench for Verilator
+            with self.active_fileset("testbench.verilator.v"):
+                self.set_topmodule("heartbeat_tb")
+                self.add_file("testbench.v")
                 self.set_param("N", "8")
 
             # ASIC timing constraints for the FreePDK45 technology.
@@ -181,7 +187,7 @@ def asic(pdk: str = "freepdk45", N: str = None):
     project.snapshot()
 
 
-def sim(N: str = None, tool: str = "verilator"):
+def sim(N: str = None, tool: str = "verilator", tb_type: str = "cc"):
     """Runs a simulation of the Heartbeat design.
 
     After the simulation completes, it attempts to open the generated
@@ -192,6 +198,9 @@ def sim(N: str = None, tool: str = "verilator"):
             Defaults to None, which uses the value set in the design schema.
         tool (str, optional): The simulation tool to use ('verilator' or
             'icarus'). Defaults to "verilator".
+        tb_type (str, optional): The file extension of the testbench ('cc' or
+            'v'). Only used for tools which can work with multiple testbench
+            types. Defaults to "cc".
     """
     # Create a project instance tailored for simulation.
     project = Sim()
@@ -201,25 +210,28 @@ def sim(N: str = None, tool: str = "verilator"):
     project.set_design(hb)
 
     # Add the tool-specific testbench and the RTL design files.
-    project.add_fileset(f"testbench.{tool}")
+    tb_fileset = f"testbench.{tool}.{tb_type}" if tool == "verilator" else f"testbench.{tool}"
+    project.add_fileset(tb_fileset)
     project.add_fileset("rtl")
     # Set the appropriate design verification flow.
     project.set_flow(DVFlow(tool=tool))
 
     # Optionally override the 'N' parameter for the testbench.
     if N is not None:
-        hb.set_param("N", N, fileset=f"testbench.{tool}")
+        hb.set_param("N", N, fileset=tb_fileset)
 
     if tool == "verilator":
         # Add trace to verilator
         CompileTask.find_task(project).set_verilator_trace(True)
+        if tb_type == "v":
+            CompileTask.find_task(project).set_verilator_main(True)
 
     # Run the simulation.
     project.run()
     project.summary()
 
     vcd = None
-    if tool == "icarus":
+    if tool == "icarus" or (tool == "verilator" and tb_type != "cc"):
         # Find the VCD (Value Change Dump) waveform file from the results.
         vcd = project.find_result(step='simulate', index='0',
                                   directory="reports",

--- a/siliconcompiler/tools/verilator/compile.py
+++ b/siliconcompiler/tools/verilator/compile.py
@@ -183,6 +183,8 @@ class CompileTask(VerilatorTask):
                 self.add_required_key(lib, "fileset", fileset, "file", "c")
                 added_key = True
         if not added_key and not self.get("var", "main"):
+            self.logger.warning("No c files found. c files are required for verilator compilation "
+                                "unless the \"main\" option is enabled.")
             self.add_required_key(self.project.design, "fileset",
                                   self.project.get("option", "fileset")[0], "file", "c")
 

--- a/siliconcompiler/tools/verilator/compile.py
+++ b/siliconcompiler/tools/verilator/compile.py
@@ -254,9 +254,15 @@ class CompileTask(VerilatorTask):
             options.append(trace_opt)
 
             # add siliconcompiler specific defines
-            c_flags.append("-DSILICONCOMPILER_TRACE_DIR=\"reports\"")
-            c_flags.append(
-                f"-DSILICONCOMPILER_TRACE_FILE=\"reports/{self.design_topmodule}.{ext}\"")
+            if self.get("var", "main"):
+                options.extend([
+                    "-DSILICONCOMPILER_TRACE_DIR=\"reports\"",
+                    f"-DSILICONCOMPILER_TRACE_FILE=\"reports/{self.design_topmodule}.{ext}\""
+                ])
+            else:
+                c_flags.append("-DSILICONCOMPILER_TRACE_DIR=\"reports\"")
+                c_flags.append(
+                    f"-DSILICONCOMPILER_TRACE_FILE=\"reports/{self.design_topmodule}.{ext}\"")
 
         if c_includes:
             c_flags.extend([f'-I{include}' for include in c_includes])

--- a/siliconcompiler/tools/verilator/compile.py
+++ b/siliconcompiler/tools/verilator/compile.py
@@ -19,6 +19,10 @@ class CompileTask(VerilatorTask):
         self.add_parameter("trace_type", "<vcd,fst>",
                            "specifies type of wave file to create when [trace] is set",
                            defvalue="vcd")
+        self.add_parameter("main", "bool",
+                           "if true, generate a toplevel C++ wrapper and relax the C++ file "
+                           "requirement. See --main in Verilator docs for more info",
+                           defvalue=False)
 
         # TODO Move to design object
         self.add_parameter("cincludes", "[dir]",
@@ -74,6 +78,19 @@ class CompileTask(VerilatorTask):
             index (str, optional): The specific index to apply this configuration to.
         """
         self.set("var", "trace_type", trace_type, step=step, index=index)
+
+    def set_verilator_main(self, enable: bool,
+                           step: Optional[str] = None,
+                           index: Optional[str] = None):
+        """
+        Enables or disables toplevel C++ wrapper generation.
+
+        Args:
+            enable (bool): Whether to enable toplevel wrapper generation.
+            step (str, optional): The specific step to apply this configuration to.
+            index (str, optional): The specific index to apply this configuration to.
+        """
+        self.set("var", "main", enable, step=step, index=index)
 
     def add_verilator_cincludes(self, include: Union[str, List[str]],
                                 step: Optional[str] = None,
@@ -165,7 +182,7 @@ class CompileTask(VerilatorTask):
             if lib.has_file(fileset=fileset, filetype="c"):
                 self.add_required_key(lib, "fileset", fileset, "file", "c")
                 added_key = True
-        if not added_key:
+        if not added_key and not self.get("var", "main"):
             self.add_required_key(self.project.design, "fileset",
                                   self.project.get("option", "fileset")[0], "file", "c")
 
@@ -198,6 +215,9 @@ class CompileTask(VerilatorTask):
 
         if self.get("var", "initialize_random"):
             options.extend(['--x-assign', 'unique'])
+
+        if self.get("var", "main"):
+            options.extend(['--main'])
 
         options.extend(['--exe', '--build'])
 

--- a/siliconcompiler/tools/verilator/compile.py
+++ b/siliconcompiler/tools/verilator/compile.py
@@ -197,6 +197,7 @@ class CompileTask(VerilatorTask):
         self.add_required_key("var", "trace")
         self.add_required_key("var", "trace_type")
         self.add_required_key("var", "initialize_random")
+        self.add_required_key("var", "main")
 
         self._setup_c_file_requirement()
 

--- a/siliconcompiler/tools/verilator/compile.py
+++ b/siliconcompiler/tools/verilator/compile.py
@@ -217,7 +217,7 @@ class CompileTask(VerilatorTask):
             options.extend(['--x-assign', 'unique'])
 
         if self.get("var", "main"):
-            options.extend(['--main'])
+            options.extend(['--main', '--timing'])
 
         options.extend(['--exe', '--build'])
 

--- a/tests/examples/test_heartbeat.py
+++ b/tests/examples/test_heartbeat.py
@@ -67,9 +67,20 @@ def test_py_make_sim_icarus():
 @pytest.mark.eda
 @pytest.mark.quick
 @pytest.mark.timeout(300)
-def test_py_make_sim_verilator():
+def test_py_make_sim_verilator_v():
     from heartbeat import make
     make.sim()
+
+    assert os.path.isfile('build/heartbeat/job0/heartbeat.pkg.json')
+    assert os.path.isfile('build/heartbeat/job0/simulate/0/reports/heartbeat_tb.vcd')
+
+
+@pytest.mark.eda
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_py_make_sim_verilator_cc():
+    from heartbeat import make
+    make.sim(tb_type='cc')
 
     assert os.path.isfile('build/heartbeat/job0/heartbeat.pkg.json')
     assert os.path.isfile('build/heartbeat/job0/simulate/0/reports/heartbeat.vcd')


### PR DESCRIPTION
Fixes #3632. Enables the use of verilog testbenches with verilator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simulation: choose testbench type (C++ or Verilog) when running sims; numeric parameter overrides apply to the selected testbench. Verilator runs enable tracing for all testbench types and adjust main-wrapper/timing behavior based on testbench selection.
* **Tests**
  * Verilator simulation coverage split into separate tests for Verilog and C++ testbenches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->