### PR TITLE
fix logging with dashboard

### DIFF
--- a/scripts/check_dashboard.py
+++ b/scripts/check_dashboard.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+Manual demo for the two logging fixes. TEMPORARY — delete when done.
+
+Run it in a REAL terminal (a TTY) so the CLI dashboard actually renders:
+
+    python demo_logging_fix.py            # dashboard on (the interesting case)
+    python demo_logging_fix.py --lines 60 # more log lines to overflow the pane
+    python demo_logging_fix.py --nodashboard   # baseline: plain terminal logging
+    python demo_logging_fix.py --hang     # then hit Ctrl+C — see below
+    python demo_logging_fix.py --multi    # several runs sharing ONE dashboard
+    python demo_logging_fix.py --multi --jobs 4 --nodes 6  # bigger multi run
+
+What it does
+------------
+Builds a one-node flow whose task logs many lines and then FAILS during setup(),
+i.e. "a run that fails immediately after the dashboard opens". A few lines are
+also logged BEFORE run() to exercise history-seeding of the dashboard log pane.
+
+What to look for (Issue #2 — "log truncated when the dashboard is open")
+------------------------------------------------------------------------
+* While running, the live pane shows only the last handful of "noisy line N".
+* When it fails, the dashboard tears down and — under a "Full log" rule — the
+  ENTIRE tail (all noisy lines + the failure messages) is reprinted to normal
+  scrollback, followed by the "Run failed" error and the RuntimeError.
+* The "pre-run banner" lines logged before run() should appear in the dashboard
+  log pane from the very start (history seeding), not just after run() begins.
+
+Before the fix the dashboard only reprinted the ~dozen visible lines, so the
+tail that explains the failure was lost.
+
+What to look for (Ctrl+C — "an interrupt is not a failure")
+-----------------------------------------------------------
+Run with --hang; the task logs the noisy lines and then sleeps. Press Ctrl+C.
+The dashboard should tear down WITHOUT printing a "Full log" dump — an
+interrupt is a clean exit, not a failure, so the tail is not reprinted.
+
+What to look for (--multi — several SC runs in ONE dashboard)
+-------------------------------------------------------------
+The CLI dashboard Board is a process-wide singleton (MPManager.get_dashboard())
+keyed by design/jobname, so several Project.run() calls in the SAME process
+render as separate rows/progress bars in ONE live view. Because the Board and
+its render thread live entirely in the main process, the concurrency here is
+threads — each run still forks its own node workers internally, but they all
+feed the one main-process dashboard. Expect --jobs progress bars advancing
+together, each labelled design_k/job0, then all completing.
+"""
+
+import argparse
+import logging
+import threading
+import time
+
+from siliconcompiler import Project, Design, Flowgraph, Task
+
+
+class WorkTask(Task):
+    """A no-exe Python task that logs a little and sleeps, to simulate work
+    so the dashboard shows progress advancing over time."""
+
+    _work = 0.4
+
+    def tool(self):
+        return "demo_tool"
+
+    def task(self):
+        return "work"
+
+    def run(self):
+        design = self.project.option.get_design()
+        for i in range(3):
+            self.logger.info(f"[{design}] working ({i + 1}/3) on {self.step}/{self.index}")
+            time.sleep(WorkTask._work / 3)
+        return 0
+
+
+class NoisyFailTask(Task):
+    """A task that floods the log, then either fails or hangs during setup()."""
+
+    _lines = 40
+    _hang = False
+
+    def tool(self):
+        return "demo_tool"
+
+    def task(self):
+        return "noisy_fail"
+
+    def setup(self):
+        super().setup()
+        for i in range(NoisyFailTask._lines):
+            self.logger.info(f"noisy line {i:02d} — this is tool output that scrolls by")
+        if NoisyFailTask._hang:
+            self.logger.info("sleeping — press Ctrl+C now (should NOT dump the full log)")
+            while True:
+                time.sleep(0.5)
+        self.logger.warning("something looks wrong...")
+        self.logger.error("fatal: the widget frobnicator exploded")
+        # Fail right here, while the dashboard owns the screen.
+        raise RuntimeError("NoisyFailTask blew up during setup")
+
+
+def _build_work_project(name, nodes):
+    """A project with an `nodes`-long chained flow of WorkTasks."""
+    design = Design(name)
+    design.set_topmodule("top", fileset="rtl")
+    proj = Project(design)
+    proj.add_fileset("rtl")
+
+    flow = Flowgraph("workflow")
+    prev = None
+    for i in range(nodes):
+        step = f"step{i}"
+        flow.node(step, WorkTask())
+        if prev is not None:
+            flow.edge(prev, step)
+        prev = step
+    proj.set_flow(flow)
+    proj.logger.setLevel(logging.INFO)
+    return proj
+
+
+def run_multi(jobs, nodes):
+    """Launch `jobs` concurrent runs that share the one singleton dashboard.
+
+    Threads (not processes) so every run feeds the same main-process Board;
+    each run still forks its own node workers internally.
+    """
+    projects = [_build_work_project(f"design_{k}", nodes) for k in range(jobs)]
+
+    errors = {}
+
+    def _run(idx, proj):
+        try:
+            proj.run()
+        except Exception as e:  # noqa BLE001 - demo: report, don't crash the thread
+            errors[idx] = e
+
+    threads = [threading.Thread(target=_run, args=(k, p), name=f"run-{k}")
+               for k, p in enumerate(projects)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    if errors:
+        print(f"\n>>> {len(errors)} run(s) errored: {errors}")
+        return 1
+    print(f"\n>>> all {jobs} runs completed in one shared dashboard view")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lines", type=int, default=40,
+                        help="number of noisy log lines to emit before failing")
+    parser.add_argument("--nodashboard", action="store_true",
+                        help="disable the dashboard (baseline plain-terminal behavior)")
+    parser.add_argument("--hang", action="store_true",
+                        help="sleep after logging so you can test Ctrl+C (no dump expected)")
+    parser.add_argument("--multi", action="store_true",
+                        help="run several SCs concurrently in ONE shared dashboard")
+    parser.add_argument("--jobs", type=int, default=3,
+                        help="--multi: number of concurrent runs (default 3)")
+    parser.add_argument("--nodes", type=int, default=4,
+                        help="--multi: chained nodes per run (default 4)")
+    args = parser.parse_args()
+
+    if args.multi:
+        return run_multi(args.jobs, args.nodes)
+
+    NoisyFailTask._lines = args.lines
+    NoisyFailTask._hang = args.hang
+
+    design = Design("demodesign")
+    design.set_topmodule("top", fileset="rtl")
+    proj = Project(design)
+    proj.add_fileset("rtl")
+
+    if args.nodashboard:
+        proj.set("option", "nodashboard", True)
+
+    flow = Flowgraph("demoflow")
+    flow.node("build", NoisyFailTask())
+    proj.set_flow(flow)
+
+    proj.logger.setLevel(logging.INFO)
+
+    # Logged BEFORE run(): should be seeded into the dashboard log pane so it
+    # shows continuity from the start rather than a blank pane.
+    for i in range(5):
+        proj.logger.info(f"pre-run banner line {i} (should be seeded into the pane)")
+
+    try:
+        proj.run()
+    except RuntimeError as e:
+        print("\n>>> demo caught the expected failure:", e)
+        return 0
+    except KeyboardInterrupt:
+        print("\n>>> interrupted (no full-log dump should have printed)")
+        return 0
+    if args.hang:
+        print("\n>>> run returned after interrupt (no full-log dump should have printed)")
+        return 0
+    print("\n>>> demo did NOT fail as expected (unexpected)")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_dashboard.py
+++ b/scripts/check_dashboard.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 """
-Manual demo for the two logging fixes. TEMPORARY — delete when done.
+Manual scenario-validation tool for the CLI dashboard logging behavior.
 
-Run it in a REAL terminal (a TTY) so the CLI dashboard actually renders:
+A persistent developer utility: run it by hand in a REAL terminal (a TTY) to
+eyeball the dashboard scenarios that automated tests can only assert on
+indirectly (they run headless, with no live screen). Keep it around for
+verifying dashboard/logging changes.
 
-    python demo_logging_fix.py            # dashboard on (the interesting case)
-    python demo_logging_fix.py --lines 60 # more log lines to overflow the pane
-    python demo_logging_fix.py --nodashboard   # baseline: plain terminal logging
-    python demo_logging_fix.py --hang     # then hit Ctrl+C — see below
-    python demo_logging_fix.py --multi    # several runs sharing ONE dashboard
-    python demo_logging_fix.py --multi --jobs 4 --nodes 6  # bigger multi run
+    python scripts/check_dashboard.py            # dashboard on (the interesting case)
+    python scripts/check_dashboard.py --lines 60 # more log lines to overflow the pane
+    python scripts/check_dashboard.py --nodashboard   # baseline: plain terminal logging
+    python scripts/check_dashboard.py --hang     # then hit Ctrl+C — see below
+    python scripts/check_dashboard.py --multi    # several runs sharing ONE dashboard
+    python scripts/check_dashboard.py --multi --jobs 4 --nodes 6  # bigger multi run
 
 What it does
 ------------

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -26,7 +26,7 @@ from siliconcompiler.schema_support.pathschema import PathSchemaBase
 
 from siliconcompiler.report.dashboard.cli import CliDashboard
 from siliconcompiler.scheduler import Scheduler, SCRuntimeError
-from siliconcompiler.utils.logging import get_stream_handler
+from siliconcompiler.utils.logging import get_stream_handler, SCHistoryLogHandler
 from siliconcompiler.utils import get_file_ext
 from siliconcompiler.utils.multiprocessing import MPManager
 from siliconcompiler.utils.paths import jobdir, workdir
@@ -148,6 +148,13 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
 
         self._logger_console = get_stream_handler(self, in_run=False, step=None, index=None)
         self.__logger.addHandler(self._logger_console)
+
+        # Retain a bounded history of records so a late-attaching sink (the CLI
+        # dashboard log pane) can be seeded with what preceded it, and so the
+        # full tail survives a teardown even when the terminal handler was
+        # suppressed while the dashboard owned the screen.
+        self._logger_history = SCHistoryLogHandler()
+        self.__logger.addHandler(self._logger_history)
 
     def __init_dashboard(self):
         """
@@ -567,6 +574,12 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
                 scheduler = Scheduler(self)
             scheduler.run()
         except SCRuntimeError as e:
+            # Tear the dashboard down first: this restores (un-suppresses) the
+            # terminal handler and dumps the full log tail to scrollback, so
+            # the messages below and the propagating error are actually visible
+            # instead of being swallowed while the dashboard owns the screen.
+            if self.__dashboard:
+                self.__dashboard.stop(force=True)
             self.logger.error(f"Run failed: {e.msg}")
             if scheduler and scheduler.log:
                 self.logger.error(f"Job log: {os.path.abspath(scheduler.log)}")
@@ -651,6 +664,7 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         # Remove logger objects since they are not serializable
         del state["_Project__logger"]
         del state["_logger_console"]
+        del state["_logger_history"]
 
         # Remove dashboard
         del state["_Project__dashboard"]

--- a/siliconcompiler/report/dashboard/cli/__init__.py
+++ b/siliconcompiler/report/dashboard/cli/__init__.py
@@ -3,7 +3,7 @@ import atexit
 from typing import TYPE_CHECKING
 
 from siliconcompiler.report.dashboard import AbstractDashboard
-from siliconcompiler.utils.logging import SCSuppressLoggerFilter
+from siliconcompiler.utils.logging import SCSuppressLoggerFilter, SCHistoryLogHandler
 
 if TYPE_CHECKING:
     from siliconcompiler import Project
@@ -153,6 +153,25 @@ class CliDashboard(AbstractDashboard):
         # explicit synchronization.
         self._dashboard_handler = self._dashboard.make_log_hander(
             formatter_source=self._terminal_handler)
+
+        # Seed the log pane with the history that preceded the dashboard so it
+        # shows continuity from the start rather than starting blank. Records
+        # are fed through the dashboard handler directly (not the logger) so
+        # they get the same color/markup processing as live lines without being
+        # re-dispatched to the other sinks.
+        for handler in list(self._logger.handlers):
+            if isinstance(handler, SCHistoryLogHandler):
+                for record in handler.records:
+                    try:
+                        self._dashboard_handler.emit(record)
+                    except Exception:
+                        pass
+                # Drop the drained backlog so these records are not seeded
+                # (and reprinted) again on a later re-attach; new records keep
+                # accumulating in the handler from here on.
+                handler.clear()
+                break
+
         self._logger.addHandler(self._dashboard_handler)
 
         # Silence the terminal handler so log emits don't corrupt the live
@@ -214,7 +233,7 @@ class CliDashboard(AbstractDashboard):
         """
         self._dashboard.end_of_run(self._project)
 
-    def stop(self):
+    def stop(self, force=False):
         """
         Stops the dashboard and restores normal terminal logging.
 
@@ -228,10 +247,16 @@ class CliDashboard(AbstractDashboard):
         shutdown, surfacing as "Exception ignored in atexit callback"
         (issue #5035). The ``try``/``finally`` guarantees the hook is released
         regardless.
+
+        Args:
+            force (bool): When True, tear down even if nodes have not completed.
+                Used on failure paths so an early failure still restores the
+                terminal and dumps the full log tail instead of leaving the
+                dashboard up with the output hidden behind it.
         """
         try:
             self._dashboard.end_of_run(self._project)
-            self._dashboard.stop()
+            self._dashboard.stop(force=force)
         except Exception:
             pass
         finally:

--- a/siliconcompiler/report/dashboard/cli/__init__.py
+++ b/siliconcompiler/report/dashboard/cli/__init__.py
@@ -167,7 +167,10 @@ class CliDashboard(AbstractDashboard):
                 # window; new records keep accumulating from here on.
                 for record in handler.drain():
                     try:
-                        self._dashboard_handler.emit(record)
+                        # handle() (not emit()) applies the handler's level and
+                        # filters and acquires its lock, per the logging
+                        # contract — safer than driving emit() directly.
+                        self._dashboard_handler.handle(record)
                     except Exception:
                         pass
                 break

--- a/siliconcompiler/report/dashboard/cli/__init__.py
+++ b/siliconcompiler/report/dashboard/cli/__init__.py
@@ -161,15 +161,15 @@ class CliDashboard(AbstractDashboard):
         # re-dispatched to the other sinks.
         for handler in list(self._logger.handlers):
             if isinstance(handler, SCHistoryLogHandler):
-                for record in handler.records:
+                # drain() snapshots and clears atomically, so the backlog is
+                # not seeded (and reprinted) again on a later re-attach and a
+                # record emitted concurrently is never lost in a read/clear
+                # window; new records keep accumulating from here on.
+                for record in handler.drain():
                     try:
                         self._dashboard_handler.emit(record)
                     except Exception:
                         pass
-                # Drop the drained backlog so these records are not seeded
-                # (and reprinted) again on a later re-attach; new records keep
-                # accumulating in the handler from here on.
-                handler.clear()
                 break
 
         self._logger.addHandler(self._dashboard_handler)

--- a/siliconcompiler/report/dashboard/cli/board.py
+++ b/siliconcompiler/report/dashboard/cli/board.py
@@ -536,14 +536,20 @@ class Board:
 
         self._update_render_data(project, complete=True)
 
-    def stop(self):
+    def stop(self, force: bool = False):
         """
         Stops the dashboard rendering thread and cleans up the terminal display.
+
+        Args:
+            force (bool): When True, tear down even if some jobs are still
+                incomplete. The completeness guard exists so a stray stop()
+                does not kill the live view mid-run; a genuine failure teardown
+                passes force=True to bypass it.
         """
         if not self.is_running():
             return
 
-        if self._job_data:
+        if not force and self._job_data:
             if any([not job.complete for job in self._job_data.values()]):
                 return
 
@@ -570,6 +576,29 @@ class Board:
                 self._console.print(self._get_rendable())
             except Exception:
                 pass
+
+        # On a failure teardown (force=True), dump the full retained log buffer
+        # to normal-terminal scrollback. The final frame above only shows the
+        # log lines that fit the visible pane; on an early failure the tail
+        # that explains it has usually scrolled past that window, so reprinting
+        # the entire buffer ensures it survives. This is deliberately skipped
+        # for a normal teardown or a Ctrl+C interrupt (force=False): those are
+        # not failures and the live view already served the log.
+        try:
+            lines = self._log_handler.get_lines() if force else []
+            if lines:
+                self._console.rule("[bold]Full log")
+                for line in lines:
+                    try:
+                        # highlight=False keeps rich from recoloring numbers/
+                        # paths inside the line, matching the live log pane
+                        # (which renders each line as a plain table cell).
+                        self._console.print(f"[white]{line}[/]", highlight=False)
+                    except Exception:
+                        pass
+        except Exception:
+            pass
+
         try:
             self._console.show_cursor()
         except Exception:

--- a/siliconcompiler/report/dashboard/cli/board.py
+++ b/siliconcompiler/report/dashboard/cli/board.py
@@ -595,7 +595,14 @@ class Board:
                         # (which renders each line as a plain table cell).
                         self._console.print(f"[white]{line}[/]", highlight=False)
                     except Exception:
-                        pass
+                        # Malformed/unterminated markup in a buffered line must
+                        # not drop it from the dump (that would defeat the whole
+                        # point). Fall back to printing it verbatim as plain
+                        # text with markup disabled.
+                        try:
+                            self._console.print(line, markup=False, highlight=False)
+                        except Exception:
+                            pass
         except Exception:
             pass
 

--- a/siliconcompiler/scheduler/scheduler.py
+++ b/siliconcompiler/scheduler/scheduler.py
@@ -305,12 +305,18 @@ class Scheduler:
         except KeyboardInterrupt:
             pass
         except SCRuntimeError:
+            # Stop the dashboard before propagating so the terminal handler is
+            # un-suppressed and the full log tail is dumped to scrollback;
+            # otherwise an early failure's output stays hidden behind the
+            # (now torn-down) live screen.
+            if self.__project._Project__dashboard:
+                self.__project._Project__dashboard.stop(force=True)
             raise
         except Exception as e:
             utils.print_traceback(self.__logger, e)
 
             if self.__project._Project__dashboard:
-                self.__project._Project__dashboard.stop()
+                self.__project._Project__dashboard.stop(force=True)
 
             MPManager.error(str(e) or "uncaught exception")
 

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -1471,9 +1471,15 @@ class Task(NamedSchema, PathSchema, DocsSchema):
                                           f'({e.available_mb:.1f} MB available)')
                         self.__terminate_exe(proc)
                         raise
-
-                    # Read any remaining I/O
-                    read_stdio(stdout_reader, stderr_reader, flush=True)
+                    finally:
+                        # Drain any remaining I/O, including a buffered trailing
+                        # partial line, so output emitted right before the
+                        # process exits reaches the log. This runs on the normal
+                        # exit path AND after an abnormal termination
+                        # (timeout/OOM/ctrl-c), where the process has already
+                        # been terminated above and its final output would
+                        # otherwise be lost.
+                        read_stdio(stdout_reader, stderr_reader, flush=True)
 
                     retcode = proc.returncode
 

--- a/siliconcompiler/utils/logging.py
+++ b/siliconcompiler/utils/logging.py
@@ -28,17 +28,46 @@ class SCHistoryLogHandler(logging.Handler):
 
     @property
     def records(self):
-        """List of retained records, oldest first."""
-        return list(self.__records)
+        """List of retained records, oldest first.
+
+        Taken under the handler lock so the snapshot cannot race with a
+        concurrent ``emit`` or ``clear``.
+        """
+        self.acquire()
+        try:
+            return list(self.__records)
+        finally:
+            self.release()
 
     def clear(self):
         """Drop all retained records.
 
         Called once a consumer (the dashboard log pane) has drained the
         history into its own buffer, so the same records are not handed out —
-        and re-rendered — again on a later attach.
+        and re-rendered — again on a later attach. Held under the handler lock
+        so it cannot race with a concurrent ``emit``.
         """
-        self.__records.clear()
+        self.acquire()
+        try:
+            self.__records.clear()
+        finally:
+            self.release()
+
+    def drain(self):
+        """Atomically return all retained records and clear the buffer.
+
+        The snapshot and the clear happen under the handler lock together, so
+        a record emitted concurrently is either fully included in the returned
+        list or retained for the next drain — never lost in a window between a
+        separate ``records`` read and ``clear`` call.
+        """
+        self.acquire()
+        try:
+            records = list(self.__records)
+            self.__records.clear()
+            return records
+        finally:
+            self.release()
 
 
 class SCSuppressLoggerFilter(logging.Filter):

--- a/siliconcompiler/utils/logging.py
+++ b/siliconcompiler/utils/logging.py
@@ -2,7 +2,43 @@ import logging
 import re
 import sys
 
+from collections import deque
+
 from siliconcompiler import utils
+
+
+class SCHistoryLogHandler(logging.Handler):
+    """
+    Retains the most recent log records in a bounded in-memory ring buffer.
+
+    Attached to the project logger for the lifetime of the project so a
+    component that attaches late — notably the CLI dashboard's log pane — can
+    be seeded with the history that preceded it, rather than starting blank.
+
+    Raw :class:`logging.LogRecord` objects are stored (not formatted strings)
+    so a late consumer can re-format them with whatever formatter it uses.
+    """
+
+    def __init__(self, capacity: int = 1000):
+        super().__init__()
+        self.__records = deque(maxlen=capacity)
+
+    def emit(self, record):
+        self.__records.append(record)
+
+    @property
+    def records(self):
+        """List of retained records, oldest first."""
+        return list(self.__records)
+
+    def clear(self):
+        """Drop all retained records.
+
+        Called once a consumer (the dashboard log pane) has drained the
+        history into its own buffer, so the same records are not handed out —
+        and re-rendered — again on a later attach.
+        """
+        self.__records.clear()
 
 
 class SCSuppressLoggerFilter(logging.Filter):

--- a/tests/report/dashboard/test_cli_dashboard.py
+++ b/tests/report/dashboard/test_cli_dashboard.py
@@ -359,6 +359,114 @@ def test_stop_dashboard(dashboard):
     assert not dashboard.is_running()
 
 
+def test_set_logger_seeds_log_pane_from_history(dashboard):
+    """When the dashboard attaches, the log pane should be seeded with the
+    records retained by an SCHistoryLogHandler already on the logger, so it
+    shows continuity from before the dashboard opened rather than blank."""
+    from siliconcompiler.utils.logging import SCHistoryLogHandler
+
+    logger = logging.getLogger("test_seed")
+    logger.setLevel(logging.INFO)
+
+    history = SCHistoryLogHandler()
+    for i in range(3):
+        history.emit(logging.LogRecord(
+            "test_seed", logging.INFO, "path", i, f"pre-dashboard {i}", (), None))
+    logger.addHandler(history)
+
+    try:
+        dashboard.set_logger(logger)
+    finally:
+        logger.removeHandler(history)
+
+    text = "\n".join(dashboard._dashboard._log_handler.get_lines())
+    for i in range(3):
+        assert f"pre-dashboard {i}" in text
+
+
+def test_stop_dumps_full_log_buffer(dashboard):
+    """Board.stop must reprint the entire retained log buffer to the normal
+    terminal, not just the lines that fit the visible pane, so an early
+    failure's tail survives the teardown."""
+    board = dashboard._dashboard
+
+    for i in range(40):
+        board._log_handler.add_line(f"log line {i}")
+
+    io_file = io.StringIO()
+    board._console = Console(file=io_file, width=120)
+
+    # Present a fake "running" thread so stop() runs its teardown path
+    # deterministically without spawning a real render thread that would
+    # concurrently write to the console under test.
+    class FakeThread:
+        def is_alive(self):
+            return True
+
+        def join(self, *args, **kwargs):
+            pass
+
+    board._render_thread = FakeThread()
+    board.stop(force=True)
+
+    out = io_file.getvalue()
+    for i in range(40):
+        assert f"log line {i}" in out, f"line {i} missing from teardown dump"
+
+
+def test_stop_without_force_does_not_dump_log(dashboard):
+    """A normal teardown or Ctrl+C interrupt (force=False) must NOT reprint the
+    full log buffer — that dump is reserved for failure teardowns."""
+    board = dashboard._dashboard
+
+    for i in range(40):
+        board._log_handler.add_line(f"log line {i}")
+
+    io_file = io.StringIO()
+    board._console = Console(file=io_file, width=120)
+
+    class FakeThread:
+        def is_alive(self):
+            return True
+
+        def join(self, *args, **kwargs):
+            pass
+
+    board._render_thread = FakeThread()
+    board.stop(force=False)
+
+    out = io_file.getvalue()
+    assert "Full log" not in out
+    # Early lines that would only appear in a full dump must be absent.
+    assert "log line 0" not in out
+
+
+def test_stop_without_force_skips_incomplete(dashboard, mock_running_job_lg):
+    """Without force, stop() must not tear down while a job is incomplete;
+    force=True bypasses that guard."""
+    board = dashboard._dashboard
+
+    class FakeThread:
+        def is_alive(self):
+            return True
+
+        def join(self, *args, **kwargs):
+            pass
+
+    board._render_thread = FakeThread()
+
+    mock_running_job_lg.complete = False
+    board._job_data["design1/job1"] = mock_running_job_lg
+
+    assert not board._render_stop_event.is_set()
+
+    board.stop()  # no force -> guard skips teardown
+    assert not board._render_stop_event.is_set()
+
+    board.stop(force=True)  # bypasses the completeness guard
+    assert board._render_stop_event.is_set()
+
+
 def test_log_buffer_handler():
     event = threading.Event()
     buffer = LogBuffer(queue.Queue(), n=2, event=event)

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -1777,7 +1777,9 @@ def test_run_with_queue(project):
          patch("siliconcompiler.scheduler.SchedulerNode.execute") as call_exec:
         node.run()
         call_exec.assert_called_once()
-        call_remove_logger.assert_called_once()
+        # The child strips every inherited handler before installing the
+        # QueueHandler: the console StreamHandler and the SCHistoryLogHandler.
+        assert call_remove_logger.call_count == 2
         assert pipe.calls == 1
 
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -2103,6 +2103,98 @@ def test_run_task_carriage_return_terminates_lines(running_node, monkeypatch, pa
             f"Missing \\r-terminated frame {frame!r} in log records: {info_msgs}"
 
 
+def test_run_task_timeout_flushes_trailing_output(running_node, monkeypatch, patch_psutil,
+                                                  caplog):
+    """Output emitted just before a timeout kills the process (including an
+    unterminated trailing line) must still reach the log via the final
+    flush-drain, rather than being dropped on the abnormal-exit path."""
+
+    assert running_node.project.set("tool", "builtin", 'task', 'nop', "format", "json")
+
+    trailing = "fatal: stuck here with no newline"
+    stdout_path = "running.log"
+
+    def dummy_popen(*args, **kwargs):
+        class Popen:
+            pid = 1
+
+            def poll(self):
+                # Emit an unterminated line, then block long enough to trip
+                # the timeout before the process would otherwise exit.
+                with open(stdout_path, 'a') as f:
+                    f.write(trailing)
+                time.sleep(3)
+                return None
+
+            def wait(self, timeout=None):
+                pass
+
+        return Popen()
+    monkeypatch.setattr(imported_subprocess, 'Popen', dummy_popen)
+
+    def dummy_get_exe(*args, **kwargs):
+        return "found/exe"
+    monkeypatch.setattr(running_node.task, 'get_exe', dummy_get_exe)
+
+    with caplog.at_level(logging.INFO):
+        with running_node.task.runtime(running_node) as runtool:
+            with pytest.raises(TaskTimeout):
+                runtool.run_task('.', False, False, None, 1)
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any(trailing in msg for msg in msgs), \
+        f"Trailing output before timeout was dropped from logs: {msgs}"
+
+
+def test_run_task_oom_flushes_trailing_output(running_node, monkeypatch, patch_psutil,
+                                              caplog):
+    """Output emitted just before an out-of-memory kill (including an
+    unterminated trailing line) must still reach the log via the final
+    flush-drain."""
+
+    assert running_node.project.set("tool", "builtin", 'task', 'nop', "format", "json")
+
+    trailing = "allocating one buffer too many"
+    stdout_path = "running.log"
+
+    def dummy_virtual_memory():
+        class Memory:
+            percent = 99.5
+            available = 100 * 1024 * 1024  # 100 MiB, below the kill limit
+        return Memory
+    monkeypatch.setattr(imported_psutil, 'virtual_memory', dummy_virtual_memory)
+
+    def dummy_popen(*args, **kwargs):
+        class Popen:
+            pid = 1
+
+            def poll(self):
+                with open(stdout_path, 'a') as f:
+                    f.write(trailing)
+                return None
+
+            def wait(self, timeout=None):
+                pass
+
+        return Popen()
+    monkeypatch.setattr(imported_subprocess, 'Popen', dummy_popen)
+
+    def dummy_get_exe(*args, **kwargs):
+        return "found/exe"
+    monkeypatch.setattr(running_node.task, 'get_exe', dummy_get_exe)
+
+    monkeypatch.setattr(Task, '_Task__IO_POLL_INTERVAL', 0)
+
+    with caplog.at_level(logging.INFO):
+        with running_node.task.runtime(running_node) as runtool:
+            with pytest.raises(TaskOutOfMemoryError):
+                runtool.run_task('.', False, False, None, None)
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any(trailing in msg for msg in msgs), \
+        f"Trailing output before OOM kill was dropped from logs: {msgs}"
+
+
 def test_select_input_nodes_entry(running_node):
     with running_node.task.runtime(running_node) as runtool:
         assert runtool.select_input_nodes() == []

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -2119,11 +2119,12 @@ def test_run_task_timeout_flushes_trailing_output(running_node, monkeypatch, pat
             pid = 1
 
             def poll(self):
-                # Emit an unterminated line, then block long enough to trip
-                # the timeout before the process would otherwise exit.
+                # Emit an unterminated line, then block just long enough to
+                # trip the timeout (0.5s below) before the process would
+                # otherwise exit. Kept short to avoid slowing the suite.
                 with open(stdout_path, 'a') as f:
                     f.write(trailing)
-                time.sleep(3)
+                time.sleep(1)
                 return None
 
             def wait(self, timeout=None):
@@ -2139,7 +2140,7 @@ def test_run_task_timeout_flushes_trailing_output(running_node, monkeypatch, pat
     with caplog.at_level(logging.INFO):
         with running_node.task.runtime(running_node) as runtool:
             with pytest.raises(TaskTimeout):
-                runtool.run_task('.', False, False, None, 1)
+                runtool.run_task('.', False, False, None, 0.5)
 
     msgs = [r.getMessage() for r in caplog.records]
     assert any(trailing in msg for msg in msgs), \

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -220,6 +220,22 @@ def test_history_clear_drops_all_records():
     assert [r.getMessage() for r in h.records] == ["three"]
 
 
+def test_history_drain_returns_and_clears():
+    h = SCHistoryLogHandler()
+    h.emit(_make_record(msg="one"))
+    h.emit(_make_record(msg="two"))
+
+    drained = h.drain()
+    assert [r.getMessage() for r in drained] == ["one", "two"]
+    # Buffer is empty after draining.
+    assert h.records == []
+
+    # A second drain returns nothing; the handler is still usable.
+    assert h.drain() == []
+    h.emit(_make_record(msg="three"))
+    assert [r.getMessage() for r in h.drain()] == ["three"]
+
+
 def test_history_captures_through_logger():
     h = SCHistoryLogHandler()
     logger = logging.getLogger("test_history_captures_through_logger")

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -2,7 +2,8 @@ import logging
 
 import pytest
 
-from siliconcompiler.utils.logging import SCSuppressLoggerFilter, SCTeeLoggerHandler
+from siliconcompiler.utils.logging import (
+    SCSuppressLoggerFilter, SCTeeLoggerHandler, SCHistoryLogHandler)
 
 
 # ---------------------------------------------------------------------------
@@ -172,3 +173,61 @@ def test_tee_tolerates_handler_emit_failure(logger):
     tee.handle(_make_record(msg="survive"))
 
     assert good.records == ["survive"]
+
+
+# ---------------------------------------------------------------------------
+# SCHistoryLogHandler
+# ---------------------------------------------------------------------------
+
+def test_history_retains_emitted_records():
+    h = SCHistoryLogHandler()
+    h.emit(_make_record(msg="one"))
+    h.emit(_make_record(msg="two"))
+
+    assert [r.getMessage() for r in h.records] == ["one", "two"]
+
+
+def test_history_records_are_a_copy():
+    """The ``records`` property must return a snapshot, not the live buffer,
+    so a caller iterating it while new records arrive is unaffected."""
+    h = SCHistoryLogHandler()
+    h.emit(_make_record(msg="one"))
+
+    snapshot = h.records
+    h.emit(_make_record(msg="two"))
+
+    assert [r.getMessage() for r in snapshot] == ["one"]
+
+
+def test_history_is_bounded_and_keeps_most_recent():
+    h = SCHistoryLogHandler(capacity=3)
+    for i in range(5):
+        h.emit(_make_record(msg=f"msg{i}"))
+
+    assert [r.getMessage() for r in h.records] == ["msg2", "msg3", "msg4"]
+
+
+def test_history_clear_drops_all_records():
+    h = SCHistoryLogHandler()
+    h.emit(_make_record(msg="one"))
+    h.emit(_make_record(msg="two"))
+
+    h.clear()
+    assert h.records == []
+
+    # Still usable after clearing.
+    h.emit(_make_record(msg="three"))
+    assert [r.getMessage() for r in h.records] == ["three"]
+
+
+def test_history_captures_through_logger():
+    h = SCHistoryLogHandler()
+    logger = logging.getLogger("test_history_captures_through_logger")
+    logger.handlers = []
+    logger.setLevel(logging.INFO)
+    logger.addHandler(h)
+
+    logger.info("captured %s", "value")
+    logger.warning("warned")
+
+    assert [r.getMessage() for r in h.records] == ["captured value", "warned"]


### PR DESCRIPTION
Closes #4255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The dashboard now buffers earlier log output and shows it when the dashboard becomes visible.
* **Bug Fixes**
  * Full retained logs are reliably printed on forced shutdown, including runtime errors and interruptions.
  * The dashboard now stops promptly when runtime failures occur.
  * Subprocess output emitted right before termination is no longer lost on timeouts, out-of-memory, or interrupts.
* **Tests**
  * Added coverage for log-buffer seeding, forced teardown behavior, and trailing subprocess output flushing.
* **Documentation**
  * Added a CLI demo to validate dashboard logging and failure/interruption scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->