### PR TITLE
Fix fork+SyncManager deadlock on job replay with the dashboard active

### DIFF
--- a/siliconcompiler/report/dashboard/cli/board.py
+++ b/siliconcompiler/report/dashboard/cli/board.py
@@ -4,6 +4,7 @@ import queue
 import re
 import time
 import threading
+import types
 
 import os.path
 
@@ -391,20 +392,28 @@ class Board:
         else:
             Board._symbols.clear()
 
-        # Cross-process "please repaint" signal, fired both by new log lines
-        # and by job-data changes (_update_render_data). It must stay a manager
-        # Event so the render loop is woken regardless of which process
-        # produced the update. Whether that repaint also needs to reload job
-        # data is decided separately via the data_modified flag below.
-        self._render_event = manager.Event()
-        self._render_stop_event = manager.Event()
+        # "Please repaint" signal, fired both by new log lines and by job-data
+        # changes (_update_render_data). Whether that repaint also needs to
+        # reload job data is decided separately via the data_modified flag below.
+        #
+        # These are deliberately plain in-process ``threading``/``queue``
+        # primitives, not SyncManager proxies. The board and its render thread
+        # live entirely in the main process (workers drop the dashboard handler
+        # and let the parent own all dispatch), so proxies would buy nothing --
+        # and under the ``fork`` start method they are actively dangerous: a
+        # forked node worker inherits the manager's live socket connection, and
+        # concurrent use from the render thread and the child corrupts the
+        # manager's framed protocol, deadlocking every proxy on a recv that
+        # never returns. Plain primitives are fork-immune (and faster).
+        self._render_event = threading.Event()
+        self._render_stop_event = threading.Event()
         self._render_thread = None
 
         # Holds thread job data
-        self._board_info = manager.Namespace()
+        self._board_info = types.SimpleNamespace()
         self._board_info.data_modified = False
-        self._job_data = manager.dict()
-        self._job_data_lock = manager.Lock()
+        self._job_data = {}
+        self._job_data_lock = threading.Lock()
 
         self._render_data = SessionData()
         self._render_data_lock = threading.Lock()
@@ -414,7 +423,7 @@ class Board:
         # _job_data_lock, so the cache itself does not need its own lock.
         self._topology_cache: Dict[str, _FlowTopology] = {}
 
-        self._log_handler_queue = manager.Queue()
+        self._log_handler_queue = queue.Queue()
 
         # The log buffer shares the render event so a new log line wakes the
         # loop to repaint promptly. It does not touch data_modified, so a

--- a/siliconcompiler/report/dashboard/cli/board.py
+++ b/siliconcompiler/report/dashboard/cli/board.py
@@ -364,8 +364,11 @@ class Board:
         Initializes the Board.
 
         Args:
-            manager: A multiprocessing.Manager object to create shared state
-                     (events, dicts, locks) between processes.
+            manager: Unused, retained for call-site compatibility
+                (``MPManager.get_dashboard``). The board and its render thread
+                live entirely in the main process, so its state is held in
+                plain in-process primitives (see ``__init__`` below) rather than
+                SyncManager proxies; no manager is needed.
         """
         self._console = Console(theme=Board.__theme)
 

--- a/siliconcompiler/scheduler/taskscheduler.py
+++ b/siliconcompiler/scheduler/taskscheduler.py
@@ -87,7 +87,22 @@ class TaskScheduler:
             to_steps=self.__project.option.get_to(),
             prune_nodes=self.__project.option.get_prune())
 
-        self.__log_queue = MPManager.get_manager().Queue()
+        # Queue for collecting log records from node worker processes.
+        #
+        # Under the ``fork`` start method (Linux) a worker inherits the parent's
+        # live SyncManager socket connections. A manager-backed queue would then
+        # have the worker's QueueHandler.put() and the parent's
+        # QueueListener.get() drive the *same* inherited connection from two
+        # processes at once, corrupting the manager's framed protocol and
+        # deadlocking every manager proxy (including the dashboard Board and its
+        # lock) on a recv that never returns. A plain pipe-backed queue is
+        # fork-safe (and faster), so use it on the fork path. Spawn cannot
+        # inherit fds and needs the picklable manager queue; it re-connects with
+        # a fresh connection per worker, so it is unaffected.
+        if get_process_context().get_start_method() == "fork":
+            self.__log_queue = get_process_context().Queue()
+        else:
+            self.__log_queue = MPManager.get_manager().Queue()
 
         self.__nodes: Dict[Tuple[str, str], Dict[str, Any]] = {}
         self.__startTimes: Dict[Optional[Tuple[str, str]], float] = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -445,6 +445,12 @@ def disable_mp_process():
     class FakeContext:
         Process = FakeProc
 
+        def get_start_method(self, *args, **kwargs):
+            return real_ctx.get_start_method(*args, **kwargs)
+
+        def Queue(self, *args, **kwargs):
+            return real_ctx.Queue(*args, **kwargs)
+
         def Pipe(self, *args, **kwargs):
             return real_ctx.Pipe(*args, **kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,8 @@ from siliconcompiler import utils, ASIC, Design, Project
 from siliconcompiler.tools.openroad._apr import APRTask
 from siliconcompiler.flows.asicflow import ASICFlow
 from siliconcompiler.targets import freepdk45_demo
-from siliconcompiler.utils.multiprocessing import _ManagerSingleton, MPManager
+from siliconcompiler.utils.multiprocessing import _ManagerSingleton, MPManager, \
+    get_process_context
 from siliconcompiler.apps import sc_server
 from siliconcompiler.schema import BaseSchema
 
@@ -439,8 +440,11 @@ def disable_mp_process():
     # The scheduler launches node workers via get_process_context().Process
     # (a context-specific Process class), not the module-level
     # multiprocessing.Process, so we fake the context: Process runs the target
-    # inline while Pipe/Pool delegate to a real context.
-    real_ctx = multiprocessing.get_context()
+    # inline while get_start_method/Queue/Pipe/Pool delegate to the real
+    # context. Delegate to siliconcompiler's get_process_context() (not the
+    # interpreter default) so the faked start method matches what the scheduler
+    # actually uses -- e.g. "fork" on Linux, not the 3.14 "forkserver" default.
+    real_ctx = get_process_context()
 
     class FakeContext:
         Process = FakeProc

--- a/tests/report/dashboard/test_board_fork_safety.py
+++ b/tests/report/dashboard/test_board_fork_safety.py
@@ -1,0 +1,53 @@
+import queue
+import threading
+import types
+
+import pytest
+
+from rich.console import Console
+
+from siliconcompiler.report.dashboard.cli.board import Board
+from siliconcompiler.utils.multiprocessing import MPManager
+
+
+@pytest.fixture(autouse=True)
+def _force_terminal(monkeypatch):
+    # The board only constructs its sync primitives when the console is a
+    # terminal; force that so the assertions below have something to inspect.
+    monkeypatch.setattr(Console, "is_terminal", True)
+
+
+def test_board_sync_primitives_are_not_manager_proxies():
+    """The dashboard Board and its render thread live entirely in the main
+    process, so its synchronization primitives must be plain in-process
+    ``threading``/``queue`` objects -- never SyncManager proxies.
+
+    A manager proxy shared across the ``fork`` start method deadlocks a run when
+    the dashboard is active: a forked node worker inherits the manager's live
+    socket connection and concurrent use corrupts the manager's framed protocol,
+    hanging every proxy on a recv that never returns. This test pins that
+    decision so a proxy cannot be silently reintroduced. See
+    ``siliconcompiler/report/dashboard/cli/board.py`` and
+    ``siliconcompiler/scheduler/taskscheduler.py``.
+    """
+    board = Board(MPManager.get_manager())
+    assert board._active, "board must be active for this test to be meaningful"
+
+    # SyncManager proxies all live in the multiprocessing.managers module.
+    for name in ("_render_event", "_render_stop_event", "_board_info",
+                 "_job_data", "_job_data_lock", "_log_handler_queue"):
+        obj = getattr(board, name)
+        assert type(obj).__module__ != "multiprocessing.managers", (
+            f"Board.{name} is a SyncManager proxy ({type(obj)!r}); it must be a "
+            "plain in-process primitive or it will deadlock across fork()")
+
+
+def test_board_sync_primitives_are_expected_plain_types():
+    board = Board(MPManager.get_manager())
+    assert board._active
+
+    assert isinstance(board._render_event, threading.Event)
+    assert isinstance(board._render_stop_event, threading.Event)
+    assert isinstance(board._board_info, types.SimpleNamespace)
+    assert isinstance(board._job_data, dict)
+    assert isinstance(board._log_handler_queue, queue.Queue)

--- a/tests/scheduler/test_taskscheduler.py
+++ b/tests/scheduler/test_taskscheduler.py
@@ -1,11 +1,12 @@
 import logging
+import multiprocessing
 
 import pytest
 
 from threading import Lock
 from unittest.mock import MagicMock
 
-from siliconcompiler.utils.multiprocessing import MPManager
+from siliconcompiler.utils.multiprocessing import MPManager, get_process_context
 from siliconcompiler import NodeStatus
 from siliconcompiler import Project, Flowgraph, Design
 from siliconcompiler.scheduler import TaskScheduler
@@ -111,6 +112,61 @@ def test_run(large_flow, make_tasks):
 
     for step, index in large_flow.get("flowgraph", "testflow", field="schema").get_nodes():
         assert large_flow.get("record", "status", step=step, index=index) == NodeStatus.SUCCESS
+
+
+def test_log_queue_matches_start_method(large_flow, make_tasks):
+    """The per-scheduler log queue must be fork-safe for the active start method.
+
+    Under ``fork`` a node worker inherits the parent's live SyncManager socket
+    connection; a manager-backed queue then has the worker's put() and the
+    parent's QueueListener get() drive the *same* inherited connection from two
+    processes at once, corrupting the manager's framed protocol and deadlocking
+    the run. So on the fork path the queue must be a plain pipe-backed
+    multiprocessing queue. Spawn/forkserver cannot inherit fds and need the
+    picklable manager queue (reconnected fresh per worker, hence safe).
+
+    This runs on every OS and asserts whichever choice this platform's start
+    method requires.
+    """
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+    log_queue = scheduler._TaskScheduler__log_queue
+
+    if get_process_context().get_start_method() == "fork":
+        assert type(log_queue).__module__ == "multiprocessing.queues", \
+            f"fork log queue must be a plain multiprocessing queue (a manager " \
+            f"proxy deadlocks across fork), got {type(log_queue)!r}"
+    else:
+        # spawn / forkserver: a picklable manager queue is required and safe.
+        assert type(log_queue).__module__ == "multiprocessing.managers", \
+            f"spawn log queue must be a picklable manager queue, " \
+            f"got {type(log_queue)!r}"
+
+
+@pytest.mark.skipif(
+    "fork" not in multiprocessing.get_all_start_methods(),
+    reason="fork start method not available on this platform (e.g. Windows)")
+def test_log_queue_is_plain_on_fork(large_flow, make_tasks, monkeypatch):
+    """Force the fork path and assert a plain, non-manager queue is chosen.
+
+    Complements ``test_log_queue_matches_start_method`` by exercising the
+    fork-safety invariant even on platforms whose *default* start method is not
+    fork (macOS), so a regression that reintroduces a manager-backed queue on
+    the fork path is caught on both Linux and macOS CI. Only the queue-selection
+    logic is exercised -- no worker is actually forked.
+    """
+    fork_ctx = multiprocessing.get_context("fork")
+    monkeypatch.setattr(taskscheduler_module, "get_process_context",
+                        lambda: fork_ctx)
+
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+    log_queue = scheduler._TaskScheduler__log_queue
+
+    assert type(log_queue).__module__ != "multiprocessing.managers", \
+        f"fork path must not select a SyncManager proxy queue, " \
+        f"got {type(log_queue)!r}"
+    assert type(log_queue).__module__ == "multiprocessing.queues", \
+        f"fork path must select a plain multiprocessing queue, " \
+        f"got {type(log_queue)!r}"
 
 
 @pytest.mark.timeout(180)


### PR DESCRIPTION
Re-running a flow (replay) hung indefinitely when the CLI dashboard was active on Linux. With the fork start method a node worker inherits the parent's live SyncManager socket connections; concurrent use of a shared proxy from a worker and the main-process dashboard/logging threads corrupts the manager's framed protocol, deadlocking every proxy on a recv that never returns. It only surfaced interactively (dashboard = TTY) and only on the replay run, so piped/CI runs looked fine.

Remove SyncManager proxies from everything the main process touches concurrently with forks:

- taskscheduler: use a plain pipe-backed queue for the node log queue on the fork path (kept as a manager queue on spawn, which needs a picklable queue and reconnects fresh per worker).
- dashboard Board: its sync primitives (_render_event, _render_stop_event, _board_info, _job_data, _job_data_lock, _log_handler_queue) become plain threading/queue objects. The board and its render thread live entirely in the main process, so proxies bought nothing and were fork-unsafe.

Add deterministic structural regression tests that fail if a SyncManager proxy is reintroduced in either the fork-path log queue or the board's sync primitives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard fork-safety by switching render coordination and log buffering to in-process primitives, avoiding multiprocessing manager proxy contention.
  * Updated scheduler log-queue selection to match the active multiprocessing start method, using fork-safe queues under `fork`.
* **Tests**
  * Added dashboard tests ensuring synchronization primitives are plain in-process types (not manager proxies).
  * Added scheduler tests validating log queue type selection for each start method.
  * Extended multiprocessing-related test fixtures to align with the scheduler’s start-method/queue behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->