### PR TITLE
prune quick CI

### DIFF
--- a/tests/apps/test_sc_remote.py
+++ b/tests/apps/test_sc_remote.py
@@ -613,8 +613,8 @@ def test_configure_add_add_whitelist_multiple(credentials_file, monkeypatch):
              os.path.abspath('add_this_too_too')])
 
 
-@pytest.mark.parametrize("args", itertools.permutations(
-        ['configure', 'reconnect', 'cancel', 'delete'], r=2))
+@pytest.mark.parametrize("args", list(itertools.permutations(
+        ['configure', 'reconnect', 'cancel', 'delete'], r=2)))
 def test_exclusive_args(args, monkeypatch):
 
     monkeypatch.setattr('sys.argv', ['sc-remote',

--- a/tests/examples/test_fibone.py
+++ b/tests/examples/test_fibone.py
@@ -4,7 +4,6 @@ import os.path
 
 
 @pytest.mark.eda
-@pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_fibone():
     from fibone import fibone

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -44,7 +44,6 @@ def test_py_gcd():
 
 
 @pytest.mark.eda
-@pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_gcd_skywater():
     from gcd import gcd_skywater
@@ -69,7 +68,6 @@ def test_py_gcd_gf180():
 
 
 @pytest.mark.eda
-@pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_gcd_ihp130():
     from gcd import gcd_ihp130
@@ -83,7 +81,6 @@ def test_py_gcd_ihp130():
 
 
 @pytest.mark.eda
-@pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_gcd_hls():
     from gcd import gcd_hls
@@ -93,7 +90,6 @@ def test_py_gcd_hls():
 
 
 @pytest.mark.eda
-@pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_gcd_chisel():
     from gcd import gcd_chisel

--- a/tests/examples/test_ghdl_fsynopsys.py
+++ b/tests/examples/test_ghdl_fsynopsys.py
@@ -4,7 +4,6 @@ import os.path
 
 
 @pytest.mark.eda
-@pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_build():
     from ghdl_fsynopsys import build

--- a/tests/examples/test_heartbeat.py
+++ b/tests/examples/test_heartbeat.py
@@ -99,7 +99,6 @@ def test_py_make_fpga():
 
 
 @pytest.mark.eda
-@pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_make_screenshot(monkeypatch):
     from heartbeat import make

--- a/tests/examples/test_heartbeat_migen.py
+++ b/tests/examples/test_heartbeat_migen.py
@@ -4,7 +4,6 @@ import os.path
 
 
 @pytest.mark.eda
-@pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_heartbeat_migen():
     from heartbeat_migen import heartbeat_migen

--- a/tests/examples/test_macro_reuse.py
+++ b/tests/examples/test_macro_reuse.py
@@ -4,7 +4,6 @@ import os.path
 
 
 @pytest.mark.eda
-@pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_py_make_top():
     from macro_reuse import make

--- a/tests/targets/test_asicsignoff.py
+++ b/tests/targets/test_asicsignoff.py
@@ -76,7 +76,7 @@ def _make_gcd(examples_root):
     pytest.param("asap7", marks=pytest.mark.timeout(1200)),
     pytest.param("skywater130", marks=pytest.mark.timeout(600)),
     pytest.param("gf180", marks=pytest.mark.timeout(1200)),
-    pytest.param("ihp130", marks=(pytest.mark.quick, pytest.mark.timeout(300))),
+    pytest.param("ihp130", marks=pytest.mark.timeout(300)),
 ))
 def test_target_signoff(name, examples_root):
     cfg = _SIGNOFF[name]

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -55,7 +55,6 @@ def test_version(asic_gcd):
 
 
 @pytest.mark.eda
-@pytest.mark.quick
 @pytest.mark.timeout(300)
 def test_openroad_images(asic_gcd):
     for task in APRTask.find_task(asic_gcd):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test categorization so hardware and EDA-related tests run under the appropriate EDA test marker instead of the quick-test category.
  * Removed quick-test classification from longer-running signoff, OpenROAD, and example tests.
  * Improved parameterized test reliability by materializing generated test cases before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->