### PR TITLE
add ASIC floorplan helpers

### DIFF
--- a/siliconcompiler/constraints/asic_floorplan.py
+++ b/siliconcompiler/constraints/asic_floorplan.py
@@ -414,6 +414,50 @@ class ASICAreaConstraint(BaseSchema):
         """
         return self.get("diearea", step=step, index=index)
 
+    def get_dieboundingbox(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) \
+            -> Tuple[Tuple[float, float], Tuple[float, float]]:
+        """
+        Retrieves the bounding box of the core area.
+
+        Args:
+            step (str, optional): The step in a workflow to retrieve from.
+                                  Defaults to None.
+            index (Union[str, int], optional): The index within a step to
+                                               retrieve from. Defaults to None.
+
+        Returns:
+            Tuple[Tuple[float, float], Tuple[float, float]]: A tuple containing the
+            lower-left and upper-right coordinates of the core area's bounding box.
+        """
+        corearea = self.get_diearea(step=step, index=index)
+        if not corearea:
+            return ((0.0, 0.0), (0.0, 0.0))
+
+        min_x = min(point[0] for point in corearea)
+        min_y = min(point[1] for point in corearea)
+        max_x = max(point[0] for point in corearea)
+        max_y = max(point[1] for point in corearea)
+
+        return ((min_x, min_y), (max_x, max_y))
+
+    def get_diesize(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) -> Tuple[float, float]:
+        """
+        Retrieves the size (width and height) of the die area.
+
+        Args:
+            step (str, optional): The step in a workflow to retrieve from.
+                                  Defaults to None.
+            index (Union[str, int], optional): The index within a step to
+                                               retrieve from. Defaults to None.
+
+        Returns:
+            Tuple[float, float]: A tuple containing the width and height of the die area.
+        """
+        (min_x, min_y), (max_x, max_y) = self.get_dieboundingbox(step=step, index=index)
+        width = max_x - min_x
+        height = max_y - min_y
+        return (width, height)
+
     def set_corearea(self,
                      points: List[Tuple[float, float]],
                      step: Optional[str] = None, index: Optional[Union[str, int]] = None):
@@ -449,6 +493,50 @@ class ASICAreaConstraint(BaseSchema):
                                        the coordinates that define the core area.
         """
         return self.get("corearea", step=step, index=index)
+
+    def get_coreboundingbox(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) \
+            -> Tuple[Tuple[float, float], Tuple[float, float]]:
+        """
+        Retrieves the bounding box of the core area.
+
+        Args:
+            step (str, optional): The step in a workflow to retrieve from.
+                                  Defaults to None.
+            index (Union[str, int], optional): The index within a step to
+                                               retrieve from. Defaults to None.
+
+        Returns:
+            Tuple[Tuple[float, float], Tuple[float, float]]: A tuple containing the
+            lower-left and upper-right coordinates of the core area's bounding box.
+        """
+        corearea = self.get_corearea(step=step, index=index)
+        if not corearea:
+            return ((0.0, 0.0), (0.0, 0.0))
+
+        min_x = min(point[0] for point in corearea)
+        min_y = min(point[1] for point in corearea)
+        max_x = max(point[0] for point in corearea)
+        max_y = max(point[1] for point in corearea)
+
+        return ((min_x, min_y), (max_x, max_y))
+
+    def get_coresize(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) -> Tuple[float, float]:
+        """
+        Retrieves the size (width and height) of the core area.
+
+        Args:
+            step (str, optional): The step in a workflow to retrieve from.
+                                  Defaults to None.
+            index (Union[str, int], optional): The index within a step to
+                                               retrieve from. Defaults to None.
+
+        Returns:
+            Tuple[float, float]: A tuple containing the width and height of the core area.
+        """
+        (min_x, min_y), (max_x, max_y) = self.get_coreboundingbox(step=step, index=index)
+        width = max_x - min_x
+        height = max_y - min_y
+        return (width, height)
 
     def calc_diearea(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) \
             -> float:

--- a/siliconcompiler/constraints/asic_floorplan.py
+++ b/siliconcompiler/constraints/asic_floorplan.py
@@ -414,11 +414,52 @@ class ASICAreaConstraint(BaseSchema):
         """
         return self.get("diearea", step=step, index=index)
 
+    @staticmethod
+    def _calc_boundingbox(points: List[Tuple[float, float]]) \
+            -> Tuple[Tuple[float, float], Tuple[float, float]]:
+        """
+        Computes the bounding box of a list of (x, y) points.
+
+        Args:
+            points (List[Tuple[float, float]]): The points to bound. An empty
+                                                list yields a zero-size box at
+                                                the origin.
+
+        Returns:
+            Tuple[Tuple[float, float], Tuple[float, float]]: The lower-left and
+            upper-right coordinates of the bounding box.
+        """
+        if not points:
+            return ((0.0, 0.0), (0.0, 0.0))
+
+        min_x = min(point[0] for point in points)
+        min_y = min(point[1] for point in points)
+        max_x = max(point[0] for point in points)
+        max_y = max(point[1] for point in points)
+
+        return ((min_x, min_y), (max_x, max_y))
+
+    @staticmethod
+    def _calc_size(boundingbox: Tuple[Tuple[float, float], Tuple[float, float]]) \
+            -> Tuple[float, float]:
+        """
+        Computes the (width, height) of a bounding box.
+
+        Args:
+            boundingbox (Tuple[Tuple[float, float], Tuple[float, float]]): The
+                lower-left and upper-right coordinates of the bounding box.
+
+        Returns:
+            Tuple[float, float]: The width and height of the bounding box.
+        """
+        (min_x, min_y), (max_x, max_y) = boundingbox
+        return (max_x - min_x, max_y - min_y)
+
     def get_dieboundingbox(self, step: Optional[str] = None,
                            index: Optional[Union[str, int]] = None) \
             -> Tuple[Tuple[float, float], Tuple[float, float]]:
         """
-        Retrieves the bounding box of the core area.
+        Retrieves the bounding box of the die area.
 
         Args:
             step (str, optional): The step in a workflow to retrieve from.
@@ -428,18 +469,9 @@ class ASICAreaConstraint(BaseSchema):
 
         Returns:
             Tuple[Tuple[float, float], Tuple[float, float]]: A tuple containing the
-            lower-left and upper-right coordinates of the core area's bounding box.
+            lower-left and upper-right coordinates of the die area's bounding box.
         """
-        corearea = self.get_diearea(step=step, index=index)
-        if not corearea:
-            return ((0.0, 0.0), (0.0, 0.0))
-
-        min_x = min(point[0] for point in corearea)
-        min_y = min(point[1] for point in corearea)
-        max_x = max(point[0] for point in corearea)
-        max_y = max(point[1] for point in corearea)
-
-        return ((min_x, min_y), (max_x, max_y))
+        return self._calc_boundingbox(self.get_diearea(step=step, index=index))
 
     def get_diesize(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) -> \
             Tuple[float, float]:
@@ -455,10 +487,7 @@ class ASICAreaConstraint(BaseSchema):
         Returns:
             Tuple[float, float]: A tuple containing the width and height of the die area.
         """
-        (min_x, min_y), (max_x, max_y) = self.get_dieboundingbox(step=step, index=index)
-        width = max_x - min_x
-        height = max_y - min_y
-        return (width, height)
+        return self._calc_size(self.get_dieboundingbox(step=step, index=index))
 
     def set_corearea(self,
                      points: List[Tuple[float, float]],
@@ -512,16 +541,7 @@ class ASICAreaConstraint(BaseSchema):
             Tuple[Tuple[float, float], Tuple[float, float]]: A tuple containing the
             lower-left and upper-right coordinates of the core area's bounding box.
         """
-        corearea = self.get_corearea(step=step, index=index)
-        if not corearea:
-            return ((0.0, 0.0), (0.0, 0.0))
-
-        min_x = min(point[0] for point in corearea)
-        min_y = min(point[1] for point in corearea)
-        max_x = max(point[0] for point in corearea)
-        max_y = max(point[1] for point in corearea)
-
-        return ((min_x, min_y), (max_x, max_y))
+        return self._calc_boundingbox(self.get_corearea(step=step, index=index))
 
     def get_coresize(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) -> \
             Tuple[float, float]:
@@ -537,10 +557,7 @@ class ASICAreaConstraint(BaseSchema):
         Returns:
             Tuple[float, float]: A tuple containing the width and height of the core area.
         """
-        (min_x, min_y), (max_x, max_y) = self.get_coreboundingbox(step=step, index=index)
-        width = max_x - min_x
-        height = max_y - min_y
-        return (width, height)
+        return self._calc_size(self.get_coreboundingbox(step=step, index=index))
 
     def calc_diearea(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) \
             -> float:

--- a/siliconcompiler/constraints/asic_floorplan.py
+++ b/siliconcompiler/constraints/asic_floorplan.py
@@ -414,7 +414,8 @@ class ASICAreaConstraint(BaseSchema):
         """
         return self.get("diearea", step=step, index=index)
 
-    def get_dieboundingbox(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) \
+    def get_dieboundingbox(self, step: Optional[str] = None,
+                           index: Optional[Union[str, int]] = None) \
             -> Tuple[Tuple[float, float], Tuple[float, float]]:
         """
         Retrieves the bounding box of the core area.
@@ -440,7 +441,8 @@ class ASICAreaConstraint(BaseSchema):
 
         return ((min_x, min_y), (max_x, max_y))
 
-    def get_diesize(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) -> Tuple[float, float]:
+    def get_diesize(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) -> \
+            Tuple[float, float]:
         """
         Retrieves the size (width and height) of the die area.
 
@@ -494,7 +496,8 @@ class ASICAreaConstraint(BaseSchema):
         """
         return self.get("corearea", step=step, index=index)
 
-    def get_coreboundingbox(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) \
+    def get_coreboundingbox(self, step: Optional[str] = None,
+                            index: Optional[Union[str, int]] = None) \
             -> Tuple[Tuple[float, float], Tuple[float, float]]:
         """
         Retrieves the bounding box of the core area.
@@ -520,7 +523,8 @@ class ASICAreaConstraint(BaseSchema):
 
         return ((min_x, min_y), (max_x, max_y))
 
-    def get_coresize(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) -> Tuple[float, float]:
+    def get_coresize(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) -> \
+            Tuple[float, float]:
         """
         Retrieves the size (width and height) of the core area.
 

--- a/siliconcompiler/constraints/asic_pins.py
+++ b/siliconcompiler/constraints/asic_pins.py
@@ -587,8 +587,12 @@ class ASICPinConstraints(BaseSchema):
 
         npins = len(pins)
         if pitch is not None:
+            if pitch <= 0:
+                raise ValueError("pitch must be a positive value")
             span = npins * pitch
         elif side_width is not None:
+            if side_width <= 0:
+                raise ValueError("side_width must be a positive value")
             span = side_width
             pitch = side_width / npins
         else:
@@ -603,6 +607,8 @@ class ASICPinConstraints(BaseSchema):
             project.constraint.area.get_dieboundingbox(step=step, index=index)
 
         # Sides 1/3 (left/right) vary along y; sides 2/4 (top/bottom) vary along x.
+        if side not in (1, 2, 3, 4):
+            raise ValueError(f"{side} is a not a recognized side")
         vertical = side in (1, 3)
         if vertical:
             perp = min_x if side == 1 else max_x

--- a/siliconcompiler/constraints/asic_pins.py
+++ b/siliconcompiler/constraints/asic_pins.py
@@ -1,4 +1,4 @@
-from typing import Union, Tuple, Optional
+from typing import Dict, List, Union, Tuple, Optional, cast
 
 from siliconcompiler.schema import BaseSchema, NamedSchema, EditableSchema, Parameter, \
     PerNode, Scope
@@ -290,17 +290,17 @@ class ASICPinConstraint(NamedSchema):
         """
         return self.get("layer", step=step, index=index)
 
-    def set_side(self, side: Union[int, str],
-                 step: Optional[str] = None, index: Optional[Union[str, int]] = None):
+    @staticmethod
+    def _normalize_side(side: Union[int, str]) -> int:
         """
-        Sets the side constraint for the pin, indicating where it should be placed.
+        Normalizes the side input to an integer representation.
 
         Args:
-            side (Union[int, str]): The side of the block where the pin should be placed.
-                                    Can be an integer or a string ('left', 'west', 'top',
-                                    'north', 'right', 'east', 'bottom', 'south').
-            step (str, optional): step name.
-            index (str, optional): index name.
+            side (Union[int, str]): The side of the block, either as an integer or a string
+                                     ('left', 'west', 'top', 'north', 'right', 'east', 'bottom', 'south').
+
+        Returns:
+            int: The normalized integer representation of the side (1 for left, 2 for top, 3 for right, 4 for bottom).
 
         Raises:
             TypeError: If `side` is not an int or string.
@@ -325,7 +325,25 @@ class ASICPinConstraint(NamedSchema):
         if side <= 0:
             raise ValueError("side must be a positive integer")
 
-        return self.set("side", side, step=step, index=index)
+        return side
+
+    def set_side(self, side: Union[int, str],
+                 step: Optional[str] = None, index: Optional[Union[str, int]] = None):
+        """
+        Sets the side constraint for the pin, indicating where it should be placed.
+
+        Args:
+            side (Union[int, str]): The side of the block where the pin should be placed.
+                                    Can be an integer or a string ('left', 'west', 'top',
+                                    'north', 'right', 'east', 'bottom', 'south').
+            step (str, optional): step name.
+            index (str, optional): index name.
+
+        Raises:
+            TypeError: If `side` is not an int or string.
+            ValueError: If `side` is an unrecognized string value or a non-positive integer.
+        """
+        return self.set("side", self._normalize_side(side), step=step, index=index)
 
     def get_side(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) -> int:
         """
@@ -408,7 +426,7 @@ class ASICPinConstraints(BaseSchema):
 
         EditableSchema(self).insert(pin.name, pin, clobber=True)
 
-    def get_pinconstraint(self, pin: Optional[str] = None):
+    def get_pinconstraint(self, pin: Optional[str] = None) -> Union[ASICPinConstraint, Dict[str, ASICPinConstraint]]:
         """
         Retrieves one or all pin constraints from the configuration.
 
@@ -470,6 +488,158 @@ class ASICPinConstraints(BaseSchema):
         constraint = ASICPinConstraint(pin)
         self.add_pinconstraint(constraint)
         return constraint
+
+    def _get_or_make_pinconstraint(self, pin: str) -> ASICPinConstraint:
+        """
+        Returns the pin constraint named ``pin``, creating it if it does not exist.
+        """
+        if self.valid(pin):
+            return cast(ASICPinConstraint, self.get(pin, field="schema"))
+        return self.make_pinconstraint(pin)
+
+    def make_buspinconstraints(self,
+                               pins: List[str],
+                               side: Union[int, str],
+                               layer: Optional[str] = None,
+                               center: Optional[float] = None,
+                               pitch: Optional[float] = None,
+                               side_width: Optional[float] = None,
+                               side_offset: Optional[float] = None,
+                               step: Optional[str] = None,
+                               index: Optional[Union[str, int]] = None) -> List[ASICPinConstraint]:
+        """
+        Creates and adds pin constraints for a bus, distributing the pins evenly
+        along a single side of the die.
+
+        The pins are laid out along the chosen side using two independent
+        quantities: the *spacing* between pins and the *position* of the bus
+        along the edge.
+
+        Spacing is derived from exactly one of:
+            * ``pitch``: the center-to-center spacing between adjacent pins. The
+              bus occupies a span of ``len(pins) * pitch``.
+            * ``side_width``: the total span occupied by the bus. The pitch is
+              derived as ``side_width / len(pins)`` and each pin is centered
+              within its slot.
+
+        Position is derived from at most one of:
+            * ``center``: the bus span is centered on this coordinate.
+            * ``side_offset``: the gap between the bus and a corner of the side.
+              A positive value measures from the near (lower/left) corner; a
+              negative value anchors the far end of the bus to the far
+              (upper/right) corner (e.g. ``-10`` leaves a 10um gap at the far end).
+            * neither: the bus is centered on the die edge.
+
+        If none of ``center``, ``pitch``, ``side_width`` or ``side_offset`` are
+        provided, the pins are placed using ``side`` + ``order`` only, leaving
+        the exact placement to the layout tool.
+
+        Args:
+            pins (List[str]): The pin names to constrain, in order along the side.
+            side (Union[int, str]): The side of the die to place the pins on
+                (integer or 'left'/'right'/'top'/'bottom' and compass aliases).
+            layer (str, optional): The metal layer for the pins.
+            center (float, optional): Center coordinate of the bus along the side.
+            pitch (float, optional): Center-to-center spacing between pins.
+            side_width (float, optional): Total span occupied by the bus.
+            side_offset (float, optional): Gap between the bus and a corner of
+                the side. Positive measures from the near corner, negative from
+                the far corner.
+            step (str, optional): step name.
+            index (str, optional): index name.
+
+        Returns:
+            List[ASICPinConstraint]: The created/updated pin constraints, ordered
+            to match ``pins``.
+
+        Raises:
+            ValueError: If ``pins`` is empty, if both ``pitch`` and ``side_width``
+                are given, if both ``center`` and ``side_offset`` are given, if a
+                position is given without any spacing, or if the bus does not fit
+                on the requested side.
+            TypeError: If the constraint is not attached to an ASIC project.
+        """
+        if not pins:
+            raise ValueError("at least one pin is required")
+
+        side = ASICPinConstraint._normalize_side(side)
+
+        # Ordering mode: no geometry supplied, let the tool place the pins.
+        if center is None and pitch is None and side_width is None and side_offset is None:
+            constraints = []
+            for order, pin in enumerate(pins):
+                constraint = self._get_or_make_pinconstraint(pin)
+                constraint.set_side(side, step=step, index=index)
+                constraint.set_order(order, step=step, index=index)
+                if layer is not None:
+                    constraint.set_layer(layer, step=step, index=index)
+                constraints.append(constraint)
+            return constraints
+
+        # Geometric mode: compute an explicit placement for each pin.
+        if pitch is not None and side_width is not None:
+            raise ValueError("specify only one of 'pitch' or 'side_width'")
+        if center is not None and side_offset is not None:
+            raise ValueError("specify only one of 'center' or 'side_offset'")
+
+        npins = len(pins)
+        if pitch is not None:
+            span = npins * pitch
+        elif side_width is not None:
+            span = side_width
+            pitch = side_width / npins
+        else:
+            raise ValueError("'pitch' or 'side_width' is required to space the pins")
+
+        from siliconcompiler import ASIC
+        project = self._parent(root=True)
+        if not isinstance(project, ASIC):
+            raise TypeError("bus pin constraints require an ASIC project")
+
+        (min_x, min_y), (max_x, max_y) = \
+            project.constraint.area.get_dieboundingbox(step=step, index=index)
+
+        # Sides 1/3 (left/right) vary along y; sides 2/4 (top/bottom) vary along x.
+        vertical = side in (1, 3)
+        if vertical:
+            perp = min_x if side == 1 else max_x
+            edge_min, edge_max = min_y, max_y
+        else:
+            perp = max_y if side == 2 else min_y
+            edge_min, edge_max = min_x, max_x
+
+        edge_length = edge_max - edge_min
+        if edge_length <= 0:
+            raise ValueError("die area must be set before placing bus pins")
+
+        # Resolve the start of the bus span along the edge. A positive offset is
+        # measured from the near (lower/left) corner of the side; a negative
+        # offset anchors the far end of the bus to the far (upper/right) corner.
+        if side_offset is not None:
+            if side_offset < 0:
+                start = edge_max + side_offset - span
+            else:
+                start = edge_min + side_offset
+        elif center is not None:
+            start = center - span / 2
+        else:
+            start = edge_min + (edge_length - span) / 2
+
+        if start < edge_min or start + span > edge_max:
+            raise ValueError("bus does not fit within the die on the requested side")
+
+        constraints = []
+        for order, pin in enumerate(pins):
+            u = start + (order + 0.5) * pitch
+            point = (perp, u) if vertical else (u, perp)
+            constraint = self._get_or_make_pinconstraint(pin)
+            constraint.set_placement(*point, step=step, index=index)
+            constraint.set_side(side, step=step, index=index)
+            constraint.set_order(order, step=step, index=index)
+            if layer is not None:
+                constraint.set_layer(layer, step=step, index=index)
+            constraints.append(constraint)
+        return constraints
 
     def copy_pinconstraint(self, pin: str, name: str, insert: bool = True) -> ASICPinConstraint:
         """

--- a/siliconcompiler/constraints/asic_pins.py
+++ b/siliconcompiler/constraints/asic_pins.py
@@ -297,10 +297,12 @@ class ASICPinConstraint(NamedSchema):
 
         Args:
             side (Union[int, str]): The side of the block, either as an integer or a string
-                                     ('left', 'west', 'top', 'north', 'right', 'east', 'bottom', 'south').
+                                     ('left', 'west', 'top', 'north', 'right', 'east', 'bottom',
+                                     'south').
 
         Returns:
-            int: The normalized integer representation of the side (1 for left, 2 for top, 3 for right, 4 for bottom).
+            int: The normalized integer representation of the side
+                (1 for left, 2 for top, 3 for right, 4 for bottom).
 
         Raises:
             TypeError: If `side` is not an int or string.
@@ -426,7 +428,8 @@ class ASICPinConstraints(BaseSchema):
 
         EditableSchema(self).insert(pin.name, pin, clobber=True)
 
-    def get_pinconstraint(self, pin: Optional[str] = None) -> Union[ASICPinConstraint, Dict[str, ASICPinConstraint]]:
+    def get_pinconstraint(self, pin: Optional[str] = None) -> \
+            Union[ASICPinConstraint, Dict[str, ASICPinConstraint]]:
         """
         Retrieves one or all pin constraints from the configuration.
 

--- a/tests/constraints/test_asic_floorplan.py
+++ b/tests/constraints/test_asic_floorplan.py
@@ -297,6 +297,127 @@ def test_set_corearea():
     assert schema.get_corearea() == [(0, 0), (10, 10), (20, 20), (20, 0), (0, 0)]
 
 
+def test_get_dieboundingbox_empty():
+    schema = ASICAreaConstraint()
+    assert schema.get_dieboundingbox() == ((0.0, 0.0), (0.0, 0.0))
+
+
+def test_get_dieboundingbox_rectangle():
+    schema = ASICAreaConstraint()
+    schema.set_diearea([(0, 0), (150, 100)])
+    assert schema.get_dieboundingbox() == ((0, 0), (150, 100))
+
+
+def test_get_dieboundingbox_polygon():
+    schema = ASICAreaConstraint()
+    schema.set_diearea([(0, 0), (0, 20), (10, 20), (10, 10), (20, 10), (20, 0)])
+    assert schema.get_dieboundingbox() == ((0, 0), (20, 20))
+
+
+@pytest.mark.parametrize("shape,expect", [
+    ([(0, 0), (150, 200)], ((0, 0), (150, 200))),
+    ([(0, 0), (0, 20), (10, 20), (10, 10), (20, 10), (20, 0)], ((0, 0), (20, 20))),
+])
+def test_get_dieboundingbox_step_index(shape, expect):
+    schema = ASICAreaConstraint()
+    schema.set_diearea([(0, 0), (100, 100)])
+    schema.set_diearea(shape, step="step0", index="0")
+    assert schema.get_dieboundingbox() == ((0, 0), (100, 100))
+    assert schema.get_dieboundingbox(step="step0", index="0") == expect
+
+
+def test_get_diesize_empty():
+    schema = ASICAreaConstraint()
+    assert schema.get_diesize() == (0.0, 0.0)
+
+
+def test_get_diesize_rectangle():
+    schema = ASICAreaConstraint()
+    schema.set_diearea([(0, 0), (150, 100)])
+    assert schema.get_diesize() == (150, 100)
+
+
+def test_get_diesize_polygon():
+    schema = ASICAreaConstraint()
+    schema.set_diearea([(0, 0), (0, 20), (10, 20), (10, 10), (20, 10), (20, 0)])
+    assert schema.get_diesize() == (20, 20)
+
+
+@pytest.mark.parametrize("shape,expect", [
+    ([(0, 0), (150, 200)], (150, 200)),
+    ([(0, 0), (0, 20), (10, 20), (10, 10), (20, 10), (20, 0)], (20, 20)),
+])
+def test_get_diesize_step_index(shape, expect):
+    schema = ASICAreaConstraint()
+    schema.set_diearea([(0, 0), (100, 100)])
+    schema.set_diearea(shape, step="step0", index="0")
+    assert schema.get_diesize() == (100, 100)
+    assert schema.get_diesize(step="step0", index="0") == expect
+
+
+def test_get_coreboundingbox_empty():
+    schema = ASICAreaConstraint()
+    assert schema.get_coreboundingbox() == ((0.0, 0.0), (0.0, 0.0))
+
+
+def test_get_coreboundingbox_rectangle():
+    schema = ASICAreaConstraint()
+    schema.set_corearea([(2, 5), (148, 95)])
+    assert schema.get_coreboundingbox() == ((2, 5), (148, 95))
+
+
+def test_get_coreboundingbox_polygon():
+    schema = ASICAreaConstraint()
+    schema.set_corearea([(0, 0), (0, 20), (10, 20), (10, 10), (20, 10), (20, 0)])
+    assert schema.get_coreboundingbox() == ((0, 0), (20, 20))
+
+
+@pytest.mark.parametrize("shape,expect", [
+    ([(2, 5), (148, 195)], ((2, 5), (148, 195))),
+    ([(0, 0), (0, 20), (10, 20), (10, 10), (20, 10), (20, 0)], ((0, 0), (20, 20))),
+])
+def test_get_coreboundingbox_step_index(shape, expect):
+    schema = ASICAreaConstraint()
+    schema.set_corearea([(0, 0), (100, 100)])
+    schema.set_corearea(shape, step="step0", index="0")
+    assert schema.get_coreboundingbox() == ((0, 0), (100, 100))
+    assert schema.get_coreboundingbox(step="step0", index="0") == expect
+
+
+def test_get_coresize_empty():
+    schema = ASICAreaConstraint()
+    assert schema.get_coresize() == (0.0, 0.0)
+
+
+def test_get_coresize_rectangle():
+    schema = ASICAreaConstraint()
+    schema.set_corearea([(2, 5), (148, 95)])
+    assert schema.get_coresize() == (146, 90)
+
+
+def test_get_coresize_polygon():
+    schema = ASICAreaConstraint()
+    schema.set_corearea([(0, 0), (0, 20), (10, 20), (10, 10), (20, 10), (20, 0)])
+    assert schema.get_coresize() == (20, 20)
+
+
+@pytest.mark.parametrize("shape,expect", [
+    ([(2, 5), (148, 195)], (146, 190)),
+    ([(0, 0), (0, 20), (10, 20), (10, 10), (20, 10), (20, 0)], (20, 20)),
+])
+def test_get_coresize_step_index(shape, expect):
+    schema = ASICAreaConstraint()
+    schema.set_corearea([(0, 0), (100, 100)])
+    schema.set_corearea(shape, step="step0", index="0")
+    assert schema.get_coresize() == (100, 100)
+    assert schema.get_coresize(step="step0", index="0") == expect
+
+
+def test_calc_area_empty():
+    schema = ASICAreaConstraint()
+    assert schema.calc_diearea() == 0.0
+
+
 @pytest.mark.parametrize("shape,expect", [
     ([(0, 0), (10, 10)], 100),
     ([(0, 0), (0, 20), (10, 20), (10, 10), (20, 10), (20, 0)], 300),

--- a/tests/constraints/test_asic_pins.py
+++ b/tests/constraints/test_asic_pins.py
@@ -466,3 +466,28 @@ def test_make_buspinconstraints_step_index(asic_pins):
         (0.0, 85.0), (0.0, 95.0), (0.0, 105.0), (0.0, 115.0)]
     for c in cons:
         assert c.get_placement() is None
+
+
+def test_make_buspinconstraints_zero_pitch(asic_pins):
+    with pytest.raises(ValueError, match=r"^pitch must be a positive value$"):
+        asic_pins.make_buspinconstraints(["a", "b"], "left", pitch=0)
+
+
+def test_make_buspinconstraints_negative_pitch(asic_pins):
+    with pytest.raises(ValueError, match=r"^pitch must be a positive value$"):
+        asic_pins.make_buspinconstraints(["a", "b"], "left", pitch=-5)
+
+
+def test_make_buspinconstraints_zero_side_width(asic_pins):
+    with pytest.raises(ValueError, match=r"^side_width must be a positive value$"):
+        asic_pins.make_buspinconstraints(["a", "b"], "left", side_width=0)
+
+
+def test_make_buspinconstraints_negative_side_width(asic_pins):
+    with pytest.raises(ValueError, match=r"^side_width must be a positive value$"):
+        asic_pins.make_buspinconstraints(["a", "b"], "left", side_width=-40)
+
+
+def test_make_buspinconstraints_unsupported_side(asic_pins):
+    with pytest.raises(ValueError, match=r"^5 is a not a recognized side$"):
+        asic_pins.make_buspinconstraints(["a", "b"], 5, pitch=10)

--- a/tests/constraints/test_asic_pins.py
+++ b/tests/constraints/test_asic_pins.py
@@ -1,5 +1,6 @@
 import pytest
 
+from siliconcompiler import ASIC
 from siliconcompiler.schema import PerNode, Scope
 
 from siliconcompiler.constraints import ASICPinConstraint, ASICPinConstraints
@@ -13,6 +14,14 @@ def pin_constraint():
 @pytest.fixture
 def pin_constraints_collection():
     return ASICPinConstraints()
+
+
+@pytest.fixture
+def asic_pins():
+    """Pin constraint collection attached to an ASIC with a 100(x) x 200(y) die."""
+    project = ASIC("top")
+    project.constraint.area.set_diearea([(0, 0), (100, 200)])
+    return project.constraint.pin
 
 
 def test_asic_pin_constraint_keys():
@@ -319,3 +328,141 @@ def test_timing_constraint_copy_pinconstraint_no_insert():
     new_obj = schema.copy_pinconstraint("pin0", "pin1", insert=False)
     assert new_obj.name == "pin1"
     assert schema.getkeys() == ("pin0",)
+
+
+def test_make_buspinconstraints_empty_pins(pin_constraints_collection):
+    with pytest.raises(ValueError, match=r"^at least one pin is required$"):
+        pin_constraints_collection.make_buspinconstraints([], "left", pitch=10)
+
+
+def test_make_buspinconstraints_ordering_mode(pin_constraints_collection):
+    cons = pin_constraints_collection.make_buspinconstraints(
+        ["a", "b", "c"], "top", layer="m4")
+    assert [c.name for c in cons] == ["a", "b", "c"]
+    for order, c in enumerate(cons):
+        assert c.get_placement() is None
+        assert c.get_side() == 2
+        assert c.get_order() == order
+        assert c.get_layer() == "m4"
+
+
+def test_make_buspinconstraints_ordering_mode_no_layer(pin_constraints_collection):
+    cons = pin_constraints_collection.make_buspinconstraints(["a", "b"], "left")
+    for c in cons:
+        assert c.get_side() == 1
+        assert c.get_layer() is None
+
+
+def test_make_buspinconstraints_reuses_existing_pin(pin_constraints_collection):
+    existing = pin_constraints_collection.make_pinconstraint("a")
+    cons = pin_constraints_collection.make_buspinconstraints(["a", "b"], "left")
+    assert cons[0] is existing
+    assert pin_constraints_collection.getkeys() == ("a", "b")
+
+
+def test_make_buspinconstraints_conflict_pitch_side_width(pin_constraints_collection):
+    with pytest.raises(ValueError, match=r"^specify only one of 'pitch' or 'side_width'$"):
+        pin_constraints_collection.make_buspinconstraints(
+            ["a"], "left", pitch=10, side_width=10)
+
+
+def test_make_buspinconstraints_conflict_center_side_offset(pin_constraints_collection):
+    with pytest.raises(ValueError, match=r"^specify only one of 'center' or 'side_offset'$"):
+        pin_constraints_collection.make_buspinconstraints(
+            ["a"], "left", pitch=10, center=10, side_offset=10)
+
+
+def test_make_buspinconstraints_position_without_spacing(pin_constraints_collection):
+    with pytest.raises(ValueError,
+                       match=r"^'pitch' or 'side_width' is required to space the pins$"):
+        pin_constraints_collection.make_buspinconstraints(["a"], "left", center=10)
+
+
+def test_make_buspinconstraints_detached_from_asic(pin_constraints_collection):
+    with pytest.raises(TypeError, match=r"^bus pin constraints require an ASIC project$"):
+        pin_constraints_collection.make_buspinconstraints(["a"], "left", pitch=10)
+
+
+def test_make_buspinconstraints_no_die_area():
+    project = ASIC("top")
+    with pytest.raises(ValueError, match=r"^die area must be set before placing bus pins$"):
+        project.constraint.pin.make_buspinconstraints(["a"], "left", pitch=10)
+
+
+def test_make_buspinconstraints_does_not_fit(asic_pins):
+    with pytest.raises(ValueError,
+                       match=r"^bus does not fit within the die on the requested side$"):
+        asic_pins.make_buspinconstraints(["a", "b"], "left", pitch=1000)
+
+
+def test_make_buspinconstraints_does_not_fit_negative_offset(asic_pins):
+    with pytest.raises(ValueError,
+                       match=r"^bus does not fit within the die on the requested side$"):
+        asic_pins.make_buspinconstraints(["a", "b"], "left", pitch=10, side_offset=-500)
+
+
+@pytest.mark.parametrize("side,expected", [
+    (1, [(0.0, 85.0), (0.0, 95.0), (0.0, 105.0), (0.0, 115.0)]),
+    ("left", [(0.0, 85.0), (0.0, 95.0), (0.0, 105.0), (0.0, 115.0)]),
+    (3, [(100.0, 85.0), (100.0, 95.0), (100.0, 105.0), (100.0, 115.0)]),
+    ("right", [(100.0, 85.0), (100.0, 95.0), (100.0, 105.0), (100.0, 115.0)]),
+    (2, [(35.0, 200.0), (45.0, 200.0), (55.0, 200.0), (65.0, 200.0)]),
+    ("top", [(35.0, 200.0), (45.0, 200.0), (55.0, 200.0), (65.0, 200.0)]),
+    (4, [(35.0, 0.0), (45.0, 0.0), (55.0, 0.0), (65.0, 0.0)]),
+    ("bottom", [(35.0, 0.0), (45.0, 0.0), (55.0, 0.0), (65.0, 0.0)]),
+])
+def test_make_buspinconstraints_pitch_centered_all_sides(asic_pins, side, expected):
+    cons = asic_pins.make_buspinconstraints(["a", "b", "c", "d"], side, pitch=10)
+    assert [c.get_placement() for c in cons] == expected
+
+
+def test_make_buspinconstraints_side_width(asic_pins):
+    # side_width=80 over 4 pins -> pitch 20, centered on the 200um edge -> start 60
+    cons = asic_pins.make_buspinconstraints(["a", "b", "c", "d"], "left", side_width=80)
+    assert [c.get_placement() for c in cons] == [
+        (0.0, 70.0), (0.0, 90.0), (0.0, 110.0), (0.0, 130.0)]
+
+
+def test_make_buspinconstraints_center_and_pitch(asic_pins):
+    cons = asic_pins.make_buspinconstraints(["a", "b", "c", "d"], "left", center=100, pitch=10)
+    assert [c.get_placement() for c in cons] == [
+        (0.0, 85.0), (0.0, 95.0), (0.0, 105.0), (0.0, 115.0)]
+
+
+def test_make_buspinconstraints_side_width_and_positive_offset(asic_pins):
+    cons = asic_pins.make_buspinconstraints(
+        ["a", "b", "c", "d"], "bottom", side_width=40, side_offset=10)
+    assert [c.get_placement() for c in cons] == [
+        (15.0, 0.0), (25.0, 0.0), (35.0, 0.0), (45.0, 0.0)]
+
+
+def test_make_buspinconstraints_negative_offset(asic_pins):
+    # negative offset anchors the far end, leaving a 10um gap at the top (y=200)
+    cons = asic_pins.make_buspinconstraints(
+        ["a", "b", "c", "d"], "left", side_width=40, side_offset=-10)
+    assert [c.get_placement() for c in cons] == [
+        (0.0, 155.0), (0.0, 165.0), (0.0, 175.0), (0.0, 185.0)]
+
+
+def test_make_buspinconstraints_sets_side_order_and_layer(asic_pins):
+    cons = asic_pins.make_buspinconstraints(
+        ["a", "b"], "left", pitch=10, layer="m3")
+    for order, c in enumerate(cons):
+        assert c.get_side() == 1
+        assert c.get_order() == order
+        assert c.get_layer() == "m3"
+
+
+def test_make_buspinconstraints_geometric_no_layer(asic_pins):
+    cons = asic_pins.make_buspinconstraints(["a", "b"], "left", pitch=10)
+    for c in cons:
+        assert c.get_layer() is None
+
+
+def test_make_buspinconstraints_step_index(asic_pins):
+    cons = asic_pins.make_buspinconstraints(
+        ["a", "b", "c", "d"], "left", pitch=10, step="place", index="0")
+    assert [c.get_placement(step="place", index="0") for c in cons] == [
+        (0.0, 85.0), (0.0, 95.0), (0.0, 105.0), (0.0, 115.0)]
+    for c in cons:
+        assert c.get_placement() is None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added query helpers for die/core axis-aligned bounding boxes and (width, height) sizes, with safe zero defaults and step/index-specific support.
  - Added bus pin constraint generation, including side-name normalization and placement modes using pitch/centering/offsets plus optional layer.
- **Tests**
  - Expanded unit tests for floorplan geometry helpers (empty/rectangle/polygon, step/index) and for bus pin placement and validation, including error handling and step/index behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->