### PR TITLE
add support for sc_get_filesets to mirror python

### DIFF
--- a/siliconcompiler/data/templates/tcl/manifest.tcl.j2
+++ b/siliconcompiler/data/templates/tcl/manifest.tcl.j2
@@ -15,6 +15,7 @@ proc sc_root {} {
     return "{{ scroot }}"
 }
 
+{% include 'tools/_common/tcl/sc_proc_args.tcl' %}
 {% include 'tools/_common/tcl/sc_schema_access.tcl' %}
 
 #############################################

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -4,7 +4,7 @@ import uuid
 
 import os.path
 
-from typing import Type, Union, List, Tuple, TextIO, Optional, Dict, Set, TypeVar
+from typing import Type, Union, List, Tuple, TextIO, Optional, Dict, Set, TypeVar, cast
 
 from siliconcompiler.schema import BaseSchema, NamedSchema, EditableSchema, Parameter, Scope, \
     __version__ as schema_version, \
@@ -693,13 +693,21 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         # Restore dashboard
         self.__init_dashboard()
 
-    def get_filesets(self) -> List[Tuple[NamedSchema, str]]:
+    def get_filesets(self,
+                     library: Optional[Union[str, Design]] = None,
+                     filesets: Optional[List[str]] = None) -> List[Tuple[NamedSchema, str]]:
         """
         Returns the filesets selected for this project, resolving any aliases.
 
         This method retrieves the filesets defined in :keypath:`option,fileset`
         and applies any aliases specified in :keypath:`option,alias` to return
         the effective list of filesets and their parent libraries.
+
+        Args:
+            library (Optional[Union[str, Design]]): The library from which to retrieve filesets.
+                If None, defaults to the project's main design.
+            filesets (Optional[List[str]]): A list of fileset names to retrieve.
+                If None, defaults to all filesets defined in the project options.
 
         Returns:
             List[Tuple[NamedSchema, str]]: A list of tuples, where each tuple
@@ -724,7 +732,17 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
                 dst_fileset = None
             alias[(src_lib, src_fileset)] = (dst_obj, dst_fileset)
 
-        return self.design.get_fileset(self.option.get_fileset(), alias=alias)
+        if isinstance(library, str):
+            library = cast(Design, self.get_library(library))
+
+        if library is None or library is self.design:
+            library = self.design
+            if filesets is None:
+                filesets = self.option.get_fileset()
+        elif filesets is None:
+            raise ValueError("Filesets must be specified if library is provided")
+
+        return library.get_fileset(filesets, alias=alias)
 
     def _get_write_depgraph_extra(self) -> Tuple[Dict[str, Set[str]], Dict[str, Dict[str, str]]]:
         """

--- a/siliconcompiler/tools/_common/tcl/sc_schema_access.tcl
+++ b/siliconcompiler/tools/_common/tcl/sc_schema_access.tcl
@@ -122,3 +122,102 @@ proc sc_cfg_get_fileset { libraries filesets filetype } {
     }
     return $files
 }
+
+# Build the alias lookup used when resolving fileset dependencies.
+#
+# Returns a dict mapping a {src_library src_fileset} pair to its
+# {dst_library dst_fileset} replacement, derived from option,alias. An empty
+# dst_library means the dependency is dropped; an empty dst_fileset means the
+# original fileset name is preserved. Mirrors Project.get_filesets.
+proc sc_get_fileset_aliases { } {
+    set aliases [dict create]
+    if { ![sc_cfg_exists option alias] } {
+        return $aliases
+    }
+
+    foreach entry [sc_cfg_get option alias] {
+        lassign $entry src_library src_fileset dst_library dst_fileset
+        if { $src_library eq $dst_library && $src_fileset eq $dst_fileset } {
+            continue
+        }
+        dict set aliases \
+            [list $src_library $src_fileset] [list $dst_library $dst_fileset]
+    }
+
+    return $aliases
+}
+
+# Recursive helper for sc_get_filesets. Performs a post-order traversal of the
+# dependency graph, appending each {library fileset} pair to filelist after its
+# dependencies. visited tracks already-processed pairs so each appears once.
+# aliases substitutes dependency edges (see sc_get_fileset_aliases).
+proc sc_get_filesets_recurse { library filesets aliases visited_var filelist_var } {
+    upvar 1 $visited_var visited
+    upvar 1 $filelist_var filelist
+
+    foreach fileset $filesets {
+        set key [list $library $fileset]
+        if { [dict exists $visited $key] } {
+            continue
+        }
+        dict set visited $key 1
+
+        if { [sc_cfg_exists library $library fileset $fileset depfileset] } {
+            foreach dep [sc_cfg_get library $library fileset $fileset depfileset] {
+                set depname [lindex $dep 0]
+                set depfileset [lindex $dep 1]
+
+                if { [dict exists $aliases $dep] } {
+                    lassign [dict get $aliases $dep] alias_library alias_fileset
+                    if { [llength $alias_library] == 0 } {
+                        # Aliased to nothing, drop the dependency.
+                        continue
+                    }
+                    set depname $alias_library
+                    if { [llength $alias_fileset] != 0 } {
+                        set depfileset $alias_fileset
+                    }
+                }
+
+                sc_get_filesets_recurse \
+                    $depname $depfileset $aliases visited filelist
+            }
+        }
+
+        lappend filelist $key
+    }
+}
+
+# Resolve the filesets selected for the build and all of their dependencies.
+#
+# Traverses the depfileset dependency graph starting from the given filesets
+# and returns a flattened, unique list of {library fileset} pairs in dependency
+# order (a dependency always precedes the fileset that requires it). Aliases
+# from option,alias are applied to dependency edges. Mirrors
+# Project.get_filesets / Design.get_fileset. Cycles are assumed to have already
+# been resolved, so no cycle detection is performed.
+#
+# With no arguments the top-level design (option,design) and its selected
+# filesets (option,fileset) are used. If -library is given, -filesets must also
+# be given.
+proc sc_get_filesets { args } {
+    sc::parse_args opts {
+        -library  {default {}}
+        -filesets {default {}}
+    } $args
+    set library [dict get $opts library]
+    set filesets [dict get $opts filesets]
+
+    if { [llength $library] == 0 } {
+        set library [sc_cfg_get option design]
+        if { [llength $filesets] == 0 } {
+            set filesets [sc_cfg_get option fileset]
+        }
+    }
+
+    set aliases [sc_get_fileset_aliases]
+    set visited [dict create]
+    set filelist []
+    sc_get_filesets_recurse $library $filesets $aliases visited filelist
+    return $filelist
+}

--- a/siliconcompiler/tools/_common/tcl/sc_schema_access.tcl
+++ b/siliconcompiler/tools/_common/tcl/sc_schema_access.tcl
@@ -198,26 +198,32 @@ proc sc_get_filesets_recurse { library filesets aliases visited_var filelist_var
 # been resolved, so no cycle detection is performed.
 #
 # With no arguments the top-level design (option,design) and its selected
-# filesets (option,fileset) are used. If -library is given, -filesets must also
-# be given.
+# filesets (option,fileset) are used. -library may name one or more libraries
+# (e.g. -library "lib_a lib_b"), all of which are traversed with the same
+# -filesets and share a single visited set so dependencies dedup across them.
+# If -library is given, -filesets must also be given.
 proc sc_get_filesets { args } {
     sc::parse_args opts {
         -library  {default {}}
         -filesets {default {}}
     } $args
-    set library [dict get $opts library]
+    set libraries [dict get $opts library]
     set filesets [dict get $opts filesets]
 
-    if { [llength $library] == 0 } {
-        set library [sc_cfg_get option design]
+    if { [llength $libraries] == 0 } {
+        set libraries [sc_cfg_get option design]
         if { [llength $filesets] == 0 } {
             set filesets [sc_cfg_get option fileset]
         }
+    } elseif { [llength $filesets] == 0 } {
+        error "sc_get_filesets: -filesets must be given when -library is given"
     }
 
     set aliases [sc_get_fileset_aliases]
     set visited [dict create]
     set filelist []
-    sc_get_filesets_recurse $library $filesets $aliases visited filelist
+    foreach library $libraries {
+        sc_get_filesets_recurse $library $filesets $aliases visited filelist
+    }
     return $filelist
 }

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -616,6 +616,92 @@ def test_get_filesets_with_deps():
     ]
 
 
+def test_get_filesets_explicit_filesets():
+    # An explicit fileset list overrides option,fileset while still defaulting
+    # to the main design.
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    with design.active_fileset("sdc"):
+        design.set_topmodule("top")
+
+    proj = Project(design)
+    assert proj.add_fileset("rtl")
+    assert proj.get_filesets(filesets=["sdc"]) == [
+        (design, "sdc"),
+    ]
+
+
+def test_get_filesets_explicit_multiple_filesets():
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+    with design.active_fileset("sdc"):
+        design.set_topmodule("top")
+
+    proj = Project(design)
+    assert proj.get_filesets(filesets=["rtl", "sdc"]) == [
+        (design, "rtl"),
+        (design, "sdc"),
+    ]
+
+
+def test_get_filesets_explicit_design_uses_option_fileset():
+    # Passing the main design explicitly behaves like the default: filesets
+    # fall back to option,fileset.
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+
+    proj = Project(design)
+    assert proj.add_fileset("rtl")
+    assert proj.get_filesets(library=design) == [
+        (design, "rtl"),
+    ]
+
+
+def test_get_filesets_explicit_library_and_filesets():
+    # A non-design library can be used as the traversal root, pulling in its own
+    # dependencies.
+    subdep = Design("subdep")
+    with subdep.active_fileset("rtl"):
+        subdep.set_topmodule("top")
+
+    dep = Design("dep")
+    with dep.active_fileset("rtl"):
+        dep.set_topmodule("top")
+        dep.add_depfileset(subdep, "rtl")
+
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+        design.add_depfileset(dep, "rtl")
+
+    proj = Project(design)
+    assert proj.add_fileset("rtl")
+    assert proj.get_filesets(library=dep, filesets=["rtl"]) == [
+        (subdep, "rtl"),
+        (dep, "rtl"),
+    ]
+
+
+def test_get_filesets_library_without_filesets_raises():
+    dep = Design("dep")
+    with dep.active_fileset("rtl"):
+        dep.set_topmodule("top")
+
+    design = Design("test")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+        design.add_depfileset(dep, "rtl")
+
+    proj = Project(design)
+    assert proj.add_fileset("rtl")
+    with pytest.raises(ValueError,
+                       match=r"^Filesets must be specified if library is provided$"):
+        proj.get_filesets(library=dep)
+
+
 def test_add_alias_invalid_src_type():
     proj = Project()
     with pytest.raises(TypeError, match=r"^source dep is not a valid type$"):

--- a/tests/tools/_common/test_tcl_schema_access.py
+++ b/tests/tools/_common/test_tcl_schema_access.py
@@ -236,6 +236,33 @@ def test_get_filesets_multiple_top_filesets(cfg):
     ]
 
 
+def test_get_filesets_multiple_libraries(cfg):
+    # -library may name several libraries; all are traversed with the same
+    # filesets and share one visited set, so a common dependency dedups.
+    cfg.eval(
+        """
+        dict set sc_cfg library lib_a fileset rtl depfileset {{lib_shared rtl}}
+        dict set sc_cfg library lib_b fileset rtl depfileset {{lib_shared rtl}}
+        dict set sc_cfg library lib_shared fileset rtl topmodule s
+        """
+    )
+
+    assert _pairs(cfg, "sc_get_filesets -library {lib_a lib_b} -filesets rtl") == [
+        ("lib_shared", "rtl"),
+        ("lib_a", "rtl"),
+        ("lib_b", "rtl"),
+    ]
+
+
+def test_get_filesets_requires_filesets_when_library_given(cfg):
+    cfg.eval("dict set sc_cfg library lib_a fileset rtl topmodule top")
+
+    with pytest.raises(
+            tkinter.TclError,
+            match=r"-filesets must be given when -library is given"):
+        cfg.eval("sc_get_filesets -library lib_a")
+
+
 def test_get_filesets_alias_swaps_library_and_fileset(cfg):
     # option,alias replaces the (lib_b, rtl) dependency edge with (lib_c, alt).
     cfg.eval(

--- a/tests/tools/_common/test_tcl_schema_access.py
+++ b/tests/tools/_common/test_tcl_schema_access.py
@@ -9,8 +9,12 @@ tkinter = pytest.importorskip("tkinter")
 
 @pytest.fixture
 def cfg(tcl_interp):
-    '''Interpreter with sc_schema_access.tcl sourced and an empty sc_cfg.'''
-    interp = tcl_interp("sc_schema_access.tcl")
+    '''Interpreter with sc_schema_access.tcl sourced and an empty sc_cfg.
+
+    sc_proc_args.tcl is sourced first since sc_get_filesets parses its keyword
+    arguments through sc::parse_args.
+    '''
+    interp = tcl_interp("sc_proc_args.tcl", "sc_schema_access.tcl")
     interp.eval("set sc_cfg [dict create]")
     return interp
 
@@ -127,3 +131,170 @@ def test_cfg_get_fileset_missing_is_skipped(cfg):
             cfg.eval("sc_cfg_get_fileset {lib_a lib_missing} rtl verilog"))
     ]
     assert files == ["only.v"]
+
+
+def _pairs(cfg, tcl):
+    '''Evaluate ``tcl`` and return its {library fileset} pairs as tuples.'''
+    return [
+        tuple(str(p) for p in cfg.tk.splitlist(pair))
+        for pair in cfg.tk.splitlist(cfg.eval(tcl))
+    ]
+
+
+def test_get_filesets_no_dependencies(cfg):
+    cfg.eval("dict set sc_cfg library lib_a fileset rtl topmodule top")
+
+    assert _pairs(cfg, "sc_get_filesets -library lib_a -filesets rtl") == [("lib_a", "rtl")]
+
+
+def test_get_filesets_orders_dependencies_first(cfg):
+    # lib_a/rtl depends on lib_b/rtl which depends on lib_c/rtl.
+    cfg.eval(
+        """
+        dict set sc_cfg library lib_a fileset rtl depfileset {{lib_b rtl}}
+        dict set sc_cfg library lib_b fileset rtl depfileset {{lib_c rtl}}
+        dict set sc_cfg library lib_c fileset rtl topmodule c
+        """
+    )
+
+    # Post-order: deepest dependency first, requesting fileset last.
+    assert _pairs(cfg, "sc_get_filesets -library lib_a -filesets rtl") == [
+        ("lib_c", "rtl"),
+        ("lib_b", "rtl"),
+        ("lib_a", "rtl"),
+    ]
+
+
+def test_get_filesets_dedups_diamond(cfg):
+    # lib_a depends on both lib_b and lib_c, which both depend on lib_d.
+    cfg.eval(
+        """
+        dict set sc_cfg library lib_a fileset rtl depfileset {{lib_b rtl} {lib_c rtl}}
+        dict set sc_cfg library lib_b fileset rtl depfileset {{lib_d rtl}}
+        dict set sc_cfg library lib_c fileset rtl depfileset {{lib_d rtl}}
+        dict set sc_cfg library lib_d fileset rtl topmodule d
+        """
+    )
+
+    pairs = _pairs(cfg, "sc_get_filesets -library lib_a -filesets rtl")
+    # lib_d appears exactly once, before both of its dependents.
+    assert pairs == [
+        ("lib_d", "rtl"),
+        ("lib_b", "rtl"),
+        ("lib_c", "rtl"),
+        ("lib_a", "rtl"),
+    ]
+
+
+def test_get_filesets_crosses_filesets(cfg):
+    # A dependency may pull in a differently-named fileset.
+    cfg.eval(
+        """
+        dict set sc_cfg library lib_a fileset rtl depfileset {{lib_b models}}
+        dict set sc_cfg library lib_b fileset models topmodule b
+        """
+    )
+
+    assert _pairs(cfg, "sc_get_filesets -library lib_a -filesets rtl") == [
+        ("lib_b", "models"),
+        ("lib_a", "rtl"),
+    ]
+
+
+def test_get_filesets_defaults_to_project_selection(cfg):
+    # With no arguments the design and selected filesets are pulled from option.
+    cfg.eval(
+        """
+        dict set sc_cfg option design lib_a
+        dict set sc_cfg option fileset rtl
+        dict set sc_cfg library lib_a fileset rtl depfileset {{lib_b rtl}}
+        dict set sc_cfg library lib_b fileset rtl topmodule b
+        """
+    )
+
+    assert _pairs(cfg, "sc_get_filesets") == [
+        ("lib_b", "rtl"),
+        ("lib_a", "rtl"),
+    ]
+
+
+def test_get_filesets_multiple_top_filesets(cfg):
+    # filesets is a list: each requested fileset is traversed in order and its
+    # dependencies pulled in ahead of it.
+    cfg.eval(
+        """
+        dict set sc_cfg library lib_a fileset rtl depfileset {{lib_b rtl}}
+        dict set sc_cfg library lib_a fileset sdc topmodule top
+        dict set sc_cfg library lib_b fileset rtl topmodule b
+        """
+    )
+
+    assert _pairs(cfg, "sc_get_filesets -library lib_a -filesets {rtl sdc}") == [
+        ("lib_b", "rtl"),
+        ("lib_a", "rtl"),
+        ("lib_a", "sdc"),
+    ]
+
+
+def test_get_filesets_alias_swaps_library_and_fileset(cfg):
+    # option,alias replaces the (lib_b, rtl) dependency edge with (lib_c, alt).
+    cfg.eval(
+        """
+        dict set sc_cfg option alias {{lib_b rtl lib_c alt}}
+        dict set sc_cfg library lib_a fileset rtl depfileset {{lib_b rtl}}
+        dict set sc_cfg library lib_b fileset rtl topmodule b
+        dict set sc_cfg library lib_c fileset alt topmodule c
+        """
+    )
+
+    assert _pairs(cfg, "sc_get_filesets -library lib_a -filesets rtl") == [
+        ("lib_c", "alt"),
+        ("lib_a", "rtl"),
+    ]
+
+
+def test_get_filesets_alias_empty_library_drops_dependency(cfg):
+    # An empty destination library removes the dependency entirely.
+    cfg.eval(
+        """
+        dict set sc_cfg option alias {{lib_b rtl {} {}}}
+        dict set sc_cfg library lib_a fileset rtl depfileset {{lib_b rtl}}
+        dict set sc_cfg library lib_b fileset rtl topmodule b
+        """
+    )
+
+    assert _pairs(cfg, "sc_get_filesets -library lib_a -filesets rtl") == [("lib_a", "rtl")]
+
+
+def test_get_filesets_alias_empty_fileset_preserves_original(cfg):
+    # An empty destination fileset keeps the original fileset name, swapping
+    # only the library.
+    cfg.eval(
+        """
+        dict set sc_cfg option alias {{lib_b rtl lib_c {}}}
+        dict set sc_cfg library lib_a fileset rtl depfileset {{lib_b rtl}}
+        dict set sc_cfg library lib_b fileset rtl topmodule b
+        dict set sc_cfg library lib_c fileset rtl topmodule c
+        """
+    )
+
+    assert _pairs(cfg, "sc_get_filesets -library lib_a -filesets rtl") == [
+        ("lib_c", "rtl"),
+        ("lib_a", "rtl"),
+    ]
+
+
+def test_get_filesets_alias_noop_when_source_equals_destination(cfg):
+    # A self-referential alias is ignored.
+    cfg.eval(
+        """
+        dict set sc_cfg option alias {{lib_b rtl lib_b rtl}}
+        dict set sc_cfg library lib_a fileset rtl depfileset {{lib_b rtl}}
+        dict set sc_cfg library lib_b fileset rtl topmodule b
+        """
+    )
+
+    assert _pairs(cfg, "sc_get_filesets -library lib_a -filesets rtl") == [
+        ("lib_b", "rtl"),
+        ("lib_a", "rtl"),
+    ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced fileset resolution to honor explicitly requested filesets and correctly traverse dependencies across selected libraries.
  * Dependency closure is returned in dependency-first (post-order) order with duplicate elimination.
  * Added/extended alias handling for swapping libraries/filesets, dropping edges when destinations are empty, and preserving names when destination filesets are empty.
  * Added validation when selecting a non-default library without specifying filesets.
* **Bug Fixes**
  * Fixed fileset selection behavior to avoid incorrectly falling back to the default project fileset when explicit filesets are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->