### PR TITLE
add helper script for handle converting openrcx from multiple files into a single one.

### DIFF
--- a/docs/reference_manual/apps.rst
+++ b/docs/reference_manual/apps.rst
@@ -36,3 +36,7 @@ Support apps
 .. scapp::
   :app: python3 -m siliconcompiler.apps.utils.cleanup
   :title: cleanup
+
+.. scapp::
+  :app: python3 -m siliconcompiler.tools.openroad.utils.rcx_merge
+  :title: OpenrROAD OpenRCX Merge Utility

--- a/docs/reference_manual/apps.rst
+++ b/docs/reference_manual/apps.rst
@@ -39,4 +39,4 @@ Support apps
 
 .. scapp::
   :app: python3 -m siliconcompiler.tools.openroad.utils.rcx_merge
-  :title: OpenrROAD OpenRCX Merge Utility
+  :title: OpenROAD OpenRCX Merge Utility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,7 @@ spaces-in-braces = true
 skip = '*/build/*,./docs/_build/*,*.json,*.xml,*.v,./siliconcompiler/data/templates/report/bootstrap.min.js,./tests/utils/test_utils.py,./tests/tools/data/klayout_pdk/interposer.drc'
 count = true
 quiet-level = 3
-ignore-words-list = 'synopsys,inout,subtile,FRAM,dffer,dffers,thirdparty'
+ignore-words-list = 'synopsys,inout,subtile,FRAM,dffer,dffers,thirdparty,RESOVER'
 
 [tool.check-wheel-contents]
 ignore = [

--- a/siliconcompiler/tools/openroad/utils/__init__.py
+++ b/siliconcompiler/tools/openroad/utils/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2026 Silicon Compiler Authors. All Rights Reserved.

--- a/siliconcompiler/tools/openroad/utils/rcx_merge.py
+++ b/siliconcompiler/tools/openroad/utils/rcx_merge.py
@@ -1,0 +1,234 @@
+# Copyright 2026 Silicon Compiler Authors. All Rights Reserved.
+"""Utility to merge per-corner OpenRCX extraction rules into a single
+multi-corner rules file.
+
+PDKs (for example the lambdapdk gf180 PDK under
+``lambdapdk/gf180/base/pex/openroad/``) ship OpenRCX extraction rules broken
+out into one ``.rules`` file per process corner. Each of those files describes
+a single corner and therefore contains exactly one ``DensityModel 0`` block::
+
+    Extraction Rules for OpenRCX
+
+    DIAGMODEL ON
+
+    LayerCount 6
+    DensityRate 1  0
+
+    DensityModel 0
+    ...
+    END DensityModel 0
+
+OpenRCX can also consume a single file that holds every corner, with one
+``DensityModel <n>`` block per corner (for example the
+``ext_pattern.rules.3corners`` file used by the OpenROAD rcx_v2 regression
+flow)::
+
+    LayerCount 6
+    DensityRate 3  0 1 2
+
+    DensityModel 0
+    ...
+    END DensityModel 0
+
+    DensityModel 1
+    ...
+    END DensityModel 1
+
+    DensityModel 2
+    ...
+    END DensityModel 2
+
+This module reads the per-corner files (in the order they are given, which
+defines the corner indices) and stitches them together into that combined
+form. The body of each corner block is copied verbatim; only the
+``DensityModel``/``END DensityModel`` markers are renumbered.
+"""
+
+import argparse
+import re
+import sys
+
+
+# ``DensityModel 0`` (allow leading/trailing whitespace)
+_DENSITY_MODEL_RE = re.compile(r"^\s*DensityModel\s+(\d+)\s*$")
+_END_DENSITY_MODEL_RE = re.compile(r"^\s*END\s+DensityModel\s+(\d+)\s*$")
+_LAYER_COUNT_RE = re.compile(r"^\s*LayerCount\s+(\d+)\s*$")
+
+
+class RCXMergeError(Exception):
+    """Raised when the input rules files cannot be merged."""
+
+
+def _parse_rules(text, source):
+    """Parse a single OpenRCX rules file.
+
+    Returns a tuple of (layer_count, [density_model_blocks]) where each block is
+    a list of lines beginning with ``DensityModel <n>`` and ending with
+    ``END DensityModel <n>``.
+    """
+    lines = text.splitlines()
+
+    layer_count = None
+    for line in lines:
+        match = _LAYER_COUNT_RE.match(line)
+        if match:
+            layer_count = int(match.group(1))
+            break
+
+    if layer_count is None:
+        raise RCXMergeError(f"{source}: could not find a 'LayerCount' line")
+
+    blocks = []
+    current = None
+    for line in lines:
+        if current is None:
+            if _DENSITY_MODEL_RE.match(line):
+                current = [line]
+        else:
+            current.append(line)
+            if _END_DENSITY_MODEL_RE.match(line):
+                blocks.append(current)
+                current = None
+
+    if current is not None:
+        raise RCXMergeError(
+            f"{source}: 'DensityModel' block is missing a matching "
+            "'END DensityModel'")
+
+    if not blocks:
+        raise RCXMergeError(f"{source}: no 'DensityModel' blocks found")
+
+    return layer_count, blocks
+
+
+def _renumber_block(block, index):
+    """Return a copy of a DensityModel block renumbered to ``index``."""
+    renumbered = list(block)
+    renumbered[0] = f"DensityModel {index}"
+    renumbered[-1] = f"END DensityModel {index}"
+    return renumbered
+
+
+def merge_openrcx_rules(inputs, corner_names=None):
+    """Merge per-corner OpenRCX rules into a single multi-corner rules string.
+
+    Args:
+        inputs (list of str): Paths to per-corner ``.rules`` files. The order
+            defines the corner indices in the output (first file -> corner 0).
+        corner_names (list of str, optional): Human readable corner names. When
+            provided a documentation-only ``Corners`` line is emitted and the
+            length must match ``inputs``.
+
+    Returns:
+        str: The contents of the merged multi-corner rules file.
+
+    Raises:
+        RCXMergeError: If the inputs are empty, disagree on ``LayerCount``, or
+            are otherwise malformed.
+    """
+    if not inputs:
+        raise RCXMergeError("at least one input rules file is required")
+
+    if corner_names is not None and len(corner_names) != len(inputs):
+        raise RCXMergeError(
+            f"number of corner names ({len(corner_names)}) does not match "
+            f"number of input files ({len(inputs)})")
+
+    layer_count = None
+    ordered_blocks = []
+    for path in inputs:
+        try:
+            with open(path, "r") as fid:
+                text = fid.read()
+        except OSError as exc:
+            raise RCXMergeError(f"unable to read '{path}': {exc}") from exc
+
+        this_count, blocks = _parse_rules(text, path)
+
+        if layer_count is None:
+            layer_count = this_count
+        elif this_count != layer_count:
+            raise RCXMergeError(
+                f"{path}: LayerCount {this_count} does not match {layer_count} "
+                "from the first input; all corners must use the same stackup")
+
+        if len(blocks) != 1:
+            raise RCXMergeError(
+                f"{path}: expected exactly one DensityModel block, found "
+                f"{len(blocks)}")
+
+        ordered_blocks.append(blocks[0])
+
+    corner_count = len(ordered_blocks)
+    indices = list(range(corner_count))
+
+    out = []
+    out.append("Extraction Rules for OpenRCX")
+    out.append("")
+    out.append("DIAGMODEL ON")
+    out.append("")
+    out.append(f"LayerCount {layer_count}")
+    out.append(f"DensityRate {corner_count}  {' '.join(str(i) for i in indices)}")
+    if corner_names is not None:
+        out.append(f"Corners {corner_count} :  {' '.join(corner_names)}")
+    out.append("")
+
+    body_blocks = []
+    for index, block in enumerate(ordered_blocks):
+        body_blocks.append("\n".join(_renumber_block(block, index)))
+
+    # ``out`` ends with a blank entry, so joining yields a single trailing
+    # newline; add one more for the blank line before the first block. Corner
+    # blocks are separated by a blank line, and the file ends with a newline.
+    return "\n".join(out) + "\n" + "\n\n".join(body_blocks) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Merge per-corner OpenRCX .rules files into a single "
+                    "multi-corner rules file.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""example:
+  python -m siliconcompiler.tools.openroad.utils.rcx_merge \\
+      -o ext_pattern.rules.3corners \\
+      corner_min.rules corner_typ.rules corner_max.rules
+
+The order of the input files defines the corner indices (DensityModel 0, 1,
+...) in the merged output.""")
+    parser.add_argument(
+        "inputs",
+        metavar="RULES",
+        nargs="+",
+        help="per-corner OpenRCX .rules files, in corner order")
+    parser.add_argument(
+        "-o", "--output",
+        metavar="FILE",
+        help="output file (defaults to stdout)")
+    parser.add_argument(
+        "-c", "--corner-names",
+        metavar="NAME[,NAME...]",
+        help="optional comma-separated corner names for a documentation-only "
+             "'Corners' line; must match the number of inputs")
+
+    args = parser.parse_args()
+
+    corner_names = None
+    if args.corner_names:
+        corner_names = args.corner_names.split(",")
+
+    try:
+        merged = merge_openrcx_rules(args.inputs, corner_names=corner_names)
+    except RCXMergeError as exc:
+        parser.error(str(exc))
+
+    if args.output:
+        with open(args.output, "w") as fid:
+            fid.write(merged)
+    else:
+        sys.stdout.write(merged)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 import os
+import re
 import pytest
 
 from siliconcompiler import Flowgraph
@@ -32,6 +33,11 @@ from siliconcompiler.tools.openroad import repair_design
 from siliconcompiler.tools.openroad import repair_timing
 from siliconcompiler.tools.openroad import screenshot
 from siliconcompiler.tools.openroad import synth_cleanup
+from siliconcompiler.tools.openroad.utils import rcx_merge
+from siliconcompiler.tools.openroad.utils.rcx_merge import (
+    merge_openrcx_rules,
+    RCXMergeError,
+)
 
 
 @pytest.mark.eda
@@ -1937,3 +1943,362 @@ def test_openroad_sc_show_tcl_removed(scroot):
                                "scripts", "sc_show.tcl")
     assert not os.path.exists(script_path), \
         f"{script_path} should be removed; sc_open.tcl is now the single entry script"
+
+
+# ---------------------------------------------------------------------------
+# OpenRCX per-corner rules merge utility (utils/rcx_merge.py)
+# ---------------------------------------------------------------------------
+def _single_corner(layer_count, corner_tag):
+    """Build a minimal single-corner OpenRCX rules file body."""
+    return (
+        "Extraction Rules for OpenRCX\n"
+        "\n"
+        "DIAGMODEL ON\n"
+        "\n"
+        f"LayerCount {layer_count}\n"
+        "DensityRate 1  0\n"
+        "\n"
+        "DensityModel 0\n"
+        "\n"
+        "Metal 1 RESOVER\n"
+        f"WIDTH Table 1 entries:  0.17 {corner_tag}\n"
+        "END DensityModel 0\n"
+    )
+
+
+def _write_rules(name, contents):
+    with open(name, "w") as fid:
+        fid.write(contents)
+    return name
+
+
+def test_rcx_merge_three_corners():
+    files = [
+        _write_rules("min.rules", _single_corner(6, "MIN")),
+        _write_rules("typ.rules", _single_corner(6, "TYP")),
+        _write_rules("max.rules", _single_corner(6, "MAX")),
+    ]
+
+    merged = merge_openrcx_rules(files)
+
+    expected = (
+        "Extraction Rules for OpenRCX\n"
+        "\n"
+        "DIAGMODEL ON\n"
+        "\n"
+        "LayerCount 6\n"
+        "DensityRate 3  0 1 2\n"
+        "\n"
+        "DensityModel 0\n"
+        "\n"
+        "Metal 1 RESOVER\n"
+        "WIDTH Table 1 entries:  0.17 MIN\n"
+        "END DensityModel 0\n"
+        "\n"
+        "DensityModel 1\n"
+        "\n"
+        "Metal 1 RESOVER\n"
+        "WIDTH Table 1 entries:  0.17 TYP\n"
+        "END DensityModel 1\n"
+        "\n"
+        "DensityModel 2\n"
+        "\n"
+        "Metal 1 RESOVER\n"
+        "WIDTH Table 1 entries:  0.17 MAX\n"
+        "END DensityModel 2\n"
+    )
+
+    assert merged == expected
+
+
+def test_rcx_merge_single_corner():
+    files = [_write_rules("typ.rules", _single_corner(2, "TYP"))]
+
+    merged = merge_openrcx_rules(files)
+
+    assert "DensityRate 1  0\n" in merged
+    assert merged.count("DensityModel 0") == 2  # begin + end marker
+    assert "END DensityModel 0\n" in merged
+
+
+def test_rcx_merge_body_is_copied_verbatim():
+    files = [
+        _write_rules("min.rules", _single_corner(6, "MIN")),
+        _write_rules("typ.rules", _single_corner(6, "TYP")),
+    ]
+
+    merged = merge_openrcx_rules(files)
+
+    # Each corner keeps its own distinct payload line.
+    assert "WIDTH Table 1 entries:  0.17 MIN" in merged
+    assert "WIDTH Table 1 entries:  0.17 TYP" in merged
+
+    # Corner indices are assigned in file order.
+    assert merged.index("0.17 MIN") < merged.index("0.17 TYP")
+
+
+def test_rcx_merge_corner_names_emit_documentation_line():
+    files = [
+        _write_rules("min.rules", _single_corner(6, "MIN")),
+        _write_rules("typ.rules", _single_corner(6, "TYP")),
+        _write_rules("max.rules", _single_corner(6, "MAX")),
+    ]
+
+    merged = merge_openrcx_rules(files, corner_names=["min", "typ", "max"])
+
+    assert "Corners 3 :  min typ max\n" in merged
+
+
+def test_rcx_merge_mismatched_layer_count_raises():
+    files = [
+        _write_rules("a.rules", _single_corner(6, "A")),
+        _write_rules("b.rules", _single_corner(5, "B")),
+    ]
+
+    with pytest.raises(RCXMergeError, match="LayerCount"):
+        merge_openrcx_rules(files)
+
+
+def test_rcx_merge_mismatched_corner_names_raises():
+    files = [_write_rules("a.rules", _single_corner(6, "A"))]
+
+    with pytest.raises(RCXMergeError, match="corner names"):
+        merge_openrcx_rules(files, corner_names=["min", "typ"])
+
+
+def test_rcx_merge_empty_inputs_raises():
+    with pytest.raises(RCXMergeError, match="at least one"):
+        merge_openrcx_rules([])
+
+
+def test_rcx_merge_missing_density_model_raises():
+    bad = (
+        "Extraction Rules for OpenRCX\n"
+        "\n"
+        "LayerCount 6\n"
+        "DensityRate 1  0\n"
+    )
+    path = _write_rules("bad.rules", bad)
+
+    with pytest.raises(RCXMergeError, match="DensityModel"):
+        merge_openrcx_rules([path])
+
+
+def test_rcx_merge_missing_layer_count_raises():
+    bad = (
+        "Extraction Rules for OpenRCX\n"
+        "\n"
+        "DensityModel 0\n"
+        "END DensityModel 0\n"
+    )
+    path = _write_rules("bad.rules", bad)
+
+    with pytest.raises(RCXMergeError, match="LayerCount"):
+        merge_openrcx_rules([path])
+
+
+def test_rcx_merge_multiple_blocks_in_one_file_raises():
+    two_block = _single_corner(6, "A") + "\n" + (
+        "DensityModel 0\n"
+        "END DensityModel 0\n"
+    )
+    path = _write_rules("two.rules", two_block)
+
+    with pytest.raises(RCXMergeError, match="exactly one"):
+        merge_openrcx_rules([path])
+
+
+def test_rcx_merge_cli(monkeypatch):
+    files = [
+        _write_rules("min.rules", _single_corner(6, "MIN")),
+        _write_rules("typ.rules", _single_corner(6, "TYP")),
+        _write_rules("max.rules", _single_corner(6, "MAX")),
+    ]
+
+    monkeypatch.setattr(
+        "sys.argv", ["sc-rcx-merge", "-o", "merged.rules"] + files)
+    assert rcx_merge.main() == 0
+
+    with open("merged.rules") as fid:
+        merged = fid.read()
+
+    assert "DensityRate 3  0 1 2\n" in merged
+    assert "END DensityModel 2\n" in merged
+    assert merged == merge_openrcx_rules(files)
+
+
+def test_rcx_merge_cli_corner_names(monkeypatch, capsys):
+    files = [
+        _write_rules("min.rules", _single_corner(6, "MIN")),
+        _write_rules("typ.rules", _single_corner(6, "TYP")),
+    ]
+    monkeypatch.setattr(
+        "sys.argv", ["sc-rcx-merge", "-c", "min,typ"] + files)
+    assert rcx_merge.main() == 0
+
+    assert "Corners 2 :  min typ" in capsys.readouterr().out
+
+
+def test_rcx_merge_cli_stdout(monkeypatch, capsys):
+    path = _write_rules("typ.rules", _single_corner(2, "TYP"))
+    monkeypatch.setattr("sys.argv", ["sc-rcx-merge", path])
+    assert rcx_merge.main() == 0
+
+    assert "DensityRate 1  0" in capsys.readouterr().out
+
+
+# A small, self-contained multi-corner rules file that mirrors the exact
+# layout OpenROAD's OpenRCX emits (as in the rcx_v2 ext_pattern.rules.3corners
+# reference): the "Extraction Rules for OpenRCX" header, blank-line spacing,
+# a "DensityRate 3  0 1 2" line, and one "DensityModel <n>" block per corner
+# separated by a single blank line. It is written out here by hand (no shared
+# code with the merge implementation) so the round-trip test below acts as an
+# independent oracle for the output format.
+_REFERENCE_3CORNERS = """\
+Extraction Rules for OpenRCX
+
+DIAGMODEL ON
+
+LayerCount 6
+DensityRate 3  0 1 2
+
+DensityModel 0
+
+Metal 1 RESOVER
+WIDTH Table 1 entries:  0.17
+
+Metal 1 RESOVER 0
+DIST count 3 width 0.17
+0 0 0 0.0681705
+0 0.31 0 0.0681705
+1.92 0 1.92 0.0681705
+END DIST
+
+Metal 1 OVER
+WIDTH Table 1 entries:  0.17
+
+Metal 1 OVER 0
+DIST count 2 width 0.17
+0.17 8.61372e-05 9.44952e-06 0.0340853
+2.04 0 3.91595e-05 0.0340853
+END DIST
+
+Metal 1 UNDER
+WIDTH Table 0 entries:
+
+Metal 1 DIAGUNDER
+WIDTH Table 0 entries:
+END DensityModel 0
+
+DensityModel 1
+
+Metal 1 RESOVER
+WIDTH Table 1 entries:  0.17
+
+Metal 1 RESOVER 0
+DIST count 3 width 0.17
+0 0 0 0.0791705
+0 0.31 0 0.0791705
+1.92 0 1.92 0.0791705
+END DIST
+
+Metal 1 OVER
+WIDTH Table 1 entries:  0.17
+
+Metal 1 OVER 0
+DIST count 2 width 0.17
+0.17 9.61372e-05 9.44952e-06 0.0440853
+2.04 0 3.91595e-05 0.0440853
+END DIST
+
+Metal 1 UNDER
+WIDTH Table 0 entries:
+
+Metal 1 DIAGUNDER
+WIDTH Table 0 entries:
+END DensityModel 1
+
+DensityModel 2
+
+Metal 1 RESOVER
+WIDTH Table 1 entries:  0.17
+
+Metal 1 RESOVER 0
+DIST count 3 width 0.17
+0 0 0 0.0981705
+0 0.31 0 0.0981705
+1.92 0 1.92 0.0981705
+END DIST
+
+Metal 1 OVER
+WIDTH Table 1 entries:  0.17
+
+Metal 1 OVER 0
+DIST count 2 width 0.17
+0.17 1.06137e-04 9.44952e-06 0.0540853
+2.04 0 3.91595e-05 0.0540853
+END DIST
+
+Metal 1 UNDER
+WIDTH Table 0 entries:
+
+Metal 1 DIAGUNDER
+WIDTH Table 0 entries:
+END DensityModel 2
+"""
+
+
+def _split_multicorner(text):
+    """Split a multi-corner rules file into a list of single-corner texts."""
+    lines = text.splitlines()
+
+    layer_count = None
+    for line in lines:
+        m = re.match(r"^\s*LayerCount\s+(\d+)\s*$", line)
+        if m:
+            layer_count = int(m.group(1))
+            break
+
+    header = (
+        "Extraction Rules for OpenRCX\n"
+        "\n"
+        "DIAGMODEL ON\n"
+        "\n"
+        f"LayerCount {layer_count}\n"
+        "DensityRate 1  0\n"
+        "\n"
+    )
+
+    blocks = []
+    current = None
+    for line in lines:
+        if current is None:
+            if re.match(r"^\s*DensityModel\s+\d+\s*$", line):
+                current = ["DensityModel 0"]
+        else:
+            if re.match(r"^\s*END\s+DensityModel\s+\d+\s*$", line):
+                current.append("END DensityModel 0")
+                blocks.append(current)
+                current = None
+            else:
+                current.append(line)
+
+    return [header + "\n".join(b) + "\n" for b in blocks]
+
+
+def test_rcx_merge_roundtrip_reference():
+    """Splitting a multi-corner rules file and re-merging reproduces it.
+
+    Uses an inline reference that matches the OpenRCX output format, so the
+    round-trip confirms the merge emits the exact multi-corner layout without
+    depending on any external file.
+    """
+    original = _REFERENCE_3CORNERS
+
+    per_corner = _split_multicorner(original)
+    assert len(per_corner) == 3
+
+    files = [_write_rules(f"corner{i}.rules", text)
+             for i, text in enumerate(per_corner)]
+
+    assert merge_openrcx_rules(files) == original


### PR DESCRIPTION
Only added as a temporary support script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new command-line utility to merge multiple OpenRCX per-corner rules files into a single combined, multi-corner rules output.
  * Supports optional corner names, writing to an output file or emitting to stdout, and validates input consistency.
* **Documentation**
  * Updated the app reference manual with the new utility entry.
* **Tests / Quality**
  * Added unit tests covering successful merges, CLI behavior, and error cases, including a multi-corner round-trip check.
* **Chores**
  * Expanded codespell ignore list for additional common word variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->