### PR TITLE
add system settings

### DIFF
--- a/docs/development_guide/options.rst
+++ b/docs/development_guide/options.rst
@@ -36,6 +36,56 @@ The JSON structure generally looks like this:
    The settings manager uses a "last-write-wins" policy per key and protects file integrity with strict error handling.
    If the settings file becomes malformed, the manager will log an error and start with an empty configuration to prevent crashes.
 
+System-Wide Defaults
+--------------------
+
+In addition to the per-user file, SiliconCompiler can read a **system-wide settings file** managed by an administrator.
+This is useful on shared machines—such as an HPC login node—where an administrator wants to provide sensible defaults (for example, cluster-wide Slurm ``sharedpaths``) to every user without asking each of them to configure their own ``~/.sc/settings.json``.
+
+The system-wide file uses the same JSON structure as the per-user file. Its location is resolved in the following order:
+
+1. The ``SC_SYSTEM_SETTINGS`` environment variable, if set, is used verbatim as the path to the file.
+   This is the recommended override for non-root installs, virtual environments, containers, and continuous integration.
+2. Otherwise, a platform-specific default location is used:
+
+   * Linux/macOS: ``/etc/siliconcompiler/settings.json``
+   * Windows: ``%PROGRAMDATA%\siliconcompiler\settings.json`` (typically ``C:\ProgramData\siliconcompiler\settings.json``)
+
+.. note::
+   The default system location (``/etc``) requires administrator privileges to write, which is intentional: only an administrator should be able to change machine-wide defaults.
+   Users who need their own machine-wide file without root access should point ``SC_SYSTEM_SETTINGS`` at a writable location.
+
+Precedence and System Priority
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, system-wide values act as **defaults** that a user may override in their own ``~/.sc/settings.json``. When resolving a setting, SiliconCompiler applies the following precedence:
+
+1. If the setting has **system priority**, the system value is used and the user value is ignored.
+2. Otherwise, the user value is used if present.
+3. Otherwise, the (plain) system default is used if present.
+4. Otherwise, the built-in default is used.
+
+An administrator can promote any default to a **system-priority** (non-overridable) value by co-locating a flag with the value.
+Instead of writing a bare value, write an object with a ``"system_priority"`` flag (and, optionally, a ``"value"``):
+
+.. code-block:: json
+
+    {
+        "record": {
+            "region": {"value": "us-east-1", "system_priority": true}
+        },
+        "scheduler-slurm": {
+            "sharedpaths": ["/nfs/tools"]
+        }
+    }
+
+In this example every user is pinned to ``region = us-east-1`` (it cannot be overridden), while ``sharedpaths`` is a plain default that users may override.
+Attempts to change or delete a system-priority setting are ignored with a warning.
+A priority wrapper may also omit ``"value"`` (e.g. ``{"system_priority": true}``) to force a setting to stay unset, so callers fall back to their built-in default.
+
+.. note::
+   Priority flags are only honored in the **system** file. A value written in this ``{"value": ..., "system_priority": ...}`` shape inside a user's ``settings.json`` is treated as an ordinary dictionary value, so existing user files are unaffected by this feature. User files are never modified to include system defaults; saving only ever writes the user's own values.
+
 Concurrency & Safety
 --------------------
 

--- a/siliconcompiler/utils/__init__.py
+++ b/siliconcompiler/utils/__init__.py
@@ -5,6 +5,7 @@ import pathlib
 import psutil
 import shutil
 import stat
+import sys
 import traceback
 
 import os.path
@@ -232,6 +233,40 @@ def default_sc_path(path: str) -> str:
         str: The absolute path joined with the default SC directory.
     """
     return os.path.join(default_sc_dir(), path)
+
+
+def default_sc_system_path() -> str:
+    """
+    Returns the path to the system-wide SiliconCompiler settings file.
+
+    This file holds administrator-managed defaults that apply to all users on a
+    machine (for example, cluster-wide Slurm defaults on a shared HPC login
+    node). It is resolved in the following order:
+
+    1. The ``SC_SYSTEM_SETTINGS`` environment variable, if set, is used
+       verbatim as the path to the settings file. This is the escape hatch for
+       non-root installs, virtual environments, containers, and testing.
+    2. Otherwise, a platform-specific default location is used:
+
+       * POSIX (Linux/macOS): ``/etc/siliconcompiler/settings.json``
+       * Windows: ``%PROGRAMDATA%\\siliconcompiler\\settings.json``
+         (typically ``C:\\ProgramData\\siliconcompiler\\settings.json``)
+
+    The returned path is not guaranteed to exist; callers are expected to
+    handle a missing file gracefully.
+
+    Returns:
+        str: The absolute path to the system-wide settings file.
+    """
+    env_path = os.environ.get("SC_SYSTEM_SETTINGS")
+    if env_path:
+        return env_path
+
+    if sys.platform == "win32":
+        program_data = os.environ.get("PROGRAMDATA", r"C:\ProgramData")
+        return os.path.join(program_data, "siliconcompiler", "settings.json")
+
+    return os.path.join(os.sep, "etc", "siliconcompiler", "settings.json")
 
 
 def default_credentials_file() -> str:

--- a/siliconcompiler/utils/multiprocessing.py
+++ b/siliconcompiler/utils/multiprocessing.py
@@ -12,7 +12,7 @@ from logging.handlers import QueueHandler
 from multiprocessing.managers import SyncManager, RemoteError
 
 from siliconcompiler.utils.settings import SettingsManager
-from siliconcompiler.utils import default_sc_path
+from siliconcompiler.utils import default_sc_path, default_sc_system_path
 
 from siliconcompiler.report.dashboard.cli.board import Board
 
@@ -151,7 +151,9 @@ class MPManager(metaclass=_ManagerSingleton):
         self.__board = None
 
         # Settings
-        self.__settings = SettingsManager(default_sc_path("settings.json"), self.__logger)
+        self.__settings = SettingsManager(
+            default_sc_path("settings.json"), self.__logger,
+            system_filepath=default_sc_system_path())
         self.__transient_settings = SettingsManager(None, self.__logger)
 
         # Register cleanup function to run at exit

--- a/siliconcompiler/utils/settings.py
+++ b/siliconcompiler/utils/settings.py
@@ -290,9 +290,6 @@ class SettingsManager:
         category exists in neither layer.
         """
         with self.__settings_lock:
-            if category not in self.__settings:
-                self.__settings[category] = {}
-
             return self._merge_category(category)
 
     def _merge_category(self, category: str):

--- a/siliconcompiler/utils/settings.py
+++ b/siliconcompiler/utils/settings.py
@@ -17,17 +17,53 @@ class SettingsManager:
     A class to manage user settings stored in a JSON file.
     Supports categories, robust error handling for malformed files,
     and simple get/set operations.
+
+    An optional read-only, administrator-managed *system* settings file can be
+    layered underneath the user file. System settings act as defaults that the
+    user may override, except for values the system marks with *system
+    priority*, which take precedence over the user's own value. This provides
+    both soft defaults and administrator-enforced values from a single file
+    (see ``system_filepath``).
+
+    In the system file, a value is given system priority by co-locating a flag
+    with it. Instead of a bare value, the setting is written as an object with a
+    ``"system_priority"`` flag (and, optionally, a ``"value"``)::
+
+        {
+            "record": {
+                "region": {"value": "us-east-1", "system_priority": true}
+            },
+            "scheduler-slurm": {
+                "sharedpaths": ["/nfs/tools"]
+            }
+        }
+
+    Here ``region`` is a system-priority value that the user cannot override
+    while ``sharedpaths`` is a plain, overridable default. The priority flag is
+    only interpreted in the system file; a value written this way in a user file
+    is treated as an ordinary (dictionary) value, so existing user files are
+    unaffected.
     """
 
-    def __init__(self, filepath: str, logger: logging.Logger, timeout: float = 1.0):
+    #: Key that marks a system value as taking priority over the user value.
+    __PRIORITY_FLAG = "system_priority"
+    #: Key that carries the actual value alongside a priority flag.
+    __VALUE_FLAG = "value"
+
+    def __init__(self, filepath: str, logger: logging.Logger, timeout: float = 1.0,
+                 system_filepath: Optional[str] = None):
         """
         Initialize the settings manager.
 
         Args:
-            filepath (str): The path to the JSON file where settings are stored.
-                If None, settings are kept in memory only.
+            filepath (str): The path to the JSON file where user settings are
+                stored. If None, settings are kept in memory only.
             logger (logging.Logger): Logger for logging errors and information.
             timeout (float): Timeout in seconds for acquiring the file lock.
+            system_filepath (str): Optional path to a read-only, system-wide
+                settings file providing administrator-managed defaults and
+                system-priority (non-overridable) values. If None, no system
+                layer is applied.
         """
         self.__filepath = filepath
         if self.__filepath is not None:
@@ -36,7 +72,15 @@ class SettingsManager:
         self.__timeout = timeout
         self.__logger = logger.getChild("settings")
         self.__settings = {}
+
+        # System layer state: resolved (unwrapped) values plus the set of
+        # system-priority keys per category.
+        self.__system_filepath = system_filepath
+        self.__system_settings = {}
+        self.__priority = {}
+
         self._load()
+        self._load_system()
 
     def _load(self):
         """
@@ -78,6 +122,89 @@ class SettingsManager:
                 self.__logger.error(f"Unexpected error loading settings: {e}")
                 self.__settings = {}
 
+    def _load_system(self):
+        """
+        Internal method to load the read-only system settings file, if any.
+
+        Unlike the user file, the system file is never locked (it is
+        administrator-managed and typically lives in a location such as
+        ``/etc`` where regular users cannot create the sibling lock file) and is
+        never written to. Any failure to read it is logged and treated as if no
+        system file were present, so it can never prevent startup.
+
+        Inline priority flags are unwrapped here into ``__system_settings``
+        (bare values) and ``__priority`` (the set of system-priority keys per
+        category).
+        """
+        self.__system_settings = {}
+        self.__priority = {}
+
+        if self.__system_filepath is None or not os.path.exists(self.__system_filepath):
+            return
+
+        try:
+            with sc_open(self.__system_filepath, encoding='utf-8') as f:
+                data = json.load(f)
+        except json.JSONDecodeError:
+            self.__logger.error(f"System settings file {self.__system_filepath} is malformed. "
+                                "Ignoring system settings.")
+            return
+        except Exception as e:
+            self.__logger.error(f"Unexpected error loading system settings: {e}")
+            return
+
+        if not isinstance(data, dict):
+            self.__logger.warning(f"System settings file {self.__system_filepath} did not contain "
+                                  "a JSON object. Ignoring system settings.")
+            return
+
+        self._unwrap_system(data)
+
+    def _is_priority_wrapper(self, value) -> bool:
+        """
+        Return True if a raw system value is a co-located priority wrapper, i.e.
+        a JSON object carrying a ``system_priority`` flag.
+        """
+        return isinstance(value, dict) and self.__PRIORITY_FLAG in value
+
+    def _unwrap_system(self, data: dict):
+        """
+        Split raw system data into resolved values and system-priority keys.
+
+        Each setting is either a bare value (a plain, overridable default) or a
+        priority wrapper (an object with a ``system_priority`` flag and optional
+        ``value``). System-priority keys are recorded per category; a wrapper
+        without a ``value`` gives priority to "unset", forcing callers to fall
+        back to their default.
+        """
+        for category, entries in data.items():
+            if not isinstance(entries, dict):
+                self.__logger.warning(f"System settings category '{category}' is not a JSON "
+                                      "object. Ignoring.")
+                continue
+
+            values = {}
+            priority = set()
+            for key, raw in entries.items():
+                if self._is_priority_wrapper(raw):
+                    if raw.get(self.__PRIORITY_FLAG):
+                        priority.add(key)
+                    if self.__VALUE_FLAG in raw:
+                        values[key] = raw[self.__VALUE_FLAG]
+                else:
+                    values[key] = raw
+
+            self.__system_settings[category] = values
+            if priority:
+                self.__priority[category] = priority
+
+    def _has_priority(self, category: str, key: str) -> bool:
+        """
+        Return True if the given category/key is a system-priority value and
+        therefore not user-overridable.
+        """
+        return key in self.__priority.get(category, ())
+
     def save(self):
         """
         Save the current settings to the disk in JSON format.
@@ -109,6 +236,11 @@ class SettingsManager:
             value: The value to store (must be JSON serializable).
             keep (bool): If True, do not overwrite existing value.
         """
+        if self._has_priority(category, key):
+            self.__logger.warning(f"Setting '{category}.{key}' has system priority and cannot be "
+                                  "overridden. Ignoring.")
+            return
+
         with self.__settings_lock:
             if category not in self.__settings:
                 self.__settings[category] = {}
@@ -121,6 +253,15 @@ class SettingsManager:
         """
         Retrieve a setting.
 
+        Resolution order:
+
+        1. If the key has system priority, the system value is returned (or
+           ``default`` if the system file does not define it); the user value is
+           ignored.
+        2. Otherwise, the user value is returned if present.
+        3. Otherwise, the (overridable) system default is returned if present.
+        4. Otherwise, ``default`` is returned.
+
         Args:
             category (str): The group name.
             key (str): The specific setting name.
@@ -130,26 +271,62 @@ class SettingsManager:
             The stored value or the default.
         """
         with self.__settings_lock:
-            if category not in self.__settings:
-                return default
+            if self._has_priority(category, key):
+                return self.__system_settings.get(category, {}).get(key, default)
 
-            return self.__settings[category].get(key, default)
+            if category in self.__settings and key in self.__settings[category]:
+                return self.__settings[category][key]
+
+            return self.__system_settings.get(category, {}).get(key, default)
 
     def get_category(self, category: str):
         """
-        Retrieve all settings for a specific category.
-        Returns an empty dict if category does not exist.
+        Retrieve all settings for a specific category, merging system defaults
+        with user overrides.
+
+        System values provide the baseline, user values override them, and
+        system-priority keys are forced back to the system value (or removed if
+        the system file does not define them). Returns an empty dict if the
+        category exists in neither layer.
         """
         with self.__settings_lock:
             if category not in self.__settings:
                 self.__settings[category] = {}
 
-            return self.__settings.get(category).copy()
+            return self._merge_category(category)
+
+    def _merge_category(self, category: str):
+        """
+        Build the effective view of a category. Assumes ``__settings_lock`` is
+        held by the caller.
+        """
+        system_cat = self.__system_settings.get(category, {})
+
+        merged = dict(system_cat)
+        merged.update(self.__settings.get(category, {}))
+
+        # Re-apply system-priority values so user values cannot leak through.
+        for priority_key in self.__priority.get(category, ()):
+            if priority_key in system_cat:
+                merged[priority_key] = system_cat[priority_key]
+            else:
+                merged.pop(priority_key, None)
+
+        return merged
 
     def delete(self, category: str, key: Optional[str] = None):
         """
-        Remove a setting.
+        Remove a user setting.
+
+        System-priority settings are administrator-managed and cannot be
+        removed; such requests are ignored with a warning. Note that deletion
+        only affects the user layer; system defaults remain in effect.
         """
+        if key is not None and self._has_priority(category, key):
+            self.__logger.warning(f"Setting '{category}.{key}' has system priority and cannot be "
+                                  "removed. Ignoring.")
+            return
+
         with self.__settings_lock:
             if category in self.__settings:
                 if key:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,6 +170,10 @@ def mock_home(monkeypatch, test_dir):
     monkeypatch.setattr(Path, 'home', _mock_home)
     monkeypatch.setenv("HOME", str(test_dir))
 
+    # Ensure a developer's ambient system settings file is never picked up
+    # during tests; individual tests can opt back in with monkeypatch.setenv.
+    monkeypatch.delenv("SC_SYSTEM_SETTINGS", raising=False)
+
 
 @pytest.fixture(scope='session')
 def scroot():

--- a/tests/utils/test_settings.py
+++ b/tests/utils/test_settings.py
@@ -203,5 +203,202 @@ def test_filepath_none():
     manager.set('memory', 'test', 123)
     assert manager.get('memory', 'test') == 123
 
+
+# ---------------------------------------------------------------------------
+# System settings layer (defaults + system priority)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def system_file(tmp_path):
+    """Fixture to provide a path for a system settings file."""
+    return str(tmp_path / "system.json")
+
+
+def _write_json(path, data):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def test_backward_compat_no_system_layer(settings_file):
+    """Old settings.json files behave exactly as before when no system file."""
+    manager = SettingsManager(settings_file, logging.getLogger())
+    manager.set("schema-options", "remote", True)
+    manager.save()
+
+    reloaded = SettingsManager(settings_file, logging.getLogger())
+    assert reloaded.get("schema-options", "remote") is True
+    assert reloaded.get("schema-options", "missing", default="d") == "d"
+    assert reloaded.get_category("schema-options") == {"remote": True}
+
+
+def test_backward_compat_missing_system_file(settings_file, system_file):
+    """A non-existent system file is a no-op, not an error."""
+    manager = SettingsManager(settings_file, logging.getLogger(), system_filepath=system_file)
+    assert manager.get("any", "key", default="d") == "d"
+    assert manager._SettingsManager__system_settings == {}
+    assert manager._SettingsManager__priority == {}
+
+
+def test_backward_compat_user_priority_wrapper_is_plain(settings_file):
+    """A priority-wrapper shape in a USER file is treated as an ordinary value."""
+    _write_json(settings_file, {"record": {"region": {"value": "eu", "system_priority": True}}})
+    manager = SettingsManager(settings_file, logging.getLogger())
+    # Priority flags are only honored in the system file; the user file is untouched.
+    assert manager._SettingsManager__priority == {}
+    assert manager.get("record", "region") == {"value": "eu", "system_priority": True}
+    manager.set("record", "region", "us")
+    assert manager.get("record", "region") == "us"
+
+
+def test_system_default_used_when_user_absent(settings_file, system_file):
+    """System values act as defaults when the user has not set them."""
+    _write_json(system_file, {"record": {"region": "us-east-1"}})
+    manager = SettingsManager(settings_file, logging.getLogger(), system_filepath=system_file)
+    assert manager.get("record", "region") == "us-east-1"
+
+
+def test_user_overrides_plain_system_default(settings_file, system_file):
+    """Plain (non-priority) system values are overridable by the user."""
+    _write_json(system_file, {"record": {"region": "us-east-1"}})
+    manager = SettingsManager(settings_file, logging.getLogger(), system_filepath=system_file)
+    manager.set("record", "region", "eu-west-1")
+    assert manager.get("record", "region") == "eu-west-1"
+
+
+def test_system_priority_wins(settings_file, system_file, caplog):
+    """A system-priority key always returns the system value and ignores user writes."""
+    _write_json(system_file, {
+        "record": {"region": {"value": "us-east-1", "system_priority": True}},
+    })
+    manager = SettingsManager(settings_file, logging.getLogger(), system_filepath=system_file)
+
+    with caplog.at_level(logging.WARNING):
+        manager.set("record", "region", "eu-west-1")
+    assert "system priority" in caplog.text
+
+    assert manager.get("record", "region") == "us-east-1"
+    # The write did not land in the user layer.
+    assert "record" not in manager._SettingsManager__settings
+
+
+def test_system_priority_without_value_returns_default(settings_file, system_file):
+    """A priority wrapper with no value returns default and ignores the user."""
+    _write_json(system_file, {"record": {"region": {"system_priority": True}}})
+    manager = SettingsManager(settings_file, logging.getLogger(), system_filepath=system_file)
+    manager.set("record", "region", "eu-west-1")
+    assert manager.get("record", "region", default="local") == "local"
+
+
+def test_explicit_non_priority_wrapper(settings_file, system_file):
+    """A wrapper with system_priority=false is an ordinary, overridable default."""
+    _write_json(system_file, {
+        "record": {"region": {"value": "us-east-1", "system_priority": False}},
+    })
+    manager = SettingsManager(settings_file, logging.getLogger(), system_filepath=system_file)
+    assert manager.get("record", "region") == "us-east-1"
+    manager.set("record", "region", "eu-west-1")
+    assert manager.get("record", "region") == "eu-west-1"
+
+
+def test_get_category_merges_layers(settings_file, system_file):
+    """get_category merges system defaults with user overrides, respecting priority."""
+    _write_json(system_file, {
+        "showtask": {
+            "gds": {"value": "klayout", "system_priority": True},
+            "def": "openroad",
+        },
+    })
+    manager = SettingsManager(settings_file, logging.getLogger(), system_filepath=system_file)
+    manager.set("showtask", "def", "innovus")   # override plain default
+    manager.set("showtask", "vcd", "gtkwave")    # new user-only key
+    manager.set("showtask", "gds", "magic")      # attempt to override priority -> ignored
+
+    assert manager.get_category("showtask") == {
+        "gds": "klayout",     # system priority -> system wins
+        "def": "innovus",     # user override
+        "vcd": "gtkwave",     # user only
+    }
+
+
+def test_delete_system_priority_key_ignored(settings_file, system_file, caplog):
+    """System-priority settings cannot be deleted."""
+    _write_json(system_file, {
+        "record": {"region": {"value": "us-east-1", "system_priority": True}},
+    })
+    manager = SettingsManager(settings_file, logging.getLogger(), system_filepath=system_file)
+    with caplog.at_level(logging.WARNING):
+        manager.delete("record", "region")
+    assert "system priority" in caplog.text
+    assert manager.get("record", "region") == "us-east-1"
+
+
+def test_save_never_persists_system_layer(settings_file, system_file):
+    """Saving only writes the user layer; system defaults/priorities are not copied in."""
+    _write_json(system_file, {
+        "record": {"region": {"value": "us-east-1", "system_priority": True}},
+    })
+    manager = SettingsManager(settings_file, logging.getLogger(), system_filepath=system_file)
+    manager.set("showtask", "vcd", "gtkwave")
+    manager.save()
+
+    with open(settings_file, encoding="utf-8") as f:
+        on_disk = json.load(f)
+    assert on_disk == {"showtask": {"vcd": "gtkwave"}}
+    assert "record" not in on_disk
+
+
+def test_malformed_system_file_ignored(settings_file, system_file, caplog):
+    """A malformed system file is ignored, and the user layer still works."""
+    with open(system_file, "w", encoding="utf-8") as f:
+        f.write("{ not valid json")
+    with caplog.at_level(logging.ERROR):
+        manager = SettingsManager(settings_file, logging.getLogger(), system_filepath=system_file)
+    assert "malformed" in caplog.text
+    assert manager._SettingsManager__system_settings == {}
+    manager.set("record", "region", "eu")
+    assert manager.get("record", "region") == "eu"
+
+
+def test_system_file_not_a_dict_ignored(settings_file, system_file, caplog):
+    """A system file that is valid JSON but not an object is ignored."""
+    _write_json(system_file, ["not", "a", "dict"])
+    with caplog.at_level(logging.WARNING):
+        manager = SettingsManager(settings_file, logging.getLogger(), system_filepath=system_file)
+    assert "did not contain" in caplog.text
+    assert manager._SettingsManager__system_settings == {}
+
+
+def test_non_dict_category_ignored(settings_file, system_file, caplog):
+    """A system category that is not a JSON object is skipped, others still load."""
+    _write_json(system_file, {
+        "bogus": "not-an-object",
+        "record": {"region": "us-east-1"},
+    })
+    with caplog.at_level(logging.WARNING):
+        manager = SettingsManager(settings_file, logging.getLogger(), system_filepath=system_file)
+    assert "bogus" in caplog.text
+    assert "bogus" not in manager._SettingsManager__system_settings
+    assert manager.get("record", "region") == "us-east-1"
+
+
+def test_mixed_priority_and_plain_in_category(settings_file, system_file):
+    """A category may mix priority wrappers, plain wrappers, and bare values."""
+    _write_json(system_file, {
+        "a": {
+            "priority_key": {"value": 1, "system_priority": True},
+            "plain_key": {"value": 2, "system_priority": False},
+            "bare_key": 3,
+        },
+    })
+    manager = SettingsManager(settings_file, logging.getLogger(), system_filepath=system_file)
+    manager.set("a", "priority_key", 99)
+    manager.set("a", "plain_key", 99)
+    manager.set("a", "bare_key", 99)
+    assert manager.get("a", "priority_key") == 1   # system priority -> system wins
+    assert manager.get("a", "plain_key") == 99     # overridable
+    assert manager.get("a", "bare_key") == 99      # overridable
+    assert manager._SettingsManager__priority == {"a": {"priority_key"}}
+
     # Save should be a safe no-op
     manager.save()

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -14,7 +14,7 @@ from siliconcompiler.utils import \
     truncate_text, safecompare, get_cores, grep, \
     get_plugins, \
     default_sc_dir, default_credentials_file, default_cache_dir, \
-    default_email_credentials_file, default_sc_path
+    default_email_credentials_file, default_sc_path, default_sc_system_path
 from siliconcompiler.utils import (
     _load_pyproject_data,
     _installed_distribution_versions,
@@ -266,6 +266,26 @@ def test_default_sc_path(path):
     with patch("pathlib.Path.home") as home:
         home.return_value = "this"
         assert default_sc_path(path) == os.path.join("this", ".sc", path)
+
+
+def test_default_sc_system_path_env_override(monkeypatch):
+    monkeypatch.setenv("SC_SYSTEM_SETTINGS", os.path.join("custom", "settings.json"))
+    assert default_sc_system_path() == os.path.join("custom", "settings.json")
+
+
+def test_default_sc_system_path_posix_default(monkeypatch):
+    monkeypatch.delenv("SC_SYSTEM_SETTINGS", raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert default_sc_system_path() == \
+        os.path.join(os.sep, "etc", "siliconcompiler", "settings.json")
+
+
+def test_default_sc_system_path_windows_default(monkeypatch):
+    monkeypatch.delenv("SC_SYSTEM_SETTINGS", raising=False)
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("PROGRAMDATA", r"C:\ProgramData")
+    assert default_sc_system_path() == \
+        os.path.join(r"C:\ProgramData", "siliconcompiler", "settings.json")
 
 
 @pytest.mark.parametrize("args,line,expected", [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added administrator-managed, system-wide default settings with platform-aware resolution and optional environment-variable override.
  * System settings now participate in precedence: users can override normal defaults, while “system-priority” entries are non-overridable and protected from deletion.
  * System-priority and defaults are respected in merged category views; system-layer changes are not persisted to user files.

* **Documentation**
  * Documented system settings locations, precedence rules, and priority-wrapper behavior.

* **Tests**
  * Added coverage for defaults/overrides, priority enforcement, deletion/save behavior, malformed system files, and platform-specific path selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->