### PR TITLE
version 0.38.2

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,21 @@ The changes in each SiliconCompiler release version are described below. Commit
 version shown in (). Where applicable, the contributors that suggested a given
 feature are shown in [].
 
+SiliconCompiler 0.38.2 (2026-07-15)
+=========================================
+
+**Minor:**
+
+ * Added a cached schema class to speed up loading, with support for frozen schemas.
+ * Added system-wide settings, letting an administrator provide machine-wide defaults.
+ * Added tool-install checks to avoid rebuilding already-installed tools.
+
+ * Tools:
+
+  * opensta: added support for reading VCD files for switching-activity-driven timing analysis.
+  * yosys: removed the standalone yosys-slang plugin now that it ships with yosys 0.67.
+
+
 SiliconCompiler 0.38.1 (2026-07-09)
 =========================================
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cached and frozen schema support.
  * Added system-wide settings for machine defaults.
  * Added checks to avoid rebuilding tools that are already installed.
  * Added VCD support for switching-activity-driven timing analysis in OpenSTA.
* **Changes**
  * Removed the standalone Yosys-Slang plugin, now included with Yosys 0.67.
* **Documentation**
  * Added release notes for SiliconCompiler 0.38.2 (July 15, 2026).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->