### PR TITLE
remove unused modules from elaborated verilog

### DIFF
--- a/siliconcompiler/tools/slang/elaborate.py
+++ b/siliconcompiler/tools/slang/elaborate.py
@@ -2,6 +2,8 @@ from typing import Optional, Union
 
 import os.path
 
+from collections import deque
+
 from siliconcompiler.tools.slang import pyslang
 
 from siliconcompiler.tools.slang import SlangTask
@@ -276,12 +278,11 @@ class Elaborate(SlangTask):
     def __get_files(self, manager, node):
         files = set()
 
-        from collections import deque
         nodes = deque([node])
 
-        def proc_range(range):
-            files.add(manager.getFileName(range.start))
-            files.add(manager.getFileName(range.end))
+        def proc_range(source_range):
+            files.add(manager.getFileName(source_range.start))
+            files.add(manager.getFileName(source_range.end))
 
         while nodes:
             node = nodes.popleft()

--- a/siliconcompiler/tools/slang/elaborate.py
+++ b/siliconcompiler/tools/slang/elaborate.py
@@ -91,6 +91,27 @@ class Elaborate(SlangTask):
         # anything that is not an instantiable definition are always kept.
         dropped = self.__unused_definitions()
 
+        # The top module's parameter defaults are rewritten to the values it was
+        # actually elaborated with (from the fileset's -G overrides). Otherwise
+        # the emitted top still advertises its original defaults, so a downstream
+        # tool that re-elaborates this file from the top picks a different
+        # configuration than we pruned for -- referencing modules we dropped.
+        overrides = self.__top_param_overrides()
+
+        # Spliced-in nodes keep pointing at the throwaway syntax tree they were
+        # parsed from, and the rewritten tree points at those; both must outlive
+        # printing or pyslang reads freed memory. Hold every such tree here for
+        # the duration of the write loop.
+        keepalive = []
+
+        def rewrite_defaults(node, rewriter):
+            if node in overrides and node.initializer is not None:
+                tree, replacement = self.__equals_value(overrides[node])
+                if replacement is not None:
+                    keepalive.append(tree)
+                    rewriter.replace(node.initializer, replacement)
+            return None
+
         def print_files(out, files):
             for src_file in files:
                 out.write(f'//   File: {src_file}\n')
@@ -112,13 +133,27 @@ class Elaborate(SlangTask):
 
         with open(f'outputs/{self._output_file()}', 'w') as out:
             for tree in self._compilation.getSyntaxTrees():
-                for member in tree.root.members:
-                    if member in dropped:
+                # Rewriting produces a new tree whose members are positionally
+                # 1:1 with the original (only parameter defaults change), so the
+                # identity-based ``dropped`` check stays keyed on the original
+                # nodes while the rewritten node is what gets printed.
+                orig_members = list(tree.root.members)
+                if overrides:
+                    # Retain the rewritten tree: its member nodes read from it
+                    # while printing, so it must not be collected mid-loop.
+                    rewritten = pyslang.syntax.rewrite(tree, rewrite_defaults)
+                    keepalive.append(rewritten)
+                    printed = list(rewritten.root.members)
+                else:
+                    printed = orig_members
+
+                for orig, member in zip(orig_members, printed):
+                    if orig in dropped:
                         continue
 
                     files = []
                     if add_source:
-                        files = self.__get_files(manager, member)
+                        files = self.__get_files(manager, orig)
 
                     out.write(
                         "////////////////////////////////////////////////////////////////\n")
@@ -159,31 +194,85 @@ class Elaborate(SlangTask):
             if syntax is not None:
                 all_defs.add(syntax)
 
-        # Walk the elaborated hierarchy from the top module(s) and record the
-        # definitions that are actually instantiated.
+        # Record the definitions actually instantiated under the top module(s).
+        # ``visit`` descends through every scope -- generate blocks, interfaces
+        # and deeply nested instances -- which a hand-rolled walk over
+        # instance-body members would miss. It is run per top instance rather
+        # than from the root: slang also elaborates other top-level modules
+        # (for diagnostics) even when --top is set, and visiting the root would
+        # sweep those uninstantiated modules back in.
         used = set()
-        seen = set()
 
-        def visit(instance):
-            body = instance.body
-            if body in seen:
-                return
-            seen.add(body)
-
-            defn = getattr(body, "definition", None)
-            if defn is not None:
-                syntax = get_syntax(defn)
+        def visitor(symbol):
+            if type(symbol).__name__ == "InstanceSymbol":
+                syntax = get_syntax(symbol.definition)
                 if syntax is not None:
                     used.add(syntax)
 
-            for member in body:
-                if isinstance(member, pyslang.ast.InstanceSymbol):
-                    visit(member)
-
         for top in self._compilation.getRoot().topInstances:
-            visit(top)
+            top.visit(visitor)
 
         return all_defs - used
+
+    def __top_param_overrides(self):
+        '''
+        Maps each top-module parameter declarator (that has a default) to the
+        concrete value the module was elaborated with, rendered as a
+        SystemVerilog literal.
+
+        Only overridable module parameters are considered -- localparams are
+        elaboration-internal and never appear in the parameter port list.
+        '''
+        def get_syntax(symbol):
+            if hasattr(symbol, "getSyntax"):
+                return symbol.getSyntax()
+            return getattr(symbol, "syntax", None)
+
+        overrides = {}
+        for top in self._compilation.getRoot().topInstances:
+            definition = getattr(top, "definition", None)
+            syntax = get_syntax(definition) if definition is not None else None
+            header = getattr(syntax, "header", None)
+            params = getattr(header, "parameters", None)
+            if params is None:
+                continue
+
+            values = {}
+            for param in top.body.parameters:
+                if getattr(param, "isLocalParam", False):
+                    continue
+                values[param.name] = str(param.value)
+
+            for declaration in params.declarations:
+                if type(declaration).__name__ != "ParameterDeclarationSyntax":
+                    continue
+                for declarator in declaration.declarators:
+                    name = declarator.name.value
+                    if declarator.initializer is not None and name in values:
+                        overrides[declarator] = values[name]
+
+        return overrides
+
+    @staticmethod
+    def __equals_value(value):
+        '''
+        Parses ``value`` as a SystemVerilog parameter default and returns
+        ``(tree, node)`` where ``node`` is the ``EqualsValueClauseSyntax``
+        (``= <value>``) to splice in as a parameter default. The owning ``tree``
+        is returned alongside because the node stays bound to it and the caller
+        must keep it alive until printing is done. Returns ``(None, None)`` if
+        ``value`` cannot be parsed.
+        '''
+        tree = pyslang.syntax.SyntaxTree.fromText(
+            f"module __sc_p #(parameter __sc_v = {value})();endmodule")
+        header = getattr(tree.root, "header", None)
+        params = getattr(header, "parameters", None)
+        if params is None:
+            return None, None
+        for declaration in params.declarations:
+            if type(declaration).__name__ == "ParameterDeclarationSyntax":
+                return tree, declaration.declarators[0].initializer
+        return None, None
 
     def __get_files(self, manager, node):
         files = set()

--- a/siliconcompiler/tools/slang/elaborate.py
+++ b/siliconcompiler/tools/slang/elaborate.py
@@ -151,21 +151,20 @@ class Elaborate(SlangTask):
                     if orig in dropped:
                         continue
 
-                    files = []
                     if add_source:
                         files = self.__get_files(manager, orig)
-
-                    out.write(
-                        "////////////////////////////////////////////////////////////////\n")
-                    out.write("// Start:\n")
-                    print_files(out, files)
+                        out.write(
+                            "////////////////////////////////////////////////////////////////\n")
+                        out.write("// Start:\n")
+                        print_files(out, files)
 
                     out.write(make_writer().print(member).str() + '\n')
 
-                    out.write("// End:\n")
-                    print_files(out, files)
-                    out.write(
-                        "////////////////////////////////////////////////////////////////\n")
+                    if add_source:
+                        out.write("// End:\n")
+                        print_files(out, files)
+                        out.write(
+                            "////////////////////////////////////////////////////////////////\n")
 
         if ok:
             return 0
@@ -277,21 +276,20 @@ class Elaborate(SlangTask):
     def __get_files(self, manager, node):
         files = set()
 
-        from queue import Queue
-        nodes = Queue(maxsize=0)
-        nodes.put(node)
+        from collections import deque
+        nodes = deque([node])
 
         def proc_range(range):
             files.add(manager.getFileName(range.start))
             files.add(manager.getFileName(range.end))
 
-        while not nodes.empty():
-            node = nodes.get()
+        while nodes:
+            node = nodes.popleft()
             proc_range(node.sourceRange)
             for token in node:
                 if isinstance(token, pyslang.parsing.Token):
                     proc_range(token.range)
                 else:
-                    nodes.put(token)
+                    nodes.append(token)
 
         return sorted([os.path.abspath(f) for f in files if os.path.isfile(f)])

--- a/siliconcompiler/tools/slang/elaborate.py
+++ b/siliconcompiler/tools/slang/elaborate.py
@@ -85,49 +85,112 @@ class Elaborate(SlangTask):
 
         add_source = self.get("var", "include_source_paths")
 
+        # Determine which definitions are actually reachable from the elaborated
+        # top module. Unreachable module/interface/program definitions are
+        # dropped from the output; packages, $unit-scope declarations and
+        # anything that is not an instantiable definition are always kept.
+        dropped = self.__unused_definitions()
+
         def print_files(out, files):
             for src_file in files:
                 out.write(f'//   File: {src_file}\n')
 
+        def make_writer():
+            writer = pyslang.syntax.SyntaxPrinter(manager)
+
+            writer.setIncludeMissing(False)
+            writer.setIncludeSkipped(False)
+            writer.setIncludeDirectives(False)
+
+            writer.setExpandMacros(True)
+            writer.setExpandIncludes(True)
+            writer.setIncludeTrivia(True)
+            writer.setIncludeComments(True)
+            writer.setSquashNewlines(True)
+
+            return writer
+
         with open(f'outputs/{self._output_file()}', 'w') as out:
             for tree in self._compilation.getSyntaxTrees():
-                files = []
-                if add_source:
-                    files = self.__get_files(manager, tree)
+                for member in tree.root.members:
+                    if member in dropped:
+                        continue
 
-                writer = pyslang.syntax.SyntaxPrinter(manager)
+                    files = []
+                    if add_source:
+                        files = self.__get_files(manager, member)
 
-                writer.setIncludeMissing(False)
-                writer.setIncludeSkipped(False)
-                writer.setIncludeDirectives(False)
+                    out.write(
+                        "////////////////////////////////////////////////////////////////\n")
+                    out.write("// Start:\n")
+                    print_files(out, files)
 
-                writer.setExpandMacros(True)
-                writer.setExpandIncludes(True)
-                writer.setIncludeTrivia(True)
-                writer.setIncludeComments(True)
-                writer.setSquashNewlines(True)
+                    out.write(make_writer().print(member).str() + '\n')
 
-                out.write("////////////////////////////////////////////////////////////////\n")
-                out.write("// Start:\n")
-                print_files(out, files)
-
-                out.write(writer.print(tree).str() + '\n')
-
-                out.write("// End:\n")
-                print_files(out, files)
-                out.write("////////////////////////////////////////////////////////////////\n")
+                    out.write("// End:\n")
+                    print_files(out, files)
+                    out.write(
+                        "////////////////////////////////////////////////////////////////\n")
 
         if ok:
             return 0
         else:
             return 1
 
-    def __get_files(self, manager, tree):
+    def __unused_definitions(self):
+        '''
+        Returns the set of definition syntax nodes (modules, interfaces,
+        programs, ...) that are not reachable from the elaborated top module(s)
+        and can therefore be omitted from the output.
+
+        Packages, $unit-scope declarations and anything that is not an
+        instantiable definition are never included in this set, so they are
+        always retained by the caller.
+        '''
+        def get_syntax(symbol):
+            if hasattr(symbol, "getSyntax"):
+                return symbol.getSyntax()
+            return getattr(symbol, "syntax", None)
+
+        # Every instantiable definition known to the compilation.
+        all_defs = set()
+        for defn in self._compilation.getDefinitions():
+            syntax = get_syntax(defn)
+            if syntax is not None:
+                all_defs.add(syntax)
+
+        # Walk the elaborated hierarchy from the top module(s) and record the
+        # definitions that are actually instantiated.
+        used = set()
+        seen = set()
+
+        def visit(instance):
+            body = instance.body
+            if body in seen:
+                return
+            seen.add(body)
+
+            defn = getattr(body, "definition", None)
+            if defn is not None:
+                syntax = get_syntax(defn)
+                if syntax is not None:
+                    used.add(syntax)
+
+            for member in body:
+                if isinstance(member, pyslang.ast.InstanceSymbol):
+                    visit(member)
+
+        for top in self._compilation.getRoot().topInstances:
+            visit(top)
+
+        return all_defs - used
+
+    def __get_files(self, manager, node):
         files = set()
 
         from queue import Queue
         nodes = Queue(maxsize=0)
-        nodes.put(tree.root)
+        nodes.put(node)
 
         def proc_range(range):
             files.add(manager.getFileName(range.start))

--- a/siliconcompiler/tools/slang/elaborate.py
+++ b/siliconcompiler/tools/slang/elaborate.py
@@ -93,25 +93,28 @@ class Elaborate(SlangTask):
         # anything that is not an instantiable definition are always kept.
         dropped = self.__unused_definitions()
 
-        # The top module's parameter defaults are rewritten to the values it was
-        # actually elaborated with (from the fileset's -G overrides). Otherwise
-        # the emitted top still advertises its original defaults, so a downstream
-        # tool that re-elaborates this file from the top picks a different
-        # configuration than we pruned for -- referencing modules we dropped.
-        overrides = self.__top_param_overrides()
-
-        # Spliced-in nodes keep pointing at the throwaway syntax tree they were
-        # parsed from, and the rewritten tree points at those; both must outlive
-        # printing or pyslang reads freed memory. Hold every such tree here for
-        # the duration of the write loop.
-        keepalive = []
+        # Only the parameters the fileset actually overrode (-G) have their
+        # default rewritten to the elaborated value. Otherwise the emitted top
+        # still advertises its original defaults, so a downstream tool that
+        # re-elaborates this file from the top picks a different configuration
+        # than we pruned for -- referencing modules we dropped. Parameters SC
+        # did not override keep their original source default verbatim.
+        overrides, keepalive, unrenderable = self.__top_param_overrides()
+        if unrenderable:
+            # Refuse to emit a file with a silently-wrong default: fail loudly
+            # naming the parameter(s) whose elaborated value we could not turn
+            # into valid SystemVerilog.
+            for name in unrenderable:
+                self.logger.error(
+                    f"cannot rewrite the default of top parameter '{name}': "
+                    f"its elaborated value could not be rendered as valid "
+                    f"SystemVerilog")
+            return 1
 
         def rewrite_defaults(node, rewriter):
-            if node in overrides and node.initializer is not None:
-                tree, replacement = self.__equals_value(overrides[node])
-                if replacement is not None:
-                    keepalive.append(tree)
-                    rewriter.replace(node.initializer, replacement)
+            replacement = overrides.get(node)
+            if replacement is not None and node.initializer is not None:
+                rewriter.replace(node.initializer, replacement)
             return None
 
         def print_files(out, files):
@@ -215,21 +218,45 @@ class Elaborate(SlangTask):
 
         return all_defs - used
 
+    def __overridden_param_names(self):
+        '''
+        Returns the set of top-module parameter names the active fileset
+        overrode via ``-G`` -- the only parameters whose emitted default can
+        legitimately differ from the source.
+        '''
+        filesets = self.project.get("option", "fileset")
+        if not filesets:
+            return set()
+        design = self.project.design
+        return set(design.getkeys("fileset", filesets[0], "param"))
+
     def __top_param_overrides(self):
         '''
-        Maps each top-module parameter declarator (that has a default) to the
-        concrete value the module was elaborated with, rendered as a
-        SystemVerilog literal.
+        Builds the parameter-default rewrites for the top module(s).
 
-        Only overridable module parameters are considered -- localparams are
-        elaboration-internal and never appear in the parameter port list.
+        Returns ``(overrides, keepalive, unrenderable)`` where ``overrides`` maps
+        each affected parameter declarator to its replacement
+        ``EqualsValueClauseSyntax`` node, ``keepalive`` holds the throwaway
+        syntax trees those nodes stay bound to (they must outlive printing), and
+        ``unrenderable`` lists the names of overridden parameters whose
+        elaborated value could not be rendered as valid SystemVerilog.
+
+        Only parameters the fileset actually overrode are considered; every
+        other parameter keeps its original source default. Localparams never
+        appear in the parameter port list and are ignored.
         '''
         def get_syntax(symbol):
             if hasattr(symbol, "getSyntax"):
                 return symbol.getSyntax()
             return getattr(symbol, "syntax", None)
 
+        names = self.__overridden_param_names()
         overrides = {}
+        keepalive = []
+        unrenderable = []
+        if not names:
+            return overrides, keepalive, unrenderable
+
         for top in self._compilation.getRoot().topInstances:
             definition = getattr(top, "definition", None)
             syntax = get_syntax(definition) if definition is not None else None
@@ -238,21 +265,63 @@ class Elaborate(SlangTask):
             if params is None:
                 continue
 
-            values = {}
+            symbols = {}
             for param in top.body.parameters:
                 if getattr(param, "isLocalParam", False):
                     continue
-                values[param.name] = str(param.value)
+                symbols[param.name] = param
 
             for declaration in params.declarations:
                 if type(declaration).__name__ != "ParameterDeclarationSyntax":
                     continue
+                type_text = pyslang.syntax.SyntaxPrinter().print(
+                    declaration.type).str().strip()
                 for declarator in declaration.declarators:
                     name = declarator.name.value
-                    if declarator.initializer is not None and name in values:
-                        overrides[declarator] = values[name]
+                    if name not in names or name not in symbols:
+                        continue
+                    if declarator.initializer is None:
+                        continue
 
-        return overrides
+                    literal = self.__param_literal(symbols[name], type_text)
+                    tree, node = self.__equals_value(literal) \
+                        if literal is not None else (None, None)
+                    if node is None:
+                        unrenderable.append(name)
+                        continue
+                    overrides[declarator] = node
+                    keepalive.append(tree)
+
+        return overrides, keepalive, unrenderable
+
+    @staticmethod
+    def __param_literal(param, type_text):
+        '''
+        Renders a parameter's elaborated value as a valid SystemVerilog literal,
+        or returns ``None`` if it cannot be rendered safely.
+
+        Integral values (including enums) are rendered at full precision -- the
+        default ``str()`` abbreviates wide values with ``...`` which is not valid
+        Verilog. Enum values are wrapped in a cast to their declared type since a
+        bare integer does not implicitly convert to an enum.
+        '''
+        ptype = param.type
+        value = param.value
+
+        if ptype.isString:
+            return str(value)
+
+        inner = getattr(value, "value", None)
+        if isinstance(inner, pyslang.SVInt):
+            literal = inner.toString(pyslang.LiteralBase.Hex, True)
+            if ptype.isEnum:
+                return f"{type_text}'({literal})"
+            return literal
+
+        if getattr(ptype, "isFloating", False):
+            return str(value)
+
+        return None
 
     @staticmethod
     def __equals_value(value):
@@ -266,6 +335,10 @@ class Elaborate(SlangTask):
         '''
         tree = pyslang.syntax.SyntaxTree.fromText(
             f"module __sc_p #(parameter __sc_v = {value})();endmodule")
+        # Reject anything that does not parse cleanly rather than splice in a
+        # node that would emit malformed SystemVerilog.
+        if list(tree.diagnostics):
+            return None, None
         header = getattr(tree.root, "header", None)
         params = getattr(header, "parameters", None)
         if params is None:

--- a/tests/tools/test_slang.py
+++ b/tests/tools/test_slang.py
@@ -163,15 +163,15 @@ def test_elaborate_bakes_top_param_overrides():
     with open(result) as fout:
         content = fout.read()
 
-    # Default baked to the elaborated value; the selected branch kept, the
-    # other pruned.
-    assert "MODE = 1" in content
-    assert "MODE = 0" not in content
+    # The selected branch is kept and the other pruned; the original default
+    # (0) is gone from the declaration.
     assert "module impl_b" in content
     assert "module impl_a" not in content
+    assert "MODE = 0" not in content
 
     # Re-elaborating the emitted file on its own (defaults only, no -G) must
-    # succeed without reaching the pruned module -- i.e. no unknown modules.
+    # succeed without reaching the pruned module -- i.e. no unknown modules --
+    # and the baked default must resolve MODE back to 1.
     driver = pyslang.driver.Driver()
     driver.addStandardArgs()
     opts = pyslang.driver.CommandLineOptions()
@@ -185,6 +185,97 @@ def test_elaborate_bakes_top_param_overrides():
                   for d in compilation.getAllDiagnostics()]
     assert pyslang.DiagnosticSeverity.Error not in severities
     assert pyslang.DiagnosticSeverity.Fatal not in severities
+
+    top_inst = compilation.getRoot().topInstances[0]
+    mode = {p.name: p for p in top_inst.body.parameters}["MODE"]
+    assert mode.value.value.toString(pyslang.LiteralBase.Decimal, False) == "1"
+
+
+_TYPED_PARAM_SRC = (
+    "package p;\n"
+    "  typedef enum logic [1:0] {A = 0, B = 1, C = 2} mode_e;\n"
+    "  typedef logic [159:0] wide_t;\n"
+    "endpackage\n"
+    "module top import p::*; #(\n"
+    "  parameter mode_e MODE = A,\n"
+    "  parameter wide_t WIDE = 160'h0\n"
+    ")(input x, output y);\n"
+    "  assign y = x ^ (|WIDE) ^ (MODE == C);\n"
+    "endmodule\n"
+)
+
+
+def _elaborate_typed(params):
+    """Run the elaborate task on the typed-parameter design with the given
+    fileset param overrides ({} for none) and return the output file path."""
+    with open("typed.sv", "w") as src:
+        src.write(_TYPED_PARAM_SRC)
+
+    design = Design("top")
+    design.set_dataroot("typed-test", os.getcwd())
+    with design.active_fileset("rtl"), design.active_dataroot("typed-test"):
+        design.set_topmodule("top")
+        design.add_file("typed.sv")
+        for name, value in params.items():
+            design.set_param(name, value)
+
+    proj = Project(design)
+    proj.add_fileset("rtl")
+    flow = Flowgraph("elaborate")
+    flow.node("elaborate", elaborate.Elaborate())
+    proj.set_flow(flow)
+    assert proj.run()
+
+    return proj.find_result("sv", step="elaborate")
+
+
+def _assert_reelaborates_clean(path):
+    """Re-elaborate a standalone file (defaults only) and assert no errors."""
+    driver = pyslang.driver.Driver()
+    driver.addStandardArgs()
+    opts = pyslang.driver.CommandLineOptions()
+    opts.ignoreProgramName = True
+    args = shlex.join(["--single-unit", "--top", "top", os.path.abspath(path)])
+    assert driver.parseCommandLine(args, opts)
+    assert driver.processOptions()
+    assert driver.parseAllSources()
+    compilation = driver.createCompilation()
+    severities = [driver.diagEngine.getSeverity(d.code, d.location)
+                  for d in compilation.getAllDiagnostics()]
+    assert pyslang.DiagnosticSeverity.Error not in severities
+    assert pyslang.DiagnosticSeverity.Fatal not in severities
+
+
+def test_elaborate_typed_param_overrides_render_valid_sv():
+    """Overriding enum- and wide-typedef-typed top parameters must emit valid
+    SystemVerilog: enums cast to their type, wide values as full literals.
+
+    This is the ibex-style regression: a bare integer default for an enum
+    parameter (or an abbreviated wide literal) does not compile.
+    """
+    result = _elaborate_typed({"MODE": "C", "WIDE": "160'hdeadbeef"})
+    with open(result) as fout:
+        content = fout.read()
+
+    # Enum default cast to its declared type; no abbreviated "..." literal.
+    assert "mode_e'(" in content
+    assert "..." not in content
+
+    # The emitted file re-elaborates standalone (defaults only) without errors.
+    _assert_reelaborates_clean(result)
+
+
+def test_elaborate_leaves_untouched_params_verbatim():
+    """Typed parameters the fileset did NOT override keep their exact source
+    default -- the rewrite never touches them, so it can't mangle enum/typedef
+    defaults it wasn't asked to change (the ibex failure mode)."""
+    result = _elaborate_typed({})
+    with open(result) as fout:
+        content = fout.read()
+
+    assert "parameter mode_e MODE = A" in content
+    assert "parameter wide_t WIDE = 160'h0" in content
+    assert "mode_e'(" not in content
 
 
 def test_slang_duplicate_inputs(heartbeat_design):

--- a/tests/tools/test_slang.py
+++ b/tests/tools/test_slang.py
@@ -121,6 +121,72 @@ def test_elaborate_drops_unused_modules():
     assert "unused.v" not in content
 
 
+def test_elaborate_bakes_top_param_overrides():
+    """The emitted top module advertises the parameters it was elaborated with.
+
+    ``top`` selects a submodule via ``generate`` on parameter ``MODE``. The
+    fileset overrides ``MODE`` to 1 (so ``impl_b`` is used and ``impl_a`` is
+    pruned). Because the top is emitted with ``MODE``'s default rewritten to 1,
+    re-elaborating the output file standalone -- with only its own defaults --
+    reproduces the same hierarchy instead of reaching the pruned ``impl_a``.
+    """
+    with open("design.sv", "w") as src:
+        src.write(
+            "module impl_a(input x, output y); assign y = x; endmodule\n"
+            "module impl_b(input x, output y); assign y = ~x; endmodule\n"
+            "module top #(parameter integer MODE = 0)(input x, output y);\n"
+            "  if (MODE == 0) begin : g\n"
+            "    impl_a u(.x(x), .y(y));\n"
+            "  end else begin : g\n"
+            "    impl_b u(.x(x), .y(y));\n"
+            "  end\n"
+            "endmodule\n"
+        )
+
+    design = Design("top")
+    design.set_dataroot("param-test", os.getcwd())
+    with design.active_fileset("rtl"), design.active_dataroot("param-test"):
+        design.set_topmodule("top")
+        design.add_file("design.sv")
+        design.set_param("MODE", "1")
+
+    proj = Project(design)
+    proj.add_fileset("rtl")
+
+    flow = Flowgraph("elaborate")
+    flow.node("elaborate", elaborate.Elaborate())
+    proj.set_flow(flow)
+
+    assert proj.run()
+
+    result = proj.find_result("sv", step="elaborate")
+    with open(result) as fout:
+        content = fout.read()
+
+    # Default baked to the elaborated value; the selected branch kept, the
+    # other pruned.
+    assert "MODE = 1" in content
+    assert "MODE = 0" not in content
+    assert "module impl_b" in content
+    assert "module impl_a" not in content
+
+    # Re-elaborating the emitted file on its own (defaults only, no -G) must
+    # succeed without reaching the pruned module -- i.e. no unknown modules.
+    driver = pyslang.driver.Driver()
+    driver.addStandardArgs()
+    opts = pyslang.driver.CommandLineOptions()
+    opts.ignoreProgramName = True
+    args = shlex.join(["--single-unit", "--top", "top", os.path.abspath(result)])
+    assert driver.parseCommandLine(args, opts)
+    assert driver.processOptions()
+    assert driver.parseAllSources()
+    compilation = driver.createCompilation()
+    severities = [driver.diagEngine.getSeverity(d.code, d.location)
+                  for d in compilation.getAllDiagnostics()]
+    assert pyslang.DiagnosticSeverity.Error not in severities
+    assert pyslang.DiagnosticSeverity.Fatal not in severities
+
+
 def test_slang_duplicate_inputs(heartbeat_design):
     heartbeat_design.copy_fileset("rtl", "rtl_double")
     heartbeat_design.add_file(heartbeat_design.get_file("rtl", "verilog"), "rtl_double")

--- a/tests/tools/test_slang.py
+++ b/tests/tools/test_slang.py
@@ -278,6 +278,130 @@ def test_elaborate_leaves_untouched_params_verbatim():
     assert "mode_e'(" not in content
 
 
+def _build_elaborate(top, filename, source, params=None,
+                     source_paths=True, dataroot="cov-test"):
+    """Write ``source`` to ``filename`` and return an elaborate-only project."""
+    with open(filename, "w") as fout:
+        fout.write(source)
+
+    design = Design(top)
+    design.set_dataroot(dataroot, os.getcwd())
+    with design.active_fileset("rtl"), design.active_dataroot(dataroot):
+        design.set_topmodule(top)
+        design.add_file(filename)
+        for name, value in (params or {}).items():
+            design.set_param(name, value)
+
+    proj = Project(design)
+    proj.add_fileset("rtl")
+    flow = Flowgraph("elaborate")
+    flow.node("elaborate", elaborate.Elaborate())
+    proj.set_flow(flow)
+    if not source_paths:
+        elaborate.Elaborate.find_task(proj).set_slang_includesourcepaths(False)
+    return proj
+
+
+def test_elaborate_source_paths_disabled():
+    """With include_source_paths off, module text is still emitted but the
+    banner / file-annotation comments are omitted entirely."""
+    proj = _build_elaborate(
+        "top", "nosrc.v",
+        "module top(input a, output b); assign b = a; endmodule\n",
+        source_paths=False)
+
+    assert proj.run()
+
+    with open(proj.find_result("v", step="elaborate")) as fout:
+        content = fout.read()
+
+    assert "module top" in content
+    assert "// Start:" not in content
+    assert "// End:" not in content
+    assert "//   File:" not in content
+    assert "////////" not in content
+
+
+def test_elaborate_errors_on_unrenderable_param():
+    """If an overridden top parameter's value cannot be rendered as valid
+    SystemVerilog, the task must fail loudly rather than emit a bad default.
+
+    An unpacked-struct parameter elaborates fine but has no simple literal
+    form, so overriding it forces the error-out path.
+    """
+    proj = _build_elaborate(
+        "top", "err.sv",
+        "package q; typedef struct { int a; int b; } up_t; endpackage\n"
+        "module top import q::*; #(parameter up_t P = '{a: 1, b: 2})\n"
+        "  (input x, output y);\n"
+        "  assign y = x ^ (P.a == 3);\n"
+        "endmodule\n",
+        params={"P": "'{a: 3, b: 4}"})
+
+    with pytest.raises(RuntimeError):
+        proj.run()
+
+
+def test_elaborate_prunes_deep_hierarchy_keeps_interface():
+    """Pruning must descend the full hierarchy (grandchildren, interfaces) and
+    keep everything reachable while dropping an uninstantiated sibling."""
+    proj = _build_elaborate(
+        "top", "hier.sv",
+        "interface bus_if; logic v; endinterface\n"
+        "module leaf(input logic a, output logic b); assign b = ~a; endmodule\n"
+        "module mid(bus_if i, output logic o); leaf l(.a(i.v), .b(o)); endmodule\n"
+        "module unused(input logic a, output logic b); assign b = a; endmodule\n"
+        "module top(output logic o);\n"
+        "  bus_if bi();\n"
+        "  assign bi.v = 1'b1;\n"
+        "  mid m(.i(bi), .o(o));\n"
+        "endmodule\n")
+
+    assert proj.run()
+
+    with open(proj.find_result("sv", step="elaborate")) as fout:
+        content = fout.read()
+
+    assert "module top" in content
+    assert "module mid" in content
+    assert "module leaf" in content        # grandchild, reached via mid
+    assert "interface bus_if" in content    # instantiated interface
+    assert "module unused" not in content   # never instantiated
+
+
+def test_elaborate_roundtrips_systemverilog_constructs():
+    """A design using packages, enums, packed structs and '{...} assignment
+    patterns must be emitted so it re-elaborates cleanly -- the ibex-shaped
+    regression. Nothing is overridden, so these constructs are verbatim."""
+    proj = _build_elaborate(
+        "top", "sv_features.sv",
+        "package p;\n"
+        "  typedef enum logic [1:0] {A = 0, B = 1, C = 2} mode_e;\n"
+        "  typedef struct packed { logic irq; logic [4:0] cause; } exc_t;\n"
+        "  localparam exc_t ExcSoft = '{irq: 1'b1, cause: 5'd03};\n"
+        "endpackage\n"
+        "module leaf import p::*; #(parameter mode_e M = A)\n"
+        "  (input logic x, output logic y);\n"
+        "  assign y = x ^ (M == C) ^ ExcSoft.irq;\n"
+        "endmodule\n"
+        "module top import p::*; (input logic x, output logic y);\n"
+        "  leaf u(.x(x), .y(y));\n"
+        "endmodule\n")
+
+    assert proj.run()
+
+    result = proj.find_result("sv", step="elaborate")
+    with open(result) as fout:
+        content = fout.read()
+
+    # SV constructs preserved verbatim (not down-converted / mangled).
+    assert "package p" in content
+    assert "'{irq: 1'b1, cause: 5'd03}" in content
+
+    # The emitted file re-elaborates on its own without errors.
+    _assert_reelaborates_clean(result)
+
+
 def test_slang_duplicate_inputs(heartbeat_design):
     heartbeat_design.copy_fileset("rtl", "rtl_double")
     heartbeat_design.add_file(heartbeat_design.get_file("rtl", "verilog"), "rtl_double")
@@ -334,17 +458,17 @@ def test_pyslang_api_surface():
         assert hasattr(pyslang.Diags, diag), f"pyslang.Diags missing: {diag}"
 
 
-def test_pyslang_driver_parses_verilog(tmp_path):
+def test_pyslang_driver_parses_verilog():
     """Drive pyslang directly on a tiny verilog file.
 
     Mirrors the calls made in SlangTask._init_driver / _compile so a regression
     in the underlying pyslang API can be reproduced without any SC plumbing."""
-    src = tmp_path / "tiny.v"
-    src.write_text(
-        "module tiny(input clk, output reg q);\n"
-        "  always @(posedge clk) q <= ~q;\n"
-        "endmodule\n"
-    )
+    with open("tiny.v", "w") as src:
+        src.write(
+            "module tiny(input clk, output reg q);\n"
+            "  always @(posedge clk) q <= ~q;\n"
+            "endmodule\n"
+        )
 
     driver = pyslang.driver.Driver()
     driver.addStandardArgs()
@@ -352,7 +476,7 @@ def test_pyslang_driver_parses_verilog(tmp_path):
     opts = pyslang.driver.CommandLineOptions()
     opts.ignoreProgramName = True
 
-    args = shlex.join(["--single-unit", "--top", "tiny", str(src)])
+    args = shlex.join(["--single-unit", "--top", "tiny", "tiny.v"])
     assert driver.parseCommandLine(args, opts)
     assert driver.processOptions()
     assert driver.parseAllSources()
@@ -366,10 +490,10 @@ def test_pyslang_driver_parses_verilog(tmp_path):
     assert pyslang.DiagnosticSeverity.Fatal not in severities
 
 
-def test_pyslang_syntax_printer(tmp_path):
+def test_pyslang_syntax_printer():
     """SyntaxPrinter + Token live in submodules in pyslang v11+."""
-    src = tmp_path / "tiny.v"
-    src.write_text("module tiny; endmodule\n")
+    with open("tiny.v", "w") as src:
+        src.write("module tiny; endmodule\n")
 
     driver = pyslang.driver.Driver()
     driver.addStandardArgs()
@@ -377,7 +501,7 @@ def test_pyslang_syntax_printer(tmp_path):
     opts = pyslang.driver.CommandLineOptions()
     opts.ignoreProgramName = True
 
-    args = shlex.join(["--single-unit", "--top", "tiny", str(src)])
+    args = shlex.join(["--single-unit", "--top", "tiny", "tiny.v"])
     assert driver.parseCommandLine(args, opts)
     assert driver.processOptions()
     assert driver.parseAllSources()

--- a/tests/tools/test_slang.py
+++ b/tests/tools/test_slang.py
@@ -6,6 +6,7 @@ import os.path
 
 from queue import Queue
 
+from siliconcompiler import Design
 from siliconcompiler import Flowgraph
 from siliconcompiler import Project
 from siliconcompiler.tools.slang import lint
@@ -66,6 +67,58 @@ def test_elaborate(heartbeat_design):
 
     assert proj.find_result("v", step="elaborate") == \
         os.path.abspath("build/heartbeat/job0/elaborate/0/outputs/heartbeat.v")
+
+
+def test_elaborate_drops_unused_modules():
+    """Only the top module and the submodules it instantiates should be
+    written to the elaborated output; unused modules present in the sources
+    must be dropped, while packages are always retained.
+
+    The unused module lives in its own file, so this also verifies that the
+    emitted source-path annotations only reference files that actually
+    contributed a module to the output."""
+    with open("used.v", "w") as src:
+        src.write(
+            "package pkg; parameter W = 1; endpackage\n"
+            "module used_child(input a, output b); assign b = ~a; endmodule\n"
+            "module top(input x, output y);\n"
+            "  used_child u0(.a(x), .b(y));\n"
+            "endmodule\n"
+        )
+    with open("unused.v", "w") as src:
+        src.write(
+            "module unused_child(input a, output b); assign b = a; endmodule\n"
+        )
+
+    design = Design("top")
+    design.set_dataroot("unused-test", os.getcwd())
+    with design.active_fileset("rtl"), design.active_dataroot("unused-test"):
+        design.set_topmodule("top")
+        design.add_file("used.v")
+        design.add_file("unused.v")
+
+    proj = Project(design)
+    proj.add_fileset("rtl")
+
+    flow = Flowgraph("elaborate")
+    flow.node("elaborate", elaborate.Elaborate())
+    proj.set_flow(flow)
+
+    assert proj.run()
+
+    result = proj.find_result("v", step="elaborate")
+    with open(result) as fout:
+        content = fout.read()
+
+    # Only reachable modules (and packages) are emitted.
+    assert "module top" in content
+    assert "module used_child" in content
+    assert "package pkg" in content
+    assert "module unused_child" not in content
+
+    # The file that only held the dropped module must not be annotated.
+    assert "used.v" in content
+    assert "unused.v" not in content
 
 
 def test_slang_duplicate_inputs(heartbeat_design):

--- a/tests/tools/test_slang.py
+++ b/tests/tools/test_slang.py
@@ -11,6 +11,7 @@ from siliconcompiler import Flowgraph
 from siliconcompiler import Project
 from siliconcompiler.tools.slang import lint
 from siliconcompiler.tools.slang import elaborate
+from siliconcompiler.utils.paths import workdir
 
 
 @pytest.mark.parametrize("task", [elaborate.Elaborate, lint.Lint])
@@ -172,20 +173,7 @@ def test_elaborate_bakes_top_param_overrides():
     # Re-elaborating the emitted file on its own (defaults only, no -G) must
     # succeed without reaching the pruned module -- i.e. no unknown modules --
     # and the baked default must resolve MODE back to 1.
-    driver = pyslang.driver.Driver()
-    driver.addStandardArgs()
-    opts = pyslang.driver.CommandLineOptions()
-    opts.ignoreProgramName = True
-    args = shlex.join(["--single-unit", "--top", "top", os.path.abspath(result)])
-    assert driver.parseCommandLine(args, opts)
-    assert driver.processOptions()
-    assert driver.parseAllSources()
-    compilation = driver.createCompilation()
-    severities = [driver.diagEngine.getSeverity(d.code, d.location)
-                  for d in compilation.getAllDiagnostics()]
-    assert pyslang.DiagnosticSeverity.Error not in severities
-    assert pyslang.DiagnosticSeverity.Fatal not in severities
-
+    compilation = _assert_reelaborates_clean(result)
     top_inst = compilation.getRoot().topInstances[0]
     mode = {p.name: p for p in top_inst.body.parameters}["MODE"]
     assert mode.value.value.toString(pyslang.LiteralBase.Decimal, False) == "1"
@@ -230,7 +218,8 @@ def _elaborate_typed(params):
 
 
 def _assert_reelaborates_clean(path):
-    """Re-elaborate a standalone file (defaults only) and assert no errors."""
+    """Re-elaborate a standalone file (defaults only), assert no errors, and
+    return the resulting compilation for further inspection."""
     driver = pyslang.driver.Driver()
     driver.addStandardArgs()
     opts = pyslang.driver.CommandLineOptions()
@@ -244,6 +233,7 @@ def _assert_reelaborates_clean(path):
                   for d in compilation.getAllDiagnostics()]
     assert pyslang.DiagnosticSeverity.Error not in severities
     assert pyslang.DiagnosticSeverity.Fatal not in severities
+    return compilation
 
 
 def test_elaborate_typed_param_overrides_render_valid_sv():
@@ -261,8 +251,15 @@ def test_elaborate_typed_param_overrides_render_valid_sv():
     assert "mode_e'(" in content
     assert "..." not in content
 
-    # The emitted file re-elaborates standalone (defaults only) without errors.
-    _assert_reelaborates_clean(result)
+    # The emitted file re-elaborates standalone (defaults only) without errors,
+    # and the baked defaults resolve to the overridden values.
+    compilation = _assert_reelaborates_clean(result)
+    params = {p.name: p
+              for p in compilation.getRoot().topInstances[0].body.parameters}
+    assert params["MODE"].value.value.toString(
+        pyslang.LiteralBase.Decimal, False) == "2"       # enum value C
+    assert params["WIDE"].value.value.toString(
+        pyslang.LiteralBase.Hex, True) == "160'hdeadbeef"
 
 
 def test_elaborate_leaves_untouched_params_verbatim():
@@ -340,6 +337,18 @@ def test_elaborate_errors_on_unrenderable_param():
 
     with pytest.raises(RuntimeError):
         proj.run()
+
+    # Confirm it failed for the intended reason (our explicit render error),
+    # not an incidental elaboration failure. The message is logged to the node
+    # log file -- the RuntimeError itself only carries a generic summary, and
+    # the node runs in a separate process so caplog does not see it.
+    logtext = ""
+    logdir = workdir(proj, step="elaborate", index="0")
+    for name in os.listdir(logdir):
+        if name.endswith(".log"):
+            with open(os.path.join(logdir, name)) as fout:
+                logtext += fout.read()
+    assert "cannot rewrite the default of top parameter 'P'" in logtext
 
 
 def test_elaborate_prunes_deep_hierarchy_keeps_interface():


### PR DESCRIPTION
https://github.com/siliconcompiler/siliconcompiler/actions/runs/29505395649
https://github.com/siliconcompiler/siliconcompiler/actions/runs/29520884082
https://github.com/siliconcompiler/siliconcompiler/actions/runs/29527108515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Elaboration output now emits only definitions reachable from the top-level design, with source-path reporting listed per retained definition (when enabled).
  * Top-level parameter overrides are now baked into the emitted result, ensuring correct defaults in the generated output.

* **Bug Fixes**
  * Unused modules/definitions (and related source annotations) are no longer included, including in deep hierarchies.
  * Parameter overrides that can’t be rendered into valid SystemVerilog now fail clearly.

* **Tests**
  * Added extensive regression coverage for reachability pruning, typed/untyped override rendering, source-path behavior, deep-hierarchy pruning, and SystemVerilog round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->