### PR TITLE
fix fill scripts

### DIFF
--- a/siliconcompiler/tools/openroad/fillmetal_insertion.py
+++ b/siliconcompiler/tools/openroad/fillmetal_insertion.py
@@ -64,22 +64,15 @@ class FillMetalTask(APRTask, OpenROADSTAParameter):
         self.add_required_key("var", "fin_add_fill")
 
         if self.get("var", "fin_add_fill"):
+            # The metal fill rules are shipped by the PDK as a fill file (filetype
+            # "fill") inside the OpenROAD APR tech fileset. Mark it required so it is
+            # hashed (cache) and copied (remote runs). If no PDK provides one, there
+            # is nothing to do and the task is skipped.
             found = False
-            # for fileset in self.pdk.get("pdk", "fill", "runsetfileset", "openroad"):
-            #     if self.pdk.valid("fileset", fileset, "file", "fill"):
-            #         self.add_required_key(self.pdk, "fileset", fileset, "file", "fill")
-            #         found = True
+            for fileset in self.pdk.get("pdk", "aprtechfileset", "openroad"):
+                if self.pdk.has_file(fileset=fileset, filetype="fill"):
+                    self.add_required_key(self.pdk, "fileset", fileset, "file", "fill")
+                    found = True
 
             if not found:
-                raise TaskSkip("no metal fill script is available")
-            # if self.pdk.valid("chip.get('pdk', pdk, 'aprtech', tool, stackup, libtype, 'fill'):
-            #     chip.add('tool', tool, 'task', task, 'require',
-            #             ",".join(['pdk', pdk, 'aprtech', tool, stackup, libtype, 'fill']),
-            #             step=step, index=index)
-            # else:
-            #     if not has_pre_post_script(chip):
-            #         # nothing to do so we can skip
-            #         return "no fill script is available"
-
-            #     chip.set('tool', tool, 'task', task, 'var', 'fin_add_fill', False,
-            #             step=step, index=index)
+                raise TaskSkip("no metal fill rules are available")

--- a/siliconcompiler/tools/openroad/rdlroute.py
+++ b/siliconcompiler/tools/openroad/rdlroute.py
@@ -73,4 +73,4 @@ class RDLRouteTask(OpenROADTask):
                 if lib.has_file(fileset=fileset, filetype="lef"):
                     self.add_required_key(lib, "fileset", fileset, "file", "lef")
 
-        self.set("var", "fin_add_fill", False)
+        self.set_openroad_addfill(False)

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_fillmetal_insertion.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_fillmetal_insertion.tcl
@@ -15,15 +15,14 @@ source "$sc_refdir/apr/preamble.tcl"
 # Do fill
 ###############################
 
-set sc_libtype [sc_cfg_get library $sc_mainlib asic libarch]
+set sc_aprfileset [sc_cfg_get library $sc_pdk pdk aprtechfileset openroad]
+set sc_fillrules [sc_cfg_get_fileset $sc_pdk $sc_aprfileset fill]
 
 if {
     [sc_cfg_tool_task_get var fin_add_fill] &&
-    [sc_cfg_exists pdk $sc_pdk aprtech openroad $sc_stackup $sc_libtype fill]
+    [llength $sc_fillrules] > 0
 } {
-    set sc_fillrules \
-        [lindex [sc_cfg_get pdk $sc_pdk aprtech openroad $sc_stackup $sc_libtype fill] 0]
-    density_fill -rules $sc_fillrules
+    density_fill -rules [lindex $sc_fillrules 0]
 }
 
 # estimate for metrics

--- a/siliconcompiler/tools/openroad/scripts/sc_rdlroute.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_rdlroute.tcl
@@ -127,10 +127,12 @@ foreach obstruction [[ord::get_db_block] getObstructions] {
 }
 utl::info FLW 1 "Deleted $removed_obs routing obstructions"
 
-if { [sc_cfg_tool_task_get var fin_add_fill] } {
-    set sc_fillrules \
-        [lindex [sc_cfg_get pdk $sc_pdk aprtech openroad $sc_stackup $sc_libtype fill] 0]
-    density_fill -rules $sc_fillrules
+set sc_fillrules [sc_cfg_get_fileset $sc_pdk $aprfileset fill]
+if {
+    [sc_cfg_tool_task_get var fin_add_fill] &&
+    [llength $sc_fillrules] > 0
+} {
+    density_fill -rules [lindex $sc_fillrules 0]
 }
 
 utl::pop_metrics_stage


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metal fill insertion by locating fill rules from the configured PDK filesets.
  * Remote runs now include the required fill-rule files automatically.
  * Fill generation is skipped cleanly when no applicable fill rules are available.
  * RDL routing now uses the same fill-rule handling and avoids attempting fill generation without valid rules.
  * Updated fill processing to run only when enabled and configured rules are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->