### PR TITLE
fix tcl write of tuple with None

### DIFF
--- a/siliconcompiler/schema/parametertype.py
+++ b/siliconcompiler/schema/parametertype.py
@@ -290,17 +290,18 @@ class NodeType:
         if isinstance(sctype, tuple):
             if value is None:
                 return '[list ]'
-            # A tuple is fixed-arity, so a None field must hold its position. A
-            # bare None serializes to '' and collapses in the '[list ...]' join,
-            # shifting every later field left; emit an explicit empty element
-            # ({}) instead so the arity survives the round-trip to Tcl.
-            valstr = ' '.join(
-                '{}' if v is None else NodeType.to_tcl(v, subtype)
-                for v, subtype in zip(value, sctype))
+            # Recurse into each field of the tuple. A None field serializes to
+            # an explicit empty element ({} for a scalar, '[list ]' for a
+            # container), so its position survives the round-trip to Tcl.
+            valstr = ' '.join(NodeType.to_tcl(v, subtype)
+                              for v, subtype in zip(value, sctype))
             return f'[list {valstr}]'
 
         if value is None:
-            return ''
+            # Emit an explicit empty Tcl element rather than '' so a None never
+            # collapses in a '[list ...]' join (which would shift later tuple
+            # fields) and is written as a valid empty value in 'dict set'.
+            return '{}'
 
         if sctype == 'str' or isinstance(sctype, NodeEnumType):
             # Escape string by surrounding it with "" and escaping the few

--- a/siliconcompiler/schema/parametertype.py
+++ b/siliconcompiler/schema/parametertype.py
@@ -290,7 +290,13 @@ class NodeType:
         if isinstance(sctype, tuple):
             if value is None:
                 return '[list ]'
-            valstr = ' '.join(NodeType.to_tcl(v, subtype) for v, subtype in zip(value, sctype))
+            # A tuple is fixed-arity, so a None field must hold its position. A
+            # bare None serializes to '' and collapses in the '[list ...]' join,
+            # shifting every later field left; emit an explicit empty element
+            # ({}) instead so the arity survives the round-trip to Tcl.
+            valstr = ' '.join(
+                '{}' if v is None else NodeType.to_tcl(v, subtype)
+                for v, subtype in zip(value, sctype))
             return f'[list {valstr}]'
 
         if value is None:

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -1076,10 +1076,6 @@ class Task(NamedSchema, PathSchema, DocsSchema):
             if valstr is None:
                 continue
 
-            # Ensure empty values are represented as empty Tcl lists
-            if valstr == '':
-                valstr = '{}'
-
             tcl_set_cmds.append(f"dict set sc_cfg {keystr} {valstr}")
 
         if template:

--- a/tests/schema/test_parameter.py
+++ b/tests/schema/test_parameter.py
@@ -1117,7 +1117,9 @@ def test_tcl_never():
 def test_tcl_empty():
     param = Parameter("str")
 
-    assert param.gettcl() == ''
+    # An unset value serializes to an explicit empty Tcl element ({}) so it is
+    # a valid empty value in 'dict set' and never collapses in a join.
+    assert param.gettcl() == '{}'
 
 
 def test_tcl_int():

--- a/tests/schema/test_parametertype.py
+++ b/tests/schema/test_parametertype.py
@@ -236,6 +236,10 @@ def test_normalize(type, value, expect):
         ("[str]", ["test"], "[list \"test\"]"),
         ("[str]", None, "[list ]"),
         ("{str}", None, "[list ]"),
+        # An empty (but non-None) container is an empty Tcl list, not a list
+        # holding one empty element ([list {}]).
+        ("[str]", [], "[list ]"),
+        ("{str}", set(), "[list ]"),
         ("[bool]", [False], "[list false]"),
         ("[int]", [12], "[list 12]"),
         ("{int}", set([12]), "[list 12]"),

--- a/tests/schema/test_parametertype.py
+++ b/tests/schema/test_parametertype.py
@@ -205,7 +205,15 @@ def test_normalize(type, value, expect):
 @pytest.mark.parametrize(
     "type,value,expect", [
         ("str", "test", "\"test\""),
-        ("str", None, ""),
+        # A None scalar serializes to an explicit empty Tcl element ({}) so it
+        # never collapses in a '[list ...]' join or 'dict set'.
+        ("str", None, "{}"),
+        ("int", None, "{}"),
+        # An empty string is a real value, distinct from None: it must remain a
+        # quoted empty string ("") and not become {}.
+        ("str", "", "\"\""),
+        ("[str]", [""], "[list \"\"]"),
+        ("(str,str)", ("", None), "[list \"\" {}]"),
         ("str", "\"test\"", "\"\\\"test\\\"\""),
         ("str", "test[0]", "\"test\\[0]\""),
         ("str", "test$next[0]", "\"test\\$next\\[0]\""),
@@ -232,7 +240,10 @@ def test_normalize(type, value, expect):
         ("[int]", [12], "[list 12]"),
         ("{int}", set([12]), "[list 12]"),
         ("{int}", set([15, 12]), "[list 12 15]"),
-        ("[int]", [None], "[list ]"),
+        # A None element keeps its position as an empty element, rather than
+        # collapsing the surrounding list.
+        ("[int]", [None], "[list {}]"),
+        ("{str}", set([None]), "[list {}]"),
         ("(int,str)", None, "[list ]"),
         ("[[str]]", [["test", "test0"], ["test"]],
             "[list [list \"test\" \"test0\"] [list \"test\"]]"),
@@ -245,6 +256,25 @@ def test_normalize(type, value, expect):
         ("(int,str,int)", (12, None, 5), "[list 12 {} 5]"),
         ("(int,str,int)", (None, None, None), "[list {} {} {}]"),
         ("(str,float)", (None, 2.5), "[list {} 2.5]"),
+        # A None field whose subtype is itself a container serializes to the
+        # empty container, not {}, so the nesting survives the round-trip.
+        ("(int,(int,str))", (1, None), "[list 1 [list ]]"),
+        ("(int,[str])", (1, None), "[list 1 [list ]]"),
+        ("(int,{str})", (1, None), "[list 1 [list ]]"),
+        ("(int,(int,str))", (1, (2, None)), "[list 1 [list 2 {}]]"),
+        # Containers of tuples: recursion composes the other direction too, and
+        # a None field inside an element still holds its position.
+        ("[(int,str)]", [(1, "a"), (2, None)],
+            "[list [list 1 \"a\"] [list 2 {}]]"),
+        ("{(int,str)}", set([(1, "a")]), "[list [list 1 \"a\"]]"),
+        # A ranged base type inside a container is unwrapped per element.
+        ("[int<0..5>]", [3], "[list 3]"),
+        # An enum value routes through the string-escaping path.
+        ("<a,b>", None, "{}"),
+        ("[<a,b>]", ["a"], "[list \"a\"]"),
+        # File env-var substitution and bracket escaping (parallel to dir).
+        ("file", "$TEST/test.txt", "\"$env(TEST)/test.txt\""),
+        ("file", "/usr/test[0].txt", "\"/usr/test\\[0].txt\""),
     ])
 def test_to_tcl(type, value, expect):
     assert NodeType.to_tcl(value, NodeType.parse(type)) == expect

--- a/tests/schema/test_parametertype.py
+++ b/tests/schema/test_parametertype.py
@@ -237,7 +237,14 @@ def test_normalize(type, value, expect):
         ("[[str]]", [["test", "test0"], ["test"]],
             "[list [list \"test\" \"test0\"] [list \"test\"]]"),
         ("(str,str)", ("test0", "test1"), "[list \"test0\" \"test1\"]"),
-        (NodeType("(str,float)"), ("1", 2.5), "[list \"1\" 2.5]")
+        (NodeType("(str,float)"), ("1", 2.5), "[list \"1\" 2.5]"),
+        # A None field must hold its position with an explicit empty element
+        # ({}) so the tuple arity survives the round-trip to Tcl.
+        ("(int,str)", (None, "test"), "[list {} \"test\"]"),
+        ("(int,str)", (12, None), "[list 12 {}]"),
+        ("(int,str,int)", (12, None, 5), "[list 12 {} 5]"),
+        ("(int,str,int)", (None, None, None), "[list {} {} {}]"),
+        ("(str,float)", (None, 2.5), "[list {} 2.5]"),
     ])
 def test_to_tcl(type, value, expect):
     assert NodeType.to_tcl(value, NodeType.parse(type)) == expect

--- a/tests/schema/test_parametervalue.py
+++ b/tests/schema/test_parametervalue.py
@@ -27,7 +27,9 @@ def test_gettcl():
 
 
 def test_gettcl_unset():
-    assert NodeValue("str").gettcl() == ""
+    # An unset scalar serializes to an explicit empty Tcl element ({}) so it
+    # remains a valid empty value in 'dict set' and never collapses in a join.
+    assert NodeValue("str").gettcl() == "{}"
 
 
 def test_set():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Tcl serialization for unset/`None` values so empty entries are emitted explicitly as `{}` instead of collapsing into blank strings.
  * Improved handling of `None` inside containers and tuples to preserve element position/arity during Tcl encoding and manifest generation.

* **Tests**
  * Updated and expanded Tcl serialization expectations across schema, parameter, and parameter value tests to reflect the new `{}` behavior for unset/`None` cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->