### PR TITLE
add testing and pex interface to OpenROAD PDK

### DIFF
--- a/siliconcompiler/tools/openroad/__init__.py
+++ b/siliconcompiler/tools/openroad/__init__.py
@@ -32,6 +32,14 @@ class OpenROADPDK(PDK):
                                    "The name of the signal layer to be used for RC extraction.")
         self.define_tool_parameter("openroad", "rclayer_clock", "str",
                                    "The name of the clock layer to be used for RC extraction.")
+        self.define_tool_parameter("openroad", "rclayer", "{(str,<via,routing>,str,float,float)}",
+                                   "Per-layer resistance and capacitance used to estimate "
+                                   "parasitics before extraction (applied via set_layer_rc). "
+                                   "Each tuple is (pexcorner, layertype, layer, resistance, "
+                                   "capacitance), where layertype is 'routing' or 'via'. "
+                                   "Resistance is ohm/um for a minimum-width routing layer or "
+                                   "ohm/cut for a via. Capacitance is F/um for a minimum-width "
+                                   "routing layer and is ignored for vias.")
 
         self.define_tool_parameter("openroad", "pin_layer_horizontal", "[str]",
                                    "A list of layers designated for horizontal pins.")
@@ -66,6 +74,36 @@ class OpenROADPDK(PDK):
             self.set("tool", "openroad", "rclayer_signal", signal)
         if clock:
             self.set("tool", "openroad", "rclayer_clock", clock)
+
+    def add_openroad_rclayer(self, corner: str, layertype: str, layer: str,
+                             resistance: float, capacitance: Optional[float] = None,
+                             clobber: bool = False):
+        """
+        Adds a per-layer parasitic estimate used to seed ``set_layer_rc`` for a PEX corner.
+
+        These values drive pre-route parasitic estimation; they are not the
+        signoff extraction model.
+
+        Args:
+            corner (str): Name of the PEX corner the values apply to.
+            layertype (str): Either "routing" or "via".
+            layer (str): Name of the routing or via (cut) layer.
+            resistance (float): Resistance, in ohm/um for a minimum-width routing
+                layer or ohm/cut for a via.
+            capacitance (float, optional): Capacitance in F/um for a minimum-width
+                routing layer. Not applicable to vias (forced to None).
+            clobber (bool, optional): If True, replaces the existing rclayer set
+                instead of adding to it. Defaults to False.
+        """
+        if layertype == "via":
+            capacitance = None  # Capacitance is not applicable for via layers
+
+        if clobber:
+            self.set("tool", "openroad", "rclayer",
+                     (corner, layertype, layer, resistance, capacitance))
+        else:
+            self.add("tool", "openroad", "rclayer",
+                     (corner, layertype, layer, resistance, capacitance))
 
     def unset_openroad_globalroutingderating(self):
         """

--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -1221,6 +1221,8 @@ class APRTask(OpenROADTask):
 
         self.add_parameter("rsz_parasitics", "file",
                            "file used to specify the parasitics for estimation", copy=False)
+        self.add_parameter("rsz_default_pex_corner", "str",
+                           "default corner to use for parasitic extraction")
         self.add_parameter("power_corner", "str",
                            "corner to use for power analysis")
 
@@ -1389,6 +1391,12 @@ class APRTask(OpenROADTask):
 
         # Set power corner
         self.set("var", "power_corner", self._get_constraint_by_check("power"), clobber=False)
+        pexmap = self._get_pex_mapping()
+        if None in pexmap:
+            self.set("var", "rsz_default_pex_corner", pexmap[None], clobber=False)
+            self.add_required_key("var", "rsz_default_pex_corner")
+        if self.pdk.get("tool", "openroad", "rclayer"):
+            self.add_required_key(self.pdk, "tool", "openroad", "rclayer")
 
         if self.get("var", "reports"):
             self.add_required_key("var", "reports")
@@ -1435,7 +1443,8 @@ class APRTask(OpenROADTask):
 
     def pre_process(self):
         super().pre_process()
-        self._build_pex_estimation_file()
+        if not self.pdk.get("tool", "openroad", "rclayer"):
+            self._build_pex_estimation_file()
 
     def __import_globalconnect_filesets(self):
         for lib in self.project.get("asic", "asiclib"):
@@ -1562,6 +1571,10 @@ class APRTask(OpenROADTask):
             if pexcorner:
                 corners[constraint] = pexcorner
 
+        default_corner = self._get_constraint_by_check("setup")
+        if default_corner in corners:
+            corners[None] = corners[default_corner]
+
         return corners
 
     def _get_constraint_by_check(self, check: str) -> str:
@@ -1579,10 +1592,6 @@ class APRTask(OpenROADTask):
 
     def _build_pex_estimation_file(self):
         corners = self._get_pex_mapping()
-
-        default_corner = self._get_constraint_by_check("setup")
-        if default_corner in corners:
-            corners[None] = corners[default_corner]
 
         path = os.path.join(self.nodeworkdir, "inputs", "sc_parasitics.tcl")
         self.set("var", "rsz_parasitics", path)

--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -970,10 +970,11 @@ proc sc_is_inside_die { x y } {
 
 proc sc_get_pexmap { map } {
     global sc_pdk
+    global sc_tool
     upvar $map pexmap
 
     set pexmap [dict create]
-    foreach pex [sc_cfg_get library $sc_pdk tool openroad rclayer] {
+    foreach pex [sc_cfg_get library $sc_pdk tool $sc_tool rclayer] {
         lassign $pex pex_corner pex_type pex_layer pex_res pex_cap
         dict set pexmap $pex_type $pex_corner $pex_layer "$pex_res $pex_cap"
     }
@@ -999,6 +1000,14 @@ proc sc_setup_pex { args } {
     }
 
     sc_get_pexmap pexmap
+
+    if {
+        ![dict exists $pexmap routing $pexcorner] &&
+        ![dict exists $pexmap via $pexcorner]
+    } {
+        utl::warn FLW 10 "No parasitic estimation layers defined for pex corner\
+            '$pexcorner' (scene: $scene_name); skipping set_layer_rc for this corner"
+    }
 
     if { [dict exists $pexmap routing $pexcorner] } {
         dict for {layer pex} [dict get $pexmap routing $pexcorner] {

--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -728,13 +728,29 @@ proc sc_setup_global_routing { } {
 proc sc_setup_parasitics { } {
     global sc_tool
     global sc_pdk
+    global sc_scenarios
 
     set sc_rc_signal [sc_get_layer_name [sc_cfg_get library $sc_pdk tool $sc_tool rclayer_signal]]
     set sc_rc_clk [sc_get_layer_name [sc_cfg_get library $sc_pdk tool $sc_tool rclayer_clock]]
 
-    set sc_parasitics [sc_cfg_tool_task_get var rsz_parasitics]
-    utl::info FLW 1 "Sourcing parasitic estimation from: $sc_parasitics"
-    source $sc_parasitics
+    if { [sc_has_pexmap] } {
+        set default_corner [sc_cfg_tool_task_get var rsz_default_pex_corner]
+        if { $default_corner != {} } {
+            utl::info FLW 1 "Setting parasitic estimation for default scenes"
+            sc_setup_pex -pexcorner $default_corner
+        }
+        foreach scene $sc_scenarios {
+            set pexcorner [sc_cfg_get constraint timing scenario $scene pexcorner]
+            if { $pexcorner != {} } {
+                utl::info FLW 1 "Setting parasitic estimation for $scene"
+                sc_setup_pex -scene $scene -pexcorner $pexcorner
+            }
+        }
+    } else {
+        set sc_parasitics [sc_cfg_tool_task_get var rsz_parasitics]
+        utl::info FLW 1 "Sourcing parasitic estimation from: $sc_parasitics"
+        source $sc_parasitics
+    }
 
     set_wire_rc -clock -layer $sc_rc_clk
     set_wire_rc -signal -layer $sc_rc_signal
@@ -950,4 +966,79 @@ proc sc_is_inside_die { x y } {
         return false
     }
     return true
+}
+
+proc sc_get_pexmap { map } {
+    global sc_pdk
+    upvar $map pexmap
+
+    set pexmap [dict create]
+    foreach pex [sc_cfg_get library $sc_pdk tool openroad rclayer] {
+        lassign $pex pex_corner pex_type pex_layer pex_res pex_cap
+        dict set pexmap $pex_type $pex_corner $pex_layer "$pex_res $pex_cap"
+    }
+}
+
+proc sc_has_pexmap { } {
+    sc_get_pexmap pexmap
+    return [expr { [dict size $pexmap] > 0 }]
+}
+
+proc sc_setup_pex { args } {
+    sta::parse_key_args "sc_setup_pex" args \
+        keys {-pexcorner -scene} \
+        flags {-verbose}
+    sta::check_argc_eq0 "sc_setup_pex" $args
+    set pexcorner $keys(-pexcorner)
+
+    set scene_name "default"
+    set corner_args []
+    if { [info exists keys(-scene)] } {
+        set scene_name $keys(-scene)
+        lappend corner_args -corner $keys(-scene)
+    }
+
+    sc_get_pexmap pexmap
+
+    if { [dict exists $pexmap routing $pexcorner] } {
+        dict for {layer pex} [dict get $pexmap routing $pexcorner] {
+            lassign $pex res cap
+
+            if { [info exists flags(-verbose)] } {
+                if { $cap == {} } {
+                    utl::info FLW 10 "Setting routing RC | $scene_name | Layer: $layer |\
+                        Res: [sta::format_resistance $res 6]\
+                        [sta::unit_scale_abbrev_suffix resistance]/um"
+                } else {
+                    utl::info FLW 10 "Setting routing RC | $scene_name | Layer: $layer |\
+                        Res: [sta::format_resistance $res 6]\
+                        [sta::unit_scale_abbrev_suffix resistance]/um |\
+                        Cap: [sta::format_capacitance $cap 6]\
+                        [sta::unit_scale_abbrev_suffix capacitance]/um"
+                }
+            }
+            set res [sta::resistance_sta_ui $res]
+            if { $cap != {} } {
+                set cap [sta::capacitance_sta_ui $cap]
+            }
+            set rc_args []
+            if { $cap != {} } {
+                lappend rc_args -capacitance $cap
+            }
+            set_layer_rc {*}$corner_args -layer $layer -resistance $res {*}$rc_args
+        }
+    }
+
+    if { [dict exists $pexmap via $pexcorner] } {
+        dict for {layer pex} [dict get $pexmap via $pexcorner] {
+            lassign $pex res cap
+            if { [info exists flags(-verbose)] } {
+                utl::info FLW 10 "Setting via RC     | $scene_name | Via: $layer   |\
+                    Res: [sta::format_resistance $res 6]\
+                    [sta::unit_scale_abbrev_suffix resistance]"
+            }
+            set res [sta::resistance_sta_ui $res]
+            set_layer_rc {*}$corner_args -via $layer -resistance $res
+        }
+    }
 }

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -8,6 +8,8 @@ from siliconcompiler.flows.asicflow import ASICFlow
 
 from siliconcompiler.scheduler import SchedulerNode
 
+from siliconcompiler.tools.openroad import OpenROADPDK
+from siliconcompiler.tools.openroad import OpenROADStdCellLibrary
 from siliconcompiler.tools.openroad import _apr
 from siliconcompiler.tools.openroad._apr import APRTask
 from siliconcompiler.tools.openroad import metrics
@@ -124,6 +126,284 @@ def test_openroad_pin_placement(asic_heartbeat):
     assert log.count("Pin clk placed at") == 1
     assert log.count("Pin nreset placed at") == 1
     assert log.count("Pin out placed at") == 1
+
+
+def test_openroad_pdk_add_rclayer_routing():
+    pdk = OpenROADPDK()
+    pdk.add_openroad_rclayer('typical', 'routing', 'm1', 0.1, 0.2)
+    assert pdk.get('tool', 'openroad', 'rclayer') == [('typical', 'routing', 'm1', 0.1, 0.2)]
+
+
+def test_openroad_pdk_add_rclayer_via_ignores_capacitance():
+    pdk = OpenROADPDK()
+    pdk.add_openroad_rclayer('typical', 'via', 'v1', 0.3, 0.4)
+    assert pdk.get('tool', 'openroad', 'rclayer') == [('typical', 'via', 'v1', 0.3, None)]
+
+
+def test_openroad_pdk_add_rclayer_default_capacitance():
+    pdk = OpenROADPDK()
+    pdk.add_openroad_rclayer('typical', 'routing', 'm1', 0.1)
+    assert pdk.get('tool', 'openroad', 'rclayer') == [('typical', 'routing', 'm1', 0.1, None)]
+
+
+def test_openroad_pdk_add_rclayer_accumulates():
+    pdk = OpenROADPDK()
+    pdk.add_openroad_rclayer('typical', 'routing', 'm1', 0.1, 0.2)
+    pdk.add_openroad_rclayer('typical', 'via', 'v1', 0.3, 0.4)
+    assert sorted(pdk.get('tool', 'openroad', 'rclayer')) == [
+        ('typical', 'routing', 'm1', 0.1, 0.2),
+        ('typical', 'via', 'v1', 0.3, None),
+    ]
+
+
+def test_openroad_pdk_add_rclayer_clobber():
+    pdk = OpenROADPDK()
+    pdk.add_openroad_rclayer('typical', 'routing', 'm1', 0.1, 0.2)
+    pdk.add_openroad_rclayer('typical', 'routing', 'm2', 0.5, clobber=True)
+    assert pdk.get('tool', 'openroad', 'rclayer') == [('typical', 'routing', 'm2', 0.5, None)]
+
+
+def test_openroad_pdk_add_rclayer_invalid_layertype():
+    pdk = OpenROADPDK()
+    with pytest.raises(ValueError):
+        pdk.add_openroad_rclayer('typical', 'bad', 'm1', 0.1, 0.2)
+
+
+def test_openroad_pdk_set_rclayers():
+    pdk = OpenROADPDK()
+    pdk.set_openroad_rclayers(signal='m3', clock='m5')
+    assert pdk.get('tool', 'openroad', 'rclayer_signal') == 'm3'
+    assert pdk.get('tool', 'openroad', 'rclayer_clock') == 'm5'
+
+
+def test_openroad_pdk_set_rclayers_signal_only():
+    pdk = OpenROADPDK()
+    pdk.set_openroad_rclayers(signal='m3')
+    assert pdk.get('tool', 'openroad', 'rclayer_signal') == 'm3'
+    assert pdk.get('tool', 'openroad', 'rclayer_clock') is None
+
+
+def test_openroad_pdk_set_rclayers_clock_only():
+    pdk = OpenROADPDK()
+    pdk.set_openroad_rclayers(clock='m5')
+    assert pdk.get('tool', 'openroad', 'rclayer_signal') is None
+    assert pdk.get('tool', 'openroad', 'rclayer_clock') == 'm5'
+
+
+def test_openroad_pdk_set_globalroutingderating():
+    pdk = OpenROADPDK()
+    pdk.set_openroad_globalroutingderating('m1', 0.5)
+    pdk.set_openroad_globalroutingderating('m2', 0.6)
+    assert sorted(pdk.get('tool', 'openroad', 'globalroutingderating')) == \
+        [('m1', 0.5), ('m2', 0.6)]
+
+
+def test_openroad_pdk_set_globalroutingderating_clobber():
+    pdk = OpenROADPDK()
+    pdk.set_openroad_globalroutingderating('m1', 0.5)
+    pdk.set_openroad_globalroutingderating('m9', 0.9, clobber=True)
+    assert pdk.get('tool', 'openroad', 'globalroutingderating') == [('m9', 0.9)]
+
+
+def test_openroad_pdk_unset_globalroutingderating():
+    pdk = OpenROADPDK()
+    pdk.set_openroad_globalroutingderating('m1', 0.5)
+    pdk.unset_openroad_globalroutingderating()
+    assert pdk.get('tool', 'openroad', 'globalroutingderating') == []
+
+
+def test_openroad_pdk_add_pinlayers():
+    pdk = OpenROADPDK()
+    pdk.add_openroad_pinlayers(horizontal='m1', vertical=['m2', 'm3'])
+    assert pdk.get('tool', 'openroad', 'pin_layer_horizontal') == ['m1']
+    assert pdk.get('tool', 'openroad', 'pin_layer_vertical') == ['m2', 'm3']
+
+
+def test_openroad_pdk_add_pinlayers_accumulates():
+    pdk = OpenROADPDK()
+    pdk.add_openroad_pinlayers(horizontal='m1')
+    pdk.add_openroad_pinlayers(horizontal='m2')
+    assert pdk.get('tool', 'openroad', 'pin_layer_horizontal') == ['m1', 'm2']
+
+
+def test_openroad_pdk_add_pinlayers_clobber():
+    pdk = OpenROADPDK()
+    pdk.add_openroad_pinlayers(horizontal='m1', vertical='m2')
+    pdk.add_openroad_pinlayers(horizontal='m5', vertical='m6', clobber=True)
+    assert pdk.get('tool', 'openroad', 'pin_layer_horizontal') == ['m5']
+    assert pdk.get('tool', 'openroad', 'pin_layer_vertical') == ['m6']
+
+
+def test_openroad_pdk_set_rcxmaxlayer():
+    pdk = OpenROADPDK()
+    pdk.set_openroad_rcxmaxlayer('m8')
+    assert pdk.get('tool', 'openroad', 'rcx_maxlayer') == 'm8'
+
+
+def test_openroad_pdk_set_processnode():
+    pdk = OpenROADPDK()
+    pdk.set_openroad_processnode('n7')
+    assert pdk.get('tool', 'openroad', 'drt_process_node') == 'n7'
+
+
+def test_openroad_pdk_set_detailedroutedisableviagen():
+    pdk = OpenROADPDK()
+    pdk.set_openroad_detailedroutedisableviagen(True)
+    assert pdk.get('tool', 'openroad', 'drt_disable_via_gen') is True
+
+
+def test_openroad_pdk_set_detailedrouteviarepair():
+    pdk = OpenROADPDK()
+    pdk.set_openroad_detailedrouteviarepair('v1')
+    assert pdk.get('tool', 'openroad', 'drt_repair_pdn_vias') == 'v1'
+
+
+def test_openroad_pdk_set_detailedrouteviainpinlayers():
+    pdk = OpenROADPDK()
+    pdk.set_openroad_detailedrouteviainpinlayers('m1', 'm2')
+    assert pdk.get('tool', 'openroad', 'drt_via_in_pin_layers') == ('m1', 'm2')
+
+
+def test_openroad_stdcell_set_tiehigh_cell():
+    lib = OpenROADStdCellLibrary()
+    lib.set_openroad_tiehigh_cell('TIEHI', 'Y')
+    assert lib.get('tool', 'openroad', 'tiehigh_cell') == ('TIEHI', 'Y')
+
+
+def test_openroad_stdcell_set_tielow_cell():
+    lib = OpenROADStdCellLibrary()
+    lib.set_openroad_tielow_cell('TIELO', 'Y')
+    assert lib.get('tool', 'openroad', 'tielow_cell') == ('TIELO', 'Y')
+
+
+def test_openroad_stdcell_set_placement_density():
+    lib = OpenROADStdCellLibrary()
+    lib.set_openroad_placement_density(0.7)
+    assert lib.get('tool', 'openroad', 'place_density') == 0.7
+
+
+def test_openroad_stdcell_cell_padding_default():
+    lib = OpenROADStdCellLibrary()
+    assert lib.get('tool', 'openroad', 'global_cell_padding') == 0
+    assert lib.get('tool', 'openroad', 'detailed_cell_padding') == 0
+
+
+def test_openroad_stdcell_set_cell_padding():
+    lib = OpenROADStdCellLibrary()
+    lib.set_openroad_cell_padding(2, 1)
+    assert lib.get('tool', 'openroad', 'global_cell_padding') == 2
+    assert lib.get('tool', 'openroad', 'detailed_cell_padding') == 1
+
+
+def test_openroad_stdcell_set_macro_placement_halo():
+    lib = OpenROADStdCellLibrary()
+    lib.set_openroad_macro_placement_halo(1.5, 2.5)
+    assert lib.get('tool', 'openroad', 'macro_placement_halo') == (1.5, 2.5)
+
+
+def test_openroad_stdcell_set_tracks_file(tmp_path):
+    tracks = tmp_path / "tracks.tcl"
+    tracks.write_text("track info")
+    lib = OpenROADStdCellLibrary()
+    lib.set_name('mylib')
+    lib.set_dataroot('root', str(tmp_path))
+    with lib.active_dataroot('root'):
+        lib.set_openroad_tracks_file('tracks.tcl')
+    assert lib.get('tool', 'openroad', 'tracks') == 'tracks.tcl'
+    assert lib.find_files('tool', 'openroad', 'tracks') == str(tracks)
+
+
+def test_openroad_stdcell_set_tracks_file_explicit_dataroot(tmp_path):
+    tracks = tmp_path / "tracks.tcl"
+    tracks.write_text("track info")
+    lib = OpenROADStdCellLibrary()
+    lib.set_name('mylib')
+    lib.set_dataroot('root', str(tmp_path))
+    lib.set_openroad_tracks_file('tracks.tcl', dataroot='root')
+    assert lib.get('tool', 'openroad', 'tracks') == 'tracks.tcl'
+    assert lib.find_files('tool', 'openroad', 'tracks') == str(tracks)
+
+
+def test_openroad_stdcell_set_tapcells_file(tmp_path):
+    tap = tmp_path / "tap.lef"
+    tap.write_text("tap info")
+    lib = OpenROADStdCellLibrary()
+    lib.set_name('mylib')
+    lib.set_dataroot('root', str(tmp_path))
+    with lib.active_dataroot('root'):
+        lib.set_openroad_tapcells_file('tap.lef')
+    assert lib.get('tool', 'openroad', 'tapcells') == 'tap.lef'
+    assert lib.find_files('tool', 'openroad', 'tapcells') == str(tap)
+
+
+def _make_lib_with_fileset(tmp_path, fileset='rtl'):
+    src = tmp_path / "gc.tcl"
+    src.write_text("connect")
+    lib = OpenROADStdCellLibrary()
+    lib.set_name('mylib')
+    lib.set_dataroot('root', str(tmp_path))
+    with lib.active_dataroot('root'):
+        with lib.active_fileset(fileset):
+            lib.add_file('gc.tcl', filetype='tcl')
+    return lib
+
+
+def test_openroad_stdcell_add_globalconnectfileset(tmp_path):
+    lib = _make_lib_with_fileset(tmp_path)
+    lib.add_openroad_globalconnectfileset('rtl')
+    assert lib.get('tool', 'openroad', 'global_connect_fileset') == ['rtl']
+
+
+def test_openroad_stdcell_add_globalconnectfileset_clobber(tmp_path):
+    lib = _make_lib_with_fileset(tmp_path)
+    lib.add_openroad_globalconnectfileset('rtl')
+    lib.add_openroad_globalconnectfileset('rtl', clobber=True)
+    assert lib.get('tool', 'openroad', 'global_connect_fileset') == ['rtl']
+
+
+def test_openroad_stdcell_add_globalconnectfileset_missing(tmp_path):
+    lib = _make_lib_with_fileset(tmp_path)
+    with pytest.raises(LookupError):
+        lib.add_openroad_globalconnectfileset('missing')
+
+
+def test_openroad_stdcell_add_powergridfileset(tmp_path):
+    lib = _make_lib_with_fileset(tmp_path)
+    lib.add_openroad_powergridfileset('rtl')
+    assert lib.get('tool', 'openroad', 'power_grid_fileset') == ['rtl']
+
+
+def test_openroad_stdcell_add_powergridfileset_clobber(tmp_path):
+    lib = _make_lib_with_fileset(tmp_path)
+    lib.add_openroad_powergridfileset('rtl')
+    lib.add_openroad_powergridfileset('rtl', clobber=True)
+    assert lib.get('tool', 'openroad', 'power_grid_fileset') == ['rtl']
+
+
+def test_openroad_stdcell_add_powergridfileset_missing(tmp_path):
+    lib = _make_lib_with_fileset(tmp_path)
+    with pytest.raises(LookupError):
+        lib.add_openroad_powergridfileset('missing')
+
+
+def test_openroad_stdcell_add_scan_chain_cells():
+    lib = OpenROADStdCellLibrary()
+    lib.add_openroad_scan_chain_cells('SC1')
+    assert lib.get('tool', 'openroad', 'scan_chain_cells') == ['SC1']
+    lib.add_openroad_scan_chain_cells(['SC2', 'SC3'])
+    assert sorted(lib.get('tool', 'openroad', 'scan_chain_cells')) == ['SC1', 'SC2', 'SC3']
+    lib.add_openroad_scan_chain_cells('SC9', clobber=True)
+    assert lib.get('tool', 'openroad', 'scan_chain_cells') == ['SC9']
+
+
+def test_openroad_stdcell_add_multibit_flipflops():
+    lib = OpenROADStdCellLibrary()
+    lib.add_openroad_multibit_flipflops('FF1')
+    assert lib.get('tool', 'openroad', 'multibit_ff_cells') == ['FF1']
+    lib.add_openroad_multibit_flipflops(['FF2', 'FF3'])
+    assert sorted(lib.get('tool', 'openroad', 'multibit_ff_cells')) == ['FF1', 'FF2', 'FF3']
+    lib.add_openroad_multibit_flipflops('FF9', clobber=True)
+    assert lib.get('tool', 'openroad', 'multibit_ff_cells') == ['FF9']
 
 
 def test_openroad_write_data_parameter_abstractlefbloatlayers():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PEX-based parasitic RC setup driven by timing scenarios, with routing/via values sourced from configuration.
  * Introduced new configuration helpers for rclayers and expanded OpenROAD PDK/stdcell-library configuration coverage.
* **Bug Fixes**
  * Improved default PEX-corner selection and handling of via-layer capacitance.
  * Updated parasitics generation so it runs only when PEX rclayer data is available.
* **Tests**
  * Added extensive unit tests for configuration APIs, including validation, accumulation, and clobber behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->