### PR TITLE
stop dashboard at end of run

### DIFF
--- a/scripts/check_dashboard.py
+++ b/scripts/check_dashboard.py
@@ -59,11 +59,9 @@ once its jobs are complete. So between serial runs you should see:
 * the live view come down and the terminal become usable again — a between-runs
   banner line prints to NORMAL scrollback (not hidden behind the live view);
 * the next run() re-open a fresh dashboard cycle for the next design;
-* a per-run report of whether the finished Project is reclaimed once its
-  reference is dropped. The end-of-run stop() releases the dashboard's atexit
-  pin, but today the project is still NOT reclaimed — run() leaves other
-  framework-level references behind (a separate leak this demo surfaces), so
-  expect "reclaimed: False".
+* a per-run report that the finished Project is reclaimed once its reference is
+  dropped. The end-of-run stop() unregisters the (weakref) atexit trampoline and
+  the non-pinning hook lets GC reclaim the project — so expect "reclaimed: True".
 On an interactive TTY (screen=True) expect an alt-screen flip per run — that is
 the known/parked cost of tearing down per run; a future screen=False switch
 removes it.
@@ -183,11 +181,10 @@ def run_serial(jobs, nodes):
     unregistered. The next run() re-opens a fresh dashboard cycle.
 
     As a diagnostic, we also drop the only reference to each finished project,
-    force a GC, and REPORT whether it was reclaimed. Note: the end-of-run stop()
-    releases the dashboard's atexit pin, but as of today a project is still NOT
-    reclaimed after run() — run() leaves other framework-level references behind
-    (independent of the dashboard). So expect "reclaimed: False" here; that is a
-    separate leak, surfaced by this demo, not a dashboard-teardown failure.
+    force a GC, and REPORT whether it was reclaimed. The end-of-run stop()
+    unregisters the (weakref) atexit trampoline, and because that hook never
+    pinned the dashboard/project, GC reclaims the project — so expect
+    "reclaimed: True".
     """
     import gc
     import weakref
@@ -217,9 +214,8 @@ def run_serial(jobs, nodes):
     print(f"\n>>> {jobs} serial runs complete; "
           f"{n_reclaimed}/{jobs} projects reclaimed after their run()")
     if n_reclaimed != jobs:
-        print(">>> (residual references outside the dashboard still pin the "
-              "project — a separate leak from the dashboard teardown)")
-    # Exit status reflects the runs succeeding, not the (known) residual leak.
+        print(">>> (unexpected: a project was NOT reclaimed — something still "
+              "pins it after run(); the atexit hook should no longer)")
     return 0
 
 

--- a/scripts/check_dashboard.py
+++ b/scripts/check_dashboard.py
@@ -13,6 +13,8 @@ verifying dashboard/logging changes.
     python scripts/check_dashboard.py --hang     # then hit Ctrl+C — see below
     python scripts/check_dashboard.py --multi    # several runs sharing ONE dashboard
     python scripts/check_dashboard.py --multi --jobs 4 --nodes 6  # bigger multi run
+    python scripts/check_dashboard.py --serial   # several run() calls, one after another
+    python scripts/check_dashboard.py --serial --jobs 5 --nodes 6  # bigger serial run
 
 What it does
 ------------
@@ -47,6 +49,24 @@ its render thread live entirely in the main process, the concurrency here is
 threads — each run still forks its own node workers internally, but they all
 feed the one main-process dashboard. Expect --jobs progress bars advancing
 together, each labelled design_k/job0, then all completing.
+
+What to look for (--serial — end-of-run teardown between sequential runs)
+------------------------------------------------------------------------
+This exercises the "auto-disconnect at end of run" behavior. Each run() now
+tears the dashboard down in its finally (the summary hack is gone): the logger
+is restored and the atexit hook is unregistered, then the shared Board stops
+once its jobs are complete. So between serial runs you should see:
+* the live view come down and the terminal become usable again — a between-runs
+  banner line prints to NORMAL scrollback (not hidden behind the live view);
+* the next run() re-open a fresh dashboard cycle for the next design;
+* a per-run report of whether the finished Project is reclaimed once its
+  reference is dropped. The end-of-run stop() releases the dashboard's atexit
+  pin, but today the project is still NOT reclaimed — run() leaves other
+  framework-level references behind (a separate leak this demo surfaces), so
+  expect "reclaimed: False".
+On an interactive TTY (screen=True) expect an alt-screen flip per run — that is
+the known/parked cost of tearing down per run; a future screen=False switch
+removes it.
 """
 
 import argparse
@@ -109,6 +129,7 @@ def _build_work_project(name, nodes):
     design.set_topmodule("top", fileset="rtl")
     proj = Project(design)
     proj.add_fileset("rtl")
+    proj.option.set_clean(True)
 
     flow = Flowgraph("workflow")
     prev = None
@@ -153,6 +174,55 @@ def run_multi(jobs, nodes):
     return 0
 
 
+def run_serial(jobs, nodes):
+    """Run `jobs` projects one after another in the SAME process to exercise
+    end-of-run dashboard teardown between sequential run() calls.
+
+    After each run() the dashboard is stopped in run()'s finally: the logger is
+    restored (terminal usable again) and the dashboard's atexit hook is
+    unregistered. The next run() re-opens a fresh dashboard cycle.
+
+    As a diagnostic, we also drop the only reference to each finished project,
+    force a GC, and REPORT whether it was reclaimed. Note: the end-of-run stop()
+    releases the dashboard's atexit pin, but as of today a project is still NOT
+    reclaimed after run() — run() leaves other framework-level references behind
+    (independent of the dashboard). So expect "reclaimed: False" here; that is a
+    separate leak, surfaced by this demo, not a dashboard-teardown failure.
+    """
+    import gc
+    import weakref
+
+    reclaimed = []
+    for k in range(jobs):
+        proj = _build_work_project(f"design_{k}", nodes)
+        ref = weakref.ref(proj)
+
+        # print(f"\n>>> serial run {k + 1}/{jobs}: design_{k}")
+        proj.run()
+
+        # Should land on the NORMAL terminal (dashboard released the screen and
+        # the logger at end of run), not be swallowed by the live view.
+        proj.logger.info(f"[design_{k}] back on the normal terminal after run()")
+        # import time; time.sleep(1)  # let the log flush before we drop the reference
+
+        # Drop the only strong reference and observe whether the project is
+        # reclaimable now that the dashboard has torn itself down.
+        del proj
+        gc.collect()
+        gcd = ref() is None
+        reclaimed.append(gcd)
+        # print(f">>> design_{k} reclaimed after run(): {gcd}")
+
+    n_reclaimed = sum(reclaimed)
+    print(f"\n>>> {jobs} serial runs complete; "
+          f"{n_reclaimed}/{jobs} projects reclaimed after their run()")
+    if n_reclaimed != jobs:
+        print(">>> (residual references outside the dashboard still pin the "
+              "project — a separate leak from the dashboard teardown)")
+    # Exit status reflects the runs succeeding, not the (known) residual leak.
+    return 0
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--lines", type=int, default=40,
@@ -163,14 +233,19 @@ def main():
                         help="sleep after logging so you can test Ctrl+C (no dump expected)")
     parser.add_argument("--multi", action="store_true",
                         help="run several SCs concurrently in ONE shared dashboard")
+    parser.add_argument("--serial", action="store_true",
+                        help="run several SCs one after another (end-of-run teardown demo)")
     parser.add_argument("--jobs", type=int, default=3,
-                        help="--multi: number of concurrent runs (default 3)")
+                        help="--multi/--serial: number of runs (default 3)")
     parser.add_argument("--nodes", type=int, default=4,
-                        help="--multi: chained nodes per run (default 4)")
+                        help="--multi/--serial: chained nodes per run (default 4)")
     args = parser.parse_args()
 
     if args.multi:
         return run_multi(args.jobs, args.nodes)
+
+    if args.serial:
+        return run_serial(args.jobs, args.nodes)
 
     NoisyFailTask._lines = args.lines
     NoisyFailTask._hang = args.hang

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -599,8 +599,10 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
                 # all jobs are done; MPManager.stop() is the process-exit backstop.
                 try:
                     self.__dashboard.update_manifest()
-                except Exception:
-                    pass
+                except Exception as e:
+                    # Best-effort final repaint: never fail or mask the run, but
+                    # record why it was skipped for diagnostics.
+                    self.logger.debug(f"Failed to update dashboard at end of run: {e}")
                 finally:
                     self.__dashboard.stop()
 

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -586,15 +586,15 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
             raise RuntimeError(f"Run failed: {e.msg}") from None
         finally:
             if self.__dashboard:
-                # Update the dashboard with the final state, then tear it down.
-                # stop() detaches the logger (restoring normal terminal output)
-                # and unregisters the atexit hook, so this project is no longer
+                # Push the final manifest, then tear the dashboard down. stop()
+                # already finalizes the run (it calls end_of_run() internally),
+                # detaches the logger (restoring normal terminal output), and
+                # unregisters the atexit hook, so this project is no longer
                 # pinned and can be garbage collected. The shared Board is a
                 # process-wide singleton: its completeness guard keeps it alive
                 # for any other concurrent runs and only truly stops it once all
                 # jobs are done; MPManager.stop() is the process-exit backstop.
                 self.__dashboard.update_manifest()
-                self.__dashboard.end_of_run()
                 self.__dashboard.stop()
 
         self.__reset_job_params()

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -586,9 +586,16 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
             raise RuntimeError(f"Run failed: {e.msg}") from None
         finally:
             if self.__dashboard:
-                # Update dashboard
+                # Update the dashboard with the final state, then tear it down.
+                # stop() detaches the logger (restoring normal terminal output)
+                # and unregisters the atexit hook, so this project is no longer
+                # pinned and can be garbage collected. The shared Board is a
+                # process-wide singleton: its completeness guard keeps it alive
+                # for any other concurrent runs and only truly stops it once all
+                # jobs are done; MPManager.stop() is the process-exit backstop.
                 self.__dashboard.update_manifest()
                 self.__dashboard.end_of_run()
+                self.__dashboard.stop()
 
         self.__reset_job_params()
 
@@ -1242,10 +1249,6 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
             self.logger.warning(f"{org_job} not found in history, picking {jobname}")
 
         history = self.history(jobname)
-
-        if not fd:
-            if self.__dashboard and self.__dashboard.is_running():
-                self.__dashboard.stop()
 
         history.get("metric", field='schema').summary(
             headers=history._summary_headers(),

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -586,16 +586,23 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
             raise RuntimeError(f"Run failed: {e.msg}") from None
         finally:
             if self.__dashboard:
-                # Push the final manifest, then tear the dashboard down. stop()
-                # already finalizes the run (it calls end_of_run() internally),
-                # detaches the logger (restoring normal terminal output), and
-                # unregisters the atexit hook, so this project is no longer
-                # pinned and can be garbage collected. The shared Board is a
-                # process-wide singleton: its completeness guard keeps it alive
-                # for any other concurrent runs and only truly stops it once all
-                # jobs are done; MPManager.stop() is the process-exit backstop.
-                self.__dashboard.update_manifest()
-                self.__dashboard.stop()
+                # Push the final manifest (best-effort), then ALWAYS tear the
+                # dashboard down. stop() finalizes the run (it calls end_of_run()
+                # internally), detaches the logger (restoring normal terminal
+                # output), and unregisters the atexit hook, so this project is no
+                # longer pinned and can be garbage collected. update_manifest()
+                # does a schema retraversal that can raise (I/O / serialization);
+                # a failing final repaint must not skip teardown, nor mask the
+                # run's own result or error, so it is guarded. The shared Board
+                # is a process-wide singleton: its completeness guard keeps it
+                # alive for other concurrent runs and only truly stops it once
+                # all jobs are done; MPManager.stop() is the process-exit backstop.
+                try:
+                    self.__dashboard.update_manifest()
+                except Exception:
+                    pass
+                finally:
+                    self.__dashboard.stop()
 
         self.__reset_job_params()
 

--- a/siliconcompiler/report/dashboard/__init__.py
+++ b/siliconcompiler/report/dashboard/__init__.py
@@ -36,7 +36,14 @@ class WeakAtexitCall:
     """
 
     def __init__(self, method):
-        self._ref = weakref.WeakMethod(method)
+        try:
+            self._ref = weakref.WeakMethod(method)
+        except TypeError:
+            # ``method`` is not a bound method (e.g. a plain function, or a
+            # unittest.mock double swapped in for one). Such a callable pins no
+            # instance, so there is nothing to weaken — resolve to it directly
+            # behind the same zero-arg protocol WeakMethod provides.
+            self._ref = lambda: method
 
     def __call__(self):
         target = self._ref()

--- a/tests/report/dashboard/test_cli_dashboard.py
+++ b/tests/report/dashboard/test_cli_dashboard.py
@@ -2549,6 +2549,33 @@ def test_atexit_hook_does_not_pin_dashboard(mock_project, fake_console):
     assert ref() is None
 
 
+def test_weak_atexit_call_tolerates_non_bound_method():
+    """weak_atexit_call must not choke on a non-bound callable. WeakMethod
+    rejects anything without __self__/__func__ (e.g. a plain function or a
+    unittest.mock double). This happens in practice when CliDashboard.stop is
+    patched at the class level while a dashboard is (re)constructed — e.g. the
+    deepcopy in Project._record_history rebuilds the dashboard. The trampoline
+    must build and, when invoked, call through to the callable."""
+    from unittest.mock import MagicMock
+    from siliconcompiler.report.dashboard import weak_atexit_call
+
+    target = MagicMock()
+    trampoline = weak_atexit_call(target)  # must not raise
+    trampoline()
+    target.assert_called_once_with()
+
+
+def test_construct_with_patched_stop_does_not_raise(mock_project, fake_console):
+    """Constructing a CliDashboard while CliDashboard.stop is class-patched with
+    a MagicMock must not raise (regression for the WeakMethod TypeError that
+    broke Project._record_history's deepcopy-rebuilt dashboard)."""
+    with patch("siliconcompiler.report.dashboard.cli.CliDashboard.stop"), \
+            patch("threading.Thread"):
+        dash = CliDashboard(mock_project)  # must not raise
+
+    assert dash._CliDashboard__atexit_func is not None
+
+
 def test_stop_unregisters_atexit_hook(mock_project, fake_console):
     """stop() must release the atexit hook it registered in __init__ so the
     trampoline does not fire again at interpreter shutdown."""

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1130,7 +1130,9 @@ def test_summary_select_job():
         history.assert_called_once_with("thatjob")
 
 
-def test_summary_stop_dashboard():
+def test_summary_does_not_stop_dashboard():
+    """summary() is a pure reporting call: the dashboard is torn down at the
+    end of run(), so summary() must not touch it (no is_running/stop calls)."""
     proj = Project(Design("testdesign"))
     proj._record_history()
 
@@ -1141,23 +1143,7 @@ def test_summary_stop_dashboard():
         is_running.return_value = True
         proj.summary()
 
-        is_running.assert_called_once()
-        stop.assert_called_once()
-        history.assert_called_once_with("job0")
-
-
-def test_summary_stop_dashboard_not_running():
-    proj = Project(Design("testdesign"))
-    proj._record_history()
-
-    with patch("siliconcompiler.report.dashboard.cli.CliDashboard.is_running") as is_running, \
-            patch("siliconcompiler.report.dashboard.cli.CliDashboard.stop") as stop, \
-            patch("siliconcompiler.Project.history") as history:
-        history.return_value = proj
-        is_running.return_value = False
-        proj.summary()
-
-        is_running.assert_called_once()
+        is_running.assert_not_called()
         stop.assert_not_called()
         history.assert_called_once_with("job0")
 
@@ -1842,7 +1828,8 @@ def test_run_with_dashboard_running():
             patch("siliconcompiler.report.dashboard.cli.CliDashboard.set_logger") as set_logger, \
             patch("siliconcompiler.report.dashboard.cli.CliDashboard.update_manifest") as \
             update_manifest, \
-            patch("siliconcompiler.report.dashboard.cli.CliDashboard.end_of_run") as end_of_run:
+            patch("siliconcompiler.report.dashboard.cli.CliDashboard.end_of_run") as end_of_run, \
+            patch("siliconcompiler.report.dashboard.cli.CliDashboard.stop") as stop:
         is_running.return_value = True
         proj._record_history()
 
@@ -1856,6 +1843,8 @@ def test_run_with_dashboard_running():
         assert set_logger.call_count == 2
         update_manifest.assert_called_once()
         end_of_run.assert_called_once()
+        # Dashboard is torn down at the end of run() (removes the summary hack).
+        stop.assert_called_once()
 
 
 def test_run_with_dashboard_notrunning():
@@ -1879,7 +1868,8 @@ def test_run_with_dashboard_notrunning():
             patch("siliconcompiler.report.dashboard.cli.CliDashboard.set_logger") as set_logger, \
             patch("siliconcompiler.report.dashboard.cli.CliDashboard.update_manifest") as \
             update_manifest, \
-            patch("siliconcompiler.report.dashboard.cli.CliDashboard.end_of_run") as end_of_run:
+            patch("siliconcompiler.report.dashboard.cli.CliDashboard.end_of_run") as end_of_run, \
+            patch("siliconcompiler.report.dashboard.cli.CliDashboard.stop") as stop:
         is_running.return_value = False
         proj._record_history()
 
@@ -1892,6 +1882,8 @@ def test_run_with_dashboard_notrunning():
         set_logger.assert_called_once()
         update_manifest.assert_called_once()
         end_of_run.assert_called_once()
+        # Dashboard is torn down at the end of run() (removes the summary hack).
+        stop.assert_called_once()
 
 
 def test_run_with_nodashboard():
@@ -1916,7 +1908,8 @@ def test_run_with_nodashboard():
             patch("siliconcompiler.report.dashboard.cli.CliDashboard.set_logger") as set_logger, \
             patch("siliconcompiler.report.dashboard.cli.CliDashboard.update_manifest") as \
             update_manifest, \
-            patch("siliconcompiler.report.dashboard.cli.CliDashboard.end_of_run") as end_of_run:
+            patch("siliconcompiler.report.dashboard.cli.CliDashboard.end_of_run") as end_of_run, \
+            patch("siliconcompiler.report.dashboard.cli.CliDashboard.stop") as stop:
         is_running.return_value = False
         proj._record_history()
 
@@ -1928,6 +1921,7 @@ def test_run_with_nodashboard():
         set_logger.assert_not_called()
         update_manifest.assert_not_called()
         end_of_run.assert_not_called()
+        stop.assert_not_called()
 
 
 def test_reset_job_params():

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1884,6 +1884,36 @@ def test_run_with_dashboard_notrunning():
         stop.assert_called_once()
 
 
+def test_run_dashboard_stopped_when_update_manifest_raises():
+    """A failing final update_manifest() in run()'s teardown must not skip
+    stop() (which restores the terminal, unregisters the atexit hook, and
+    unpins the project) nor fail the otherwise-successful run."""
+    design = Design("testdesign")
+    design.set_topmodule("top", fileset="test")
+    proj = Project(design)
+    proj.add_fileset("test")
+
+    flow = Flowgraph("testflow")
+    flow.node("stepone", FauxTask0())
+    proj.set_flow(flow)
+
+    with patch("siliconcompiler.scheduler.Scheduler.run"), \
+            patch("siliconcompiler.report.dashboard.cli.CliDashboard.is_running") as is_running, \
+            patch("siliconcompiler.report.dashboard.cli.CliDashboard.open_dashboard"), \
+            patch("siliconcompiler.report.dashboard.cli.CliDashboard.set_logger"), \
+            patch("siliconcompiler.report.dashboard.cli.CliDashboard.update_manifest") as \
+            update_manifest, \
+            patch("siliconcompiler.report.dashboard.cli.CliDashboard.stop") as stop:
+        is_running.return_value = True
+        update_manifest.side_effect = RuntimeError("manifest boom")
+        proj._record_history()
+
+        proj.run()  # must not raise despite update_manifest() blowing up
+
+        update_manifest.assert_called_once()
+        stop.assert_called_once()
+
+
 def test_run_with_nodashboard():
     design = Design("testdesign")
     design.set_topmodule("top", fileset="test")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1828,7 +1828,6 @@ def test_run_with_dashboard_running():
             patch("siliconcompiler.report.dashboard.cli.CliDashboard.set_logger") as set_logger, \
             patch("siliconcompiler.report.dashboard.cli.CliDashboard.update_manifest") as \
             update_manifest, \
-            patch("siliconcompiler.report.dashboard.cli.CliDashboard.end_of_run") as end_of_run, \
             patch("siliconcompiler.report.dashboard.cli.CliDashboard.stop") as stop:
         is_running.return_value = True
         proj._record_history()
@@ -1842,8 +1841,8 @@ def test_run_with_dashboard_running():
         set_logger.assert_called()
         assert set_logger.call_count == 2
         update_manifest.assert_called_once()
-        end_of_run.assert_called_once()
-        # Dashboard is torn down at the end of run() (removes the summary hack).
+        # stop() finalizes the run (calls end_of_run internally) and tears the
+        # dashboard down at the end of run() — this removes the summary hack.
         stop.assert_called_once()
 
 
@@ -1868,7 +1867,6 @@ def test_run_with_dashboard_notrunning():
             patch("siliconcompiler.report.dashboard.cli.CliDashboard.set_logger") as set_logger, \
             patch("siliconcompiler.report.dashboard.cli.CliDashboard.update_manifest") as \
             update_manifest, \
-            patch("siliconcompiler.report.dashboard.cli.CliDashboard.end_of_run") as end_of_run, \
             patch("siliconcompiler.report.dashboard.cli.CliDashboard.stop") as stop:
         is_running.return_value = False
         proj._record_history()
@@ -1881,8 +1879,8 @@ def test_run_with_dashboard_notrunning():
         open_dashboard.assert_called_once()
         set_logger.assert_called_once()
         update_manifest.assert_called_once()
-        end_of_run.assert_called_once()
-        # Dashboard is torn down at the end of run() (removes the summary hack).
+        # stop() finalizes the run (calls end_of_run internally) and tears the
+        # dashboard down at the end of run() — this removes the summary hack.
         stop.assert_called_once()
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual CLI `--serial` mode to validate dashboard teardown and resource reclamation between sequential runs.
* **Bug Fixes**
  * Improved `Project.run()` teardown to always stop the dashboard and handle manifest update failures gracefully.
  * Updated `Project.summary()` to remain dashboard-agnostic and avoid dashboard shutdown behavior.
  * Made dashboard atexit handling more tolerant of non-standard callable types.
* **Tests**
  * Expanded dashboard lifecycle tests to verify shutdown behavior across scenarios and tolerate teardown errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->