### PR TITLE
fix untap warning in macos CI

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Install Dependencies (macos)
         if: matrix.os == 'macos-latest'
         run: |
+          # aws/tap comes pre-tapped on the GitHub runner and is untrusted,
+          # which makes every brew command emit a tap-trust warning. SC does
+          # not use it, so drop it rather than weakening trust checks.
+          brew untap aws/tap || true
           brew install graphviz
 
       - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -107,6 +107,10 @@ jobs:
     - name: Setup env (macOS)
       if: matrix.platform.os == 'macos-latest'
       run: |
+        # aws/tap comes pre-tapped on the GitHub runner and is untrusted,
+        # which makes every brew command emit a tap-trust warning. SC does
+        # not use it, so drop it rather than weakening trust checks.
+        brew untap aws/tap || true
         # || true is needed to avoid failure on brew link error with python3.12
         brew install graphviz || true
         # klayout cask is Qt-Cocoa and requires a WindowServer session;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS build and test setup reliability by removing an automatically added Homebrew tap before dependency installation.
  * Reduced trust-related warnings on hosted macOS runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->