### PR TITLE
fix registration of atexit hooks

### DIFF
--- a/siliconcompiler/report/dashboard/cli/__init__.py
+++ b/siliconcompiler/report/dashboard/cli/__init__.py
@@ -217,16 +217,29 @@ class CliDashboard(AbstractDashboard):
     def stop(self):
         """
         Stops the dashboard and restores normal terminal logging.
+
+        Teardown must always release the atexit hook registered in
+        :meth:`__init__`, even when the underlying dashboard teardown raises.
+        The ``Board`` is built from :class:`MPManager` shared proxy objects
+        (events, dicts, queues) which can be torn down before this runs during
+        multiprocess exit; touching them then raises. If that exception were
+        allowed to propagate before the ``atexit.unregister`` below, the bound
+        ``self.stop`` would stay registered and fire again at interpreter
+        shutdown, surfacing as "Exception ignored in atexit callback"
+        (issue #5035). The ``try``/``finally`` guarantees the hook is released
+        regardless.
         """
-        self._dashboard.end_of_run(self._project)
+        try:
+            self._dashboard.end_of_run(self._project)
+            self._dashboard.stop()
+        except Exception:
+            pass
+        finally:
+            self._detach_logger()
 
-        self._dashboard.stop()
-
-        self._detach_logger()
-
-        if self.__exit_registered:
-            atexit.unregister(self.stop)
-            self.__exit_registered = False
+            if self.__exit_registered:
+                atexit.unregister(self.stop)
+                self.__exit_registered = False
 
     def _detach_logger(self):
         """

--- a/siliconcompiler/report/dashboard/web/__init__.py
+++ b/siliconcompiler/report/dashboard/web/__init__.py
@@ -109,6 +109,7 @@ class WebDashboard(AbstractDashboard):
         self.__lock = fasteners.InterProcessLock(self.__manifest_lock)
 
         # Ensure cleanup is called on exit
+        self.__exit_registered = True
         atexit.register(self.__cleanup)
 
     def open_dashboard(self):
@@ -253,11 +254,30 @@ class WebDashboard(AbstractDashboard):
         """
         Cleans up resources by stopping the dashboard and removing the temp directory.
         This method is registered with atexit to be called on program exit.
-        """
-        self.stop()
 
-        if os.path.exists(self.__directory):
-            shutil.rmtree(self.__directory)
+        Teardown must always release the atexit hook registered in
+        :meth:`__init__`, even when stopping the dashboard raises (at
+        interpreter shutdown the ``multiprocessing.Process`` internals may
+        already be torn down, and ``signal.signal`` raises off the main
+        thread). If such an exception escaped this atexit callback it would
+        surface as "Exception ignored in atexit callback" and skip the temp
+        directory removal below. The ``try``/``finally`` guarantees both the
+        hook release and the cleanup run regardless.
+        """
+        try:
+            self.stop()
+        except Exception:
+            pass
+        finally:
+            if self.__exit_registered:
+                atexit.unregister(self.__cleanup)
+                self.__exit_registered = False
+
+            try:
+                if os.path.exists(self.__directory):
+                    shutil.rmtree(self.__directory)
+            except Exception:
+                pass
 
     @staticmethod
     def get_next_port():

--- a/tests/report/dashboard/test_cli_dashboard.py
+++ b/tests/report/dashboard/test_cli_dashboard.py
@@ -2405,3 +2405,101 @@ def test_should_disable_with_breakpoint(project_logger, caplog):
 
     assert CliDashboard.should_disable(proj) is True
     assert "Disabling dashboard due to breakpoints at: faux/0" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# CliDashboard atexit lifecycle (issue #5035)
+# ---------------------------------------------------------------------------
+
+def test_init_registers_atexit_hook(mock_project, fake_console):
+    """__init__ registers stop() with atexit so the dashboard is torn down
+    on program exit."""
+    with patch("siliconcompiler.report.dashboard.cli.atexit") as mock_atexit, \
+            patch("threading.Thread"):
+        dash = CliDashboard(mock_project)
+
+    assert dash._CliDashboard__exit_registered is True
+    mock_atexit.register.assert_called_once_with(dash.stop)
+
+
+def test_stop_unregisters_atexit_hook(mock_project, fake_console):
+    """stop() must release the atexit hook it registered in __init__ so the
+    bound method does not fire again at interpreter shutdown."""
+    with patch("threading.Thread"):
+        dash = CliDashboard(mock_project)
+
+    assert dash._CliDashboard__exit_registered is True
+
+    with patch("siliconcompiler.report.dashboard.cli.atexit") as mock_atexit:
+        dash.stop()
+
+    assert dash._CliDashboard__exit_registered is False
+    mock_atexit.unregister.assert_called_once_with(dash.stop)
+
+
+def test_stop_unregisters_atexit_when_teardown_raises(mock_project, fake_console):
+    """Even when the underlying dashboard teardown raises (e.g. MPManager
+    proxy objects torn down during multiprocess exit), stop() must not
+    propagate and must still release the atexit hook. Otherwise the dangling
+    hook fires again at exit and surfaces as "Exception ignored in atexit
+    callback" (issue #5035)."""
+    with patch("threading.Thread"):
+        dash = CliDashboard(mock_project)
+
+    with patch.object(dash._dashboard, "end_of_run", side_effect=EOFError), \
+            patch.object(dash._dashboard, "stop", side_effect=EOFError), \
+            patch("siliconcompiler.report.dashboard.cli.atexit") as mock_atexit:
+        dash.stop()  # must not raise
+
+    assert dash._CliDashboard__exit_registered is False
+    mock_atexit.unregister.assert_called_once_with(dash.stop)
+
+
+def test_stop_restores_logger_when_teardown_raises(mock_project, fake_console):
+    """A raising dashboard teardown must not leave the dashboard log sink
+    attached — the logger is restored via the finally block."""
+    with patch("threading.Thread"):
+        dash = CliDashboard(mock_project)
+
+    dash.set_logger(mock_project.logger)
+    attached = dash._dashboard_handler
+    assert attached is not None
+
+    with patch.object(dash._dashboard, "stop", side_effect=EOFError):
+        dash.stop()
+
+    assert dash._dashboard_handler is None
+    assert attached not in mock_project.logger.handlers
+    assert dash._suppress_filter.active is False
+
+
+def test_stop_is_idempotent(mock_project, fake_console):
+    """Calling stop() twice must only unregister the hook once and must not
+    raise on the second call."""
+    with patch("threading.Thread"):
+        dash = CliDashboard(mock_project)
+
+    with patch("siliconcompiler.report.dashboard.cli.atexit") as mock_atexit:
+        dash.stop()
+        dash.stop()
+
+    assert dash._CliDashboard__exit_registered is False
+    mock_atexit.unregister.assert_called_once_with(dash.stop)
+
+
+def test_nodashboard_after_construction_releases_hook(mock_project, fake_console):
+    """Setting option 'nodashboard' after a dashboard was constructed runs
+    Project.__init_dashboard, which stops the old dashboard. That teardown
+    must not leave a dangling atexit hook even when the underlying dashboard
+    raises (issue #5035)."""
+    with patch("threading.Thread"):
+        dash = CliDashboard(mock_project)
+    mock_project._Project__dashboard = dash
+
+    with patch.object(dash._dashboard, "end_of_run", side_effect=EOFError), \
+            patch.object(dash._dashboard, "stop", side_effect=EOFError):
+        # Triggers the nodashboard callback -> dash.stop()
+        mock_project.set("option", "nodashboard", True)
+
+    assert mock_project._Project__dashboard is None
+    assert dash._CliDashboard__exit_registered is False

--- a/tests/report/dashboard/test_web_dashboard.py
+++ b/tests/report/dashboard/test_web_dashboard.py
@@ -1,4 +1,8 @@
+import os
+
 import pytest
+
+from unittest.mock import patch
 
 from siliconcompiler.report.dashboard.web import WebDashboard
 
@@ -18,3 +22,70 @@ def test_dashboard(asic_gcd, unused_tcp_port, wait_for_port):
     dashboard.stop()
 
     assert not dashboard.is_running()
+
+
+# ---------------------------------------------------------------------------
+# WebDashboard atexit lifecycle (issue #5035)
+# ---------------------------------------------------------------------------
+
+def test_init_registers_atexit_hook(asic_gcd, unused_tcp_port):
+    """__init__ registers __cleanup with atexit so resources are torn down on
+    program exit."""
+    pytest.importorskip("streamlit")
+
+    with patch("siliconcompiler.report.dashboard.web.atexit") as mock_atexit:
+        dashboard = WebDashboard(asic_gcd, port=unused_tcp_port)
+
+    assert dashboard._WebDashboard__exit_registered is True
+    mock_atexit.register.assert_called_once_with(dashboard._WebDashboard__cleanup)
+
+
+def test_cleanup_unregisters_atexit_and_removes_directory(asic_gcd, unused_tcp_port):
+    """__cleanup must release the atexit hook and remove the temp directory."""
+    pytest.importorskip("streamlit")
+
+    dashboard = WebDashboard(asic_gcd, port=unused_tcp_port)
+    directory = dashboard._WebDashboard__directory
+    assert os.path.isdir(directory)
+
+    with patch("siliconcompiler.report.dashboard.web.atexit") as mock_atexit:
+        dashboard._WebDashboard__cleanup()
+
+    assert dashboard._WebDashboard__exit_registered is False
+    mock_atexit.unregister.assert_called_once_with(dashboard._WebDashboard__cleanup)
+    assert not os.path.exists(directory)
+
+
+def test_cleanup_unregisters_atexit_when_stop_raises(asic_gcd, unused_tcp_port):
+    """Even when stop() raises (e.g. multiprocessing internals torn down during
+    exit, or signal.signal off the main thread), __cleanup must not propagate,
+    must still release the atexit hook, and must still remove the temp
+    directory. Otherwise the dangling hook fires again at exit and surfaces as
+    "Exception ignored in atexit callback" (issue #5035)."""
+    pytest.importorskip("streamlit")
+
+    dashboard = WebDashboard(asic_gcd, port=unused_tcp_port)
+    directory = dashboard._WebDashboard__directory
+
+    with patch.object(dashboard, "stop", side_effect=RuntimeError), \
+            patch("siliconcompiler.report.dashboard.web.atexit") as mock_atexit:
+        dashboard._WebDashboard__cleanup()  # must not raise
+
+    assert dashboard._WebDashboard__exit_registered is False
+    mock_atexit.unregister.assert_called_once_with(dashboard._WebDashboard__cleanup)
+    assert not os.path.exists(directory)
+
+
+def test_cleanup_is_idempotent(asic_gcd, unused_tcp_port):
+    """Calling __cleanup twice must only unregister the hook once and must not
+    raise on the second call (the directory is already gone)."""
+    pytest.importorskip("streamlit")
+
+    dashboard = WebDashboard(asic_gcd, port=unused_tcp_port)
+
+    with patch("siliconcompiler.report.dashboard.web.atexit") as mock_atexit:
+        dashboard._WebDashboard__cleanup()
+        dashboard._WebDashboard__cleanup()
+
+    assert dashboard._WebDashboard__exit_registered is False
+    mock_atexit.unregister.assert_called_once_with(dashboard._WebDashboard__cleanup)


### PR DESCRIPTION
Closes: #5035

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard shutdown reliability so cleanup errors are less likely to interrupt exit or leave the app in a bad state.
  * Reduced “ignored exception” messages during interpreter shutdown and made temporary cleanup more dependable.

* **Tests**
  * Added coverage for dashboard shutdown and cleanup behavior to verify hooks are removed correctly and repeated cleanup remains safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->