### PR TITLE
move dashboard to optional section

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -108,7 +108,7 @@ jobs:
 
           python3 -m pip install --upgrade pip
 
-          python3 -m pip install .[test,cocotb]
+          python3 -m pip install .[test,cocotb,dashboard]
           python3 -m pip install -r ./examples/requirements.txt
 
       - name: Start slurm

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -63,7 +63,7 @@ jobs:
           . .venv/bin/activate
           python3 --version
           pip install --upgrade pip
-          pip install -e .[test]
+          pip install -e .[test,dashboard]
 
       - name: Run Python tests
         timeout-minutes: 15
@@ -85,7 +85,7 @@ jobs:
           .\venv\Scripts\activate
           python3 --version
           python.exe -m pip install --upgrade pip
-          pip install -e .[test]
+          pip install -e .[test,dashboard]
 
       - name: Run Python tests (windows)
         if: runner.os == 'Windows'

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -29,3 +29,4 @@ python:
         - docs
         - optimizer
         - cocotb
+        - dashboard

--- a/docs/reference_manual/appendix/dashboard_how_to_guide.rst
+++ b/docs/reference_manual/appendix/dashboard_how_to_guide.rst
@@ -2,7 +2,15 @@
 Dashboard
 =========
 
-To start, run the command:
+To start, ensure you install the dashboard dependencies by running:
+
+.. code-block:: bash
+
+    pip install siliconcompiler[dashboard]
+
+At this point, you should have the dashboard in your environment.
+
+Then, run the command:
 
 .. code-block:: bash
 

--- a/docs/user_guide/tutorials/dashboard_tutorial.rst
+++ b/docs/user_guide/tutorials/dashboard_tutorial.rst
@@ -2,9 +2,15 @@
 Dashboard Tutorial
 ==================
 
-At this point, you should have built a project on your computer.
+To start, ensure you install the dashboard dependencies by running:
 
-To start, run the command:
+.. code-block:: bash
+
+    pip install siliconcompiler[dashboard]
+
+At this point, you should have the dashboard in your environment.
+
+Then, run the command:
 
 .. code-block:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,6 @@ dependencies = [
 
     "pyslang == 11.0.0",
 
-    # dashboard
-    "streamlit == 1.58.0",
-    "streamlit_agraph == 0.0.45",
-    "streamlit-antd-components == 0.3.2",
-    "streamlit_javascript == 0.1.5",
-    "streamlit-autorefresh == 1.0.1",
-
     # CLI dashboard
     "rich >= 14.0.0, < 16.0.0"
 ]
@@ -131,6 +124,14 @@ optimizer = [
 ]
 cocotb = [
     "cocotb >= 2.0.1, < 2.1.0; python_version >= '3.7' and python_version <= '3.13'"
+]
+dashboard = [
+    # dashboard
+    "streamlit == 1.58.0",
+    "streamlit_agraph == 0.0.45",
+    "streamlit-antd-components == 0.3.2",
+    "streamlit_javascript == 0.1.5",
+    "streamlit-autorefresh == 1.0.1"
 ]
 
 [tool.setuptools]

--- a/siliconcompiler/apps/sc_dashboard.py
+++ b/siliconcompiler/apps/sc_dashboard.py
@@ -106,7 +106,7 @@ To include another project object to compare to:
 
     try:
         dashboard = WebDashboard(project, port=cli.get("cmdarg", "port"), graph_projs=graph_projs)
-    except NotImplementedError as e:
+    except ModuleNotFoundError as e:
         cli.logger.error(e)
         return 1
 

--- a/siliconcompiler/report/dashboard/web/__init__.py
+++ b/siliconcompiler/report/dashboard/web/__init__.py
@@ -46,7 +46,7 @@ class WebDashboard(AbstractDashboard):
         try:
             from streamlit.web import bootstrap  # noqa: F401
         except ModuleNotFoundError:
-            raise NotImplementedError('streamlit is not available for dashboard')
+            raise ModuleNotFoundError('streamlit is not available for dashboard')
 
         super().__init__(project)
 


### PR DESCRIPTION
Based on recent experience, it seems like we can generate a new dashboard fairly cleanly with claude or some other tool. Since the web-dashboard brings in a relatively large number of dependencies and is probably not very heavily used, this moves it to an optional install with the plan being to deprecate in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Dashboard-related packages are now installed via a dedicated optional `dashboard` extra, so they’re only pulled in when required.
  * Dashboard startup now provides clearer feedback when the needed dashboard dependency is missing.

* **Documentation**
  * Updated the Dashboard how-to guide and tutorial to instruct installing dashboard dependencies (`pip install siliconcompiler[dashboard]`) before running `sc-dashboard`.

* **Tests / Chores**
  * Updated CI and hosted documentation builds to install with the `dashboard` extra.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->