### PR TITLE
fix missing openrcx

### DIFF
--- a/siliconcompiler/tools/openroad/write_data.py
+++ b/siliconcompiler/tools/openroad/write_data.py
@@ -158,7 +158,7 @@ class WriteViewsTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
         if self.get("var", "write_spef"):
             self.add_required_key("var", "pex_corners")
             self.add_required_key("var", "use_spef")
-            for corner in self.pdk.getkeys("pdk", "pexmodelfileset", "openroad"):
+            for corner in self.get("var", "pex_corners"):
                 self.add_required_key(self.pdk, "pdk", "pexmodelfileset", "openroad", corner)
                 for fileset in self.pdk.get("pdk", "pexmodelfileset", "openroad", corner):
                     self.add_required_key(self.pdk, "fileset", fileset, "file", "openrcx")
@@ -179,10 +179,8 @@ class WriteViewsTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
         self.add_required_key("var", "write_sdf")
 
     def __has_openrcx(self):
-        if not self.pdk.valid("pdk", "pexmodelfileset", "openroad"):
-            return False
         for corner in self.pdk.getkeys("pdk", "pexmodelfileset", "openroad"):
             for fileset in self.pdk.get("pdk", "pexmodelfileset", "openroad", corner):
-                if self.pdk.valid("pdk", "fileset", fileset, "file", "openrcx"):
+                if self.pdk.get("fileset", fileset, "file", "openrcx"):
                     return True
         return False

--- a/siliconcompiler/tools/openroad/write_data.py
+++ b/siliconcompiler/tools/openroad/write_data.py
@@ -178,7 +178,6 @@ class WriteViewsTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
         self.add_required_key("var", "write_liberty")
         self.add_required_key("var", "write_sdf")
 
-
     def __has_openrcx(self):
         if not self.pdk.valid("pdk", "pexmodelfileset", "openroad"):
             return False

--- a/siliconcompiler/tools/openroad/write_data.py
+++ b/siliconcompiler/tools/openroad/write_data.py
@@ -150,11 +150,18 @@ class WriteViewsTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
         self.add_output_file(ext="lef")
         self.add_output_file(ext="lvs.vg")
 
+        if not self.__has_openrcx():
+            self.set("var", "write_spef", False)
+
         if self.get("var", "write_cdl"):
             self.add_output_file(ext="cdl")
         if self.get("var", "write_spef"):
             self.add_required_key("var", "pex_corners")
             self.add_required_key("var", "use_spef")
+            for corner in self.pdk.getkeys("pdk", "pexmodelfileset", "openroad"):
+                self.add_required_key(self.pdk, "pdk", "pexmodelfileset", "openroad", corner)
+                for fileset in self.pdk.get("pdk", "pexmodelfileset", "openroad", corner):
+                    self.add_required_key(self.pdk, "fileset", fileset, "file", "openrcx")
             for corner in self.get("var", "pex_corners"):
                 self.add_output_file(ext=f"{corner}.spef")
         if self.get("var", "write_liberty"):
@@ -170,3 +177,13 @@ class WriteViewsTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
         self.add_required_key("var", "write_spef")
         self.add_required_key("var", "write_liberty")
         self.add_required_key("var", "write_sdf")
+
+
+    def __has_openrcx(self):
+        if not self.pdk.valid("pdk", "pexmodelfileset", "openroad"):
+            return False
+        for corner in self.pdk.getkeys("pdk", "pexmodelfileset", "openroad"):
+            for fileset in self.pdk.get("pdk", "pexmodelfileset", "openroad", corner):
+                if self.pdk.valid("pdk", "fileset", fileset, "file", "openrcx"):
+                    return True
+        return False

--- a/siliconcompiler/tools/openroad/write_data.py
+++ b/siliconcompiler/tools/openroad/write_data.py
@@ -118,8 +118,6 @@ class WriteViewsTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
 
         self.set("var", "pex_corners", list(self._get_pex_mapping().values()))
 
-        self.set("var", "use_spef", self.get("var", "write_spef"))
-
         self._set_reports([
             'setup',
             'hold',
@@ -152,6 +150,8 @@ class WriteViewsTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
 
         if not self.__has_openrcx():
             self.set("var", "write_spef", False)
+
+        self.set("var", "use_spef", self.get("var", "write_spef"))
 
         if self.get("var", "write_cdl"):
             self.add_output_file(ext="cdl")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SPEF output is now automatically disabled when required PDK model files for OpenROAD are missing, preventing failed or partial SPEF generation.
  * Per-corner SPEF generation now only proceeds when a valid model file entry exists for every PEX corner/fileset, avoiding incomplete per-corner outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->