### PR TITLE
schematic: Fix reversed and dropped bus ranges in `write_verilog`

### DIFF
--- a/siliconcompiler/schematic.py
+++ b/siliconcompiler/schematic.py
@@ -267,9 +267,7 @@ class Schematic(BaseSchema):
         pinlist = []
         for item in keys:
             t = self.get('schematic', 'part', part.name, 'pin', item, 'bitrange')
-            if t != (0, 0):
-                item = f"{item}[{t[0]}:{t[1]}]"
-            pinlist.append(item)
+            pinlist.append(f"{item}{self._format_bitrange(t)}")
         pins = tuple(pinlist)
 
         return pins
@@ -359,20 +357,14 @@ class Schematic(BaseSchema):
 
             direction = self.get('schematic', 'pin', pin, 'direction')
             bits = self.get('schematic', 'pin', pin, 'bitrange')
-            if bits[1]:
-                bitrange = f"[{bits[1]}:{bits[0]}]"
-            else:
-                bitrange = ""
+            bitrange = self._format_bitrange(bits)
             lines.append(f"  {direction} {bitrange} {pin};")
 
         # Declare nets
         lines.append("\n  // wires\n")
         for net in self.all_nets():
             bits = self.get('schematic', 'net', net, 'bitrange')
-            if bits[1]:
-                bitrange = f"[{bits[1]}:{bits[0]}]"
-            else:
-                bitrange = ""
+            bitrange = self._format_bitrange(bits)
             if net not in self.pins:
                 lines.append(f"  wire {bitrange} {net};")
 
@@ -431,6 +423,25 @@ class Schematic(BaseSchema):
         if hasattr(pin_obj, "pin"):
             return pin_obj.pin
         return getattr(pin_obj, "name", None)
+
+    @staticmethod
+    def _format_bitrange(bits: Tuple[int, int]) -> str:
+        """
+        Format a stored ``(max, min)`` bitrange tuple as a Verilog vector range.
+
+        This helper is used to turn a stored bitrange into its textual
+        ``[max:min]`` form.
+
+        Args:
+            bits (tuple[int, int]): Bit range as a ``(max, min)`` tuple. The
+                sentinel ``(0, 0)`` denotes a scalar (single-bit) signal.
+
+        Returns:
+            str: ``"[max:min]"`` for vectors or ``""`` for scalar signals.
+        """
+        if bits == (0, 0):
+            return ""
+        return f"[{bits[0]}:{bits[1]}]"
 
 
 ###########################################################################

--- a/tests/data/schematic_buses.vg
+++ b/tests/data/schematic_buses.vg
@@ -1,0 +1,15 @@
+module buses(addr, clk, data);
+
+  output [7:2] addr;
+  input  clk;
+  input [7:0] data;
+
+  // wires
+
+  wire [15:0] dbus;
+  wire [3:1] sel;
+
+  // components
+
+
+endmodule

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -165,3 +165,16 @@ def test_write_verilog():
     d = hello_world()
     d.write_verilog("test.vg")
     assert filecmp.cmp("test.vg", golden_file)
+
+
+def test_write_verilog_buses():
+    test_dir = Path(__file__).parent
+    golden_file = test_dir / "data" / "schematic_buses.vg"
+    d = Schematic("buses")
+    d.add_pin("data[7:0]", "input")
+    d.add_pin("addr[7:2]", "output")
+    d.add_pin("clk", "input")
+    d.add_net("dbus[15:0]")
+    d.add_net("sel[3:1]")
+    d.write_verilog("buses.vg")
+    assert filecmp.cmp("buses.vg", golden_file)


### PR DESCRIPTION
Bit ranges are stored as (max, min) tuples, but `write_verilog` emitted them reversed as "[min:max]" and guarded the range with `if bits[1]:`. That truthiness check treated any bus whose low bit is 0 as a scalar, silently dropping the width and producing structurally wrong Verilog for every vector port and net.

Reconstruct the range through a single `_format_bitrange()` helper that returns "[max:min]" for vectors and "" for the (0, 0) scalar sentinel. `get_partpins()` already rebuilt ranges correctly, so route it through the same helper to keep the two paths from diverging again.

Add `test_write_verilog_buses` with a golden netlist covering both the "[N:0]" and non-zero low bit cases for pins and nets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Verilog output for buses and bit ranges, with consistent formatting for scalar and vector pins and nets.
  * Added support for generating and validating Verilog for designs that include mixed-width interface signals.

* **Tests**
  * Added coverage for bus-style Verilog generation to help ensure the emitted hardware description matches expected output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->