### PR TITLE
use None internally for global keys

### DIFF
--- a/siliconcompiler/scheduler/send_messages.py
+++ b/siliconcompiler/scheduler/send_messages.py
@@ -23,7 +23,6 @@ from pathlib import Path
 from siliconcompiler import sc_open
 from siliconcompiler.utils import default_email_credentials_file, get_file_template
 from siliconcompiler.report import utils as report_utils
-from siliconcompiler.schema import Parameter
 from siliconcompiler.flowgraph import RuntimeFlowgraph
 from siliconcompiler.utils.paths import workdir
 
@@ -83,13 +82,8 @@ def send(project, msg_type, step, index):
         index (str): The index associated with the event. Can be None for
             global events.
     """
-    project_step, project_index = step, index
-    if step is None:
-        project_step = Parameter.GLOBAL_KEY
-    if index is None:
-        project_index = Parameter.GLOBAL_KEY
-    to = project.option.scheduler.get_msgcontact(step=project_step, index=project_index)
-    event = project.option.scheduler.get_msgevent(step=project_step, index=project_index)
+    to = project.option.scheduler.get_msgcontact(step=step, index=index)
+    event = project.option.scheduler.get_msgevent(step=step, index=index)
 
     if not to or not event:
         # nothing to do

--- a/siliconcompiler/schema/parameter.py
+++ b/siliconcompiler/schema/parameter.py
@@ -262,12 +262,12 @@ class Parameter:
                     return self.__defvalue.get(field=field)
 
             try:
-                return self.__node[step][Parameter.GLOBAL_KEY].get(field=field)
+                return self.__node[step][None].get(field=field)
             except KeyError:
                 pass
 
             try:
-                return self.__node[Parameter.GLOBAL_KEY][Parameter.GLOBAL_KEY].get(field=field)
+                return self.__node[None][None].get(field=field)
             except KeyError:
                 return self.__defvalue.get(field=field)
         elif field == "type":
@@ -360,9 +360,6 @@ class Parameter:
             if isinstance(index, int):
                 index = str(index)
 
-            step = step if step is not None else Parameter.GLOBAL_KEY
-            index = index if index is not None else Parameter.GLOBAL_KEY
-
             if step not in self.__node:
                 self.__node[step] = {}
             if index not in self.__node[step]:
@@ -441,9 +438,6 @@ class Parameter:
             if isinstance(index, int):
                 index = str(index)
 
-            step = step if step is not None else Parameter.GLOBAL_KEY
-            index = index if index is not None else Parameter.GLOBAL_KEY
-
             if step not in self.__node:
                 self.__node[step] = {}
             if index not in self.__node[step]:
@@ -489,9 +483,6 @@ class Parameter:
 
         if isinstance(index, int):
             index = str(index)
-
-        step = step if step is not None else Parameter.GLOBAL_KEY
-        index = index if index is not None else Parameter.GLOBAL_KEY
 
         try:
             del self.__node[step][index]
@@ -550,9 +541,11 @@ class Parameter:
         }
 
         for step in self.__node:
-            dictvals["node"][step] = {}
+            out_step = Parameter.GLOBAL_KEY if step is None else step
+            dictvals["node"][out_step] = {}
             for index, val in self.__node[step].items():
-                dictvals["node"][step][index] = val.getdict()
+                out_index = Parameter.GLOBAL_KEY if index is None else index
+                dictvals["node"][out_step][out_index] = val.getdict()
 
         if include_default:
             dictvals["node"].setdefault("default", {})["default"] = self.__defvalue.getdict()
@@ -637,11 +630,13 @@ class Parameter:
             self.__defvalue._from_dict(defvalue, keypath, version)
 
         for step, indexdata in manifest["node"].items():
-            self.__node[step] = {}
+            in_step = None if step == Parameter.GLOBAL_KEY else step
+            self.__node[in_step] = {}
             for index, nodedata in indexdata.items():
+                in_index = None if index == Parameter.GLOBAL_KEY else index
                 value = self.__defvalue.copy()
                 value._from_dict(nodedata, keypath, version)
-                self.__node[step][index] = value
+                self.__node[in_step][in_index] = value
 
         if requires_set:
             for step, indexdata in self.__node.items():
@@ -674,12 +669,12 @@ class Parameter:
                 return self.__defvalue.gettcl()
 
         try:
-            return self.__node[step][Parameter.GLOBAL_KEY].gettcl()
+            return self.__node[step][None].gettcl()
         except KeyError:
             pass
 
         try:
-            return self.__node[Parameter.GLOBAL_KEY][Parameter.GLOBAL_KEY].gettcl()
+            return self.__node[None][None].gettcl()
         except KeyError:
             return self.__defvalue.gettcl()
 
@@ -700,14 +695,12 @@ class Parameter:
         has_global = False
         for step in self.__node:
             for index in self.__node[step]:
-                step_arg = None if step == Parameter.GLOBAL_KEY else step
-                index_arg = None if index == Parameter.GLOBAL_KEY else index
-                if step_arg is None and index_arg is None:
+                if step is None and index is None:
                     has_global = True
                 if return_values:
-                    vals.append((self.__node[step][index].get(), step_arg, index_arg))
+                    vals.append((self.__node[step][index].get(), step, index))
                 else:
-                    vals.append((self.__node[step][index], step_arg, index_arg))
+                    vals.append((self.__node[step][index], step, index))
 
         if self.__pernode != PerNode.REQUIRED and not has_global and return_defvalue:
             if return_values:
@@ -786,16 +779,14 @@ class Parameter:
         A value counts as set if a user has set a global value OR a value for
         the provided step/index.
         '''
-        if Parameter.GLOBAL_KEY in self.__node and \
-                Parameter.GLOBAL_KEY in self.__node[Parameter.GLOBAL_KEY] and \
-                self.__node[Parameter.GLOBAL_KEY][Parameter.GLOBAL_KEY]:
+        if None in self.__node and \
+                None in self.__node[None] and \
+                self.__node[None][None]:
             # global value is set
             return True
 
         if step is None:
             return False
-        if index is None:
-            index = Parameter.GLOBAL_KEY
 
         return step in self.__node and \
             index in self.__node[step] and \
@@ -820,12 +811,12 @@ class Parameter:
                 return self.__defvalue.has_value
 
         try:
-            return self.__node[step][Parameter.GLOBAL_KEY].has_value
+            return self.__node[step][None].has_value
         except KeyError:
             pass
 
         try:
-            return self.__node[Parameter.GLOBAL_KEY][Parameter.GLOBAL_KEY].has_value
+            return self.__node[None][None].has_value
         except KeyError:
             return self.__defvalue.has_value
 

--- a/siliconcompiler/schema/parameter.py
+++ b/siliconcompiler/schema/parameter.py
@@ -249,27 +249,12 @@ class Parameter:
             Returns the value stored in the parameter.
         """
 
+        step, index = self.__map_global(step, index)
+
         self.__assert_step_index(field, step, index)
 
         if field in self.__defvalue.fields:
-            if isinstance(index, int):
-                index = str(index)
-
-            try:
-                return self.__node[step][index].get(field=field)
-            except KeyError:
-                if self.__pernode == PerNode.REQUIRED:
-                    return self.__defvalue.get(field=field)
-
-            try:
-                return self.__node[step][None].get(field=field)
-            except KeyError:
-                pass
-
-            try:
-                return self.__node[None][None].get(field=field)
-            except KeyError:
-                return self.__defvalue.get(field=field)
+            return self.__resolve(step, index).get(field=field)
         elif field == "type":
             return NodeType.encode(self.__type)
         elif field == "scope":
@@ -298,6 +283,47 @@ class Parameter:
             return self.__require
 
         raise ValueError(f'"{field}" is not a valid field')
+
+    @staticmethod
+    def __map_global(step: Optional[str],
+                     index: Optional[Union[int, str]]) \
+            -> Tuple[Optional[str], Optional[Union[int, str]]]:
+        # GLOBAL_KEY is only a serialization alias for the internal None
+        # sentinel. Normalize it away on the way in so the string never becomes
+        # an internal node key.
+        if step == Parameter.GLOBAL_KEY:
+            step = None
+        if index == Parameter.GLOBAL_KEY:
+            index = None
+        return step, index
+
+    def __resolve(self, step: Optional[str], index: Optional[Union[int, str]]):
+        """
+        Resolves the underlying value object for a step/index, applying the
+        global (None) fallback chain: exact node -> step-global -> fully global
+        -> default value. Shared by all per-node value accessors so the lookup
+        (and the None/GLOBAL_KEY handling) lives in one place.
+
+        Callers are responsible for normalizing step/index via ``__map_global``.
+        """
+        if isinstance(index, int):
+            index = str(index)
+
+        try:
+            return self.__node[step][index]
+        except KeyError:
+            if self.__pernode == PerNode.REQUIRED:
+                return self.__defvalue
+
+        try:
+            return self.__node[step][None]
+        except KeyError:
+            pass
+
+        try:
+            return self.__node[None][None]
+        except KeyError:
+            return self.__defvalue
 
     def __assert_step_index(self, field: Optional[str],
                             step: Optional[str],
@@ -346,6 +372,8 @@ class Parameter:
             >>> param.set('top')
             Sets the value to 'top'
         '''
+
+        step, index = self.__map_global(step, index)
 
         if field != "lock":
             if self.__lock:
@@ -426,6 +454,8 @@ class Parameter:
             Adds the file 'hello.v' the parameter.
         '''
 
+        step, index = self.__map_global(step, index)
+
         if self.__lock:
             return False
 
@@ -480,6 +510,8 @@ class Parameter:
 
         if self.__lock:
             return False
+
+        step, index = self.__map_global(step, index)
 
         if isinstance(index, int):
             index = str(index)
@@ -630,6 +662,7 @@ class Parameter:
             self.__defvalue._from_dict(defvalue, keypath, version)
 
         for step, indexdata in manifest["node"].items():
+            # GLOBAL_KEY is the wire alias for the internal None sentinel.
             in_step = None if step == Parameter.GLOBAL_KEY else step
             self.__node[in_step] = {}
             for index, nodedata in indexdata.items():
@@ -656,27 +689,12 @@ class Parameter:
                 on a per-node basis.
         """
 
+        step, index = self.__map_global(step, index)
+
         if self.__pernode == PerNode.REQUIRED and (step is None or index is None):
             return None
 
-        if isinstance(index, int):
-            index = str(index)
-
-        try:
-            return self.__node[step][index].gettcl()
-        except KeyError:
-            if self.__pernode == PerNode.REQUIRED:
-                return self.__defvalue.gettcl()
-
-        try:
-            return self.__node[step][None].gettcl()
-        except KeyError:
-            pass
-
-        try:
-            return self.__node[None][None].gettcl()
-        except KeyError:
-            return self.__defvalue.gettcl()
+        return self.__resolve(step, index).gettcl()
 
     def getvalues(self, return_defvalue: bool = True, return_values: bool = True) \
             -> List[Tuple[Union[Any, NodeValue, NodeSetValue, NodeListValue],
@@ -779,6 +797,8 @@ class Parameter:
         A value counts as set if a user has set a global value OR a value for
         the provided step/index.
         '''
+        step, index = self.__map_global(step, index)
+
         if None in self.__node and \
                 None in self.__node[None] and \
                 self.__node[None][None]:
@@ -801,24 +821,9 @@ class Parameter:
         the provided step/index.
         '''
 
-        if isinstance(index, int):
-            index = str(index)
+        step, index = self.__map_global(step, index)
 
-        try:
-            return self.__node[step][index].has_value
-        except KeyError:
-            if self.__pernode == PerNode.REQUIRED:
-                return self.__defvalue.has_value
-
-        try:
-            return self.__node[step][None].has_value
-        except KeyError:
-            pass
-
-        try:
-            return self.__node[None][None].has_value
-        except KeyError:
-            return self.__defvalue.has_value
+        return self.__resolve(step, index).has_value
 
     @property
     def default(self) -> Union[NodeValue, NodeSetValue, NodeListValue]:

--- a/tests/schema/test_parameter.py
+++ b/tests/schema/test_parameter.py
@@ -355,6 +355,81 @@ def test_from_dict_round_trip():
     assert param.getdict() == param_check.getdict()
 
 
+def test_global_key_input_maps_to_none():
+    # GLOBAL_KEY is only a serialization alias for the internal None sentinel.
+    # Passing it through the public API must behave identically to None so the
+    # string never leaks into the internal node representation.
+    param = Parameter("int", pernode=PerNode.OPTIONAL)
+    param.set(4, step=Parameter.GLOBAL_KEY, index=Parameter.GLOBAL_KEY)
+
+    # reachable as the global value with or without the alias
+    assert param.get() == 4
+    assert param.get(step=Parameter.GLOBAL_KEY, index=Parameter.GLOBAL_KEY) == 4
+
+    # internally represented purely as the None/global bucket
+    assert param.getvalues() == [(4, None, None)]
+
+    # the wire form uses GLOBAL_KEY, and round-trips back to the same value
+    manifest = param.getdict()
+    assert list(manifest["node"]) == [Parameter.GLOBAL_KEY, "default"]
+    assert Parameter.from_dict(manifest, [], None).get() == 4
+
+    # unset via the alias clears the global value
+    assert param.unset(step=Parameter.GLOBAL_KEY, index=Parameter.GLOBAL_KEY)
+    assert not param.is_set()
+
+
+@pytest.mark.parametrize("scope", ["global", "step-global"])
+def test_accessors_honor_global_key_alias(scope):
+    # Every step/index accessor must treat GLOBAL_KEY identically to None so the
+    # alias never leaks into (or is missed by) the internal representation.
+    GK = Parameter.GLOBAL_KEY
+
+    def build():
+        p = Parameter("int", pernode=PerNode.OPTIONAL)
+        p.set(4)                          # fully-global value
+        p.set(5, step="syn", index="0")   # per-node value
+        p.set(7, step="syn")              # step-scoped global value
+        return p
+
+    # the None-form coordinate we are probing, and its GLOBAL_KEY alias
+    none_args, alias_args = {
+        "global": ((None, None), (GK, GK)),
+        "step-global": (("syn", None), ("syn", GK)),
+    }[scope]
+
+    p = build()
+    (s0, i0), (s1, i1) = none_args, alias_args
+    assert p.get(step=s0, index=i0) == p.get(step=s1, index=i1)
+    assert bool(p.is_set(s0, i0)) == bool(p.is_set(s1, i1))
+    assert p.has_value(s0, i0) == p.has_value(s1, i1)
+    assert p.gettcl(s0, i0) == p.gettcl(s1, i1)
+
+
+def test_mutators_honor_global_key_alias():
+    GK = Parameter.GLOBAL_KEY
+
+    # set via alias == set via None
+    p_alias = Parameter("int", pernode=PerNode.OPTIONAL)
+    p_alias.set(4, step=GK, index=GK)
+    p_none = Parameter("int", pernode=PerNode.OPTIONAL)
+    p_none.set(4)
+    assert p_alias.getdict() == p_none.getdict()
+
+    # add via alias == add via None
+    l_alias = Parameter("[int]", pernode=PerNode.OPTIONAL)
+    l_alias.add(4, step=GK, index=GK)
+    l_none = Parameter("[int]", pernode=PerNode.OPTIONAL)
+    l_none.add(4)
+    assert l_alias.getdict() == l_none.getdict()
+
+    # unset via alias == unset via None
+    p_alias.unset(step=GK, index=GK)
+    p_none.unset()
+    assert p_alias.getdict() == p_none.getdict()
+    assert not p_alias.is_set()
+
+
 def test_from_dict_version0_50_0():
     param = Parameter.from_dict({
         'enum': [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of “global” parameter values so lookups, updates, and unset operations behave consistently across scoped and fully global cases.
  * Global values now serialize and deserialize correctly using the expected manifest representation, preserving round-trip behavior.
  * Message routing for events now resolves contacts and configurations using the provided step/index inputs more reliably for global events.
* **Tests**
  * Added unit tests covering alias behavior for global step/index values and verifying correct serialization and round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->