### PR TITLE
add rename_node to allow for node renames

### DIFF
--- a/siliconcompiler/flowgraph.py
+++ b/siliconcompiler/flowgraph.py
@@ -62,6 +62,38 @@ class Flowgraph(NamedSchema, DocsSchema):
 
         self.__cache_tasks = None
 
+    @staticmethod
+    def _assert_valid_step(step: str) -> None:
+        '''
+        Validates a step name, raising if it is reserved or malformed.
+
+        Args:
+            step (str): The step name to validate.
+
+        Raises:
+            ValueError: If ``step`` is a reserved name or contains a '/'.
+        '''
+        if step in (Parameter.GLOBAL_KEY, 'default') or step.startswith("sc_"):
+            raise ValueError(f"{step} is a reserved name")
+        if '/' in step:
+            raise ValueError(f"{step} is not a valid step, it cannot contain '/'")
+
+    @staticmethod
+    def _assert_valid_index(index: str) -> None:
+        '''
+        Validates an index name, raising if it is reserved or malformed.
+
+        Args:
+            index (str): The index name to validate.
+
+        Raises:
+            ValueError: If ``index`` is a reserved name or contains a '/'.
+        '''
+        if index in (Parameter.GLOBAL_KEY, 'default'):
+            raise ValueError(f"{index} is a reserved name")
+        if '/' in index:
+            raise ValueError(f"{index} is not a valid index, it cannot contain '/'")
+
     def node(self, step: str, task: "Task", index: Optional[Union[str, int]] = 0) -> None:
         '''
         Creates or updates a flowgraph node.
@@ -107,17 +139,10 @@ class Flowgraph(NamedSchema, DocsSchema):
         '''
         from siliconcompiler import Task
 
-        if step in (Parameter.GLOBAL_KEY, 'default') or step.startswith("sc_"):
-            raise ValueError(f"{step} is a reserved name")
+        self._assert_valid_step(step)
 
         index = str(index)
-        if index in (Parameter.GLOBAL_KEY, 'default'):
-            raise ValueError(f"{index} is a reserved name")
-
-        if '/' in step:
-            raise ValueError(f"{step} is not a valid step, it cannot contain '/'")
-        if '/' in index:
-            raise ValueError(f"{index} is not a valid index, it cannot contain '/'")
+        self._assert_valid_index(index)
 
         # Determine task name and module
         task_module = None
@@ -296,6 +321,69 @@ class Flowgraph(NamedSchema, DocsSchema):
             self.set(istep, iindex, "input", inputs)
             self.add(istep, iindex, "input", (step, index))
         self.set(step, index, "input", [(before_step, before_index)])
+
+        self.__clear_cache()
+
+    def rename_node(self, step: str, new_step: str) -> None:
+        '''
+        Renames a step, preserving its nodes, tasks, and connectivity.
+
+        Every node belonging to ``step`` (all of its indices) is moved to
+        ``new_step``, keeping the same indices, task bindings, goals, and
+        input edges. All edges elsewhere in the graph that referenced
+        ``step`` are rewired to point at ``new_step``, so the topology of
+        the flow is unchanged.
+
+        This is primarily useful after :meth:`graph` when a sub-flow's step
+        names need to be re-badged to fit a parent flow's naming scheme
+        (e.g. renaming ``synmin`` to ``synthesis.min``) without having to
+        prefix every step in the sub-flow.
+
+        Args:
+            step (str): Existing step name to rename.
+            new_step (str): New step name. Must not already exist and must
+                obey the same naming rules as :meth:`node`.
+
+        Raises:
+            ValueError: If ``step`` does not exist, if ``new_step`` is a
+                reserved name or contains a '/', or if ``new_step`` is
+                already defined in the flowgraph.
+
+        Examples:
+            >>> flow.node('synmin', minimum.MinimumTask())
+            >>> flow.rename_node('synmin', 'synthesis.min')
+            # ('synmin', '0') is now ('synthesis.min', '0'); all edges follow.
+        '''
+
+        if step not in self.getkeys():
+            raise ValueError(f"{step} is not a valid step in {self.name}")
+
+        if new_step == step:
+            # Nothing to do
+            return
+
+        self._assert_valid_step(new_step)
+
+        if new_step in self.getkeys():
+            raise ValueError(f"{new_step} is already defined in {self.name}")
+
+        # Copy all node data (task, goals, inputs, ...) from step to new_step
+        for keys in self.allkeys(step):
+            self.set(new_step, *keys, self.get(step, *keys))
+
+        # Drop the original step.
+        self.remove(step)
+
+        # Rewire every edge that referenced the old step, including any
+        # self-references that were copied over to new_step above.
+        for flow_step in self.getkeys():
+            for flow_index in self.getkeys(flow_step):
+                inputs = self.get(flow_step, flow_index, 'input')
+                if any(in_step == step for in_step, _ in inputs):
+                    self.set(flow_step, flow_index, 'input', [
+                        (new_step if in_step == step else in_step, in_index)
+                        for in_step, in_index in inputs
+                    ])
 
         self.__clear_cache()
 

--- a/siliconcompiler/flowgraph.py
+++ b/siliconcompiler/flowgraph.py
@@ -220,6 +220,27 @@ class Flowgraph(NamedSchema, DocsSchema):
 
         self.__clear_cache()
 
+    def _rewire_inputs(self, transform) -> None:
+        '''
+        Rewrites the input edges of every node in the flowgraph.
+
+        Iterates over all nodes and passes each node's list of
+        ``(step, index)`` input tuples through ``transform``. When
+        ``transform`` returns a new list, the node's inputs are replaced
+        with it; when it returns ``None`` the node is left untouched.
+
+        Args:
+            transform (callable): Function taking a node's current list of
+                input tuples and returning the new list, or ``None`` to
+                leave the inputs unchanged.
+        '''
+        for flow_step in self.getkeys():
+            for flow_index in self.getkeys(flow_step):
+                inputs = self.get(flow_step, flow_index, 'input')
+                new_inputs = transform(inputs)
+                if new_inputs is not None:
+                    self.set(flow_step, flow_index, 'input', new_inputs)
+
     def remove_node(self, step: str, index: Optional[Union[str, int]] = None) -> None:
         '''
         Removes a flowgraph node and reconnects its inputs to its outputs.
@@ -265,18 +286,17 @@ class Flowgraph(NamedSchema, DocsSchema):
             self.remove(step)
 
         # Re-wire: Find all nodes that had the removed node as an input
-        for flow_step in self.getkeys():
-            for flow_index in self.getkeys(flow_step):
-                current_node = self.get_graph_node(flow_step, flow_index)
-                inputs = current_node.get_input()
+        def rewire(inputs):
+            if node_to_remove not in inputs:
+                return None
+            # Remove the old edge
+            inputs = [inode for inode in inputs if inode != node_to_remove]
+            # Add new edges from the removed node's inputs
+            inputs.extend(node_inputs)
+            # Return the new list of inputs, removing duplicates
+            return sorted(set(inputs))
 
-                if node_to_remove in inputs:
-                    # Remove the old edge
-                    inputs = [inode for inode in inputs if inode != node_to_remove]
-                    # Add new edges from the removed node's inputs
-                    inputs.extend(node_inputs)
-                    # Set the new list of inputs, removing duplicates
-                    self.set(flow_step, flow_index, 'input', sorted(set(inputs)))
+        self._rewire_inputs(rewire)
 
         self.__clear_cache()
 
@@ -376,14 +396,15 @@ class Flowgraph(NamedSchema, DocsSchema):
 
         # Rewire every edge that referenced the old step, including any
         # self-references that were copied over to new_step above.
-        for flow_step in self.getkeys():
-            for flow_index in self.getkeys(flow_step):
-                inputs = self.get(flow_step, flow_index, 'input')
-                if any(in_step == step for in_step, _ in inputs):
-                    self.set(flow_step, flow_index, 'input', [
-                        (new_step if in_step == step else in_step, in_index)
-                        for in_step, in_index in inputs
-                    ])
+        def rewire(inputs):
+            if not any(in_step == step for in_step, _ in inputs):
+                return None
+            return [
+                (new_step if in_step == step else in_step, in_index)
+                for in_step, in_index in inputs
+            ]
+
+        self._rewire_inputs(rewire)
 
         self.__clear_cache()
 

--- a/tests/test_flowgraph.py
+++ b/tests/test_flowgraph.py
@@ -293,6 +293,184 @@ def test_insert_node_invalid(large_flow):
         )
 
 
+def test_rename_node_preserves_task(large_flow):
+    # joinone is a single-index node feeding all steptwo indices
+    large_flow.rename_node("joinone", "merge")
+
+    assert "joinone" not in large_flow.getkeys()
+    assert "merge" in large_flow.getkeys()
+
+    # Task binding follows the rename
+    assert large_flow.get("merge", "0", "tool") == "builtin"
+    assert large_flow.get("merge", "0", "task") == "join"
+    assert large_flow.get("merge", "0", "taskmodule") == \
+        "siliconcompiler.tools.builtin.join/JoinTask"
+
+
+def test_rename_node_rewires_inputs(large_flow):
+    large_flow.rename_node("joinone", "merge")
+
+    # merge inherits joinone's inputs...
+    assert large_flow.get("merge", "0", "input") == [
+        ("stepone", "0"), ("stepone", "1"), ("stepone", "2")]
+
+    # ...and the downstream steptwo nodes now point at merge
+    for n in range(3):
+        assert large_flow.get("steptwo", str(n), "input") == [("merge", "0")]
+
+
+def test_rename_node_multi_index(large_flow):
+    # stepone has three indices; rename must carry them all
+    large_flow.rename_node("stepone", "start")
+
+    assert "stepone" not in large_flow.getkeys()
+    assert large_flow.getkeys("start") == ("0", "1", "2")
+
+    # downstream joinone now references start for every index
+    assert large_flow.get("joinone", "0", "input") == [
+        ("start", "0"), ("start", "1"), ("start", "2")]
+
+
+def test_rename_node_preserves_topology(large_flow):
+    large_flow.rename_node("steptwo", "middle")
+
+    assert large_flow.get_execution_order() == (
+        (('stepone', '0'), ('stepone', '1'), ('stepone', '2')),
+        (('joinone', '0'),),
+        (('middle', '0'), ('middle', '1'), ('middle', '2')),
+        (('jointwo', '0'),),
+        (('stepthree', '0'), ('stepthree', '1'), ('stepthree', '2')),
+        (('jointhree', '0'),))
+
+
+def test_rename_node_preserves_goals():
+    flow = Flowgraph("testflow")
+    flow.node("synthesis", NOPTask())
+    flow.get_graph_node("synthesis", "0").add_goal("errors", 0)
+
+    flow.rename_node("synthesis", "syn")
+
+    assert "synthesis" not in flow.getkeys()
+    assert flow.get_graph_node("syn", "0").get_goal("errors") == 0
+
+
+def test_rename_node_entry_node(large_flow):
+    # renaming an entry node keeps it an entry node
+    large_flow.rename_node("stepone", "start")
+    assert large_flow.get_entry_nodes() == (
+        ("start", "0"), ("start", "1"), ("start", "2"))
+
+
+def test_rename_node_exit_node(large_flow):
+    large_flow.rename_node("jointhree", "finish")
+    assert large_flow.get_exit_nodes() == (("finish", "0"),)
+
+
+def test_rename_node_dotted_name(large_flow):
+    # dotted names (the grouping convention) are valid targets
+    large_flow.rename_node("joinone", "synthesis.min")
+    assert "synthesis.min" in large_flow.getkeys()
+    assert large_flow.get_node_outputs("synthesis.min", "0") == (
+        ("steptwo", "0"), ("steptwo", "1"), ("steptwo", "2"))
+
+
+def test_rename_node_clears_cache(large_flow):
+    # populate caches
+    assert ("joinone", "0") in large_flow.get_nodes()
+
+    large_flow.rename_node("joinone", "merge")
+
+    nodes = large_flow.get_nodes()
+    assert ("joinone", "0") not in nodes
+    assert ("merge", "0") in nodes
+
+
+def test_rename_node_same_name_noop(large_flow):
+    before = large_flow.get_execution_order()
+    large_flow.rename_node("joinone", "joinone")
+    assert large_flow.get_execution_order() == before
+    assert "joinone" in large_flow.getkeys()
+
+
+def test_rename_node_invalid_step(large_flow):
+    with pytest.raises(ValueError,
+                       match=r"^invalidstep is not a valid step in testflow$"):
+        large_flow.rename_node("invalidstep", "whatever")
+
+
+def test_rename_node_existing_target(large_flow):
+    with pytest.raises(ValueError,
+                       match=r"^steptwo is already defined in testflow$"):
+        large_flow.rename_node("joinone", "steptwo")
+
+
+def test_rename_node_reserved_target(large_flow):
+    with pytest.raises(ValueError, match=r"^default is a reserved name$"):
+        large_flow.rename_node("joinone", "default")
+
+
+def test_rename_node_slash_target(large_flow):
+    with pytest.raises(ValueError,
+                       match=r"^bad/name is not a valid step, it cannot contain '/'$"):
+        large_flow.rename_node("joinone", "bad/name")
+
+
+def test_rename_node_self_referential_indices():
+    # a step whose indices feed a shared node, then a join fanning back:
+    # ensure references from the renamed step to itself are rewired too
+    flow = Flowgraph("testflow")
+    flow.node("a", NOPTask())
+    flow.node("b", NOPTask())
+    flow.edge("a", "b")
+    flow.node("c", NOPTask())
+    flow.edge("b", "c")
+
+    flow.rename_node("b", "b.renamed")
+
+    assert flow.get("b.renamed", "0", "input") == [("a", "0")]
+    assert flow.get("c", "0", "input") == [("b.renamed", "0")]
+    assert flow.get_execution_order() == (
+        (("a", "0"),),
+        (("b.renamed", "0"),),
+        (("c", "0"),))
+
+
+def test_rename_node_intra_step_reference():
+    # An edge between two indices of the *same* step: after copying the step
+    # to its new name, that input still references the old name and must be
+    # rewired to the new name too.
+    flow = Flowgraph("testflow")
+    flow.node("s", NOPTask(), index=0)
+    flow.node("s", NOPTask(), index=1)
+    flow.edge("s", "s", tail_index=0, head_index=1)
+
+    flow.rename_node("s", "renamed")
+
+    assert "s" not in flow.getkeys()
+    assert flow.get("renamed", "0", "input") == []
+    assert flow.get("renamed", "1", "input") == [("renamed", "0")]
+    assert flow.get_execution_order() == (
+        (("renamed", "0"),),
+        (("renamed", "1"),))
+
+
+def test_rename_node_preserves_arbitrary_fields():
+    # Fields beyond task/goal (e.g. weight) are copied generically.
+    flow = Flowgraph("testflow")
+    flow.node("synthesis", NOPTask())
+    flow.get_graph_node("synthesis", "0").add_weight("area_cells", 2.5)
+
+    flow.rename_node("synthesis", "syn")
+
+    assert flow.get_graph_node("syn", "0").get_weight("area_cells") == 2.5
+
+
+def test_rename_node_keeps_graph_valid(large_flow):
+    assert large_flow.validate()
+    large_flow.rename_node("steptwo", "middle")
+    assert large_flow.validate()
+
+
 def test_get_nodes(large_flow):
     assert large_flow.get_nodes() == (
         ('joinone', '0'), ('jointhree', '0'), ('jointwo', '0'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to rename nodes in a flow graph while preserving task bindings, goals, indices, and overall topology.

* **Bug Fixes**
  * Improved step/index naming validation to reject reserved, prefixed, or slash-containing names consistently.
  * Updated graph rewiring logic to ensure connections (including self-references and entry/exit nodes) remain correct after node removal/renaming.
  * Refreshes internal state after renames so subsequent queries reflect changes.

* **Tests**
  * Added extensive regression coverage for `rename_node`, including multi-index behavior, no-op renames, error cases, and validation success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->