### PR TITLE
allow partial matches on set and get flows

### DIFF
--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -868,7 +868,7 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         if len(flows) == 1:
             return flows[0]
         else:
-            if flow not in self.__flow_warnings:
+            if flows and flow not in self.__flow_warnings:
                 self.__flow_warnings.append(flow)
                 self.logger.warning(f"Flowgraph '{flow}' not found, and multiple "
                                     f"matches exist: {', '.join(flows)}")

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -857,6 +857,9 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         Args:
             flow (str): The name of the flowgraph to search for.
         """
+        if not flow:
+            return None
+
         if flow in self.getkeys("flowgraph"):
             return flow
 

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -128,6 +128,9 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         # Init options callbacks
         self.__init_option_callbacks()
 
+        # Init flow warnings list
+        self.__flow_warnings = []
+
         if design:
             if isinstance(design, str):
                 self.option.set_design(design)
@@ -847,6 +850,31 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
 
         return self.option.set_design(design)
 
+    def __find_flow(self, flow: str) -> Optional[str]:
+        """
+        Attempts to find a flowgraph by name, allowing for partial matches.
+
+        Args:
+            flow (str): The name of the flowgraph to search for.
+        """
+        if flow in self.getkeys("flowgraph"):
+            return flow
+
+        flows = []
+        for loaded_flow in self.getkeys("flowgraph"):
+            if loaded_flow.startswith(flow):
+                flows.append(loaded_flow)
+
+        if len(flows) == 1:
+            return flows[0]
+        else:
+            if flow not in self.__flow_warnings:
+                self.__flow_warnings.append(flow)
+                self.logger.warning(f"Flowgraph '{flow}' not found, and multiple "
+                                    f"matches exist: {', '.join(flows)}")
+
+        return None
+
     def set_flow(self, flow: Union[Flowgraph, str]):
         """
         Sets the active flowgraph for this project.
@@ -855,12 +883,23 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         (the flow) that the project will execute. If a `Flowgraph` object
         is provided, it is first added as a dependency.
 
+        When given a string, the name is resolved against the flowgraphs already
+        loaded into the project. An exact match is preferred; if none exists, the
+        name is treated as a prefix and matched against the loaded flowgraph
+        names. This allows a short name to select a variant-suffixed flow, for
+        example ``"synflow"`` resolves to ``"synflow-verilog"``. The match must be
+        unique: if the prefix matches more than one loaded flowgraph, a warning
+        listing the candidates is logged and a `KeyError` is raised.
+
         Args:
-            flow (Union[Flowgraph, str]): The flowgraph object or its name (string)
-                                                to be set as the current flow.
+            flow (Union[Flowgraph, str]): The flowgraph object, or the full or
+                partial (prefix) name of a flowgraph already loaded into the
+                project.
 
         Raises:
             TypeError: If the provided `flow` is not a string or a `Flowgraph` object.
+            KeyError: If no loaded flowgraph matches the given name, or if a partial
+                name matches more than one loaded flowgraph.
         """
         if isinstance(flow, Flowgraph):
             self.add_dep(flow)
@@ -868,21 +907,42 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         elif not isinstance(flow, str):
             raise TypeError("flow must be a string or a Flowgraph object")
 
+        # Attempt to find the flow
+        if not self.valid("flowgraph", flow):
+            find_flow = self.__find_flow(flow)
+            if find_flow:
+                self.logger.debug(
+                    f"Flowgraph '{flow}' not found, using '{find_flow}' instead")
+                flow = find_flow
+            else:
+                raise KeyError(f"{flow} flowgraph has not been loaded")
+
         return self.option.set_flow(flow)
 
     def get_flow(self, name: Optional[str] = None) -> Flowgraph:
         """
         Retrieves a flowgraph by name.
 
+        The name is resolved against the flowgraphs already loaded into the
+        project. An exact match is preferred; if none exists, the name is treated
+        as a prefix and matched against the loaded flowgraph names. This allows a
+        short name to select a variant-suffixed flow, for example ``"synflow"``
+        resolves to ``"synflow-verilog"``. The match must be unique: if the prefix
+        matches more than one loaded flowgraph, a warning listing the candidates
+        is logged and a `KeyError` is raised.
+
         Args:
-            name (str, optional): The name of the flowgraph to retrieve. If None,
-                                  retrieves the currently selected flowgraph.
+            name (str, optional): The full or partial (prefix) name of the
+                flowgraph to retrieve. If None, the currently selected flowgraph
+                (:keypath:`option,flow`) is used.
 
         Returns:
-            Flowgraph: The `Flowgraph` object corresponding to the specified name.
+            Flowgraph: The `Flowgraph` object corresponding to the resolved name.
 
         Raises:
-            KeyError: If the specified flowgraph is not found in the project.
+            KeyError: If no flow is currently selected (when `name` is None), if no
+                loaded flowgraph matches the given name, or if a partial name
+                matches more than one loaded flowgraph.
         """
         if name is None:
             name = self.option.get_flow()
@@ -890,7 +950,13 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
                 raise KeyError("no flow is currently selected")
 
         if not self.valid("flowgraph", name):
-            raise KeyError(f"{name} flowgraph has not been loaded")
+            find_flow = self.__find_flow(name)
+            if find_flow:
+                self.logger.debug(
+                    f"Flowgraph '{name}' not found, using '{find_flow}' instead")
+                name = find_flow
+            else:
+                raise KeyError(f"{name} flowgraph has not been loaded")
 
         return self.get("flowgraph", name, field="schema")
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -262,6 +262,18 @@ def test_get_flow_by_name_partial_unclear_double(project_logger, caplog):
         "Flowgraph 'test' not found, and multiple matches exist: testflow-0, testflow-1") == 1
 
 
+def test_get_flow_by_name_partial_unclear_none(project_logger, caplog):
+    project = Project()
+    project_logger(project)
+    project.logger.setLevel(logging.INFO)
+    flow = Flowgraph("testflow-0")
+    project.set_flow(flow)
+    project.add_dep(Flowgraph("testflow-1"))
+    with pytest.raises(KeyError, match=r"^'test0 flowgraph has not been loaded'$"):
+        project.get_flow("test0")
+    assert "Flowgraph 'test0' not found, and multiple matches exist:" not in caplog.text
+
+
 def test_get_flow_default_selected():
     project = Project()
     flow = Flowgraph("testflow")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -163,10 +163,37 @@ def test_set_design_obj():
     assert project.design is design
 
 
+def test_set_flow_not_loaded():
+    project = Project()
+    with pytest.raises(KeyError, match=r"^'testflow flowgraph has not been loaded'$"):
+        project.set_flow("testflow")
+
+
 def test_set_flow_str():
     project = Project()
+    project.add_dep(Flowgraph("testflow"))
     project.set_flow("testflow")
     assert project.get("option", "flow") == "testflow"
+
+
+def test_set_flow_partial():
+    project = Project()
+    project.add_dep(Flowgraph("testflow"))
+    project.set_flow("test")
+    assert project.get("option", "flow") == "testflow"
+
+
+
+def test_set_flow_partial_unclear(project_logger, caplog):
+    project = Project()
+    project_logger(project)
+    project.logger.setLevel(logging.INFO)
+    project.add_dep(Flowgraph("testflow-0"))
+    project.add_dep(Flowgraph("testflow-1"))
+    with pytest.raises(KeyError, match=r"^'test flowgraph has not been loaded'$"):
+        project.set_flow("test")
+    assert "Flowgraph 'test' not found, and multiple matches exist: testflow-0, testflow-1" \
+        in caplog.text
 
 
 def test_set_flow_not_valid():
@@ -189,7 +216,7 @@ def test_get_flow_no_selection():
 
 def test_get_flow_missing_flowgraph():
     project = Project()
-    project.set_flow("testflow")
+    project.set("option", "flow", "testflow")
     with pytest.raises(KeyError, match=r"^'testflow flowgraph has not been loaded'$"):
         project.get_flow()
 
@@ -199,6 +226,40 @@ def test_get_flow_by_name():
     flow = Flowgraph("testflow")
     project.set_flow(flow)
     assert project.get_flow("testflow") is flow
+
+
+def test_get_flow_by_name_partial():
+    project = Project()
+    flow = Flowgraph("testflow")
+    project.set_flow(flow)
+    assert project.get_flow("test") is flow
+
+
+def test_get_flow_by_name_partial_unclear(project_logger, caplog):
+    project = Project()
+    project_logger(project)
+    project.logger.setLevel(logging.INFO)
+    flow = Flowgraph("testflow-0")
+    project.set_flow(flow)
+    project.add_dep(Flowgraph("testflow-1"))
+    with pytest.raises(KeyError, match=r"^'test flowgraph has not been loaded'$"):
+        project.get_flow("test")
+    assert "Flowgraph 'test' not found, and multiple matches exist: testflow-0, testflow-1" \
+        in caplog.text
+
+
+def test_get_flow_by_name_partial_unclear_double(project_logger, caplog):
+    project = Project()
+    project_logger(project)
+    project.logger.setLevel(logging.INFO)
+    flow = Flowgraph("testflow-0")
+    project.set_flow(flow)
+    project.add_dep(Flowgraph("testflow-1"))
+    with pytest.raises(KeyError, match=r"^'test flowgraph has not been loaded'$"):
+        project.get_flow("test")
+    with pytest.raises(KeyError, match=r"^'test flowgraph has not been loaded'$"):
+        project.get_flow("test")
+    assert caplog.text.count("Flowgraph 'test' not found, and multiple matches exist: testflow-0, testflow-1") == 1
 
 
 def test_get_flow_default_selected():
@@ -2159,13 +2220,6 @@ def test_set_design_with_whitespace_name():
     proj = Project()
     proj.set_design("test design")
     assert proj.name == "test design"
-
-
-def test_set_flow_with_empty_string():
-    """Test set_flow with empty string."""
-    proj = Project()
-    proj.set_flow("")
-    assert proj.get("option", "flow") == ""
 
 
 def test_add_alias_repeat_with_same_values():

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -183,7 +183,6 @@ def test_set_flow_partial():
     assert project.get("option", "flow") == "testflow"
 
 
-
 def test_set_flow_partial_unclear(project_logger, caplog):
     project = Project()
     project_logger(project)
@@ -259,7 +258,8 @@ def test_get_flow_by_name_partial_unclear_double(project_logger, caplog):
         project.get_flow("test")
     with pytest.raises(KeyError, match=r"^'test flowgraph has not been loaded'$"):
         project.get_flow("test")
-    assert caplog.text.count("Flowgraph 'test' not found, and multiple matches exist: testflow-0, testflow-1") == 1
+    assert caplog.text.count(
+        "Flowgraph 'test' not found, and multiple matches exist: testflow-0, testflow-1") == 1
 
 
 def test_get_flow_default_selected():

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -274,6 +274,18 @@ def test_get_flow_by_name_partial_unclear_none(project_logger, caplog):
     assert "Flowgraph 'test0' not found, and multiple matches exist:" not in caplog.text
 
 
+def test_get_flow_by_name_partial_unclear_empty(project_logger, caplog):
+    project = Project()
+    project_logger(project)
+    project.logger.setLevel(logging.INFO)
+    flow = Flowgraph("testflow-0")
+    project.set_flow(flow)
+    project.add_dep(Flowgraph("testflow-1"))
+    with pytest.raises(KeyError, match=r"^' flowgraph has not been loaded'$"):
+        project.get_flow("")
+    assert "multiple matches exist:" not in caplog.text
+
+
 def test_get_flow_default_selected():
     project = Project()
     flow = Flowgraph("testflow")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flow selection and retrieval now support partial name matching when the match is unambiguous.

* **Bug Fixes**
  * Improved handling for flows that haven’t been loaded yet, with consistent failures instead of incorrect selections.
  * Ambiguous partial matches now produce a clear “multiple matches exist” warning and do not select a wrong flow.
  * Repeated ambiguous lookups no longer spam the same warning.

* **Tests**
  * Expanded coverage for partial matching success and failure, warning behavior, and additional project scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->