### PR TITLE
add cached schema class to speed up loading and support for frozen

### DIFF
--- a/docs/user_guide/faq.rst
+++ b/docs/user_guide/faq.rst
@@ -141,3 +141,49 @@ How do I...
     .. code-block:: python
 
        project.option.write_defaults()
+
+... avoid rebuilding an expensive object (such as a PDK) many times?
+
+    If a schema object is a pure function of its construction arguments, base it
+    on ``CachedSchema``. Instances are built once per unique (hashable) set of
+    arguments, and the shared, frozen instance is returned on subsequent
+    constructions. This is useful for heavy objects, like PDKs, that would
+    otherwise be re-created dozens of times while loading a target.
+
+    .. code-block:: python
+
+       from siliconcompiler import PDK
+       from siliconcompiler.schema import CachedSchema
+
+       class MyPDK(PDK, CachedSchema):
+           def __init__(self):
+               super().__init__("mypdk")
+               # ... expensive schema population ...
+
+       MyPDK() is MyPDK()   # True -- same shared instance, built only once
+
+    The shared instance is *frozen*: calling ``set``, ``add``, ``unset``,
+    ``remove``, or using ``EditableSchema`` on it raises a
+    ``SchemaFrozenError``. This protects the shared object from accidental
+    modification.
+
+... get a modifiable version of a frozen (cached) object?
+
+    Use ``copy()``. A copy is always mutable and fully independent of the shared
+    instance, so you are free to modify it. Objects reloaded from a manifest
+    (for example, inside a run) are likewise mutable.
+
+    .. code-block:: python
+
+       my_pdk = MyPDK()          # frozen, shared
+       local = my_pdk.copy()     # mutable, independent
+       local.set("pdk", "foundry", "virtual")
+
+    To modify a frozen object in place (for example, to write resolved file
+    paths or hashes back into a shared object during a run), use the ``_thaw``
+    context manager, which restores the frozen state on exit:
+
+    .. code-block:: python
+
+       with my_pdk._thaw():
+           my_pdk.set(*keypath, hashes, field="filehash")

--- a/siliconcompiler/schema/__init__.py
+++ b/siliconcompiler/schema/__init__.py
@@ -4,7 +4,8 @@ from .parameter import Parameter, Scope, PerNode
 from .journal import Journal
 from .safeschema import SafeSchema
 from .editableschema import EditableSchema
-from .baseschema import BaseSchema, LazyLoad
+from .baseschema import BaseSchema, LazyLoad, CachedSchema, CachedSchemaMeta, \
+    SchemaFrozenError
 from .namedschema import NamedSchema
 from .docschema import DocsSchema
 
@@ -18,7 +19,10 @@ __all__ = [
     "PerNode",
     "Journal",
     "DocsSchema",
-    "LazyLoad"
+    "LazyLoad",
+    "CachedSchema",
+    "CachedSchemaMeta",
+    "SchemaFrozenError"
 ]
 
 SCHEMA_VERSION = __version__

--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -202,6 +202,21 @@ class BaseSchema:
                 "_thaw() to modify in place.")
 
     @staticmethod
+    def __instantiate(cls: Type[TSchema]) -> TSchema:
+        """
+        Constructs a schema object while loading from disk. Objects loaded from
+        disk are repopulated in place, so cached (:class:`CachedSchema`) classes
+        must be built fresh and unfrozen rather than returning the shared,
+        frozen singleton.
+        """
+        if isinstance(cls, CachedSchemaMeta):
+            # Loading from disk repopulates the object in place, so it must not
+            # return the shared, frozen singleton. Copy it to get a fresh,
+            # mutable instance (copy() unfreezes).
+            return cls().copy()
+        return cls()
+
+    @staticmethod
     @cache
     def __get_child_classes() -> Dict[str, Type["BaseSchema"]]:
         """
@@ -369,7 +384,7 @@ class BaseSchema:
                     for cls in clss:
                         # Create object and connect to schema
                         try:
-                            obj = cls()
+                            obj = BaseSchema.__instantiate(cls)
                             break
                         except Exception:
                             continue
@@ -422,7 +437,7 @@ class BaseSchema:
         schema = None
         for new_cls in new_clss:
             try:
-                schema = new_cls()
+                schema = BaseSchema.__instantiate(new_cls)
                 break
             except Exception:
                 pass
@@ -1525,6 +1540,10 @@ class CachedSchemaMeta(type):
     Because instances are cached and shared, all construction arguments must be
     hashable and the returned object is frozen to guard against accidental
     in-place mutation. Use :meth:`BaseSchema.copy` to obtain a mutable version.
+
+    Deserialization (loading from disk) copies the shared instance to get a
+    fresh, unfrozen object to repopulate, rather than returning the shared
+    singleton.
     """
 
     @lru_cache(maxsize=None)

--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -26,7 +26,7 @@ except ModuleNotFoundError:
 import os.path
 
 from enum import Enum, auto
-from functools import cache
+from functools import cache, lru_cache
 from typing import Dict, Type, Tuple, TypeVar, Union, Set, Callable, List, Optional, \
     TextIO, Iterable, Any
 
@@ -35,6 +35,14 @@ from .journal import Journal
 from ._metadata import version
 
 TSchema = TypeVar('TSchema', bound='BaseSchema')
+
+
+class SchemaFrozenError(RuntimeError):
+    """
+    Raised when an attempt is made to modify a frozen (immutable) schema.
+
+    See :meth:`BaseSchema._freeze` and :class:`CachedSchema`.
+    """
 
 
 class LazyLoad(Enum):
@@ -81,6 +89,7 @@ class BaseSchema:
         self.__active: Optional[Dict] = None
         self.__key: Optional[str] = None
         self.__lazy: Optional[Tuple[Optional[Tuple[int, ...]], Dict]] = None
+        self.__frozen: bool = False
 
     @property
     def __is_root(self) -> bool:
@@ -106,6 +115,91 @@ class BaseSchema:
             # Guard against partially setup parents during serialization
             return tuple()
         return tuple([*parentpath, key])
+
+    def __child_schemas(self) -> "List[BaseSchema]":
+        '''
+        Returns the immediate child :class:`BaseSchema` objects held by this
+        schema (manifest entries and the default template).
+        '''
+        children = [value for value in self.__manifest.values()
+                    if isinstance(value, BaseSchema)]
+        if isinstance(self.__default, BaseSchema):
+            children.append(self.__default)
+        return children
+
+    def __iter_subtree(self) -> "List[BaseSchema]":
+        '''
+        Returns this schema followed by every nested child schema (depth first).
+        '''
+        nodes = [self]
+        for child in self.__child_schemas():
+            nodes.extend(child.__iter_subtree())
+        return nodes
+
+    @property
+    def _is_frozen(self) -> bool:
+        '''
+        Returns True if this schema is frozen and cannot be modified.
+        '''
+        try:
+            return self.__frozen
+        except AttributeError:
+            # Guard against partially constructed objects during serialization
+            return False
+
+    def _freeze(self) -> None:
+        '''
+        Marks this schema and all of its child schemas as frozen, preventing
+        further modification via :meth:`set`, :meth:`add`, :meth:`unset`,
+        :meth:`remove`, or :class:`EditableSchema`.
+
+        This is used to protect shared/cached schema objects (see
+        :class:`CachedSchema`) from accidental in-place mutation. A frozen
+        object can still be copied via :meth:`copy` or serialized and
+        deserialized; the resulting object is always mutable.
+        '''
+        for node in self.__iter_subtree():
+            node.__frozen = True
+
+    def _unfreeze(self) -> None:
+        '''
+        Clears the frozen state on this schema and all of its child schemas,
+        making it mutable again.
+        '''
+        for node in self.__iter_subtree():
+            node.__frozen = False
+
+    @contextlib.contextmanager
+    def _thaw(self):
+        '''
+        Context manager that temporarily unfreezes this schema (and its
+        children), restoring the previous frozen state on exit.
+
+        This is the sanctioned mechanism for mutating a frozen object in place,
+        for example when writing resolved file paths or hashes back into a
+        shared object during a run:
+
+        >>> with pdk._thaw():
+        ...     pdk.set(*keypath, hashes, field="filehash")
+        '''
+        snapshot = [(node, node._is_frozen) for node in self.__iter_subtree()]
+        for node, _ in snapshot:
+            node.__frozen = False
+        try:
+            yield self
+        finally:
+            for node, was_frozen in snapshot:
+                node.__frozen = was_frozen
+
+    def __assert_mutable(self, action: str, keypath: Tuple[str, ...]) -> None:
+        '''
+        Raises :class:`SchemaFrozenError` if this schema is frozen.
+        '''
+        if self._is_frozen:
+            raise SchemaFrozenError(
+                f"cannot {action} {self.__format_key(*keypath)}: "
+                "schema is frozen. Use copy() to obtain a mutable version or "
+                "_thaw() to modify in place.")
 
     @staticmethod
     @cache
@@ -452,6 +546,11 @@ class BaseSchema:
                     raise KeyError
                 key_param = self.__default.copy(key=complete_path)
                 self.__manifest[keypath[0]] = key_param
+                # Keep lazily-materialized children as frozen as their parent so
+                # freezing cannot be escaped by reaching a not-yet-instantiated
+                # keypath (e.g. via get(field="schema")).
+                if self._is_frozen and isinstance(key_param, BaseSchema):
+                    key_param._freeze()
             elif use_default and self.__default:
                 key_param = self.__default
             else:
@@ -560,6 +659,8 @@ class BaseSchema:
 
         *keypath, value = args
 
+        self.__assert_mutable("set", tuple(keypath))
+
         try:
             param: Parameter = self.__search(*keypath, insert_defaults=True)
         except KeyError:
@@ -606,6 +707,8 @@ class BaseSchema:
 
         *keypath, value = args
 
+        self.__assert_mutable("add to", tuple(keypath))
+
         try:
             param: Parameter = self.__search(*keypath, insert_defaults=True)
         except KeyError:
@@ -651,6 +754,8 @@ class BaseSchema:
                 on a per-node basis.
         '''
 
+        self.__assert_mutable("unset", tuple(keypath))
+
         try:
             param = self.__search(*keypath, use_default=True)
         except KeyError:
@@ -671,6 +776,8 @@ class BaseSchema:
         Args:
             keypath (list): Parameter keypath to clear.
         '''
+
+        self.__assert_mutable("remove", tuple(keypath))
 
         search_path = keypath[0:-1]
         removal_key = keypath[-1]
@@ -894,6 +1001,10 @@ class BaseSchema:
 
         if key:
             schema_copy.__key = key[-1]
+
+        # A copy is always mutable, even when derived from a frozen (cached)
+        # object, so callers are free to modify their own instance.
+        schema_copy._unfreeze()
 
         return schema_copy
 
@@ -1401,3 +1512,38 @@ class BaseSchema:
             if table:
                 return table
             return None
+
+
+class CachedSchemaMeta(type):
+    """
+    Metaclass that memoizes instances of :class:`CachedSchema` subclasses.
+
+    Instantiating a class that uses this metaclass with the same arguments
+    returns the same (frozen) instance every time, so schema objects that are a
+    pure function of their construction arguments are built once and reused.
+
+    Because instances are cached and shared, all construction arguments must be
+    hashable and the returned object is frozen to guard against accidental
+    in-place mutation. Use :meth:`BaseSchema.copy` to obtain a mutable version.
+    """
+
+    @lru_cache(maxsize=None)
+    def __call__(cls, *args, **kwargs):
+        obj = super().__call__(*args, **kwargs)
+        obj._freeze()
+        return obj
+
+
+class CachedSchema(BaseSchema, metaclass=CachedSchemaMeta):
+    """
+    Base for schema objects that are a pure function of their construction
+    arguments -- built once, reused.
+
+    Subclasses are instantiated once per unique set of (hashable) construction
+    arguments; subsequent instantiations with the same arguments return the same
+    shared, frozen instance. This is useful for heavy objects (such as PDKs)
+    that are otherwise rebuilt many times over the course of loading a target.
+
+    The shared instance is frozen; obtain a mutable, independent object with
+    :meth:`copy`.
+    """

--- a/siliconcompiler/schema/editableschema.py
+++ b/siliconcompiler/schema/editableschema.py
@@ -5,7 +5,7 @@
 # that have isolated Python environments.
 
 from .parameter import Parameter
-from .baseschema import BaseSchema
+from .baseschema import BaseSchema, SchemaFrozenError
 from .namedschema import NamedSchema
 
 from typing import Union, Tuple
@@ -110,6 +110,10 @@ class EditableSchema:
         if not isinstance(value, (Parameter, BaseSchema)):
             raise ValueError(f"Value ({type(value)}) must be schema type: Parameter, BaseSchema")
 
+        if self.__schema._is_frozen:
+            raise SchemaFrozenError(
+                f"cannot insert [{','.join(keypath)}]: schema is frozen")
+
         self.__insert(keypath, value, keypath, clobber=clobber)
 
     def remove(self, *keypath: str) -> None:
@@ -129,6 +133,10 @@ class EditableSchema:
 
         if any([not isinstance(key, str) for key in keypath]):
             raise ValueError("Keypath must only be strings")
+
+        if self.__schema._is_frozen:
+            raise SchemaFrozenError(
+                f"cannot remove [{','.join(keypath)}]: schema is frozen")
 
         self.__remove(keypath, keypath)
 

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -10,6 +10,8 @@ from siliconcompiler.schema import BaseSchema, LazyLoad
 from siliconcompiler.schema import EditableSchema
 from siliconcompiler.schema import Parameter, PerNode
 from siliconcompiler.schema import Journal
+from siliconcompiler.schema import NamedSchema
+from siliconcompiler.schema import CachedSchema, CachedSchemaMeta, SchemaFrozenError
 
 
 @pytest.fixture
@@ -4409,3 +4411,262 @@ def test_from_dict_with_nofailure():
 
     assert schema.get("dummy", "default", field="schema").__class__ is BaseSchema
     assert schema.get("dummy", "newdummy", field="schema").__class__ is DummySchema1
+
+
+def _freezable_schema(value="hello"):
+    """Two-level schema with a scalar, a list and a nested child."""
+    schema = BaseSchema()
+    edit = EditableSchema(schema)
+    edit.insert("scalar", Parameter("str"))
+    edit.insert("mylist", Parameter("[str]"))
+    edit.insert("child", "leaf", Parameter("str"))
+    schema.set("scalar", value)
+    schema.add("mylist", "a")
+    schema.set("child", "leaf", "nested")
+    return schema
+
+
+def test_not_frozen_by_default():
+    assert _freezable_schema()._is_frozen is False
+
+
+def test_freeze_sets_flag():
+    schema = _freezable_schema()
+    schema._freeze()
+    assert schema._is_frozen is True
+
+
+def test_freeze_is_recursive():
+    schema = _freezable_schema()
+    child = schema.get("child", field="schema")
+    assert child._is_frozen is False
+    schema._freeze()
+    assert child._is_frozen is True
+
+
+def test_unfreeze():
+    schema = _freezable_schema()
+    schema._freeze()
+    schema._unfreeze()
+    assert schema._is_frozen is False
+    assert schema.get("child", field="schema")._is_frozen is False
+
+
+def test_frozen_set_raises():
+    schema = _freezable_schema()
+    schema._freeze()
+    with pytest.raises(SchemaFrozenError, match="frozen"):
+        schema.set("scalar", "world")
+    assert schema.get("scalar") == "hello"
+
+
+def test_frozen_add_raises():
+    schema = _freezable_schema()
+    schema._freeze()
+    with pytest.raises(SchemaFrozenError, match="frozen"):
+        schema.add("mylist", "b")
+    assert schema.get("mylist") == ["a"]
+
+
+def test_frozen_unset_raises():
+    schema = _freezable_schema()
+    schema._freeze()
+    with pytest.raises(SchemaFrozenError, match="frozen"):
+        schema.unset("scalar")
+
+
+def test_frozen_remove_raises():
+    schema = _freezable_schema()
+    schema._freeze()
+    with pytest.raises(SchemaFrozenError, match="frozen"):
+        schema.remove("scalar")
+
+
+def test_frozen_set_on_child_raises():
+    schema = _freezable_schema()
+    schema._freeze()
+    child = schema.get("child", field="schema")
+    with pytest.raises(SchemaFrozenError, match="frozen"):
+        child.set("leaf", "changed")
+
+
+def test_mutation_allowed_before_freeze():
+    schema = _freezable_schema()
+    schema.set("scalar", "before")
+    assert schema.get("scalar") == "before"
+
+
+def test_lazy_materialized_child_inherits_frozen():
+    schema = BaseSchema()
+    EditableSchema(schema).insert("lib", "default", "leaf", Parameter("str"))
+    schema._freeze()
+    child = schema.get("lib", "anytoolname", field="schema")
+    assert child._is_frozen is True
+    with pytest.raises(SchemaFrozenError, match="frozen"):
+        child.set("leaf", "x")
+
+
+def test_thaw_allows_mutation():
+    schema = _freezable_schema()
+    schema._freeze()
+    with schema._thaw():
+        schema.set("scalar", "thawed")
+    assert schema.get("scalar") == "thawed"
+
+
+def test_thaw_restores_frozen_state():
+    schema = _freezable_schema()
+    schema._freeze()
+    with schema._thaw():
+        pass
+    assert schema._is_frozen is True
+    with pytest.raises(SchemaFrozenError):
+        schema.set("scalar", "nope")
+
+
+def test_thaw_restores_on_exception():
+    schema = _freezable_schema()
+    schema._freeze()
+    with pytest.raises(ValueError):
+        with schema._thaw():
+            raise ValueError("boom")
+    assert schema._is_frozen is True
+
+
+def test_thaw_restores_child_state():
+    schema = _freezable_schema()
+    schema._freeze()
+    child = schema.get("child", field="schema")
+    with schema._thaw():
+        assert child._is_frozen is False
+        child.set("leaf", "viathaw")
+    assert child._is_frozen is True
+    assert schema.get("child", "leaf") == "viathaw"
+
+
+def test_thaw_on_unfrozen_stays_unfrozen():
+    schema = _freezable_schema()
+    with schema._thaw():
+        schema.set("scalar", "ok")
+    assert schema._is_frozen is False
+
+
+def test_copy_of_frozen_is_mutable():
+    schema = _freezable_schema()
+    schema._freeze()
+    dup = schema.copy()
+    assert dup._is_frozen is False
+    dup.set("scalar", "changed")
+    assert dup.get("scalar") == "changed"
+    assert schema.get("scalar") == "hello"
+    assert schema._is_frozen is True
+
+
+def test_copy_of_frozen_is_mutable_recursively():
+    schema = _freezable_schema()
+    schema._freeze()
+    dup = schema.copy()
+    assert dup.get("child", field="schema")._is_frozen is False
+    dup.set("child", "leaf", "changed")
+    assert dup.get("child", "leaf") == "changed"
+
+
+def test_from_dict_of_frozen_produces_mutable():
+    schema = _freezable_schema()
+    schema._freeze()
+    manifest = schema.getdict()
+
+    reloaded = _freezable_schema()
+    reloaded._from_dict(manifest, [], None)
+    assert reloaded._is_frozen is False
+    reloaded.set("scalar", "reloaded")
+    assert reloaded.get("scalar") == "reloaded"
+
+
+class _Widget(CachedSchema):
+    def __init__(self, name="default"):
+        super().__init__()
+        edit = EditableSchema(self)
+        edit.insert("name", Parameter("str"))
+        self.set("name", name)
+
+
+def test_cached_same_args_same_instance():
+    assert _Widget("a") is _Widget("a")
+
+
+def test_cached_different_args_different_instance():
+    assert _Widget("a") is not _Widget("b")
+
+
+def test_cached_instance_is_frozen():
+    assert _Widget("frozen")._is_frozen is True
+
+
+def test_cached_instance_populated():
+    assert _Widget("populated").get("name") == "populated"
+
+
+def test_cached_instance_cannot_be_mutated():
+    with pytest.raises(SchemaFrozenError):
+        _Widget("immutable").set("name", "other")
+
+
+def test_cached_copy_is_mutable_and_independent():
+    w = _Widget("shared")
+    dup = w.copy()
+    assert dup is not w
+    assert dup._is_frozen is False
+    dup.set("name", "mine")
+    assert dup.get("name") == "mine"
+    assert w.get("name") == "shared"
+
+
+def test_cached_metaclass_type():
+    assert isinstance(_Widget, CachedSchemaMeta)
+
+
+def test_cached_built_once():
+    calls = []
+
+    class _CountingWidget(CachedSchema):
+        def __init__(self):
+            calls.append(1)
+            super().__init__()
+
+    for _ in range(5):
+        _CountingWidget()
+    assert sum(calls) == 1
+
+
+def test_cached_unhashable_arg_raises():
+    class _Bad(CachedSchema):
+        def __init__(self, data):
+            super().__init__()
+
+    with pytest.raises(TypeError):
+        _Bad(["unhashable"])
+
+
+def test_cached_composed_with_namedschema():
+    # The real-world pattern: compose CachedSchema with a heavy named schema
+    # (e.g. a PDK) to get a built-once, frozen, shared instance.
+    class _CachedNamed(NamedSchema, CachedSchema):
+        def __init__(self, name):
+            super().__init__(name)
+            edit = EditableSchema(self)
+            edit.insert("val", Parameter("str"))
+            self.set("val", "populated")
+
+    a = _CachedNamed("libname")
+    b = _CachedNamed("libname")
+    assert a is b
+    assert a._is_frozen is True
+    assert a.name == "libname"
+    assert a.get("val") == "populated"
+    assert _CachedNamed("other") is not a
+
+    dup = a.copy()
+    assert dup._is_frozen is False
+    dup.set("val", "mine")
+    assert a.get("val") == "populated"

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -4670,3 +4670,27 @@ def test_cached_composed_with_namedschema():
     assert dup._is_frozen is False
     dup.set("val", "mine")
     assert a.get("val") == "populated"
+
+
+class _CachedLib(NamedSchema, CachedSchema):
+    def __init__(self, name="libname"):
+        super().__init__(name)
+        EditableSchema(self).insert("val", Parameter("str"))
+        self.set("val", "built")
+
+
+def test_cached_from_manifest_is_unfrozen_and_distinct():
+    # Loading a cached object from disk must produce a fresh, mutable instance,
+    # not the shared frozen singleton (which _from_dict would otherwise clobber).
+    lib = _CachedLib("orig")
+    assert lib._is_frozen is True
+
+    loaded = _CachedLib.from_manifest(cfg=lib.getdict())
+    assert loaded is not lib
+    assert loaded._is_frozen is False
+    loaded.set("val", "changed")
+    assert loaded.get("val") == "changed"
+
+    # the shared singleton is untouched and still frozen
+    assert _CachedLib("orig").get("val") == "built"
+    assert _CachedLib("orig")._is_frozen is True

--- a/tests/schema/test_editableschema.py
+++ b/tests/schema/test_editableschema.py
@@ -3,6 +3,7 @@ import pytest
 from siliconcompiler.schema import BaseSchema, NamedSchema
 from siliconcompiler.schema import Parameter
 from siliconcompiler.schema import EditableSchema
+from siliconcompiler.schema import SchemaFrozenError
 
 
 @pytest.mark.parametrize("child", (BaseSchema(), Parameter("str")))
@@ -389,3 +390,27 @@ def test_rename_bad_type():
     obj = BaseSchema()
     with pytest.raises(TypeError, match=r'^schema must be a named schema$'):
         EditableSchema(obj).rename("this")
+
+
+def test_insert_on_frozen_raises():
+    schema = BaseSchema()
+    EditableSchema(schema).insert("existing", Parameter("str"))
+    schema._freeze()
+    with pytest.raises(SchemaFrozenError, match="frozen"):
+        EditableSchema(schema).insert("newkey", Parameter("str"))
+
+
+def test_remove_on_frozen_raises():
+    schema = BaseSchema()
+    EditableSchema(schema).insert("existing", Parameter("str"))
+    schema._freeze()
+    with pytest.raises(SchemaFrozenError, match="frozen"):
+        EditableSchema(schema).remove("existing")
+
+
+def test_insert_allowed_after_unfreeze():
+    schema = BaseSchema()
+    schema._freeze()
+    schema._unfreeze()
+    EditableSchema(schema).insert("newkey", Parameter("str"))
+    assert "newkey" in schema.getkeys()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable cached schema instances that are automatically frozen, with enforced immutability.
  * Added freeze/unfreeze controls, safe temporary editing, and guaranteed creation of independent mutable copies.
  * Cache loading/copying now returns unfrozen instances rather than reusing frozen singletons.
  * Editable operations now block changes to frozen schemas with a dedicated error.

* **Documentation**
  * Updated FAQ with guidance on cached schemas, copying, and temporarily modifying frozen objects.

* **Tests**
  * Added extensive coverage for freezing/thawing, cached reuse, copy behavior, and mutation protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->