### PR TITLE
rename 3dblox tasks and use commandline threads for openroad

### DIFF
--- a/siliconcompiler/tools/openroad/__init__.py
+++ b/siliconcompiler/tools/openroad/__init__.py
@@ -504,6 +504,8 @@ class OpenROADTask(ASICTask):
     def runtime_options(self):
         options = super().runtime_options()
         options.append("-no_init")
+        options.extend(["-threads", self.get_threads()])
+
         options.extend(["-metrics", "reports/metrics.json"])
 
         if not self.has_breakpoint():

--- a/siliconcompiler/tools/openroad/scripts/apr/preamble.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/preamble.tcl
@@ -44,9 +44,6 @@ set sc_pdk [sc_cfg_get asic pdk]
 set sc_logiclibs [sc_cfg_get asic asiclib]
 set sc_delaymodel [sc_cfg_get asic delaymodel]
 
-# Threads
-set_thread_count [sc_cfg_tool_task_get threads]
-
 ###############################
 # Read Files
 ###############################

--- a/siliconcompiler/tools/openroad/scripts/sc_open.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_open.tcl
@@ -32,9 +32,6 @@ set sc_pdk [sc_cfg_get library $sc_mainlib asic pdk]
 set sc_logiclibs [sc_cfg_get asic asiclib]
 set sc_delaymodel [sc_cfg_get asic delaymodel]
 
-# Threads
-set_thread_count [sc_cfg_tool_task_get threads]
-
 ###############################
 # Read Files
 ###############################

--- a/siliconcompiler/tools/openroad/scripts/sc_open_3dblox.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_open_3dblox.tcl
@@ -24,13 +24,6 @@ if { [gui::enabled] } {
 }
 
 ###############################
-# Design information
-###############################
-
-# Threads
-set_thread_count [sc_cfg_tool_task_get threads]
-
-###############################
 # Read Files
 ###############################
 

--- a/siliconcompiler/tools/openroad/scripts/sc_rcx.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_rcx.tcl
@@ -40,8 +40,6 @@ read_lef $sc_techlef
 # Run task
 ###############################
 
-set_thread_count [sc_cfg_tool_task_get threads]
-
 utl::set_metrics_stage "sc__step__{}"
 source "${sc_refdir}/rcx/sc_${sc_task}.tcl"
 utl::pop_metrics_stage

--- a/siliconcompiler/tools/openroad/scripts/sc_rdlroute.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_rdlroute.tcl
@@ -9,7 +9,6 @@ source ./sc_manifest.tcl
 ###############################
 
 set sc_pdk [sc_cfg_get asic pdk]
-set sc_threads [sc_cfg_tool_task_get threads]
 
 ##############################
 # Setup debugging
@@ -26,8 +25,6 @@ source "$sc_refdir/common/procs.tcl"
 ###############################
 # Common Setup
 ###############################
-
-set_thread_count $sc_threads
 
 # Read techlef
 set aprfileset [sc_cfg_get library $sc_pdk pdk aprtechfileset openroad]

--- a/siliconcompiler/tools/openroad/show.py
+++ b/siliconcompiler/tools/openroad/show.py
@@ -79,7 +79,7 @@ class Show3DBloxWebTask(Show3DBloxTask):
         super().__init__()
 
     def task(self) -> str:
-        return "show3dbloxweb"
+        return "web3dblox"
 
     def setup(self):
         super().setup()

--- a/siliconcompiler/tools/opensta/__init__.py
+++ b/siliconcompiler/tools/opensta/__init__.py
@@ -42,10 +42,10 @@ class OpenSTATask(Task):
     def runtime_options(self):
         options = super().runtime_options()
         options.append("-no_init")
+        options.extend(["-threads", self.get_threads()])
+
         if not self.has_breakpoint():
             options.append("-exit")
-
-        options.extend(["-threads", self.get_threads()])
 
         return options
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenROAD now consistently applies the configured thread count when launching tasks, improving support for parallel execution.
* **Bug Fixes**
  * Corrected selection of the 3D web viewer workflow.
  * Improved compatibility of OpenSTA command-line options when running with breakpoints or automatic exit behavior.
* **Performance**
  * Streamlined thread configuration across OpenROAD workflows, including routing, extraction, and 3D design processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->