### PR TITLE
fix timescale units in timing task

### DIFF
--- a/siliconcompiler/tools/opensta/timing.py
+++ b/siliconcompiler/tools/opensta/timing.py
@@ -217,7 +217,7 @@ class TimingTaskBase(OpenSTATask):
                 skew = f'{skewtype}skew'
                 self.record_metric(skew, max(values),
                                    source_file=self.__report_map(skew),
-                                   source_unit='W')
+                                   source_unit=timescale)
 
         drv_report = "reports/drv_violators.rpt"
         if os.path.exists(drv_report):


### PR DESCRIPTION
Closes #5064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the unit metadata recorded for timing skew metrics, so setup and hold skew values now use the proper parsed time scale instead of an incorrect placeholder unit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->