### PR TITLE
Add support for verilator's `--trace-structs` and `--trace-depth`.

### DIFF
--- a/siliconcompiler/tools/verilator/compile.py
+++ b/siliconcompiler/tools/verilator/compile.py
@@ -19,6 +19,12 @@ class CompileTask(VerilatorTask):
         self.add_parameter("trace_type", "<vcd,fst>",
                            "specifies type of wave file to create when [trace] is set",
                            defvalue="vcd")
+        self.add_parameter("trace_structs", "bool",
+                           "Enable tracing structure names",
+                           defvalue=True)
+        self.add_parameter("trace_depth", "int",
+                           "Specify the number of levels deep to enable tracing")
+
         self.add_parameter("main", "bool",
                            "if true, generate a toplevel C++ wrapper and relax the C++ file "
                            "requirement. See --main in Verilator docs for more info",
@@ -70,6 +76,18 @@ class CompileTask(VerilatorTask):
         """
         self.set("var", "trace", enable, step=step, index=index)
 
+    def get_verilator_trace(self,
+                            step: Optional[str] = None,
+                            index: Optional[str] = None) -> bool:
+        """
+        Returns whether trace generation is enabled.
+
+        Args:
+            step (str, optional): The specific step to read the configuration from.
+            index (str, optional): The specific index to read the configuration from.
+        """
+        return self.get("var", "trace", step=step, index=index)
+
     def set_verilator_tracetype(self, trace_type: str,
                                 step: Optional[str] = None,
                                 index: Optional[str] = None):
@@ -82,6 +100,71 @@ class CompileTask(VerilatorTask):
             index (str, optional): The specific index to apply this configuration to.
         """
         self.set("var", "trace_type", trace_type, step=step, index=index)
+
+    def get_verilator_tracetype(self,
+                                step: Optional[str] = None,
+                                index: Optional[str] = None) -> str:
+        """
+        Returns the type of wave file to create when trace is enabled.
+
+        Args:
+            step (str, optional): The specific step to read the configuration from.
+            index (str, optional): The specific index to read the configuration from.
+        """
+        return self.get("var", "trace_type", step=step, index=index)
+
+    def set_verilator_trace_structs(self, enable: bool,
+                                    step: Optional[str] = None,
+                                    index: Optional[str] = None):
+        """
+        Enables or disables the decomposition of structures & packed arrays
+        in fields in the output traces.
+
+        Args:
+            enable (bool): Whether to decompose structures in the output trace.
+            step (str, optional): The specific step to apply this configuration to.
+            index (str, optional): The specific index to apply this configuration to.
+        """
+        self.set("var", "trace_structs", enable, step=step, index=index)
+
+    def get_verilator_trace_structs(self,
+                                    step: Optional[str] = None,
+                                    index: Optional[str] = None) -> bool:
+        """
+        Returns whether structures & packed arrays are decomposed into fields
+        in the output traces.
+
+        Args:
+            step (str, optional): The specific step to read the configuration from.
+            index (str, optional): The specific index to read the configuration from.
+        """
+        return self.get("var", "trace_structs", step=step, index=index)
+
+    def set_verilator_trace_depth(self, level: int,
+                                  step: Optional[str] = None,
+                                  index: Optional[str] = None):
+        """
+        Specify the depth limit at which to stop tracing module signals.
+
+        Args:
+            level (int): The number of levels of hierarchy to trace.
+            step (str, optional): The specific step to apply this configuration to.
+            index (str, optional): The specific index to apply this configuration to.
+        """
+        self.set("var", "trace_depth", level, step=step, index=index)
+
+    def get_verilator_trace_depth(self,
+                                  step: Optional[str] = None,
+                                  index: Optional[str] = None) -> Optional[int]:
+        """
+        Returns the depth limit at which to stop tracing module signals,
+        or None if no limit is set.
+
+        Args:
+            step (str, optional): The specific step to read the configuration from.
+            index (str, optional): The specific index to read the configuration from.
+        """
+        return self.get("var", "trace_depth", step=step, index=index)
 
     def set_verilator_main(self, enable: bool,
                            step: Optional[str] = None,
@@ -222,6 +305,10 @@ class CompileTask(VerilatorTask):
         # trace_type is only read when tracing is enabled
         if self.get("var", "trace"):
             self.add_required_key("var", "trace_type")
+            self.add_required_key("var", "trace_structs")
+            if self.get("var", "trace_depth") is not None:
+                self.add_required_key("var", "trace_depth")
+
         self.add_required_key("var", "initialize_random")
         self.add_required_key("var", "main")
         if self.get("var", "timescale"):
@@ -297,6 +384,12 @@ class CompileTask(VerilatorTask):
                 c_flags.append("-DSILICONCOMPILER_TRACE_DIR=\"reports\"")
                 c_flags.append(
                     f"-DSILICONCOMPILER_TRACE_FILE=\"reports/{self.design_topmodule}.{ext}\"")
+
+            if self.get("var", "trace_structs"):
+                options.append("--trace-structs")
+
+            if (level := self.get("var", "trace_depth")) is not None:
+                options.extend(("--trace-depth", level))
 
         if c_includes:
             c_flags.extend([f'-I{include}' for include in c_includes])

--- a/tests/tools/test_verilator.py
+++ b/tests/tools/test_verilator.py
@@ -240,8 +240,47 @@ def test_runtime_args_trace(heartbeat_design, monkeypatch):
             '--cc',
             '-o', '../outputs/heartbeat.vexe',
             '--trace',
+            '--trace-structs',
             '-CFLAGS', '\'-DSILICONCOMPILER_TRACE_DIR="reports"\' '
                        '\'-DSILICONCOMPILER_TRACE_FILE="reports/heartbeat.vcd"\'']
+
+
+def test_runtime_args_trace_fst_depth_2_no_structs(heartbeat_design, monkeypatch):
+    proj = Project(heartbeat_design)
+    heartbeat_design.set_param("N", "8", "rtl")
+    proj.add_fileset("rtl")
+
+    flow = Flowgraph("testflow")
+    flow.node("version", compile.CompileTask())
+    proj.set_flow(flow)
+    task = compile.CompileTask.find_task(proj)
+    task.set_verilator_trace(True)
+    task.set_verilator_tracetype("fst")
+    task.set_verilator_trace_structs(False)
+    task.set_verilator_trace_depth(2)
+
+    def limit_cpu(*args, **kwargs):
+        return 2
+
+    monkeypatch.setattr(utils, 'get_cores', limit_cpu)
+
+    node = SchedulerNode(proj, "version", "0")
+    with node.runtime():
+        assert node.setup() is True
+        assert node.task.get_runtime_arguments() == [
+            '-sv',
+            '--top-module', 'heartbeat',
+            '-GN=8',
+            heartbeat_design.get_file("rtl", "verilog")[0],
+            '--exe',
+            '--build',
+            '-j', '2',
+            '--cc',
+            '-o', '../outputs/heartbeat.vexe',
+            '--trace-fst',
+            '--trace-depth', '2',
+            '-CFLAGS', '\'-DSILICONCOMPILER_TRACE_DIR="reports"\' '
+                       '\'-DSILICONCOMPILER_TRACE_FILE="reports/heartbeat.fst"\'']
 
 
 def test_runtime_args_timescale(heartbeat_design, monkeypatch):
@@ -296,19 +335,39 @@ def test_verilator_parameter_mode():
 def test_verilator_parameter_trace():
     task = compile.CompileTask()
     task.set_verilator_trace(True)
-    assert task.get("var", "trace") is True
+    assert task.get_verilator_trace() is True
     task.set_verilator_trace(False, step='compile', index='1')
-    assert task.get("var", "trace", step='compile', index='1') is False
-    assert task.get("var", "trace") is True
+    assert task.get_verilator_trace(step='compile', index='1') is False
+    assert task.get_verilator_trace() is True
 
 
 def test_verilator_parameter_trace_type():
     task = compile.CompileTask()
     task.set_verilator_tracetype('fst')
-    assert task.get("var", "trace_type") == 'fst'
+    assert task.get_verilator_tracetype() == 'fst'
     task.set_verilator_tracetype('vcd', step='compile', index='1')
-    assert task.get("var", "trace_type", step='compile', index='1') == 'vcd'
-    assert task.get("var", "trace_type") == 'fst'
+    assert task.get_verilator_tracetype(step='compile', index='1') == 'vcd'
+    assert task.get_verilator_tracetype() == 'fst'
+
+
+def test_verilator_parameter_trace_structs():
+    task = compile.CompileTask()
+    assert task.get_verilator_trace_structs() is True
+    task.set_verilator_trace_structs(False)
+    assert task.get_verilator_trace_structs() is False
+    task.set_verilator_trace_structs(True, step='compile', index='1')
+    assert task.get_verilator_trace_structs(step='compile', index='1') is True
+    assert task.get_verilator_trace_structs() is False
+
+
+def test_verilator_parameter_trace_depth():
+    task = compile.CompileTask()
+    assert task.get_verilator_trace_depth() is None
+    task.set_verilator_trace_depth(3)
+    assert task.get_verilator_trace_depth() == 3
+    task.set_verilator_trace_depth(5, step='compile', index='1')
+    assert task.get_verilator_trace_depth(step='compile', index='1') == 5
+    assert task.get_verilator_trace_depth() == 3
 
 
 def test_verilator_parameter_cincludes():


### PR DESCRIPTION
An decision to take note of: I've enabled trace_structs by default. I think this is a good default, so new users don't have to struggle before finding the option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Verilator trace configuration to optionally include signal structure details (`trace_structs`, enabled by default).
  * Added support for setting Verilator trace depth (`trace_depth`) to limit tracing detail.
  * Existing trace waveform options remain unchanged.
* **Tests**
  * Updated Verilator runtime-argument tests to include the new `--trace-structs` flag.
  * Added regression coverage for FST tracing with `trace_structs` disabled and `trace_depth` set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->