### PR TITLE
use weakref to avoid dashboard and project from getting stuck in memory

### DIFF
--- a/siliconcompiler/report/dashboard/__init__.py
+++ b/siliconcompiler/report/dashboard/__init__.py
@@ -1,5 +1,70 @@
+import weakref
+
 from abc import ABC, abstractmethod
 from enum import Enum
+
+
+def _dead_ref():
+    """Stand-in for a resolved-empty weak reference (used after unpickling)."""
+    return None
+
+
+class WeakAtexitCall:
+    """
+    A picklable, zero-argument trampoline that invokes a bound method through
+    a :class:`weakref.WeakMethod`, suitable for :func:`atexit.register`.
+
+    Registering a bound method directly with ``atexit`` (e.g.
+    ``atexit.register(self.stop)``) stores a strong reference to the instance
+    in the atexit registry, keeping it — and everything it transitively
+    references — alive until interpreter exit. For a dashboard that means the
+    whole :class:`~siliconcompiler.Project` leaks and can never be garbage
+    collected.
+
+    This trampoline holds only a weak reference to the bound method. When
+    invoked at exit it resolves the weak reference and calls the method only
+    if the instance is still alive; otherwise it is a harmless no-op, letting
+    the garbage collector reclaim the instance early.
+
+    A :class:`weakref.WeakMethod` cannot be pickled, and the reference would be
+    meaningless in another process, so the trampoline pickles as a dead no-op.
+    This matters because it is stored on the dashboard instance, and a
+    dashboard may itself be pickled to a subprocess (e.g. the
+    :class:`~siliconcompiler.report.dashboard.web.WebDashboard` sent to the
+    Streamlit process). The subprocess never re-registers atexit hooks, so the
+    dead stand-in is correct there.
+    """
+
+    def __init__(self, method):
+        self._ref = weakref.WeakMethod(method)
+
+    def __call__(self):
+        target = self._ref()
+        if target is not None:
+            target()
+
+    def __getstate__(self):
+        # A WeakMethod is not picklable and carries no meaning across a
+        # process boundary; drop it so an embedding object can still be
+        # pickled to a subprocess.
+        return {}
+
+    def __setstate__(self, state):
+        self._ref = _dead_ref
+
+
+def weak_atexit_call(method):
+    """
+    Build a :class:`WeakAtexitCall` trampoline for ``method``.
+
+    Args:
+        method: A bound method to invoke at interpreter exit.
+
+    Returns:
+        WeakAtexitCall: A picklable, zero-argument callable to pass to
+        ``atexit.register`` (and later ``atexit.unregister``).
+    """
+    return WeakAtexitCall(method)
 
 
 class DashboardType(Enum):

--- a/siliconcompiler/report/dashboard/cli/__init__.py
+++ b/siliconcompiler/report/dashboard/cli/__init__.py
@@ -2,7 +2,7 @@ import atexit
 
 from typing import TYPE_CHECKING
 
-from siliconcompiler.report.dashboard import AbstractDashboard
+from siliconcompiler.report.dashboard import AbstractDashboard, weak_atexit_call
 from siliconcompiler.utils.logging import SCSuppressLoggerFilter, SCHistoryLogHandler
 
 if TYPE_CHECKING:
@@ -50,9 +50,12 @@ class CliDashboard(AbstractDashboard):
             # Attach logger when already running
             self.set_logger(self._project.logger)
 
-        # Ensure the dashboard is properly stopped on program exit
-        self.__exit_registered = True
-        atexit.register(self.stop)
+        # Ensure the dashboard is properly stopped on program exit. Register
+        # via a weakref trampoline so the atexit registry does not pin this
+        # dashboard (and, transitively, its project) alive for the whole
+        # process — a bound-method registration would leak both.
+        self.__atexit_func = weak_atexit_call(self.stop)
+        atexit.register(self.__atexit_func)
 
     @staticmethod
     def should_disable(project: "Project") -> bool:
@@ -190,10 +193,10 @@ class CliDashboard(AbstractDashboard):
         `Board` object to start its live-rendering thread.
         """
 
-        if not self.__exit_registered:
+        if self.__atexit_func is None:
             # Ensure the dashboard is properly stopped on program exit
-            self.__exit_registered = True
-            atexit.register(self.stop)
+            self.__atexit_func = weak_atexit_call(self.stop)
+            atexit.register(self.__atexit_func)
 
         self.set_logger(self._project.logger)
 
@@ -245,8 +248,8 @@ class CliDashboard(AbstractDashboard):
         The ``Board`` is built from :class:`MPManager` shared proxy objects
         (events, dicts, queues) which can be torn down before this runs during
         multiprocess exit; touching them then raises. If that exception were
-        allowed to propagate before the ``atexit.unregister`` below, the bound
-        ``self.stop`` would stay registered and fire again at interpreter
+        allowed to propagate before the ``atexit.unregister`` below, the
+        trampoline would stay registered and fire again at interpreter
         shutdown, surfacing as "Exception ignored in atexit callback"
         (issue #5035). The ``try``/``finally`` guarantees the hook is released
         regardless.
@@ -265,9 +268,9 @@ class CliDashboard(AbstractDashboard):
         finally:
             self._detach_logger()
 
-            if self.__exit_registered:
-                atexit.unregister(self.stop)
-                self.__exit_registered = False
+            if self.__atexit_func is not None:
+                atexit.unregister(self.__atexit_func)
+                self.__atexit_func = None
 
     def _detach_logger(self):
         """

--- a/siliconcompiler/report/dashboard/web/__init__.py
+++ b/siliconcompiler/report/dashboard/web/__init__.py
@@ -11,7 +11,7 @@ import signal
 import socketserver
 import subprocess
 
-from siliconcompiler.report.dashboard import AbstractDashboard
+from siliconcompiler.report.dashboard import AbstractDashboard, weak_atexit_call
 from siliconcompiler.report.dashboard.web import utils
 
 
@@ -108,9 +108,12 @@ class WebDashboard(AbstractDashboard):
 
         self.__lock = fasteners.InterProcessLock(self.__manifest_lock)
 
-        # Ensure cleanup is called on exit
-        self.__exit_registered = True
-        atexit.register(self.__cleanup)
+        # Ensure cleanup is called on exit. Register via a weakref trampoline
+        # so the atexit registry does not pin this dashboard (and, transitively,
+        # its project) alive for the whole process — a bound-method
+        # registration would leak both.
+        self.__atexit_func = weak_atexit_call(self.__cleanup)
+        atexit.register(self.__atexit_func)
 
     def open_dashboard(self):
         """
@@ -273,9 +276,9 @@ class WebDashboard(AbstractDashboard):
         except Exception:
             pass
         finally:
-            if self.__exit_registered:
-                atexit.unregister(self.__cleanup)
-                self.__exit_registered = False
+            if self.__atexit_func is not None:
+                atexit.unregister(self.__atexit_func)
+                self.__atexit_func = None
 
             try:
                 if os.path.exists(self.__directory):

--- a/tests/report/dashboard/test_cli_dashboard.py
+++ b/tests/report/dashboard/test_cli_dashboard.py
@@ -2520,29 +2520,49 @@ def test_should_disable_with_breakpoint(project_logger, caplog):
 # ---------------------------------------------------------------------------
 
 def test_init_registers_atexit_hook(mock_project, fake_console):
-    """__init__ registers stop() with atexit so the dashboard is torn down
-    on program exit."""
+    """__init__ registers a weakref trampoline with atexit so the dashboard is
+    torn down on program exit without the atexit registry pinning it alive."""
     with patch("siliconcompiler.report.dashboard.cli.atexit") as mock_atexit, \
             patch("threading.Thread"):
         dash = CliDashboard(mock_project)
 
-    assert dash._CliDashboard__exit_registered is True
-    mock_atexit.register.assert_called_once_with(dash.stop)
+    hook = dash._CliDashboard__atexit_func
+    assert hook is not None
+    mock_atexit.register.assert_called_once_with(hook)
+
+
+def test_atexit_hook_does_not_pin_dashboard(mock_project, fake_console):
+    """The atexit hook must not keep the dashboard alive: dropping the last
+    strong reference lets the garbage collector reclaim it (and, transitively,
+    its project) even though the hook is still registered. Regression test for
+    the WeakMethod trampoline."""
+    import gc
+    import weakref
+
+    with patch("threading.Thread"):
+        dash = CliDashboard(mock_project)
+
+    ref = weakref.ref(dash)
+    del dash
+    gc.collect()
+
+    assert ref() is None
 
 
 def test_stop_unregisters_atexit_hook(mock_project, fake_console):
     """stop() must release the atexit hook it registered in __init__ so the
-    bound method does not fire again at interpreter shutdown."""
+    trampoline does not fire again at interpreter shutdown."""
     with patch("threading.Thread"):
         dash = CliDashboard(mock_project)
 
-    assert dash._CliDashboard__exit_registered is True
+    hook = dash._CliDashboard__atexit_func
+    assert hook is not None
 
     with patch("siliconcompiler.report.dashboard.cli.atexit") as mock_atexit:
         dash.stop()
 
-    assert dash._CliDashboard__exit_registered is False
-    mock_atexit.unregister.assert_called_once_with(dash.stop)
+    assert dash._CliDashboard__atexit_func is None
+    mock_atexit.unregister.assert_called_once_with(hook)
 
 
 def test_stop_unregisters_atexit_when_teardown_raises(mock_project, fake_console):
@@ -2554,13 +2574,15 @@ def test_stop_unregisters_atexit_when_teardown_raises(mock_project, fake_console
     with patch("threading.Thread"):
         dash = CliDashboard(mock_project)
 
+    hook = dash._CliDashboard__atexit_func
+
     with patch.object(dash._dashboard, "end_of_run", side_effect=EOFError), \
             patch.object(dash._dashboard, "stop", side_effect=EOFError), \
             patch("siliconcompiler.report.dashboard.cli.atexit") as mock_atexit:
         dash.stop()  # must not raise
 
-    assert dash._CliDashboard__exit_registered is False
-    mock_atexit.unregister.assert_called_once_with(dash.stop)
+    assert dash._CliDashboard__atexit_func is None
+    mock_atexit.unregister.assert_called_once_with(hook)
 
 
 def test_stop_restores_logger_when_teardown_raises(mock_project, fake_console):
@@ -2587,12 +2609,14 @@ def test_stop_is_idempotent(mock_project, fake_console):
     with patch("threading.Thread"):
         dash = CliDashboard(mock_project)
 
+    hook = dash._CliDashboard__atexit_func
+
     with patch("siliconcompiler.report.dashboard.cli.atexit") as mock_atexit:
         dash.stop()
         dash.stop()
 
-    assert dash._CliDashboard__exit_registered is False
-    mock_atexit.unregister.assert_called_once_with(dash.stop)
+    assert dash._CliDashboard__atexit_func is None
+    mock_atexit.unregister.assert_called_once_with(hook)
 
 
 def test_nodashboard_after_construction_releases_hook(mock_project, fake_console):
@@ -2610,4 +2634,4 @@ def test_nodashboard_after_construction_releases_hook(mock_project, fake_console
         mock_project.set("option", "nodashboard", True)
 
     assert mock_project._Project__dashboard is None
-    assert dash._CliDashboard__exit_registered is False
+    assert dash._CliDashboard__atexit_func is None

--- a/tests/report/dashboard/test_web_dashboard.py
+++ b/tests/report/dashboard/test_web_dashboard.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 import pytest
 
@@ -29,15 +30,40 @@ def test_dashboard(asic_gcd, unused_tcp_port, wait_for_port):
 # ---------------------------------------------------------------------------
 
 def test_init_registers_atexit_hook(asic_gcd, unused_tcp_port):
-    """__init__ registers __cleanup with atexit so resources are torn down on
-    program exit."""
+    """__init__ registers a weakref trampoline with atexit so resources are
+    torn down on program exit without the atexit registry pinning it alive."""
     pytest.importorskip("streamlit")
 
     with patch("siliconcompiler.report.dashboard.web.atexit") as mock_atexit:
         dashboard = WebDashboard(asic_gcd, port=unused_tcp_port)
 
-    assert dashboard._WebDashboard__exit_registered is True
-    mock_atexit.register.assert_called_once_with(dashboard._WebDashboard__cleanup)
+    hook = dashboard._WebDashboard__atexit_func
+    assert hook is not None
+    mock_atexit.register.assert_called_once_with(hook)
+
+
+def test_atexit_hook_does_not_pin_dashboard(asic_gcd, unused_tcp_port):
+    """The atexit hook must not keep the dashboard alive: dropping the last
+    strong reference lets the garbage collector reclaim it even though the hook
+    is still registered. Regression test for the WeakMethod trampoline."""
+    pytest.importorskip("streamlit")
+
+    import gc
+    import weakref
+
+    dashboard = WebDashboard(asic_gcd, port=unused_tcp_port)
+    directory = dashboard._WebDashboard__directory
+    ref = weakref.ref(dashboard)
+
+    del dashboard
+    gc.collect()
+
+    assert ref() is None
+
+    # The temp directory outlives the (uncalled) hook; clean it up here since
+    # __cleanup never ran.
+    if os.path.exists(directory):
+        shutil.rmtree(directory)
 
 
 def test_cleanup_unregisters_atexit_and_removes_directory(asic_gcd, unused_tcp_port):
@@ -46,13 +72,14 @@ def test_cleanup_unregisters_atexit_and_removes_directory(asic_gcd, unused_tcp_p
 
     dashboard = WebDashboard(asic_gcd, port=unused_tcp_port)
     directory = dashboard._WebDashboard__directory
+    hook = dashboard._WebDashboard__atexit_func
     assert os.path.isdir(directory)
 
     with patch("siliconcompiler.report.dashboard.web.atexit") as mock_atexit:
         dashboard._WebDashboard__cleanup()
 
-    assert dashboard._WebDashboard__exit_registered is False
-    mock_atexit.unregister.assert_called_once_with(dashboard._WebDashboard__cleanup)
+    assert dashboard._WebDashboard__atexit_func is None
+    mock_atexit.unregister.assert_called_once_with(hook)
     assert not os.path.exists(directory)
 
 
@@ -66,13 +93,14 @@ def test_cleanup_unregisters_atexit_when_stop_raises(asic_gcd, unused_tcp_port):
 
     dashboard = WebDashboard(asic_gcd, port=unused_tcp_port)
     directory = dashboard._WebDashboard__directory
+    hook = dashboard._WebDashboard__atexit_func
 
     with patch.object(dashboard, "stop", side_effect=RuntimeError), \
             patch("siliconcompiler.report.dashboard.web.atexit") as mock_atexit:
         dashboard._WebDashboard__cleanup()  # must not raise
 
-    assert dashboard._WebDashboard__exit_registered is False
-    mock_atexit.unregister.assert_called_once_with(dashboard._WebDashboard__cleanup)
+    assert dashboard._WebDashboard__atexit_func is None
+    mock_atexit.unregister.assert_called_once_with(hook)
     assert not os.path.exists(directory)
 
 
@@ -82,10 +110,11 @@ def test_cleanup_is_idempotent(asic_gcd, unused_tcp_port):
     pytest.importorskip("streamlit")
 
     dashboard = WebDashboard(asic_gcd, port=unused_tcp_port)
+    hook = dashboard._WebDashboard__atexit_func
 
     with patch("siliconcompiler.report.dashboard.web.atexit") as mock_atexit:
         dashboard._WebDashboard__cleanup()
         dashboard._WebDashboard__cleanup()
 
-    assert dashboard._WebDashboard__exit_registered is False
-    mock_atexit.unregister.assert_called_once_with(dashboard._WebDashboard__cleanup)
+    assert dashboard._WebDashboard__atexit_func is None
+    mock_atexit.unregister.assert_called_once_with(hook)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard shutdown cleanup when the application exits.
  * Prevented exit handlers from keeping dashboard instances alive unnecessarily.
  * Ensured cleanup hooks are safely removed and remain idempotent, including when shutdown encounters errors.
* **Tests**
  * Added coverage for dashboard lifecycle, garbage collection, and repeated cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->