### PR TITLE
add istype to parameter for better type checking

### DIFF
--- a/siliconcompiler/checklist.py
+++ b/siliconcompiler/checklist.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Tuple, List, Optional, Union, Dict, Iterable
 
 from siliconcompiler.schema import NamedSchema, EditableSchema, Parameter, Scope, BaseSchema
+from siliconcompiler.schema.parametertype import NodeType
 from siliconcompiler.schema.utils import trim
 from siliconcompiler import NodeStatus, utils
 from siliconcompiler.utils.paths import cwdirsafe
@@ -397,7 +398,7 @@ class Checklist(NamedSchema):
                         error = True
                         continue
 
-                    if job_data.get("metric", metric, field='type').startswith('int'):
+                    if NodeType.istype(job_data.get("metric", metric, field='type'), 'int'):
                         goal = int(m.group(3))
                         number_format = 'd'
                     else:

--- a/siliconcompiler/report/utils.py
+++ b/siliconcompiler/report/utils.py
@@ -1,4 +1,5 @@
 from siliconcompiler import NodeStatus
+from siliconcompiler.schema.parametertype import NodeType
 from siliconcompiler.utils import units
 
 from siliconcompiler.flowgraph import RuntimeFlowgraph
@@ -110,7 +111,7 @@ def _format_value(metric, value, metric_unit, metric_type, format_as_string):
     elif metric in ['exetime', 'tasktime', 'totaltime']:
         if format_as_string:
             return units.format_time(value)
-    elif metric_type == 'int':
+    elif NodeType.istype(metric_type, 'int'):
         if format_as_string:
             return str(value)
     else:

--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -1278,7 +1278,7 @@ class BaseSchema:
                     self, *keypath, missing_ok=True, step=step, index=index,
                     dataroots=dataroots, collection_dir=collection_dir, cwd=cwd)
 
-                if not param.is_list():
+                if not param.istype("list", "set"):
                     check_files = [check_files]
                     found_files = [found_files]
 

--- a/siliconcompiler/schema/docs/utils.py
+++ b/siliconcompiler/schema/docs/utils.py
@@ -292,7 +292,11 @@ def build_schema_value_table(params, refdoc, keypath_prefix=None, trim_prefix=No
             is_list = NodeType.istype(param_type, "list")
             is_set = NodeType.istype(param_type, "set")
             if param.is_path:
-                val_node = format_value_file(is_list, value,
+                # Paths can be scalars, lists or (ordered) sets. Treat both list
+                # and set containers as collections so each file is rendered
+                # individually; value and its dataroot come back as parallel,
+                # order-preserving lists.
+                val_node = format_value_file(is_list or is_set, value,
                                              param.get(field='dataroot',
                                                        step=step, index=index))
             else:

--- a/siliconcompiler/schema/docs/utils.py
+++ b/siliconcompiler/schema/docs/utils.py
@@ -236,6 +236,8 @@ def parse_rst(state, content, dest, errorloc):
 
 def build_schema_value_table(params, refdoc, keypath_prefix=None, trim_prefix=None):
     '''Helper function for displaying values set in schema as a docutils table.'''
+    from siliconcompiler.schema.parametertype import NodeType
+
     table = [[strong('Keypath'), strong('Type'), strong('Value')]]
 
     if not keypath_prefix:
@@ -286,17 +288,20 @@ def build_schema_value_table(params, refdoc, keypath_prefix=None, trim_prefix=No
                 continue
 
             val_type = param.get(field='type')
+            param_type = NodeType.parse(val_type)
+            is_list = NodeType.istype(param_type, "list")
+            is_set = NodeType.istype(param_type, "set")
             if param.is_path:
-                val_node = format_value_file(val_type.startswith('['), value,
+                val_node = format_value_file(is_list, value,
                                              param.get(field='dataroot',
                                                        step=step, index=index))
             else:
-                val_node = format_value(val_type.startswith('['), val_type.startswith('{'), value)
+                val_node = format_value(is_list, is_set, value)
 
-            if "<" in val_type:
-                if val_type.startswith('['):
+            if NodeType.contains(param_type, "enum"):
+                if is_list:
                     val_type = "[enum]"
-                elif val_type.startswith('{'):
+                elif is_set:
                     val_type = "{enum}"
                 else:
                     val_type = "enum"

--- a/siliconcompiler/schema/parameter.py
+++ b/siliconcompiler/schema/parameter.py
@@ -8,6 +8,7 @@ import argparse
 import copy
 import re
 import shlex
+import warnings
 
 from enum import Enum
 from typing import Tuple, Optional, Union, List, Dict, Any, Set
@@ -172,10 +173,10 @@ class Parameter:
         allowed = []
         if NodeType.contains(self.__type, NodeEnumType):
             type_str = "enum"
-            if self.is_list():
+            if self.istype("list"):
                 type_str = "[enum]"
                 values = list(self.__type)[0].values
-            elif self.is_set():
+            elif self.istype("set"):
                 type_str = "{enum}"
                 values = list(self.__type)[0].values
             else:
@@ -462,7 +463,7 @@ class Parameter:
         self.__assert_step_index(field, step, index)
 
         if field in self.__defvalue.fields:
-            if not self.is_list() and field == 'value':
+            if not self.istype("list", "set") and field == 'value':
                 raise ValueError("add can only be used on lists or sets")
 
             if isinstance(index, int):
@@ -548,7 +549,7 @@ class Parameter:
 
         if values_only:
             dictvals = {}
-            is_list = self.is_list()
+            is_list = self.istype("list", "set")
             for value, step, index in self.getvalues(return_defvalue=include_default):
                 if is_list:
                     if value:
@@ -747,12 +748,42 @@ class Parameter:
         return copy.deepcopy(self)
 
     # Utility functions
+    def istype(self, *types) -> bool:
+        """
+        Returns true if this parameter's top-level type is exactly one of
+        ``types``.
+
+        This does not recurse into container types, so ``istype('int')`` is
+        ``False`` for a ``[int]`` parameter. See :meth:`NodeType.istype` for the
+        accepted checks (scalar names, the ``'list'``/``'set'``/``'tuple'``
+        container tokens, and ``'enum'``/``'range'``).
+        """
+
+        return NodeType.istype(self.__type, *types)
+
+    def basetype(self) -> Optional[str]:
+        """
+        Returns the underlying scalar base type name of this parameter,
+        unwrapping any container nesting and range/enum wrappers (e.g. ``[int]``
+        and ``int<0..>`` both return ``'int'``). Returns ``None`` for
+        heterogeneous tuples. See :meth:`NodeType.basetype`.
+        """
+
+        return NodeType.basetype(self.__type)
+
     def is_list(self) -> bool:
         """
         Returns true is this parameter is a list type
+
+        .. deprecated::
+            Use :meth:`istype` instead, e.g. ``param.istype('list', 'set')``.
         """
 
-        return isinstance(self.__type, (list, set))
+        warnings.warn(
+            "is_list is deprecated, use istype('list', 'set') instead",
+            DeprecationWarning,
+            stacklevel=2)
+        return NodeType.istype(self.__type, "list", "set")
 
     @property
     def is_file(self) -> bool:

--- a/siliconcompiler/schema/parameter.py
+++ b/siliconcompiler/schema/parameter.py
@@ -175,10 +175,10 @@ class Parameter:
             type_str = "enum"
             if self.istype("list"):
                 type_str = "[enum]"
-                values = list(self.__type)[0].values
+                values = next(iter(self.__type)).values
             elif self.istype("set"):
                 type_str = "{enum}"
-                values = list(self.__type)[0].values
+                values = next(iter(self.__type)).values
             else:
                 values = self.__type.values
             allowed = sorted(values)

--- a/siliconcompiler/schema/parametertype.py
+++ b/siliconcompiler/schema/parametertype.py
@@ -165,6 +165,9 @@ class NodeType:
         accepted by :meth:`astype` (e.g. ``'enum'``, ``'list'``), as well as a
         scalar type name (``'int'``, ``'file'``, ...).
         """
+        if isinstance(value, NodeType):
+            value = value.type
+
         check = NodeType.astype(check)
         if check in (list, tuple, set, NodeEnumType, NodeRangeType):
             if isinstance(value, check):

--- a/siliconcompiler/schema/parametertype.py
+++ b/siliconcompiler/schema/parametertype.py
@@ -1,6 +1,15 @@
 import re
 from collections.abc import Iterable
 from pathlib import Path, PureWindowsPath
+from typing import Optional, Union
+
+# A schema type in any of its accepted representations: an encoded string, a
+# NodeType wrapper, or a parsed structure (scalar name, container, enum/range).
+SchemaType = Union[str, "NodeType", list, set, tuple, "NodeEnumType", "NodeRangeType"]
+
+# A candidate accepted by NodeType.astype/contains/istype: a class, a
+# NodeEnumType/NodeRangeType instance, or a string token resolving to one.
+TypeCheck = Union[str, type, "NodeEnumType", "NodeRangeType"]
 
 
 class NodeType:
@@ -116,10 +125,47 @@ class NodeType:
         raise ValueError(f"{sctype} not a recognized type")
 
     @staticmethod
-    def contains(value, check):
+    def astype(spec: TypeCheck) -> TypeCheck:
+        """
+        Resolve a friendly type token into the object used for type checks by
+        :meth:`contains` and :meth:`istype`.
+
+        This lets callers use plain strings everywhere instead of importing the
+        ``NodeEnumType`` / ``NodeRangeType`` classes:
+
+        - ``'enum'`` resolves to ``NodeEnumType``
+        - ``'range'`` resolves to ``NodeRangeType``
+        - ``'list'``, ``'set'``, ``'tuple'`` resolve to the container classes
+
+        Scalar type names (``'int'``, ``'float'``, ``'str'``, ``'bool'``,
+        ``'file'``, ``'dir'``) and anything already resolved (a class, or a
+        ``NodeEnumType`` / ``NodeRangeType`` instance) are returned unchanged.
+
+        Args:
+            spec (str or type): the token or type to resolve.
+        """
+
+        if isinstance(spec, str):
+            return {
+                "list": list,
+                "set": set,
+                "tuple": tuple,
+                "enum": NodeEnumType,
+                "range": NodeRangeType,
+            }.get(spec, spec)
+        return spec
+
+    @staticmethod
+    def contains(value: SchemaType, check: TypeCheck) -> bool:
         """
         Check if the type contains a specific type.
+
+        ``check`` may be a class (``list``, ``tuple``, ``set``,
+        ``NodeEnumType``, ``NodeRangeType``) or the equivalent string token
+        accepted by :meth:`astype` (e.g. ``'enum'``, ``'list'``), as well as a
+        scalar type name (``'int'``, ``'file'``, ...).
         """
+        check = NodeType.astype(check)
         if check in (list, tuple, set, NodeEnumType, NodeRangeType):
             if isinstance(value, check):
                 return True
@@ -132,6 +178,86 @@ class NodeType:
         if isinstance(value, NodeRangeType):
             return value.base == check
         return value == check
+
+    @staticmethod
+    def istype(sctype: SchemaType, *types: TypeCheck) -> bool:
+        """
+        Check whether the top-level type is exactly one of ``types``.
+
+        Unlike :meth:`contains`, this does not recurse into container types, so
+        ``istype('[int]', 'int')`` is ``False`` while ``istype('[int]', list)``
+        is ``True``. This makes it the right check for asking "is this
+        parameter a scalar ``int``" without matching ``[int]``/``(int,int)``.
+
+        Accepted checks are the scalar type names (``'int'``, ``'float'``,
+        ``'str'``, ``'bool'``, ``'file'``, ``'dir'``), plus any token accepted
+        by :meth:`astype` for containers, enums and ranges (``'list'``,
+        ``'set'``, ``'tuple'``, ``'enum'``, ``'range'``, or the equivalent
+        classes). Range types match their numeric base (``'int'``/``'float'``)
+        as well as ``'range'``/``NodeRangeType``.
+
+        Args:
+            sctype (str, NodeType, or type): the type to inspect.
+            *types: one or more candidate types to match against.
+        """
+
+        if isinstance(sctype, NodeType):
+            sctype = sctype.type
+        elif isinstance(sctype, str):
+            sctype = NodeType.parse(sctype)
+
+        types = tuple(NodeType.astype(check) for check in types)
+
+        if isinstance(sctype, list):
+            return list in types
+        if isinstance(sctype, set):
+            return set in types
+        if isinstance(sctype, tuple):
+            return tuple in types
+        if isinstance(sctype, NodeRangeType):
+            return NodeRangeType in types or sctype.base in types
+        if isinstance(sctype, NodeEnumType):
+            return NodeEnumType in types
+        if isinstance(sctype, str):
+            return sctype in types
+        return False
+
+    @staticmethod
+    def basetype(sctype: SchemaType) -> Optional[str]:
+        """
+        Return the underlying scalar base type name of a type, unwrapping any
+        container nesting (list, set, tuple) and range/enum wrappers.
+
+        - Range types return their numeric base (``'int'``/``'float'``).
+        - Enum types return ``'enum'``.
+        - Homogeneous containers return their element base (``'[int]'`` ->
+          ``'int'``).
+        - Heterogeneous tuples (e.g. ``'(str,int)'``) return ``None`` since they
+          have no single base type.
+
+        Args:
+            sctype (str, NodeType, or type): the type to inspect.
+        """
+
+        if isinstance(sctype, NodeType):
+            sctype = sctype.type
+        elif isinstance(sctype, str):
+            sctype = NodeType.parse(sctype)
+
+        if isinstance(sctype, list):
+            return NodeType.basetype(sctype[0])
+        if isinstance(sctype, set):
+            return NodeType.basetype(next(iter(sctype)))
+        if isinstance(sctype, tuple):
+            bases = {NodeType.basetype(subtype) for subtype in sctype}
+            return bases.pop() if len(bases) == 1 else None
+        if isinstance(sctype, NodeRangeType):
+            return sctype.base
+        if isinstance(sctype, NodeEnumType):
+            return 'enum'
+        if isinstance(sctype, str):
+            return sctype
+        return None
 
     @staticmethod
     def to_tcl(value, sctype):

--- a/siliconcompiler/schema_support/cmdlineschema.py
+++ b/siliconcompiler/schema_support/cmdlineschema.py
@@ -282,7 +282,7 @@ class CommandLineSchema(BaseSchema):
                     logger.info(msg)
 
                 # Storing in manifest
-                if param.is_list():
+                if param.istype("list", "set"):
                     schema.add(*valkeypath, item, step=step, index=index)
                 else:
                     schema.set(*valkeypath, item, step=step, index=index)

--- a/siliconcompiler/schema_support/metric.py
+++ b/siliconcompiler/schema_support/metric.py
@@ -5,6 +5,7 @@ from typing import List, Tuple, TextIO, Union, Optional, TYPE_CHECKING
 
 from siliconcompiler.schema import BaseSchema
 from siliconcompiler.schema import EditableSchema, Parameter, PerNode, Scope
+from siliconcompiler.schema.parametertype import NodeType
 from siliconcompiler.schema.utils import trim
 
 from siliconcompiler.utils import truncate_text, units
@@ -269,7 +270,7 @@ class MetricSchema(BaseSchema):
                                        self.get(metric, field="unit"))
         elif metric in ['exetime', 'tasktime', 'totaltime']:
             return units.format_time(self.get(metric, step=step, index=index))
-        elif self.get(metric, field="type") == 'int':
+        elif NodeType.istype(self.get(metric, field="type"), 'int'):
             return str(self.get(metric, step=step, index=index))
         else:
             return units.format_si(self.get(metric, step=step, index=index),

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -36,7 +36,7 @@ from pathlib import Path
 
 from siliconcompiler.schema import BaseSchema, NamedSchema, DocsSchema, LazyLoad
 from siliconcompiler.schema import EditableSchema, Parameter, PerNode, Scope
-from siliconcompiler.schema.parametertype import NodeType, NodeEnumType
+from siliconcompiler.schema.parametertype import NodeType
 from siliconcompiler.schema.utils import trim
 
 from siliconcompiler import utils, NodeStatus, Flowgraph
@@ -2398,15 +2398,15 @@ class Task(NamedSchema, PathSchema, DocsSchema):
 
                 val_type = param.get(field="type")
                 encode_type = NodeType.parse(val_type)
-                if NodeType.contains(encode_type, NodeEnumType):
+                if NodeType.contains(encode_type, "enum"):
                     try:
-                        if val_type.startswith('['):
+                        if NodeType.istype(encode_type, "list"):
                             allowed = list(encode_type)[0].values
                             val_type = "[enum]"
-                        elif val_type.startswith('{'):
+                        elif NodeType.istype(encode_type, "set"):
                             allowed = list(encode_type)[0].values
                             val_type = "{enum}"
-                        elif val_type.startswith('('):
+                        elif NodeType.istype(encode_type, "tuple"):
                             allowed = []
                             val_type = val_type
                         else:

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -2401,10 +2401,10 @@ class Task(NamedSchema, PathSchema, DocsSchema):
                 if NodeType.contains(encode_type, "enum"):
                     try:
                         if NodeType.istype(encode_type, "list"):
-                            allowed = list(encode_type)[0].values
+                            allowed = next(iter(encode_type)).values
                             val_type = "[enum]"
                         elif NodeType.istype(encode_type, "set"):
-                            allowed = list(encode_type)[0].values
+                            allowed = next(iter(encode_type)).values
                             val_type = "{enum}"
                         elif NodeType.istype(encode_type, "tuple"):
                             allowed = []

--- a/tests/schema/test_parameter.py
+++ b/tests/schema/test_parameter.py
@@ -789,10 +789,52 @@ def test_is_set():
 
 def test_is_list():
     param = Parameter("str")
-    assert not param.is_list()
+    with pytest.warns(DeprecationWarning, match="is_list is deprecated"):
+        assert not param.is_list()
 
     param = Parameter("[str]")
-    assert param.is_list()
+    with pytest.warns(DeprecationWarning, match="is_list is deprecated"):
+        assert param.is_list()
+
+
+def test_is_list_deprecated():
+    """is_list warns but still reports list and set container types."""
+    with pytest.warns(DeprecationWarning,
+                      match=r"is_list is deprecated, use istype\('list', 'set'\) instead"):
+        assert Parameter("{str}").is_list()
+
+
+@pytest.mark.parametrize("sctype,check,expect", [
+    ("int", ("int",), True),
+    ("int", ("float",), False),
+    ("int", ("int", "float"), True),
+    ("[int]", ("int",), False),
+    ("[int]", ("list",), True),
+    ("[int]", ("list", "set"), True),
+    ("{int}", ("set",), True),
+    ("{int}", ("list", "set"), True),
+    ("(int,str)", ("tuple",), True),
+    ("int<0..10>", ("int",), True),
+    ("int<0..10>", ("range",), True),
+    ("<a,b>", ("enum",), True),
+])
+def test_istype(sctype, check, expect):
+    """Parameter.istype forwards to NodeType.istype on the parameter's type."""
+    assert Parameter(sctype).istype(*check) is expect
+
+
+@pytest.mark.parametrize("sctype,expect", [
+    ("int", "int"),
+    ("float", "float"),
+    ("[int]", "int"),
+    ("{str}", "str"),
+    ("int<0..10>", "int"),
+    ("<a,b>", "enum"),
+    ("(str,int)", None),
+])
+def test_basetype(sctype, expect):
+    """Parameter.basetype forwards to NodeType.basetype on the parameter's type."""
+    assert Parameter(sctype).basetype() == expect
 
 
 @pytest.mark.parametrize("sctype", (

--- a/tests/schema/test_parameter.py
+++ b/tests/schema/test_parameter.py
@@ -804,6 +804,29 @@ def test_is_list_deprecated():
         assert Parameter("{str}").is_list()
 
 
+@pytest.mark.parametrize("sctype,expect", [
+    # Any list container is a list, regardless of element type
+    ("[file]", True),
+    ("[dir]", True),
+    ("[int]", True),
+    ("[str]", True),
+    ("[<a,b>]", True),
+    # Sets count too
+    ("{file}", True),
+    ("{dir}", True),
+    ("{str}", True),
+    # Scalars and tuples are not
+    ("file", False),
+    ("dir", False),
+    ("int", False),
+    ("(str,int)", False),
+])
+def test_is_list_container_types(sctype, expect):
+    """is_list is true for any list/set container, including lists of files."""
+    with pytest.warns(DeprecationWarning):
+        assert Parameter(sctype).is_list() is expect
+
+
 @pytest.mark.parametrize("sctype,check,expect", [
     ("int", ("int",), True),
     ("int", ("float",), False),

--- a/tests/schema/test_parametertype.py
+++ b/tests/schema/test_parametertype.py
@@ -724,7 +724,7 @@ def test_normalize_float_range_invalid(range_str, value, match):
         NodeType.normalize(value, NodeType.parse(range_str))
 
 
-@pytest.mark.parametrize("type,check,expect", [
+@pytest.mark.parametrize("sctype,check,expect", [
     # Scalar exact match
     ("int", "int", True),
     ("int", "float", False),
@@ -781,13 +781,13 @@ def test_normalize_float_range_invalid(range_str, value, match):
     ("int", "set", False),
     ("int", "tuple", False),
 ])
-def test_istype(type, check, expect):
+def test_istype(sctype, check, expect):
     """istype matches the top-level type only, without recursing into containers.
 
     Checks are exercised both as classes (``list``, ``NodeEnumType``, ...) and
     as the equivalent :meth:`astype` string tokens (``'list'``, ``'enum'``, ...).
     """
-    assert NodeType.istype(type, check) is expect
+    assert NodeType.istype(sctype, check) is expect
 
 
 def test_istype_multiple_checks():
@@ -814,7 +814,7 @@ def test_istype_accepts_nodetype_and_type_objects():
     assert NodeType.istype(NodeType.parse("<one,two>"), "enum") is True
 
 
-@pytest.mark.parametrize("type,expect", [
+@pytest.mark.parametrize("sctype,expect", [
     # Scalars return themselves
     ("int", "int"),
     ("float", "float"),
@@ -842,9 +842,9 @@ def test_istype_accepts_nodetype_and_type_objects():
     ("(str,int)", None),
     ("(int,float)", None),
 ])
-def test_basetype(type, expect):
+def test_basetype(sctype, expect):
     """basetype unwraps containers and range/enum wrappers to the scalar base."""
-    assert NodeType.basetype(type) == expect
+    assert NodeType.basetype(sctype) == expect
 
 
 def test_basetype_accepts_nodetype_and_type_objects():

--- a/tests/schema/test_parametertype.py
+++ b/tests/schema/test_parametertype.py
@@ -480,7 +480,9 @@ def test_str_invalid():
     ("[file]", "file", True),
 ])
 def test_contains(sctype, check, expect):
+    # Parsed structure and NodeType wrapper inputs must give the same result.
     assert NodeType.contains(NodeType.parse(sctype), check) is expect
+    assert NodeType.contains(NodeType(sctype), check) is expect
 
 
 def test_parse_negative_float_range():

--- a/tests/schema/test_parametertype.py
+++ b/tests/schema/test_parametertype.py
@@ -411,6 +411,7 @@ def test_str_invalid():
     ("bool", list, False),
     ("bool", tuple, False),
     ("bool", NodeEnumType, False),
+    ("bool", "enum", False),
     ("(str,int)", "str", True),
     ("(str,int)", "int", True),
     ("(str,int)", tuple, True),
@@ -428,14 +429,55 @@ def test_str_invalid():
     ("{(str,int)}", tuple, True),
     ("{(str,int)}", list, False),
     ("{(str,int)}", set, True),
+    ("{(str,int)}", "tuple", True),
+    ("{(str,int)}", "list", False),
+    ("{(str,int)}", "set", True),
     ("{(str,int)}", "bool", False),
     ("(str,int,bool,float,<hello,world>)", "str", True),
     ("(str,int,bool,float,<hello,world>)", "int", True),
     ("(str,int,bool,float,<hello,world>)", "bool", True),
     ("(str,int,bool,float,<hello,world>)", "float", True),
+    ("(str,int,bool,float,<hello,world>)", "enum", True),
     ("(str,int,bool,float,<hello,world>)", NodeEnumType, True),
     ("(str,int,bool,float,<hello,world>)", tuple, True),
-    ("(str,int,bool,float,<hello,world>)", list, False)
+    ("(str,int,bool,float,<hello,world>)", "tuple", True),
+    ("(str,int,bool,float,<hello,world>)", list, False),
+    ("(str,int,bool,float,<hello,world>)", "list", False),
+    ("(str,int,bool,float,<hello,world>)", "set", False),
+    ("(str,int,bool,float,<hello,world>)", set, False),
+    # Remaining scalar bases (float/file/dir) matched directly
+    ("float", "float", True),
+    ("float", "int", False),
+    ("file", "file", True),
+    ("file", "dir", False),
+    ("dir", "dir", True),
+    ("dir", "file", False),
+    # Enum scalar, via 'enum' token and the NodeEnumType class
+    ("<one,two>", "enum", True),
+    ("<one,two>", NodeEnumType, True),
+    ("<one,two>", "str", False),
+    ("int", "enum", False),
+    ("[<one,two>]", "enum", True),
+    ("[<one,two>]", NodeEnumType, True),
+    # Range scalar matches its numeric base, 'range' token, and NodeRangeType
+    ("int<0..10>", "int", True),
+    ("int<0..10>", "float", False),
+    ("int<0..10>", "range", True),
+    ("int<0..10>", NodeRangeType, True),
+    ("float<0.0..1.0>", "float", True),
+    ("int", "range", False),
+    # Simple single-element containers, via class and string token (recursing)
+    ("[int]", "int", True),
+    ("[int]", list, True),
+    ("[int]", "list", True),
+    ("[int]", set, False),
+    ("[int]", "set", False),
+    ("{int}", "int", True),
+    ("{int}", set, True),
+    ("{int}", "set", True),
+    ("{int}", list, False),
+    ("{int}", "list", False),
+    ("[file]", "file", True),
 ])
 def test_contains(sctype, check, expect):
     assert NodeType.contains(NodeType.parse(sctype), check) is expect
@@ -680,3 +722,158 @@ def test_normalize_float_range_invalid(range_str, value, match):
     """Poorly formatted or out-of-range values raise on normalize."""
     with pytest.raises(ValueError, match=match):
         NodeType.normalize(value, NodeType.parse(range_str))
+
+
+@pytest.mark.parametrize("type,check,expect", [
+    # Scalar exact match
+    ("int", "int", True),
+    ("int", "float", False),
+    ("float", "float", True),
+    ("float", "int", False),
+    ("str", "str", True),
+    ("bool", "bool", True),
+    ("file", "file", True),
+    ("dir", "dir", True),
+    ("file", "dir", False),
+    ("str", "enum", False),
+    # Range types match on their numeric base
+    ("int<0..10>", "int", True),
+    ("int<0..10>", "float", False),
+    ("float<0.0..1.0>", "float", True),
+    ("float<0.0..1.0>", "int", False),
+    ("int<0..10>", NodeRangeType, True),
+    ("float<0.0..1.0>", NodeRangeType, True),
+    ("int", NodeRangeType, False),
+    # Enum types match 'enum' or the NodeEnumType class
+    ("<one,two,three>", "enum", True),
+    ("<one,two,three>", "str", False),
+    ("<one,two,three>", NodeEnumType, True),
+    ("int", NodeEnumType, False),
+    # Containers never match a scalar name (this is the precision contains lacks)
+    ("[int]", "int", False),
+    ("{int}", "int", False),
+    ("(int,int)", "int", False),
+    ("[<one,two>]", "enum", False),
+    # Containers match their own class only, non-recursively
+    ("[int]", list, True),
+    ("[int]", set, False),
+    ("[int]", tuple, False),
+    ("{int}", set, True),
+    ("{int}", list, False),
+    ("(int,str)", tuple, True),
+    ("(int,str)", list, False),
+    ("int", list, False),
+    ("int", set, False),
+    ("int", tuple, False),
+    # The same checks expressed as astype string tokens instead of classes
+    ("int<0..10>", "range", True),
+    ("int", "range", False),
+    ("<one,two,three>", "enum", True),
+    ("[<one,two>]", "enum", False),
+    ("[int]", "list", True),
+    ("[int]", "set", False),
+    ("[int]", "tuple", False),
+    ("{int}", "set", True),
+    ("{int}", "list", False),
+    ("(int,str)", "tuple", True),
+    ("(int,str)", "list", False),
+    ("int", "list", False),
+    ("int", "set", False),
+    ("int", "tuple", False),
+])
+def test_istype(type, check, expect):
+    """istype matches the top-level type only, without recursing into containers.
+
+    Checks are exercised both as classes (``list``, ``NodeEnumType``, ...) and
+    as the equivalent :meth:`astype` string tokens (``'list'``, ``'enum'``, ...).
+    """
+    assert NodeType.istype(type, check) is expect
+
+
+def test_istype_multiple_checks():
+    """istype accepts several candidate types and matches any of them."""
+    assert NodeType.istype("int", "int", "float") is True
+    assert NodeType.istype("float", "int", "float") is True
+    assert NodeType.istype("str", "int", "float") is False
+    assert NodeType.istype("int", "int", "float", "str", "bool") is True
+    assert NodeType.istype("[int]", list, set, tuple) is True
+    assert NodeType.istype("int", list, set, tuple) is False
+
+
+def test_istype_no_checks():
+    """istype with no candidate types matches nothing."""
+    assert NodeType.istype("int") is False
+    assert NodeType.istype("[int]") is False
+
+
+def test_istype_accepts_nodetype_and_type_objects():
+    """istype works on NodeType instances and raw parsed type objects."""
+    assert NodeType.istype(NodeType("int"), "int") is True
+    assert NodeType.istype(NodeType("[int]"), list) is True
+    assert NodeType.istype(NodeType.parse("int<0..10>"), "int") is True
+    assert NodeType.istype(NodeType.parse("<one,two>"), "enum") is True
+
+
+@pytest.mark.parametrize("type,expect", [
+    # Scalars return themselves
+    ("int", "int"),
+    ("float", "float"),
+    ("str", "str"),
+    ("bool", "bool"),
+    ("file", "file"),
+    ("dir", "dir"),
+    # Range types collapse to their numeric base
+    ("int<0..10>", "int"),
+    ("float<0.0..1.0>", "float"),
+    # Enum types collapse to 'enum'
+    ("<one,two,three>", "enum"),
+    # Homogeneous containers return their element base
+    ("[int]", "int"),
+    ("{str}", "str"),
+    ("[file]", "file"),
+    ("{dir}", "dir"),
+    ("[<one,two>]", "enum"),
+    ("[int<0..10>]", "int"),
+    ("(int,int)", "int"),
+    ("(str,str)", "str"),
+    # Nested containers recurse to the leaf
+    ("[[int]]", "int"),
+    # Heterogeneous tuples have no single base
+    ("(str,int)", None),
+    ("(int,float)", None),
+])
+def test_basetype(type, expect):
+    """basetype unwraps containers and range/enum wrappers to the scalar base."""
+    assert NodeType.basetype(type) == expect
+
+
+def test_basetype_accepts_nodetype_and_type_objects():
+    """basetype works on NodeType instances and raw parsed type objects."""
+    assert NodeType.basetype(NodeType("int")) == "int"
+    assert NodeType.basetype(NodeType("[int]")) == "int"
+    assert NodeType.basetype(NodeType.parse("int<0..10>")) == "int"
+    assert NodeType.basetype(NodeType.parse("(str,int)")) is None
+
+
+@pytest.mark.parametrize("spec,expect", [
+    # String tokens resolve to their classes
+    ("list", list),
+    ("set", set),
+    ("tuple", tuple),
+    ("enum", NodeEnumType),
+    ("range", NodeRangeType),
+    # Scalar names pass through unchanged
+    ("int", "int"),
+    ("float", "float"),
+    ("file", "file"),
+    # Unknown strings pass through unchanged
+    ("bogus", "bogus"),
+    # Classes and instances pass through unchanged
+    (list, list),
+    (NodeEnumType, NodeEnumType),
+    (NodeRangeType, NodeRangeType),
+    (enum1, enum1),
+])
+def test_astype(spec, expect):
+    """astype maps friendly tokens to check objects and passes the rest through."""
+    assert NodeType.astype(spec) == expect


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced schema type-checking utilities, including exact type matching, container-aware checks, base-type extraction, and type token resolution.
  * Improved schema/parameter documentation rendering for list/set and enum shapes (including allowed-values help text).
* **Bug Fixes**
  * Fixed integer-type handling in metrics and checklist goal parsing using robust type detection.
  * Improved file-path validation and command-line parsing for set-valued parameters.
* **Deprecations**
  * Deprecated `Parameter.is_list()`; it now emits a `DeprecationWarning` (use the new type helpers).
* **Tests**
  * Expanded tests for the new type utilities and the deprecation warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->