### PR TITLE
add checks on tool installs to avoid rebuilding tools

### DIFF
--- a/siliconcompiler/apps/sc_install.py
+++ b/siliconcompiler/apps/sc_install.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Silicon Compiler Authors. All Rights Reserved.
 import argparse
 import glob
+import hashlib
+import json
 import re
 import shutil
 import subprocess
@@ -90,6 +92,155 @@ class ChoiceOptional(Container):
         """
         items = set(choices)
         return sorted(items)
+
+
+_MANIFEST_VERSION = 1
+
+
+def _get_manifest_path(build_dir: str) -> Path:
+    """Return the path to the install-tracking manifest for a given build directory."""
+    return Path(build_dir) / ".sc_install_manifest.json"
+
+
+def _load_manifest(build_dir: str) -> Dict[str, dict]:
+    """
+    Load the install-tracking manifest, returning an empty mapping if it is missing or unreadable.
+
+    Parameters:
+        build_dir (str): Base build directory where the manifest is stored.
+
+    Returns:
+        dict: Mapping from tool name to its recorded install state.
+    """
+    path = _get_manifest_path(build_dir)
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data.get("tools", {})
+
+
+def _save_manifest(build_dir: str, tools: Dict[str, dict]) -> None:
+    """
+    Persist the install-tracking manifest for the given build directory.
+
+    Parameters:
+        build_dir (str): Base build directory where the manifest is stored.
+        tools (dict): Mapping from tool name to its recorded install state.
+    """
+    path = _get_manifest_path(build_dir)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            json.dump({"version": _MANIFEST_VERSION, "tools": tools}, f, indent=2)
+    except OSError as e:
+        print(f"Warning: unable to update install manifest: {e}", file=sys.stderr)
+
+
+def _expand_docker_depends(names: Set[str], data: Dict[str, dict]) -> Set[str]:
+    """
+    Expand a set of tool names with their transitive ``docker-depends`` ancestors.
+
+    The ``docker-depends`` field in ``_tools.json`` may be absent, a single tool name, or
+    a list of tool names. This walks the dependency graph so that a dependent tool's
+    fingerprint reflects the pinned versions of everything it is built against (e.g. a
+    ``yosys`` bump must invalidate ``sby``). Cycles and unknown names are handled safely.
+
+    Parameters:
+        names (Set[str]): Starting tool names.
+        data (Dict[str, dict]): Parsed ``_tools.json`` contents.
+
+    Returns:
+        Set[str]: `names` plus all transitive `docker-depends` ancestors.
+    """
+    result: Set[str] = set()
+    stack = list(names)
+    while stack:
+        name = stack.pop()
+        if name in result:
+            continue
+        result.add(name)
+        depends = data.get(name, {}).get("docker-depends", [])
+        if isinstance(depends, str):
+            depends = [depends]
+        stack.extend(depends)
+    return result
+
+
+def compute_fingerprint(tool: str, script: str) -> Optional[str]:
+    """
+    Built-in fingerprint provider for a tool's install script.
+
+    The fingerprint combines the install script contents with the pinned version
+    metadata (git-commit/version/git-url) of the tool itself and its transitive
+    ``docker-depends`` ancestors. This ensures the fingerprint changes when the install
+    procedure, the tool's pinned upstream version, or any dependency's pinned version
+    changes.
+
+    This is the default provider registered under the ``siliconcompiler.install``
+    ``fingerprint`` plugin group; plugins that supply their own tools may register a
+    replacement (see :func:`_get_fingerprint`).
+
+    Parameters:
+        tool (str): Tool identifier (used by plugins; the built-in relies on the script).
+        script (str): Path to the install script.
+
+    Returns:
+        Optional[str]: Hex digest fingerprint, or `None` if the script cannot be read
+        (in which case the caller should treat the tool as always needing a rebuild).
+    """
+    try:
+        with open(script, "rb") as f:
+            script_bytes = f.read()
+    except OSError:
+        return None
+
+    h = hashlib.sha256()
+    h.update(script_bytes)
+
+    tools_json = _get_tool_script_dir() / "_tools.json"
+    if tools_json.exists():
+        try:
+            with open(tools_json) as f:
+                data = json.load(f)
+            names = _expand_docker_depends({tool}, data)
+            subset = {name: data[name] for name in sorted(names) if name in data}
+            h.update(json.dumps(subset, sort_keys=True).encode("utf-8"))
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    return h.hexdigest()
+
+
+def _get_fingerprint(tool: str, script: str) -> Optional[str]:
+    """
+    Resolve the install fingerprint for a tool via the fingerprint plugin group.
+
+    Plugins registered under the ``siliconcompiler.install`` group with the name
+    ``fingerprint`` are consulted first, in discovery order; the first one returning a
+    non-``None`` value wins, letting external tool packages override how their tools are
+    fingerprinted. If no plugin claims the tool, the built-in
+    :func:`compute_fingerprint` is used as a fallback so that script-based tracking is
+    always available.
+
+    Each plugin is a callable ``(tool: str, script: str) -> Optional[str]``.
+
+    Parameters:
+        tool (str): Tool identifier.
+        script (str): Path to the install script.
+
+    Returns:
+        Optional[str]: The resolved fingerprint, or `None` if it cannot be computed (the
+        tool is then always rebuilt and never recorded in the manifest).
+    """
+    for plugin in get_plugins("install", name="fingerprint"):
+        fingerprint = plugin(tool, script)
+        if fingerprint is not None:
+            return fingerprint
+    return compute_fingerprint(tool, script)
 
 
 def install_tool(tool: str, script: str, build_dir: str, prefix: str,
@@ -216,7 +367,8 @@ def print_machine_info() -> None:
 
 def __print_summary(successful: Optional[Set[str]],
                     failed: Optional[str],
-                    notstarted: Optional[Set[str]]) -> None:
+                    notstarted: Optional[Set[str]],
+                    skipped: Optional[Set[str]] = None) -> None:
     """
     Prints a fixed-width summary banner listing installed, failed, and pending tools.
 
@@ -227,11 +379,17 @@ def __print_summary(successful: Optional[Set[str]],
                                 under "Failed to install".
         notstarted (Optional[Set[str]]): Set of tool names that were not started or are pending;
                                          when provided, they are shown under "Pending".
+        skipped (Optional[Set[str]]): Set of tool names that were already up to date and skipped;
+                                      when provided, they are shown under "Up to date".
     """
     max_len = 64
     print("#"*max_len)
     if successful:
         msg = f"Installed: {', '.join(sorted(successful))}"
+        print(f"# {msg}")
+
+    if skipped:
+        msg = f"Up to date: {', '.join(sorted(skipped))}"
         print(f"# {msg}")
 
     if failed:
@@ -323,6 +481,9 @@ To limit parallel build jobs (useful for memory-constrained systems):
 To combine options (custom location with limited parallelism):
     sc-install -prefix /opt/tools -jobs 8 openroad yosys
 
+To force a rebuild even if the tool is already up to date:
+    sc-install -force yosys
+
 To show the install script:
     sc-install -show openroad
 
@@ -378,6 +539,11 @@ Tool groups:
         metavar="<int>")
 
     parser.add_argument(
+        "-force",
+        action="store_true",
+        help="Force a rebuild even if the tool is already up to date")
+
+    parser.add_argument(
         "-show",
         action="store_true",
         help="Show the install script and exit")
@@ -407,9 +573,13 @@ Tool groups:
 
     tools_handled = set()
     tools_completed = set()
+    tools_skipped = set()
     if args.jobs is not None and args.jobs < 1:
         print("Error: -jobs must be a positive integer", file=sys.stderr)
         return 1
+
+    prefix = str(args.prefix)
+    manifest = {} if args.show else _load_manifest(args.build_dir)
     for tool in args.tool:
         if tool in tools_handled:
             continue
@@ -417,15 +587,26 @@ Tool groups:
         if args.show:
             show_tool(tool, tools[tool])
         else:
-            if not install_tool(tool, tools[tool], args.build_dir, args.prefix, args.jobs):
-                notstarted = set(args.tool) - tools_completed - tools_handled
-                __print_summary(tools_completed, tool, notstarted)
+            fingerprint = _get_fingerprint(tool, tools[tool])
+            record = manifest.get(tool)
+            if (not args.force and fingerprint is not None and record and
+                    record.get("fingerprint") == fingerprint and
+                    record.get("prefix") == prefix):
+                print(f"{tool} is already up to date (use -force to rebuild)")
+                tools_skipped.add(tool)
+                continue
+            if not install_tool(tool, tools[tool], args.build_dir, prefix, args.jobs):
+                notstarted = set(args.tool) - tools_completed - tools_skipped - tools_handled
+                __print_summary(tools_completed, tool, notstarted, tools_skipped)
                 return 1
             else:
                 tools_completed.add(tool)
+                if fingerprint is not None:
+                    manifest[tool] = {"fingerprint": fingerprint, "prefix": prefix}
+                    _save_manifest(args.build_dir, manifest)
 
     if not args.show:
-        __print_summary(tools_completed, None, None)
+        __print_summary(tools_completed, None, None, tools_skipped)
 
         msgs = []
         for env, path in (

--- a/tests/apps/test_sc_install.py
+++ b/tests/apps/test_sc_install.py
@@ -54,6 +54,238 @@ def test_install_failed(call, monkeypatch, capfd):
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_install_skips_when_up_to_date(monkeypatch, datadir, capfd):
+    """A second install of an unchanged tool is skipped unless -force is given."""
+    script = os.path.join(datadir, "echo_prefix.sh")
+
+    def return_os():
+        return {"echo": script}
+    monkeypatch.setattr(sc_install, '_get_tools_list', return_os)
+
+    build_dir = os.path.abspath("build_track")
+
+    # First install builds the tool and records the manifest.
+    monkeypatch.setattr('sys.argv', ['sc-install', 'echo', '-build_dir', build_dir])
+    assert sc_install.main() == 0
+    assert "is already up to date" not in capfd.readouterr().out
+
+    # Second install with an unchanged script is skipped.
+    monkeypatch.setattr('sys.argv', ['sc-install', 'echo', '-build_dir', build_dir])
+    assert sc_install.main() == 0
+    out = capfd.readouterr().out
+    assert "echo is already up to date" in out
+    assert "# Up to date: echo" in out
+
+    # -force rebuilds regardless of the manifest.
+    monkeypatch.setattr('sys.argv', ['sc-install', 'echo', '-build_dir', build_dir, '-force'])
+    assert sc_install.main() == 0
+    assert "is already up to date" not in capfd.readouterr().out
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_install_rebuilds_when_fingerprint_changes(monkeypatch, datadir, tmp_path, capfd):
+    """Changing the install script contents invalidates the manifest and forces a rebuild."""
+    import shutil as _shutil
+    script = str(tmp_path / "install-echo.sh")
+    _shutil.copy(os.path.join(datadir, "echo_prefix.sh"), script)
+    os.chmod(script, 0o755)
+
+    def return_os():
+        return {"echo": script}
+    monkeypatch.setattr(sc_install, '_get_tools_list', return_os)
+
+    build_dir = os.path.abspath("build_track_fp")
+
+    monkeypatch.setattr('sys.argv', ['sc-install', 'echo', '-build_dir', build_dir])
+    assert sc_install.main() == 0
+
+    # Mutate the script so its fingerprint changes.
+    with open(script, "a") as f:
+        f.write("\n# changed\n")
+
+    monkeypatch.setattr('sys.argv', ['sc-install', 'echo', '-build_dir', build_dir])
+    assert sc_install.main() == 0
+    assert "is already up to date" not in capfd.readouterr().out
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_install_rebuilds_when_prefix_changes(monkeypatch, datadir, capfd):
+    """Installing to a different prefix is not skipped even if the script is unchanged."""
+    script = os.path.join(datadir, "echo_prefix.sh")
+
+    def return_os():
+        return {"echo": script}
+    monkeypatch.setattr(sc_install, '_get_tools_list', return_os)
+
+    build_dir = os.path.abspath("build_track_prefix")
+
+    monkeypatch.setattr('sys.argv', [
+        'sc-install', 'echo', '-build_dir', build_dir, '-prefix', os.path.abspath('p1')])
+    assert sc_install.main() == 0
+
+    monkeypatch.setattr('sys.argv', [
+        'sc-install', 'echo', '-build_dir', build_dir, '-prefix', os.path.abspath('p2')])
+    assert sc_install.main() == 0
+    assert "is already up to date" not in capfd.readouterr().out
+
+
+def test_expand_docker_depends():
+    """Transitive docker-depends closure handles str, list, chains, and cycles."""
+    data = {
+        "sby": {"docker-depends": "yosys"},
+        "yosys": {},
+        "boolector": {},
+        "leaf": {"docker-depends": ["a", "b"]},
+        "a": {"docker-depends": "yosys"},
+        "b": {},
+        # cycle: c -> d -> c
+        "c": {"docker-depends": "d"},
+        "d": {"docker-depends": "c"},
+    }
+    assert sc_install._expand_docker_depends({"sby", "boolector"}, data) == \
+        {"sby", "yosys", "boolector"}
+    assert sc_install._expand_docker_depends({"leaf"}, data) == \
+        {"leaf", "a", "b", "yosys"}
+    # cycle terminates
+    assert sc_install._expand_docker_depends({"c"}, data) == {"c", "d"}
+    # unknown names are preserved but contribute no dependencies
+    assert sc_install._expand_docker_depends({"unknown"}, data) == {"unknown"}
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_fingerprint_tracks_docker_depends(monkeypatch, tmp_path):
+    """A tool's fingerprint changes when a docker-depends dependency's version changes."""
+    import json as _json
+    scripts_dir = tmp_path / "toolscripts"
+    scripts_dir.mkdir()
+
+    tools_data = {
+        "child": {"git-url": "https://example/child.git", "git-commit": "v1"},
+        "parent": {"git-url": "https://example/parent.git", "git-commit": "v1",
+                   "docker-depends": "child"},
+    }
+    tools_json = scripts_dir / "_tools.json"
+    tools_json.write_text(_json.dumps(tools_data))
+
+    # parent's install script only references itself, not the dependency.
+    script = scripts_dir / "install-parent.sh"
+    script.write_text("#!/bin/sh\n_tools.py --tool parent --field git-commit\n")
+
+    monkeypatch.setattr(sc_install, "_get_tool_script_dir", lambda: scripts_dir)
+
+    fp_before = sc_install.compute_fingerprint("parent", str(script))
+
+    # Bump only the dependency's pinned version.
+    tools_data["child"]["git-commit"] = "v2"
+    tools_json.write_text(_json.dumps(tools_data))
+
+    fp_after = sc_install.compute_fingerprint("parent", str(script))
+    assert fp_before != fp_after
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_fingerprint_tracks_tool_without_self_reference(monkeypatch, tmp_path):
+    """The tool's own version is tracked even if its script never references it."""
+    import json as _json
+    scripts_dir = tmp_path / "toolscripts"
+    scripts_dir.mkdir()
+
+    tools_data = {"montage": {"version": "1.0", "docker-depends": "dep"},
+                  "dep": {"version": "1.0"}}
+    tools_json = scripts_dir / "_tools.json"
+    tools_json.write_text(_json.dumps(tools_data))
+
+    # Script installs via apt and never mentions _tools.py / --tool.
+    script = scripts_dir / "install-montage.sh"
+    script.write_text("#!/bin/sh\nsudo apt-get install -y imagemagick\n")
+
+    monkeypatch.setattr(sc_install, "_get_tool_script_dir", lambda: scripts_dir)
+
+    fp_before = sc_install.compute_fingerprint("montage", str(script))
+
+    # Bump the tool's own pinned version -> fingerprint must change.
+    tools_data["montage"]["version"] = "2.0"
+    tools_json.write_text(_json.dumps(tools_data))
+    assert sc_install.compute_fingerprint("montage", str(script)) != fp_before
+
+    # And bumping its docker-depends dependency must also change it.
+    tools_data["montage"]["version"] = "1.0"
+    tools_data["dep"]["version"] = "2.0"
+    tools_json.write_text(_json.dumps(tools_data))
+    assert sc_install.compute_fingerprint("montage", str(script)) != fp_before
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_fingerprint_plugin_overrides_builtin(monkeypatch, datadir, capfd):
+    """A fingerprint plugin takes precedence over the built-in provider."""
+    script = os.path.join(datadir, "echo_prefix.sh")
+
+    def return_os():
+        return {"echo": script}
+    monkeypatch.setattr(sc_install, '_get_tools_list', return_os)
+
+    calls = []
+    fp_value = ["v1"]
+
+    def fingerprint_plugin(tool, script_path):
+        calls.append((tool, script_path))
+        return fp_value[0]
+
+    def get_plugins(system, name=None):
+        if name == "fingerprint":
+            return [fingerprint_plugin]
+        return []
+    monkeypatch.setattr(sc_install, "get_plugins", get_plugins)
+
+    build_dir = os.path.abspath("build_track_plugin")
+
+    # First install uses the plugin fingerprint and records it.
+    monkeypatch.setattr('sys.argv', ['sc-install', 'echo', '-build_dir', build_dir])
+    assert sc_install.main() == 0
+    assert calls and calls[0][0] == "echo"
+
+    # Same plugin fingerprint -> skipped.
+    monkeypatch.setattr('sys.argv', ['sc-install', 'echo', '-build_dir', build_dir])
+    assert sc_install.main() == 0
+    assert "echo is already up to date" in capfd.readouterr().out
+
+    # Plugin reports a new fingerprint -> rebuilt.
+    fp_value[0] = "v2"
+    monkeypatch.setattr('sys.argv', ['sc-install', 'echo', '-build_dir', build_dir])
+    assert sc_install.main() == 0
+    assert "is already up to date" not in capfd.readouterr().out
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_fingerprint_plugin_falls_back_to_builtin(monkeypatch, datadir, capfd):
+    """When a plugin returns None the built-in fingerprint is used."""
+    script = os.path.join(datadir, "echo_prefix.sh")
+
+    def return_os():
+        return {"echo": script}
+    monkeypatch.setattr(sc_install, '_get_tools_list', return_os)
+
+    def fingerprint_plugin(tool, script_path):
+        return None
+
+    def get_plugins(system, name=None):
+        if name == "fingerprint":
+            return [fingerprint_plugin]
+        return []
+    monkeypatch.setattr(sc_install, "get_plugins", get_plugins)
+
+    build_dir = os.path.abspath("build_track_fallback")
+
+    monkeypatch.setattr('sys.argv', ['sc-install', 'echo', '-build_dir', build_dir])
+    assert sc_install.main() == 0
+
+    # Built-in fingerprint (script unchanged) -> skipped on second run.
+    monkeypatch.setattr('sys.argv', ['sc-install', 'echo', '-build_dir', build_dir])
+    assert sc_install.main() == 0
+    assert "echo is already up to date" in capfd.readouterr().out
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
 @mock.patch("subprocess.call")
 def test_install_two_tools(call, monkeypatch, capfd):
     def return_os():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `sc_install` now records installation state and skips tools that are already up to date.
  * Added a `-force` option to reinstall tools even when no changes are detected.
  * Install summaries now include an “Up to date” section for skipped tools.

* **Bug Fixes**
  * Reinstalls now trigger when install scripts, tool metadata, dependencies, or install location change.
  * Added support for custom fingerprinting while safely falling back to the built-in behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->