### PR TITLE
add check for pip versions to provide warning when they are out of sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "lambdapdk >= 0.2.14",
 
     "fasteners >= 0.20",
+    "tomli >= 2.0.0; python_version < '3.11'",
     "pandas >= 1.1.5",
     "psutil >= 5.8.0",
     "Jinja2 >= 2.11.3",

--- a/siliconcompiler/scheduler/scheduler.py
+++ b/siliconcompiler/scheduler/scheduler.py
@@ -255,6 +255,10 @@ class Scheduler:
             # Configure run
             self.__project._init_run()
 
+            # Informational check: warn if an editable install's environment is
+            # out of sync with its declared pyproject.toml dependencies.
+            utils.check_python_dependencies(self.__logger)
+
             # Check validity of setup
             if not self.check_manifest():
                 raise SCRuntimeError("check_manifest() failed")

--- a/siliconcompiler/utils/__init__.py
+++ b/siliconcompiler/utils/__init__.py
@@ -15,7 +15,19 @@ from jinja2 import Environment, FileSystemLoader, Template
 
 from typing import Dict, Optional, Union, Callable, List, TYPE_CHECKING
 
-from importlib.metadata import entry_points
+import importlib.util
+from importlib.metadata import distributions, entry_points
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+try:
+    import tomllib
+except ImportError:  # Python < 3.11
+    try:
+        import tomli as tomllib
+    except ImportError:  # pragma: no cover - only when tomli is not yet installed
+        tomllib = None
 
 from siliconcompiler.utils.paths import builddir
 
@@ -578,6 +590,329 @@ def print_traceback(logger: logging.Logger, exception: Exception):
     logger.error("Backtrace:")
     for line in trace.getvalue().splitlines():
         logger.error(line)
+
+
+# Optional-dependency groups that provide development, testing, or CI tooling
+# rather than runtime functionality. These are skipped by the pre-run dependency
+# check because they are not required to execute a flow. Names are matched
+# case-insensitively.
+_IGNORED_OPTIONAL_GROUPS = frozenset({
+    "test", "tests", "testing",
+    "dev", "develop", "development",
+    "lint", "linting",
+    "doc", "docs", "documentation",
+    "type", "types", "typing", "mypy",
+    "cov", "coverage",
+    "ci", "cicd",
+    "build",
+    "release",
+    "format", "formatting", "style",
+    "bench", "benchmark", "benchmarks",
+    "check", "checks",
+})
+
+
+def _load_pyproject_data(pyproject_path: str) -> Optional[Dict]:
+    """
+    Parses a pyproject.toml file.
+
+    Args:
+        pyproject_path (str): Path to the pyproject.toml file.
+
+    Returns:
+        dict or None: The parsed contents, or None if the file is missing,
+            malformed, or no TOML parser is available.
+    """
+    if tomllib is None:
+        return None
+
+    try:
+        with open(pyproject_path, "rb") as f:
+            return tomllib.load(f)
+    except (OSError, ValueError):
+        # ValueError covers tomllib.TOMLDecodeError (a ValueError subclass).
+        return None
+
+
+def _installed_distribution_versions() -> Dict[str, str]:
+    """
+    Maps canonicalized distribution names to their installed versions.
+
+    Returns:
+        dict: A mapping of :func:`packaging.utils.canonicalize_name` names to
+            installed version strings for every distribution in the environment.
+    """
+    installed: Dict[str, str] = {}
+    for dist in distributions():
+        try:
+            name = dist.metadata["Name"]
+        except Exception:
+            name = None
+        if not name:
+            continue
+        canon = canonicalize_name(name)
+        # Multiple site directories may expose the same distribution; keep the
+        # first one found (matches import resolution order).
+        if canon not in installed:
+            installed[canon] = dist.version
+    return installed
+
+
+def _evaluate_requirement(req_str: str, installed: Dict[str, str]):
+    """
+    Evaluates a single PEP 508 requirement against the installed environment.
+
+    Args:
+        req_str (str): The raw requirement string from pyproject.toml.
+        installed (dict): Mapping of canonicalized names to installed versions.
+
+    Returns:
+        tuple: ``(status, name, have)`` where ``status`` is one of ``"ok"``,
+            ``"missing"``, ``"incompatible"``, or ``"skip"``. ``name`` is the
+            distribution name (or None when unparsable) and ``have`` is the
+            installed version (or None when not installed).
+    """
+    try:
+        req = Requirement(req_str)
+    except Exception:
+        # Unparsable requirement (e.g. a bare URL); nothing actionable to report.
+        return ("skip", None, None)
+
+    try:
+        if req.marker is not None and not req.marker.evaluate():
+            # Requirement does not apply to this environment (OS/Python version).
+            return ("skip", None, None)
+    except Exception:
+        return ("skip", None, None)
+
+    name = req.name
+    canon = canonicalize_name(name)
+    if canon not in installed:
+        return ("missing", name, None)
+
+    have = installed[canon]
+    try:
+        if req.specifier and not req.specifier.contains(have, prereleases=True):
+            return ("incompatible", name, have)
+    except Exception:
+        # Installed version could not be compared (non-PEP440); do not report.
+        return ("skip", name, have)
+
+    return ("ok", name, have)
+
+
+def _check_optional_group(group: str, reqs: List, installed: Dict[str, str],
+                          proj_name: str, logger: logging.Logger) -> int:
+    """
+    Reports issues for a single optional-dependencies group.
+
+    A group is only treated as "opted into" when all-but-one of its applicable
+    members are installed; only then are missing members reported. Version
+    incompatibilities are always reported for members that are installed,
+    regardless of whether the group is considered active.
+
+    Returns:
+        int: The number of issues reported for this group.
+    """
+    applicable = []
+    for req_str in reqs:
+        if not isinstance(req_str, str):
+            continue
+        status, name, have = _evaluate_requirement(req_str, installed)
+        if status == "skip":
+            continue
+        applicable.append((req_str, status, name, have))
+
+    if not applicable:
+        return 0
+
+    installed_count = sum(1 for (_, status, _, _) in applicable if status != "missing")
+    # "active" == all-but-one applicable members are present (and at least one is).
+    active = installed_count > 0 and installed_count >= len(applicable) - 1
+
+    issues = 0
+    for req_str, status, name, have in applicable:
+        if status == "incompatible":
+            logger.warning(
+                f"installed '{name}' ({have}) does not satisfy '{req_str.strip()}' "
+                f"from optional group '{group}' in {proj_name}")
+            issues += 1
+        elif status == "missing" and active:
+            logger.warning(
+                f"optional group '{group}' in {proj_name} appears installed, but "
+                f"'{name}' is missing (declared as '{req_str.strip()}')")
+            issues += 1
+    return issues
+
+
+def _check_project_dependencies(data: Dict, installed: Dict[str, str],
+                                logger: logging.Logger) -> int:
+    """
+    Reports declared-vs-installed dependency issues for a parsed pyproject.toml.
+
+    Args:
+        data (dict): Parsed pyproject.toml contents.
+        installed (dict): Mapping of canonicalized names to installed versions.
+        logger (logging.Logger): Logger used to emit warnings.
+
+    Returns:
+        int: Total number of issues reported.
+    """
+    project = data.get("project") if isinstance(data, dict) else None
+    if not isinstance(project, dict):
+        return 0
+
+    proj_name = project.get("name") or "this project"
+    issues = 0
+
+    core = project.get("dependencies")
+    if isinstance(core, list):
+        for req_str in core:
+            if not isinstance(req_str, str):
+                continue
+            status, name, have = _evaluate_requirement(req_str, installed)
+            if status == "missing":
+                logger.warning(
+                    f"required dependency '{name}' is declared in {proj_name}'s "
+                    f"pyproject.toml but is not installed")
+                issues += 1
+            elif status == "incompatible":
+                logger.warning(
+                    f"installed '{name}' ({have}) does not satisfy "
+                    f"'{req_str.strip()}' declared in {proj_name}'s pyproject.toml")
+                issues += 1
+
+    groups_with_issues = []
+    optional = project.get("optional-dependencies")
+    if isinstance(optional, dict):
+        for group, reqs in optional.items():
+            if not isinstance(reqs, list):
+                continue
+            if isinstance(group, str) and group.lower() in _IGNORED_OPTIONAL_GROUPS:
+                # Development/testing tooling is not required to run a flow.
+                continue
+            group_issues = _check_optional_group(group, reqs, installed, proj_name, logger)
+            if group_issues:
+                groups_with_issues.append(group)
+            issues += group_issues
+
+    if issues:
+        # Include any affected optional groups so the reinstall covers them too.
+        if groups_with_issues:
+            target = f".[{','.join(groups_with_issues)}]"
+        else:
+            target = "."
+        logger.warning(
+            f"{proj_name} environment is out of sync with pyproject.toml; "
+            f"run 'pip install -e {target}' to update")
+    return issues
+
+
+def _locate_pyproject_for_module(module: str) -> Optional[str]:
+    """
+    Finds the source pyproject.toml associated with an importable module.
+
+    Walks upward from the module's location to the nearest ancestor directory
+    containing a pyproject.toml.
+
+    Args:
+        module (str): The top-level importable module name.
+
+    Returns:
+        str or None: Absolute path to the pyproject.toml, or None if not found.
+    """
+    try:
+        spec = importlib.util.find_spec(module)
+    except (ImportError, ValueError, AttributeError, ModuleNotFoundError):
+        return None
+    if spec is None:
+        return None
+
+    if spec.origin and spec.origin != "namespace":
+        start = os.path.dirname(spec.origin)
+    else:
+        locations = list(spec.submodule_search_locations or [])
+        if not locations:
+            return None
+        start = locations[0]
+
+    current = os.path.abspath(start)
+    while True:
+        candidate = os.path.join(current, "pyproject.toml")
+        if os.path.isfile(candidate):
+            return candidate
+        parent = os.path.dirname(current)
+        if parent == current:
+            return None
+        current = parent
+
+
+def _find_editable_pyproject_paths() -> List[str]:
+    """
+    Locates source pyproject.toml files for all editable-installed distributions.
+
+    Reuses :class:`siliconcompiler.package.PythonPathResolver` to enumerate
+    importable modules and to determine which are installed in editable mode.
+
+    Returns:
+        list: Absolute paths to discovered pyproject.toml files, de-duplicated.
+    """
+    # Imported lazily: siliconcompiler.package imports from siliconcompiler.utils,
+    # so a module-level import here would be circular.
+    try:
+        from siliconcompiler.package import PythonPathResolver
+    except Exception:
+        return []
+
+    try:
+        mapping = PythonPathResolver.get_python_module_mapping()
+    except Exception:
+        return []
+
+    paths: List[str] = []
+    seen = set()
+    for module in mapping:
+        try:
+            if not PythonPathResolver.is_python_module_editable(module):
+                continue
+        except Exception:
+            continue
+
+        pyproject = _locate_pyproject_for_module(module)
+        if pyproject and pyproject not in seen:
+            seen.add(pyproject)
+            paths.append(pyproject)
+    return paths
+
+
+def check_python_dependencies(logger: logging.Logger) -> None:
+    """
+    Warns when an editable install's environment is out of sync with its
+    declared pyproject.toml dependencies.
+
+    This is a purely informative pre-run check aimed at editable (``pip install
+    -e .``) installs, where changes to ``pyproject.toml`` are not reflected in
+    the environment until a reinstall. For every editable-installed distribution
+    whose source pyproject.toml can be located, declared dependencies are
+    compared against what is actually installed, and mismatches are logged as
+    warnings. Non-editable installs are skipped because their metadata is
+    authoritative.
+
+    The check never raises: any unexpected failure is logged at debug level so
+    that it can never interfere with a run.
+
+    Args:
+        logger (logging.Logger): Logger used to emit warnings.
+    """
+    try:
+        installed = _installed_distribution_versions()
+        for pyproject in _find_editable_pyproject_paths():
+            data = _load_pyproject_data(pyproject)
+            if data is None:
+                continue
+            _check_project_dependencies(data, installed, logger)
+    except Exception as e:
+        logger.debug(f"python dependency check skipped: {e}")
 
 
 class FilterDirectories:

--- a/siliconcompiler/utils/__init__.py
+++ b/siliconcompiler/utils/__init__.py
@@ -906,13 +906,21 @@ def check_python_dependencies(logger: logging.Logger) -> None:
     """
     try:
         installed = _installed_distribution_versions()
-        for pyproject in _find_editable_pyproject_paths():
+        pyprojects = _find_editable_pyproject_paths()
+    except Exception as e:
+        logger.debug(f"python dependency check skipped: {e}")
+        return
+
+    # Check each discovered project independently so that a single bad
+    # pyproject.toml does not prevent the remaining ones from being checked.
+    for pyproject in pyprojects:
+        try:
             data = _load_pyproject_data(pyproject)
             if data is None:
                 continue
             _check_project_dependencies(data, installed, logger)
-    except Exception as e:
-        logger.debug(f"python dependency check skipped: {e}")
+        except Exception as e:
+            logger.debug(f"python dependency check skipped for {pyproject}: {e}")
 
 
 class FilterDirectories:

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -4,14 +4,27 @@ import pytest
 import os
 import os.path
 import psutil
+import sys
+import types
 
 from unittest.mock import patch
 
+from siliconcompiler import utils
 from siliconcompiler.utils import \
     truncate_text, safecompare, get_cores, grep, \
     get_plugins, \
     default_sc_dir, default_credentials_file, default_cache_dir, \
     default_email_credentials_file, default_sc_path
+from siliconcompiler.utils import (
+    _load_pyproject_data,
+    _installed_distribution_versions,
+    _evaluate_requirement,
+    _check_optional_group,
+    _check_project_dependencies,
+    _locate_pyproject_for_module,
+    _find_editable_pyproject_paths,
+    check_python_dependencies,
+)
 
 
 @pytest.mark.parametrize("text", (
@@ -315,3 +328,515 @@ def test_invalid_regex_error(caplog):
     grep(logging.getLogger(), "*", "test")
     # Check that we logged an error starting with our specific message
     assert "Invalid regex pattern" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# check_python_dependencies (pre-run informative dependency check)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test-python-deps")
+
+
+class FakeDist:
+    """Minimal stand-in for an importlib.metadata Distribution."""
+
+    def __init__(self, name, version, raise_meta=False):
+        self._name = name
+        self.version = version
+        self._raise = raise_meta
+
+    @property
+    def metadata(self):
+        if self._raise:
+            raise RuntimeError("metadata unavailable")
+        return {"Name": self._name}
+
+
+class FakeSpec:
+    def __init__(self, origin=None, locations=None):
+        self.origin = origin
+        self.submodule_search_locations = locations
+
+
+# ---------------------------------------------------------------------------
+# _import_toml / _load_pyproject_data
+# ---------------------------------------------------------------------------
+
+
+def test_load_pyproject_data_valid(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "demo"\ndependencies = ["foo"]\n')
+    data = _load_pyproject_data(str(pyproject))
+    assert data["project"]["name"] == "demo"
+
+
+def test_load_pyproject_data_missing_file(tmp_path):
+    assert _load_pyproject_data(str(tmp_path / "does_not_exist.toml")) is None
+
+
+def test_load_pyproject_data_malformed(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("this is = not valid toml =====")
+    assert _load_pyproject_data(str(pyproject)) is None
+
+
+def test_load_pyproject_data_no_toml_parser(tmp_path, monkeypatch):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "demo"\n')
+
+    # Simulate an interpreter where neither tomllib nor tomli is available.
+    monkeypatch.setattr(utils, "tomllib", None)
+    assert _load_pyproject_data(str(pyproject)) is None
+
+
+# ---------------------------------------------------------------------------
+# _installed_distribution_versions
+# ---------------------------------------------------------------------------
+
+
+def test_installed_distribution_versions(monkeypatch):
+    dists = [
+        FakeDist("Foo_Bar", "1.2.3"),
+        FakeDist("", "0.0.0"),                 # empty name -> skipped
+        FakeDist("broken", "9.9", raise_meta=True),  # metadata raises -> skipped
+        FakeDist("Foo-Bar", "2.0.0"),          # duplicate canonical -> first wins
+    ]
+    monkeypatch.setattr(utils, "distributions", lambda: iter(dists))
+
+    installed = _installed_distribution_versions()
+    assert installed == {"foo-bar": "1.2.3"}
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_requirement
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_requirement_unparsable():
+    assert _evaluate_requirement("git+https://example.com/x.git", {}) == \
+        ("skip", None, None)
+
+
+def test_evaluate_requirement_marker_excluded():
+    # Marker that never applies on any supported interpreter.
+    assert _evaluate_requirement("foo; python_version < '3.0'", {}) == \
+        ("skip", None, None)
+
+
+def test_evaluate_requirement_missing():
+    assert _evaluate_requirement("foo >= 1.0", {}) == ("missing", "foo", None)
+
+
+def test_evaluate_requirement_incompatible():
+    result = _evaluate_requirement("foo >= 2.0", {"foo": "1.0"})
+    assert result == ("incompatible", "foo", "1.0")
+
+
+def test_evaluate_requirement_ok():
+    assert _evaluate_requirement("foo >= 1.0", {"foo": "2.0"}) == ("ok", "foo", "2.0")
+
+
+def test_evaluate_requirement_ok_no_specifier():
+    assert _evaluate_requirement("foo", {"foo": "2.0"}) == ("ok", "foo", "2.0")
+
+
+def test_evaluate_requirement_specifier_contains_raises(monkeypatch):
+    # An installed version that cannot be compared against the specifier -> skip.
+    class BadSpecifier:
+        def __bool__(self):
+            return True
+
+        def contains(self, *args, **kwargs):
+            raise RuntimeError("uncomparable version")
+
+    class FakeReq:
+        def __init__(self, _):
+            self.marker = None
+            self.name = "foo"
+            self.specifier = BadSpecifier()
+
+    monkeypatch.setattr(utils, "Requirement", FakeReq)
+    assert _evaluate_requirement("foo", {"foo": "weird"}) == ("skip", "foo", "weird")
+
+
+def test_evaluate_requirement_marker_evaluate_raises(monkeypatch):
+    class BadMarker:
+        def evaluate(self):
+            raise RuntimeError("bad marker")
+
+    class FakeReq:
+        def __init__(self, _):
+            self.marker = BadMarker()
+            self.name = "foo"
+            self.specifier = None
+
+    monkeypatch.setattr(utils, "Requirement", FakeReq)
+    assert _evaluate_requirement("foo", {}) == ("skip", None, None)
+
+
+# ---------------------------------------------------------------------------
+# _check_optional_group
+# ---------------------------------------------------------------------------
+
+
+def test_check_optional_group_non_string_and_all_skipped(logger, caplog):
+    with caplog.at_level(logging.WARNING):
+        # None entry is skipped; marker-excluded entry is skipped -> nothing applicable.
+        issues = _check_optional_group(
+            "docs", [None, "foo; python_version < '3.0'"], {}, "demo", logger)
+    assert issues == 0
+    assert caplog.records == []
+
+
+def test_check_optional_group_active_reports_missing(logger, caplog):
+    # Two members, one installed -> all-but-one -> active -> report the missing one.
+    with caplog.at_level(logging.WARNING):
+        issues = _check_optional_group(
+            "docs", ["present", "absent"], {"present": "1.0"}, "demo", logger)
+    assert issues == 1
+    assert caplog.messages == [
+        "optional group 'docs' in demo appears installed, but 'absent' is missing "
+        "(declared as 'absent')",
+    ]
+
+
+def test_check_optional_group_inactive_stays_silent(logger, caplog):
+    # Three members, only one installed -> not active -> no missing warnings.
+    with caplog.at_level(logging.WARNING):
+        issues = _check_optional_group(
+            "docs", ["a", "b", "c"], {"a": "1.0"}, "demo", logger)
+    assert issues == 0
+    assert caplog.records == []
+
+
+def test_check_optional_group_incompatible_always_reported(logger, caplog):
+    # Not active (too few installed), but an installed member conflicts -> reported.
+    with caplog.at_level(logging.WARNING):
+        issues = _check_optional_group(
+            "docs", ["a >= 2.0", "b", "c"], {"a": "1.0"}, "demo", logger)
+    assert issues == 1
+    assert caplog.messages == [
+        "installed 'a' (1.0) does not satisfy 'a >= 2.0' from optional group "
+        "'docs' in demo",
+    ]
+
+
+def test_check_optional_group_fully_installed_silent(logger, caplog):
+    with caplog.at_level(logging.WARNING):
+        issues = _check_optional_group(
+            "docs", ["a >= 1.0", "b"], {"a": "1.0", "b": "1.0"}, "demo", logger)
+    assert issues == 0
+    assert caplog.records == []
+
+
+# ---------------------------------------------------------------------------
+# _check_project_dependencies
+# ---------------------------------------------------------------------------
+
+
+def test_check_project_dependencies_not_a_dict(logger):
+    assert _check_project_dependencies("nope", {}, logger) == 0
+
+
+def test_check_project_dependencies_no_project_table(logger):
+    assert _check_project_dependencies({"build-system": {}}, {}, logger) == 0
+
+
+def test_check_project_dependencies_project_not_dict(logger):
+    assert _check_project_dependencies({"project": "oops"}, {}, logger) == 0
+
+
+def test_check_project_dependencies_core_missing_and_conflict(logger, caplog):
+    data = {
+        "project": {
+            "name": "demo",
+            "dependencies": [
+                "missingpkg >= 1.0",
+                "oldpkg >= 2.0",
+                None,                         # non-string -> skipped
+                "okpkg",                      # satisfied -> silent
+            ],
+        }
+    }
+    installed = {"oldpkg": "1.0", "okpkg": "1.0"}
+    with caplog.at_level(logging.WARNING):
+        issues = _check_project_dependencies(data, installed, logger)
+
+    assert issues == 2
+    # Core-only drift -> plain reinstall, no extras suffix.
+    assert caplog.messages == [
+        "required dependency 'missingpkg' is declared in demo's pyproject.toml "
+        "but is not installed",
+        "installed 'oldpkg' (1.0) does not satisfy 'oldpkg >= 2.0' declared in "
+        "demo's pyproject.toml",
+        "demo environment is out of sync with pyproject.toml; "
+        "run 'pip install -e .' to update",
+    ]
+
+
+def test_check_project_dependencies_default_name(logger, caplog):
+    data = {"project": {"dependencies": ["missingpkg"]}}
+    with caplog.at_level(logging.WARNING):
+        issues = _check_project_dependencies(data, {}, logger)
+    assert issues == 1
+    assert caplog.messages == [
+        "required dependency 'missingpkg' is declared in this project's "
+        "pyproject.toml but is not installed",
+        "this project environment is out of sync with pyproject.toml; "
+        "run 'pip install -e .' to update",
+    ]
+
+
+def test_check_project_dependencies_non_list_sections(logger, caplog):
+    data = {
+        "project": {
+            "name": "demo",
+            "dependencies": "not-a-list",
+            "optional-dependencies": {
+                "good": ["missingextra", "present"],
+                "bad": "not-a-list",           # skipped
+            },
+        }
+    }
+    installed = {"present": "1.0"}
+    with caplog.at_level(logging.WARNING):
+        issues = _check_project_dependencies(data, installed, logger)
+    # Only the "good" group is active (all-but-one) and reports its missing member;
+    # the affected optional group is named in the reinstall hint.
+    assert issues == 1
+    assert caplog.messages == [
+        "optional group 'good' in demo appears installed, but 'missingextra' is "
+        "missing (declared as 'missingextra')",
+        "demo environment is out of sync with pyproject.toml; "
+        "run 'pip install -e .[good]' to update",
+    ]
+
+
+def test_check_project_dependencies_hint_lists_multiple_groups(logger, caplog):
+    data = {
+        "project": {
+            "name": "demo",
+            "dependencies": ["coremissing"],
+            "optional-dependencies": {
+                "gui": ["presentgui", "missinggui"],     # active -> missing reported
+                "remote": ["presentremote >= 2.0"],      # installed but conflicting
+                "quiet": ["a", "b", "c"],                # inactive -> silent
+            },
+        }
+    }
+    installed = {"presentgui": "1.0", "presentremote": "1.0"}
+    with caplog.at_level(logging.WARNING):
+        issues = _check_project_dependencies(data, installed, logger)
+
+    assert issues == 3  # 1 core + 1 gui-missing + 1 remote-conflict
+    assert caplog.messages == [
+        "required dependency 'coremissing' is declared in demo's pyproject.toml "
+        "but is not installed",
+        "optional group 'gui' in demo appears installed, but 'missinggui' is "
+        "missing (declared as 'missinggui')",
+        "installed 'presentremote' (1.0) does not satisfy 'presentremote >= 2.0' "
+        "from optional group 'remote' in demo",
+        "demo environment is out of sync with pyproject.toml; "
+        "run 'pip install -e .[gui,remote]' to update",
+    ]
+
+
+def test_check_project_dependencies_ignores_dev_groups(logger, caplog):
+    # Development/testing groups are skipped even when active and out of sync.
+    data = {
+        "project": {
+            "name": "demo",
+            "optional-dependencies": {
+                "test": ["presenttest", "missingtest"],   # active drift, but ignored
+                "Lint": ["oldlint >= 2.0"],               # conflict, but ignored (case)
+                "docs": ["missingdoc", "presentdoc"],     # active drift, but ignored
+            },
+        }
+    }
+    installed = {"presenttest": "1.0", "oldlint": "1.0", "presentdoc": "1.0"}
+    with caplog.at_level(logging.WARNING):
+        issues = _check_project_dependencies(data, installed, logger)
+
+    assert issues == 0
+    assert caplog.records == []
+
+
+def test_check_project_dependencies_optional_not_dict(logger):
+    data = {"project": {"name": "demo", "optional-dependencies": "nope"}}
+    assert _check_project_dependencies(data, {}, logger) == 0
+
+
+def test_check_project_dependencies_clean_no_hint(logger, caplog):
+    data = {"project": {"name": "demo", "dependencies": ["okpkg >= 1.0"]}}
+    with caplog.at_level(logging.WARNING):
+        issues = _check_project_dependencies(data, {"okpkg": "2.0"}, logger)
+    assert issues == 0
+    assert caplog.records == []
+
+
+# ---------------------------------------------------------------------------
+# _locate_pyproject_for_module
+# ---------------------------------------------------------------------------
+
+
+def test_locate_pyproject_find_spec_raises(monkeypatch):
+    def _boom(_):
+        raise ValueError("bad module")
+
+    monkeypatch.setattr("importlib.util.find_spec", _boom)
+    assert _locate_pyproject_for_module("whatever") is None
+
+
+def test_locate_pyproject_spec_none(monkeypatch):
+    monkeypatch.setattr("importlib.util.find_spec", lambda _: None)
+    assert _locate_pyproject_for_module("whatever") is None
+
+
+def test_locate_pyproject_from_origin(tmp_path, monkeypatch):
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "demo"\n')
+    origin = str(pkg / "__init__.py")
+    monkeypatch.setattr("importlib.util.find_spec", lambda _: FakeSpec(origin=origin))
+
+    found = _locate_pyproject_for_module("pkg")
+    assert found == str(tmp_path / "pyproject.toml")
+
+
+def test_locate_pyproject_not_found_within_limit(tmp_path, monkeypatch):
+    # Deeply nested with no pyproject.toml anywhere within the walk limit.
+    deep = tmp_path / "a" / "b" / "c" / "d" / "e"
+    deep.mkdir(parents=True)
+    origin = str(deep / "__init__.py")
+    monkeypatch.setattr("importlib.util.find_spec", lambda _: FakeSpec(origin=origin))
+    assert _locate_pyproject_for_module("pkg") is None
+
+
+def test_locate_pyproject_namespace_package(tmp_path, monkeypatch):
+    pkg = tmp_path / "nspkg"
+    pkg.mkdir()
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "demo"\n')
+    monkeypatch.setattr(
+        "importlib.util.find_spec",
+        lambda _: FakeSpec(origin="namespace", locations=[str(pkg)]))
+
+    assert _locate_pyproject_for_module("nspkg") == str(tmp_path / "pyproject.toml")
+
+
+def test_locate_pyproject_namespace_no_locations(monkeypatch):
+    monkeypatch.setattr(
+        "importlib.util.find_spec",
+        lambda _: FakeSpec(origin=None, locations=None))
+    assert _locate_pyproject_for_module("nspkg") is None
+
+
+def test_locate_pyproject_walk_stops_at_root(monkeypatch, tmp_path):
+    # Origin directly at a directory whose parent is itself (simulate fs root).
+    monkeypatch.setattr(
+        "importlib.util.find_spec",
+        lambda _: FakeSpec(origin="/__init__.py"))
+    assert _locate_pyproject_for_module("pkg") is None
+
+
+# ---------------------------------------------------------------------------
+# _find_editable_pyproject_paths
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_resolver(monkeypatch, mapping, editable, locate):
+    import siliconcompiler.package as package
+
+    monkeypatch.setattr(
+        package.PythonPathResolver, "get_python_module_mapping",
+        staticmethod(lambda: mapping))
+    monkeypatch.setattr(
+        package.PythonPathResolver, "is_python_module_editable",
+        staticmethod(editable))
+    monkeypatch.setattr(utils, "_locate_pyproject_for_module", locate)
+
+
+def test_find_editable_pyproject_paths_happy(monkeypatch):
+    mapping = {"a": ["A"], "b": ["B"], "c": ["C"], "d": ["D"], "e": ["E"]}
+
+    def editable(module):
+        if module == "e":
+            raise RuntimeError("cannot determine")
+        return module in ("a", "b", "d")
+
+    def locate(module):
+        return {
+            "a": "/proj1/pyproject.toml",
+            "b": "/proj1/pyproject.toml",   # duplicate -> deduped
+            "d": None,                        # editable but no pyproject -> skipped
+        }[module]
+
+    _install_fake_resolver(monkeypatch, mapping, editable, locate)
+    assert _find_editable_pyproject_paths() == ["/proj1/pyproject.toml"]
+
+
+def test_find_editable_pyproject_paths_import_fails(monkeypatch):
+    broken = types.ModuleType("siliconcompiler.package")
+    monkeypatch.setitem(sys.modules, "siliconcompiler.package", broken)
+    assert _find_editable_pyproject_paths() == []
+
+
+def test_find_editable_pyproject_paths_mapping_raises(monkeypatch):
+    import siliconcompiler.package as package
+
+    def _boom():
+        raise RuntimeError("mapping failed")
+
+    monkeypatch.setattr(
+        package.PythonPathResolver, "get_python_module_mapping",
+        staticmethod(_boom))
+    assert _find_editable_pyproject_paths() == []
+
+
+# ---------------------------------------------------------------------------
+# check_python_dependencies (orchestrator)
+# ---------------------------------------------------------------------------
+
+
+def test_check_python_dependencies_happy(monkeypatch, tmp_path, logger, caplog):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "demo"\ndependencies = ["missingpkg >= 1.0"]\n')
+
+    monkeypatch.setattr(
+        utils, "_find_editable_pyproject_paths", lambda: [str(pyproject)])
+    monkeypatch.setattr(
+        utils, "_installed_distribution_versions", lambda: {})
+
+    with caplog.at_level(logging.WARNING):
+        check_python_dependencies(logger)
+    assert caplog.messages == [
+        "required dependency 'missingpkg' is declared in demo's pyproject.toml "
+        "but is not installed",
+        "demo environment is out of sync with pyproject.toml; "
+        "run 'pip install -e .' to update",
+    ]
+
+
+def test_check_python_dependencies_skips_unparseable_pyproject(
+        monkeypatch, tmp_path, logger, caplog):
+    bad = tmp_path / "pyproject.toml"
+    bad.write_text("== not valid ==")
+
+    monkeypatch.setattr(utils, "_find_editable_pyproject_paths", lambda: [str(bad)])
+    monkeypatch.setattr(utils, "_installed_distribution_versions", lambda: {})
+
+    with caplog.at_level(logging.WARNING):
+        check_python_dependencies(logger)
+    assert caplog.records == []
+
+
+def test_check_python_dependencies_never_raises(monkeypatch, logger, caplog):
+    def _boom():
+        raise RuntimeError("catastrophe")
+
+    monkeypatch.setattr(utils, "_installed_distribution_versions", _boom)
+    with caplog.at_level(logging.DEBUG):
+        check_python_dependencies(logger)  # must not raise
+    assert caplog.messages == ["python dependency check skipped: catastrophe"]

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -840,3 +840,32 @@ def test_check_python_dependencies_never_raises(monkeypatch, logger, caplog):
     with caplog.at_level(logging.DEBUG):
         check_python_dependencies(logger)  # must not raise
     assert caplog.messages == ["python dependency check skipped: catastrophe"]
+
+
+def test_check_python_dependencies_isolates_per_project(
+        monkeypatch, tmp_path, logger, caplog):
+    # A failure checking one project must not prevent the others being checked.
+    good = tmp_path / "good_pyproject.toml"
+    good.write_text('[project]\nname = "good"\ndependencies = ["missingpkg"]\n')
+
+    def fake_load(path):
+        if path == "/bad/pyproject.toml":
+            raise RuntimeError("boom")
+        return _load_pyproject_data(path)
+
+    monkeypatch.setattr(
+        utils, "_find_editable_pyproject_paths",
+        lambda: ["/bad/pyproject.toml", str(good)])
+    monkeypatch.setattr(utils, "_installed_distribution_versions", lambda: {})
+    monkeypatch.setattr(utils, "_load_pyproject_data", fake_load)
+
+    with caplog.at_level(logging.DEBUG):
+        check_python_dependencies(logger)
+
+    assert caplog.messages == [
+        "python dependency check skipped for /bad/pyproject.toml: boom",
+        "required dependency 'missingpkg' is declared in good's pyproject.toml "
+        "but is not installed",
+        "good environment is out of sync with pyproject.toml; "
+        "run 'pip install -e .' to update",
+    ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-run Python dependency synchronization check that logs warnings for missing or incompatible required packages before execution begins.
  * Improved project metadata reading on older Python versions by adding a TOML parser fallback.

* **Bug Fixes**
  * Increased resilience of startup validation so dependency issues are surfaced earlier and the run continues even if some environment/project metadata can’t be processed.

* **Tests**
  * Expanded automated coverage for dependency-check behavior and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->