### PR TITLE
add ubuntu26 tool scripts, not all checked

### DIFF
--- a/.github/workflows/bin/build_matrix.py
+++ b/.github/workflows/bin/build_matrix.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
                 prebuild = [f"install-{pretool}.sh" for pretool in prebuild]
 
             for runon, arm64 in (("ubuntu-latest", False), ("ubuntu-24.04-arm", True)):
-                if arm64 and osname not in ("ubuntu22", "ubuntu24"):
+                if arm64 and osname not in ("ubuntu22", "ubuntu24", "ubuntu26"):
                     continue
 
                 arch = "x86_64"

--- a/setup/ubuntu26/Docker.testbuild
+++ b/setup/ubuntu26/Docker.testbuild
@@ -1,0 +1,52 @@
+# Copyright (C) 2023 Zero ASIC
+
+FROM ubuntu:26.04
+
+LABEL org.opencontainers.image.source="https://github.com/siliconcompiler/siliconcompiler"
+LABEL org.opencontainers.image.description="Test tool build for SiliconCompiler tools"
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# Ensure we only install the required tools to keep images small
+RUN echo "APT::Install-Recommends \"false\";" >> /etc/apt/apt.conf
+RUN echo "APT::Install-Suggests \"false\";" >> /etc/apt/apt.conf
+
+# Since scripts are written to run locally,
+# we need to install sudo
+RUN apt-get update
+RUN TZ=Etc/UTC apt-get install -y tzdata && \
+    apt-get clean
+RUN apt-get install -y sudo \
+                       python3 python3-pip python3-venv && \
+    apt-get clean
+
+# Ensure PREFIX is captured by sudo for "sudo make install"
+RUN echo "Defaults env_keep += \"PREFIX\"" >> /etc/sudoers
+
+# Setup build environment
+ARG SC_PREFIX=/sc_tools
+ARG SC_BUILD=/sc_build
+
+RUN mkdir -p $SC_PREFIX
+RUN mkdir -p $SC_BUILD
+
+# Setup build environment
+ENV SC_PREFIX=$SC_PREFIX
+ENV SC_BUILD=$SC_BUILD
+ENV PREFIX=$SC_PREFIX
+ENV PATH="$SC_PREFIX/bin:$PATH"
+ENV LD_LIBRARY_PATH="$SC_PREFIX/lib:$SC_PREFIX/lib64"
+ENV C_INCLUDE_PATH="$SC_PREFIX/include"
+ENV CPLUS_INCLUDE_PATH="$SC_PREFIX/include"
+
+# Copy in support files
+COPY setup/build_tools.sh $SC_BUILD/
+COPY siliconcompiler/toolscripts/_tools.py $SC_BUILD/..
+COPY siliconcompiler/toolscripts/_tools.json $SC_BUILD/..
+COPY siliconcompiler/toolscripts/ubuntu26 $SC_BUILD
+
+WORKDIR $SC_BUILD
+
+ARG SC_INSTALL_SCRIPT
+RUN bash build_tools.sh ${SC_INSTALL_SCRIPT}

--- a/setup/ubuntu26/all.sh
+++ b/setup/ubuntu26/all.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-openfpga.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-bambu.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-sv2v.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-yosys.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-gtkwave.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-netgen.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-chisel.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-montage.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-klayout.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-vpr.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-bluespec.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-magic.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-verible.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-xyce.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-xdm.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-slurm.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-verilator.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-ghdl.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-surelog.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-slang.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-icepack.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-icarus.sh"
+docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-openroad.sh"
+
+# Skip due to yosys dependency
+#docker build ../.. --file Docker.testbuild --build-arg="SC_INSTALL_SCRIPT=install-nextpnr.sh"

--- a/siliconcompiler/toolscripts/ubuntu26/install-bambu.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-bambu.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y autoconf autoconf-archive automake libtool \
+    libbdd-dev libboost-all-dev libmpc-dev libmpfr-dev \
+    libxml2-dev liblzma-dev libmpfi-dev zlib1g-dev libicu-dev bison doxygen flex \
+    graphviz iverilog verilator make libsuitesparse-dev libglpk-dev libgmp-dev \
+    libfl-dev
+sudo apt-get install -y \
+    gcc-11 gcc-11-multilib g++-11 g++-11-multilib \
+    llvm-17 llvm-17-dev libllvm17 \
+    clang-17 libclang-17-dev
+
+sudo apt-get install -y git build-essential
+
+mkdir -p deps
+cd deps
+
+git clone $(python3 ${src_path}/_tools.py --tool bambu --field git-url) bambu
+cd bambu
+git checkout $(python3 ${src_path}/_tools.py --tool bambu --field git-commit)
+git submodule update --init --recursive
+
+if [ ! -z ${PREFIX} ]; then
+    args=--prefix="$PREFIX"
+else
+    args=--prefix=/opt/panda
+    SUDO_INSTALL=sudo
+
+    $SUDO_INSTALL mkdir -p /opt/panda
+    $SUDO_INSTALL chown $USER:$USER /opt/panda
+fi
+
+make -f Makefile.init
+
+mkdir obj
+cd obj
+
+CC=$(which gcc-11) CXX=$(which g++-11) ../configure --enable-release --disable-flopoco --with-opt-level=2 $args
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install
+
+cd -
+
+if [ -z ${PREFIX} ]; then
+    echo "Please add \"export PATH="/opt/panda/bin:\$PATH"\" to your .bashrc"
+fi

--- a/siliconcompiler/toolscripts/ubuntu26/install-bluespec.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-bluespec.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y ghc libghc-regex-compat-dev libghc-syb-dev \
+    libghc-old-time-dev libghc-split-dev tcl-dev build-essential pkg-config \
+    autoconf gperf flex bison
+
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+git clone $(python3 ${src_path}/_tools.py --tool bluespec --field git-url) bluespec
+cd bluespec
+git checkout $(python3 ${src_path}/_tools.py --tool bluespec --field git-commit)
+git submodule update --init --recursive
+
+make -j${NPROC:-$(nproc)} install-src
+
+if [ -z ${PREFIX} ]; then
+    # install
+    $SUDO_INSTALL mkdir -p /opt/tools/bsc
+    $SUDO_INSTALL chown $USER:$USER /opt/tools/bsc
+
+    BSC_VERSION=$(echo 'puts [lindex [Bluetcl::version] 0]' | inst/bin/bluetcl)
+    mv inst /opt/tools/bsc/bsc-${BSC_VERSION}
+    ln -s /opt/tools/bsc/bsc-${BSC_VERSION} /opt/tools/bsc/latest
+
+    echo "Please add \"export PATH=/opt/tools/bsc/latest/bin:\$PATH to your .bashrc"
+fi
+
+cd -
+

--- a/siliconcompiler/toolscripts/ubuntu26/install-chisel.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-chisel.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y wget
+
+mkdir -p deps
+cd deps
+
+version=$(python3 ${src_path}/_tools.py --tool chisel --field version)
+
+wget -O sbt.tgz https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.tgz
+
+args=
+if [ ! -z ${PREFIX} ]; then
+    args="-C $PREFIX --strip-components 1"
+fi
+
+$SUDO_INSTALL tar xvf sbt.tgz $args
+
+cd -
+
+if [ -z ${PREFIX} ]; then
+    echo "Please add \"export PATH="${src_path}/deps/sbt/bin:\$PATH"\" to your .bashrc"
+fi

--- a/siliconcompiler/toolscripts/ubuntu26/install-ghdl.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-ghdl.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y llvm-dev clang gnat libgnat-9 libz-dev
+
+sudo apt-get install -y git build-essential
+
+mkdir -p deps
+cd deps
+
+git clone $(python3 ${src_path}/_tools.py --tool ghdl --field git-url) ghdl
+cd ghdl
+git checkout $(python3 ${src_path}/_tools.py --tool ghdl --field git-commit)
+
+args=
+if [ ! -z ${PREFIX} ]; then
+    args=--prefix="$PREFIX"
+fi
+
+./configure --with-llvm-config $args
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-gtkwave.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-gtkwave.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y build-essential gperf libgtk-3-dev \
+    libbz2-dev libjudy-dev liblzma-dev tcl-dev tk-dev autotools-dev \
+    automake
+
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+git clone $(python3 ${src_path}/_tools.py --tool gtkwave --field git-url) gtkwave
+cd gtkwave
+git checkout $(python3 ${src_path}/_tools.py --tool gtkwave --field git-commit)
+
+args=
+if [ ! -z ${PREFIX} ]; then
+    args=--prefix="$PREFIX"
+fi
+
+cd gtkwave3-gtk3
+
+./autogen.sh
+./configure --enable-gtk3 $args
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install

--- a/siliconcompiler/toolscripts/ubuntu26/install-icarus.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-icarus.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y build-essential bison flex gperf libreadline-dev libncurses-dev \
+    autotools-dev automake
+
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+git clone $(python3 ${src_path}/_tools.py --tool icarus --field git-url) icarus
+cd icarus
+git checkout $(python3 ${src_path}/_tools.py --tool icarus --field git-commit)
+
+args=
+if [ ! -z ${PREFIX} ]; then
+    args=--prefix="$PREFIX"
+fi
+
+sh autoconf.sh
+./configure $args
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install

--- a/siliconcompiler/toolscripts/ubuntu26/install-icepack.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-icepack.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y build-essential clang bison flex libreadline-dev \
+                        gawk tcl-dev libffi-dev git mercurial graphviz   \
+                        xdot pkg-config python3 libftdi-dev \
+                        qtbase5-dev python3-dev libboost-all-dev cmake libeigen3-dev
+
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+git clone $(python3 ${src_path}/_tools.py --tool icepack --field git-url) icepack
+cd icepack
+git checkout $(python3 ${src_path}/_tools.py --tool icepack --field git-commit)
+
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install PREFIX="$PREFIX"
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-keplerformal.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-keplerformal.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y build-essential libfl-dev
+
+# From: https://github.com/keplertech/kepler-formal/blob/ea6b0ce62f6f8fd2327e79913a07c74a3210551d/README.md
+sudo apt-get install -y g++ libboost-dev python3-dev capnproto libcapnp-dev libtbb-dev \
+    pkg-config bison flex doxygen libspdlog-dev libfmt-dev libboost-iostreams-dev zlib1g-dev
+
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+python3 -m venv .keplerformal --clear
+. .keplerformal/bin/activate
+python3 -m pip install cmake==3.31.6
+
+git clone $(python3 ${src_path}/_tools.py --tool keplerformal --field git-url) keplerformal
+cd keplerformal
+git checkout $(python3 ${src_path}/_tools.py --tool keplerformal --field git-commit)
+git submodule update --init --recursive
+
+git apply - <<EOF
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 65d0d04..a67d38f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -26,9 +26,9 @@ add_subdirectory(thirdparty)
+ 
+ # option(ENABLE_UNIT_TESTS ON)
+ # if(ENABLE_UNIT_TESTS)
+-include(CTest)
+-enable_testing()
+-add_subdirectory(test)
++# include(CTest)
++# enable_testing()
++# add_subdirectory(test)
+ # endif()
+ 
+ option(CODE_COVERAGE "Enable coverage reporting" OFF)
+EOF
+
+cmake_args=""
+if [ ! -z ${PREFIX} ]; then
+    cmake_args="-DCMAKE_INSTALL_PREFIX=$PREFIX"
+fi
+
+mkdir -p build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS_RELEASE="-Ofast -march=native -ffast-math -flto" \
+    -DCMAKE_EXE_LINKER_FLAGS="-flto" \
+	-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE \
+    $cmake_args
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install
+
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-klayout.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-klayout.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y wget software-properties-common
+
+mkdir -p deps
+cd deps
+
+pkg_version=$(python3 ${src_path}/_tools.py --tool klayout --field version)
+version=$(lsb_release -sr)
+
+# KLayout does not publish a versioned Ubuntu-26 .deb, and the Ubuntu-24 build is
+# not installable on 26.04 (it pins Qt5/libgit2-1.7/libruby3.2/libpython3.12).
+# Use the distro package from the 26.04 universe repository instead.
+if [ "$version" = "26.04" ]; then
+    sudo add-apt-repository -y universe
+    sudo apt-get update
+    sudo apt-get install -y klayout
+    cd -
+    exit 0
+fi
+
+if [ "$version" = "18.04" ]; then
+    url="https://www.klayout.org/downloads/Ubuntu-18/klayout_${pkg_version}-1_amd64.deb"
+elif [ "$version" = "20.04" ]; then
+    url="https://www.klayout.org/downloads/Ubuntu-20/klayout_${pkg_version}-1_amd64.deb"
+elif [ "$version" = "22.04" ]; then
+    url="https://www.klayout.org/downloads/Ubuntu-22/klayout_${pkg_version}-1_amd64.deb"
+elif [ "$version" = "24.04" ]; then
+    url="https://www.klayout.org/downloads/Ubuntu-24/klayout_${pkg_version}-1_amd64.deb"
+else
+    echo "Script doesn't support Ubuntu version $version."
+fi
+
+# Fetch package
+wget -O klayout.deb $url
+# Install package
+sudo apt-get install -y ./klayout.deb
+
+if [ ! -z ${SC_PREFIX+x} ]; then
+    sudo cp ./klayout.deb "${SC_PREFIX}/"
+fi
+
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-magic.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-magic.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y build-essential m4 tcsh csh libx11-dev tcl-dev tk-dev
+
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+git clone $(python3 ${src_path}/_tools.py --tool magic --field git-url) magic
+cd magic
+git checkout $(python3 ${src_path}/_tools.py --tool magic --field git-commit)
+
+args=
+if [ ! -z ${PREFIX} ]; then
+    args=--prefix="$PREFIX"
+fi
+
+LD_FLAGS=-shared ./configure $args
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install

--- a/siliconcompiler/toolscripts/ubuntu26/install-montage.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-montage.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -ex
+
+sudo apt-get update
+
+sudo apt-get install -y imagemagick

--- a/siliconcompiler/toolscripts/ubuntu26/install-netgen.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-netgen.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y build-essential tcl-dev tk-dev m4
+
+sudo apt-get install -y git autotools-dev automake
+
+mkdir -p deps
+cd deps
+
+git clone $(python3 ${src_path}/_tools.py --tool netgen --field git-url) netgen
+cd netgen
+git checkout $(python3 ${src_path}/_tools.py --tool netgen --field git-commit)
+
+args=
+if [ ! -z ${PREFIX} ]; then
+    args=--prefix="$PREFIX"
+fi
+
+./configure $args
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install

--- a/siliconcompiler/toolscripts/ubuntu26/install-nextpnr.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-nextpnr.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -ex
+
+sudo apt-get update
+
+sudo apt-get install -y build-essential clang bison flex libreadline-dev \
+                        gawk tcl-dev libffi-dev git mercurial graphviz   \
+                        xdot pkg-config python3 libftdi-dev \
+                        qtbase5-dev python3-dev libboost-all-dev cmake libeigen3-dev
+
+sudo apt-get install -y git
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+mkdir -p deps
+cd deps
+
+python3 -m venv .nextpnr --clear
+. .nextpnr/bin/activate
+python3 -m pip install cmake==3.28.4
+
+git clone $(python3 ${src_path}/_tools.py --tool nextpnr --field git-url) nextpnr
+cd nextpnr
+git checkout $(python3 ${src_path}/_tools.py --tool nextpnr --field git-commit)
+
+args=
+if [ ! -z ${PREFIX} ]; then
+    args=-DCMAKE_INSTALL_PREFIX="$PREFIX"
+fi
+
+cmake -S . -B build -DARCH=ice40 $args
+cmake --build build -j${NPROC:-$(nproc)}
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+cd build
+$SUDO_INSTALL make install
+
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-openroad.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-openroad.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+set -ex
+
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y git curl
+sudo apt-get install -y make pandoc groff bsdmainutils
+
+mkdir -p deps
+cd deps
+
+mkdir -p bazelbin/bin
+BAZEL_PREFIX=$(pwd)/bazelbin
+
+PATH="$BAZEL_PREFIX/bin:$PATH"
+
+git clone $(python3 ${src_path}/_tools.py --tool openroad --field git-url) openroad
+cd openroad
+git checkout $(python3 ${src_path}/_tools.py --tool openroad --field git-commit)
+git submodule update --init --recursive
+
+sudo ./etc/DependencyInstaller.sh -bazel -prefix="$BAZEL_PREFIX"
+sudo chown -R $USER:$USER $BAZEL_PREFIX
+
+if [ ! -z ${PREFIX} ]; then
+    install_loc="$PREFIX"
+else
+    install_loc="$HOME/.local"
+fi
+
+bazelisk run :install --config=release --//:platform=gui -- "$install_loc"
+
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-opensta.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-opensta.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+set -ex
+
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+sudo apt-get update
+
+sudo apt-get install -y git build-essential wget
+sudo apt-get install -y tcl-dev tcl-tclreadline \
+    bison flex libfl-dev zlib1g-dev automake autotools-dev
+
+mkdir -p deps
+cd deps
+
+python3 -m venv .opensta --clear
+. .opensta/bin/activate
+python3 -m pip install cmake==3.31.6
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+if [ ! -z ${PREFIX} ]; then
+    cmake_args="-DCMAKE_INSTALL_PREFIX=$PREFIX"
+    config_prefix="--prefix=$PREFIX"
+    export PATH="$PREFIX/bin:$PATH"
+fi
+
+# eigen
+mkdir -p eigen3
+cd eigen3
+git clone --depth=1 -b 3.4 https://gitlab.com/libeigen/eigen.git
+cd eigen
+mkdir build
+cd build
+cmake $cmake_args ..
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install
+
+cd ../../..
+# cudd
+mkdir -p cudd
+cd cudd
+git clone --depth=1 -b 3.0.0 https://github.com/The-OpenROAD-Project/cudd.git
+cd cudd
+autoreconf
+./configure $config_prefix
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install
+
+cd ../..
+#swig
+wget -O swig.tar.gz https://github.com/swig/swig/archive/v4.1.0.tar.gz
+tar xfz swig.tar.gz
+cd swig-4.1.0
+
+wget https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.42/pcre2-10.42.tar.gz
+./Tools/pcre-build.sh
+
+./autogen.sh
+./configure $config_prefix
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make -j${NPROC:-$(nproc)} install
+
+cd ../..
+# opensta
+git clone $(python3 ${src_path}/_tools.py --tool opensta --field git-url) opensta
+cd opensta
+git checkout $(python3 ${src_path}/_tools.py --tool opensta --field git-commit)
+git submodule update --init --recursive
+
+mkdir -p build
+cd build
+cmake .. $cmake_args
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install
+
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-slurm.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-slurm.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+set -ex
+
+sudo apt-get update
+
+sudo apt-get install -y munge libmunge-dev build-essential libmariadb-dev lbzip2 libjson-c-dev
+sudo apt-get install -y libdbus-1-dev
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get install -y wget
+
+mkdir -p deps
+cd deps
+
+pkg_version=$(python3 ${src_path}/_tools.py --tool slurm --field version)
+
+# Build and install Slurm
+wget -O slurm.tar.bz2 https://download.schedmd.com/slurm/slurm-${pkg_version}.tar.bz2
+mkdir -p slurm
+tar xvf slurm.tar.bz2 --strip-components=1 -C slurm
+
+cd slurm
+
+cfg_args=""
+if [ ! -z ${PREFIX} ]; then
+    cfg_args="--prefix=$PREFIX"
+fi
+
+./configure $cfg_args
+
+make -j${NPROC:-$(nproc)}
+
+$SUDO_INSTALL make install

--- a/siliconcompiler/toolscripts/ubuntu26/install-surelog.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-surelog.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+sudo apt-get update
+
+# These dependencies are up-to-date with instructions from the INSTALL.md from the commit we are pinned to below
+sudo apt-get install -y build-essential cmake git pkg-config \
+    tclsh swig uuid-dev libgoogle-perftools-dev python3 \
+    python3-orderedmultidict python3-psutil python3-dev \
+    default-jre lcov zlib1g-dev
+
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+python3 -m venv .surelog --clear
+. .surelog/bin/activate
+python3 -m pip install cmake==3.31.6
+python3 -m pip install orderedmultidict
+
+git clone $(python3 ${src_path}/_tools.py --tool surelog --field git-url) surelog
+cd surelog
+git checkout $(python3 ${src_path}/_tools.py --tool surelog --field git-commit)
+git submodule update --init --recursive
+
+make -j${NPROC:-$(nproc)}
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+$SUDO_INSTALL make install
+
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-surfer.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-surfer.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+mkdir -p deps
+cd deps
+
+sudo apt-get update
+
+sudo apt-get install -y build-essential curl git libssl-dev openssl pkg-config
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s - -y
+export PATH="$HOME/.cargo/bin:$PATH"
+
+git clone $(python3 ${src_path}/_tools.py --tool surfer --field git-url) surfer
+cd surfer
+git checkout $(python3 ${src_path}/_tools.py --tool surfer --field git-commit)
+git submodule update --init
+
+cargo fetch --locked
+cargo build -j ${NPROC:-$(nproc)} --frozen --release
+
+if [ ! -z ${PREFIX} ]; then
+    $SUDO_INSTALL install -Dm00755 target/release/surfer -t ${PREFIX}/bin
+fi

--- a/siliconcompiler/toolscripts/ubuntu26/install-sv2v.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-sv2v.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+mkdir -p deps
+cd deps
+
+sudo apt-get update
+
+sudo apt-get install -y curl git
+
+haskell_args=""
+if [ ! -z ${PREFIX} ]; then
+    haskell_args="-d $PREFIX"
+    export PATH="$PREFIX:$PATH"
+fi
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+curl -sSL https://get.haskellstack.org/ | $SUDO_INSTALL sh -s - -f $haskell_args
+
+git clone $(python3 ${src_path}/_tools.py --tool sv2v --field git-url) sv2v
+cd sv2v
+git checkout $(python3 ${src_path}/_tools.py --tool sv2v --field git-commit)
+
+make -j${NPROC:-$(nproc)}
+
+if [ ! -z ${PREFIX} ]; then
+    $SUDO_INSTALL mkdir -p ${PREFIX}/bin/
+    $SUDO_INSTALL cp bin/* ${PREFIX}/bin/
+fi
+
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-vcd2fst.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-vcd2fst.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+sudo apt-get update
+
+sudo apt-get install -y build-essential make curl libdwarf-dev libdw-dev
+
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+python3 -m venv .vcd2fst --clear
+. .vcd2fst/bin/activate
+python3 -m pip install cmake==3.31.6
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+if [ ! -z ${PREFIX} ]; then
+    cmake_args="-DCMAKE_INSTALL_PREFIX=$PREFIX"
+fi
+
+git clone $(python3 ${src_path}/_tools.py --tool vcd2fst --field git-url) vcd2fst
+cd vcd2fst
+git checkout $(python3 ${src_path}/_tools.py --tool vcd2fst --field git-commit)
+git submodule update --init --recursive
+
+mkdir -p build
+cd build
+cmake .. $cmake_args -DCMAKE_BUILD_TYPE=Release
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL mkdir -p $PREFIX/bin
+$SUDO_INSTALL cp vcd2fst $PREFIX/bin
+
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-verible.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-verible.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y wget
+
+mkdir -p deps
+cd deps
+
+version=$(python3 ${src_path}/_tools.py --tool verible --field version)
+filename=verible-$version-linux-static-x86_64.tar.gz
+
+wget https://github.com/chipsalliance/verible/releases/download/$version/$filename
+
+tar xzf $filename
+
+if [ -z ${PREFIX} ]; then
+    PREFIX=/opt/verible
+    SUDO_INSTALL=sudo
+    $SUDO_INSTALL mkdir -p $PREFIX
+    echo "Please add \"export PATH="/opt/verible/bin:\$PATH"\" to your .bashrc"
+fi
+
+$SUDO_INSTALL mkdir -p $PREFIX/bin
+$SUDO_INSTALL mv verible-$version/bin/* $PREFIX/bin/

--- a/siliconcompiler/toolscripts/ubuntu26/install-verilator.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-verilator.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y git perl python3 make autoconf g++ flex bison ccache
+sudo apt-get install -y libgoogle-perftools-dev numactl perl-doc help2man
+sudo apt-get install -y libfl2
+sudo apt-get install -y libfl-dev
+sudo apt-get install -y zlib1g zlib1g-dev
+
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+unset VERILATOR_ROOT
+
+git clone $(python3 ${src_path}/_tools.py --tool verilator --field git-url) verilator
+cd verilator
+git checkout $(python3 ${src_path}/_tools.py --tool verilator --field git-commit)
+
+autoconf
+
+args=
+if [ ! -z ${PREFIX} ]; then
+    args=--prefix="$PREFIX"
+fi
+
+./configure $args
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install
+
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-vpr.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-vpr.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y git wget
+
+mkdir -p deps
+cd deps
+
+git clone $(python3 ${src_path}/_tools.py --tool vpr --field git-url) vpr
+cd vpr
+git checkout $(python3 ${src_path}/_tools.py --tool vpr --field git-commit)
+git submodule update --init --recursive
+
+./install_apt_packages.sh
+
+args=
+if [ ! -z ${PREFIX} ]; then
+    args="-DCMAKE_INSTALL_PREFIX=$PREFIX"
+fi
+
+make CMAKE_PARAMS="$args -DWITH_PARMYS=OFF -DWITH_ABC=OFF -DSLANG_SYSTEMVERILOG=OFF" -j${NPROC:-$(nproc)}
+cd build
+$SUDO_INSTALL make install

--- a/siliconcompiler/toolscripts/ubuntu26/install-wildebeest.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-wildebeest.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+sudo apt-get update
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+python3 -m venv .wildebeest --clear
+. .wildebeest/bin/activate
+python3 -m pip install cmake==3.31.6
+
+git clone $(python3 ${src_path}/_tools.py --tool wildebeest --field git-url) wildebeest
+cd wildebeest
+git checkout $(python3 ${src_path}/_tools.py --tool wildebeest --field git-commit)
+
+cmake -S . -B build
+cmake --build build -j${NPROC:-$(nproc)}
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+cd build
+$SUDO_INSTALL make install
+
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-xdm.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-xdm.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+sudo apt-get update
+
+sudo apt-get install -y wget unzip
+
+mkdir -p deps
+cd deps
+
+version=$(python3 ${src_path}/_tools.py --tool xdm --field version)
+
+wget -O xdm.zip https://xyce.sandia.gov/files/xyce/Binaries/xdm-${version}-Linux.zip
+
+unzip xdm.zip
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo"
+else
+    SUDO_INSTALL=""
+fi
+
+$SUDO_INSTALL mkdir -p $PREFIX/bin
+$SUDO_INSTALL cp xdm*/bin/xdm_bdl $PREFIX/bin/
+
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-xyce.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-xyce.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+sudo apt-get update
+
+# Install core dependencies.
+sudo apt-get install -y build-essential gcc g++ make cmake automake autoconf bison flex git libblas-dev \
+    liblapack-dev liblapack64-dev libfftw3-dev libsuitesparse-dev libopenmpi-dev libboost-all-dev \
+    libnetcdf-dev libmatio-dev gfortran libfl-dev libtool python3-venv
+
+sudo apt-get install -y wget
+
+mkdir -p deps
+cd deps
+
+if [ -z ${PREFIX} ]; then
+    PREFIX=~/.local
+fi
+
+# Install CMAKE
+python3 -m venv .xyce --clear
+. .xyce/bin/activate
+python3 -m pip install cmake>=3.23.0
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+# Download Trilinos.
+## Version specified in: https://github.com/Xyce/Xyce/blob/master/INSTALL.md#building-trilinos
+trilinos_version=14-4-0
+wget https://github.com/trilinos/Trilinos/archive/refs/tags/trilinos-release-${trilinos_version}.tar.gz --no-verbose -O trilinos.tar.gz
+mkdir -p trilinos
+tar --strip-components=1 -xf trilinos.tar.gz -C trilinos
+
+# Download Xyce.
+git clone $(python3 ${src_path}/_tools.py --tool xyce --field git-url) xyce
+cd xyce
+git checkout $(python3 ${src_path}/_tools.py --tool xyce --field git-commit)
+
+# Build Trilinos
+mkdir trilinos-build
+cd trilinos-build
+cmake \
+    -D CMAKE_INSTALL_PREFIX=$PREFIX/trilinos \
+    -D AMD_LIBRARY_DIRS="/usr/lib" \
+    -D TPL_AMD_INCLUDE_DIRS="/usr/include/suitesparse" \
+    -C ../cmake/trilinos/trilinos-base.cmake \
+    ../../trilinos
+cmake --build . -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install
+
+cd ..
+
+# Build Xyce
+mkdir xyce-build
+cd xyce-build
+
+cmake \
+    -D CMAKE_INSTALL_PREFIX=$PREFIX \
+    -D Trilinos_ROOT=$PREFIX/trilinos \
+    -D BUILD_SHARED_LIBS=ON \
+    ..
+
+cmake --build . -j${NPROC:-$(nproc)}
+cmake --build . -j${NPROC:-$(nproc)} --target xycecinterface
+$SUDO_INSTALL make install

--- a/siliconcompiler/toolscripts/ubuntu26/install-yosys-moosic.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-yosys-moosic.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+git clone $(python3 ${src_path}/_tools.py --tool yosys-moosic --field git-url) yosys-moosic
+cd yosys-moosic
+git checkout $(python3 ${src_path}/_tools.py --tool yosys-moosic --field git-commit)
+
+make -j${NPROC:-$(nproc)}
+$SUDO_INSTALL make install
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-yosys-slang.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-yosys-slang.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+sudo apt-get update
+
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+python3 -m venv .yosys-slang --clear
+. .yosys-slang/bin/activate
+python3 -m pip install cmake==3.31.6
+
+git clone $(python3 ${src_path}/_tools.py --tool yosys-slang --field git-url) yosys-slang
+cd yosys-slang
+git checkout $(python3 ${src_path}/_tools.py --tool yosys-slang --field git-commit)
+git submodule update --init --recursive
+
+make -j${NPROC:-$(nproc)}
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL="sudo -E PATH=$PATH"
+else
+    SUDO_INSTALL=""
+fi
+
+$SUDO_INSTALL make install
+cd -

--- a/siliconcompiler/toolscripts/ubuntu26/install-yosys.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-yosys.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -ex
+
+# Get directory of script
+src_path=$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)/..
+
+USE_SUDO_INSTALL="${USE_SUDO_INSTALL:-yes}"
+if [ "${USE_SUDO_INSTALL:-yes}" = "yes" ]; then
+    SUDO_INSTALL=sudo
+else
+    SUDO_INSTALL=""
+fi
+
+sudo apt-get update
+
+# From: https://github.com/YosysHQ/yosys/blob/f2c689403ace0637b7455bac8f1e8d4bc312e74f/README.md
+sudo apt-get install -y build-essential clang bison flex \
+	libreadline-dev gawk tcl-dev libffi-dev git libfl-dev \
+	graphviz xdot pkg-config python3 libboost-system-dev \
+	libboost-python-dev libboost-filesystem-dev zlib1g-dev
+
+sudo apt-get install -y git
+
+mkdir -p deps
+cd deps
+
+git clone $(python3 ${src_path}/_tools.py --tool yosys --field git-url) yosys
+cd yosys
+git checkout $(python3 ${src_path}/_tools.py --tool yosys --field git-commit)
+git submodule update --init --recursive
+
+make -j${NPROC:-$(nproc)} PREFIX="$PREFIX"
+$SUDO_INSTALL make install PREFIX="$PREFIX"
+cd -


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ubuntu 26.04 support for build and install workflows.
  * Introduced install scripts for many tools, making it easier to set up supported dependencies on Ubuntu 26.
  * Added an automated build matrix update so ARM64 builds now include the new Ubuntu target.

* **Bug Fixes**
  * Improved installer behavior across different environments with optional install prefixes and sudo handling.
  * Added a special-case path for KLayout on Ubuntu 26.04 to use the available package source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->