### PR TITLE
DRCFlow: Add 'tool' argument for selecting between magic and klayout

### DIFF
--- a/siliconcompiler/flows/drcflow.py
+++ b/siliconcompiler/flows/drcflow.py
@@ -7,7 +7,7 @@ class DRCFlow(Flowgraph):
     '''A design rule check (DRC) flow.
 
     This flow is designed to perform a DRC run on an input GDSII file using
-    KLayout.
+    KLayout or Magic.
     '''
     def __init__(self, name: str = "drcflow", tool: str = "klayout"):
         """

--- a/siliconcompiler/flows/drcflow.py
+++ b/siliconcompiler/flows/drcflow.py
@@ -1,5 +1,6 @@
 from siliconcompiler import Flowgraph
-from siliconcompiler.tools.klayout import drc
+from siliconcompiler.tools.klayout import drc as klayout_drc
+from siliconcompiler.tools.magic import drc as magic_drc
 
 
 class DRCFlow(Flowgraph):
@@ -8,16 +9,25 @@ class DRCFlow(Flowgraph):
     This flow is designed to perform a DRC run on an input GDSII file using
     KLayout.
     '''
-    def __init__(self, name: str = "drcflow"):
+    def __init__(self, name: str = "drcflow", tool: str = "klayout"):
         """
         Initializes the DRCFlow.
 
         Args:
-            name (str): The name of the flow.
+            * name (str): The name of the flow.
+            * tool (str): The DRC tool to use. Supported options are 'klayout' and 'magic'.
+
+        Raises:
+            ValueError: If an unsupported tool is specified.
         """
         super().__init__(name)
 
-        self.node("drc", drc.DRCTask())
+        if tool == "klayout":
+            self.node("drc", klayout_drc.DRCTask())
+        elif tool == "magic":
+            self.node("drc", magic_drc.DRCTask())
+        else:
+            raise ValueError(f'{tool} is not a supported tool')
 
 
 ##################################################

--- a/tests/flows/test_flows.py
+++ b/tests/flows/test_flows.py
@@ -16,7 +16,7 @@ from siliconcompiler.tools.builtin.nop import NOPTask
 
 @pytest.mark.parametrize("flow", [
     ASICFlow(), HLSASICFlow(), VHDLASICFlow(),
-    DRCFlow(),
+    DRCFlow(tool="klayout"), DRCFlow(tool="magic"),
     DVFlow(tool="icarus"), DVFlow(tool="verilator"), DVFlow(tool="xyce"), DVFlow(tool="xdm-xyce"),
     FPGANextPNRFlow(), FPGAVPRFlow(), FPGAXilinxFlow(),
     GenerateOpenRCXFlow(NOPTask()),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DRC flow now lets you choose the DRC backend tool (KLayout or Magic); KLayout is the default. It will report an error for unsupported tool values.
* **Tests**
  * Test suite updated to explicitly specify the DRC tool selection in relevant flow tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->