### PR TITLE
add remove_parent to editable schema and ensure deps are part of disk IO

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-extend-exclude = third_party,setup/*/deps,_skbuild,.venv/,build/
+extend-exclude = third_party,setup/*/deps,_skbuild,.venv*/,build/
 max-line-length = 100
 extend-ignore =

--- a/siliconcompiler/schema/editableschema.py
+++ b/siliconcompiler/schema/editableschema.py
@@ -188,4 +188,7 @@ class EditableSchema:
         '''
         Removes the parent of a schema object, disconnecting it from any parent schema
         '''
+        if self.__schema._is_frozen:
+            raise SchemaFrozenError("cannot remove parent: schema is frozen")
+
         self.__schema._BaseSchema__parent = None

--- a/siliconcompiler/schema/editableschema.py
+++ b/siliconcompiler/schema/editableschema.py
@@ -168,7 +168,7 @@ class EditableSchema:
 
         new_schema = self.__schema.copy()
         if new_schema._parent() is not new_schema:
-            new_schema._BaseSchema__parent = None
+            EditableSchema(new_schema).remove_parent()
         return new_schema
 
     def rename(self, name: str) -> None:
@@ -183,3 +183,9 @@ class EditableSchema:
             raise ValueError("object is already in a schema")
 
         self.__schema._NamedSchema__name = name
+
+    def remove_parent(self) -> None:
+        '''
+        Removes the parent of a schema object, disconnecting it from any parent schema
+        '''
+        self.__schema._BaseSchema__parent = None

--- a/siliconcompiler/schema_support/dependencyschema.py
+++ b/siliconcompiler/schema_support/dependencyschema.py
@@ -50,26 +50,39 @@ class DependencySchema(BaseSchema):
         Returns:
             The result of the parent class's _from_dict method.
         '''
-        deps = {}
+        depsdict = None
         if "__meta__" in manifest and "__deps__" in manifest["__meta__"]:
-            scversion = None
-            if version:
-                scversion = {
-                    BaseSchema._version_key:
-                        Parameter("str", defvalue=".".join(map(str, version))).getdict()
-                }
-            for name, depcfg in manifest["__meta__"]["__deps__"].items():
-                if scversion:
-                    depcfg.update(scversion)
-                deps[name] = NamedSchema.from_manifest(cfg=depcfg, lazyload=lazyload)
+            depsdict = manifest["__meta__"]["__deps__"]
+
+        # Defer dependency loading while lazy loading is enforced: the parent
+        # loader stashes the manifest (including the embedded __deps__) and
+        # re-invokes this method with a non-enforced mode on elaboration.
+        process_deps = depsdict is not None and not lazyload.is_enforced
+
+        deps = {}
+        if process_deps:
+            depversion = ".".join(map(str, version)) if version else None
+            for name, depcfg in depsdict.items():
+                if depversion:
+                    # Build a fresh parameter per dependency: Parameter.from_dict
+                    # consumes the dict, so a shared instance would be exhausted
+                    # after the first dependency.
+                    depcfg[BaseSchema._version_key] = \
+                        Parameter("str", defvalue=depversion).getdict()
+                # from_manifest expects a bool; dependencies are materialized
+                # eagerly so the full graph is available once elaborated.
+                deps[name] = NamedSchema.from_manifest(cfg=depcfg, lazyload=False)
             del manifest["__meta__"]["__deps__"]
 
         self.set("deps", False, field="lock")
         ret = super()._from_dict(manifest, keypath, version=version, lazyload=lazyload)
         self.set("deps", True, field="lock")
-        if deps:
+        if process_deps:
+            # Reset even for an explicitly empty dependency set so stale
+            # dependencies do not survive a reload.
             self._reset_deps()
-            self._populate_deps(deps)
+            if deps:
+                self._populate_deps(deps)
         return ret
 
     def _getdict_meta(self):
@@ -283,6 +296,10 @@ class DependencySchema(BaseSchema):
         Returns:
             list: A list of dependency objects.
         '''
+
+        # Ensure a deferred (lazily-loaded) manifest is elaborated so the
+        # internal dependency map is populated before it is read.
+        self.get("deps")
 
         if name:
             if not self.has_dep(name):

--- a/siliconcompiler/schema_support/dependencyschema.py
+++ b/siliconcompiler/schema_support/dependencyschema.py
@@ -50,10 +50,49 @@ class DependencySchema(BaseSchema):
         Returns:
             The result of the parent class's _from_dict method.
         '''
+        deps = {}
+        if "__meta__" in manifest and "__deps__" in manifest["__meta__"]:
+            scversion = None
+            if version:
+                scversion = {
+                    BaseSchema._version_key:
+                        Parameter("str", defvalue=".".join(map(str, version))).getdict()
+                }
+            for name, depcfg in manifest["__meta__"]["__deps__"].items():
+                if scversion:
+                    depcfg.update(scversion)
+                deps[name] = NamedSchema.from_manifest(cfg=depcfg, lazyload=lazyload)
+            del manifest["__meta__"]["__deps__"]
+
         self.set("deps", False, field="lock")
         ret = super()._from_dict(manifest, keypath, version=version, lazyload=lazyload)
         self.set("deps", True, field="lock")
+        if deps:
+            self._reset_deps()
+            self._populate_deps(deps)
         return ret
+
+    def _getdict_meta(self):
+        from siliconcompiler import Project
+        meta = super()._getdict_meta()
+        if isinstance(self._parent(root=True), Project):
+            return meta
+
+        # Root is not project, so we need to add the deps to the meta
+        all_deps = self.get_dep(hierarchy=False)
+        if all_deps:
+            meta['__deps__'] = {}
+            for dep in all_deps:
+                meta['__deps__'][dep.name] = dep.getdict()
+
+        return meta
+
+    def write_manifest(self, filename: str) -> None:
+        # Create copy without any parent
+        depschema = EditableSchema(self).copy()
+        for dep in depschema.get_dep(hierarchy=True):
+            EditableSchema(dep).remove_parent()
+        BaseSchema.write_manifest(depschema, filename)
 
     def add_dep(self, obj: NamedSchema, clobber: bool = True) -> bool:
         """

--- a/siliconcompiler/schema_support/dependencyschema.py
+++ b/siliconcompiler/schema_support/dependencyschema.py
@@ -91,20 +91,29 @@ class DependencySchema(BaseSchema):
         if isinstance(self._parent(root=True), Project):
             return meta
 
-        # Root is not project, so we need to add the deps to the meta
-        all_deps = self.get_dep(hierarchy=False)
+        # Root is not a project, so emit a flat, de-duplicated map of the full
+        # transitive dependency set. get_dep(hierarchy=True) already collapses
+        # diamonds and tolerates cycles, so the map is finite. Each entry is
+        # serialized without its own nested __deps__ (its "deps" name list is
+        # preserved), and the graph is re-linked from this flat map on load.
+        all_deps = self.get_dep(hierarchy=True)
         if all_deps:
             meta['__deps__'] = {}
             for dep in all_deps:
-                meta['__deps__'][dep.name] = dep.getdict()
+                # Copy so the original is untouched, then clear the copy's
+                # dependency objects so it serializes as a flat leaf entry.
+                flat = EditableSchema(dep).copy()
+                if isinstance(flat, DependencySchema):
+                    flat._reset_deps()
+                meta['__deps__'][dep.name] = flat.getdict()
 
         return meta
 
     def write_manifest(self, filename: str) -> None:
-        # Create copy without any parent
+        # Detach a copy from any parent project so the dependency graph is
+        # embedded (as a flat map, see _getdict_meta) rather than deferred to
+        # the project. The original object is left untouched.
         depschema = EditableSchema(self).copy()
-        for dep in depschema.get_dep(hierarchy=True):
-            EditableSchema(dep).remove_parent()
         BaseSchema.write_manifest(depschema, filename)
 
     def add_dep(self, obj: NamedSchema, clobber: bool = True) -> bool:

--- a/tests/schema/test_editableschema.py
+++ b/tests/schema/test_editableschema.py
@@ -356,6 +356,25 @@ def test_copy():
 
     copy = EditableSchema(obj).copy()
     assert copy._keypath == tuple()
+    assert copy._parent() is copy
+
+
+def test_remove_parent():
+    schema = BaseSchema()
+
+    assert len(schema.getkeys()) == 0
+
+    obj = BaseSchema()
+
+    edit = EditableSchema(schema)
+    edit.insert("test0", "default", "test2", "test3", obj)
+
+    assert obj._keypath == ("test0", "default", "test2", "test3")
+
+    assert obj._parent() is not obj
+    EditableSchema(obj).remove_parent()
+    assert obj._parent() is obj
+    assert obj._keypath == tuple()
 
 
 def test_rename_in_schema():

--- a/tests/schema/test_editableschema.py
+++ b/tests/schema/test_editableschema.py
@@ -427,6 +427,27 @@ def test_remove_on_frozen_raises():
         EditableSchema(schema).remove("existing")
 
 
+def test_remove_parent_on_frozen_raises():
+    schema = BaseSchema()
+    obj = BaseSchema()
+    EditableSchema(schema).insert("test0", obj)
+    obj._freeze()
+    with pytest.raises(SchemaFrozenError, match="frozen"):
+        EditableSchema(obj).remove_parent()
+    # The parent link must be left intact when the schema is frozen.
+    assert obj._parent() is not obj
+
+
+def test_remove_parent_allowed_after_unfreeze():
+    schema = BaseSchema()
+    obj = BaseSchema()
+    EditableSchema(schema).insert("test0", obj)
+    obj._freeze()
+    obj._unfreeze()
+    EditableSchema(obj).remove_parent()
+    assert obj._parent() is obj
+
+
 def test_insert_allowed_after_unfreeze():
     schema = BaseSchema()
     schema._freeze()

--- a/tests/schema_support/test_dependencyschema.py
+++ b/tests/schema_support/test_dependencyschema.py
@@ -290,27 +290,26 @@ def test_get_dep_circle():
     assert schema.get_dep() == [dep00, dep10, dep01, dep11]
 
 
-@pytest.mark.skip(reason="cyclic dependency graphs cannot yet be serialized "
-                         "into a self-contained manifest (see finding A); "
-                         "revisit once dependency serialization is reworked")
 def test_getdict_with_cycle():
-    # A cyclic dependency graph is permitted by add_dep (see test_get_dep_circle)
-    # but the nested manifest embedding recurses indefinitely on a cycle. Once
-    # dependency serialization preserves graph identity (canonical name table),
-    # this should produce a finite, reloadable manifest instead of recursing.
-    class Test(NamedSchema, DependencySchema):
-        def __init__(self, name):
-            super().__init__()
-            self.set_name(name)
-
-    dep0 = Test("dep0")
-    dep1 = Test("dep1")
+    # A cyclic dependency graph is permitted by add_dep (see test_get_dep_circle).
+    # Dependencies are serialized as a flat, de-duplicated map, so a cycle yields
+    # a finite, reloadable manifest instead of recursing indefinitely. A resolvable
+    # class (Design) is used so the graph is reconstructed on reload.
+    dep0 = Design("dep0")
+    dep1 = Design("dep1")
     assert dep0.add_dep(dep1)
     assert dep1.add_dep(dep0)
 
     cfg = dep0.getdict()
 
-    reload = Test.from_manifest(name="dep0", cfg=cfg)
+    # Flat map: both nodes present, each without a nested __deps__.
+    deps = cfg["__meta__"]["__deps__"]
+    assert set(deps) == {"dep0", "dep1"}
+    for entry in deps.values():
+        assert "__deps__" not in entry["__meta__"]
+
+    # The cyclic graph reloads into a finite, fully linked structure.
+    reload = Design.from_manifest(cfg=cfg)
     assert sorted(d.name for d in reload.get_dep()) == ["dep0", "dep1"]
 
 
@@ -1047,12 +1046,11 @@ def test_getdict_with_deps():
 
     assert "__deps__" in cfg['__meta__']
     dpescfg = cfg['__meta__']["__deps__"]
-    assert "level0-0" in dpescfg
-    assert "level0-1" not in dpescfg
-    assert "level0-1" in dpescfg["level0-0"]["__meta__"]["__deps__"]
-    assert "level0-2" not in dpescfg
-    assert "level0-2" in \
-        dpescfg["level0-0"]["__meta__"]["__deps__"]["level0-1"]["__meta__"]["__deps__"]
+    # The full transitive dependency set is emitted as a flat map, and each
+    # entry is a leaf (no nested __deps__).
+    assert set(dpescfg) == {"level0-0", "level0-1", "level0-2"}
+    for entry in dpescfg.values():
+        assert "__deps__" not in entry["__meta__"]
 
 
 def test_getdict_with_deps_project():
@@ -1104,9 +1102,13 @@ def test_write_manifest_self_contained_for_design_in_project(tmp_path):
     with open(path) as fout:
         cfg = json.load(fout)
 
+    # The full transitive dependency set is embedded as a flat map, so the
+    # manifest is self-contained (and finite regardless of graph shape).
     deps = cfg["__meta__"].get("__deps__", {})
     assert "child" in deps
-    assert "grandchild" in deps["child"]["__meta__"].get("__deps__", {})
+    assert "grandchild" in deps
+    for entry in deps.values():
+        assert "__deps__" not in entry["__meta__"]
 
 
 def test_write_manifest_roundtrip_for_design_in_project(tmp_path):

--- a/tests/schema_support/test_dependencyschema.py
+++ b/tests/schema_support/test_dependencyschema.py
@@ -1,11 +1,15 @@
 import graphviz
 import pytest
 
+import copy
+import json
 import os.path
 
 from unittest.mock import patch, MagicMock
 
+from siliconcompiler import Design, Project
 from siliconcompiler.schema import NamedSchema, BaseSchema
+from siliconcompiler.schema.parameter import Parameter
 from siliconcompiler.schema_support.dependencyschema import DependencySchema
 from siliconcompiler.schema_support.pathschema import PathSchemaSimpleBase, PathSchema
 
@@ -122,6 +126,25 @@ def test_remove_dep_with_object():
     assert schema.get("deps", field="lock") is True
     assert schema.get_dep() == []
     assert schema.get("deps") == []
+
+
+def test_remove_dep_multiple():
+    schema = DependencySchema()
+    dep_a = NamedSchema("a")
+    dep_b = NamedSchema("b")
+    dep_c = NamedSchema("c")
+    schema.add_dep(dep_a)
+    schema.add_dep(dep_b)
+    schema.add_dep(dep_c)
+
+    assert schema.get("deps") == ["a", "b", "c"]
+
+    # Removing one dependency leaves the others intact and ordered.
+    assert schema.remove_dep("b") is True
+    assert schema.has_dep("b") is False
+    assert schema.get("deps") == ["a", "c"]
+    assert schema.get_dep() == [dep_a, dep_c]
+    assert schema.get("deps", field="lock") is True
 
 
 def test_get_dep_empty():
@@ -397,6 +420,34 @@ def test_populate_deps_empty():
     schema._populate_deps({})
 
 
+def test_populate_deps_missing_meta():
+    class Test(NamedSchema, DependencySchema):
+        def __init__(self, name=None):
+            super().__init__()
+            self.set_name(name)
+
+    schema = Test("top")
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep10 = Test("level1-0")
+    dep11 = Test("level1-1")
+
+    assert dep00.add_dep(dep10)
+    assert dep01.add_dep(dep11)
+
+    assert schema.add_dep(dep00)
+    assert schema.add_dep(dep01)
+
+    cfg = schema.getdict()
+    del cfg['__meta__']['__deps__']
+    check = Test.from_manifest(name="test", cfg=cfg)
+    assert check.get_dep() == []
+    module_map = {obj.name: obj for obj in schema.get_dep()}
+    check._populate_deps(module_map)
+    assert check.get_dep() == schema.get_dep()
+
+
 def test_populate_deps():
     class Test(NamedSchema, DependencySchema):
         def __init__(self, name=None):
@@ -416,9 +467,81 @@ def test_populate_deps():
     assert schema.add_dep(dep00)
     assert schema.add_dep(dep01)
 
-    check = Test.from_manifest(name="test", cfg=schema.getdict())
-    assert check.get_dep() == []
+    cfg = schema.getdict()
+    check = Test.from_manifest(name="test", cfg=cfg)
+    assert sorted([dep.name for dep in check.get_dep()]) == ["level0-0", "level0-1"]
+
+
+def test_from_dict_with_version():
+    # from_manifest does not expose the version argument, so _from_dict is
+    # driven directly to exercise the branch that injects the schema version
+    # into each dependency's manifest before it is loaded.
+    class Test(NamedSchema, DependencySchema):
+        def __init__(self, name=None):
+            super().__init__()
+            self.set_name(name)
+
+    schema = Test("top")
+
+    dep00 = Test("level0-0")
+    dep10 = Test("level1-0")
+
+    assert dep00.add_dep(dep10)
+    assert schema.add_dep(dep00)
+
+    cfg = schema.getdict()
+
+    seen_cfgs = []
+    orig_from_manifest = NamedSchema.from_manifest.__func__
+
+    def spy(cls, *args, cfg=None, **kwargs):
+        # snapshot before loading mutates the dict in place
+        seen_cfgs.append(copy.deepcopy(cfg))
+        return orig_from_manifest(cls, *args, cfg=cfg, **kwargs)
+
+    check = Test("top")
+    with patch.object(NamedSchema, "from_manifest", classmethod(spy)):
+        check._from_dict(cfg, tuple(), version=(1, 2, 3))
+
+    # The version path still populates the dependencies correctly.
+    assert [dep.name for dep in check.get_dep(hierarchy=False)] == ["level0-0"]
+
+    # Each dependency manifest had the schema version injected before loading.
+    # Round-trip the injected field through Parameter so a malformed cfg would
+    # surface here rather than being silently accepted.
+    assert seen_cfgs
+    for depcfg in seen_cfgs:
+        assert BaseSchema._version_key in depcfg
+        param = Parameter.from_dict(depcfg[BaseSchema._version_key],
+                                    (BaseSchema._version_key,),
+                                    None)
+        assert param.get() == "1.2.3"
+
+
+def test_populate_deps_reset():
+    class Test(NamedSchema, DependencySchema):
+        def __init__(self, name=None):
+            super().__init__()
+            self.set_name(name)
+
+    schema = Test("top")
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep10 = Test("level1-0")
+    dep11 = Test("level1-1")
+
+    assert dep00.add_dep(dep10)
+    assert dep01.add_dep(dep11)
+
+    assert schema.add_dep(dep00)
+    assert schema.add_dep(dep01)
+
+    cfg = schema.getdict()
+    check = Test.from_manifest(name="test", cfg=cfg)
+    assert sorted([dep.name for dep in check.get_dep()]) == ["level0-0", "level0-1"]
     module_map = {obj.name: obj for obj in schema.get_dep()}
+    check._reset_deps()
     check._populate_deps(module_map)
     assert check.get_dep() == schema.get_dep()
 
@@ -442,7 +565,9 @@ def test_populate_deps_missing():
     assert schema.add_dep(dep00)
     assert schema.add_dep(dep01)
 
-    check = Test.from_manifest(name="test", cfg=schema.getdict())
+    cfg = schema.getdict()
+    del cfg['__meta__']['__deps__']
+    check = Test.from_manifest(name="test", cfg=cfg)
     with pytest.raises(ValueError, match=r"^level0-0 not available in map$"):
         check._populate_deps({})
 
@@ -475,6 +600,38 @@ def test_populate_deps_already_populated():
     assert check.get_dep() == [dep00, dep10]
 
 
+def test_populate_deps_recursive():
+    # Exercises the recursive branch of _populate_deps: a dependency that is
+    # itself an unpopulated DependencySchema must have its own deps resolved.
+    class Test(NamedSchema, DependencySchema):
+        def __init__(self, name):
+            super().__init__()
+            self.set_name(name)
+
+    top = Test("top")
+    mid = Test("mid")
+    leaf = Test("leaf")
+
+    assert mid.add_dep(leaf)
+    assert top.add_dep(mid)
+
+    # Clear the resolved object maps while leaving the "deps" name lists intact,
+    # so _populate_deps has to rebuild the hierarchy from the module map.
+    top._reset_deps()
+    mid._reset_deps()
+
+    assert top.get_dep(hierarchy=False) == []
+    assert mid.get_dep(hierarchy=False) == []
+
+    module_map = {"mid": mid, "leaf": leaf}
+    top._populate_deps(module_map)
+
+    # Direct dep resolved on top, and the nested dep resolved recursively on mid.
+    assert top.get_dep(hierarchy=False) == [mid]
+    assert mid.get_dep(hierarchy=False) == [leaf]
+    assert top.get_dep() == [mid, leaf]
+
+
 def test_check_filepaths_none():
     assert DependencySchema().check_filepaths() is True
 
@@ -499,6 +656,40 @@ def test_check_filepaths_self_fail(pcls):
         cf.return_value = False
         assert Test().check_filepaths() is False
         cf.assert_called_once()
+
+
+def test_check_filepaths_skips_non_pathschema_dep():
+    class Test(DependencySchema, PathSchema):
+        pass
+
+    dut = Test()
+    # A dependency that is not a PathSchemaBase must be skipped, not checked.
+    dut.add_dep(NamedSchema("plaindep"))
+
+    with patch("siliconcompiler.schema_support.pathschema.PathSchemaBase.check_filepaths") as cf:
+        cf.return_value = True
+        assert dut.check_filepaths() is True
+        # Only self is checked; the plain NamedSchema dependency is skipped.
+        cf.assert_called_once()
+
+
+def test_check_filepaths_ignore_keys_forwarded():
+    class Test(NamedSchema, DependencySchema, PathSchema):
+        def __init__(self, name=None):
+            super().__init__()
+            self.set_name(name)
+
+    dut = Test("top")
+    dut.add_dep(Test("dep0"))
+
+    ignore = [("key", "path")]
+    with patch("siliconcompiler.schema_support.pathschema.PathSchemaBase.check_filepaths") as cf:
+        cf.return_value = True
+        assert dut.check_filepaths(ignore_keys=ignore) is True
+        assert cf.call_count == 2
+        # ignore_keys is forwarded to every checked object (self and deps).
+        for call in cf.call_args_list:
+            assert call.kwargs["ignore_keys"] is ignore
 
 
 def test_check_filepaths_depth_fail():
@@ -798,3 +989,125 @@ def test_write_depgraph_visual_params_forwarded():
     assert kw["fontsize"] == "18"
     assert kw["border"] is False
     assert kw["landscape"] is True
+
+
+def test_getdict_with_nodeps():
+    class Test(NamedSchema, DependencySchema):
+        def __init__(self, name):
+            super().__init__()
+            self.set_name(name)
+
+    schema = DependencySchema()
+
+    assert "__deps__" not in schema.getdict()['__meta__']
+
+
+def test_getdict_with_deps():
+    class Test(NamedSchema, DependencySchema):
+        def __init__(self, name):
+            super().__init__()
+            self.set_name(name)
+
+    schema = DependencySchema()
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep02 = Test("level0-2")
+
+    assert dep00.add_dep(dep01)
+    assert dep01.add_dep(dep02)
+
+    assert schema.add_dep(dep00)
+
+    cfg = schema.getdict()
+
+    assert "__deps__" in cfg['__meta__']
+    dpescfg = cfg['__meta__']["__deps__"]
+    assert "level0-0" in dpescfg
+    assert "level0-1" not in dpescfg
+    assert "level0-1" in dpescfg["level0-0"]["__meta__"]["__deps__"]
+    assert "level0-2" not in dpescfg
+    assert "level0-2" in \
+        dpescfg["level0-0"]["__meta__"]["__deps__"]["level0-1"]["__meta__"]["__deps__"]
+
+
+def test_getdict_with_deps_project():
+    class Test(Design):
+        def __init__(self, name):
+            super().__init__()
+            self.set_name(name)
+
+    schema = Test("top")
+
+    dep00 = Test("level0-0")
+    dep01 = Test("level0-1")
+    dep02 = Test("level0-2")
+
+    assert dep00.add_dep(dep01)
+    assert dep01.add_dep(dep02)
+
+    assert schema.add_dep(dep00)
+
+    d = Design("test")
+    d.add_dep(schema)
+
+    Project(d)
+
+    assert "__deps__" not in schema.getdict()['__meta__']
+
+
+def test_write_manifest_self_contained_for_design_in_project(tmp_path):
+    # A design imported into a project stores its deps centrally in the project,
+    # so the project-owned manifest omits them. But writing that design's
+    # manifest *directly* must still produce a self-contained file: the on-disk
+    # manifest should embed the full, recursive dependency tree.
+    #
+    # This fails until write_manifest on a design that lives inside a project
+    # emits its dependencies; today the deps are dropped.
+    top = Design("top")
+    child = Design("child")
+    grandchild = Design("grandchild")
+
+    assert child.add_dep(grandchild)
+    assert top.add_dep(child)
+
+    Project(top)
+    assert isinstance(top._parent(root=True), Project)
+
+    path = str(tmp_path / "top.json")
+    top.write_manifest(path)
+
+    with open(path) as fout:
+        cfg = json.load(fout)
+
+    deps = cfg["__meta__"].get("__deps__", {})
+    assert "child" in deps
+    assert "grandchild" in deps["child"]["__meta__"].get("__deps__", {})
+
+
+def test_write_manifest_roundtrip_for_design_in_project(tmp_path):
+    # The self-contained manifest of a design taken from a project must reload
+    # on its own into a fully populated design hierarchy of the correct types.
+    #
+    # This fails until write_manifest on a design that lives inside a project
+    # emits its dependencies; today the reloaded design has no deps.
+    top = Design("top")
+    child = Design("child")
+    grandchild = Design("grandchild")
+
+    assert child.add_dep(grandchild)
+    assert top.add_dep(child)
+
+    Project(top)
+
+    path = str(tmp_path / "top.json")
+    top.write_manifest(path)
+
+    reload = NamedSchema.from_manifest(filepath=path)
+    assert isinstance(reload, Design)
+    assert reload.name == "top"
+    assert [dep.name for dep in reload.get_dep(hierarchy=False)] == ["child"]
+
+    reload_child = reload.get_dep("child")
+    assert isinstance(reload_child, Design)
+    assert [dep.name for dep in reload_child.get_dep(hierarchy=False)] == ["grandchild"]

--- a/tests/schema_support/test_dependencyschema.py
+++ b/tests/schema_support/test_dependencyschema.py
@@ -290,6 +290,30 @@ def test_get_dep_circle():
     assert schema.get_dep() == [dep00, dep10, dep01, dep11]
 
 
+@pytest.mark.skip(reason="cyclic dependency graphs cannot yet be serialized "
+                         "into a self-contained manifest (see finding A); "
+                         "revisit once dependency serialization is reworked")
+def test_getdict_with_cycle():
+    # A cyclic dependency graph is permitted by add_dep (see test_get_dep_circle)
+    # but the nested manifest embedding recurses indefinitely on a cycle. Once
+    # dependency serialization preserves graph identity (canonical name table),
+    # this should produce a finite, reloadable manifest instead of recursing.
+    class Test(NamedSchema, DependencySchema):
+        def __init__(self, name):
+            super().__init__()
+            self.set_name(name)
+
+    dep0 = Test("dep0")
+    dep1 = Test("dep1")
+    assert dep0.add_dep(dep1)
+    assert dep1.add_dep(dep0)
+
+    cfg = dep0.getdict()
+
+    reload = Test.from_manifest(name="dep0", cfg=cfg)
+    assert sorted(d.name for d in reload.get_dep()) == ["dep0", "dep1"]
+
+
 def test_write_depgraph_no_graphviz_exe():
     class Test(NamedSchema, DependencySchema):
         def __init__(self, name):
@@ -469,7 +493,7 @@ def test_populate_deps():
 
     cfg = schema.getdict()
     check = Test.from_manifest(name="test", cfg=cfg)
-    assert sorted([dep.name for dep in check.get_dep()]) == ["level0-0", "level0-1"]
+    assert sorted([dep.name for dep in check.get_dep(hierarchy=False)]) == ["level0-0", "level0-1"]
 
 
 def test_from_dict_with_version():
@@ -539,7 +563,7 @@ def test_populate_deps_reset():
 
     cfg = schema.getdict()
     check = Test.from_manifest(name="test", cfg=cfg)
-    assert sorted([dep.name for dep in check.get_dep()]) == ["level0-0", "level0-1"]
+    assert sorted([dep.name for dep in check.get_dep(hierarchy=False)]) == ["level0-0", "level0-1"]
     module_map = {obj.name: obj for obj in schema.get_dep()}
     check._reset_deps()
     check._populate_deps(module_map)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dependency information is preserved in saved/loading manifests.
  - Manifests for designs inside projects can be self-contained, embedding complete dependency hierarchies.
  - Dependency and parent relationships can be detached and reconstructed safely during schema editing.

- **Bug Fixes**
  - Restores dependency data reliably when dependency metadata is missing or after resets.
  - Correctly serializes cyclic dependency graphs into a finite form and reloads them back into a linked structure.
  - Improves file-path validation across dependency configurations (including proper ignore handling).

- **Tests**
  - Expanded coverage for dependency management and schema parent detachment behavior, including frozen-schema error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->