### PR TITLE
remove entrypoints to ensure SC preference is overwritable.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,8 +23,7 @@ sys.path.insert(0, sc_root)
 import siliconcompiler  # noqa E402
 sys.path.insert(0, os.path.join(sc_root, 'docs', '_ext'))
 
-from siliconcompiler.schema.docs import get_codeurl  # noqa E402
-from siliconcompiler.utils import get_plugins  # noqa E402
+from siliconcompiler.schema.docs import get_codeurl, resolve_codeurl  # noqa E402
 
 
 # -- Project information -----------------------------------------------------
@@ -177,11 +176,7 @@ def linkcode_resolve(domain, info):
         # e.g. object is a typing.Union
         return None
 
-    path = None
-    for link in get_plugins("docs", name="linkcode"):
-        path = link(file=file)
-        if path:
-            break
+    path = resolve_codeurl(file)
 
     if path:
         start, end = lines[1], lines[1] + len(lines[0]) - 1

--- a/docs/development_guide/external_libraries.rst
+++ b/docs/development_guide/external_libraries.rst
@@ -129,11 +129,33 @@ Points worth calling out:
 
 .. note::
 
-   More advanced packages can also register SiliconCompiler *entry points* to
-   plug into documentation source links, ``show``/``open`` tasks, and
-   tool-install helpers (the ``siliconcompiler.docs``, ``siliconcompiler.showtask``,
-   and ``siliconcompiler.install`` groups), plus ``[project.scripts]`` for CLI
-   apps.
+   More advanced packages can also register SiliconCompiler *entry points* to plug into
+   documentation source links, ``show``/``open`` tasks, data source resolvers, and
+   tool-install helpers, plus ``[project.scripts]`` for CLI apps. SiliconCompiler
+   registers its own built-ins in code before consulting these groups, so an entry point
+   you provide takes precedence wherever the two overlap.
+
+   .. code-block:: toml
+
+      # pyproject.toml
+      [project.entry-points."siliconcompiler.showtask"]
+      mylib = "mylib.showtools:showtasks"
+
+      [project.entry-points."siliconcompiler.path_resolver"]
+      myscheme = "mylib.resolver:get_resolver"
+
+      [project.entry-points."siliconcompiler.docs"]
+      linkcode = "mylib.docs:get_codeurl"
+
+      [project.entry-points."siliconcompiler.install"]
+      tools = "mylib.install:get_install_tools"
+      groups = "mylib.install:get_install_groups"
+      fingerprint = "mylib.install:compute_fingerprint"
+
+   The names in the ``siliconcompiler.docs`` and ``siliconcompiler.install`` groups are
+   fixed, since SiliconCompiler looks them up by name. Names in the
+   ``siliconcompiler.showtask`` and ``siliconcompiler.path_resolver`` groups are
+   free-form; pick something unique to your package.
 
 .. _ext_lib_path_mixin:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,22 +83,6 @@ sc-show = "siliconcompiler.apps.sc_show:main"
 sc-install = "siliconcompiler.apps.sc_install:main"
 smake = "siliconcompiler.apps.smake:main"
 
-[project.entry-points."siliconcompiler.showtask"]
-scsetup = "siliconcompiler.utils.showtools:showtasks"
-
-[project.entry-points."siliconcompiler.path_resolver"]
-https = "siliconcompiler.package.https:get_resolver"
-git = "siliconcompiler.package.git:get_resolver"
-github = "siliconcompiler.package.github:get_resolver"
-scp = "siliconcompiler.package.scp:get_resolver"
-
-[project.entry-points."siliconcompiler.docs"]
-linkcode = "siliconcompiler.schema.docs:get_codeurl"
-
-[project.entry-points."siliconcompiler.install"]
-groups = "siliconcompiler.apps.sc_install:get_install_groups"
-tools = "siliconcompiler.apps.sc_install:get_install_tools"
-
 [project.optional-dependencies]
 test = [
     "pytest == 9.1.1",

--- a/siliconcompiler/apps/sc_install.py
+++ b/siliconcompiler/apps/sc_install.py
@@ -40,7 +40,7 @@ def get_install_groups() -> Dict[str, List[str]]:
     }
 
 
-def get_install_tools(osname: str) -> Dict[str, str]:
+def get_install_tools(osname: Optional[str]) -> Dict[str, str]:
     tools_root = _get_tool_script_dir()
 
     script_dir = None
@@ -180,9 +180,9 @@ def compute_fingerprint(tool: str, script: str) -> Optional[str]:
     ensures the fingerprint changes when the install procedure, the tool's pinned
     upstream version, or any dependency's pinned version changes.
 
-    This is the default provider registered under the ``siliconcompiler.install``
-    ``fingerprint`` plugin group; plugins that supply their own tools may register a
-    replacement (see :func:`_get_fingerprint`).
+    This is the built-in fingerprint provider; plugins that supply their own tools may
+    register a replacement under the ``siliconcompiler.install`` ``fingerprint`` group
+    (see :func:`_get_fingerprint`).
 
     Parameters:
         tool (str): Tool identifier (used by plugins; the built-in relies on the script).
@@ -414,8 +414,10 @@ def _get_tool_script_dir() -> Path:
 
 
 def _get_tools_list() -> Dict[str, str]:
-    tools = {}
     os = _get_os_name()
+
+    # Built-in tools first, so plugins can override the scripts they supply.
+    tools = get_install_tools(os)
     for plugin in get_plugins("install", name="tools"):
         tools.update(plugin(os))
 
@@ -423,7 +425,8 @@ def _get_tools_list() -> Dict[str, str]:
 
 
 def _recommended_tool_groups(tools) -> Dict[str, List[str]]:
-    groups = {}
+    # Built-in groups first, so plugins can override them.
+    groups = get_install_groups()
     for plugin in get_plugins("install", name="groups"):
         groups.update(plugin())
 

--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -86,9 +86,14 @@ class Resolver:
         Scans for and registers all available resolver plugins.
 
         This method populates the internal `_RESOLVERS` dictionary with both
-        built-in resolvers (file, key, python) and any resolvers provided
-        by external plugins.
+        built-in resolvers (file, key, python, http, git, github, scp) and any
+        resolvers provided by external plugins. Built-ins are registered first,
+        so a plugin claiming the same scheme takes precedence.
         """
+        # Imported here because each of these modules imports RemoteResolver from
+        # this module.
+        from siliconcompiler.package import git, github, https, scp
+
         settings = MPManager().get_transient_settings()
         if settings.get_category("resolvers"):
             # Already populated
@@ -100,7 +105,8 @@ class Resolver:
         settings.set("resolvers", "python", PythonPathResolver)
         settings.set("resolvers", "dataroot", DatarootResolver)
 
-        for resolver in get_plugins("path_resolver"):
+        builtins = (https.get_resolver, git.get_resolver, github.get_resolver, scp.get_resolver)
+        for resolver in (*builtins, *get_plugins("path_resolver")):
             for scheme, res in resolver().items():
                 settings.set("resolvers", scheme, res)
 

--- a/siliconcompiler/schema/docs/__init__.py
+++ b/siliconcompiler/schema/docs/__init__.py
@@ -1,6 +1,7 @@
 import os.path
 
 from pathlib import PureWindowsPath
+from typing import Optional
 
 import siliconcompiler
 from siliconcompiler import __version__ as sc_version
@@ -36,3 +37,28 @@ def get_codeurl(file=None):
             return None
 
     return f"{base_url}/{file}"
+
+
+def resolve_codeurl(file: str) -> Optional[str]:
+    """
+    Resolves a source file to a browsable URL.
+
+    :func:`get_codeurl` is consulted first, so files inside the siliconcompiler tree
+    always link to the siliconcompiler repository. Files outside that tree are handed
+    to the ``siliconcompiler.docs`` ``linkcode`` plugins, in discovery order, until one
+    claims the file.
+
+    Args:
+        file (str): Path to the source file.
+
+    Returns:
+        Optional[str]: The URL for the file, or None if nothing can resolve it.
+    """
+    from siliconcompiler.utils import get_plugins
+
+    for docs_link in (get_codeurl, *get_plugins("docs", name="linkcode")):
+        src_link = docs_link(file=file)
+        if src_link:
+            return src_link
+
+    return None

--- a/siliconcompiler/schema/docs/__init__.py
+++ b/siliconcompiler/schema/docs/__init__.py
@@ -56,7 +56,13 @@ def resolve_codeurl(file: str) -> Optional[str]:
     """
     from siliconcompiler.utils import get_plugins
 
-    for docs_link in (get_codeurl, *get_plugins("docs", name="linkcode")):
+    src_link = get_codeurl(file=file)
+    if src_link:
+        return src_link
+
+    # Only scan for plugins once the built-in has declined the file, so the common case
+    # does not pay for entry point discovery and plugin imports.
+    for docs_link in get_plugins("docs", name="linkcode"):
         src_link = docs_link(file=file)
         if src_link:
             return src_link

--- a/siliconcompiler/schema/docs/schemagen.py
+++ b/siliconcompiler/schema/docs/schemagen.py
@@ -21,7 +21,7 @@ from siliconcompiler.schema.docschema import DocsSchema
 from siliconcompiler.schema.docs.utils import parse_rst, link, para, \
     literalblock, build_section_with_target, KeyPath, build_section, \
     image
-from siliconcompiler.utils import get_plugins
+from siliconcompiler.schema.docs import resolve_codeurl
 
 # near top-level scope
 logger = sphinx_logging.getLogger(__name__)
@@ -105,12 +105,8 @@ class SchemaGen(SphinxDirective):
             if docstring:
                 parse_rst(self.state, docstring, schema_sec, docsfile)
 
-            src_link = None
             src_file = inspect.getfile(schema_cls)
-            for docs_link in get_plugins("docs", name="linkcode"):
-                src_link = docs_link(file=src_file)
-                if src_link:
-                    break
+            src_link = resolve_codeurl(src_file)
 
             if src_link:
                 p = para('File: ')
@@ -237,12 +233,8 @@ class ToolGen(SchemaGen):
         if docstring:
             parse_rst(self.state, docstring, sec, inspect.getfile(tool_mod))
 
-        src_link = None
         src_file = inspect.getfile(tool_mod)
-        for docs_link in get_plugins("docs", name="linkcode"):
-            src_link = docs_link(file=src_file)
-            if src_link:
-                break
+        src_link = resolve_codeurl(src_file)
 
         if src_link:
             p = para('File: ')
@@ -304,12 +296,8 @@ class TargetGen(SchemaGen):
         if docstring:
             parse_rst(self.state, docstring, target_doc, docsfile)
 
-        src_link = None
         src_file = inspect.getfile(target)
-        for docs_link in get_plugins("docs", name="linkcode"):
-            src_link = docs_link(file=src_file)
-            if src_link:
-                break
+        src_link = resolve_codeurl(src_file)
 
         if src_link:
             p = para('File: ')

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -2760,7 +2760,8 @@ class OpenTask(Task):
         This method recursively finds all subclasses and also loads tasks from
         any installed plugins. Tasks are registered in a stable order:
         1. Core siliconcompiler tasks (sorted by module path)
-        2. Plugin-provided tasks (in plugin load order)
+        2. The built-in siliconcompiler viewers, in their preferred order
+        3. Plugin-provided tasks (in plugin load order)
 
         This ensures that later-registered extensions take precedence over
         earlier core tasks when multiple tools support the same extension.
@@ -2791,6 +2792,16 @@ class OpenTask(Task):
         # Register core tasks first
         for c in core_classes:
             cls.register_task(c)
+
+        # Register the built-in viewers, in the order showtools prefers.
+        #
+        # Imported here rather than at module scope because showtools imports from
+        # siliconcompiler, which imports this module. The import must also stay below the
+        # recursion above: it is what pulls the viewer modules in, and if it ran first the
+        # recursion would register them in module-path order and showtools could no longer
+        # influence which one wins (re-registering a task does not reorder it).
+        from siliconcompiler.utils.showtools import showtasks
+        showtasks()
 
         # Support non-SC defined tasks from plugins (these override core tasks)
         # Sort plugins deterministically for consistent ordering

--- a/tests/apps/test_sc_install.py
+++ b/tests/apps/test_sc_install.py
@@ -246,7 +246,7 @@ def test_fingerprint_tracks_tool_without_self_reference(monkeypatch, tmp_path):
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
-def test_fingerprint_plugin_overrides_builtin(monkeypatch, datadir, capfd):
+def test_fingerprint_plugin_overrides_builtin(monkeypatch, datadir, capfd, fake_plugins):
     """A fingerprint plugin takes precedence over the built-in provider."""
     script = os.path.join(datadir, "echo_prefix.sh")
 
@@ -261,11 +261,7 @@ def test_fingerprint_plugin_overrides_builtin(monkeypatch, datadir, capfd):
         calls.append((tool, script_path))
         return fp_value[0]
 
-    def get_plugins(system, name=None):
-        if name == "fingerprint":
-            return [fingerprint_plugin]
-        return []
-    monkeypatch.setattr(sc_install, "get_plugins", get_plugins)
+    fake_plugins("install", "fingerprint", fingerprint_plugin)
 
     build_dir = os.path.abspath("build_track_plugin")
 
@@ -287,7 +283,7 @@ def test_fingerprint_plugin_overrides_builtin(monkeypatch, datadir, capfd):
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
-def test_fingerprint_plugin_falls_back_to_builtin(monkeypatch, datadir, capfd):
+def test_fingerprint_plugin_falls_back_to_builtin(monkeypatch, datadir, capfd, fake_plugins):
     """When a plugin returns None the built-in fingerprint is used."""
     script = os.path.join(datadir, "echo_prefix.sh")
 
@@ -298,11 +294,7 @@ def test_fingerprint_plugin_falls_back_to_builtin(monkeypatch, datadir, capfd):
     def fingerprint_plugin(tool, script_path):
         return None
 
-    def get_plugins(system, name=None):
-        if name == "fingerprint":
-            return [fingerprint_plugin]
-        return []
-    monkeypatch.setattr(sc_install, "get_plugins", get_plugins)
+    fake_plugins("install", "fingerprint", fingerprint_plugin)
 
     build_dir = os.path.abspath("build_track_fallback")
 
@@ -736,14 +728,10 @@ def test_debug_machine_unsupported_install(monkeypatch, capsys, sys, dist, ver):
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
-def test_groups(monkeypatch):
+def test_groups(monkeypatch, fake_plugins):
     def os_info_name():
         return "<os>"
     monkeypatch.setattr(sc_install, '_get_os_name', os_info_name)
-
-    def get_plugins(*_args, **_kwargs):
-        return [sc_install.get_install_groups]
-    monkeypatch.setattr(sc_install, "get_plugins", get_plugins)
 
     tools_asic = ("sv2v", "yosys", "openroad", "klayout")
     tools_fpga = ("sv2v", "yosys", "vpr", "wildebeest", "opensta")
@@ -795,21 +783,66 @@ def test_show(monkeypatch, capsys, scroot):
     assert file_content in capsys.readouterr().out
 
 
-def test_get_tools_list(monkeypatch):
-    def get_plugins(*_args, **_kwargs):
-        def tools0(osname):
-            return {"tool0": "script0.sh", "tool1": "script1.sh"}
+def test_get_tools_list(monkeypatch, fake_plugins):
+    # "<os>" has no toolscripts directory, so the built-in contributes nothing
+    monkeypatch.setattr(sc_install, '_get_os_name', lambda: "<os>")
 
-        def tools1(osname):
-            return {"tool2": "script2.sh", "tool3": "script3.sh"}
-        return [tools0, tools1]
-    monkeypatch.setattr(sc_install, "get_plugins", get_plugins)
+    def tools0(osname):
+        return {"tool0": "script0.sh", "tool1": "script1.sh"}
+
+    def tools1(osname):
+        return {"tool2": "script2.sh", "tool3": "script3.sh"}
+
+    fake_plugins("install", "tools", tools0)
+    fake_plugins("install", "tools", tools1)
+
     assert sc_install._get_tools_list() == {
         "tool0": "script0.sh",
         "tool1": "script1.sh",
         "tool2": "script2.sh",
         "tool3": "script3.sh"
     }
+
+
+def test_get_tools_list_builtin_without_plugins(monkeypatch, fake_plugins):
+    """The bundled toolscripts are found in code, with no plugins at all."""
+    monkeypatch.setattr(sc_install, '_get_os_name', lambda: "ubuntu22")
+
+    tools = sc_install._get_tools_list()
+    assert "yosys" in tools
+    assert tools["yosys"].endswith("ubuntu22/install-yosys.sh")
+
+
+def test_get_tools_list_plugin_overrides_builtin(monkeypatch, fake_plugins):
+    monkeypatch.setattr(sc_install, '_get_os_name', lambda: "ubuntu22")
+
+    def tools(osname):
+        return {"yosys": "myscript.sh", "mytool": "mytool.sh"}
+
+    fake_plugins("install", "tools", tools)
+
+    found = sc_install._get_tools_list()
+    assert found["yosys"] == "myscript.sh"
+    assert found["mytool"] == "mytool.sh"
+    # Tools the plugin does not claim keep their built-in script
+    assert found["openroad"].endswith("ubuntu22/install-openroad.sh")
+
+
+def test_recommended_tool_groups_plugin_overrides_builtin(monkeypatch, fake_plugins):
+    monkeypatch.setattr(sc_install, '_get_os_name', lambda: "<os>")
+
+    def groups():
+        return {"asic": ["mytool"], "mygroup": ["mytool"]}
+
+    fake_plugins("install", "groups", groups)
+
+    recommend = sc_install._recommended_tool_groups(["mytool", "sv2v", "yosys"])
+    assert recommend["asic"] == ["mytool"]
+    assert recommend["mygroup"] == ["mytool"]
+    # Groups the plugin does not claim keep their built-in definition
+    assert recommend["analog-simulation"] == \
+        "analog-simulation group is not available for <os> " \
+        "due to lack of support for the following tools: xyce"
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")

--- a/tests/apps/test_sc_install.py
+++ b/tests/apps/test_sc_install.py
@@ -810,7 +810,7 @@ def test_get_tools_list_builtin_without_plugins(monkeypatch, fake_plugins):
 
     tools = sc_install._get_tools_list()
     assert "yosys" in tools
-    assert tools["yosys"].endswith("ubuntu22/install-yosys.sh")
+    assert tools["yosys"].endswith(os.path.join("ubuntu22", "install-yosys.sh"))
 
 
 def test_get_tools_list_plugin_overrides_builtin(monkeypatch, fake_plugins):
@@ -825,7 +825,7 @@ def test_get_tools_list_plugin_overrides_builtin(monkeypatch, fake_plugins):
     assert found["yosys"] == "myscript.sh"
     assert found["mytool"] == "mytool.sh"
     # Tools the plugin does not claim keep their built-in script
-    assert found["openroad"].endswith("ubuntu22/install-openroad.sh")
+    assert found["openroad"].endswith(os.path.join("ubuntu22", "install-openroad.sh"))
 
 
 def test_recommended_tool_groups_plugin_overrides_builtin(monkeypatch, fake_plugins):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,6 +147,45 @@ def disable_or_images(monkeypatch, request):
     monkeypatch.setattr(Project, '_init_run', mock_init)
 
 
+class _FakeEntryPoint:
+    '''
+    Stand-in for importlib.metadata.EntryPoint that hands back an already-loaded object.
+    '''
+
+    def __init__(self, name, obj):
+        self.name = name
+        self.__obj = obj
+
+    def load(self):
+        return self.__obj
+
+
+@pytest.fixture
+def fake_plugins(monkeypatch):
+    '''
+    Register fake siliconcompiler entry points.
+
+    SiliconCompiler registers no entry points of its own, so discovery is empty unless a
+    test opts in. The returned callable takes the plugin group suffix (for example
+    "showtask"), the entry point name, and the object the entry point should load to.
+    '''
+
+    registry = {}
+
+    def register(system, name, obj):
+        registry.setdefault(system, []).append(_FakeEntryPoint(name, obj))
+
+    def fake_entry_points(group):
+        prefix = "siliconcompiler."
+        if not group.startswith(prefix):
+            return []
+        return list(registry.get(group[len(prefix):], []))
+
+    monkeypatch.setattr(utils, "entry_points", fake_entry_points)
+
+    return register
+
+
 @pytest.fixture
 def project_logger(monkeypatch):
     def setup(proj):

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -182,6 +182,38 @@ def test_find_resolver_python():
     assert Resolver.find_resolver("python://siliconcompiler") is PythonPathResolver
 
 
+@pytest.mark.parametrize("source,resolver", [
+    ("http://host/file", "HTTPResolver"),
+    ("https://host/file", "HTTPResolver"),
+    ("git://host/repo", "GitResolver"),
+    ("git+https://host/repo", "GitResolver"),
+    ("git+ssh://host/repo", "GitResolver"),
+    ("ssh://host/repo", "GitResolver"),
+    ("github://owner/repo/ref/file", "GithubResolver"),
+    ("github+private://owner/repo/ref/file", "GithubResolver"),
+    ("scp://host/file", "SCPResolver")
+])
+def test_find_resolver_builtin_without_plugins(source, resolver):
+    """The remote resolvers are registered in code, so they work with no plugins at all."""
+    assert Resolver.find_resolver(source).__name__ == resolver
+
+
+def test_find_resolver_plugin(fake_plugins):
+    """A plugin can add a new scheme and override a built-in one."""
+    class PluginResolver(Resolver):
+        pass
+
+    def get_resolver():
+        return {"myscheme": PluginResolver, "https": PluginResolver}
+
+    fake_plugins("path_resolver", "myscheme", get_resolver)
+
+    assert Resolver.find_resolver("myscheme://host/file") is PluginResolver
+    assert Resolver.find_resolver("https://host/file") is PluginResolver
+    # Schemes the plugin does not claim keep their built-in resolver
+    assert Resolver.find_resolver("scp://host/file").__name__ == "SCPResolver"
+
+
 def test_file_env_var():
     resolver = FileResolver("test", None, "$THIS_PATH/hello")
     assert resolver.source == "file://$THIS_PATH/hello"

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -193,7 +193,7 @@ def test_find_resolver_python():
     ("github+private://owner/repo/ref/file", "GithubResolver"),
     ("scp://host/file", "SCPResolver")
 ])
-def test_find_resolver_builtin_without_plugins(source, resolver):
+def test_find_resolver_builtin_without_plugins(source, resolver, fake_plugins):
     """The remote resolvers are registered in code, so they work with no plugins at all."""
     assert Resolver.find_resolver(source).__name__ == resolver
 

--- a/tests/schema/test_schema_docs.py
+++ b/tests/schema/test_schema_docs.py
@@ -33,3 +33,32 @@ def test_get_codeurl_with_file(monkeypatch):
 @pytest.mark.skipif(sys.platform == 'win32', reason='/notafile is not an abspath in Windows')
 def test_get_codeurl_with_no_file():
     assert docs.get_codeurl("/notafile") is None
+
+
+def test_resolve_codeurl_builtin_without_plugins(monkeypatch):
+    """Files in the siliconcompiler tree resolve with no plugins at all."""
+    monkeypatch.setattr(docs, "sc_version", "sc_version")
+    assert docs.resolve_codeurl(__file__) == \
+        "https://github.com/siliconcompiler/siliconcompiler/blob/vsc_version/" \
+        "tests/schema/test_schema_docs.py"
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='/notafile is not an abspath in Windows')
+def test_resolve_codeurl_no_resolver(fake_plugins):
+    assert docs.resolve_codeurl("/notafile") is None
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='/notafile is not an abspath in Windows')
+def test_resolve_codeurl_plugin(fake_plugins, monkeypatch):
+    """A plugin claims files the built-in cannot resolve, but not siliconcompiler's own."""
+    monkeypatch.setattr(docs, "sc_version", "sc_version")
+
+    def linkcode(file=None):
+        return f"https://example.com/{file}"
+
+    fake_plugins("docs", "linkcode", linkcode)
+
+    assert docs.resolve_codeurl("/notafile") == "https://example.com//notafile"
+    assert docs.resolve_codeurl(__file__) == \
+        "https://github.com/siliconcompiler/siliconcompiler/blob/vsc_version/" \
+        "tests/schema/test_schema_docs.py"

--- a/tests/schema/test_schema_docs.py
+++ b/tests/schema/test_schema_docs.py
@@ -35,7 +35,7 @@ def test_get_codeurl_with_no_file():
     assert docs.get_codeurl("/notafile") is None
 
 
-def test_resolve_codeurl_builtin_without_plugins(monkeypatch):
+def test_resolve_codeurl_builtin_without_plugins(monkeypatch, fake_plugins):
     """Files in the siliconcompiler tree resolve with no plugins at all."""
     monkeypatch.setattr(docs, "sc_version", "sc_version")
     assert docs.resolve_codeurl(__file__) == \

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -3231,7 +3231,7 @@ def register_plugin_showtask():
     ShowTask.register_task(PluginShow)
 
 
-def test_showtask_builtin_without_plugins():
+def test_showtask_builtin_without_plugins(fake_plugins):
     """The built-in viewers are registered in code, so they work with no plugins at all."""
     assert ShowTask.get_task("gds").tool() == "klayout"
     assert ScreenshotTask.get_task("gds").tool() == "klayout"

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -3210,6 +3210,41 @@ def test_find_task_missing():
         FauxTask.find_task(Project())
 
 
+def register_plugin_showtask():
+    """
+    Stand-in for an external package's siliconcompiler.showtask entry point.
+
+    The task class is defined here rather than at module scope so it is not picked up by
+    the subclass recursion in unrelated tests.
+    """
+
+    class PluginShow(ShowTask):
+        def tool(self):
+            return "pluginviewer"
+
+        def task(self):
+            return "show"
+
+        def get_supported_task_extentions(self):
+            return ["gds"]
+
+    ShowTask.register_task(PluginShow)
+
+
+def test_showtask_builtin_without_plugins():
+    """The built-in viewers are registered in code, so they work with no plugins at all."""
+    assert ShowTask.get_task("gds").tool() == "klayout"
+    assert ScreenshotTask.get_task("gds").tool() == "klayout"
+    assert OpenTask.get_task("odb").tool() == "openroad"
+
+
+def test_showtask_plugin_overrides_builtin(fake_plugins):
+    """A plugin viewer wins over the built-in for an extension they both support."""
+    fake_plugins("showtask", "myviewer", register_plugin_showtask)
+
+    assert ShowTask.get_task("gds").tool() == "pluginviewer"
+
+
 def test_showtask_default_discovery():
     """Test that it picks a tool (order indeterminate but valid) when no setting exists."""
 

--- a/tests/utils/test_showtools.py
+++ b/tests/utils/test_showtools.py
@@ -1,5 +1,7 @@
 # Copyright 2020 Silicon Compiler Authors. All Rights Reserved.
 import pytest
+import subprocess
+import sys
 
 import os.path
 
@@ -290,3 +292,32 @@ def test_show_task_core_tools_ordered():
 
     assert prev_order == curr_order, \
         f"Core tool registration order should be stable: {prev_order} vs {curr_order}"
+
+
+# The viewer preference in showtools only takes effect if the module is imported after
+# the subclass recursion in __populate_tasks has run, so this has to be checked in a
+# fresh interpreter where nothing has imported showtools yet.
+VCD_PREFERENCE_PROBE = """
+import sys, shutil
+want = sys.argv[1] if len(sys.argv) > 1 else None
+shutil.which = lambda name, *a, **k: ("/usr/bin/" + name) if name == want else None
+
+from unittest.mock import patch
+import siliconcompiler.utils as utils
+with patch.object(utils, "entry_points", lambda group: []):
+    from siliconcompiler import ShowTask
+    assert "siliconcompiler.utils.showtools" not in sys.modules, "showtools imported early"
+    print(ShowTask.get_task("vcd").tool())
+"""
+
+
+@pytest.mark.parametrize("available,expected", [
+    ("surfer", "surfer"),
+    ("gtkwave", "gtkwave")
+])
+def test_vcd_viewer_preference(available, expected):
+    """The installed VCD viewer is preferred, with no plugins involved."""
+    proc = subprocess.run([sys.executable, "-c", VCD_PREFERENCE_PROBE, available],
+                          capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == expected

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -7,6 +7,7 @@ import psutil
 import sys
 import types
 
+from importlib.metadata import entry_points
 from unittest.mock import patch
 
 from siliconcompiler import utils
@@ -231,10 +232,38 @@ def test_get_cores_empty_affinity_falls_back(monkeypatch):
 
 def test_get_plugin():
     assert [] == get_plugins("nothingtofind")
-    assert len(get_plugins("showtask")) > 0
-    assert len(get_plugins("path_resolver")) > 0
 
-    assert len(get_plugins("path_resolver", "https")) == 1
+
+def test_no_internal_entrypoints():
+    """
+    siliconcompiler must not register its own plugin groups; built-ins are wired up in
+    code so they work regardless of how siliconcompiler was installed. External packages
+    may still register into these groups.
+
+    A failure here usually means stale install metadata from before the entry points were
+    removed - reinstall siliconcompiler to regenerate it.
+    """
+    for group in ("showtask", "path_resolver", "docs", "install"):
+        for entry in entry_points(group=f"siliconcompiler.{group}"):
+            assert not entry.value.startswith("siliconcompiler"), \
+                f"siliconcompiler.{group} must not be registered by siliconcompiler itself"
+
+
+def test_get_plugin_discovery(fake_plugins):
+    def first():
+        pass
+
+    def second():
+        pass
+
+    fake_plugins("path_resolver", "https", first)
+    fake_plugins("path_resolver", "other", second)
+
+    assert get_plugins("path_resolver") == [first, second]
+    assert get_plugins("path_resolver", "https") == [first]
+    assert get_plugins("path_resolver", "other") == [second]
+    assert get_plugins("path_resolver", "notthere") == []
+    assert get_plugins("nothingtofind") == []
 
 
 def test_default_sc_dir():

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -245,7 +245,10 @@ def test_no_internal_entrypoints():
     """
     for group in ("showtask", "path_resolver", "docs", "install"):
         for entry in entry_points(group=f"siliconcompiler.{group}"):
-            assert not entry.value.startswith("siliconcompiler"), \
+            # Match the module, not the string prefix, so external packages named
+            # siliconcompiler_something are not flagged.
+            module = entry.value.split(":")[0].strip()
+            assert module != "siliconcompiler" and not module.startswith("siliconcompiler."), \
                 f"siliconcompiler.{group} must not be registered by siliconcompiler itself"
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in resolution support for common remote source schemes (HTTPS, Git, GitHub, SCP).
  * Documentation “File:” links are now resolved more deterministically, using built-in behavior first and then plugins when needed.
  * Built-in viewer tasks are registered in a defined order before plugin tasks.
  * Install tool discovery now merges built-in OS tools with plugin overrides.
* **Documentation**
  * Expanded the development guide with examples for advanced plugin registration via Python entry points.
* **Tests**
  * Updated and expanded test coverage for resolver, viewer, and install-tool precedence/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->