### PR TITLE
Fix deprecated OpenROAD RCX commands

### DIFF
--- a/siliconcompiler/tools/openroad/scripts/apr/sc_write_data.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_write_data.tcl
@@ -69,8 +69,12 @@ if { [sc_cfg_tool_task_get var write_spef] } {
     foreach pexcorner [sc_cfg_tool_task_get var pex_corners] {
         set pex_model [lindex [sc_cfg_get_fileset $sc_pdk $pexfileset openrcx] 0]
         puts "Writing SPEF for $pexcorner"
-        set_extraction_rules_file $pex_model
-        extract_parasitics
+        if { [sc_check_version 26 3 23] } {
+            set_extraction_rules_file $pex_model
+            extract_parasitics
+        } else {
+            extract_parasitics -ext_model_file $pex_model
+        }
         write_spef "outputs/${sc_topmodule}.${pexcorner}.spef"
     }
 

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_write_data.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_write_data.tcl
@@ -69,7 +69,8 @@ if { [sc_cfg_tool_task_get var write_spef] } {
     foreach pexcorner [sc_cfg_tool_task_get var pex_corners] {
         set pex_model [lindex [sc_cfg_get_fileset $sc_pdk $pexfileset openrcx] 0]
         puts "Writing SPEF for $pexcorner"
-        extract_parasitics -ext_model_file $pex_model
+        set_extraction_rules_file $pex_model
+        extract_parasitics
         write_spef "outputs/${sc_topmodule}.${pexcorner}.spef"
     }
 

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -40,7 +40,7 @@ def test_py_gcd():
     assert project.get('metric', 'warnings', step='route.global', index='0') == 0
 
     assert project.get('metric', 'warnings', step='write.gds', index='0') == 0
-    assert project.get('metric', 'warnings', step='write.views', index='0') == 1
+    assert project.get('metric', 'warnings', step='write.views', index='0') == 0
 
 
 @pytest.mark.eda


### PR DESCRIPTION
Previously RC extraction with OpenROAD would generate a number of warnings about the deprecated `-ext_model_file` arg on the `extract_parasitics` command. This PR updates the tcl scripts to use the `set_extraction_rules_file` command instead. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated per-corner parasitic (PEX) extraction used during SPEF generation to apply extraction rules correctly for newer tool versions, while preserving the prior flow for older versions.
  * Improves consistency of SPEF output across supported extraction corners.

* **Tests**
  * Updated the GCD test to expect the current warning count for the `write.views` step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->