### PR TITLE
explicitly set context

### DIFF
--- a/siliconcompiler/scheduler/scheduler.py
+++ b/siliconcompiler/scheduler/scheduler.py
@@ -25,7 +25,7 @@ from siliconcompiler.tool import TaskExecutableNotFound, TaskExecutableNotReceiv
 
 from siliconcompiler import utils
 from siliconcompiler.utils.logging import SCLoggerFormatter
-from siliconcompiler.utils.multiprocessing import MPManager
+from siliconcompiler.utils.multiprocessing import MPManager, get_process_context
 from siliconcompiler.scheduler import send_messages, SCRuntimeError
 from siliconcompiler.utils.paths import collectiondir, jobdir
 from siliconcompiler.utils.curation import collect
@@ -712,7 +712,7 @@ class Scheduler:
         # Call this in case this was invoked without __main__
         multiprocessing.freeze_support()
 
-        with multiprocessing.get_context("spawn").Pool(pool_size) as pool:
+        with get_process_context().Pool(pool_size) as pool:
             while True:
                 # Filter nodes
                 filter_nodes(nodes)

--- a/siliconcompiler/scheduler/taskscheduler.py
+++ b/siliconcompiler/scheduler/taskscheduler.py
@@ -19,7 +19,7 @@ from siliconcompiler.schema import Journal
 
 from siliconcompiler.utils.logging import SCBlankLoggerFormatter, \
     SCBlankColorlessLoggerFormatter, SCTeeLoggerHandler
-from siliconcompiler.utils.multiprocessing import MPManager
+from siliconcompiler.utils.multiprocessing import MPManager, get_process_context
 from siliconcompiler.scheduler import SCRuntimeError
 
 if TYPE_CHECKING:
@@ -135,7 +135,7 @@ class TaskScheduler:
                 threads = self.__max_threads
             task["threads"] = max(1, min(threads, self.__max_threads))
 
-            task["proc"] = multiprocessing.Process(target=task["node"].run)
+            task["proc"] = get_process_context().Process(target=task["node"].run)
             self.__nodes[(step, index)] = task
 
         # Create ordered list of nodes
@@ -404,7 +404,7 @@ class TaskScheduler:
 
         # Start the process
         info["running"] = True
-        info["parent_pipe"], pipe = multiprocessing.Pipe()
+        info["parent_pipe"], pipe = get_process_context().Pipe()
         info["node"].set_queue(pipe, self.__log_queue)
         info["proc"].start()
 

--- a/siliconcompiler/utils/multiprocessing.py
+++ b/siliconcompiler/utils/multiprocessing.py
@@ -1,5 +1,7 @@
 import atexit
 import logging
+import multiprocessing
+import sys
 import tempfile
 import threading
 
@@ -9,12 +11,40 @@ from typing import Union, Optional
 
 from datetime import datetime
 from logging.handlers import QueueHandler
+from multiprocessing.context import BaseContext
 from multiprocessing.managers import SyncManager, RemoteError
 
 from siliconcompiler.utils.settings import SettingsManager
 from siliconcompiler.utils import default_sc_path, default_sc_system_path
 
 from siliconcompiler.report.dashboard.cli.board import Board
+
+
+def get_process_context() -> BaseContext:
+    """Returns the multiprocessing context used to launch scheduler workers.
+
+    SiliconCompiler launches node workers and the run-check pool by handing
+    them an already-configured, non-picklable object graph (the node with its
+    log pipe attached, inherited logger handlers, etc.) and expects unguarded
+    module-level ``proj.run()`` scripts to work. Both of those require the
+    ``fork`` start method: ``spawn``/``forkserver`` re-import ``__main__`` (so
+    an unguarded script recurses into the bootstrapping error) and cannot
+    inherit the pre-attached pipe.
+
+    We therefore pin ``fork`` explicitly on Linux rather than relying on the
+    interpreter default, which changed to ``forkserver`` in Python 3.14.
+
+    Everywhere else we pin ``spawn``. Note this is deliberately keyed on the
+    platform, not on ``"fork" in get_all_start_methods()``: fork *is* available
+    on macOS, but it is unsafe there with threads (SC runs a logging
+    ``QueueListener`` and the dashboard board on threads), which is why CPython
+    itself defaults macOS to ``spawn``. Windows has no fork at all. On those
+    platforms callers must guard scripts with ``if __name__ == "__main__"``, as
+    has always been required.
+    """
+    if sys.platform.startswith("linux"):
+        return multiprocessing.get_context("fork")
+    return multiprocessing.get_context("spawn")
 
 
 class _ManagerSingleton(type):
@@ -141,7 +171,12 @@ class MPManager(metaclass=_ManagerSingleton):
                 self.__logger.warning("Manager address file not found; falling back to server mode")
                 is_server = True  # fall back to create new manager
         if is_server:
-            self.__manager = SyncManager(authkey=MPManager.__authkey)
+            # Pin the start method for the manager's server process: its
+            # start() launches a process, and under the Python 3.14 default
+            # (forkserver) that re-imports __main__ and breaks unguarded
+            # module-level proj.run() scripts. See get_process_context().
+            self.__manager = SyncManager(authkey=MPManager.__authkey,
+                                         ctx=get_process_context())
             self.__manager.start()
             MPManager._set_manager_address(self.__manager.address)
             self.__manager_server = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -436,6 +436,24 @@ def disable_mp_process():
         def is_alive(self):
             return False
 
-    with patch("multiprocessing.Process") as proc:
-        proc.side_effect = FakeProc
+    # The scheduler launches node workers via get_process_context().Process
+    # (a context-specific Process class), not the module-level
+    # multiprocessing.Process, so we fake the context: Process runs the target
+    # inline while Pipe/Pool delegate to a real context.
+    real_ctx = multiprocessing.get_context()
+
+    class FakeContext:
+        Process = FakeProc
+
+        def Pipe(self, *args, **kwargs):
+            return real_ctx.Pipe(*args, **kwargs)
+
+        def Pool(self, *args, **kwargs):
+            return real_ctx.Pool(*args, **kwargs)
+
+    fake_ctx = FakeContext()
+    with patch("siliconcompiler.scheduler.taskscheduler.get_process_context",
+               return_value=fake_ctx), \
+         patch("siliconcompiler.scheduler.scheduler.get_process_context",
+               return_value=fake_ctx):
         yield

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -1,6 +1,9 @@
 import logging
 import os
 import pytest
+import subprocess
+import sys
+import textwrap
 import time
 
 import os.path
@@ -1663,3 +1666,59 @@ def test_logger_cleanup_on_manifest_exception(basic_project):
 
     # Handler should be cleaned up
     assert isinstance(scheduler._Scheduler__joblog_handler, logging.NullHandler)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"),
+                    reason="unguarded module-level run() is only supported on linux, "
+                           "where the fork start method is pinned")
+def test_unguarded_run_with_non_fork_default():
+    '''Regression: an unguarded module-level ``proj.run()`` script must succeed
+    even when the interpreter's default start method is not fork.
+
+    Python 3.14 changed the POSIX default to ``forkserver``; both it and
+    ``spawn`` re-import ``__main__`` and would recurse into the multiprocessing
+    "bootstrapping phase" RuntimeError for a script without an
+    ``if __name__ == "__main__"`` guard. SiliconCompiler pins fork on Linux for
+    every process it launches (node workers, the run-check pool and the
+    SyncManager), so this must work regardless of the default. This runs twice:
+    a clean run and a re-run (the re-run exercises the check pool, which is
+    skipped on a clean run).'''
+    # The test already runs in its own isolated cwd (autouse test_wrapper
+    # fixture), so write the script and let its build dir land there.
+    script = Path("unguarded_flow.py")
+    # NOTE: deliberately NO ``if __name__ == "__main__"`` guard, and the default
+    # start method is forced to spawn to emulate a hostile (non-fork) default.
+    script.write_text(textwrap.dedent(
+        """
+        import multiprocessing
+        multiprocessing.set_start_method("spawn", force=True)
+
+        from siliconcompiler import Design, Project, Flowgraph
+        from siliconcompiler.tools.builtin.nop import NOPTask
+
+        design = Design("testdesign")
+        with design.active_fileset("rtl"):
+            design.set_topmodule("designtop")
+
+        proj = Project(design)
+        proj.add_fileset("rtl")
+
+        flow = Flowgraph("testflow")
+        flow.node("stepone", NOPTask())
+        flow.node("steptwo", NOPTask())
+        flow.edge("stepone", "steptwo")
+        proj.set_flow(flow)
+
+        proj.run()
+        print("SC_RUN_OK")
+        """))
+
+    for run in ("clean", "rerun"):
+        proc = subprocess.run(
+            [sys.executable, str(script)],
+            capture_output=True, text=True, timeout=120)
+        combined = proc.stdout + proc.stderr
+        assert proc.returncode == 0, f"[{run}] failed:\n{combined}"
+        assert "SC_RUN_OK" in proc.stdout, f"[{run}] missing success marker:\n{combined}"
+        assert "bootstrapping phase" not in combined, \
+            f"[{run}] hit the multiprocessing guard error:\n{combined}"

--- a/tests/utils/test_multiprocessing.py
+++ b/tests/utils/test_multiprocessing.py
@@ -5,9 +5,26 @@ from unittest.mock import patch
 
 import pytest
 
-from siliconcompiler.utils.multiprocessing import MPManager, MPQueueHandler, _ManagerSingleton
+from siliconcompiler.utils.multiprocessing import MPManager, MPQueueHandler, \
+    _ManagerSingleton, get_process_context
 from siliconcompiler.report.dashboard.cli.board import Board
 from siliconcompiler.utils.settings import SettingsManager
+
+
+def test_get_process_context_linux(monkeypatch):
+    '''On Linux the start method is pinned to fork so that unguarded
+    module-level proj.run() scripts keep working regardless of the interpreter
+    default (which became forkserver in Python 3.14).'''
+    monkeypatch.setattr("sys.platform", "linux")
+    assert get_process_context().get_start_method() == "fork"
+
+
+@pytest.mark.parametrize("platform", ["darwin", "win32"])
+def test_get_process_context_non_linux(monkeypatch, platform):
+    '''Off Linux fork is either unavailable (Windows) or unsafe with threads
+    (macOS), so we pin spawn explicitly rather than relying on the default.'''
+    monkeypatch.setattr("sys.platform", platform)
+    assert get_process_context().get_start_method() == "spawn"
 
 
 def test_init_singleton():

--- a/tests/utils/test_multiprocessing.py
+++ b/tests/utils/test_multiprocessing.py
@@ -14,9 +14,15 @@ from siliconcompiler.utils.settings import SettingsManager
 def test_get_process_context_linux(monkeypatch):
     '''On Linux the start method is pinned to fork so that unguarded
     module-level proj.run() scripts keep working regardless of the interpreter
-    default (which became forkserver in Python 3.14).'''
+    default (which became forkserver in Python 3.14).
+
+    Assert on the requested method name rather than the returned context so the
+    test is portable: Windows has no fork context, so actually calling
+    get_context("fork") there raises ValueError.'''
     monkeypatch.setattr("sys.platform", "linux")
-    assert get_process_context().get_start_method() == "fork"
+    with patch("siliconcompiler.utils.multiprocessing.multiprocessing.get_context") as get_ctx:
+        get_process_context()
+        get_ctx.assert_called_once_with("fork")
 
 
 @pytest.mark.parametrize("platform", ["darwin", "win32"])
@@ -24,7 +30,9 @@ def test_get_process_context_non_linux(monkeypatch, platform):
     '''Off Linux fork is either unavailable (Windows) or unsafe with threads
     (macOS), so we pin spawn explicitly rather than relying on the default.'''
     monkeypatch.setattr("sys.platform", platform)
-    assert get_process_context().get_start_method() == "spawn"
+    with patch("siliconcompiler.utils.multiprocessing.multiprocessing.get_context") as get_ctx:
+        get_process_context()
+        get_ctx.assert_called_once_with("spawn")
 
 
 def test_init_singleton():


### PR DESCRIPTION
Resolves issues on 3.14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multiprocessing reliability across supported platforms by standardizing the worker/process context selection.
  * Prevented startup errors when running from unguarded scripts by ensuring a safe multiprocessing start method policy.
  * Ensured scheduler worker processes and their communication are created using the same consistent process configuration.

* **Tests**
  * Added a regression test for unguarded execution when `spawn` is used.
  * Added platform-specific checks validating the multiprocessing start method selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->