### PR TITLE
register both vcd tools

### DIFF
--- a/siliconcompiler/utils/showtools.py
+++ b/siliconcompiler/utils/showtools.py
@@ -44,9 +44,14 @@ def showtasks():
 
     # Register VCD viewer - prefer surfer if available, otherwise fall back to gtkwave
     if which('surfer') is not None:
+        ShowTask.register_task(GTKWaveShow)
         ShowTask.register_task(SurferShow)
+    elif which('gtkwave') is not None:
+        ShowTask.register_task(SurferShow)
+        ShowTask.register_task(GTKWaveShow)
     else:
         ShowTask.register_task(GTKWaveShow)
+        ShowTask.register_task(SurferShow)
 
     # Register Screenshot tasks - same order as Show tasks
     ScreenshotTask.register_task(KlayoutScreenshot)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VCD viewer tool detection and registration.
  * Both GTKWave and Surfer are now made available when supported, with ordering based on detected installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->