### PR TITLE
make jobname better for show

### DIFF
--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -1379,7 +1379,7 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
 
     def show(self, filename: Optional[str] = None, screenshot: bool = False,
              extension: Optional[str] = None, tool: Optional[str] = None,
-             open: bool = False) -> str:
+             open: bool = False) -> Optional[str]:
         '''
         Opens a graphical viewer for a specified file or the last generated layout.
 
@@ -1529,7 +1529,13 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         if not proj.option.get_nodashboard():
             proj.option.set_nodashboard(not screenshot)
 
-        jobname = f"_{task.task()}_{sc_jobname}_{sc_step}_{sc_index}_{task.tool()}"
+        jobname = f"_{task.task()}_{sc_jobname}_"
+        if sc_step is not None:
+            jobname += f"{sc_step}_"
+        if sc_index is not None:
+            jobname += f"{sc_index}_"
+        jobname += f"{task.tool()}"
+
         proj.option.set_jobname(jobname)
 
         # Setup in task variables

--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -863,6 +863,9 @@ proc sc_set_gui_title { } {
     if { [sc_cfg_exists "tool" $sc_tool "task" $sc_task "var" "show_job"] } {
         set job [sc_cfg_get "tool" $sc_tool "task" $sc_task "var" "show_job"]
     }
+    if { [string index $job 0] == "_" } {
+        set job [string range $job 1 end]
+    }
 
     set title "OpenROAD - ${job} / ${step}${index}"
     gui::set_title $title


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected job naming in show results to avoid displaying unwanted “None” values.
  - Improved GUI window titles by removing unnecessary leading underscores.
  - Updated show behavior to accurately indicate when no result is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->