### PR TITLE
make get_cores aware of scheduler proc affinity

### DIFF
--- a/siliconcompiler/utils/__init__.py
+++ b/siliconcompiler/utils/__init__.py
@@ -540,7 +540,10 @@ def get_cores(physical: bool = False) -> int:
             total_physical = psutil.cpu_count(logical=False)
             if total_logical and total_physical and total_physical < total_logical:
                 threads_per_core = total_logical / total_physical
-                cores = int(logical_available / threads_per_core)
+                # Clamp to at least 1 so a tight affinity mask (e.g. a single
+                # logical CPU) still reports a usable core rather than falling
+                # through to the machine-wide fallback below.
+                cores = max(1, int(logical_available / threads_per_core))
             else:
                 cores = logical_available
         else:

--- a/siliconcompiler/utils/__init__.py
+++ b/siliconcompiler/utils/__init__.py
@@ -505,7 +505,13 @@ def truncate_text(text: str, width: int) -> str:
 
 def get_cores(physical: bool = False) -> int:
     '''
-    Get max number of cores for this machine.
+    Get max number of cores available to this process.
+
+    On Linux this honors the process' CPU affinity mask, so restrictions
+    applied via cgroups/cpuset (e.g. containers) or ``taskset`` cap the value
+    returned. This lets an operator bound SiliconCompiler's CPU usage without
+    any additional configuration. On platforms without affinity support the
+    machine-wide core count is used instead.
 
     Args:
         physical (bool): if true, only count physical cores. Defaults to False.
@@ -514,7 +520,34 @@ def get_cores(physical: bool = False) -> int:
         int: The number of available cores. Defaults to 1 if detection fails.
     '''
 
-    cores = psutil.cpu_count(logical=not physical)
+    cores = None
+
+    try:
+        # os.sched_getaffinity respects cgroup/cpuset and taskset restrictions,
+        # so it reflects the cores actually usable by this process rather than
+        # every core on the machine.
+        logical_available = len(os.sched_getaffinity(0))
+    except AttributeError:
+        # Not available on this platform (e.g. macOS, Windows).
+        logical_available = None
+
+    if logical_available:
+        if physical:
+            # sched_getaffinity only reports logical CPUs, so scale the
+            # affinity-limited count down by the machine's hyperthreading
+            # ratio to approximate the number of physical cores available.
+            total_logical = psutil.cpu_count(logical=True)
+            total_physical = psutil.cpu_count(logical=False)
+            if total_logical and total_physical and total_physical < total_logical:
+                threads_per_core = total_logical / total_physical
+                cores = int(logical_available / threads_per_core)
+            else:
+                cores = logical_available
+        else:
+            cores = logical_available
+
+    if not cores:
+        cores = psutil.cpu_count(logical=not physical)
 
     if not cores:
         cores = os.cpu_count()

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,7 +1,9 @@
 import logging
 import pytest
 
+import os
 import os.path
+import psutil
 
 from unittest.mock import patch
 
@@ -82,9 +84,60 @@ def test_safecompare_invalid_operator():
         safecompare(1, "!", 2)
 
 
-def test_get_cores_logical(monkeypatch):
-    import psutil
+@pytest.fixture(autouse=True)
+def disable_affinity(monkeypatch):
+    """Give every get_cores() test a deterministic baseline by removing
+    os.sched_getaffinity (as on macOS/Windows). Tests that exercise the
+    affinity path re-add it explicitly with raising=False."""
+    monkeypatch.delattr(os, 'sched_getaffinity', raising=False)
 
+
+def test_get_cores_affinity(monkeypatch):
+    # sched_getaffinity is preferred when available so cpuset/taskset limits
+    # are honored, regardless of the machine's total core count.
+    monkeypatch.setattr(os, 'sched_getaffinity', lambda pid: {0, 1, 2, 3},
+                        raising=False)
+    monkeypatch.setattr(
+        psutil, 'cpu_count',
+        lambda logical: pytest.fail('affinity should be preferred'))
+    assert get_cores() == 4
+
+
+def test_get_cores_affinity_respects_cpuset(monkeypatch):
+    # Even on a large machine, a narrow affinity mask caps the reported cores.
+    monkeypatch.setattr(os, 'sched_getaffinity', lambda pid: {2, 5},
+                        raising=False)
+    monkeypatch.setattr(psutil, 'cpu_count', lambda logical: 64)
+    assert get_cores() == 2
+
+
+def test_get_cores_affinity_physical(monkeypatch):
+    # Physical count scales the affinity-limited logical count down by the
+    # machine's hyperthreading ratio (2 threads/core here -> 6/2 == 3).
+    monkeypatch.setattr(os, 'sched_getaffinity', lambda pid: set(range(6)),
+                        raising=False)
+
+    def cpu_count(logical):
+        return 16 if logical else 8
+
+    monkeypatch.setattr(psutil, 'cpu_count', cpu_count)
+    assert get_cores() == 6
+    assert get_cores(physical=True) == 3
+
+
+def test_get_cores_affinity_physical_no_hyperthreading(monkeypatch):
+    # No hyperthreading -> physical count equals the affinity-limited count.
+    monkeypatch.setattr(os, 'sched_getaffinity', lambda pid: {0, 1, 2, 3},
+                        raising=False)
+
+    def cpu_count(logical):
+        return 8
+
+    monkeypatch.setattr(psutil, 'cpu_count', cpu_count)
+    assert get_cores(physical=True) == 4
+
+
+def test_get_cores_logical(monkeypatch):
     def cpu_count(logical):
         assert logical
         return 2
@@ -94,8 +147,6 @@ def test_get_cores_logical(monkeypatch):
 
 
 def test_get_cores_physical(monkeypatch):
-    import psutil
-
     def cpu_count(logical):
         assert not logical
         return 2
@@ -105,9 +156,6 @@ def test_get_cores_physical(monkeypatch):
 
 
 def test_get_cores_use_os(monkeypatch):
-    import psutil
-    import os
-
     def psutil_cpu_count(logical):
         return None
 
@@ -121,9 +169,6 @@ def test_get_cores_use_os(monkeypatch):
 
 
 def test_get_cores_use_os_one_core(monkeypatch):
-    import psutil
-    import os
-
     def psutil_cpu_count(logical):
         return None
 
@@ -137,9 +182,6 @@ def test_get_cores_use_os_one_core(monkeypatch):
 
 
 def test_get_cores_fallback(monkeypatch):
-    import psutil
-    import os
-
     def psutil_cpu_count(logical):
         return None
 
@@ -150,6 +192,14 @@ def test_get_cores_fallback(monkeypatch):
     monkeypatch.setattr(os, 'cpu_count', os_cpu_count)
     assert get_cores() == 1
     assert get_cores(physical=True) == 1
+
+
+def test_get_cores_empty_affinity_falls_back(monkeypatch):
+    # An empty affinity set is treated as "unknown" and falls through to psutil.
+    monkeypatch.setattr(os, 'sched_getaffinity', lambda pid: set(),
+                        raising=False)
+    monkeypatch.setattr(psutil, 'cpu_count', lambda logical: 4)
+    assert get_cores() == 4
 
 
 def test_get_plugin():

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -125,6 +125,20 @@ def test_get_cores_affinity_physical(monkeypatch):
     assert get_cores(physical=True) == 3
 
 
+def test_get_cores_affinity_physical_single_logical_core(monkeypatch):
+    # A tight affinity mask (single logical CPU) on a hyperthreaded machine
+    # must still report at least one physical core rather than truncating to
+    # 0 and falling through to the machine-wide fallback.
+    monkeypatch.setattr(os, 'sched_getaffinity', lambda pid: {0},
+                        raising=False)
+
+    def cpu_count(logical):
+        return 16 if logical else 8
+
+    monkeypatch.setattr(psutil, 'cpu_count', cpu_count)
+    assert get_cores(physical=True) == 1
+
+
 def test_get_cores_affinity_physical_no_hyperthreading(monkeypatch):
     # No hyperthreading -> physical count equals the affinity-limited count.
     monkeypatch.setattr(os, 'sched_getaffinity', lambda pid: {0, 1, 2, 3},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU core-count detection to respect process CPU affinity when supported, better matching container and scheduler limits.
  * Enhanced physical-core estimation using hyperthreading-aware scaling, with robust fallbacks when affinity data is unavailable or empty.

* **Tests**
  * Expanded automated coverage for affinity-aware logical/physical core reporting and fallback behavior when affinity is disabled or empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->