### PR TITLE
honor depfilesets where it makes sense

### DIFF
--- a/siliconcompiler/tools/netgen/lvs.py
+++ b/siliconcompiler/tools/netgen/lvs.py
@@ -73,9 +73,13 @@ class LVSTask(Task):
         pdk = self.project.get_library(self.project.get("asic", "pdk"))
         if pdk.get("pdk", "lvs", "runsetfileset", "netgen", "basic"):
             self.add_required_key(pdk, "pdk", "lvs", "runsetfileset", "netgen", "basic")
-            for fileset in pdk.get("pdk", "lvs", "runsetfileset", "netgen", "basic"):
-                if pdk.has_file(fileset=fileset, filetype="tcl"):
-                    self.add_required_key(pdk, "fileset", fileset, "file", "tcl")
+            # sc_lvs.tcl reads the runset resolving aliases and depfilesets;
+            # mirror that here so the files are hashed (cache) and copied
+            # (remote runs).
+            runsets = pdk.get("pdk", "lvs", "runsetfileset", "netgen", "basic")
+            for fs_lib, fs in self.project.get_filesets(library=pdk, filesets=runsets):
+                if fs_lib.has_file(fileset=fs, filetype="tcl"):
+                    self.add_required_key(fs_lib, "fileset", fs, "file", "tcl")
 
         self.set_logdestination("stderr", "log", suffix="errors")
         self.add_regex("warnings", '^Warning:')

--- a/siliconcompiler/tools/netgen/scripts/sc_lvs.tcl
+++ b/siliconcompiler/tools/netgen/scripts/sc_lvs.tcl
@@ -2,7 +2,13 @@ source ./sc_manifest.tcl
 
 set sc_pdk [sc_cfg_get asic pdk]
 set fileset [sc_cfg_get library $sc_pdk pdk lvs runsetfileset netgen basic]
-set sc_runset [sc_cfg_get_fileset $sc_pdk $fileset tcl]
+set sc_runset []
+if { [llength $fileset] != 0 } {
+    foreach fs [sc_get_filesets -library $sc_pdk -filesets $fileset] {
+        lassign $fs fs_lib fs_name
+        lappend sc_runset {*}[sc_cfg_get_fileset $fs_lib $fs_name tcl]
+    }
+}
 
 if { [sc_cfg_tool_task_exists var exclude] } {
     set sc_exclude [sc_cfg_tool_task_get var exclude]

--- a/siliconcompiler/tools/netgen/scripts/sc_lvs.tcl
+++ b/siliconcompiler/tools/netgen/scripts/sc_lvs.tcl
@@ -22,8 +22,9 @@ if { [file exists "inputs/${sc_topmodule}.vg"] } {
     set schematic_file "inputs/${sc_topmodule}.vg"
 } else {
     set schematic_file []
-    foreach fileset [sc_cfg_get option fileset] {
-        foreach file [sc_cfg_get_fileset $sc_designlib $fileset verilog] {
+    foreach fs [sc_get_filesets] {
+        lassign $fs fs_lib fs_name
+        foreach file [sc_cfg_get_fileset $fs_lib $fs_name verilog] {
             lappend schematic_file $file
         }
     }

--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -1415,8 +1415,14 @@ class APRTask(OpenROADTask):
 
         if self.get("var", "global_connect_fileset"):
             self.add_required_key("var", "global_connect_fileset")
+            # sc_global_connections resolves aliases and depfilesets for each
+            # global connect fileset; mirror that here so the files are hashed
+            # (cache) and copied (remote runs).
             for lib, fileset in self.get("var", "global_connect_fileset"):
-                self.add_required_key("library", lib, "fileset", fileset, "file", "tcl")
+                libobj = self.project.get_library(lib)
+                for fs_lib, fs in self.project.get_filesets(library=libobj, filesets=fileset):
+                    if fs_lib.has_file(fileset=fs, filetype="tcl"):
+                        self.add_required_key(fs_lib, "fileset", fs, "file", "tcl")
 
         libcorners = set()
         for scenario in self.project.constraint.timing.get_scenario().values():
@@ -1508,7 +1514,12 @@ class APRTask(OpenROADTask):
                     mode_obj = self.project.constraint.timing.get_mode(mode)
                     for lib, fileset in mode_obj.get_sdcfileset():
                         libobj = self.project.get_library(lib)
-                        self.add_required_key(libobj, "fileset", fileset, "file", "sdc")
+                        # read_timing_constraints.tcl resolves aliases and
+                        # depfilesets for the mode sdcfileset; mirror that here.
+                        for fs_lib, fs in self.project.get_filesets(library=libobj,
+                                                                    filesets=fileset):
+                            if fs_lib.has_file(fileset=fs, filetype="sdc"):
+                                self.add_required_key(fs_lib, "fileset", fs, "file", "sdc")
 
         load_vg = False
         load_tech = True

--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -1419,8 +1419,7 @@ class APRTask(OpenROADTask):
             # global connect fileset; mirror that here so the files are hashed
             # (cache) and copied (remote runs).
             for lib, fileset in self.get("var", "global_connect_fileset"):
-                libobj = self.project.get_library(lib)
-                for fs_lib, fs in self.project.get_filesets(library=libobj, filesets=fileset):
+                for fs_lib, fs in self.project.get_filesets(library=lib, filesets=[fileset]):
                     if fs_lib.has_file(fileset=fs, filetype="tcl"):
                         self.add_required_key(fs_lib, "fileset", fs, "file", "tcl")
 
@@ -1517,7 +1516,7 @@ class APRTask(OpenROADTask):
                         # read_timing_constraints.tcl resolves aliases and
                         # depfilesets for the mode sdcfileset; mirror that here.
                         for fs_lib, fs in self.project.get_filesets(library=libobj,
-                                                                    filesets=fileset):
+                                                                    filesets=[fileset]):
                             if fs_lib.has_file(fileset=fs, filetype="sdc"):
                                 self.add_required_key(fs_lib, "fileset", fs, "file", "sdc")
 

--- a/siliconcompiler/tools/openroad/init_floorplan.py
+++ b/siliconcompiler/tools/openroad/init_floorplan.py
@@ -207,17 +207,26 @@ class InitFloorplanTask(APRTask,
         if self.get("var", "routingblockage"):
             self.add_required_key("var", "routingblockage")
 
+        # sc_init_floorplan.tcl reads the padring/bumpmap files from the design's
+        # filesets, resolving aliases and depfilesets; mirror that here so the
+        # files are hashed (cache) and copied (remote runs).
         if self.get("var", "padringfileset"):
             self.add_required_key("var", "padringfileset")
 
-            for fileset in self.get("var", "padringfileset"):
-                self.add_required_key(self.project.design, "fileset", fileset, "file", "tcl")
+            for fs_lib, fs in self.project.get_filesets(library=self.project.design,
+                                                        filesets=self.get("var",
+                                                                          "padringfileset")):
+                if fs_lib.has_file(fileset=fs, filetype="tcl"):
+                    self.add_required_key(fs_lib, "fileset", fs, "file", "tcl")
 
         if self.get("var", "bumpmapfileset"):
             self.add_required_key("var", "bumpmapfileset")
 
-            for fileset in self.get("var", "bumpmapfileset"):
-                self.add_required_key(self.project.design, "fileset", fileset, "file", "bmap")
+            for fs_lib, fs in self.project.get_filesets(library=self.project.design,
+                                                        filesets=self.get("var",
+                                                                          "bumpmapfileset")):
+                if fs_lib.has_file(fileset=fs, filetype="bmap"):
+                    self.add_required_key(fs_lib, "fileset", fs, "file", "bmap")
 
         # Mark requires for components, pin, and floorplan placements
         for component in self.project.constraint.component.get_component().values():

--- a/siliconcompiler/tools/openroad/power_grid.py
+++ b/siliconcompiler/tools/openroad/power_grid.py
@@ -98,8 +98,14 @@ class PowerGridTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
 
         if self.get("var", "pdn_fileset"):
             self.add_required_key("var", "pdn_fileset")
+            # sc_power_grid.tcl resolves aliases and depfilesets for each pdn
+            # fileset; mirror that here so the files are hashed (cache) and
+            # copied (remote runs).
             for lib, fileset in self.get("var", "pdn_fileset"):
-                self.add_required_key("library", lib, "fileset", fileset, "file", "tcl")
+                libobj = self.project.get_library(lib)
+                for fs_lib, fs in self.project.get_filesets(library=libobj, filesets=fileset):
+                    if fs_lib.has_file(fileset=fs, filetype="tcl"):
+                        self.add_required_key(fs_lib, "fileset", fs, "file", "tcl")
 
     def __import_pdn_filesets(self):
         for lib in self.project.get("asic", "asiclib"):

--- a/siliconcompiler/tools/openroad/power_grid.py
+++ b/siliconcompiler/tools/openroad/power_grid.py
@@ -102,8 +102,7 @@ class PowerGridTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
             # fileset; mirror that here so the files are hashed (cache) and
             # copied (remote runs).
             for lib, fileset in self.get("var", "pdn_fileset"):
-                libobj = self.project.get_library(lib)
-                for fs_lib, fs in self.project.get_filesets(library=libobj, filesets=fileset):
+                for fs_lib, fs in self.project.get_filesets(library=lib, filesets=[fileset]):
                     if fs_lib.has_file(fileset=fs, filetype="tcl"):
                         self.add_required_key(fs_lib, "fileset", fs, "file", "tcl")
 

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_init_floorplan.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_init_floorplan.tcl
@@ -98,7 +98,11 @@ if { [llength [sc_cfg_tool_task_get var bumpmapfileset]] > 0 } {
 
     set bmaps_read []
     set bumpmapfileset [sc_cfg_tool_task_get var bumpmapfileset]
-    set bmapfiles [sc_cfg_get_fileset $sc_designlib $bumpmapfileset bmap]
+    set bmapfiles []
+    foreach fs [sc_get_filesets -library $sc_designlib -filesets $bumpmapfileset] {
+        lassign $fs fs_lib fs_name
+        lappend bmapfiles {*}[sc_cfg_get_fileset $fs_lib $fs_name bmap]
+    }
     foreach bmap_file $bmapfiles {
         if { [lsearch -exact $bmaps_read $bmap_file] != -1 } {
             continue
@@ -441,7 +445,11 @@ if { [llength [sc_cfg_tool_task_get var padringfileset]] > 0 } {
 
     set padringfiles_read []
     set padringfileset [sc_cfg_tool_task_get var padringfileset]
-    set padringfiles [sc_cfg_get_fileset $sc_designlib $padringfileset tcl]
+    set padringfiles []
+    foreach fs [sc_get_filesets -library $sc_designlib -filesets $padringfileset] {
+        lassign $fs fs_lib fs_name
+        lappend padringfiles {*}[sc_cfg_get_fileset $fs_lib $fs_name tcl]
+    }
     foreach padring_file $padringfiles {
         if { [lsearch -exact $padringfiles_read $padring_file] != -1 } {
             continue

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_power_grid.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_power_grid.tcl
@@ -68,14 +68,17 @@ if { $pdn_pin_keepout > 0 } {
 set pdn_files []
 foreach pdnconfig_set [sc_cfg_tool_task_get var pdn_fileset] {
     lassign $pdnconfig_set lib fileset
-    foreach pdnconfig [sc_cfg_get_fileset $lib $fileset tcl] {
-        if { [lsearch -exact $pdn_files $pdnconfig] != -1 } {
-            continue
-        }
-        puts "Sourcing PDNGEN configuration: ${pdnconfig}"
-        source $pdnconfig
+    foreach fs [sc_get_filesets -library $lib -filesets $fileset] {
+        lassign $fs fs_lib fs_name
+        foreach pdnconfig [sc_cfg_get_fileset $fs_lib $fs_name tcl] {
+            if { [lsearch -exact $pdn_files $pdnconfig] != -1 } {
+                continue
+            }
+            puts "Sourcing PDNGEN configuration: ${pdnconfig}"
+            source $pdnconfig
 
-        lappend pdn_files $pdnconfig
+            lappend pdn_files $pdnconfig
+        }
     }
 }
 tee -quiet -file reports/power_grid_configuration.rpt {pdngen -report_only}

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_write_data.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_write_data.tcl
@@ -35,8 +35,14 @@ if { [sc_cfg_tool_task_get var write_cdl] } {
     set sc_cdl_masters []
     foreach lib $sc_logiclibs {
         set filesets [sc_cfg_get library $lib asic aprfileset]
-        foreach cdl_file [sc_cfg_get_fileset $lib $filesets cdl] {
-            lappend sc_cdl_masters $cdl_file
+        if { [llength $filesets] == 0 } {
+            continue
+        }
+        foreach fs [sc_get_filesets -library $lib -filesets $filesets] {
+            lassign $fs fs_lib fs_name
+            foreach cdl_file [sc_cfg_get_fileset $fs_lib $fs_name cdl] {
+                lappend sc_cdl_masters $cdl_file
+            }
         }
     }
     write_cdl -masters $sc_cdl_masters "outputs/${sc_topmodule}.cdl"

--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -927,14 +927,17 @@ proc sc_global_connections { args } {
     set global_connect_files []
     foreach global_connect_set [sc_cfg_tool_task_get var global_connect_fileset] {
         lassign $global_connect_set lib fileset
-        foreach global_connect [sc_cfg_get_fileset $lib $fileset tcl] {
-            if { [lsearch -exact $global_connect_files $global_connect] != -1 } {
-                continue
-            }
-            puts "Loading global connect configuration: ${global_connect}"
-            source $global_connect
+        foreach fs [sc_get_filesets -library $lib -filesets $fileset] {
+            lassign $fs fs_lib fs_name
+            foreach global_connect [sc_cfg_get_fileset $fs_lib $fs_name tcl] {
+                if { [lsearch -exact $global_connect_files $global_connect] != -1 } {
+                    continue
+                }
+                puts "Loading global connect configuration: ${global_connect}"
+                source $global_connect
 
-            lappend global_connect_files $global_connect
+                lappend global_connect_files $global_connect
+            }
         }
     }
     tee -file reports/global_connections.rpt {report_global_connect}

--- a/siliconcompiler/tools/openroad/scripts/common/read_timing_constraints.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/read_timing_constraints.tcl
@@ -17,7 +17,11 @@ if { [sc_cfg_tool_task_get var load_sdcs] } {
                 lappend sc_modes $mode
             }
         }
-        set base_sdcs [sc_cfg_get_fileset $sc_designlib [sc_cfg_get option fileset] sdc]
+        set base_sdcs []
+        foreach fs [sc_get_filesets] {
+            lassign $fs fs_lib fs_name
+            lappend base_sdcs {*}[sc_cfg_get_fileset $fs_lib $fs_name sdc]
+        }
         set sc_modes [lsort -unique $sc_modes]
         foreach mode $sc_modes {
             puts "Creating mode: $mode"
@@ -35,7 +39,10 @@ if { [sc_cfg_tool_task_get var load_sdcs] } {
                 lappend mode_sdcs {*}$base_sdcs
                 foreach sdcinfo [sc_cfg_get constraint timing mode $mode sdcfileset] {
                     lassign $sdcinfo lib mode_fileset
-                    lappend mode_sdcs {*}[sc_cfg_get_fileset $lib $mode_fileset sdc]
+                    foreach fs [sc_get_filesets -library $lib -filesets $mode_fileset] {
+                        lassign $fs fs_lib fs_name
+                        lappend mode_sdcs {*}[sc_cfg_get_fileset $fs_lib $fs_name sdc]
+                    }
                 }
             }
 
@@ -74,7 +81,11 @@ if { [sc_cfg_tool_task_get var load_sdcs] } {
             puts "Reading SDC: ${sdc}"
             read_sdc $sdc
         } else {
-            set sdcs [sc_cfg_get_fileset $sc_designlib [sc_cfg_get option fileset] sdc]
+            set sdcs []
+            foreach fs [sc_get_filesets] {
+                lassign $fs fs_lib fs_name
+                lappend sdcs {*}[sc_cfg_get_fileset $fs_lib $fs_name sdc]
+            }
             if { [llength $sdcs] > 0 } {
                 foreach sdc $sdcs {
                     puts "Reading SDC: ${sdc}"

--- a/siliconcompiler/tools/openroad/scripts/sc_rdlroute.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_rdlroute.tcl
@@ -54,9 +54,12 @@ if { [file exists "inputs/${sc_topmodule}.vg"] } {
     puts "Reading netlist verilog: inputs/${sc_topmodule}.v"
     read_verilog "inputs/${sc_topmodule}.v"
 } else {
-    foreach netlist [sc_cfg_get_fileset $sc_designlib [sc_cfg_get option fileset] verilog] {
-        puts "Reading netlist verilog: ${netlist}"
-        read_verilog $netlist
+    foreach fs [sc_get_filesets] {
+        lassign $fs fs_lib fs_name
+        foreach netlist [sc_cfg_get_fileset $fs_lib $fs_name verilog] {
+            puts "Reading netlist verilog: ${netlist}"
+            read_verilog $netlist
+        }
     }
 }
 link_design $sc_topmodule

--- a/siliconcompiler/tools/openroad/write_data.py
+++ b/siliconcompiler/tools/openroad/write_data.py
@@ -174,6 +174,18 @@ class WriteViewsTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
         self.add_required_key("var", "ord_abstract_lef_bloat_layers")
         self.add_required_key("var", "ord_abstract_lef_bloat_factor")
         self.add_required_key("var", "write_cdl")
+        if self.get("var", "write_cdl"):
+            # sc_write_data.tcl reads the CDL masters from each asiclib's
+            # aprfileset, resolving aliases and depfilesets; mirror that here so
+            # the files are hashed (cache) and copied (remote runs).
+            for lib in self.project.get("asic", "asiclib"):
+                libobj = self.project.get_library(lib)
+                filesets = libobj.get("asic", "aprfileset")
+                if not filesets:
+                    continue
+                for fs_lib, fs in self.project.get_filesets(library=libobj, filesets=filesets):
+                    if fs_lib.has_file(fileset=fs, filetype="cdl"):
+                        self.add_required_key(fs_lib, "fileset", fs, "file", "cdl")
         self.add_required_key("var", "write_spef")
         self.add_required_key("var", "write_liberty")
         self.add_required_key("var", "write_sdf")

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -8,7 +8,6 @@ source ./sc_manifest.tcl
 # Schema Adapter
 ###############################
 
-
 # APR Parameters
 set sc_timing_mode [sc_cfg_tool_task_get var timing_mode]
 

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -8,8 +8,6 @@ source ./sc_manifest.tcl
 # Schema Adapter
 ###############################
 
-set sc_topmodulelib [sc_cfg_get option design]
-set sc_filesets [sc_cfg_get option fileset]
 
 # APR Parameters
 set sc_timing_mode [sc_cfg_tool_task_get var timing_mode]
@@ -90,8 +88,9 @@ if { [file exists "inputs/${sc_topmodule}.vg"] } {
     puts "Reading netlist verilog: inputs/${sc_topmodule}.vg"
     read_verilog "inputs/${sc_topmodule}.vg"
 } else {
-    foreach fileset $sc_filesets {
-        foreach verilog [sc_cfg_get_fileset $sc_topmodulelib $fileset verilog] {
+    foreach fs [sc_get_filesets] {
+        lassign $fs fs_lib fs_name
+        foreach verilog [sc_cfg_get_fileset $fs_lib $fs_name verilog] {
             puts "Reading netlist verilog: ${verilog}"
             read_verilog $verilog
         }
@@ -107,7 +106,12 @@ if { [file exists "inputs/${sc_topmodule}.sdc"] } {
     read_sdc "inputs/${sc_topmodule}.sdc"
 } else {
     set sdc_files []
-    foreach sdc [sc_cfg_get_fileset $sc_topmodulelib [sc_cfg_get option fileset] sdc] {
+    set base_sdcs []
+    foreach fs [sc_get_filesets] {
+        lassign $fs fs_lib fs_name
+        lappend base_sdcs {*}[sc_cfg_get_fileset $fs_lib $fs_name sdc]
+    }
+    foreach sdc $base_sdcs {
         # read step constraint if exists
         puts "Reading SDC: ${sdc}"
         read_sdc $sdc
@@ -115,13 +119,18 @@ if { [file exists "inputs/${sc_topmodule}.sdc"] } {
     }
 
     if { $sc_timing_mode != {} } {
-        set sdcfileset [sc_cfg_get constraint timing mode $sc_timing_mode sdcfileset]
-        foreach sdc [sc_cfg_get_fileset $sc_topmodulelib $sdcfileset sdc] {
-            if { [lsearch -exact $sdc_files $sdc] == -1 } {
-                # read step constraint if exists
-                puts "Reading mode (${sc_timing_mode}) SDC: ${sdc}"
-                lappend sdc_files $sdc
-                read_sdc $sdc
+        foreach sdcinfo [sc_cfg_get constraint timing mode $sc_timing_mode sdcfileset] {
+            lassign $sdcinfo mode_lib mode_fileset
+            foreach fs [sc_get_filesets -library $mode_lib -filesets $mode_fileset] {
+                lassign $fs fs_lib fs_name
+                foreach sdc [sc_cfg_get_fileset $fs_lib $fs_name sdc] {
+                    if { [lsearch -exact $sdc_files $sdc] == -1 } {
+                        # read step constraint if exists
+                        puts "Reading mode (${sc_timing_mode}) SDC: ${sdc}"
+                        lappend sdc_files $sdc
+                        read_sdc $sdc
+                    }
+                }
             }
         }
     }

--- a/siliconcompiler/tools/opensta/timing.py
+++ b/siliconcompiler/tools/opensta/timing.py
@@ -105,6 +105,12 @@ class TimingTaskBase(OpenSTATask):
 
         if f"{self.design_topmodule}.vg" in self.get_files_from_input_nodes():
             self.add_input_file(ext="vg")
+        else:
+            # sc_timing.tcl reads the netlist from the design filesets when no vg
+            # input is present; declare them required so they are hashed (cache)
+            # and copied (remote runs).
+            for obj, key in self.get_fileset_file_keys("verilog"):
+                self.add_required_key(obj, *key)
 
         if self.get("var", "timing_mode"):
             self.add_required_key("var", "timing_mode")
@@ -293,6 +299,19 @@ class TimingTask(TimingTaskBase):
         else:
             for obj, key in self.get_fileset_file_keys("sdc"):
                 self.add_required_key(obj, *key)
+
+            # sc_timing.tcl also reads the timing mode's sdcfileset, resolving
+            # aliases and depfilesets; mirror that here so the files are hashed
+            # (cache) and copied (remote runs).
+            timing_mode = self.get("var", "timing_mode")
+            if timing_mode:
+                mode_obj = self.project.constraint.timing.get_mode(timing_mode)
+                for lib, fileset in mode_obj.get_sdcfileset():
+                    libobj = self.project.get_library(lib)
+                    for fs_lib, fs in self.project.get_filesets(library=libobj,
+                                                                filesets=fileset):
+                        if fs_lib.has_file(fileset=fs, filetype="sdc"):
+                            self.add_required_key(fs_lib, "fileset", fs, "file", "sdc")
 
         # per-corner liberty files are read by sc_timing.tcl; declare them required
         # so they are hashed (cache) and copied (remote runs).

--- a/siliconcompiler/tools/opensta/timing.py
+++ b/siliconcompiler/tools/opensta/timing.py
@@ -309,7 +309,7 @@ class TimingTask(TimingTaskBase):
                 for lib, fileset in mode_obj.get_sdcfileset():
                     libobj = self.project.get_library(lib)
                     for fs_lib, fs in self.project.get_filesets(library=libobj,
-                                                                filesets=fileset):
+                                                                filesets=[fileset]):
                         if fs_lib.has_file(fileset=fs, filetype="sdc"):
                             self.add_required_key(fs_lib, "fileset", fs, "file", "sdc")
 

--- a/siliconcompiler/tools/vivado/scripts/sc_syn_fpga.tcl
+++ b/siliconcompiler/tools/vivado/scripts/sc_syn_fpga.tcl
@@ -22,7 +22,7 @@ foreach fs [sc_get_filesets] {
         if { [string equal [get_filesets -quiet constrs_1] ""] } {
             create_fileset -constrset constrs_1
         }
-        add_files -norecurse -fileset [current_fileset] $xdc_file
+        add_files -norecurse -fileset [get_filesets constrs_1] $xdc_file
     }
 }
 

--- a/siliconcompiler/tools/vivado/scripts/sc_syn_fpga.tcl
+++ b/siliconcompiler/tools/vivado/scripts/sc_syn_fpga.tcl
@@ -16,11 +16,14 @@ add_files -norecurse -fileset [get_filesets sources_1] "inputs/${sc_topmodule}.v
 set_property top $sc_topmodule [current_fileset]
 
 # add constraints
-foreach xdc_file [sc_cfg_get_fileset $sc_designlib [sc_cfg_get option fileset] xdc] {
-    if { [string equal [get_filesets -quiet constrs_1] ""] } {
-        create_fileset -constrset constrs_1
+foreach fs [sc_get_filesets] {
+    lassign $fs fs_lib fs_name
+    foreach xdc_file [sc_cfg_get_fileset $fs_lib $fs_name xdc] {
+        if { [string equal [get_filesets -quiet constrs_1] ""] } {
+            create_fileset -constrset constrs_1
+        }
+        add_files -norecurse -fileset [current_fileset] $xdc_file
     }
-    add_files -norecurse -fileset [current_fileset] $xdc_file
 }
 
 # run synthesis

--- a/siliconcompiler/tools/vivado/syn_fpga.py
+++ b/siliconcompiler/tools/vivado/syn_fpga.py
@@ -52,7 +52,6 @@ class SynthesisTask(VivadoTask):
 
         # sc_syn_fpga.tcl applies the design's xdc constraint files; declare them
         # required so they are hashed (cache) and copied (remote runs).
-        design = self.project.design
-        for fileset in self.project.get("option", "fileset"):
-            if design.has_file(fileset=fileset, filetype="xdc"):
-                self.add_required_key(design, "fileset", fileset, "file", "xdc")
+        for lib, fileset in self.project.get_filesets():
+            if lib.has_file(fileset=fileset, filetype="xdc"):
+                self.add_required_key(lib, "fileset", fileset, "file", "xdc")

--- a/siliconcompiler/tools/yosys/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/yosys/scripts/common/procs.tcl
@@ -221,8 +221,13 @@ proc sc_get_blackboxes { } {
     foreach lib [sc_cfg_get asic asiclib] {
         if { [sc_cfg_exists library $lib tool yosys blackbox_fileset] } {
             set lib_fileset [sc_cfg_get library $lib tool yosys blackbox_fileset]
-            foreach lib_f [sc_cfg_get_fileset $lib $lib_fileset verilog] {
-                lappend blackboxes $lib_f
+            if { [llength $lib_fileset] != 0 } {
+                foreach fs [sc_get_filesets -library $lib -filesets $lib_fileset] {
+                    lassign $fs fs_lib fs_name
+                    foreach lib_f [sc_cfg_get_fileset $fs_lib $fs_name verilog] {
+                        lappend blackboxes $lib_f
+                    }
+                }
             }
         }
     }

--- a/siliconcompiler/tools/yosys/syn_asic.py
+++ b/siliconcompiler/tools/yosys/syn_asic.py
@@ -53,9 +53,12 @@ class _ASICTask(ASICTask, YosysTask):
             bb_filesets = lib_obj.get("tool", "yosys", "blackbox_fileset")
             if bb_filesets:
                 self.add_required_key(lib_obj, "tool", "yosys", "blackbox_fileset")
-                for bb_fileset in bb_filesets:
-                    if lib_obj.has_file(fileset=bb_fileset, filetype="verilog"):
-                        self.add_required_key(lib_obj, "fileset", bb_fileset, "file", "verilog")
+                # sc_get_blackboxes resolves aliases and depfilesets, so mirror that
+                # here when declaring the required verilog keys.
+                for bb_lib, bb_fileset in self.project.get_filesets(library=lib_obj,
+                                                                    filesets=bb_filesets):
+                    if bb_lib.has_file(fileset=bb_fileset, filetype="verilog"):
+                        self.add_required_key(bb_lib, "fileset", bb_fileset, "file", "verilog")
 
     def _determine_synthesis_corner(self):
         if self.get("var", "synthesis_corner"):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discovery of configured filesets (including alias/depfileset expansion) for LVS runsets, APR global connections/floorplanning/PDN, and OpenSTA/OpenROAD constraint and netlist inputs.
  * Correctly registers required Tcl, SDC, CDL, Verilog, and XDC/bump-map/pad-ring inputs for more reliable hashing/caching and remote-run file copying.
  * Prevents duplicates and fixes CDL generation and Yosys black-box model discovery when multiple filesets are configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->