### PR TITLE
fix set vs list ordering

### DIFF
--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -1475,7 +1475,12 @@ class APRTask(OpenROADTask):
                 "clock_placement",
                 "clock_trees"))
 
-        do_reports = set(task_reports).difference(skip_reports)
+        # Iterate the ordered task_reports rather than a Python set: a set's
+        # iteration order is hash-randomized and varies between processes, which
+        # makes the scheduler's order-sensitive value comparison flag the node
+        # as "modified from previous run" on every incremental re-run. The
+        # reports var is itself a deduplicated, order-preserving set.
+        do_reports = [r for r in task_reports if r not in skip_reports]
         self.set("var", "reports", do_reports)
 
         if "power" in self.get("var", "reports"):

--- a/siliconcompiler/tools/opensta/timing.py
+++ b/siliconcompiler/tools/opensta/timing.py
@@ -210,7 +210,12 @@ class TimingTaskBase(OpenSTATask):
         # in a commented-out fallback (the live reader is OpenROAD's separate same-named parameter).
 
         skip_reports = set(self.get("var", "skip_reports"))
-        self.set("var", "reports", set(self.REPORT_TYPES).difference(skip_reports))
+        # Iterate the ordered REPORT_TYPES rather than a Python set: a set's
+        # iteration order is hash-randomized and varies between processes, which
+        # makes the scheduler's order-sensitive value comparison flag the node
+        # as "modified from previous run" on every incremental re-run. The
+        # reports var is itself a deduplicated, order-preserving set.
+        self.set("var", "reports", [r for r in self.REPORT_TYPES if r not in skip_reports])
         if self.get("var", "reports"):
             self.add_required_key("var", "reports")
         if skip_reports:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report generation consistency by preserving the configured report order.
  * Prevented unnecessary changes during incremental runs caused by inconsistent report ordering.
  * Continued to exclude any reports that are intentionally skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->