### PR TITLE
switch to bazel build for openroad

### DIFF
--- a/Changes
+++ b/Changes
@@ -781,7 +781,7 @@ SiliconCompiler 0.28.4 (2024-10-28)
   * surelog: ensure its require list is complete to properly detect changes in inputs.
   * yosys: added screenshot task.
   * klayout: added drc task to run DRC and convert_drc_db task to convert a klayout DRC database to openroads.
-  * vpr: added `vpr_device_code` support. 
+  * vpr: added `vpr_device_code` support.
   * magic: added support for uncompressing LEF files.
 
 

--- a/docs/user_guide/tutorials/emails.rst
+++ b/docs/user_guide/tutorials/emails.rst
@@ -52,4 +52,3 @@ The summary email will contain a metrics table and the output image if one is av
 
    * - .. image:: _images/email/end.png
      - .. image:: _images/email/summary.png
- 

--- a/setup/docker/tool.docker
+++ b/setup/docker/tool.docker
@@ -33,7 +33,7 @@ RUN apt-get update && \
     ./{{ install_script }} && \
     rm -rf $SC_BUILD/* && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \ 
+    rm -rf /var/lib/apt/lists/* && \
     rm -rf $HOME/.cache
 
 # Generate list of installed programs

--- a/setup/docker/tool.docker
+++ b/setup/docker/tool.docker
@@ -33,7 +33,8 @@ RUN apt-get update && \
     ./{{ install_script }} && \
     rm -rf $SC_BUILD/* && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \ 
+    rm -rf $HOME/.cache
 
 # Generate list of installed programs
 RUN apt list --installed | grep "\[installed\(.*\)\]" | sed 's/\/.*//' > $SC_PREFIX/apt.txt

--- a/siliconcompiler/data/demo_fpga/tech_flops.lib
+++ b/siliconcompiler/data/demo_fpga/tech_flops.lib
@@ -19,7 +19,7 @@ library (TechFlops) {
 
         pin (D) {
             direction: input;
-            
+
             timing() {
                 related_pin: "clk";
                 timing_type: hold_rising;
@@ -65,7 +65,7 @@ library (TechFlops) {
         pin (Q) {
             direction: output;
             function: "IQ";
-            
+
             timing() {
                 related_pin: "clk";
                 timing_type: rising_edge;
@@ -120,7 +120,7 @@ library (TechFlops) {
 
         pin (D) {
             direction: input;
-            
+
             timing() {
                 related_pin: "clk";
                 timing_type: hold_rising;
@@ -203,7 +203,7 @@ library (TechFlops) {
         pin (Q) {
             direction: output;
             function: "IQ";
-            
+
             timing() {
                 related_pin: "clk";
                 timing_type: rising_edge;
@@ -377,7 +377,7 @@ library (TechFlops) {
 
         pin (D) {
             direction: input;
-            
+
             timing() {
                 related_pin: "clk";
                 timing_type: hold_rising;
@@ -451,7 +451,7 @@ library (TechFlops) {
         pin (Q) {
             direction: output;
             function: "IQ";
-            
+
             timing() {
                 related_pin: "clk";
                 timing_type: rising_edge;
@@ -506,7 +506,7 @@ library (TechFlops) {
 
         pin (D) {
             direction: input;
-            
+
             timing() {
                 related_pin: "clk";
                 timing_type: hold_rising;
@@ -621,7 +621,7 @@ library (TechFlops) {
         pin (Q) {
             direction: output;
             function: "IQ";
-            
+
             timing() {
                 related_pin: "clk";
                 timing_type: rising_edge;

--- a/siliconcompiler/data/demo_fpga/vtr_primitives.lib
+++ b/siliconcompiler/data/demo_fpga/vtr_primitives.lib
@@ -189,7 +189,7 @@ library (VTRPrimitives) {
 
         pin (D) {
             direction: input;
-            
+
             timing() {
                 related_pin: "clock";
                 timing_type: hold_rising;
@@ -235,7 +235,7 @@ library (VTRPrimitives) {
         pin (Q) {
             direction: output;
             function: "IQ";
-            
+
             timing() {
                 related_pin: "clock";
                 timing_type: rising_edge;

--- a/siliconcompiler/toolscripts/rhel8/install-surelog.sh
+++ b/siliconcompiler/toolscripts/rhel8/install-surelog.sh
@@ -10,7 +10,7 @@ sudo yum install -y git
 # These dependencies are up-to-date with instructions from the INSTALL.md from the commit we are pinned to below
 sudo yum install -y gcc-toolset-12
 sudo dnf config-manager --set-enabled devel || true
-sudo yum install -y libuuid-devel java-11-openjdk-devel python3 zlib-static openssl-devel 
+sudo yum install -y libuuid-devel java-11-openjdk-devel python3 zlib-static openssl-devel
 sudo dnf config-manager --set-disabled devel || true
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/rhel9/install-openroad.sh
+++ b/siliconcompiler/toolscripts/rhel9/install-openroad.sh
@@ -11,34 +11,30 @@ else
     SUDO_INSTALL=""
 fi
 
-sudo yum install -y git
+sudo yum install -y git curl --skip-broken
 
 mkdir -p deps
 cd deps
+
+mkdir -p bazelbin/bin
+BAZEL_PREFIX=$(pwd)/bazelbin
+
+PATH="$BAZEL_PREFIX/bin:$PATH"
 
 git clone $(python3 ${src_path}/_tools.py --tool openroad --field git-url) openroad
 cd openroad
 git checkout $(python3 ${src_path}/_tools.py --tool openroad --field git-commit)
 git submodule update --init --recursive
 
-# Install missing dependencies
-sudo yum install -y bison byacc
+sudo ./etc/DependencyInstaller.sh -bazel -prefix="$BAZEL_PREFIX"
+sudo chown -R $USER:$USER $BAZEL_PREFIX
 
-deps_args=""
 if [ ! -z ${PREFIX} ]; then
-    deps_args="-prefix=$PREFIX"
-fi
-sudo ./etc/DependencyInstaller.sh -base
-$SUDO_INSTALL ./etc/DependencyInstaller.sh -common $deps_args
-
-cmake_args="-DENABLE_TESTS=OFF"
-if [ ! -z ${PREFIX} ]; then
-    cmake_args="$cmake_args -DCMAKE_INSTALL_PREFIX=$PREFIX"
+    install_loc="$PREFIX"
+else
+    install_loc="$HOME/.local"
 fi
 
-./etc/Build.sh -cmake="$cmake_args" -threads=${NPROC:-$(nproc)}
-
-cd build
-$SUDO_INSTALL make install
+bazelisk run :install --config=release --//:platform=gui -- "$install_loc"
 
 cd -

--- a/siliconcompiler/toolscripts/rhel9/install-surelog.sh
+++ b/siliconcompiler/toolscripts/rhel9/install-surelog.sh
@@ -8,7 +8,7 @@ src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
 # These dependencies are up-to-date with instructions from the INSTALL.md from the commit we are pinned to below
 sudo yum install -y gcc-toolset-12
 sudo dnf config-manager --set-enabled devel || true
-sudo yum install -y libuuid-devel java-11-openjdk-devel python3 zlib-static openssl-devel 
+sudo yum install -y libuuid-devel java-11-openjdk-devel python3 zlib-static openssl-devel
 sudo dnf config-manager --set-disabled devel || true
 sudo yum install -y git
 

--- a/siliconcompiler/toolscripts/ubuntu22/install-openroad.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-openroad.sh
@@ -13,35 +13,30 @@ fi
 
 sudo apt-get update
 
-sudo apt-get install -y git
+sudo apt-get install -y git curl
 
 mkdir -p deps
 cd deps
+
+mkdir -p bazelbin/bin
+BAZEL_PREFIX=$(pwd)/bazelbin
+
+PATH="$BAZEL_PREFIX/bin:$PATH"
 
 git clone $(python3 ${src_path}/_tools.py --tool openroad --field git-url) openroad
 cd openroad
 git checkout $(python3 ${src_path}/_tools.py --tool openroad --field git-commit)
 git submodule update --init --recursive
 
-git config user.email "bot@siliconcompiler.com"
-git config user.name "SC-Install"
-git revert -m 1 --no-edit 3548df8222cbd2ef4a4b2900e720948205791eed
+sudo ./etc/DependencyInstaller.sh -bazel -prefix="$BAZEL_PREFIX"
+sudo chown -R $USER:$USER $BAZEL_PREFIX
 
-deps_args=""
 if [ ! -z ${PREFIX} ]; then
-    deps_args="-prefix=$PREFIX"
-fi
-sudo ./etc/DependencyInstaller.sh -base
-$SUDO_INSTALL ./etc/DependencyInstaller.sh -common $deps_args
-
-cmake_args="-DENABLE_TESTS=OFF"
-if [ ! -z ${PREFIX} ]; then
-    cmake_args="$cmake_args -DCMAKE_INSTALL_PREFIX=$PREFIX"
+    install_loc="$PREFIX"
+else
+    install_loc="$HOME/.local"
 fi
 
-./etc/Build.sh -cmake="$cmake_args" -threads=${NPROC:-$(nproc)}
-
-cd build
-$SUDO_INSTALL make install
+bazelisk run :install --config=release --//:platform=gui -- "$install_loc"
 
 cd -

--- a/siliconcompiler/toolscripts/ubuntu24/install-openroad.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-openroad.sh
@@ -13,31 +13,30 @@ fi
 
 sudo apt-get update
 
-sudo apt-get install -y git
+sudo apt-get install -y git curl
 
 mkdir -p deps
 cd deps
+
+mkdir -p bazelbin/bin
+BAZEL_PREFIX=$(pwd)/bazelbin
+
+PATH="$BAZEL_PREFIX/bin:$PATH"
 
 git clone $(python3 ${src_path}/_tools.py --tool openroad --field git-url) openroad
 cd openroad
 git checkout $(python3 ${src_path}/_tools.py --tool openroad --field git-commit)
 git submodule update --init --recursive
 
-deps_args=""
-if [ ! -z ${PREFIX} ]; then
-    deps_args="-prefix=$PREFIX"
-fi
-sudo ./etc/DependencyInstaller.sh -base
-$SUDO_INSTALL ./etc/DependencyInstaller.sh -common $deps_args
+sudo ./etc/DependencyInstaller.sh -bazel -prefix="$BAZEL_PREFIX"
+sudo chown -R $USER:$USER $BAZEL_PREFIX
 
-cmake_args="-DENABLE_TESTS=OFF"
 if [ ! -z ${PREFIX} ]; then
-    cmake_args="$cmake_args -DCMAKE_INSTALL_PREFIX=$PREFIX"
+    install_loc="$PREFIX"
+else
+    install_loc="$HOME/.local"
 fi
 
-./etc/Build.sh -cmake="$cmake_args" -threads=${NPROC:-$(nproc)}
-
-cd build
-$SUDO_INSTALL make install
+bazelisk run :install --config=release --//:platform=gui -- "$install_loc"
 
 cd -

--- a/tests/data/heartbeat.f
+++ b/tests/data/heartbeat.f
@@ -1,6 +1,6 @@
 // This is a comment
 +incdir+.
-// Ingoree empty file below
+// Ignore empty file below
    
 +define+ASIC
 heartbeat.v


### PR DESCRIPTION
https://github.com/siliconcompiler/siliconcompiler/actions/runs/27102389125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced Docker image size by removing additional build artifacts and user cache during install.
  * Revised OpenROAD installation flow across RHEL9, Ubuntu22 and Ubuntu24 to a Bazel-based process with updated prerequisites and install location handling.
* **Documentation**
  * Minor formatting adjustments in a user tutorial.
* **Data**
  * Whitespace-only tidy-ups in demo library files.
* **Tests**
  * Fixed a misspelled placeholder comment in test data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->