### PR TITLE
dedup arguments to frontend tools

### DIFF
--- a/siliconcompiler/tools/_common/__init__.py
+++ b/siliconcompiler/tools/_common/__init__.py
@@ -11,14 +11,7 @@ def distinct(values: List[str]) -> List[str]:
     Passing duplicates to a tool is at best wasteful and at worst an error, so
     the collected lists are run through this helper before being emitted.
     """
-    seen = set()
-    result = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        result.append(value)
-    return result
+    return list(dict.fromkeys(values))
 
 
 class PlusArgs(Task):

--- a/siliconcompiler/tools/_common/__init__.py
+++ b/siliconcompiler/tools/_common/__init__.py
@@ -2,6 +2,25 @@ from typing import List, Tuple, Optional, Union
 from siliconcompiler import Task
 
 
+def distinct(values: List[str]) -> List[str]:
+    """Return ``values`` with duplicates removed, preserving first-seen order.
+
+    Frontend command lines are assembled by iterating over every selected
+    fileset, so the same include directory, define, or source file can be
+    contributed more than once (e.g. by a library shared between filesets).
+    Passing duplicates to a tool is at best wasteful and at worst an error, so
+    the collected lists are run through this helper before being emitted.
+    """
+    seen = set()
+    result = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
 class PlusArgs(Task):
     '''Mixin task for tools that support Verilog-style plusargs.
 

--- a/siliconcompiler/tools/bambu/convert.py
+++ b/siliconcompiler/tools/bambu/convert.py
@@ -10,6 +10,7 @@ from siliconcompiler.utils import sc_open
 
 from siliconcompiler import Task
 from siliconcompiler.asic import ASICTask
+from siliconcompiler.tools._common import distinct
 
 
 class ConvertTask(ASICTask, Task):
@@ -89,6 +90,8 @@ class ConvertTask(ASICTask, Task):
         for lib, fileset in filesets:
             idirs.extend(lib.get_idir(fileset))
             defines.extend(lib.get("fileset", fileset, "define"))
+        idirs = distinct(idirs)
+        defines = distinct(defines)
 
         for idir in idirs:
             options.append(f"-I{idir}")
@@ -96,13 +99,14 @@ class ConvertTask(ASICTask, Task):
         for define in defines:
             options.append(f"-D{define}")
 
+        sources = []
         for lib, fileset in filesets:
             if lib.get_file(fileset=fileset, filetype="c"):
-                for value in lib.get_file(fileset=fileset, filetype="c"):
-                    options.append(value)
+                sources.extend(lib.get_file(fileset=fileset, filetype="c"))
             elif lib.get_file(fileset=fileset, filetype="llvm"):
-                for value in lib.get_file(fileset=fileset, filetype="llvm"):
-                    options.append(value)
+                sources.extend(lib.get_file(fileset=fileset, filetype="llvm"))
+        for value in distinct(sources):
+            options.append(value)
 
         options.append('--soft-float')
         options.append('--memory-allocation-policy=NO_BRAM')

--- a/siliconcompiler/tools/bluespec/convert.py
+++ b/siliconcompiler/tools/bluespec/convert.py
@@ -6,6 +6,7 @@ import os.path
 from siliconcompiler import sc_open
 
 from siliconcompiler import Task
+from siliconcompiler.tools._common import distinct
 
 
 class ConvertTask(Task):
@@ -80,6 +81,8 @@ class ConvertTask(Task):
         for lib, fileset in filesets:
             idirs.extend(lib.get_idir(fileset))
             defines.extend(lib.get("fileset", fileset, "define"))
+        idirs = distinct(idirs)
+        defines = distinct(defines)
 
         bsc_path = ':'.join(idirs + ['%/Libraries'])
         options.extend(['-p', bsc_path])
@@ -91,9 +94,8 @@ class ConvertTask(Task):
 
         sources = []
         for lib, fileset in filesets:
-            if lib.get_file(fileset=fileset, filetype="bsv"):
-                for value in lib.get_file(fileset=fileset, filetype="bsv"):
-                    sources.append(value)
+            sources.extend(lib.get_file(fileset=fileset, filetype="bsv"))
+        sources = distinct(sources)
         if len(sources) != 1:
             raise ValueError('Bluespec only supports one source file!')
         options.extend(sources)

--- a/siliconcompiler/tools/ghdl/convert.py
+++ b/siliconcompiler/tools/ghdl/convert.py
@@ -1,5 +1,6 @@
 from typing import Optional
 from siliconcompiler import Task
+from siliconcompiler.tools._common import distinct
 
 
 class ConvertTask(Task):
@@ -110,15 +111,18 @@ class ConvertTask(Task):
         defines = []
         for lib, fileset in filesets:
             defines.extend(lib.get("fileset", fileset, "define"))
+        defines = distinct(defines)
 
         # Add defines
         for define in defines:
             options.append(f'-g{define}')
 
         # Add sources
+        sources = []
         for lib, fileset in filesets:
-            for value in lib.get_file(fileset=fileset, filetype="vhdl"):
-                options.append(value)
+            sources.extend(lib.get_file(fileset=fileset, filetype="vhdl"))
+        for value in distinct(sources):
+            options.append(value)
 
         # Set top module
         options.append('-e')

--- a/siliconcompiler/tools/icarus/compile.py
+++ b/siliconcompiler/tools/icarus/compile.py
@@ -1,5 +1,6 @@
 from typing import Optional, Union
 from siliconcompiler import Task
+from siliconcompiler.tools._common import distinct
 
 
 class CompileTask(Task):
@@ -169,6 +170,8 @@ endmodule
         for lib, fileset in filesets:
             idirs.extend(lib.get_idir(fileset))
             defines.extend(lib.get("fileset", fileset, "define"))
+        idirs = distinct(idirs)
+        defines = distinct(defines)
         fileset = self.project.get("option", "fileset")[0]
 
         design = self.project.design
@@ -205,19 +208,21 @@ endmodule
         if self.get("var", "timescale"):
             options.extend(['-f', 'sc_timescale.f'])
 
+        cmdfiles = []
         for lib, fileset in filesets:
-            for value in lib.get_file(fileset=fileset, filetype="commandfile"):
-                options.extend(['-f', value])
+            cmdfiles.extend(lib.get_file(fileset=fileset, filetype="commandfile"))
+        for value in distinct(cmdfiles):
+            options.extend(['-f', value])
 
         #######################
         # Sources
         #######################
-        for lib, fileset in filesets:
-            for value in lib.get_file(fileset=fileset, filetype="systemverilog"):
-                options.append(value)
-        for lib, fileset in filesets:
-            for value in lib.get_file(fileset=fileset, filetype="verilog"):
-                options.append(value)
+        sources = []
+        for filetype in ("systemverilog", "verilog"):
+            for lib, fileset in filesets:
+                sources.extend(lib.get_file(fileset=fileset, filetype=filetype))
+        for value in distinct(sources):
+            options.append(value)
 
         # Add trace dump module if tracing is enabled
         if self.get("var", "trace"):

--- a/siliconcompiler/tools/slang/__init__.py
+++ b/siliconcompiler/tools/slang/__init__.py
@@ -19,6 +19,7 @@ except ModuleNotFoundError:
     pyslang = None
 
 from siliconcompiler import Task
+from siliconcompiler.tools._common import distinct
 
 
 class SlangTask(Task):
@@ -92,6 +93,9 @@ class SlangTask(Task):
             idirs.extend(lib.get_idir(fileset))
             defines.extend(lib.get("fileset", fileset, "define"))
             undefines.extend(lib.get("fileset", fileset, "undefine"))
+        idirs = distinct(idirs)
+        defines = distinct(defines)
+        undefines = distinct(undefines)
 
         params = []
         fileset = self.project.get("option", "fileset")[0]
@@ -122,20 +126,20 @@ class SlangTask(Task):
         #######################
         cmdfiles = []
         for lib, fileset in filesets:
-            for value in lib.get_file(fileset=fileset, filetype="commandfile"):
-                cmdfiles.append(value)
+            cmdfiles.extend(lib.get_file(fileset=fileset, filetype="commandfile"))
+        cmdfiles = distinct(cmdfiles)
         if cmdfiles:
             options.extend(['-F', f'{",".join(cmdfiles)}'])
 
         #######################
         # Sources
         #######################
-        for lib, fileset in filesets:
-            for value in lib.get_file(fileset=fileset, filetype="systemverilog"):
-                options.append(value)
-        for lib, fileset in filesets:
-            for value in lib.get_file(fileset=fileset, filetype="verilog"):
-                options.append(value)
+        sources = []
+        for filetype in ("systemverilog", "verilog"):
+            for lib, fileset in filesets:
+                sources.extend(lib.get_file(fileset=fileset, filetype=filetype))
+        for value in distinct(sources):
+            options.append(value)
 
         #######################
         # Top Module

--- a/siliconcompiler/tools/surelog/parse.py
+++ b/siliconcompiler/tools/surelog/parse.py
@@ -9,6 +9,7 @@ from siliconcompiler import sc_open
 from siliconcompiler import utils
 
 from siliconcompiler import Task
+from siliconcompiler.tools._common import distinct
 
 
 class ElaborateTask(Task):
@@ -179,6 +180,8 @@ class ElaborateTask(Task):
         for lib, fileset in filesets:
             idirs.extend(lib.get_idir(fileset))
             defines.extend(lib.get("fileset", fileset, "define"))
+        idirs = distinct(idirs)
+        defines = distinct(defines)
 
         params = []
         fileset = self.project.get("option", "fileset")[0]
@@ -203,19 +206,21 @@ class ElaborateTask(Task):
         #######################
         # Command files
         #######################
+        cmdfiles = []
         for lib, fileset in filesets:
-            for value in lib.get_file(fileset=fileset, filetype="commandfile"):
-                options.extend(['-f', value])
+            cmdfiles.extend(lib.get_file(fileset=fileset, filetype="commandfile"))
+        for value in distinct(cmdfiles):
+            options.extend(['-f', value])
 
         #######################
         # Sources
         #######################
-        for lib, fileset in filesets:
-            for value in lib.get_file(fileset=fileset, filetype="systemverilog"):
-                options.append(value)
-        for lib, fileset in filesets:
-            for value in lib.get_file(fileset=fileset, filetype="verilog"):
-                options.append(value)
+        sources = []
+        for filetype in ("systemverilog", "verilog"):
+            for lib, fileset in filesets:
+                sources.extend(lib.get_file(fileset=fileset, filetype=filetype))
+        for value in distinct(sources):
+            options.append(value)
 
         #######################
         # Top Module

--- a/siliconcompiler/tools/verilator/__init__.py
+++ b/siliconcompiler/tools/verilator/__init__.py
@@ -16,6 +16,7 @@ Installation: https://verilator.org/guide/latest/install.html
 import os.path
 
 from siliconcompiler import Task
+from siliconcompiler.tools._common import distinct
 
 
 class VerilatorTask(Task):
@@ -98,21 +99,19 @@ class VerilatorTask(Task):
         for cmdfile in self.find_files("var", "config"):
             options.append(cmdfile)
 
+        ctrlfiles = []
         for lib, fileset in filesets:
-            for value in lib.get_file(fileset=fileset, filetype="verilatorctrlfile"):
-                options.append(value)
+            ctrlfiles.extend(lib.get_file(fileset=fileset, filetype="verilatorctrlfile"))
+        for value in distinct(ctrlfiles):
+            options.append(value)
 
         idirs = []
         defines = []
-        params = []
         for lib, fileset in filesets:
             idirs.extend(lib.get_idir(fileset))
             defines.extend(lib.get("fileset", fileset, "define"))
-        fileset = self.project.get("option", "fileset")[0]
-
-        design = self.project.design
-        for param in design.getkeys("fileset", fileset, "param"):
-            params.append((param, design.get("fileset", fileset, "param", param)))
+        idirs = distinct(idirs)
+        defines = distinct(defines)
 
         fileset = self.project.get("option", "fileset")[0]
         design = self.project.design
@@ -137,15 +136,17 @@ class VerilatorTask(Task):
             #######################
             # Sources
             #######################
-            for lib, fileset in filesets:
-                for value in lib.get_file(fileset=fileset, filetype="systemverilog"):
-                    options.append(value)
-            for lib, fileset in filesets:
-                for value in lib.get_file(fileset=fileset, filetype="verilog"):
-                    options.append(value)
+            sources = []
+            for filetype in ("systemverilog", "verilog"):
+                for lib, fileset in filesets:
+                    sources.extend(lib.get_file(fileset=fileset, filetype=filetype))
+            for value in distinct(sources):
+                options.append(value)
 
+        cmdfiles = []
         for lib, fileset in filesets:
-            for value in lib.get_file(fileset=fileset, filetype="commandfile"):
-                options.extend(['-f', value])
+            cmdfiles.extend(lib.get_file(fileset=fileset, filetype="commandfile"))
+        for value in distinct(cmdfiles):
+            options.extend(['-f', value])
 
         return options

--- a/tests/tools/_common/test_distinct.py
+++ b/tests/tools/_common/test_distinct.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Silicon Compiler Authors. All Rights Reserved.
+from siliconcompiler.tools._common import distinct
+
+
+def test_distinct_empty():
+    assert distinct([]) == []
+
+
+def test_distinct_no_duplicates():
+    # Order preserved, nothing removed.
+    assert distinct(["a", "b", "c"]) == ["a", "b", "c"]
+
+
+def test_distinct_removes_duplicates():
+    assert distinct(["a", "b", "a", "c", "b"]) == ["a", "b", "c"]
+
+
+def test_distinct_preserves_first_seen_order():
+    # 'c' first appears before 'a', so it must come first in the result.
+    assert distinct(["c", "a", "c", "a", "b"]) == ["c", "a", "b"]
+
+
+def test_distinct_all_duplicates():
+    assert distinct(["x", "x", "x"]) == ["x"]
+
+
+def test_distinct_does_not_mutate_input():
+    values = ["a", "a", "b"]
+    result = distinct(values)
+    assert values == ["a", "a", "b"]
+    assert result == ["a", "b"]
+    assert result is not values
+
+
+def test_distinct_returns_new_list_when_unique():
+    values = ["a", "b"]
+    result = distinct(values)
+    assert result == values
+    assert result is not values
+
+
+def test_distinct_paths():
+    # Typical frontend use case: the same include dir contributed by two filesets.
+    idirs = ["/proj/rtl/include", "/proj/common/include", "/proj/rtl/include"]
+    assert distinct(idirs) == ["/proj/rtl/include", "/proj/common/include"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated repeated compilation inputs and flags across supported tool integrations, including source files, include paths, macro defines/undefines, and command files.
  * Kept the first-seen ordering of inputs while removing duplicates to produce cleaner, more consistent builds.
* **Tests**
  * Added unit test coverage for the new deduplication helper, including empty inputs, ordering guarantees, and non-mutation of inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->