### PR TITLE
add read_vcd to timing task and add example

### DIFF
--- a/examples/heartbeat/heartbeat8.v
+++ b/examples/heartbeat/heartbeat8.v
@@ -1,0 +1,21 @@
+module heartbeat8 (
+    //inputs
+    input      clk,     // clock
+    input      nreset,  //async active low reset
+    //outputs
+    output reg out      //heartbeat
+);
+
+    reg [7:0] counter_reg;
+
+    always @(posedge clk or negedge nreset) begin
+        if (!nreset) begin
+            counter_reg <= 8'b0;
+            out <= 1'b0;
+        end else begin
+            counter_reg <= counter_reg + 1'b1;
+            out <= (counter_reg == 8'hff);
+        end
+    end
+
+endmodule

--- a/examples/heartbeat/make.py
+++ b/examples/heartbeat/make.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 # Copyright 2025 Silicon Compiler Authors. All Rights Reserved.
 
-from siliconcompiler import Design, FPGADevice
+from typing import Optional
+
+from siliconcompiler import Design, FPGADevice, Flowgraph
 from siliconcompiler import Lint, Sim
 from siliconcompiler import ASIC, FPGA
 
@@ -10,10 +12,11 @@ from siliconcompiler.flows.dvflow import DVFlow
 from siliconcompiler.flows.fpgaflow import FPGAXilinxFlow
 from siliconcompiler.flows.highresscreenshotflow import HighResScreenshotFlow
 
-from siliconcompiler.targets import asic_target
+from siliconcompiler.targets import asic_target, skywater130_demo
 from siliconcompiler.tools.verilator.compile import CompileTask
 from siliconcompiler.tools.builtin.importfiles import ImportFilesTask
 from siliconcompiler.tools.klayout.screenshot import ScreenshotTask
+from siliconcompiler.tools.opensta.timing import TimingTask
 
 
 class HeartbeatDesign(Design):
@@ -47,11 +50,21 @@ class HeartbeatDesign(Design):
                 self.add_file("heartbeat.v")
                 self.set_param("N", "8")  # Default parameter value
 
+            # RTL sources with fixed N=8
+            with self.active_fileset("rtl.8"):
+                self.set_topmodule("heartbeat8")
+                self.add_file("heartbeat8.v")
+
             # Testbench for Icarus Verilog
             with self.active_fileset("testbench.icarus.v"):
                 self.set_topmodule("heartbeat_tb")
                 self.add_file("testbench.v")
                 self.set_param("N", "8")
+
+            # Testbench for fixed N=8
+            with self.active_fileset("testbench.8"):
+                self.set_topmodule("heartbeat8_tb")
+                self.add_file("testbench8.v")
 
             # C++ Testbench for Verilator
             with self.active_fileset("testbench.verilator.cc"):
@@ -73,12 +86,17 @@ class HeartbeatDesign(Design):
             with self.active_fileset("sdc.asap7"):
                 self.add_file("heartbeat_asap7.sdc")
 
+            # ASIC timing constraints for the Skywater130 technology
+            # (the generic clock constraints are reused).
+            with self.active_fileset("sdc.skywater130"):
+                self.add_file("heartbeat.sdc")
+
             # FPGA timing and pin constraints for a Xilinx Artix-7 device.
             with self.active_fileset("fpga.xc7a100tcsg324"):
                 self.add_file("heartbeat.xdc")
 
 
-def lint(N: str = None):
+def lint(N: Optional[str] = None):
     """Runs the linting flow on the Heartbeat design.
 
     Linting checks the Verilog source code for syntax errors and style
@@ -112,7 +130,7 @@ def lint(N: str = None):
     project.summary()
 
 
-def syn(pdk: str = "freepdk45", N: str = None):
+def syn(pdk: str = "freepdk45", N: Optional[str] = None):
     """Runs the synthesis flow for the Heartbeat design.
 
     Synthesis converts the RTL Verilog code into a gate-level netlist
@@ -149,7 +167,8 @@ def syn(pdk: str = "freepdk45", N: str = None):
     project.summary()
 
 
-def asic(pdk: str = "freepdk45", N: str = None):
+def asic(pdk: str = "freepdk45", N: Optional[str] = None, jobname: Optional[str] = None,
+         fileset: str = "rtl"):
     """Runs the full ASIC implementation flow for the Heartbeat design.
 
     This flow includes synthesis, floorplanning, placement, clock tree synthesis,
@@ -160,6 +179,8 @@ def asic(pdk: str = "freepdk45", N: str = None):
             Defaults to "freepdk45".
         N (str, optional): The value for the Verilog parameter 'N'.
             Defaults to None, which uses the value set in the design schema.
+        jobname (str, optional): The name of the job.
+        fileset (str, optional): The RTL fileset to implement. Defaults to "rtl".
     """
     # Create a project instance for an ASIC flow.
     project = ASIC()
@@ -169,15 +190,19 @@ def asic(pdk: str = "freepdk45", N: str = None):
     project.set_design(hb)
 
     # Add the necessary filesets.
-    project.add_fileset("rtl")
+    project.add_fileset(fileset)
     project.add_fileset(f"sdc.{pdk}")
 
     # Optionally override the 'N' parameter.
     if N is not None:
-        hb.set_param("N", N, fileset="rtl")
+        hb.set_param("N", N, fileset=fileset)
 
     # Load the target, which automatically selects the default 'asicflow'.
     asic_target(project, pdk=pdk)
+
+    # Set the jobname, if specificed
+    if jobname:
+        project.option.set_jobname(jobname)
 
     # Run the full place-and-route flow.
     project.run()
@@ -187,7 +212,7 @@ def asic(pdk: str = "freepdk45", N: str = None):
     project.snapshot()
 
 
-def sim(N: str = None, tool: str = "verilator", tb_type: str = "v"):
+def sim(N: Optional[str] = None, tool: str = "verilator", tb_type: str = "v"):
     """Runs a simulation of the Heartbeat design.
 
     After the simulation completes, it attempts to open the generated
@@ -244,7 +269,7 @@ def sim(N: str = None, tool: str = "verilator", tb_type: str = "v"):
         project.show(vcd)
 
 
-def fpga(N: str = None):
+def fpga(N: Optional[str] = None):
     """Runs the FPGA implementation flow for the Heartbeat design.
 
     This flow targets a Xilinx Artix-7 FPGA (xc7a100tcsg324) and generates
@@ -279,6 +304,164 @@ def fpga(N: str = None):
     # Run the FPGA flow (synthesis, place, route, bitstream generation).
     project.run()
     project.summary()
+
+
+def sim_postpnr(pnr_jobname: Optional[str] = None,
+                jobname: str = "sim", show_vcd: bool = True) -> str:
+    """Runs a gate-level (post-PnR) simulation of the Heartbeat design.
+
+    The implemented gate-level netlist is simulated against the Skywater130
+    standard-cell Verilog models to capture a switching-activity waveform (VCD)
+    that can later drive vector-based power analysis.
+
+    If ``pnr_jobname`` is not provided, the ASIC implementation flow is run
+    automatically (via :func:`asic`) under the job name ``"pnr"``; otherwise the
+    netlist is reused from the named existing job.
+
+    Args:
+        pnr_jobname (str, optional): Job name of an existing ASIC implementation
+            run to reuse. If None, :func:`asic` is run first.
+        jobname (str): Job name for this simulation. Defaults to "sim".
+        show_vcd (bool): If True, open the captured waveform in a viewer once the
+            simulation completes. Defaults to True.
+
+    Returns:
+        str: The job name of the ASIC implementation whose netlist was simulated.
+    """
+    # Ensure an implemented netlist exists; run PnR if one was not provided.
+    if pnr_jobname is None:
+        pnr_jobname = "pnr"
+        asic(pdk="skywater130", N=None, jobname=pnr_jobname, fileset="rtl.8")
+
+    # Load the completed implementation manifest to locate its outputs and the
+    # standard-cell library (no project setup needed).
+    impl = ASIC.from_manifest(
+        filepath=f"build/heartbeat/{pnr_jobname}/heartbeat.pkg.json")
+    netlist = impl.find_result("lec.vg", step="write.views")
+
+    # The standard-cell simulation models live in the main library's 'rtl'
+    # fileset; depend on it so the netlist's cell instances resolve.
+    mainlib = impl.get_library(impl.get("asic", "mainlib"))
+
+    gate = HeartbeatDesign()
+    # Gate-level netlist (absolute path from find_result, so no dataroot needed)
+    # plus the standard-cell simulation models.
+    with gate.active_fileset("netlist"):
+        gate.add_file(netlist)
+        gate.add_depfileset(mainlib, "rtl")
+
+    sim = Sim(gate)
+    sim.add_fileset(["testbench.8", "netlist"])
+    sim.set_flow(DVFlow(tool="icarus"))
+    sim.option.set_jobname(jobname)
+
+    sim.run()
+    sim.summary()
+
+    vcd = sim.find_result(step="simulate", index="0", directory="reports",
+                          filename="heartbeat8_tb.vcd")
+
+    # If a VCD file is found, open it with the default waveform viewer.
+    if show_vcd and vcd:
+        sim.show(vcd)
+
+    return pnr_jobname
+
+
+def power(pnr_jobname: Optional[str] = None, sim_jobname: Optional[str] = None):
+    """Runs vector-based (VCD-driven) power signoff for the Heartbeat design.
+
+    Chains three flows on the Skywater130 PDK to obtain a power estimate driven
+    by real switching activity rather than default toggle rates:
+
+        1. **asicflow** (:func:`asic`): RTL-to-GDS implementation, producing a
+           gate-level netlist and extracted parasitics (SPEF).
+        2. **dvflow** (:func:`sim_postpnr`): gate-level simulation of the
+           netlist, capturing a switching-activity waveform (VCD).
+        3. **timing signoff**: OpenSTA reads the netlist and SDC from the design
+           filesets, the SPEF from the staged step inputs and the VCD (via
+           ``read_vcd``), and reports vector-based power.
+
+    Any prerequisite job that is not supplied is run automatically: if
+    ``sim_jobname`` is None the simulation (and, if needed, the implementation)
+    is run; if only ``pnr_jobname`` is None the implementation is run.
+
+    Gate-level simulation is demonstrated with Skywater130 because it is the demo
+    PDK that ships behavioral Verilog cell models (FreePDK45/Nangate45 does not).
+
+    Args:
+        pnr_jobname (str, optional): Job name of an existing ASIC implementation
+            run to reuse.
+        sim_jobname (str, optional): Job name of an existing gate-level
+            simulation to reuse.
+    """
+    # Ensure the simulation (and, transitively, the implementation) exist.
+    if sim_jobname is None:
+        sim_jobname = "sim"
+        pnr_jobname = sim_postpnr(pnr_jobname=pnr_jobname, jobname=sim_jobname, show_vcd=False)
+    elif pnr_jobname is None:
+        pnr_jobname = "pnr"
+
+    # Load the completed implementation manifest to locate its outputs (netlist,
+    # the implementation-generated SDC and extracted parasitics).
+    impl = ASIC.from_manifest(
+        filepath=f"build/heartbeat/{pnr_jobname}/heartbeat.pkg.json")
+    netlist = impl.find_result("lec.vg", step="write.views")
+    sdc = impl.find_result("sdc", step="write.views")
+    spef = impl.find_result("typical.spef", step="write.views")
+
+    # Load the simulation manifest to locate the captured waveform.
+    sim = Sim.from_manifest(
+        filepath=f"build/heartbeat/{sim_jobname}/heartbeat.pkg.json")
+    vcd = sim.find_result(step="simulate", index="0", directory="reports",
+                          filename="heartbeat8_tb.vcd")
+
+    # ------------------------------------------------------------------
+    # Timing signoff: netlist + SDC (filesets) + SPEF (inputs) + VCD -> power
+    # ------------------------------------------------------------------
+    signoff = ASIC()
+    sign_d = HeartbeatDesign()
+    # netlist, sdc and vcd are absolute paths from find_result, so no dataroot
+    # is needed.
+    #
+    # The netlist is read as verilog straight from this fileset; STA resolves the
+    # cell instances from the Liberty models, so no cell Verilog is needed here.
+    with sign_d.active_fileset("netlist"):
+        sign_d.set_topmodule("heartbeat8")
+        sign_d.add_file(netlist)
+    # The implementation-generated SDC (with propagated clocks) is the correct
+    # constraint set for signoff.
+    with sign_d.active_fileset("sdc.netlist"):
+        sign_d.add_file(sdc)
+    # Register the captured VCD in its own fileset but do NOT make it active: it
+    # requires a scope, so it is consumed only via the scoped power-activity
+    # configuration below (never as a plain active fileset).
+    sign_d.add_file(vcd, fileset="sim.vcd", filetype="vcd")
+    signoff.set_design(sign_d)
+    signoff.add_fileset(["netlist", "sdc.netlist"])
+
+    # Reuse the Skywater130 target for libraries, corners and the delay model,
+    # then replace its flow with the timing-signoff flow.
+    skywater130_demo(signoff)
+
+    signoff_flow = Flowgraph("timingsignoff")
+    # Stage the parasitics into the timing node's inputs; sc_timing.tcl reads
+    # the per-corner SPEF from the step inputs (there is no SPEF fileset type).
+    signoff_flow.node("stage", ImportFilesTask())
+    signoff_flow.node("signoff", TimingTask())
+    signoff_flow.edge("stage", "signoff")
+    signoff.set_flow(signoff_flow)
+    signoff.option.set_jobname("timingsignoff")
+
+    ImportFilesTask.find_task(signoff).add_import_file(spef)
+
+    # Annotate switching activity from the VCD. The DUT is instantiated in the
+    # testbench as heartbeat8_tb/DUT, so that is the scope of the design top.
+    TimingTask.find_task(signoff).add_opensta_poweractivity(
+        "heartbeat8_tb/DUT", sign_d.name, "sim.vcd")
+
+    signoff.run()
+    signoff.summary()
 
 
 def check():

--- a/examples/heartbeat/make.py
+++ b/examples/heartbeat/make.py
@@ -200,7 +200,7 @@ def asic(pdk: str = "freepdk45", N: Optional[str] = None, jobname: Optional[str]
     # Load the target, which automatically selects the default 'asicflow'.
     asic_target(project, pdk=pdk)
 
-    # Set the jobname, if specificed
+    # Set the jobname, if specified
     if jobname:
         project.option.set_jobname(jobname)
 

--- a/examples/heartbeat/make.py
+++ b/examples/heartbeat/make.py
@@ -400,7 +400,11 @@ def power(pnr_jobname: Optional[str] = None, sim_jobname: Optional[str] = None):
         sim_jobname = "sim"
         pnr_jobname = sim_postpnr(pnr_jobname=pnr_jobname, jobname=sim_jobname, show_vcd=False)
     elif pnr_jobname is None:
-        pnr_jobname = "pnr"
+        # Reusing an existing simulation: the netlist and parasitics must come
+        # from the matching implementation, so require it explicitly rather than
+        # silently pairing the VCD with the default "pnr" job.
+        raise ValueError(
+            "pnr_jobname is required when reusing an existing sim_jobname")
 
     # Load the completed implementation manifest to locate its outputs (netlist,
     # the implementation-generated SDC and extracted parasitics).

--- a/examples/heartbeat/testbench8.v
+++ b/examples/heartbeat/testbench8.v
@@ -1,0 +1,32 @@
+`timescale 1ns / 1ns
+module heartbeat8_tb ();
+
+    reg  clk;
+    reg  n_reset;
+    wire beat;
+
+    heartbeat8 DUT (
+        .clk(clk),
+        .nreset(n_reset),
+        .out(beat)
+    );
+
+    initial begin
+        $dumpfile(`SILICONCOMPILER_TRACE_FILE);
+        $dumpvars(0, heartbeat8_tb);
+
+        clk = 1'b0;
+        n_reset = 1'b1;
+
+        $monitor("time=%0t, reset=%0b beat=%0b", $time, DUT.nreset, beat);
+
+        #2 n_reset = 1'b0;
+
+        #10 n_reset = 1'b1;
+
+        #10000 $finish();
+    end
+
+    always #5 clk = ~clk;
+
+endmodule

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -239,7 +239,8 @@ if { [llength $sc_power_activities] == 0 } {
 # Report how much of the design's switching activity was annotated from the VCD
 if { $sc_read_vcd } {
     puts "Reporting power activity annotation coverage"
-    report_activity_annotation -report_annotated -report_unannotated > reports/activity_annotation.rpt
+    report_activity_annotation -report_annotated -report_unannotated > \
+        reports/activity_annotation.rpt
 }
 
 ###############################

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -234,6 +234,12 @@ if { [llength $sc_power_activities] == 0 } {
             }
         }
     }
+    # Warn: activities were explicitly configured, so falling back to default
+    # toggle rates would produce misleading power numbers.
+    if { !$sc_read_vcd } {
+        puts "Warning: power_activities is configured but no VCD files were\
+            resolved from the referenced filesets"
+    }
 }
 
 # Report how much of the design's switching activity was annotated from the VCD

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -98,7 +98,6 @@ if { [file exists "inputs/${sc_topmodule}.vg"] } {
 link_design $sc_topmodule
 
 # Read SDC (in order of priority)
-# TODO: add logic for reading from ['constraint', ...] once we support MCMM
 if { [file exists "inputs/${sc_topmodule}.sdc"] } {
     # get from previous step
     puts "Reading SDC: inputs/${sc_topmodule}.sdc"
@@ -134,13 +133,6 @@ if { [file exists "inputs/${sc_topmodule}.sdc"] } {
         }
     }
 }
-# } else {
-#     # fall back on default auto generated constraints file
-#     set sdc "[sc_cfg_tool_task_get file opensta_generic_sdc]"
-#     puts "Reading SDC: ${sdc}"
-#     puts "Warning: Defaulting back to default SDC"
-#     read_sdc "${sdc}"
-# }
 
 # Create path groups
 if { [llength [sta::path_group_names]] == 0 } {
@@ -178,7 +170,7 @@ if { $opensta_timing_mode == "asic" } {
 
         set spef_file "inputs/${sc_topmodule}.${pex_corner}.spef"
         if { [file exists $spef_file] } {
-            puts "Reading SPEF ($corner): $spef_file"
+            puts "Reading SPEF ($corner / $pex_corner): $spef_file"
             read_spef -corner $corner $spef_file
         }
     }
@@ -188,7 +180,7 @@ if { $opensta_timing_mode == "asic" } {
 
         set input_sdf_file "inputs/${sc_topmodule}.${pex_corner}.sdf"
         if { [file exists $input_sdf_file] } {
-            puts "Reading SDF ($corner): $input_sdf_file"
+            puts "Reading SDF ($corner / $pex_corner): $input_sdf_file"
             read_sdf -corner $corner $input_sdf_file
         }
     }
@@ -196,10 +188,58 @@ if { $opensta_timing_mode == "asic" } {
     foreach corner $sc_scenarios {
         set input_sdf_file "inputs/${sc_topmodule}.typical.sdf"
         if { [file exists $input_sdf_file] } {
-            puts "Reading SDF ($corner): $input_sdf_file"
+            puts "Reading SDF ($corner / typical): $input_sdf_file"
             read_sdf -corner $corner $input_sdf_file
         }
     }
+}
+
+###############################
+# Read power activities (VCD)
+###############################
+# Vector-based power analysis: annotate switching activity from a VCD so the
+# report_power calls below use real activity instead of default toggle rates.
+
+set sc_power_activities [sc_cfg_tool_task_get var power_activities]
+set sc_read_vcd false
+if { [llength $sc_power_activities] == 0 } {
+    # Default: read the VCD from the active filesets (or the step input) with no
+    # scope, i.e. the VCD hierarchy is assumed to match the design top.
+    set vcd_files []
+    set input_vcd "inputs/${sc_topmodule}.vcd"
+    if { [file exists $input_vcd] } {
+        lappend vcd_files $input_vcd
+    } else {
+        foreach fs [sc_get_filesets] {
+            lassign $fs fs_lib fs_name
+            lappend vcd_files {*}[sc_cfg_get_fileset $fs_lib $fs_name vcd]
+        }
+    }
+    foreach vcd $vcd_files {
+        puts "Reading power activities (VCD): $vcd"
+        read_vcd $vcd
+        set sc_read_vcd true
+    }
+} else {
+    # Configured: each entry maps a VCD scope (the instance path of the design
+    # top within the VCD) to a (library, fileset) source containing the VCD.
+    foreach activity $sc_power_activities {
+        lassign $activity scope act_lib act_fileset
+        foreach fs [sc_get_filesets -library $act_lib -filesets $act_fileset] {
+            lassign $fs fs_lib fs_name
+            foreach vcd [sc_cfg_get_fileset $fs_lib $fs_name vcd] {
+                puts "Reading power activities (VCD) for scope '$scope': $vcd"
+                read_vcd -scope $scope $vcd
+                set sc_read_vcd true
+            }
+        }
+    }
+}
+
+# Report how much of the design's switching activity was annotated from the VCD
+if { $sc_read_vcd } {
+    puts "Reporting power activity annotation coverage"
+    report_activity_annotation -report_annotated -report_unannotated > reports/activity_annotation.rpt
 }
 
 ###############################

--- a/siliconcompiler/tools/opensta/timing.py
+++ b/siliconcompiler/tools/opensta/timing.py
@@ -34,6 +34,12 @@ class TimingTaskBase(OpenSTATask):
         self.add_parameter("write_liberty", "bool", "if true will write liberty for every corner",
                            defvalue=False)
 
+        self.add_parameter("power_activities", "[(str,str,str)]",
+                           "list of (VCD scope, library, fileset) tuples specifying VCD files to "
+                           "read for vector-based power analysis. The scope is the instance path "
+                           "of the design top within the VCD. If empty, a VCD is read from the "
+                           "active filesets (or the step input) with no scope.")
+
     def set_opensta_topnpaths(self, n: int,
                               step: Optional[str] = None,
                               index: Optional[str] = None):
@@ -98,6 +104,28 @@ class TimingTaskBase(OpenSTATask):
         """
         self.set("var", "write_liberty", enable, step=step, index=index)
 
+    def add_opensta_poweractivity(self, scope: str, library: str, fileset: str,
+                                  clobber: bool = False,
+                                  step: Optional[str] = None,
+                                  index: Optional[str] = None):
+        """
+        Adds a VCD source for vector-based power analysis.
+
+        Args:
+            scope (str): The instance path of the design top within the VCD.
+            library (str): The library (design) providing the VCD fileset.
+            fileset (str): The fileset containing the VCD file.
+            clobber (bool): If True, overwrites any existing entries. If False (default),
+                the entry is appended.
+            step (str, optional): The specific step to apply this configuration to.
+            index (str, optional): The specific index to apply this configuration to.
+        """
+        if clobber:
+            return self.set("var", "power_activities", (scope, library, fileset),
+                            step=step, index=index)
+        return self.add("var", "power_activities", (scope, library, fileset),
+                        step=step, index=index)
+
     def setup(self):
         super().setup()
 
@@ -130,6 +158,25 @@ class TimingTaskBase(OpenSTATask):
         if self.get("var", "write_liberty"):
             for corner in self.project.getkeys('constraint', 'timing', 'scenario'):
                 self.add_output_file(ext=f"{corner}.lib")
+
+        # VCD power activities are read by sc_timing.tcl; declare the source files
+        # required so they are hashed (cache) and copied (remote runs). The
+        # power_activities var itself is optional (defaults to an empty list), but
+        # is required once activities are configured.
+        power_activities = self.get("var", "power_activities")
+        if power_activities:
+            self.add_required_key("var", "power_activities")
+            for _, lib_name, fileset in power_activities:
+                lib = self.project.get_library(lib_name)
+                for fs_lib, fs in self.project.get_filesets(library=lib, filesets=[fileset]):
+                    self.add_required_key(fs_lib, "fileset", fs, "file", "vcd")
+        elif f"{self.design_topmodule}.vcd" in self.get_files_from_input_nodes():
+            # default: VCD delivered from a previous node in the same flowgraph
+            self.add_input_file(ext="vcd")
+        else:
+            # default: VCD provided via the active filesets
+            for obj, key in self.get_fileset_file_keys("vcd"):
+                self.add_required_key(obj, *key)
 
     def post_process(self):
         super().post_process()

--- a/tests/examples/test_heartbeat.py
+++ b/tests/examples/test_heartbeat.py
@@ -89,6 +89,40 @@ def test_py_make_sim_verilator_cc():
 
 
 @pytest.mark.eda
+@pytest.mark.timeout(1200)
+def test_py_make_sim_postpnr():
+    from heartbeat import make
+    # Auto-runs PnR ('pnr') then the gate-level simulation ('sim').
+    make.sim_postpnr(show_vcd=False)
+
+    assert os.path.isfile('build/heartbeat/pnr/heartbeat.pkg.json')
+    assert os.path.isfile('build/heartbeat/sim/simulate/0/reports/heartbeat8_tb.vcd')
+
+
+@pytest.mark.eda
+@pytest.mark.timeout(1800)
+def test_py_make_power():
+    from heartbeat import make
+    # Runs the full chain: PnR ('pnr') -> gate-level sim ('sim') -> signoff.
+    make.power()
+
+    # Gate-level simulation produced a switching-activity waveform.
+    assert os.path.isfile('build/heartbeat/sim/simulate/0/reports/heartbeat8_tb.vcd')
+
+    # Timing signoff annotated the VCD and reported activity coverage.
+    annotation = 'build/heartbeat/timingsignoff/signoff/0/reports/activity_annotation.rpt'
+    assert os.path.isfile(annotation)
+
+    # Every pin's activity should be annotated from the VCD (a wrong scope would
+    # leave pins unannotated). The report prints "unannotated <count>"; the
+    # vcd/saif/input lines only appear when non-zero, so match on content rather
+    # than a fixed line number.
+    with open(annotation) as f:
+        counts = [line.split() for line in f.read().splitlines()]
+    assert ["unannotated", "0"] in counts
+
+
+@pytest.mark.eda
 @pytest.mark.timeout(300)
 @pytest.mark.skipif(shutil.which("vivado") is None, reason="Vivado is not available in CI")
 def test_py_make_fpga():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an 8-bit heartbeat RTL example and a matching testbench with waveform capture.
  - Expanded the example build flow to support 8-bit RTL/testbench variants and additional SkyWater 130nm constraints/workflows.
  - Added VCD-driven switching activity configuration for timing analysis, including post-layout gate simulation + power/timing signoff.

- **Enhancements**
  - Improved OpenSTA timing/power log context (scenario/corner) and switching-activity coverage reporting.

- **Tests**
  - Added CI checks for post-PnR gate simulation outputs and power/timing signoff activity annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->