### PR TITLE
add missing 3dbx show/opens

### DIFF
--- a/siliconcompiler/tools/openroad/open.py
+++ b/siliconcompiler/tools/openroad/open.py
@@ -113,3 +113,24 @@ class OpenTask(BaseOpenTask, APRTask, OpenROADSTAParameter):
         vars = super().get_tcl_variables(manifest)
         vars.setdefault("sc_do_screenshot", "false")
         return vars
+
+
+class Open3DBloxTask(OpenTask):
+    '''
+    Open a 3D view of the design in openroad.
+    '''
+    def __init__(self):
+        super().__init__()
+
+    def task(self) -> str:
+        return "open3dblox"
+
+    def setup(self):
+        super().setup()
+        self.set_script("sc_open_3dblox.tcl")
+
+        # Set minimum version
+        self.add_version(">=26Q2-565", clobber=True)
+
+    def get_supported_task_extentions(self):
+        return ["3dbx"]

--- a/siliconcompiler/tools/openroad/open.py
+++ b/siliconcompiler/tools/openroad/open.py
@@ -127,6 +127,7 @@ class Open3DBloxTask(OpenTask):
 
     def setup(self):
         super().setup()
+        self.set_threads(clobber=True)
         self.set_script("sc_open_3dblox.tcl")
 
         # Set minimum version

--- a/siliconcompiler/tools/openroad/scripts/sc_open_3dblox.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_open_3dblox.tcl
@@ -16,10 +16,12 @@ source "$sc_refdir/common/debugging.tcl"
 
 source "$sc_refdir/common/procs.tcl"
 
-###############################
-# Setup GUI title early
-###############################
-sc_set_gui_title
+if { [gui::enabled] } {
+    ###############################
+    # Setup GUI title early
+    ###############################
+    sc_set_gui_title
+}
 
 ###############################
 # Design information

--- a/siliconcompiler/tools/openroad/show.py
+++ b/siliconcompiler/tools/openroad/show.py
@@ -55,6 +55,7 @@ class Show3DBloxTask(BaseShowTask, OpenROADTask):
 
     def setup(self):
         super().setup()
+        self.set_threads(clobber=True)
         self.set_script("sc_open_3dblox.tcl")
 
     def get_supported_task_extentions(self):

--- a/siliconcompiler/tools/openroad/show.py
+++ b/siliconcompiler/tools/openroad/show.py
@@ -55,8 +55,7 @@ class Show3DBloxTask(BaseShowTask, OpenROADTask):
 
     def setup(self):
         super().setup()
-        self.set_threads()
-        self.set_script("sc_show_3dblox.tcl")
+        self.set_script("sc_open_3dblox.tcl")
 
     def get_supported_task_extentions(self):
         return ["3dbx"]
@@ -68,4 +67,30 @@ class Show3DBloxTask(BaseShowTask, OpenROADTask):
         except ValueError:
             pass
         options.append("-gui")
+        return options
+
+
+class Show3DBloxWebTask(Show3DBloxTask):
+    '''
+    Show a 3D view of the design in openroad with webviewer
+    '''
+    def __init__(self):
+        super().__init__()
+
+    def task(self) -> str:
+        return "show3dbloxweb"
+
+    def setup(self):
+        super().setup()
+
+        # Set minimum version
+        self.add_version(">=26Q2-565", clobber=True)
+
+    def runtime_options(self):
+        options = super().runtime_options()
+        try:
+            options.remove("-gui")
+        except ValueError:
+            pass
+        options.append("-web")
         return options

--- a/siliconcompiler/utils/showtools.py
+++ b/siliconcompiler/utils/showtools.py
@@ -6,9 +6,11 @@ from siliconcompiler.tools.klayout.show import ShowTask as KlayoutShow
 from siliconcompiler.tools.klayout.screenshot import ScreenshotTask as KlayoutScreenshot
 
 from siliconcompiler.tools.openroad.open import OpenTask as OpenROADOpen
+from siliconcompiler.tools.openroad.open import Open3DBloxTask as OpenROADOpen3DBlox
 from siliconcompiler.tools.openroad.show import ShowTask as OpenROADShow
 from siliconcompiler.tools.openroad.show import Show3DBloxTask as OpenROADShow3DBlox
 from siliconcompiler.tools.openroad.show import WebTask as OpenROADWeb
+from siliconcompiler.tools.openroad.show import Show3DBloxWebTask as OpenROADShow3DBloxWeb
 from siliconcompiler.tools.openroad.screenshot import ScreenshotTask as OpenROADScreenshot
 
 from siliconcompiler.tools.graphviz.show import ShowTask as GraphvizShow
@@ -33,11 +35,13 @@ def showtasks():
     """
     # Register Open tasks
     OpenTask.register_task(OpenROADOpen)
+    OpenTask.register_task(OpenROADOpen3DBlox)
 
     # Register Show tasks - core tools first
     ShowTask.register_task(KlayoutShow)
     ShowTask.register_task(OpenROADWeb)
     ShowTask.register_task(OpenROADShow)
+    ShowTask.register_task(OpenROADShow3DBloxWeb)
     ShowTask.register_task(OpenROADShow3DBlox)
     ShowTask.register_task(GraphvizShow)
     ShowTask.register_task(VPRShow)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OpenROAD 3D Blox tasks for `.3dbx` workflows, including support for web-based viewing.
  - Introduced the required OpenROAD version targeting for 3D Blox flows.
- **Bug Fixes**
  - GUI title initialization now happens only when GUI mode is enabled.
  - Improved web viewing runtime options by disabling GUI and enabling web mode.
- **Chores**
  - Updated task discovery/registration and ensured consistent thread configuration for 3D Blox runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->