### PR TITLE
switch global to *, to avoid name conflicts

### DIFF
--- a/docs/reference_manual/appendix/dashboard_how_to_guide.rst
+++ b/docs/reference_manual/appendix/dashboard_how_to_guide.rst
@@ -142,10 +142,10 @@ Manifest Tab
 The next tab you can select is the manifest tab.
 This displays the manifest after it has been filtered through to make it more readable.
 More specifically, if the :term:`pernode` value of the leaf of the Schema is :term:`pernode` is "never", the value of the leaf
-is the value of the leaf['node']['global']['global']['value']. If there is no value for that, then
+is the value of the leaf['node']['*']['*']['value']. If there is no value for that, then
 it is the value of the leaf['node']['default']['default']['value']. Outside of that,
 the nodes will be concatenated, or if the step and index is :term:`default` and :term:`default`
-or "global" and "global", the node will be :term:`default` or "global", respectively.
+or "*" and "*", the node will be :term:`default` or "global", respectively.
 
 To view the manifest, click the arrow on the dictionary (arrow A). The search bars will return partial matches for either
 the keys (arrow B in image below) or the values (arrow C in image below). Press enter to search.

--- a/docs/reference_manual/schema.rst
+++ b/docs/reference_manual/schema.rst
@@ -75,7 +75,7 @@ Per-node Parameter Fields
 ---------------------------
 
 The following fields are specified inside the ``node`` dictionary on a per-step/index basis.
-Default values for each field are stored under the special keys ``"default", "default"``, and global values are specified under the special keys ``"global", "global"``.
+Default values for each field are stored under the special keys ``"default", "default"``, and global values are specified under the special keys ``"*", "*"``.
 
 .. glossary::
 

--- a/siliconcompiler/flowgraph.py
+++ b/siliconcompiler/flowgraph.py
@@ -90,7 +90,7 @@ class Flowgraph(NamedSchema, DocsSchema):
 
         Raises:
             ValueError: If 'step' or 'index' are reserved names (like
-                'default' or 'global') or contain invalid characters ('/').
+                'default' or '*') or contain invalid characters ('/').
             ValueError: If 'task' is not a valid Task object, string, or class.
 
         Examples:

--- a/siliconcompiler/schema/_metadata.py
+++ b/siliconcompiler/schema/_metadata.py
@@ -1,2 +1,2 @@
 # Version number following semver standard.
-version = '0.54.0'
+version = '0.55.0'

--- a/siliconcompiler/schema/parameter.py
+++ b/siliconcompiler/schema/parameter.py
@@ -64,7 +64,7 @@ class Parameter:
         kwargs: forwarded to default value constructor
     '''
 
-    GLOBAL_KEY = 'global'
+    GLOBAL_KEY = '*'
 
     def __init__(self,
                  type: str,
@@ -661,12 +661,18 @@ class Parameter:
         if defvalue:
             self.__defvalue._from_dict(defvalue, keypath, version)
 
+        # GLOBAL_KEY is the wire alias for the internal None sentinel. It changed
+        # from the bare word "global" to "*" in schema 0.55.0; read the legacy
+        # token for older manifests so their global values still load.
+        global_key = Parameter.GLOBAL_KEY
+        if version and version < (0, 55, 0):
+            global_key = "global"
+
         for step, indexdata in manifest["node"].items():
-            # GLOBAL_KEY is the wire alias for the internal None sentinel.
-            in_step = None if step == Parameter.GLOBAL_KEY else step
+            in_step = None if step == global_key else step
             self.__node[in_step] = {}
             for index, nodedata in indexdata.items():
-                in_index = None if index == Parameter.GLOBAL_KEY else index
+                in_index = None if index == global_key else index
                 value = self.__defvalue.copy()
                 value._from_dict(nodedata, keypath, version)
                 self.__node[in_step][in_index] = value

--- a/tests/data/defaults.json
+++ b/tests/data/defaults.json
@@ -17,7 +17,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.54.0",
+              "value": "0.55.0",
               "signature": null
             }
           }
@@ -2989,7 +2989,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.54.0",
+              "value": "0.55.0",
               "signature": null
             }
           }
@@ -6759,7 +6759,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.54.0",
+              "value": "0.55.0",
               "signature": null
             }
           }
@@ -11415,7 +11415,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.54.0",
+              "value": "0.55.0",
               "signature": null
             }
           }
@@ -14387,7 +14387,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.54.0",
+              "value": "0.55.0",
               "signature": null
             }
           }

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -707,8 +707,8 @@ def test_getdict_param_keypath():
                     'value': None,
                 },
             },
-            'global': {
-                'global': {
+            '*': {
+                '*': {
                     'signature': None,
                     'value': "thistest",
                 },
@@ -1220,7 +1220,7 @@ def test_from_manifest_cfg_no_meta():
                 'help': None,
                 'notes': None,
                 'pernode': 'never',
-                'node': {'global': {'global': {'value': 'testthis', 'signature': None}},
+                'node': {'*': {'*': {'value': 'testthis', 'signature': None}},
                          'default': {'default': {'value': None, 'signature': None}}}
             }
         }
@@ -1262,7 +1262,7 @@ def test_from_manifest_cfg_different_base_correct_base_class():
                     'help': None,
                     'notes': None,
                     'pernode': 'never',
-                    'node': {'global': {'global': {'value': 'testthis', 'signature': None}},
+                    'node': {'*': {'*': {'value': 'testthis', 'signature': None}},
                              'default': {'default': {'value': None, 'signature': None}}}
                 }
             },
@@ -2218,8 +2218,8 @@ def test_getdict_with_journal():
                             'value': None,
                         },
                     },
-                    'global': {
-                        'global': {
+                    '*': {
+                        '*': {
                             'signature': None,
                             'value': 'hello',
                         },
@@ -2685,7 +2685,7 @@ def test_from_dict_composite_type_names():
                         'help': None,
                         'notes': None,
                         'pernode': 'never',
-                        'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                        'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                                  'default': {'default': {'value': None, 'signature': None}}}
                     },
                     '__meta__': {
@@ -2718,7 +2718,7 @@ def test_from_dict_composite_type_names():
                     'help': None,
                     'notes': None,
                     'pernode': 'never',
-                    'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                    'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                              'default': {'default': {'value': None, 'signature': None}}}
                 }
             }
@@ -2778,7 +2778,7 @@ def test_from_dict_composite_type_names_lazy():
                         'help': None,
                         'notes': None,
                         'pernode': 'never',
-                        'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                        'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                                  'default': {'default': {'value': None, 'signature': None}}}
                     },
                     '__meta__': {
@@ -2811,7 +2811,7 @@ def test_from_dict_composite_type_names_lazy():
                     'help': None,
                     'notes': None,
                     'pernode': 'never',
-                    'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                    'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                              'default': {'default': {'value': None, 'signature': None}}}
                 }
             }
@@ -2902,8 +2902,7 @@ def test_from_dict_composite_nested():
                                 'help': None,
                                 'notes': None,
                                 'pernode': 'never',
-                                'node': {'global': {'global': {'value': 'teststring',
-                                                               'signature': None}},
+                                'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                                          'default': {'default': {'value': None, 'signature': None}}}
                             },
                             '__meta__': {
@@ -2971,7 +2970,7 @@ def test_from_dict_composite_type_names_use_default():
                         'help': None,
                         'notes': None,
                         'pernode': 'never',
-                        'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                        'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                                  'default': {'default': {'value': None, 'signature': None}}}
                     },
                     '__meta__': {
@@ -3004,7 +3003,7 @@ def test_from_dict_composite_type_names_use_default():
                     'help': None,
                     'notes': None,
                     'pernode': 'never',
-                    'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                    'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                              'default': {'default': {'value': None, 'signature': None}}}
                 }
             }
@@ -3065,7 +3064,7 @@ def test_from_dict_composite_type_load_via_class_name():
                         'help': None,
                         'notes': None,
                         'pernode': 'never',
-                        'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                        'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                                  'default': {'default': {'value': None, 'signature': None}}}
                     },
                     '__meta__': {
@@ -3098,7 +3097,7 @@ def test_from_dict_composite_type_load_via_class_name():
                     'help': None,
                     'notes': None,
                     'pernode': 'never',
-                    'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                    'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                              'default': {'default': {'value': None, 'signature': None}}}
                 }
             }
@@ -3158,7 +3157,7 @@ def test_from_dict_composite_using_cls_name():
                         'help': None,
                         'notes': None,
                         'pernode': 'never',
-                        'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                        'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                                  'default': {'default': {'value': None, 'signature': None}}}
                     },
                     '__meta__': {
@@ -3191,7 +3190,7 @@ def test_from_dict_composite_using_cls_name():
                     'help': None,
                     'notes': None,
                     'pernode': 'never',
-                    'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                    'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                              'default': {'default': {'value': None, 'signature': None}}}
                 }
             }
@@ -3235,7 +3234,7 @@ def test_from_dict_composite_no_meta():
                     'help': None,
                     'notes': None,
                     'pernode': 'never',
-                    'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                    'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                              'default': {'default': {'value': None, 'signature': None}}}
                 }
             },
@@ -3251,7 +3250,7 @@ def test_from_dict_composite_no_meta():
                     'help': None,
                     'notes': None,
                     'pernode': 'never',
-                    'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                    'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                              'default': {'default': {'value': None, 'signature': None}}}
                 }
             }
@@ -4174,7 +4173,7 @@ def test_from_dict_with_failure():
                         'help': None,
                         'notes': None,
                         'pernode': 'never',
-                        'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                        'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                                  'default': {'default': {'value': None, 'signature': None}}}
                     },
                     '__meta__': {
@@ -4208,7 +4207,7 @@ def test_from_dict_with_failure():
                     'help': None,
                     'notes': None,
                     'pernode': 'never',
-                    'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                    'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                              'default': {'default': {'value': None, 'signature': None}}}
                 }
             }
@@ -4271,7 +4270,7 @@ def test_from_dict_with_failure_raise():
                         'help': None,
                         'notes': None,
                         'pernode': 'never',
-                        'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                        'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                                  'default': {'default': {'value': None, 'signature': None}}}
                     },
                     '__meta__': {
@@ -4305,7 +4304,7 @@ def test_from_dict_with_failure_raise():
                     'help': None,
                     'notes': None,
                     'pernode': 'never',
-                    'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                    'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                              'default': {'default': {'value': None, 'signature': None}}}
                 }
             }
@@ -4366,7 +4365,7 @@ def test_from_dict_with_nofailure():
                         'help': None,
                         'notes': None,
                         'pernode': 'never',
-                        'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                        'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                                  'default': {'default': {'value': None, 'signature': None}}}
                     },
                     '__meta__': {
@@ -4400,7 +4399,7 @@ def test_from_dict_with_nofailure():
                     'help': None,
                     'notes': None,
                     'pernode': 'never',
-                    'node': {'global': {'global': {'value': 'teststring', 'signature': None}},
+                    'node': {'*': {'*': {'value': 'teststring', 'signature': None}},
                              'default': {'default': {'value': None, 'signature': None}}}
                 }
             }

--- a/tests/schema/test_parameter.py
+++ b/tests/schema/test_parameter.py
@@ -486,6 +486,43 @@ def test_from_dict_version0_50_0():
     assert param.get(step="teststep", index="0") == ['test1', 'test0']
 
 
+def test_from_dict_version0_54_0():
+    # Prior to schema 0.55.0 the global node bucket was serialized under the
+    # bare word "global". Manifests at those versions must still load the global
+    # value into the internal None bucket (not a literal "global" node).
+    param = Parameter.from_dict({
+        'node': {
+            'default': {
+                'default': {
+                    'signature': None,
+                    'value': None,
+                },
+            },
+            'global': {
+                'global': {
+                    'signature': None,
+                    'value': 4,
+                },
+            },
+            'teststep': {
+                '0': {
+                    'signature': None,
+                    'value': 5,
+                },
+            },
+        },
+        'pernode': 'optional',
+        'type': 'int',
+    }, [], (0, 54, 0))
+
+    assert param.get() == 4
+    assert param.get(step="teststep", index="0") == 5
+    # the legacy "global" token was mapped to the internal None sentinel
+    assert param.getvalues() == [(4, None, None), (5, "teststep", "0")]
+    # re-serialization uses the current "*" token
+    assert list(param.getdict()["node"]) == [Parameter.GLOBAL_KEY, "teststep", "default"]
+
+
 def test_from_dict():
     param = Parameter.from_dict({
         'example': [
@@ -494,8 +531,8 @@ def test_from_dict():
         'help': 'long help',
         'lock': False,
         'node': {
-            'global': {
-                'global': {
+            '*': {
+                '*': {
                     'signature': None,
                     'value': (
                         'test',
@@ -581,8 +618,8 @@ def test_from_dict_round_trip_enum():
                     'value': None,
                 },
             },
-            'global': {
-                'global': {
+            '*': {
+                '*': {
                     'signature': None,
                     'value': (
                         'test',
@@ -1509,8 +1546,8 @@ def test_getdict_with_vals():
                     'value': None,
                 },
             },
-            'global': {
-              'global': {
+            '*': {
+              '*': {
                    'signature': None,
                    'value': 1,
                },
@@ -1535,8 +1572,8 @@ def test_getdict_with_vals():
         'help': None,
         'lock': False,
         'node': {
-            'global': {
-              'global': {
+            '*': {
+              '*': {
                    'signature': None,
                    'value': 1,
                },
@@ -1574,8 +1611,8 @@ def test_getdict_with_vals_list():
                     'value': [],
                 },
             },
-            'global': {
-              'global': {
+            '*': {
+              '*': {
                    'signature': [None],
                    'value': [1],
                },
@@ -1600,8 +1637,8 @@ def test_getdict_with_vals_list():
         'help': None,
         'lock': False,
         'node': {
-            'global': {
-              'global': {
+            '*': {
+              '*': {
                    'signature': [None],
                    'value': [1],
                },

--- a/tests/test_flowgraph.py
+++ b/tests/test_flowgraph.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+import re
 
 import os.path
 
@@ -10,6 +11,7 @@ from siliconcompiler import NodeStatus
 from siliconcompiler.schema_support.record import RecordSchema
 from siliconcompiler.flowgraph import RuntimeFlowgraph
 from siliconcompiler.schema import BaseSchema
+from siliconcompiler.schema import Parameter
 from siliconcompiler.tools.builtin.nop import NOPTask
 from siliconcompiler.tools.builtin.join import JoinTask
 
@@ -125,12 +127,12 @@ def test_node_index():
     assert flow.get("teststep", "1", "taskmodule") == "siliconcompiler.tools.builtin.nop/NOPTask"
 
 
-@pytest.mark.parametrize("step", ["global", "default",
+@pytest.mark.parametrize("step", [Parameter.GLOBAL_KEY, "default",
                                   "sc_collected_files", "sc_config", "sc_blah"])
 def test_node_reserved_step(step):
     flow = Flowgraph("testflow")
 
-    with pytest.raises(ValueError, match=rf"^{step} is a reserved name$"):
+    with pytest.raises(ValueError, match=rf"^{re.escape(step)} is a reserved name$"):
         flow.node(step, "siliconcompiler.tools.builtin.nop/NOPTask")
 
 
@@ -138,12 +140,24 @@ def test_node_allow_step():
     Flowgraph("testflow").node("scblah", "siliconcompiler.tools.builtin.nop/NOPTask")
 
 
-@pytest.mark.parametrize("index", ["global", "default"])
+@pytest.mark.parametrize("name", ["global", "globals"])
+def test_node_allow_global_step(name):
+    # "global" is no longer reserved: the global sentinel serializes under
+    # GLOBAL_KEY ("*"), freeing the bare word for flow nodes.
+    Flowgraph("testflow").node(name, "siliconcompiler.tools.builtin.nop/NOPTask")
+
+
+@pytest.mark.parametrize("index", [Parameter.GLOBAL_KEY, "default"])
 def test_node_reserved_index(index):
     flow = Flowgraph("testflow")
 
-    with pytest.raises(ValueError, match=rf"^{index} is a reserved name$"):
+    with pytest.raises(ValueError, match=rf"^{re.escape(index)} is a reserved name$"):
         flow.node("teststep", "siliconcompiler.tools.builtin.nop/NOPTask", index=index)
+
+
+def test_node_allow_global_index():
+    Flowgraph("testflow").node(
+        "teststep", "siliconcompiler.tools.builtin.nop/NOPTask", index="global")
 
 
 def test_edge():


### PR DESCRIPTION
Change global keyword to * to avoid name conflicts with common terms like global.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved backward compatibility when loading older manifests by correctly interpreting legacy global keys.
  - Standardized how global/default node values are serialized and recognized using wildcard keys.

- **Documentation**
  - Updated the reference guide for Manifest Tab filtering behavior and clarified schema glossary wording.

- **Tests**
  - Added version-specific deserialization coverage and expanded round-trip/compatibility assertions.
  - Updated expected schema outputs and reserved-name checks to match the wildcard global sentinel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->