### PR TITLE
fix docstring toavoid warning in docs build

### DIFF
--- a/siliconcompiler/targets/dvflow_cocotb.py
+++ b/siliconcompiler/targets/dvflow_cocotb.py
@@ -19,28 +19,24 @@ def dvflow_cocotb(
     seed: Optional[int] = None,
     np: int = 1
 ):
-    """Configures a simulation project for a cocotb design verification run.
-
-    Registers both the Icarus and Verilator cocotb flows on the project
-    (Icarus is selected as the active flow; Verilator is added as a
-    dependency so it can be selected later via
-    ``project.set_flow("verilatorcocotbdvflow")``) and applies the shared
-    trace, timescale, and seed settings to the compile and execution tasks
-    of each flow.
-
-    Args:
-        project (Sim): The simulation project to configure.
-        trace (bool, optional): Enable waveform tracing. Defaults to True.
-        trace_type (str, optional): Waveform format for Verilator, 'vcd' or
-            'fst'. Defaults to "fst".
-        timescale (tuple[str, str], optional): Simulation timescale as a
-            (unit, precision) pair, e.g. ("1ns", "1ps"). If None, no
-            timescale is set. Defaults to None.
-        seed (int, optional): Random seed for cocotb test reproducibility.
-            If None, cocotb generates a random seed. Defaults to None.
-        np (int, optional): Number of parallel simulation nodes in each
-            flow. Defaults to 1.
     """
+        Configures a simulation project for a cocotb design verification run.
+
+        Registers both the Icarus and Verilator cocotb flows on the project
+        (Icarus is selected as the active flow; Verilator is added as a
+        dependency so it can be selected later via
+        ``project.set_flow("verilatorcocotbdvflow")``) and applies the shared
+        trace, timescale, and seed settings to the compile and execution tasks
+        of each flow.
+
+        Parameters:
+            * project (Sim): The simulation project to configure.
+            * trace (bool): Enable waveform tracing. Defaults to True.
+            * trace_type (str): Waveform format for Verilator, 'vcd' or 'fst'. Defaults to "fst".
+            * timescale (tuple[str, str]): Simulation timescale as a (unit, precision) pair, e.g. ("1ns", "1ps"). If None, no timescale is set. Defaults to None.
+            * seed (int): Random seed for cocotb test reproducibility. If None, cocotb generates a random seed. Defaults to None.
+            * np (int): Number of parallel simulation nodes in each flow. Defaults to 1.
+        """
 
     # Add cocotb flows
     project.set_flow(IcarusCocotbDVFlow(np=np))

--- a/siliconcompiler/targets/dvflow_cocotb.py
+++ b/siliconcompiler/targets/dvflow_cocotb.py
@@ -33,8 +33,10 @@ def dvflow_cocotb(
             * project (Sim): The simulation project to configure.
             * trace (bool): Enable waveform tracing. Defaults to True.
             * trace_type (str): Waveform format for Verilator, 'vcd' or 'fst'. Defaults to "fst".
-            * timescale (tuple[str, str]): Simulation timescale as a (unit, precision) pair, e.g. ("1ns", "1ps"). If None, no timescale is set. Defaults to None.
-            * seed (int): Random seed for cocotb test reproducibility. If None, cocotb generates a random seed. Defaults to None.
+            * timescale (tuple[str, str]): Simulation timescale as a (unit, precision) pair, e.g.
+                ("1ns", "1ps"). If None, no timescale is set. Defaults to None.
+            * seed (int): Random seed for cocotb test reproducibility. If None, cocotb generates a
+                random seed. Defaults to None.
             * np (int): Number of parallel simulation nodes in each flow. Defaults to 1.
         """
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved the function documentation with clearer parameter descriptions and type details.
  * Reworked the parameter section formatting for easier readability (including clearer guidance for `trace`, `trace_type`, `timescale`, `seed`, and `np`).
  * No functional behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->