### PR TITLE
remove old input/output key references

### DIFF
--- a/siliconcompiler/tools/magic/scripts/sc_extspice.tcl
+++ b/siliconcompiler/tools/magic/scripts/sc_extspice.tcl
@@ -1,12 +1,3 @@
-# set sc_logiclibs [sc_get_asic_libraries logic]
-# set sc_mainlib [lindex $sc_logiclibs 0]
-# set sc_stackup [sc_cfg_get option stackup]
-# set sc_pdk [sc_cfg_get option pdk]
-# set sc_libtype [sc_cfg_get library $sc_mainlib asic libarch]
-# set sc_techlef [sc_cfg_get pdk $sc_pdk aprtech magic $sc_stackup $sc_libtype lef]
-# set sc_liblef [sc_cfg_get library $sc_mainlib output $sc_stackup lef]
-# set sc_macrolibs [sc_get_asic_libraries macro]
-
 foreach sc_lef [sc_cfg_tool_task_get var read_lef] {
     puts "Reading LEF $sc_lef"
     lef read $sc_lef

--- a/siliconcompiler/tools/netgen/scripts/sc_lvs.tcl
+++ b/siliconcompiler/tools/netgen/scripts/sc_lvs.tcl
@@ -32,15 +32,6 @@ puts "Schematic file: ${schematic_file}"
 set layout_fileset [readnet spice $layout_file]
 set schematic_fileset [readnet verilog $schematic_file]
 
-# # Read netlists associated with all non-excluded macro libraries
-# foreach lib $sc_macrolibs {
-#     if { [lsearch -exact $sc_exclude $lib] < 0 } {
-#         set netlist [sc_cfg_get library $lib output netlist verilog]
-#         # Read $netlist into group of files associated with schematic
-#         readnet verilog $netlist $schematic_fileset
-#     }
-# }
-
 lvs "$layout_fileset $sc_topmodule" \
     "$schematic_fileset $sc_topmodule" \
     $sc_runset \

--- a/siliconcompiler/tools/openroad/init_floorplan.py
+++ b/siliconcompiler/tools/openroad/init_floorplan.py
@@ -219,6 +219,14 @@ class InitFloorplanTask(APRTask,
             for fileset in self.get("var", "bumpmapfileset"):
                 self.add_required_key(self.project.design, "fileset", fileset, "file", "bmap")
 
+        # sc_init_floorplan.tcl seeds the floorplan from a design DEF when one is
+        # present in the active filesets; declare it required so it is hashed and copied.
+        floorplan_def = False
+        for lib, fileset in self.project.get_filesets():
+            if lib.has_file(fileset=fileset, filetype="def"):
+                self.add_required_key(lib, "fileset", fileset, "file", "def")
+                floorplan_def = True
+
         # Mark requires for components, pin, and floorplan placements
         for component in self.project.constraint.component.get_component().values():
             if component.get_placement(step=self.step, index=self.index) is not None:
@@ -247,15 +255,18 @@ class InitFloorplanTask(APRTask,
                 if pin.get_shape(step=self.step, index=self.index) != "square":
                     self.add_required_key(pin, "length")
 
-        self.add_required_key(self.mainlib, "asic", "site")
-        if self.project.constraint.area.get_diearea(step=self.step, index=self.index) and \
-                self.project.constraint.area.get_corearea(step=self.step, index=self.index):
-            self.add_required_key(self.project.constraint.area, "diearea")
-            self.add_required_key(self.project.constraint.area, "corearea")
-        else:
-            self.add_required_key(self.project.constraint.area, "aspectratio")
-            self.add_required_key(self.project.constraint.area, "density")
-            self.add_required_key(self.project.constraint.area, "coremargin")
+        # The die/core geometry and site come from the DEF when one is provided, so the
+        # area/site floorplanning keys are only required when initializing from scratch.
+        if not floorplan_def:
+            self.add_required_key(self.mainlib, "asic", "site")
+            if self.project.constraint.area.get_diearea(step=self.step, index=self.index) and \
+                    self.project.constraint.area.get_corearea(step=self.step, index=self.index):
+                self.add_required_key(self.project.constraint.area, "diearea")
+                self.add_required_key(self.project.constraint.area, "corearea")
+            else:
+                self.add_required_key(self.project.constraint.area, "aspectratio")
+                self.add_required_key(self.project.constraint.area, "density")
+                self.add_required_key(self.project.constraint.area, "coremargin")
 
         if self.mainlib.get("tool", "openroad", "tracks"):
             self.add_required_key(self.mainlib, "tool", "openroad", "tracks")

--- a/siliconcompiler/tools/openroad/rdlroute.py
+++ b/siliconcompiler/tools/openroad/rdlroute.py
@@ -54,6 +54,19 @@ class RDLRouteTask(OpenROADTask):
                 if lib.has_file(fileset=fileset, filetype="verilog"):
                     self.add_required_key(lib, "fileset", fileset, "file", "verilog")
 
+        # sc_rdlroute.tcl seeds the floorplan from a design DEF when one is present
+        # in the active filesets; declare it required so it is hashed and copied.
+        floorplan_def = False
+        for lib, fileset in self.project.get_filesets():
+            if lib.has_file(fileset=fileset, filetype="def"):
+                self.add_required_key(lib, "fileset", fileset, "file", "def")
+                floorplan_def = True
+
+        # Without a DEF the die area is initialized from constraint,area,diearea, so it is
+        # only required when not seeding the floorplan from a DEF.
+        if not floorplan_def:
+            self.add_required_key(self.project.constraint.area, "diearea")
+
         self.add_output_file(ext="vg")
         self.add_output_file(ext="def.gz")
         self.add_output_file(ext="odb.gz")

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_init_floorplan.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_init_floorplan.tcl
@@ -36,8 +36,9 @@ foreach blockage [sc_cfg_tool_task_get var placementblockage] {
 # Initialize floorplan
 ###############################
 
-if { [sc_cfg_exists input asic floorplan] } {
-    set def [lindex [sc_cfg_get input asic floorplan] 0]
+set sc_floorplan_def [sc_cfg_get_fileset $sc_designlib [sc_cfg_get option fileset] def]
+if { [llength $sc_floorplan_def] > 0 } {
+    set def [lindex $sc_floorplan_def 0]
     puts "Reading floorplan DEF: ${def}"
     read_def -floorplan_initialize $def
 } else {

--- a/siliconcompiler/tools/openroad/scripts/sc_rdlroute.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_rdlroute.tcl
@@ -80,8 +80,9 @@ utl::push_metrics_stage "sc__step__{}"
 # Initialize floorplan
 ###########################
 
-if { [sc_cfg_exists input asic floorplan] } {
-    set def [lindex [sc_cfg_get input asic floorplan] 0]
+set sc_floorplan_def [sc_cfg_get_fileset $sc_designlib [sc_cfg_get option fileset] def]
+if { [llength $sc_floorplan_def] > 0 } {
+    set def [lindex $sc_floorplan_def 0]
     puts "Reading floorplan DEF: ${def}"
     read_def -floorplan_initialize $def
 } else {

--- a/siliconcompiler/tools/opensta/scripts/sc_check_library.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_check_library.tcl
@@ -42,8 +42,10 @@ foreach lib "$sc_targetlibs $sc_macrolibs" {
     #Liberty
     foreach corner $sc_scenarios {
         foreach libcorner [sc_cfg_get constraint timing scenario $corner libcorner] {
-            if { [sc_cfg_exists library $lib output $libcorner $sc_delaymodel] } {
-                foreach lib_file [sc_cfg_get library $lib output $libcorner $sc_delaymodel] {
+            if { [sc_cfg_exists library $lib asic libcornerfileset $libcorner $sc_delaymodel] } {
+                set lib_filesets \
+                    [sc_cfg_get library $lib asic libcornerfileset $libcorner $sc_delaymodel]
+                foreach lib_file [sc_cfg_get_fileset $lib $lib_filesets liberty] {
                     puts "Reading liberty file for ${corner} ($libcorner): ${lib_file}"
                     read_liberty -corner $corner $lib_file
                 }

--- a/siliconcompiler/tools/opensta/scripts/sc_check_library.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_check_library.tcl
@@ -41,16 +41,16 @@ define_corners {*}$sc_scenarios
 foreach lib "$sc_targetlibs $sc_macrolibs" {
     #Liberty
     foreach corner $sc_scenarios {
+        set lib_filesets []
         foreach libcorner [sc_cfg_get constraint timing scenario $corner libcorner] {
             if { [sc_cfg_exists library $lib asic libcornerfileset $libcorner $sc_delaymodel] } {
-                set lib_filesets \
-                    [sc_cfg_get library $lib asic libcornerfileset $libcorner $sc_delaymodel]
-                foreach lib_file [sc_cfg_get_fileset $lib $lib_filesets liberty] {
-                    puts "Reading liberty file for ${corner} ($libcorner): ${lib_file}"
-                    read_liberty -corner $corner $lib_file
-                }
-                break
+                lappend lib_filesets \
+                    {*}[sc_cfg_get library $lib asic libcornerfileset $libcorner $sc_delaymodel]
             }
+        }
+        foreach lib_file [sc_cfg_get_fileset $lib $lib_filesets liberty] {
+            puts "Reading liberty file for ${corner}: ${lib_file}"
+            read_liberty -corner $corner $lib_file
         }
     }
 }

--- a/siliconcompiler/tools/opensta/scripts/sc_report_libraries.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_report_libraries.tcl
@@ -42,8 +42,10 @@ foreach lib "$sc_targetlibs $sc_macrolibs" {
     #Liberty
     foreach corner $sc_scenarios {
         foreach libcorner [sc_cfg_get constraint timing scenario $corner libcorner] {
-            if { [sc_cfg_exists library $lib output $libcorner $sc_delaymodel] } {
-                foreach lib_file [sc_cfg_get library $lib output $libcorner $sc_delaymodel] {
+            if { [sc_cfg_exists library $lib asic libcornerfileset $libcorner $sc_delaymodel] } {
+                set lib_filesets \
+                    [sc_cfg_get library $lib asic libcornerfileset $libcorner $sc_delaymodel]
+                foreach lib_file [sc_cfg_get_fileset $lib $lib_filesets liberty] {
                     puts "Reading liberty file for ${corner} ($libcorner): ${lib_file}"
                     read_liberty -corner $corner $lib_file
                 }

--- a/siliconcompiler/tools/opensta/scripts/sc_report_libraries.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_report_libraries.tcl
@@ -41,16 +41,16 @@ define_corners {*}$sc_scenarios
 foreach lib "$sc_targetlibs $sc_macrolibs" {
     #Liberty
     foreach corner $sc_scenarios {
+        set lib_filesets []
         foreach libcorner [sc_cfg_get constraint timing scenario $corner libcorner] {
             if { [sc_cfg_exists library $lib asic libcornerfileset $libcorner $sc_delaymodel] } {
-                set lib_filesets \
-                    [sc_cfg_get library $lib asic libcornerfileset $libcorner $sc_delaymodel]
-                foreach lib_file [sc_cfg_get_fileset $lib $lib_filesets liberty] {
-                    puts "Reading liberty file for ${corner} ($libcorner): ${lib_file}"
-                    read_liberty -corner $corner $lib_file
-                }
-                break
+                lappend lib_filesets \
+                    {*}[sc_cfg_get library $lib asic libcornerfileset $libcorner $sc_delaymodel]
             }
+        }
+        foreach lib_file [sc_cfg_get_fileset $lib $lib_filesets liberty] {
+            puts "Reading liberty file for ${corner}: ${lib_file}"
+            read_liberty -corner $corner $lib_file
         }
     }
 }

--- a/siliconcompiler/tools/yosys/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/yosys/scripts/common/procs.tcl
@@ -213,9 +213,8 @@ proc sc_read_design_verilog { } {
 }
 
 proc sc_get_blackboxes { } {
-    # Collect blackbox model files from the asic libraries. Two mechanisms are
-    # supported: libraries that declare a yosys blackbox_fileset, and macro
-    # libraries that export their blackbox verilog via output files.
+    # Collect blackbox model files from the asic libraries that declare a
+    # yosys blackbox_fileset.
     set blackboxes []
 
     foreach lib [sc_cfg_get asic asiclib] {
@@ -223,16 +222,6 @@ proc sc_get_blackboxes { } {
             set lib_fileset [sc_cfg_get library $lib tool yosys blackbox_fileset]
             foreach lib_f [sc_cfg_get_fileset $lib $lib_fileset verilog] {
                 lappend blackboxes $lib_f
-            }
-        }
-    }
-
-    if { [sc_cfg_exists asic macrolib] } {
-        foreach lib [sc_get_asic_libraries macro] {
-            if { [sc_cfg_exists library $lib output blackbox verilog] } {
-                foreach lib_f [sc_cfg_get library $lib output blackbox verilog] {
-                    lappend blackboxes $lib_f
-                }
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for DEF-based floorplans during floorplan initialization and RDL routing (including geometry/site sourced from DEF).
  * Floorplan initialization can now pull DEFs from the design library’s DEF fileset.
  * Improved timing-library discovery for corner-specific Liberty files using configured corner filesets.

* **Bug Fixes**
  * Improved consistency in layout extraction and LVS by simplifying how input configuration and netlists are selected.
  * Simplified blackbox handling to rely on configured blackbox sources only.
  * Preserved constraint-based floorplan initialization when no DEF file is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->