### PR TITLE
reorganize reports in openroad and opensta to make it easier to follow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,7 @@ spaces-in-braces = true
 skip = '*/build/*,./docs/_build/*,*.json,*.xml,*.v,./siliconcompiler/data/templates/report/bootstrap.min.js,./tests/utils/test_utils.py,./tests/tools/data/klayout_pdk/interposer.drc'
 count = true
 quiet-level = 3
-ignore-words-list = 'synopsys,inout,subtile,FRAM,dffer,dffers,thirdparty,dout,RESOVER'
+ignore-words-list = 'synopsys,inout,subtile,FRAM,dffer,dffers,thirdparty,dout,RESOVER,iterm'
 
 [tool.check-wheel-contents]
 ignore = [

--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -1652,7 +1652,7 @@ class APRTask(OpenROADTask):
 
         metric_reports = {
             "setuptns": [
-                "timing/total_negative_slack.rpt",
+                "timing/total_negative_slack.setup.rpt",
                 "timing/setup.rpt",
                 "timing/setup.histogram.rpt",
                 "images/timing/setup.histogram.png"
@@ -1665,7 +1665,7 @@ class APRTask(OpenROADTask):
                 "images/timing/setup.histogram.png"
             ],
             "setupskew": [
-                "timing/skew.setup.rpt",
+                "clocks/skew.setup.rpt",
                 "timing/worst_slack.setup.rpt",
                 "timing/setup.rpt",
                 "timing/setup.topN.rpt"
@@ -1684,7 +1684,7 @@ class APRTask(OpenROADTask):
                 "images/timing/hold.histogram.png"
             ],
             "holdskew": [
-                "timing/skew.hold.rpt",
+                "clocks/skew.hold.rpt",
                 "timing/worst_slack.hold.rpt",
                 "timing/hold.rpt",
                 "timing/hold.topN.rpt"
@@ -1706,15 +1706,15 @@ class APRTask(OpenROADTask):
                     for corner in self.project.getkeys('constraint', 'timing', 'scenario')]
             ],
             "drvs": [
-                "timing/drv_violators.rpt",
-                "floating_nets.rpt",
-                "overdriven_nets.rpt",
-                "overdriven_nets_with_parallel.rpt",
-                f"{self.design_topmodule}_antenna.rpt",
-                f"{self.design_topmodule}_antenna_post_repair.rpt"
+                "checks/drv_violators.rpt",
+                "checks/floating_nets.rpt",
+                "checks/overdriven_nets.rpt",
+                "checks/overdriven_nets_with_parallel.rpt",
+                f"route/{self.design_topmodule}.antenna.rpt",
+                f"route/{self.design_topmodule}.antenna_post_repair.rpt"
             ],
             "drcs": [
-                f"{self.design_topmodule}_drc.rpt",
+                f"checks/{self.design_topmodule}.drc.rpt",
                 f"markers/{self.design_topmodule}.drc.rpt",
                 f"markers/{self.design_topmodule}.drc.json",
                 f"images/markers/{self.design_topmodule}.DRC.png"
@@ -2013,4 +2013,5 @@ class APRTask(OpenROADTask):
             process_cell(module)
 
         if cellarea_report.size() > 0:
-            cellarea_report.write_report("reports/hierarchical_cell_area.json")
+            os.makedirs("reports/design", exist_ok=True)
+            cellarea_report.write_report("reports/design/hierarchical_cell_area.json")

--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -1191,6 +1191,8 @@ class APRTask(OpenROADTask):
             "fmax",
             "power",
             "logicdepth",
+            "design_stats",
+            "scenarios",
             "check_setup",
             "report_buffers",
             "placement_density",
@@ -1650,10 +1652,12 @@ class APRTask(OpenROADTask):
         Extract metrics
         '''
 
+        scenario_corners = self.project.getkeys('constraint', 'timing', 'scenario')
         metric_reports = {
             "setuptns": [
                 "timing/total_negative_slack.setup.rpt",
                 "timing/setup.rpt",
+                "timing/setup.failing.rpt",
                 "timing/setup.histogram.rpt",
                 "images/timing/setup.histogram.png"
             ],
@@ -1661,6 +1665,10 @@ class APRTask(OpenROADTask):
                 "timing/worst_slack.setup.rpt",
                 "timing/setup.rpt",
                 "timing/setup.topN.rpt",
+                "timing/setup.failing.rpt",
+                "timing/setup.endpoints.rpt",
+                *[f"timing/setup.{corner}.rpt" for corner in scenario_corners],
+                *[f"timing/setup.topN.{corner}.rpt" for corner in scenario_corners],
                 "timing/setup.histogram.rpt",
                 "images/timing/setup.histogram.png"
             ],
@@ -1673,13 +1681,28 @@ class APRTask(OpenROADTask):
             "setuppaths": [
                 "timing/setup.rpt",
                 "timing/setup.topN.rpt",
+                "timing/setup.failing.rpt",
+                "timing/setup.endpoints.rpt",
+                *[f"timing/setup.{corner}.rpt" for corner in scenario_corners],
+                *[f"timing/setup.topN.{corner}.rpt" for corner in scenario_corners],
                 "timing/setup.histogram.rpt",
                 "images/timing/setup.histogram.png"
+            ],
+            "holdtns": [
+                "timing/total_negative_slack.hold.rpt",
+                "timing/hold.rpt",
+                "timing/hold.failing.rpt",
+                "timing/hold.histogram.rpt",
+                "images/timing/hold.histogram.png"
             ],
             "holdslack": [
                 "timing/worst_slack.hold.rpt",
                 "timing/hold.rpt",
                 "timing/hold.topN.rpt",
+                "timing/hold.failing.rpt",
+                "timing/hold.endpoints.rpt",
+                *[f"timing/hold.{corner}.rpt" for corner in scenario_corners],
+                *[f"timing/hold.topN.{corner}.rpt" for corner in scenario_corners],
                 "timing/hold.histogram.rpt",
                 "images/timing/hold.histogram.png"
             ],
@@ -1692,8 +1715,18 @@ class APRTask(OpenROADTask):
             "holdpaths": [
                 "timing/hold.rpt",
                 "timing/hold.topN.rpt",
+                "timing/hold.failing.rpt",
+                "timing/hold.endpoints.rpt",
+                *[f"timing/hold.{corner}.rpt" for corner in scenario_corners],
+                *[f"timing/hold.topN.{corner}.rpt" for corner in scenario_corners],
                 "timing/hold.histogram.rpt",
                 "images/timing/hold.histogram.png"
+            ],
+            "registers": [
+                "design/registers.rpt"
+            ],
+            "logicdepth": [
+                "design/logic_depth.rpt"
             ],
             "unconstrained": [
                 "timing/unconstrained.rpt",

--- a/siliconcompiler/tools/openroad/antenna_repair.py
+++ b/siliconcompiler/tools/openroad/antenna_repair.py
@@ -54,6 +54,7 @@ class AntennaRepairTask(APRTask, OpenROADSTAParameter, OpenROADGRTParameter, Ope
         self.set_script("apr/sc_antenna_repair.tcl")
 
         self._set_reports([
+            'scenarios',
             'setup',
             'hold',
             'unconstrained',

--- a/siliconcompiler/tools/openroad/clock_tree_synthesis.py
+++ b/siliconcompiler/tools/openroad/clock_tree_synthesis.py
@@ -30,6 +30,8 @@ class CTSTask(APRTask, OpenROADSTAParameter, OpenROADDPLParameter, OpenROADCTSPa
             'floating_nets',
             'overdriven_nets',
             "logicdepth",
+            'design_stats',
+            'scenarios',
 
             # Images
             'snapshot',

--- a/siliconcompiler/tools/openroad/detailed_placement.py
+++ b/siliconcompiler/tools/openroad/detailed_placement.py
@@ -20,6 +20,7 @@ class DetailedPlacementTask(APRTask, OpenROADSTAParameter, OpenROADDPLParameter,
         self.set_script("apr/sc_detailed_placement.tcl")
 
         self._set_reports([
+            'scenarios',
             'setup',
             'unconstrained',
             'power',

--- a/siliconcompiler/tools/openroad/detailed_route.py
+++ b/siliconcompiler/tools/openroad/detailed_route.py
@@ -30,6 +30,8 @@ class DetailedRouteTask(APRTask, OpenROADSTAParameter, OpenROADDRTPinAccessParam
             'floating_nets',
             'overdriven_nets',
             "logicdepth",
+            'design_stats',
+            'scenarios',
 
             # Images
             'snapshot',

--- a/siliconcompiler/tools/openroad/endcap_tapcell_insertion.py
+++ b/siliconcompiler/tools/openroad/endcap_tapcell_insertion.py
@@ -18,6 +18,7 @@ class EndCapTapCellTask(APRTask, OpenROADSTAParameter):
         self.set_script("apr/sc_endcap_tapcell_insertion.tcl")
 
         self._set_reports([
+            'scenarios',
             'floating_nets',
             'overdriven_nets',
 

--- a/siliconcompiler/tools/openroad/fillercell_insertion.py
+++ b/siliconcompiler/tools/openroad/fillercell_insertion.py
@@ -19,6 +19,7 @@ class FillCellTask(APRTask, OpenROADSTAParameter, OpenROADDPLParameter, OpenROAD
         self.set_script("apr/sc_fillercell_insertion.tcl")
 
         self._set_reports([
+            'scenarios',
             'setup',
             'hold',
             'unconstrained',

--- a/siliconcompiler/tools/openroad/fillmetal_insertion.py
+++ b/siliconcompiler/tools/openroad/fillmetal_insertion.py
@@ -38,6 +38,7 @@ class FillMetalTask(APRTask, OpenROADSTAParameter):
         self.set_script("apr/sc_fillmetal_insertion.tcl")
 
         self._set_reports([
+            'scenarios',
             'setup',
             'hold',
             'unconstrained',

--- a/siliconcompiler/tools/openroad/global_placement.py
+++ b/siliconcompiler/tools/openroad/global_placement.py
@@ -108,6 +108,8 @@ class GlobalPlacementTask(APRTask, OpenROADSTAParameter, OpenROADGPLParameter,
             'floating_nets',
             'overdriven_nets',
             "logicdepth",
+            'design_stats',
+            'scenarios',
 
             # Images
             'snapshot',

--- a/siliconcompiler/tools/openroad/global_route.py
+++ b/siliconcompiler/tools/openroad/global_route.py
@@ -49,6 +49,8 @@ class GlobalRouteTask(APRTask, OpenROADSTAParameter, OpenROADGRTParameter,
             'floating_nets',
             'overdriven_nets',
             "logicdepth",
+            'design_stats',
+            'scenarios',
 
             # Images
             'snapshot',

--- a/siliconcompiler/tools/openroad/init_floorplan.py
+++ b/siliconcompiler/tools/openroad/init_floorplan.py
@@ -192,6 +192,8 @@ class InitFloorplanTask(APRTask,
             'floating_nets',
             'overdriven_nets',
             "logicdepth",
+            'design_stats',
+            'scenarios',
 
             # Images
             'snapshot',

--- a/siliconcompiler/tools/openroad/macro_placement.py
+++ b/siliconcompiler/tools/openroad/macro_placement.py
@@ -343,6 +343,7 @@ class MacroPlacementTask(APRTask, OpenROADSTAParameter, OpenROADGPLParameter):
         self.set_script("apr/sc_macro_placement.tcl")
 
         self._set_reports([
+            'scenarios',
             'setup',
             'unconstrained',
             'floating_nets',

--- a/siliconcompiler/tools/openroad/metrics.py
+++ b/siliconcompiler/tools/openroad/metrics.py
@@ -25,6 +25,8 @@ class MetricsTask(APRTask, OpenROADSTAParameter):
             'floating_nets',
             'overdriven_nets',
             "logicdepth",
+            'design_stats',
+            'scenarios',
 
             # Images
             'snapshot',

--- a/siliconcompiler/tools/openroad/pin_placement.py
+++ b/siliconcompiler/tools/openroad/pin_placement.py
@@ -19,6 +19,7 @@ class PinPlacementTask(APRTask, OpenROADSTAParameter, OpenROADGPLParameter, Open
         self.set_script("apr/sc_pin_placement.tcl")
 
         self._set_reports([
+            'scenarios',
             'setup',
             'unconstrained',
             'floating_nets',

--- a/siliconcompiler/tools/openroad/power_grid.py
+++ b/siliconcompiler/tools/openroad/power_grid.py
@@ -78,6 +78,7 @@ class PowerGridTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
         self.set_script("apr/sc_power_grid.tcl")
 
         self._set_reports([
+            'scenarios',
             'floating_nets',
             'overdriven_nets',
 

--- a/siliconcompiler/tools/openroad/repair_design.py
+++ b/siliconcompiler/tools/openroad/repair_design.py
@@ -79,6 +79,8 @@ class RepairDesignTask(APRTask, OpenROADSTAParameter, OpenROADRSZDRVParameter):
             'floating_nets',
             'overdriven_nets',
             "logicdepth",
+            'design_stats',
+            'scenarios',
 
             # Images
             'snapshot',

--- a/siliconcompiler/tools/openroad/repair_timing.py
+++ b/siliconcompiler/tools/openroad/repair_timing.py
@@ -95,6 +95,8 @@ class RepairTimingTask(APRTask, OpenROADSTAParameter, OpenROADDPLParameter,
             'floating_nets',
             'overdriven_nets',
             "logicdepth",
+            'design_stats',
+            'scenarios',
 
             # Images
             'snapshot',

--- a/siliconcompiler/tools/openroad/scripts/apr/preamble.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/preamble.tcl
@@ -17,6 +17,21 @@ source "$sc_refdir/common/debugging.tcl"
 source "$sc_refdir/common/procs.tcl"
 
 ###############################
+# Setup report directories
+###############################
+
+file mkdir \
+    reports/checks \
+    reports/clocks \
+    reports/constraints \
+    reports/design \
+    reports/markers \
+    reports/power \
+    reports/route \
+    reports/setup \
+    reports/timing
+
+###############################
 # Design information
 ###############################
 
@@ -86,24 +101,24 @@ if { [llength $openroad_dont_touch] > 0 } {
     # set don't touch list
     set_dont_touch $openroad_dont_touch
 }
-tee -quiet -file reports/dont_touch.start.rpt {report_dont_touch}
-tee -quiet -file reports/dont_use.start.rpt {report_dont_use}
-tee -file reports/global_connections.start.rpt {report_global_connect}
+tee -quiet -file reports/setup/dont_touch.start.rpt {report_dont_touch}
+tee -quiet -file reports/setup/dont_use.start.rpt {report_dont_use}
+tee -quiet -file reports/setup/global_connections.start.rpt {report_global_connect}
 if { [sc_cfg_tool_task_check_in_list report_buffers var reports] && [sc_check_version 24 3 7677] } {
-    tee -quiet -file reports/report_buffers.rpt {report_buffers -filtered}
+    tee -quiet -file reports/setup/buffers.rpt {report_buffers -filtered}
 }
-tee -quiet -file reports/report_units.rpt {report_units}
+tee -quiet -file reports/setup/units.rpt {report_units}
 
-tee -quiet -file reports/report_layer_rc.rpt {report_layer_rc}
+tee -quiet -file reports/setup/layer_rc.rpt {report_layer_rc}
 if { [sc_has_sta_mcmm_support] } {
     foreach scene $sc_scenarios {
-        tee -quiet -append -file reports/report_layer_rc.rpt "puts \"Scene: $scene\""
-        tee -quiet -append -file reports/report_layer_rc.rpt "report_layer_rc -corner $scene"
+        tee -quiet -append -file reports/setup/layer_rc.rpt "puts \"Scene: $scene\""
+        tee -quiet -append -file reports/setup/layer_rc.rpt "report_layer_rc -corner $scene"
     }
 } else {
     foreach corner [sta::corners] {
         set corner_name [$corner name]
-        tee -quiet -append -file reports/report_layer_rc.rpt "puts \"Corner: $corner_name\""
-        tee -quiet -append -file reports/report_layer_rc.rpt "report_layer_rc -corner $corner_name"
+        tee -quiet -append -file reports/setup/layer_rc.rpt "puts \"Corner: $corner_name\""
+        tee -quiet -append -file reports/setup/layer_rc.rpt "report_layer_rc -corner $corner_name"
     }
 }

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_antenna_repair.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_antenna_repair.tcl
@@ -18,7 +18,7 @@ source "$sc_refdir/apr/preamble.tcl"
 estimate_parasitics -global_routing
 if {
     [sc_cfg_tool_task_get var ant_check] &&
-    [check_antennas -report_file "reports/${sc_topmodule}_antenna.rpt"] != 0
+    [check_antennas -report_file "reports/route/${sc_topmodule}.antenna.rpt"] != 0
 } {
     if {
         [sc_cfg_tool_task_get var ant_repair] &&
@@ -39,7 +39,7 @@ if {
         sc_insert_fillers
 
         # Check antennas again to get final report
-        check_antennas -report_file "reports/${sc_topmodule}_antenna_post_repair.rpt"
+        check_antennas -report_file "reports/route/${sc_topmodule}.antenna_post_repair.rpt"
     }
 }
 

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_clock_tree_synthesis.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_clock_tree_synthesis.tcl
@@ -43,7 +43,7 @@ if { [llength [all_clocks]] > 0 } {
         -distance_between_buffers $cts_distance_between_buffers \
         {*}$sc_cts_arguments
 
-    tee -file reports/cts.rpt {report_cts}
+    tee -file reports/clocks/cts.rpt {report_cts}
 
     set_propagated_clock [all_clocks]
 

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_detailed_route.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_detailed_route.tcl
@@ -59,8 +59,7 @@ if { [sc_check_version 24 3 7648] } {
 sc_report_args -command detailed_route -args $drt_arguments
 detailed_route \
     -save_guide_updates \
-    -output_drc "reports/${sc_topmodule}_drc.rpt" \
-    -output_maze "reports/${sc_topmodule}_maze.log" \
+    -output_drc "reports/checks/${sc_topmodule}.drc.rpt" \
     -verbose 1 \
     {*}$drt_arguments
 

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_global_placement.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_global_placement.tcl
@@ -43,7 +43,7 @@ if { [sc_cfg_tool_task_get var enable_scan_chains] } {
 
     sc_report_args -command set_dft_config -args $dft_args
     set_dft_config -clock_mixing clock_mix {*}$dft_args
-    tee -file reports/scan_chain_config.rpt {report_dft_config}
+    tee -file reports/checks/scan_chain_config.rpt {report_dft_config}
     scan_replace
 }
 
@@ -66,7 +66,7 @@ sc_global_placement
 ###############################
 
 if { [sc_cfg_tool_task_get var enable_scan_chains] } {
-    tee -file reports/scan_chain.rpt {preview_dft -verbose}
+    tee -file reports/checks/scan_chain.rpt {preview_dft -verbose}
     insert_dft
 
     set new_ios [sc_get_unplaced_io_nets]

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_global_route.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_global_route.tcl
@@ -49,14 +49,14 @@ if { [sc_cfg_tool_task_get {var} grt_allow_congestion] } {
 sc_report_args -command global_route -args $sc_grt_arguments
 if {
     [catch {
-        global_route -guide_file "reports/route.guide" \
+        global_route \
             -congestion_iterations [sc_cfg_tool_task_get var grt_overflow_iter] \
-            -congestion_report_file "reports/${sc_topmodule}_congestion.rpt" \
+            -congestion_report_file "reports/route/${sc_topmodule}.congestion.rpt" \
             -verbose \
             {*}$sc_grt_arguments
     }]
 } {
-    set err_db "reports/${sc_topmodule}.globalroute-error.odb"
+    set err_db "reports/route/${sc_topmodule}.globalroute-error.odb"
     write_db $err_db
     utl::error FLW 1 \
         "Global routing failed, saving database to $err_db"

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_irdrop.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_irdrop.tcl
@@ -85,12 +85,12 @@ sc_image_setup_default
 gui::set_display_controls "Shape Types/Pin*" visible false
 
 foreach net $nets {
-    file mkdir reports/${net}
+    file mkdir reports/power/irdrop/${net}
     foreach corner $sc_scenarios {
         analyze_power_grid -net $net -corner $corner -allow_reuse
 
-        set gif [save_animated_gif -start "reports/${net}/${corner}.gif"]
-        set gif_log [save_animated_gif -start "reports/${net}/${corner}_log.gif"]
+        set gif [save_animated_gif -start "reports/power/irdrop/${net}/${corner}.gif"]
+        set gif_log [save_animated_gif -start "reports/power/irdrop/${net}/${corner}_log.gif"]
 
         foreach layer [[ord::get_db_tech] getLayers] {
             if { [$layer getRoutingLevel] == 0 } {
@@ -114,7 +114,7 @@ foreach net $nets {
             }
 
             # Save CSV
-            gui::dump_heatmap IRDrop reports/${net}/${corner}.${layer_name}.csv
+            gui::dump_heatmap IRDrop reports/power/irdrop/${net}/${corner}.${layer_name}.csv
 
             set box [[ord::get_db_block] getDieArea]
             set x [ord::dbu_to_microns [$box xMax]]
@@ -124,7 +124,7 @@ foreach net $nets {
             sc_save_image \
                 -title "IR drop for $net on $layer_name for $corner heatmap" \
                 -gif $gif \
-                reports/${net}/${corner}.${layer_name}.png
+                reports/power/irdrop/${net}/${corner}.${layer_name}.png
 
             gui::set_heatmap IRDrop LogScale 1
             gui::set_heatmap IRDrop rebuild
@@ -132,7 +132,7 @@ foreach net $nets {
             sc_save_image \
                 -title "IR drop for $net on $layer_name for $corner heatmap" \
                 -gif $gif_log \
-                reports/${net}/${corner}.${layer_name}_log.png
+                reports/power/irdrop/${net}/${corner}.${layer_name}_log.png
 
             gui::set_display_controls "Heat Maps/IR Drop" visible false
 

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_power_grid.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_power_grid.tcl
@@ -81,8 +81,8 @@ foreach pdnconfig_set [sc_cfg_tool_task_get var pdn_fileset] {
         }
     }
 }
-tee -quiet -file reports/power_grid_configuration.rpt {pdngen -report_only}
-pdngen -failed_via_report "reports/${sc_topmodule}_pdngen_failed_vias.rpt"
+tee -quiet -file reports/setup/power_grid_configuration.rpt {pdngen -report_only}
+pdngen -failed_via_report "reports/checks/${sc_topmodule}.pdngen_failed_vias.rpt"
 
 ###############################
 # Remove blockages
@@ -120,7 +120,7 @@ foreach net [sc_psm_check_nets] {
     catch {
         check_power_grid \
             -floorplanning \
-            -error_file "reports/check_power_grid_${net}.rpt" \
+            -error_file "reports/checks/check_power_grid_${net}.rpt" \
             -net $net \
             {*}$check_args
     }

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_repair_timing.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_repair_timing.tcl
@@ -65,7 +65,7 @@ if { ![sc_cfg_tool_task_get var rsz_skip_drv_repair] } {
         -verbose \
         {*}$repair_design_args
 
-    sc_detailed_placement -congestion_report reports/congestion.drv.rpt
+    sc_detailed_placement -congestion_report reports/route/congestion.drv.rpt
 
     # Restore dont use
     sc_set_dont_use
@@ -90,7 +90,7 @@ if { ![sc_cfg_tool_task_get var rsz_skip_setup_repair] } {
         -repair_tns $rsz_repair_tns \
         {*}$repair_timing_args
 
-    sc_detailed_placement -congestion_report reports/congestion.setup_repair.rpt
+    sc_detailed_placement -congestion_report reports/route/congestion.setup_repair.rpt
 
     # Restore dont use
     sc_set_dont_use
@@ -115,7 +115,7 @@ if { ![sc_cfg_tool_task_get var rsz_skip_hold_repair] } {
         -repair_tns $rsz_repair_tns \
         {*}$repair_timing_args
 
-    sc_detailed_placement -congestion_report reports/congestion.hold_repair.rpt
+    sc_detailed_placement -congestion_report reports/route/congestion.hold_repair.rpt
 
     # Restore dont use
     sc_set_dont_use
@@ -139,7 +139,7 @@ if { ![sc_cfg_tool_task_get var rsz_skip_recover_power] } {
         -hold_margin $rsz_hold_slack_margin \
         {*}$repair_timing_args
 
-    sc_detailed_placement -congestion_report reports/congestion.power_recovery.rpt
+    sc_detailed_placement -congestion_report reports/route/congestion.power_recovery.rpt
 
     # Restore dont use
     sc_set_dont_use

--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -518,21 +518,41 @@ proc sc_image_setup_default { } {
 # Count the logic depth of the critical path
 ###########################
 
-proc sc_count_logic_depth { } {
+proc sc_count_logic_depth { args } {
+    sta::parse_key_args "sc_count_logic_depth" args \
+        keys {-report} \
+        flags {}
+
     set count 0
+    set drivers []
     set paths [find_timing_paths -sort_by_slack]
-    if { [llength $paths] == 0 } {
-        return 0
-    }
-    set path_ref [[lindex $paths 0] path]
-    set pins [$path_ref pins]
-    foreach pin $pins {
-        if { [$pin is_driver] } {
-            incr count
+    if { [llength $paths] > 0 } {
+        set path_ref [[lindex $paths 0] path]
+        set pins [$path_ref pins]
+        foreach pin $pins {
+            if { [$pin is_driver] } {
+                incr count
+                lappend drivers [get_full_name $pin]
+            }
         }
     }
     # Subtract 1 to account for initial launch
-    return [expr { $count - 1 }]
+    set depth [expr { max($count - 1, 0) }]
+
+    if { [info exists keys(-report)] } {
+        set fid [open $keys(-report) w]
+        puts $fid "Logic depth: $depth"
+        if { [llength $drivers] > 0 } {
+            puts $fid ""
+            puts $fid "Critical path drivers:"
+            foreach driver $drivers {
+                puts $fid "  $driver"
+            }
+        }
+        close $fid
+    }
+
+    return $depth
 }
 
 ###########################
@@ -661,8 +681,7 @@ proc sc_setup_sta { } {
 
     # Check timing setup
     if { [sc_cfg_tool_task_check_in_list check_setup var reports] } {
-        file mkdir reports/constraints
-        tee -file "reports/constraints/check_timing.rpt" {check_setup -verbose}
+        sc_report_check_timing
     }
 
     if { [llength [all_clocks]] == 0 } {
@@ -907,6 +926,92 @@ proc sc_setup_detailed_route { } {
         utl::info FLW 1 "Marking $layer as a unidirectional routing layer"
         detailed_route_set_unidirectional_layer $layer
     }
+}
+
+proc sc_display_report { report } {
+    if { ![file exists $report] } {
+        return
+    }
+    set fid [open $report r]
+    set report_content [read $fid]
+    close $fid
+    puts $report_content
+}
+
+proc sc_report_check_timing { } {
+    sc_report_banner "Check timing setup"
+    file mkdir reports/constraints/check_timing
+    set checks "generated_clocks loops multiple_clock no_clock no_input_delay \
+        no_output_delay unconstrained_endpoints"
+    foreach check $checks {
+        puts "report: reports/constraints/check_timing/${check}.rpt"
+        tee -quiet -file reports/constraints/check_timing/${check}.rpt \
+            "check_setup -${check}"
+    }
+}
+
+proc sc_report_scene_timing { args } {
+    sta::parse_key_args "sc_report_scene_timing" args \
+        keys {-delay -name -fields -top_paths} \
+        flags {}
+
+    global sc_scenarios
+
+    if { [sc_has_sta_mcmm_support] } {
+        set scenes $sc_scenarios
+        set scene_arg "-scenes"
+    } else {
+        set scenes []
+        foreach corner [sta::corners] {
+            lappend scenes [$corner name]
+        }
+        set scene_arg "-corner"
+    }
+
+    # A single scene would just duplicate the combined timing reports
+    if { [llength $scenes] <= 1 } {
+        return
+    }
+
+    foreach scene $scenes {
+        puts "report: reports/timing/$keys(-name).${scene}.rpt"
+        tee -quiet -file reports/timing/$keys(-name).${scene}.rpt \
+            "report_checks -sort_by_slack -fields $keys(-fields) -path_delay $keys(-delay) \
+            -format full_clock_expanded $scene_arg $scene"
+        puts "report: reports/timing/$keys(-name).topN.${scene}.rpt"
+        tee -quiet -file reports/timing/$keys(-name).topN.${scene}.rpt \
+            "report_checks -sort_by_slack -fields $keys(-fields) -path_delay $keys(-delay) \
+            -group_path_count $keys(-top_paths) $scene_arg $scene"
+    }
+}
+
+proc sc_report_scenarios { } {
+    global sc_sdc_files_read
+
+    file mkdir reports/constraints
+    set fid [open reports/constraints/scenarios.rpt w]
+
+    puts $fid "Timing scenarios:"
+    foreach scenario [dict keys [sc_cfg_get constraint timing scenario]] {
+        puts $fid "  ${scenario}:"
+        puts $fid "    libcorner: [sc_cfg_get constraint timing scenario $scenario libcorner]"
+        puts $fid "    pexcorner: [sc_cfg_get constraint timing scenario $scenario pexcorner]"
+        puts $fid "    mode: [sc_cfg_get constraint timing scenario $scenario mode]"
+        puts $fid "    checks: [sc_cfg_get constraint timing scenario $scenario check]"
+    }
+
+    puts $fid ""
+    puts $fid "SDC files loaded:"
+    if { [info exists sc_sdc_files_read] && [llength $sc_sdc_files_read] > 0 } {
+        foreach sdc $sc_sdc_files_read {
+            puts $fid "  $sdc"
+        }
+    } else {
+        puts $fid "  none"
+    }
+    close $fid
+
+    sc_display_report reports/constraints/scenarios.rpt
 }
 
 proc sc_report_banner { title args } {

--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -661,7 +661,8 @@ proc sc_setup_sta { } {
 
     # Check timing setup
     if { [sc_cfg_tool_task_check_in_list check_setup var reports] } {
-        tee -file "reports/check_timing_setup.rpt" {check_setup -verbose}
+        file mkdir reports/constraints
+        tee -file "reports/constraints/check_timing.rpt" {check_setup -verbose}
     }
 
     if { [llength [all_clocks]] == 0 } {
@@ -890,8 +891,9 @@ proc sc_set_dont_use { args } {
     }
 
     if { [info exists keys(-report)] } {
-        puts "Dont use report: reports/$keys(-report).rpt"
-        tee -quiet -file reports/$keys(-report).rpt {report_dont_use}
+        file mkdir reports/setup
+        puts "Dont use report: reports/setup/$keys(-report).rpt"
+        tee -quiet -file reports/setup/$keys(-report).rpt {report_dont_use}
     }
 }
 
@@ -905,6 +907,17 @@ proc sc_setup_detailed_route { } {
         utl::info FLW 1 "Marking $layer as a unidirectional routing layer"
         detailed_route_set_unidirectional_layer $layer
     }
+}
+
+proc sc_report_banner { title args } {
+    set width 60
+    puts ""
+    puts [string repeat "=" $width]
+    puts "== $title"
+    foreach report $args {
+        puts "== report: $report"
+    }
+    puts [string repeat "=" $width]
 }
 
 proc sc_report_args { args } {
@@ -940,7 +953,8 @@ proc sc_global_connections { args } {
             }
         }
     }
-    tee -file reports/global_connections.rpt {report_global_connect}
+    file mkdir reports/setup
+    tee -quiet -file reports/setup/global_connections.rpt {report_global_connect}
 }
 
 proc sc_format_area { area } {

--- a/siliconcompiler/tools/openroad/scripts/common/read_timing_constraints.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/read_timing_constraints.tcl
@@ -4,6 +4,9 @@
 
 set sc_default_mode "**sc_default_mode**"
 
+# Record every SDC read so sc_report_scenarios can list them
+set sc_sdc_files_read []
+
 if { [sc_cfg_tool_task_get var load_sdcs] } {
     if { [sc_has_sta_mcmm_support] } {
         if { ![sc_cfg_exists constraint timing mode] } {
@@ -49,6 +52,7 @@ if { [sc_cfg_tool_task_get var load_sdcs] } {
             foreach sdc $mode_sdcs {
                 puts "Reading SDC into mode ($mode): ${sdc}"
                 read_sdc -mode $mode $sdc
+                lappend sc_sdc_files_read "($mode) $sdc"
             }
 
             if { [llength $mode_sdcs] == 0 } {
@@ -80,6 +84,7 @@ if { [sc_cfg_tool_task_get var load_sdcs] } {
             set sdc "inputs/${sc_topmodule}.sdc"
             puts "Reading SDC: ${sdc}"
             read_sdc $sdc
+            lappend sc_sdc_files_read $sdc
         } else {
             set sdcs []
             foreach fs [sc_get_filesets] {
@@ -90,6 +95,7 @@ if { [sc_cfg_tool_task_get var load_sdcs] } {
                 foreach sdc $sdcs {
                     puts "Reading SDC: ${sdc}"
                     read_sdc $sdc
+                    lappend sc_sdc_files_read $sdc
                 }
             } else {
                 # fall back on default auto generated constraints file
@@ -97,6 +103,7 @@ if { [sc_cfg_tool_task_get var load_sdcs] } {
                 puts "Reading SDC: ${sdc}"
                 utl::warn FLW 1 "Defaulting back to default SDC"
                 read_sdc "${sdc}"
+                lappend sc_sdc_files_read "(generic fallback) $sdc"
             }
         }
     }

--- a/siliconcompiler/tools/openroad/scripts/common/reports.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/reports.tcl
@@ -214,7 +214,8 @@ if { [llength [all_clocks]] > 0 } {
 
 # get logic depth of design
 if { [sc_cfg_tool_task_check_in_list logicdepth var reports] } {
-    utl::metric_int "design__logic__depth" [sc_count_logic_depth]
+    utl::metric_int "design__logic__depth" \
+        [sc_count_logic_depth -report reports/design/logic_depth.rpt]
 }
 
 if { [sc_cfg_tool_task_check_in_list power var reports] } {

--- a/siliconcompiler/tools/openroad/scripts/common/reports.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/reports.tcl
@@ -2,46 +2,45 @@
 # Report Metrics
 ###############################
 
-# Setup reports directories
-file mkdir reports/timing
-file mkdir reports/power
-file mkdir reports/markers
-
 set fields "{capacitance slew input_pins hierarcial_pins net fanout}"
 set sta_top_n_paths [sc_cfg_tool_task_get var sta_top_n_paths]
-set PREFIX "SC_METRIC:"
 
 if { [sc_cfg_tool_task_check_in_list setup var reports] } {
-    puts "$PREFIX report_checks -path_delay max"
+    sc_report_banner "Setup timing" \
+        reports/timing/setup.rpt \
+        reports/timing/setup.topN.rpt \
+        reports/timing/worst_slack.setup.rpt \
+        reports/timing/total_negative_slack.setup.rpt
     tee -file reports/timing/setup.rpt \
         "report_checks -fields $fields -path_delay max -format full_clock_expanded"
     tee -file reports/timing/setup.topN.rpt -quiet \
-        "report_checks -fields $fields -path_delay max -group_count $sta_top_n_paths"
+        "report_checks -fields $fields -path_delay max -group_path_count $sta_top_n_paths"
 
-    puts "$PREFIX setupslack"
     tee -file reports/timing/worst_slack.setup.rpt \
         "report_worst_slack -max"
     report_worst_slack_metric -setup
 
-    puts "$PREFIX tns"
-    tee -file reports/timing/total_negative_slack.rpt \
+    tee -file reports/timing/total_negative_slack.setup.rpt \
         "report_tns"
     report_tns_metric -setup
 
     if { [sc_check_version 24 3 3932] && [llength [all_clocks]] > 0 } {
+        puts "report: reports/timing/setup.histogram.rpt"
         tee -quiet -file reports/timing/setup.histogram.rpt \
             "report_timing_histogram -num_bins 20 -setup"
     }
 }
 
 if { [sc_cfg_tool_task_check_in_list hold var reports] } {
-    puts "$PREFIX report_checks -path_delay min"
-    tee -file reports/timing/hold.rpt \
+    sc_report_banner "Hold timing" \
+        reports/timing/hold.rpt \
+        reports/timing/hold.topN.rpt \
+        reports/timing/worst_slack.hold.rpt
+    tee -quiet -file reports/timing/hold.rpt \
         "report_checks -fields $fields -path_delay min -format full_clock_expanded"
     tee -file reports/timing/hold.topN.rpt -quiet \
-        "report_checks -fields $fields -path_delay min -group_count $sta_top_n_paths"
+        "report_checks -fields $fields -path_delay min -group_path_count $sta_top_n_paths"
 
-    puts "$PREFIX holdslack"
     tee -file reports/timing/worst_slack.hold.rpt \
         "report_worst_slack -min"
     report_worst_slack_metric -hold
@@ -49,57 +48,63 @@ if { [sc_cfg_tool_task_check_in_list hold var reports] } {
     report_tns_metric -hold
 
     if { [sc_check_version 24 3 3932] && [llength [all_clocks]] > 0 } {
+        puts "report: reports/timing/hold.histogram.rpt"
         tee -quiet -file reports/timing/hold.histogram.rpt \
             "report_timing_histogram -num_bins 20 -hold"
     }
 }
 
 if { [sc_cfg_tool_task_check_in_list unconstrained var reports] } {
-    puts "$PREFIX unconstrained"
+    sc_report_banner "Unconstrained paths" \
+        reports/timing/unconstrained.rpt \
+        reports/timing/unconstrained.topN.rpt
     tee -file reports/timing/unconstrained.rpt \
         "report_checks -fields $fields -unconstrained -format full_clock_expanded \
         -path_group unconstrained"
     tee -file reports/timing/unconstrained.topN.rpt -quiet \
-        "report_checks -fields $fields -unconstrained -group_count $sta_top_n_paths"
+        "report_checks -fields $fields -unconstrained -group_path_count $sta_top_n_paths"
 }
 
 if {
     [sc_cfg_tool_task_check_in_list clock_skew var reports] &&
     [llength [all_clocks]] > 0
 } {
-    puts "$PREFIX clock_skew"
-    tee -file reports/timing/skew.setup.rpt \
+    sc_report_banner "Clock skew" \
+        reports/clocks/skew.setup.rpt \
+        reports/clocks/skew.hold.rpt
+    tee -file reports/clocks/skew.setup.rpt \
         "report_clock_skew -setup -digits 4"
     report_clock_skew_metric -setup
-    tee -file reports/timing/skew.hold.rpt \
+    tee -file reports/clocks/skew.hold.rpt \
         "report_clock_skew -hold -digits 4"
     report_clock_skew_metric -hold
 }
 
 if { [sc_cfg_tool_task_check_in_list drv_violations var reports] } {
-    puts "$PREFIX DRV violators"
-    tee -file reports/timing/drv_violators.rpt \
+    sc_report_banner "DRV violators" \
+        reports/checks/drv_violators.rpt
+    tee -quiet -file reports/checks/drv_violators.rpt \
         "report_check_types -max_slew -max_capacitance -max_fanout -violators"
     report_erc_metrics
 }
 
 if { [sc_cfg_tool_task_check_in_list floating_nets var reports] } {
-    puts "$PREFIX floating nets"
-    puts "Reporting floating nets: reports/floating_nets.rpt"
-    tee -quiet -file reports/floating_nets.rpt \
+    sc_report_banner "Floating nets" \
+        reports/checks/floating_nets.rpt
+    tee -quiet -file reports/checks/floating_nets.rpt \
         "report_floating_nets -verbose"
 }
 if {
     [sc_cfg_tool_task_check_in_list overdriven_nets var reports] &&
     [sc_check_version 24 3 3461]
 } {
-    puts "$PREFIX overdriven nets"
-    puts "Reporting overdriven nets: reports/overdriven_nets.rpt"
-    tee -quiet -file reports/overdriven_nets.rpt \
+    sc_report_banner "Overdriven nets" \
+        reports/checks/overdriven_nets.rpt \
+        reports/checks/overdriven_nets_with_parallel.rpt
+    tee -quiet -file reports/checks/overdriven_nets.rpt \
         "report_overdriven_nets -verbose"
     utl::push_metrics_stage "sc__metric__{}_parallel"
-    puts "Reporting overdriven nets: reports/overdriven_nets_with_parallel.rpt"
-    tee -quiet -file reports/overdriven_nets_with_parallel.rpt \
+    tee -quiet -file reports/checks/overdriven_nets_with_parallel.rpt \
         "report_overdriven_nets -include_parallel_driven -verbose"
     utl::pop_metrics_stage
 }
@@ -107,7 +112,7 @@ if {
 utl::metric_int "timing__clocks" [llength [all_clocks]]
 
 if { [sc_cfg_tool_task_check_in_list fmax var reports] } {
-    puts "$PREFIX fmax"
+    sc_report_banner "Fmax"
     # Model on: https://github.com/The-OpenROAD-Project/OpenSTA/blob/f913c3ddbb3e7b4364ed4437c65ac78c4da9174b/tcl/Search.tcl#L1078
     set fmax_metric 0
     foreach clk [sta::sort_by_name [all_clocks]] {
@@ -150,7 +155,9 @@ if { [sc_cfg_tool_task_check_in_list fmax var reports] } {
 }
 
 if { [llength [all_clocks]] > 0 } {
-    tee -file "reports/timing/clocks.rpt" {report_clock_properties}
+    sc_report_banner "Clock properties" \
+        reports/clocks/clocks.rpt
+    tee -file "reports/clocks/clocks.rpt" {report_clock_properties}
 }
 
 # get logic depth of design
@@ -159,7 +166,7 @@ if { [sc_cfg_tool_task_check_in_list logicdepth var reports] } {
 }
 
 if { [sc_cfg_tool_task_check_in_list power var reports] } {
-    puts "$PREFIX power"
+    sc_report_banner "Power"
     if { [sc_has_sta_mcmm_support] } {
         foreach scene $sc_scenarios {
             if {
@@ -170,6 +177,7 @@ if { [sc_cfg_tool_task_check_in_list power var reports] } {
                 continue
             }
             puts "Power for scene: $scene"
+            puts "report: reports/power/${scene}.rpt"
 
             tee -file reports/power/${scene}.rpt \
                 "report_power -scene $scene"
@@ -178,6 +186,7 @@ if { [sc_cfg_tool_task_check_in_list power var reports] } {
         foreach corner [sta::corners] {
             set corner_name [$corner name]
             puts "Power for corner: $corner_name"
+            puts "report: reports/power/${corner_name}.rpt"
 
             tee -file reports/power/${corner_name}.rpt \
                 "report_power -corner $corner_name"
@@ -187,7 +196,7 @@ if { [sc_cfg_tool_task_check_in_list power var reports] } {
     report_power_metric -corner [sc_cfg_tool_task_get var power_corner]
 }
 
-puts "$PREFIX cellarea"
+sc_report_banner "Design area"
 report_design_area
 report_design_area_metrics
 
@@ -242,10 +251,14 @@ foreach markerdb [[ord::get_db_block] getMarkerCategories] {
         continue
     }
 
+    puts "report: reports/markers/${sc_topmodule}.[$markerdb getName].rpt"
     $markerdb writeTR "reports/markers/${sc_topmodule}.[$markerdb getName].rpt"
+    puts "report: reports/markers/${sc_topmodule}.[$markerdb getName].json"
     $markerdb writeJSON "reports/markers/${sc_topmodule}.[$markerdb getName].json"
 }
 
 utl::push_metrics_stage "sc__cellarea__{}"
-tee -file reports/cell_usage.rpt {report_cell_usage -verbose}
+sc_report_banner "Cell usage" \
+    reports/design/cell_usage.rpt
+tee -file reports/design/cell_usage.rpt {report_cell_usage -verbose}
 utl::pop_metrics_stage

--- a/siliconcompiler/tools/openroad/scripts/common/reports.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/reports.tcl
@@ -5,16 +5,31 @@
 set fields "{capacitance slew input_pins hierarcial_pins net fanout}"
 set sta_top_n_paths [sc_cfg_tool_task_get var sta_top_n_paths]
 
+if { [sc_cfg_tool_task_check_in_list scenarios var reports] } {
+    sc_report_banner "Timing scenarios" \
+        reports/constraints/scenarios.rpt
+    sc_report_scenarios
+}
+
 if { [sc_cfg_tool_task_check_in_list setup var reports] } {
     sc_report_banner "Setup timing" \
         reports/timing/setup.rpt \
         reports/timing/setup.topN.rpt \
+        reports/timing/setup.failing.rpt \
+        reports/timing/setup.endpoints.rpt \
         reports/timing/worst_slack.setup.rpt \
         reports/timing/total_negative_slack.setup.rpt
     tee -file reports/timing/setup.rpt \
-        "report_checks -fields $fields -path_delay max -format full_clock_expanded"
+        "report_checks -sort_by_slack -fields $fields -path_delay max -format full_clock_expanded"
     tee -file reports/timing/setup.topN.rpt -quiet \
-        "report_checks -fields $fields -path_delay max -group_path_count $sta_top_n_paths"
+        "report_checks -sort_by_slack -fields $fields -path_delay max \
+        -group_path_count $sta_top_n_paths"
+    tee -quiet -file reports/timing/setup.failing.rpt \
+        "report_checks -sort_by_slack -path_delay max -slack_max 0 -endpoint_path_count 1 \
+        -group_path_count $sta_top_n_paths -format short"
+    tee -quiet -file reports/timing/setup.endpoints.rpt \
+        "report_checks -sort_by_slack -path_delay max -endpoint_path_count 1 \
+        -group_path_count $sta_top_n_paths -format end"
 
     tee -file reports/timing/worst_slack.setup.rpt \
         "report_worst_slack -max"
@@ -29,22 +44,37 @@ if { [sc_cfg_tool_task_check_in_list setup var reports] } {
         tee -quiet -file reports/timing/setup.histogram.rpt \
             "report_timing_histogram -num_bins 20 -setup"
     }
+
+    sc_report_scene_timing -delay max -name setup \
+        -fields $fields -top_paths $sta_top_n_paths
 }
 
 if { [sc_cfg_tool_task_check_in_list hold var reports] } {
     sc_report_banner "Hold timing" \
         reports/timing/hold.rpt \
         reports/timing/hold.topN.rpt \
-        reports/timing/worst_slack.hold.rpt
+        reports/timing/hold.failing.rpt \
+        reports/timing/hold.endpoints.rpt \
+        reports/timing/worst_slack.hold.rpt \
+        reports/timing/total_negative_slack.hold.rpt
     tee -quiet -file reports/timing/hold.rpt \
-        "report_checks -fields $fields -path_delay min -format full_clock_expanded"
+        "report_checks -sort_by_slack -fields $fields -path_delay min -format full_clock_expanded"
     tee -file reports/timing/hold.topN.rpt -quiet \
-        "report_checks -fields $fields -path_delay min -group_path_count $sta_top_n_paths"
+        "report_checks -sort_by_slack -fields $fields -path_delay min \
+        -group_path_count $sta_top_n_paths"
+    tee -quiet -file reports/timing/hold.failing.rpt \
+        "report_checks -sort_by_slack -path_delay min -slack_max 0 -endpoint_path_count 1 \
+        -group_path_count $sta_top_n_paths -format short"
+    tee -quiet -file reports/timing/hold.endpoints.rpt \
+        "report_checks -sort_by_slack -path_delay min -endpoint_path_count 1 \
+        -group_path_count $sta_top_n_paths -format end"
 
     tee -file reports/timing/worst_slack.hold.rpt \
         "report_worst_slack -min"
     report_worst_slack_metric -hold
 
+    tee -file reports/timing/total_negative_slack.hold.rpt \
+        "report_tns -min"
     report_tns_metric -hold
 
     if { [sc_check_version 24 3 3932] && [llength [all_clocks]] > 0 } {
@@ -52,6 +82,9 @@ if { [sc_cfg_tool_task_check_in_list hold var reports] } {
         tee -quiet -file reports/timing/hold.histogram.rpt \
             "report_timing_histogram -num_bins 20 -hold"
     }
+
+    sc_report_scene_timing -delay min -name hold \
+        -fields $fields -top_paths $sta_top_n_paths
 }
 
 if { [sc_cfg_tool_task_check_in_list unconstrained var reports] } {
@@ -59,10 +92,11 @@ if { [sc_cfg_tool_task_check_in_list unconstrained var reports] } {
         reports/timing/unconstrained.rpt \
         reports/timing/unconstrained.topN.rpt
     tee -file reports/timing/unconstrained.rpt \
-        "report_checks -fields $fields -unconstrained -format full_clock_expanded \
+        "report_checks -sort_by_slack -fields $fields -unconstrained -format full_clock_expanded \
         -path_group unconstrained"
     tee -file reports/timing/unconstrained.topN.rpt -quiet \
-        "report_checks -fields $fields -unconstrained -group_path_count $sta_top_n_paths"
+        "report_checks -sort_by_slack -fields $fields -unconstrained \
+        -group_path_count $sta_top_n_paths"
 }
 
 if {
@@ -112,20 +146,38 @@ if {
 utl::metric_int "timing__clocks" [llength [all_clocks]]
 
 if { [sc_cfg_tool_task_check_in_list fmax var reports] } {
-    sc_report_banner "Fmax"
+    set fmax_report ""
+    if { [llength [all_clocks]] > 0 } {
+        sc_report_banner "Fmax" \
+            reports/clocks/fmax.rpt
+        set fmax_report [open reports/clocks/fmax.rpt w]
+        puts $fmax_report [format "%-30s %12s %12s %12s %10s" \
+            "clock" "period" "min_period" "fmax_mhz" "registers"]
+    } else {
+        sc_report_banner "Fmax"
+    }
     # Model on: https://github.com/The-OpenROAD-Project/OpenSTA/blob/f913c3ddbb3e7b4364ed4437c65ac78c4da9174b/tcl/Search.tcl#L1078
     set fmax_metric 0
     foreach clk [sta::sort_by_name [all_clocks]] {
         set clk_name [get_name $clk]
+        set period [get_property $clk period]
+        set regs [llength [all_registers -clock $clk]]
         set min_period [sta::find_clk_min_period $clk 1]
         if { $min_period == 0.0 } {
+            puts $fmax_report [format "%-30s %12.4f %12s %12s %10d" \
+                $clk_name $period "-" "-" $regs]
             continue
         }
         set fmax [expr { 1.0 / $min_period }]
-        set regs [llength [all_registers -clock $clk]]
         utl::metric_float "timing__fmax__clock:${clk_name}" $fmax
         puts "$clk_name fmax = [format %.2f [expr { $fmax / 1e6 }]] MHz (registers: $regs)"
+        puts $fmax_report [format "%-30s %12.4f %12.4f %12.2f %10d" \
+            $clk_name $period [sta::time_sta_ui $min_period] \
+            [expr { $fmax / 1e6 }] $regs]
         set fmax_metric [expr { max($fmax_metric, $fmax) }]
+    }
+    if { $fmax_report != "" } {
+        close $fmax_report
     }
     if { $fmax_metric == 0 } {
         # attempt to compute based on combinatorial path
@@ -194,11 +246,66 @@ if { [sc_cfg_tool_task_check_in_list power var reports] } {
     }
 
     report_power_metric -corner [sc_cfg_tool_task_get var power_corner]
+
+    puts "report: reports/power/activity_annotation.rpt"
+    tee -quiet -file reports/power/activity_annotation.rpt \
+        "report_activity_annotation"
 }
 
 sc_report_banner "Design area"
 report_design_area
 report_design_area_metrics
+
+if { [sc_cfg_tool_task_check_in_list design_stats var reports] } {
+    sc_report_banner "Design statistics" \
+        reports/design/area.rpt \
+        reports/design/registers.rpt \
+        reports/design/high_fanout.rpt \
+        reports/design/logic_depth.rpt
+
+    tee -quiet -file reports/design/area.rpt {report_design_area}
+
+    set regs []
+    foreach inst [all_registers] {
+        lappend regs [get_full_name $inst]
+    }
+    set fid [open reports/design/registers.rpt w]
+    foreach reg [lsort $regs] {
+        puts $fid $reg
+    }
+    close $fid
+    puts "Registers: [llength $regs]"
+
+    set net_fanouts []
+    foreach net [[ord::get_db_block] getNets] {
+        set sig_type [$net getSigType]
+        if { $sig_type == "POWER" || $sig_type == "GROUND" || $sig_type == "CLOCK" } {
+            continue
+        }
+        set loads 0
+        foreach iterm [$net getITerms] {
+            if { [$iterm isInputSignal] } {
+                incr loads
+            }
+        }
+        foreach bterm [$net getBTerms] {
+            if { [$bterm getIoType] == "OUTPUT" } {
+                incr loads
+            }
+        }
+        lappend net_fanouts [list [$net getName] $loads]
+    }
+    set net_fanouts [lsort -integer -decreasing -index 1 $net_fanouts]
+    set fid [open reports/design/high_fanout.rpt w]
+    puts $fid [format "%-60s %8s" "net" "fanout"]
+    foreach net_info [lrange $net_fanouts 0 49] {
+        lassign $net_info net_name net_fanout
+        puts $fid [format "%-60s %8d" $net_name $net_fanout]
+    }
+    close $fid
+
+    sc_count_logic_depth -report reports/design/logic_depth.rpt
+}
 
 if { ![sc_check_version 26 2 219] } {
     # get number of nets in design

--- a/siliconcompiler/tools/openroad/synth_cleanup.py
+++ b/siliconcompiler/tools/openroad/synth_cleanup.py
@@ -50,6 +50,7 @@ class CleanupSynthTask(APRTask, OpenROADSTAParameter):
         self.set_script("apr/sc_cleanup_synth.tcl")
 
         self._set_reports([
+            'scenarios',
             'check_setup',
             'setup',
             'unconstrained',

--- a/siliconcompiler/tools/openroad/write_data.py
+++ b/siliconcompiler/tools/openroad/write_data.py
@@ -129,6 +129,8 @@ class WriteViewsTask(APRTask, OpenROADSTAParameter, OpenROADPSMParameter):
             'floating_nets',
             'overdriven_nets',
             "logicdepth",
+            'design_stats',
+            'scenarios',
 
             # Images
             'snapshot',

--- a/siliconcompiler/tools/opensta/scripts/sc_procs.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_procs.tcl
@@ -2,21 +2,41 @@
 # Count the logic depth of the critical path
 ###########################
 
-proc sc_count_logic_depth { } {
+proc sc_count_logic_depth { args } {
+    sta::parse_key_args "sc_count_logic_depth" args \
+        keys {-report} \
+        flags {}
+
     set count 0
+    set drivers []
     set paths [find_timing_paths -sort_by_slack]
-    if { [llength $paths] == 0 } {
-        return 0
-    }
-    set path_ref [[lindex $paths 0] path]
-    set pins [$path_ref pins]
-    foreach pin $pins {
-        if { [$pin is_driver] } {
-            incr count
+    if { [llength $paths] > 0 } {
+        set path_ref [[lindex $paths 0] path]
+        set pins [$path_ref pins]
+        foreach pin $pins {
+            if { [$pin is_driver] } {
+                incr count
+                lappend drivers [get_full_name $pin]
+            }
         }
     }
     # Subtract 1 to account for initial launch
-    return [expr { $count - 1 }]
+    set depth [expr { max($count - 1, 0) }]
+
+    if { [info exists keys(-report)] } {
+        set fid [open $keys(-report) w]
+        puts $fid "Logic depth: $depth"
+        if { [llength $drivers] > 0 } {
+            puts $fid ""
+            puts $fid "Critical path drivers:"
+            foreach driver $drivers {
+                puts $fid "  $driver"
+            }
+        }
+        close $fid
+    }
+
+    return $depth
 }
 
 proc sc_design_area { } {
@@ -65,6 +85,80 @@ proc sc_path_group { args } {
         return
     }
     group_path -name $keys(-name) -from $keys(-from) -to $keys(-to)
+}
+
+proc sc_report_check_timing { } {
+    sc_report_banner "Check timing setup"
+    file mkdir reports/constraints/check_timing
+    set checks "generated_clocks loops multiple_clock no_clock no_input_delay \
+        no_output_delay unconstrained_endpoints"
+    foreach check $checks {
+        puts "report: reports/constraints/check_timing/${check}.rpt"
+        check_setup -${check} > reports/constraints/check_timing/${check}.rpt
+    }
+}
+
+proc sc_report_corner_timing { args } {
+    sta::parse_key_args "sc_report_corner_timing" args \
+        keys {-delay -name -fields -top_paths} \
+        flags {}
+
+    global sc_scenarios
+
+    # A single corner would just duplicate the combined timing reports
+    if { [llength $sc_scenarios] <= 1 } {
+        return
+    }
+
+    foreach corner $sc_scenarios {
+        puts "report: reports/timing/$keys(-name).${corner}.rpt"
+        report_checks -sort_by_slack -fields $keys(-fields) -path_delay $keys(-delay) \
+            -format full_clock_expanded -corner $corner \
+            > reports/timing/$keys(-name).${corner}.rpt
+        puts "report: reports/timing/$keys(-name).topN.${corner}.rpt"
+        report_checks -sort_by_slack -path_delay $keys(-delay) \
+            -group_path_count $keys(-top_paths) -corner $corner \
+            > reports/timing/$keys(-name).topN.${corner}.rpt
+    }
+}
+
+proc sc_report_scenarios { } {
+    global opensta_timing_mode
+    global sc_scenarios
+    global sc_sdc_files_read
+
+    file mkdir reports/constraints
+    set fid [open reports/constraints/scenarios.rpt w]
+
+    puts $fid "Timing scenarios:"
+    if { $opensta_timing_mode == "asic" } {
+        foreach scenario $sc_scenarios {
+            puts $fid "  ${scenario}:"
+            puts $fid \
+                "    libcorner: [sc_cfg_get constraint timing scenario $scenario libcorner]"
+            puts $fid \
+                "    pexcorner: [sc_cfg_get constraint timing scenario $scenario pexcorner]"
+            puts $fid "    mode: [sc_cfg_get constraint timing scenario $scenario mode]"
+            puts $fid "    checks: [sc_cfg_get constraint timing scenario $scenario check]"
+        }
+    } else {
+        foreach scenario $sc_scenarios {
+            puts $fid "  ${scenario}"
+        }
+    }
+
+    puts $fid ""
+    puts $fid "SDC files loaded:"
+    if { [info exists sc_sdc_files_read] && [llength $sc_sdc_files_read] > 0 } {
+        foreach sdc $sc_sdc_files_read {
+            puts $fid "  $sdc"
+        }
+    } else {
+        puts $fid "  none"
+    }
+    close $fid
+
+    sc_display_report reports/constraints/scenarios.rpt
 }
 
 proc sc_is_scene_enabled { scene check } {

--- a/siliconcompiler/tools/opensta/scripts/sc_procs.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_procs.tcl
@@ -30,6 +30,17 @@ proc sc_design_area { } {
     return $area
 }
 
+proc sc_report_banner { title args } {
+    set width 60
+    puts ""
+    puts [string repeat "=" $width]
+    puts "== $title"
+    foreach report $args {
+        puts "== report: $report"
+    }
+    puts [string repeat "=" $width]
+}
+
 proc sc_display_report { report } {
     if { ![file exists $report] } {
         return

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -245,8 +245,10 @@ if { [llength $sc_power_activities] == 0 } {
 # Report how much of the design's switching activity was annotated from the VCD
 if { $sc_read_vcd } {
     puts "Reporting power activity annotation coverage"
+    puts "report: reports/power/activity_annotation.rpt"
+    file mkdir reports/power
     report_activity_annotation -report_annotated -report_unannotated > \
-        reports/activity_annotation.rpt
+        reports/power/activity_annotation.rpt
 }
 
 ###############################
@@ -279,6 +281,12 @@ if { [sc_cfg_tool_task_get var write_liberty] } {
 # Report Metrics
 ###############################
 
+file mkdir \
+    reports/checks \
+    reports/clocks \
+    reports/power \
+    reports/timing
+
 set opensta_top_n_paths [sc_cfg_tool_task_get var top_n_paths]
 
 set fields "{capacitance slew input_pins hierarcial_pins net fanout}"
@@ -287,34 +295,42 @@ set PREFIX "SC_METRIC:"
 puts "$PREFIX timeunit"
 puts [sta::unit_scale_abbreviation time]
 
+sc_report_banner "Setup timing" \
+    reports/timing/setup.rpt \
+    reports/timing/setup.topN.rpt \
+    reports/timing/worst_slack.setup.rpt \
+    reports/timing/total_negative_slack.setup.rpt
 puts "$PREFIX report_checks -path_delay max"
 report_checks -fields $fields -path_delay max -format full_clock_expanded \
-    > reports/setup.rpt
-sc_display_report reports/setup.rpt
-report_checks -path_delay max -group_count $opensta_top_n_paths \
-    > reports/setup.topN.rpt
+    > reports/timing/setup.rpt
+sc_display_report reports/timing/setup.rpt
+report_checks -path_delay max -group_path_count $opensta_top_n_paths \
+    > reports/timing/setup.topN.rpt
 
 puts "$PREFIX setupslack"
-report_worst_slack -max > reports/worst_slack.setup.rpt
-sc_display_report reports/worst_slack.setup.rpt
+report_worst_slack -max > reports/timing/worst_slack.setup.rpt
+sc_display_report reports/timing/worst_slack.setup.rpt
 
 puts "$PREFIX setuppaths"
 puts [sta::endpoint_violation_count max]
 
 puts "$PREFIX setuptns"
-report_tns > reports/total_negative_slack.rpt
-sc_display_report reports/total_negative_slack.rpt
+report_tns > reports/timing/total_negative_slack.setup.rpt
+sc_display_report reports/timing/total_negative_slack.setup.rpt
 
+sc_report_banner "Hold timing" \
+    reports/timing/hold.rpt \
+    reports/timing/hold.topN.rpt \
+    reports/timing/worst_slack.hold.rpt
 puts "$PREFIX report_checks -path_delay min"
 report_checks -fields $fields -path_delay min -format full_clock_expanded \
-    > reports/hold.rpt
-sc_display_report reports/hold.rpt
-report_checks -path_delay min -group_count $opensta_top_n_paths \
-    > reports/hold.topN.rpt
+    > reports/timing/hold.rpt
+report_checks -path_delay min -group_path_count $opensta_top_n_paths \
+    > reports/timing/hold.topN.rpt
 
 puts "$PREFIX holdslack"
-report_worst_slack -min > reports/worst_slack.hold.rpt
-sc_display_report reports/worst_slack.hold.rpt
+report_worst_slack -min > reports/timing/worst_slack.hold.rpt
+sc_display_report reports/timing/worst_slack.hold.rpt
 
 puts "$PREFIX holdpaths"
 puts [sta::endpoint_violation_count max]
@@ -322,26 +338,34 @@ puts [sta::endpoint_violation_count max]
 puts "$PREFIX holdtns"
 puts "tns [sta::time_sta_ui [sta::total_negative_slack_cmd min]]"
 
+sc_report_banner "Unconstrained paths" \
+    reports/timing/unconstrained.rpt \
+    reports/timing/unconstrained.topN.rpt
 report_checks -fields $fields -unconstrained -format full_clock_expanded \
-    -path_group unconstrained > reports/unconstrained.rpt
-sc_display_report reports/unconstrained.rpt
-report_checks -unconstrained -group_count $opensta_top_n_paths \
-    > reports/unconstrained.topN.rpt
+    -path_group unconstrained > reports/timing/unconstrained.rpt
+sc_display_report reports/timing/unconstrained.rpt
+report_checks -unconstrained -group_path_count $opensta_top_n_paths \
+    > reports/timing/unconstrained.topN.rpt
 
 if { [llength [all_clocks]] > 0 } {
+    sc_report_banner "Clock skew" \
+        reports/clocks/skew.setup.rpt \
+        reports/clocks/skew.hold.rpt
     puts "$PREFIX setupskew"
-    report_clock_skew -setup -digits 4 > reports/skew.setup.rpt
-    sc_display_report reports/skew.setup.rpt
+    report_clock_skew -setup -digits 4 > reports/clocks/skew.setup.rpt
+    sc_display_report reports/clocks/skew.setup.rpt
     puts "$PREFIX holdskew"
-    report_clock_skew -hold -digits 4 > reports/skew.hold.rpt
-    sc_display_report reports/skew.hold.rpt
+    report_clock_skew -hold -digits 4 > reports/clocks/skew.hold.rpt
+    sc_display_report reports/clocks/skew.hold.rpt
 }
 
+sc_report_banner "DRV violators" \
+    reports/checks/drv_violators.rpt
 puts "$PREFIX drvs"
 report_check_types -max_slew -max_capacitance -max_fanout -violators -no_line_splits \
-    > reports/drv_violators.rpt
-sc_display_report reports/drv_violators.rpt
+    > reports/checks/drv_violators.rpt
 
+sc_report_banner "Fmax"
 # Model on: https://github.com/The-OpenROAD-Project/OpenSTA/blob/f913c3ddbb3e7b4364ed4437c65ac78c4da9174b/tcl/Search.tcl#L1078
 set fmax_metric 0
 foreach clk [sta::sort_by_name [all_clocks]] {
@@ -363,6 +387,7 @@ if { $fmax_metric > 0 } {
 puts "$PREFIX logicdepth"
 puts [sc_count_logic_depth]
 
+sc_report_banner "Power"
 puts "$PREFIX power"
 foreach scene $sc_scenarios {
     if {
@@ -373,10 +398,12 @@ foreach scene $sc_scenarios {
         continue
     }
     puts "Power for scene: $scene"
-    report_power -corner $scene > reports/power.${scene}.rpt
-    sc_display_report reports/power.${scene}.rpt
+    puts "report: reports/power/${scene}.rpt"
+    report_power -corner $scene > reports/power/${scene}.rpt
+    sc_display_report reports/power/${scene}.rpt
 }
 
+sc_report_banner "Design statistics"
 puts "$PREFIX cells"
 puts [llength [get_cells *]]
 

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -98,10 +98,13 @@ if { [file exists "inputs/${sc_topmodule}.vg"] } {
 link_design $sc_topmodule
 
 # Read SDC (in order of priority)
+# Record every SDC read so sc_report_scenarios can list them
+set sc_sdc_files_read []
 if { [file exists "inputs/${sc_topmodule}.sdc"] } {
     # get from previous step
     puts "Reading SDC: inputs/${sc_topmodule}.sdc"
     read_sdc "inputs/${sc_topmodule}.sdc"
+    lappend sc_sdc_files_read "inputs/${sc_topmodule}.sdc"
 } else {
     set sdc_files []
     set base_sdcs []
@@ -114,6 +117,7 @@ if { [file exists "inputs/${sc_topmodule}.sdc"] } {
         puts "Reading SDC: ${sdc}"
         read_sdc $sdc
         lappend sdc_files $sdc
+        lappend sc_sdc_files_read $sdc
     }
 
     if { $sc_timing_mode != {} } {
@@ -127,6 +131,7 @@ if { [file exists "inputs/${sc_topmodule}.sdc"] } {
                         puts "Reading mode (${sc_timing_mode}) SDC: ${sdc}"
                         lappend sdc_files $sdc
                         read_sdc $sdc
+                        lappend sc_sdc_files_read "(${sc_timing_mode}) $sdc"
                     }
                 }
             }
@@ -284,6 +289,8 @@ if { [sc_cfg_tool_task_get var write_liberty] } {
 file mkdir \
     reports/checks \
     reports/clocks \
+    reports/constraints \
+    reports/design \
     reports/power \
     reports/timing
 
@@ -295,59 +302,103 @@ set PREFIX "SC_METRIC:"
 puts "$PREFIX timeunit"
 puts [sta::unit_scale_abbreviation time]
 
-sc_report_banner "Setup timing" \
-    reports/timing/setup.rpt \
-    reports/timing/setup.topN.rpt \
-    reports/timing/worst_slack.setup.rpt \
-    reports/timing/total_negative_slack.setup.rpt
-puts "$PREFIX report_checks -sort_by_slack -path_delay max"
-report_checks -sort_by_slack -fields $fields -path_delay max -format full_clock_expanded \
-    > reports/timing/setup.rpt
-sc_display_report reports/timing/setup.rpt
-report_checks -sort_by_slack -path_delay max -group_path_count $opensta_top_n_paths \
-    > reports/timing/setup.topN.rpt
+if { [sc_cfg_tool_task_check_in_list scenarios var reports] } {
+    sc_report_banner "Timing scenarios" \
+        reports/constraints/scenarios.rpt
+    sc_report_scenarios
+}
 
-puts "$PREFIX setupslack"
-report_worst_slack -max > reports/timing/worst_slack.setup.rpt
-sc_display_report reports/timing/worst_slack.setup.rpt
+if { [sc_cfg_tool_task_check_in_list check_setup var reports] } {
+    sc_report_check_timing
+}
 
-puts "$PREFIX setuppaths"
-puts [sta::endpoint_violation_count max]
+if { [sc_cfg_tool_task_check_in_list setup var reports] } {
+    sc_report_banner "Setup timing" \
+        reports/timing/setup.rpt \
+        reports/timing/setup.topN.rpt \
+        reports/timing/setup.failing.rpt \
+        reports/timing/setup.endpoints.rpt \
+        reports/timing/worst_slack.setup.rpt \
+        reports/timing/total_negative_slack.setup.rpt
+    puts "$PREFIX report_checks -path_delay max"
+    report_checks -sort_by_slack -fields $fields -path_delay max \
+        -format full_clock_expanded \
+        > reports/timing/setup.rpt
+    sc_display_report reports/timing/setup.rpt
+    report_checks -sort_by_slack -path_delay max -group_path_count $opensta_top_n_paths \
+        > reports/timing/setup.topN.rpt
+    report_checks -sort_by_slack -path_delay max -slack_max 0 -endpoint_path_count 1 \
+        -group_path_count $opensta_top_n_paths -format short \
+        > reports/timing/setup.failing.rpt
+    report_checks -sort_by_slack -path_delay max -endpoint_path_count 1 \
+        -group_path_count $opensta_top_n_paths -format end \
+        > reports/timing/setup.endpoints.rpt
+    sc_report_corner_timing -delay max -name setup \
+        -fields $fields -top_paths $opensta_top_n_paths
 
-puts "$PREFIX setuptns"
-report_tns > reports/timing/total_negative_slack.setup.rpt
-sc_display_report reports/timing/total_negative_slack.setup.rpt
+    puts "$PREFIX setupslack"
+    report_worst_slack -max > reports/timing/worst_slack.setup.rpt
+    sc_display_report reports/timing/worst_slack.setup.rpt
 
-sc_report_banner "Hold timing" \
-    reports/timing/hold.rpt \
-    reports/timing/hold.topN.rpt \
-    reports/timing/worst_slack.hold.rpt
-puts "$PREFIX report_checks -sort_by_slack -path_delay min"
-report_checks -sort_by_slack -fields $fields -path_delay min -format full_clock_expanded \
-    > reports/timing/hold.rpt
-report_checks -sort_by_slack -path_delay min -group_path_count $opensta_top_n_paths \
-    > reports/timing/hold.topN.rpt
+    puts "$PREFIX setuppaths"
+    puts [sta::endpoint_violation_count max]
 
-puts "$PREFIX holdslack"
-report_worst_slack -min > reports/timing/worst_slack.hold.rpt
-sc_display_report reports/timing/worst_slack.hold.rpt
+    puts "$PREFIX setuptns"
+    report_tns > reports/timing/total_negative_slack.setup.rpt
+    sc_display_report reports/timing/total_negative_slack.setup.rpt
+}
 
-puts "$PREFIX holdpaths"
-puts [sta::endpoint_violation_count max]
+if { [sc_cfg_tool_task_check_in_list hold var reports] } {
+    sc_report_banner "Hold timing" \
+        reports/timing/hold.rpt \
+        reports/timing/hold.topN.rpt \
+        reports/timing/hold.failing.rpt \
+        reports/timing/hold.endpoints.rpt \
+        reports/timing/worst_slack.hold.rpt \
+        reports/timing/total_negative_slack.hold.rpt
+    puts "$PREFIX report_checks -path_delay min"
+    report_checks -sort_by_slack -fields $fields -path_delay min \
+        -format full_clock_expanded \
+        > reports/timing/hold.rpt
+    report_checks -sort_by_slack -path_delay min -group_path_count $opensta_top_n_paths \
+        > reports/timing/hold.topN.rpt
+    report_checks -sort_by_slack -path_delay min -slack_max 0 -endpoint_path_count 1 \
+        -group_path_count $opensta_top_n_paths -format short \
+        > reports/timing/hold.failing.rpt
+    report_checks -sort_by_slack -path_delay min -endpoint_path_count 1 \
+        -group_path_count $opensta_top_n_paths -format end \
+        > reports/timing/hold.endpoints.rpt
+    sc_report_corner_timing -delay min -name hold \
+        -fields $fields -top_paths $opensta_top_n_paths
 
-puts "$PREFIX holdtns"
-puts "tns [sta::time_sta_ui [sta::total_negative_slack_cmd min]]"
+    puts "$PREFIX holdslack"
+    report_worst_slack -min > reports/timing/worst_slack.hold.rpt
+    sc_display_report reports/timing/worst_slack.hold.rpt
 
-sc_report_banner "Unconstrained paths" \
-    reports/timing/unconstrained.rpt \
-    reports/timing/unconstrained.topN.rpt
-report_checks -sort_by_slack -fields $fields -unconstrained -format full_clock_expanded \
-    -path_group unconstrained > reports/timing/unconstrained.rpt
-sc_display_report reports/timing/unconstrained.rpt
-report_checks -sort_by_slack -unconstrained -group_path_count $opensta_top_n_paths \
-    > reports/timing/unconstrained.topN.rpt
+    puts "$PREFIX holdpaths"
+    puts [sta::endpoint_violation_count max]
 
-if { [llength [all_clocks]] > 0 } {
+    puts "$PREFIX holdtns"
+    report_tns -min > reports/timing/total_negative_slack.hold.rpt
+    puts "tns [sta::time_sta_ui [sta::total_negative_slack_cmd min]]"
+}
+
+if { [sc_cfg_tool_task_check_in_list unconstrained var reports] } {
+    sc_report_banner "Unconstrained paths" \
+        reports/timing/unconstrained.rpt \
+        reports/timing/unconstrained.topN.rpt
+    report_checks -sort_by_slack -fields $fields -unconstrained \
+        -format full_clock_expanded \
+        -path_group unconstrained > reports/timing/unconstrained.rpt
+    sc_display_report reports/timing/unconstrained.rpt
+    report_checks -sort_by_slack -unconstrained -group_path_count $opensta_top_n_paths \
+        > reports/timing/unconstrained.topN.rpt
+}
+
+if {
+    [sc_cfg_tool_task_check_in_list clock_skew var reports] &&
+    [llength [all_clocks]] > 0
+} {
     sc_report_banner "Clock skew" \
         reports/clocks/skew.setup.rpt \
         reports/clocks/skew.hold.rpt
@@ -359,51 +410,121 @@ if { [llength [all_clocks]] > 0 } {
     sc_display_report reports/clocks/skew.hold.rpt
 }
 
-sc_report_banner "DRV violators" \
-    reports/checks/drv_violators.rpt
-puts "$PREFIX drvs"
-report_check_types -max_slew -max_capacitance -max_fanout -violators -no_line_splits \
-    > reports/checks/drv_violators.rpt
-
-sc_report_banner "Fmax"
-# Model on: https://github.com/The-OpenROAD-Project/OpenSTA/blob/f913c3ddbb3e7b4364ed4437c65ac78c4da9174b/tcl/Search.tcl#L1078
-set fmax_metric 0
-foreach clk [sta::sort_by_name [all_clocks]] {
-    puts "$PREFIX fmax"
-    set clk_name [get_name $clk]
-    set min_period [sta::find_clk_min_period $clk 1]
-    if { $min_period == 0.0 } {
-        continue
-    }
-    set fmax [expr { 1.0 / $min_period }]
-    puts "$clk_name fmax = [format %.2f [expr { $fmax / 1e6 }]] MHz"
-    set fmax_metric [expr { max($fmax_metric, $fmax) }]
+if { [sc_cfg_tool_task_check_in_list drv_violations var reports] } {
+    sc_report_banner "DRV violators" \
+        reports/checks/drv_violators.rpt
+    puts "$PREFIX drvs"
+    report_check_types -max_slew -max_capacitance -max_fanout -violators -no_line_splits \
+        > reports/checks/drv_violators.rpt
 }
-if { $fmax_metric > 0 } {
-    puts "fmax = [format %.2f [expr { $fmax_metric / 1e6 }]] MHz"
+
+if { [sc_cfg_tool_task_check_in_list fmax var reports] } {
+    set fmax_report ""
+    if { [llength [all_clocks]] > 0 } {
+        sc_report_banner "Fmax" \
+            reports/clocks/fmax.rpt
+        set fmax_report [open reports/clocks/fmax.rpt w]
+        puts $fmax_report [format "%-30s %12s %12s %12s %10s" \
+            "clock" "period" "min_period" "fmax_mhz" "registers"]
+    } else {
+        sc_report_banner "Fmax"
+    }
+    # Model on: https://github.com/The-OpenROAD-Project/OpenSTA/blob/f913c3ddbb3e7b4364ed4437c65ac78c4da9174b/tcl/Search.tcl#L1078
+    set fmax_metric 0
+    foreach clk [sta::sort_by_name [all_clocks]] {
+        puts "$PREFIX fmax"
+        set clk_name [get_name $clk]
+        set period [get_property $clk period]
+        set regs [llength [all_registers -clock $clk]]
+        set min_period [sta::find_clk_min_period $clk 1]
+        if { $min_period == 0.0 } {
+            puts $fmax_report [format "%-30s %12.4f %12s %12s %10d" \
+                $clk_name $period "-" "-" $regs]
+            continue
+        }
+        set fmax [expr { 1.0 / $min_period }]
+        puts "$clk_name fmax = [format %.2f [expr { $fmax / 1e6 }]] MHz"
+        puts $fmax_report [format "%-30s %12.4f %12.4f %12.2f %10d" \
+            $clk_name $period [sta::time_sta_ui $min_period] \
+            [expr { $fmax / 1e6 }] $regs]
+        set fmax_metric [expr { max($fmax_metric, $fmax) }]
+    }
+    if { $fmax_report != "" } {
+        close $fmax_report
+    }
+    if { $fmax_metric > 0 } {
+        puts "fmax = [format %.2f [expr { $fmax_metric / 1e6 }]] MHz"
+    }
 }
 
 # get logic depth of design
-puts "$PREFIX logicdepth"
-puts [sc_count_logic_depth]
-
-sc_report_banner "Power"
-puts "$PREFIX power"
-foreach scene $sc_scenarios {
-    if {
-        ![sc_is_scene_enabled $scene power] &&
-        ![sc_is_scene_enabled $scene leakagepower] &&
-        ![sc_is_scene_enabled $scene dynamicpower]
-    } {
-        continue
-    }
-    puts "Power for scene: $scene"
-    puts "report: reports/power/${scene}.rpt"
-    report_power -corner $scene > reports/power/${scene}.rpt
-    sc_display_report reports/power/${scene}.rpt
+if { [sc_cfg_tool_task_check_in_list logicdepth var reports] } {
+    puts "$PREFIX logicdepth"
+    puts [sc_count_logic_depth]
 }
 
-sc_report_banner "Design statistics"
+if { [sc_cfg_tool_task_check_in_list power var reports] } {
+    sc_report_banner "Power"
+    puts "$PREFIX power"
+    foreach scene $sc_scenarios {
+        if {
+            ![sc_is_scene_enabled $scene power] &&
+            ![sc_is_scene_enabled $scene leakagepower] &&
+            ![sc_is_scene_enabled $scene dynamicpower]
+        } {
+            continue
+        }
+        puts "Power for scene: $scene"
+        puts "report: reports/power/${scene}.rpt"
+        report_power -corner $scene > reports/power/${scene}.rpt
+        sc_display_report reports/power/${scene}.rpt
+    }
+}
+
+if { [sc_cfg_tool_task_check_in_list design_stats var reports] } {
+    sc_report_banner "Design statistics" \
+        reports/design/area.rpt \
+        reports/design/registers.rpt \
+        reports/design/high_fanout.rpt \
+        reports/design/logic_depth.rpt
+
+    set fid [open reports/design/area.rpt w]
+    puts $fid "Design area: [sc_design_area]"
+    close $fid
+
+    set design_regs []
+    foreach inst [all_registers] {
+        lappend design_regs [get_full_name $inst]
+    }
+    set fid [open reports/design/registers.rpt w]
+    foreach reg [lsort $design_regs] {
+        puts $fid $reg
+    }
+    close $fid
+
+    set net_fanouts []
+    foreach net [get_nets -hierarchical *] {
+        set loads 0
+        foreach pin [get_pins -quiet -of_objects $net] {
+            if { [get_property $pin direction] == "input" } {
+                incr loads
+            }
+        }
+        lappend net_fanouts [list [get_full_name $net] $loads]
+    }
+    set net_fanouts [lsort -integer -decreasing -index 1 $net_fanouts]
+    set fid [open reports/design/high_fanout.rpt w]
+    puts $fid [format "%-60s %8s" "net" "fanout"]
+    foreach net_info [lrange $net_fanouts 0 49] {
+        lassign $net_info net_name net_fanout
+        puts $fid [format "%-60s %8d" $net_name $net_fanout]
+    }
+    close $fid
+
+    sc_count_logic_depth -report reports/design/logic_depth.rpt
+} else {
+    sc_report_banner "Design statistics"
+}
 puts "$PREFIX cells"
 puts [llength [get_cells *]]
 
@@ -445,10 +566,12 @@ puts "$PREFIX pins"
 puts [llength [get_ports *]]
 
 # get number of unconstrained endpoints
-with_output_to_variable endpoints {check_setup -unconstrained_endpoints}
-set unconstrained_endpoints [regexp -all -inline {[0-9]+} $endpoints]
-if { $unconstrained_endpoints == "" } {
-    set unconstrained_endpoints 0
+if { [sc_cfg_tool_task_check_in_list unconstrained var reports] } {
+    with_output_to_variable endpoints {check_setup -unconstrained_endpoints}
+    set unconstrained_endpoints [regexp -all -inline {[0-9]+} $endpoints]
+    if { $unconstrained_endpoints == "" } {
+        set unconstrained_endpoints 0
+    }
+    puts "$PREFIX unconstrained"
+    puts $unconstrained_endpoints
 }
-puts "$PREFIX unconstrained"
-puts $unconstrained_endpoints

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -376,7 +376,7 @@ if { [sc_cfg_tool_task_check_in_list hold var reports] } {
     sc_display_report reports/timing/worst_slack.hold.rpt
 
     puts "$PREFIX holdpaths"
-    puts [sta::endpoint_violation_count max]
+    puts [sta::endpoint_violation_count min]
 
     puts "$PREFIX holdtns"
     report_tns -min > reports/timing/total_negative_slack.hold.rpt
@@ -460,7 +460,7 @@ if { [sc_cfg_tool_task_check_in_list fmax var reports] } {
 # get logic depth of design
 if { [sc_cfg_tool_task_check_in_list logicdepth var reports] } {
     puts "$PREFIX logicdepth"
-    puts [sc_count_logic_depth]
+    puts [sc_count_logic_depth -report reports/design/logic_depth.rpt]
 }
 
 if { [sc_cfg_tool_task_check_in_list power var reports] } {

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -300,11 +300,11 @@ sc_report_banner "Setup timing" \
     reports/timing/setup.topN.rpt \
     reports/timing/worst_slack.setup.rpt \
     reports/timing/total_negative_slack.setup.rpt
-puts "$PREFIX report_checks -path_delay max"
-report_checks -fields $fields -path_delay max -format full_clock_expanded \
+puts "$PREFIX report_checks -sort_by_slack -path_delay max"
+report_checks -sort_by_slack -fields $fields -path_delay max -format full_clock_expanded \
     > reports/timing/setup.rpt
 sc_display_report reports/timing/setup.rpt
-report_checks -path_delay max -group_path_count $opensta_top_n_paths \
+report_checks -sort_by_slack -path_delay max -group_path_count $opensta_top_n_paths \
     > reports/timing/setup.topN.rpt
 
 puts "$PREFIX setupslack"
@@ -322,10 +322,10 @@ sc_report_banner "Hold timing" \
     reports/timing/hold.rpt \
     reports/timing/hold.topN.rpt \
     reports/timing/worst_slack.hold.rpt
-puts "$PREFIX report_checks -path_delay min"
-report_checks -fields $fields -path_delay min -format full_clock_expanded \
+puts "$PREFIX report_checks -sort_by_slack -path_delay min"
+report_checks -sort_by_slack -fields $fields -path_delay min -format full_clock_expanded \
     > reports/timing/hold.rpt
-report_checks -path_delay min -group_path_count $opensta_top_n_paths \
+report_checks -sort_by_slack -path_delay min -group_path_count $opensta_top_n_paths \
     > reports/timing/hold.topN.rpt
 
 puts "$PREFIX holdslack"
@@ -341,10 +341,10 @@ puts "tns [sta::time_sta_ui [sta::total_negative_slack_cmd min]]"
 sc_report_banner "Unconstrained paths" \
     reports/timing/unconstrained.rpt \
     reports/timing/unconstrained.topN.rpt
-report_checks -fields $fields -unconstrained -format full_clock_expanded \
+report_checks -sort_by_slack -fields $fields -unconstrained -format full_clock_expanded \
     -path_group unconstrained > reports/timing/unconstrained.rpt
 sc_display_report reports/timing/unconstrained.rpt
-report_checks -unconstrained -group_path_count $opensta_top_n_paths \
+report_checks -sort_by_slack -unconstrained -group_path_count $opensta_top_n_paths \
     > reports/timing/unconstrained.topN.rpt
 
 if { [llength [all_clocks]] > 0 } {

--- a/siliconcompiler/tools/opensta/timing.py
+++ b/siliconcompiler/tools/opensta/timing.py
@@ -1,10 +1,13 @@
+import fnmatch
 import re
 
 import os.path
 
-from typing import Optional
+from typing import List, Optional, Union
 
 from siliconcompiler import sc_open
+from siliconcompiler.schema import BaseSchema
+from siliconcompiler.schema.parametertype import NodeType
 
 from siliconcompiler.tools.opensta import OpenSTATask
 
@@ -15,6 +18,21 @@ class TimingTaskBase(OpenSTATask):
     '''
     Base class for generating static timing reports.
     '''
+
+    REPORT_TYPES = (
+        "setup",
+        "hold",
+        "unconstrained",
+        "clock_skew",
+        "drv_violations",
+        "fmax",
+        "power",
+        "logicdepth",
+        "check_setup",
+        "design_stats",
+        "scenarios"
+    )
+
     def __init__(self):
         super().__init__()
 
@@ -39,6 +57,11 @@ class TimingTaskBase(OpenSTATask):
                            "read for vector-based power analysis. The scope is the instance path "
                            "of the design top within the VCD. If empty, a VCD is read from the "
                            "active filesets (or the step input) with no scope.")
+
+        self.add_parameter("reports", f"{{<{','.join(self.REPORT_TYPES)}>}}",
+                           "list of reports to generate, auto generated")
+        self.add_parameter("skip_reports", f"{{<{','.join(self.REPORT_TYPES)}>}}",
+                           "list of reports to skip")
 
     def set_opensta_topnpaths(self, n: int,
                               step: Optional[str] = None,
@@ -126,6 +149,43 @@ class TimingTaskBase(OpenSTATask):
         return self.add("var", "power_activities", (scope, library, fileset),
                         step=step, index=index)
 
+    def add_opensta_skipreport(self, report_type: Union[List[str], str],
+                               step: Optional[str] = None, index: Optional[str] = None,
+                               clobber: bool = False) -> None:
+        """
+        Adds or sets report types to be skipped during OpenSTA execution.
+
+        Args:
+            report_type: The name of the report(s) to skip (e.g., 'clock_skew').
+            step: The specific step to apply this configuration to.
+            index: The specific index to apply this configuration to.
+            clobber: If True, overwrites the existing list of skipped reports.
+                     If False, appends to the existing list.
+        """
+        if isinstance(report_type, str):
+            patterns = [report_type]
+        else:
+            patterns = list(report_type)
+
+        if any("*" in pattern for pattern in patterns):
+            enum_type = list(
+                NodeType.parse(BaseSchema.get(self, "var", "skip_reports", field="type")))[0]
+            supported_report_types = sorted(NodeType.parse(enum_type).values)
+            expanded: List[str] = []
+            for pattern in patterns:
+                matches = fnmatch.filter(supported_report_types, pattern)
+                if not matches:
+                    raise ValueError(
+                        f"Report type pattern '{pattern}' did not match any supported "
+                        f"report types: {supported_report_types}")
+                expanded.extend(matches)
+            report_type = expanded
+
+        if clobber:
+            self.set("var", "skip_reports", report_type, step=step, index=index)
+        else:
+            self.add("var", "skip_reports", report_type, step=step, index=index)
+
     def setup(self):
         super().setup()
 
@@ -148,6 +208,13 @@ class TimingTaskBase(OpenSTATask):
         self.add_required_key("var", "unique_path_groups_per_clock")
         # NOTE: opensta_generic_sdc is intentionally not required — the opensta scripts only read it
         # in a commented-out fallback (the live reader is OpenROAD's separate same-named parameter).
+
+        skip_reports = set(self.get("var", "skip_reports"))
+        self.set("var", "reports", set(self.REPORT_TYPES).difference(skip_reports))
+        if self.get("var", "reports"):
+            self.add_required_key("var", "reports")
+        if skip_reports:
+            self.add_required_key("var", "skip_reports")
 
         self.add_required_key("var", "write_sdf")
         if self.get("var", "write_sdf"):
@@ -285,21 +352,39 @@ class TimingTaskBase(OpenSTATask):
     def __report_map(self, metric):
         corners = self.project.getkeys('constraint', 'timing', 'scenario')
         power_reports = [f"reports/power/{corner}.rpt" for corner in corners]
+        setup_reports = [
+            "reports/timing/setup.rpt",
+            "reports/timing/setup.topN.rpt",
+            "reports/timing/setup.failing.rpt",
+            "reports/timing/setup.endpoints.rpt",
+            *[f"reports/timing/setup.{corner}.rpt" for corner in corners],
+            *[f"reports/timing/setup.topN.{corner}.rpt" for corner in corners]
+        ]
+        hold_reports = [
+            "reports/timing/hold.rpt",
+            "reports/timing/hold.topN.rpt",
+            "reports/timing/hold.failing.rpt",
+            "reports/timing/hold.endpoints.rpt",
+            *[f"reports/timing/hold.{corner}.rpt" for corner in corners],
+            *[f"reports/timing/hold.topN.{corner}.rpt" for corner in corners]
+        ]
         mapping = {
             "peakpower": power_reports,
             "leakagepower": power_reports,
             "unconstrained": ["reports/timing/unconstrained.rpt",
                               "reports/timing/unconstrained.topN.rpt"],
-            "setuppaths": ["reports/timing/setup.rpt", "reports/timing/setup.topN.rpt"],
-            "holdpaths": ["reports/timing/hold.rpt", "reports/timing/hold.topN.rpt"],
-            "holdslack": ["reports/timing/hold.rpt", "reports/timing/hold.topN.rpt"],
-            "setupslack": ["reports/timing/setup.rpt", "reports/timing/setup.topN.rpt"],
-            "setuptns": ["reports/timing/setup.rpt", "reports/timing/setup.topN.rpt"],
-            "holdtns": ["reports/timing/hold.rpt", "reports/timing/hold.topN.rpt"],
-            "setupskew": ["reports/clocks/skew.setup.rpt",
-                          "reports/timing/setup.rpt", "reports/timing/setup.topN.rpt"],
-            "holdskew": ["reports/clocks/skew.hold.rpt",
-                         "reports/timing/hold.rpt", "reports/timing/hold.topN.rpt"]
+            "setuppaths": setup_reports,
+            "holdpaths": hold_reports,
+            "holdslack": hold_reports,
+            "setupslack": setup_reports,
+            "setuptns": ["reports/timing/total_negative_slack.setup.rpt", *setup_reports],
+            "holdtns": ["reports/timing/total_negative_slack.hold.rpt", *hold_reports],
+            "setupskew": ["reports/clocks/skew.setup.rpt", *setup_reports],
+            "holdskew": ["reports/clocks/skew.hold.rpt", *hold_reports],
+            "fmax": ["reports/clocks/fmax.rpt"],
+            "logicdepth": ["reports/design/logic_depth.rpt"],
+            "registers": ["reports/design/registers.rpt"],
+            "cellarea": ["reports/design/area.rpt"]
         }
 
         if metric in mapping:

--- a/siliconcompiler/tools/opensta/timing.py
+++ b/siliconcompiler/tools/opensta/timing.py
@@ -272,7 +272,7 @@ class TimingTaskBase(OpenSTATask):
                                    source_file=self.__report_map(skew),
                                    source_unit=timescale)
 
-        drv_report = "reports/drv_violators.rpt"
+        drv_report = "reports/checks/drv_violators.rpt"
         if os.path.exists(drv_report):
             drv_count = 0
             with sc_open(drv_report) as f:
@@ -284,17 +284,22 @@ class TimingTaskBase(OpenSTATask):
 
     def __report_map(self, metric):
         corners = self.project.getkeys('constraint', 'timing', 'scenario')
+        power_reports = [f"reports/power/{corner}.rpt" for corner in corners]
         mapping = {
-            "power": [f"reports/power.{corner}.rpt" for corner in corners],
-            "unconstrained": ["reports/unconstrained.rpt", "reports/unconstrained.topN.rpt"],
-            "setuppaths": ["reports/setup.rpt", "reports/setup.topN.rpt"],
-            "holdpaths": ["reports/hold.rpt", "reports/hold.topN.rpt"],
-            "holdslack": ["reports/hold.rpt", "reports/hold.topN.rpt"],
-            "setupslack": ["reports/setup.rpt", "reports/setup.topN.rpt"],
-            "setuptns": ["reports/setup.rpt", "reports/setup.topN.rpt"],
-            "holdtns": ["reports/hold.rpt", "reports/hold.topN.rpt"],
-            "setupskew": ["reports/skew.setup.rpt", "reports/setup.rpt", "reports/setup.topN.rpt"],
-            "holdskew": ["reports/skew.hold.rpt", "reports/hold.rpt", "reports/hold.topN.rpt"]
+            "peakpower": power_reports,
+            "leakagepower": power_reports,
+            "unconstrained": ["reports/timing/unconstrained.rpt",
+                              "reports/timing/unconstrained.topN.rpt"],
+            "setuppaths": ["reports/timing/setup.rpt", "reports/timing/setup.topN.rpt"],
+            "holdpaths": ["reports/timing/hold.rpt", "reports/timing/hold.topN.rpt"],
+            "holdslack": ["reports/timing/hold.rpt", "reports/timing/hold.topN.rpt"],
+            "setupslack": ["reports/timing/setup.rpt", "reports/timing/setup.topN.rpt"],
+            "setuptns": ["reports/timing/setup.rpt", "reports/timing/setup.topN.rpt"],
+            "holdtns": ["reports/timing/hold.rpt", "reports/timing/hold.topN.rpt"],
+            "setupskew": ["reports/clocks/skew.setup.rpt",
+                          "reports/timing/setup.rpt", "reports/timing/setup.topN.rpt"],
+            "holdskew": ["reports/clocks/skew.hold.rpt",
+                         "reports/timing/hold.rpt", "reports/timing/hold.topN.rpt"]
         }
 
         if metric in mapping:

--- a/siliconcompiler/tools/opensta/timing.py
+++ b/siliconcompiler/tools/opensta/timing.py
@@ -168,9 +168,9 @@ class TimingTaskBase(OpenSTATask):
             patterns = list(report_type)
 
         if any("*" in pattern for pattern in patterns):
-            enum_type = list(
-                NodeType.parse(BaseSchema.get(self, "var", "skip_reports", field="type")))[0]
-            supported_report_types = sorted(NodeType.parse(enum_type).values)
+            enum_type = next(iter(
+                NodeType.parse(BaseSchema.get(self, "var", "skip_reports", field="type"))))
+            supported_report_types = sorted(enum_type.values)
             expanded: List[str] = []
             for pattern in patterns:
                 matches = fnmatch.filter(supported_report_types, pattern)

--- a/tests/examples/test_heartbeat.py
+++ b/tests/examples/test_heartbeat.py
@@ -110,7 +110,7 @@ def test_py_make_power():
     assert os.path.isfile('build/heartbeat/sim/simulate/0/reports/heartbeat8_tb.vcd')
 
     # Timing signoff annotated the VCD and reported activity coverage.
-    annotation = 'build/heartbeat/timingsignoff/signoff/0/reports/activity_annotation.rpt'
+    annotation = 'build/heartbeat/timingsignoff/signoff/0/reports/power/activity_annotation.rpt'
     assert os.path.isfile(annotation)
 
     # Every pin's activity should be annotated from the VCD (a wrong scope would

--- a/tests/tools/test_opensta.py
+++ b/tests/tools/test_opensta.py
@@ -133,6 +133,47 @@ def test_opensta_parameter_write_liberty():
     assert task.get("var", "write_liberty") is True
 
 
+def test_opensta_parameter_skip_report():
+    task = timing.TimingTask()
+    task.add_opensta_skipreport('clock_skew')
+    assert task.get("var", "skip_reports") == ['clock_skew']
+    task.add_opensta_skipreport(['setup', 'hold'], step='timing', index='1')
+    assert task.get("var", "skip_reports", step='timing', index='1') == ['setup', 'hold']
+    assert task.get("var", "skip_reports") == ['clock_skew']
+    task.add_opensta_skipreport('fmax', clobber=True)
+    assert task.get("var", "skip_reports") == ['fmax']
+
+
+def test_opensta_parameter_skip_report_wildcard():
+    task = timing.TimingTask()
+    task.add_opensta_skipreport('*skew*')
+    assert task.get("var", "skip_reports") == ['clock_skew']
+    with pytest.raises(ValueError,
+                       match="Report type pattern 'nomatch\\*' did not match any supported"):
+        task.add_opensta_skipreport('nomatch*')
+
+
+def test_opensta_reports_computed_at_setup():
+    proj = ASIC(Design("testdesign"))
+    with proj.design.active_fileset("rtl"):
+        proj.design.set_topmodule("top")
+    proj.add_fileset("rtl")
+    freepdk45_demo(proj)
+
+    flow = Flowgraph("testflow")
+    flow.node("timing", timing.TimingTask())
+    proj.set_flow(flow)
+
+    task = timing.TimingTask.find_task(proj)
+    task.add_opensta_skipreport(['power', 'design_stats'])
+
+    with task.runtime(SchedulerNode(proj, "timing", "0")) as runtask:
+        runtask.setup()
+
+    reports = set(task.get("var", "reports", step="timing", index="0"))
+    assert reports == set(timing.TimingTaskBase.REPORT_TYPES) - {'power', 'design_stats'}
+
+
 def test_timing_write_sdf_and_liberty():
     """Test that both write_sdf and write_liberty can be enabled together."""
     design = Design("test")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scenario-aware outputs across placement, routing, clock tree, repair, metrics, and write-data flows (including `design_stats` and `scenarios`).
  * Expanded timing/checks/metrics reporting with scenario/corner-aware setup and hold information.
  * Added OpenSTA report selection with skip support, including wildcard patterns.

* **Improvements**
  * Standardized output under structured `reports/*` subdirectories and updated key report locations (timing, route/checks, clocks, power, design, constraints).
  * Improved hierarchical cell-area JSON placement.

* **Bug Fixes**
  * Logic depth reporting now clamps to non-negative values and includes optional report output.

* **Tests**
  * Updated and added regression tests for skip/report selection and report path changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->