### PR TITLE
fix remote package redownload

### DIFF
--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -64,6 +64,20 @@ class Resolver:
     #: off for local ones, which fail instantly and identically every time.
     _track_failures: bool = False
 
+    #: Whether a resolved path may be shared through the process-wide cache.
+    #:
+    #: The cache is keyed by :attr:`cache_id`, a hash of the source URI and its
+    #: reference, which identifies a path only when the source means the same
+    #: thing everywhere. That holds for an absolute ``file://`` path, a
+    #: ``python://`` module or a remote URL at a fixed reference, but not for a
+    #: source resolved *relative to a schema* -- ``dataroot://name`` and
+    #: ``key://keypath`` name something different in each project or design.
+    #: Sharing those would let two schemas collide on one entry and hand each
+    #: other the wrong path, so they opt out and resolve every time. They are
+    #: cheap to resolve, and where they delegate to an expensive source the
+    #: inner resolver still caches.
+    _shared_cache: bool = True
+
     def __init__(self, name: str,
                  schema: Optional[Union["Project", "BaseSchema"]],
                  source: str,
@@ -275,9 +289,10 @@ class Resolver:
         """
         cache = self.cache
 
-        cache_path: Optional[str] = cache.get(self.cache_id)
-        if cache_path:
-            return cache_path
+        if self._shared_cache:
+            cache_path: Optional[str] = cache.get(self.cache_id)
+            if cache_path:
+                return cache_path
 
         if self._track_failures:
             if cache.is_exhausted(self.cache_id):
@@ -307,7 +322,8 @@ class Resolver:
             self.logger.info(f'Found {self.display_name} data at {path}')
 
         cache.clear_failure(self.cache_id)
-        cache.set(self.cache_id, path)
+        if self._shared_cache:
+            cache.set(self.cache_id, path)
         return str(path)
 
     def __resolve_env(self, path: str) -> str:
@@ -436,9 +452,12 @@ class RemoteResolver(Resolver):
         """
         Gets the download lock for this resolver's data source.
 
-        The lock is keyed by cache ID, matching the granularity of
-        :attr:`lock_file`, so two resolvers pointing at the same source share a
-        lock while resolvers for unrelated sources never contend.
+        The lock is keyed by :attr:`cache_id`, so resolvers for unrelated sources
+        never contend. Note this is not the same granularity as
+        :attr:`lock_file`, which is derived from :attr:`cache_name` and so also
+        varies with :attr:`name`: two resolvers naming one source differently
+        share this lock but take different lock files, because they also download
+        to different :attr:`cache_path` directories.
         """
         return self.cache.thread_lock(self.cache_id)
 
@@ -837,6 +856,10 @@ class KeyPathResolver(Resolver):
     `find_files` method of the root project object to locate the corresponding file.
     """
 
+    # The same keypath names a different file in every schema, so this cannot be
+    # shared through a cache keyed only by the source string.
+    _shared_cache: bool = False
+
     def __init__(self, name: str, schema: "Project", source: str, reference: Optional[str] = None):
         super().__init__(name, schema, source, None)
 
@@ -870,6 +893,11 @@ class DatarootResolver(Resolver):
     """
     A resolver for finding file paths stored with other dataroots.
     """
+
+    # A dataroot name is only meaningful within the schema that defines it, so
+    # this cannot be shared through a cache keyed only by the source string. The
+    # dataroot it points at is resolved by its own resolver, which still caches.
+    _shared_cache: bool = False
 
     def __init__(self, name: str, schema: "Project", source: str, reference: Optional[str] = None):
         super().__init__(name, schema, source, None)

--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -58,31 +58,6 @@ class Resolver:
         reference (str): A version, commit hash, or tag for remote sources.
     """
 
-    #: Whether repeated failures to resolve this kind of source are tracked and
-    #: eventually abandoned. Only worth doing where an attempt is expensive, so
-    #: it is enabled for remote sources (see :class:`RemoteResolver`) and left
-    #: off for local ones, which fail instantly and identically every time.
-    _track_failures: bool = False
-
-    #: Whether this resolver is an indirection rather than a location of its own.
-    #:
-    #: ``dataroot://name`` and ``key://keypath`` do not name data; they name
-    #: something *within a schema* that in turn names data, and they hand the real
-    #: work to that resolver. Two consequences follow, both handled by
-    #: :meth:`get_path`:
-    #:
-    #: * They are not cached. The cache is keyed by :attr:`cache_id`, a hash of
-    #:   the source URI and reference, which identifies a path only for a source
-    #:   that means the same thing everywhere -- an absolute ``file://`` path, a
-    #:   ``python://`` module, a remote URL at a fixed reference. A dataroot name
-    #:   or a keypath means something different in every project or design, so
-    #:   caching one would let two schemas collide and hand each other the wrong
-    #:   path. Resolving an indirection is cheap, and where it points at an
-    #:   expensive source that resolver still caches.
-    #: * They do not announce where data was found, because the resolver they
-    #:   delegate to already reported the same location.
-    _indirect: bool = False
-
     def __init__(self, name: str,
                  schema: Optional[Union["Project", "BaseSchema"]],
                  source: str,
@@ -174,6 +149,42 @@ class Resolver:
             if keypath:
                 return f"{self.name} [{','.join(keypath)}]"
         return self.name
+
+    @property
+    def is_retryable(self) -> bool:
+        """
+        True if a failed resolution is worth retrying.
+
+        Failures are then counted in the shared cache, delayed with a growing
+        backoff, and abandoned once the budget runs out. Only worth doing where an
+        attempt is expensive, so remote sources enable it (see
+        :class:`RemoteResolver`) while local ones leave it off: they fail
+        instantly and identically every time, so a retry cannot help.
+        """
+        return False
+
+    @property
+    def is_indirect(self) -> bool:
+        """
+        True if this resolver is an indirection rather than a location of its own.
+
+        ``dataroot://name`` and ``key://keypath`` do not name data; they name
+        something *within a schema* that in turn names data, and they hand the
+        real work to that resolver. Two consequences follow, both applied by
+        :meth:`get_path`:
+
+        * An indirection is not cached. The cache is keyed by :attr:`cache_id`, a
+          hash of the source URI and reference, which identifies a path only for a
+          source that means the same thing everywhere -- an absolute ``file://``
+          path, a ``python://`` module, a remote URL at a fixed reference. A
+          dataroot name or a keypath means something different in every project or
+          design, so caching one would let two schemas collide and hand each other
+          the wrong path. Resolving an indirection is cheap, and where it points
+          at an expensive source that resolver still caches.
+        * An indirection does not announce where data was found, because the
+          resolver it delegates to already reported the same location.
+        """
+        return False
 
     @property
     def root(self) -> Optional[Union["Project", "BaseSchema"]]:
@@ -278,7 +289,7 @@ class Resolver:
         source is not cached, it calls `resolve()` and caches the result.
 
         Each call makes at most one attempt at resolving the source. For sources
-        where an attempt is expensive (see :attr:`_track_failures`), failures are
+        where an attempt is expensive (see :attr:`is_retryable`), failures are
         counted in the shared :class:`~siliconcompiler.package.cache.PathCache`,
         so the repeated lookups a run performs consume a bounded budget rather
         than re-fetching indefinitely. Once the budget is spent, later calls fail
@@ -294,12 +305,12 @@ class Resolver:
         """
         cache = self.cache
 
-        if not self._indirect:
+        if not self.is_indirect:
             cache_path: Optional[str] = cache.get(self.cache_id)
             if cache_path:
                 return cache_path
 
-        if self._track_failures:
+        if self.is_retryable:
             if cache.is_exhausted(self.cache_id):
                 raise DataRootResolutionError(self.__abandoned_message(cache))
 
@@ -316,18 +327,18 @@ class Resolver:
             # Deliberately narrower than BaseException: a KeyboardInterrupt or
             # SystemExit says nothing about whether the source is reachable, so
             # it must not consume the budget or poison the cache.
-            if self._track_failures:
+            if self.is_retryable:
                 if cache.record_failure(self.cache_id, e) >= cache.max_attempts:
                     self.logger.error(self.__abandoned_message(cache))
             raise
 
-        if self._track_failures:
+        if self.is_retryable:
             cache.clear_failure(self.cache_id)
 
-        if self._indirect:
+        if self.is_indirect:
             # An indirection owns no location: the resolver it delegated to has
             # already reported where the data is, and its schema-relative source
-            # string is not a safe cache key. See :attr:`_indirect`.
+            # string is not a safe cache key. See :attr:`is_indirect`.
             return str(path)
 
         if self.changed:
@@ -366,9 +377,13 @@ class RemoteResolver(Resolver):
     multiple SC instances try to download the same resource simultaneously.
     """
 
-    # Fetching a remote source is expensive, so give up on one that keeps
-    # failing instead of letting every caller re-download it.
-    _track_failures: bool = True
+    @property
+    def is_retryable(self) -> bool:
+        """
+        True. Fetching a remote source is expensive, so give up on one that keeps
+        failing instead of letting every caller re-download it.
+        """
+        return True
 
     def __init__(self, name: str,
                  schema: Optional[Union["Project", "BaseSchema"]],
@@ -868,8 +883,10 @@ class KeyPathResolver(Resolver):
     `find_files` method of the root project object to locate the corresponding file.
     """
 
-    # A keypath names something inside a schema, not a location of its own.
-    _indirect: bool = True
+    @property
+    def is_indirect(self) -> bool:
+        """True. A keypath names something inside a schema, not a location."""
+        return True
 
     def __init__(self, name: str, schema: "Project", source: str, reference: Optional[str] = None):
         super().__init__(name, schema, source, None)
@@ -905,9 +922,13 @@ class DatarootResolver(Resolver):
     A resolver for finding file paths stored with other dataroots.
     """
 
-    # A dataroot name is only meaningful within the schema that defines it, and
-    # the dataroot it points at is resolved by its own resolver.
-    _indirect: bool = True
+    @property
+    def is_indirect(self) -> bool:
+        """
+        True. A dataroot name is only meaningful within the schema that defines
+        it, and the dataroot it points at is resolved by its own resolver.
+        """
+        return True
 
     def __init__(self, name: str, schema: "Project", source: str, reference: Optional[str] = None):
         super().__init__(name, schema, source, None)

--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -64,19 +64,24 @@ class Resolver:
     #: off for local ones, which fail instantly and identically every time.
     _track_failures: bool = False
 
-    #: Whether a resolved path may be shared through the process-wide cache.
+    #: Whether this resolver is an indirection rather than a location of its own.
     #:
-    #: The cache is keyed by :attr:`cache_id`, a hash of the source URI and its
-    #: reference, which identifies a path only when the source means the same
-    #: thing everywhere. That holds for an absolute ``file://`` path, a
-    #: ``python://`` module or a remote URL at a fixed reference, but not for a
-    #: source resolved *relative to a schema* -- ``dataroot://name`` and
-    #: ``key://keypath`` name something different in each project or design.
-    #: Sharing those would let two schemas collide on one entry and hand each
-    #: other the wrong path, so they opt out and resolve every time. They are
-    #: cheap to resolve, and where they delegate to an expensive source the
-    #: inner resolver still caches.
-    _shared_cache: bool = True
+    #: ``dataroot://name`` and ``key://keypath`` do not name data; they name
+    #: something *within a schema* that in turn names data, and they hand the real
+    #: work to that resolver. Two consequences follow, both handled by
+    #: :meth:`get_path`:
+    #:
+    #: * They are not cached. The cache is keyed by :attr:`cache_id`, a hash of
+    #:   the source URI and reference, which identifies a path only for a source
+    #:   that means the same thing everywhere -- an absolute ``file://`` path, a
+    #:   ``python://`` module, a remote URL at a fixed reference. A dataroot name
+    #:   or a keypath means something different in every project or design, so
+    #:   caching one would let two schemas collide and hand each other the wrong
+    #:   path. Resolving an indirection is cheap, and where it points at an
+    #:   expensive source that resolver still caches.
+    #: * They do not announce where data was found, because the resolver they
+    #:   delegate to already reported the same location.
+    _indirect: bool = False
 
     def __init__(self, name: str,
                  schema: Optional[Union["Project", "BaseSchema"]],
@@ -289,7 +294,7 @@ class Resolver:
         """
         cache = self.cache
 
-        if self._shared_cache:
+        if not self._indirect:
             cache_path: Optional[str] = cache.get(self.cache_id)
             if cache_path:
                 return cache_path
@@ -316,14 +321,21 @@ class Resolver:
                     self.logger.error(self.__abandoned_message(cache))
             raise
 
+        if self._track_failures:
+            cache.clear_failure(self.cache_id)
+
+        if self._indirect:
+            # An indirection owns no location: the resolver it delegated to has
+            # already reported where the data is, and its schema-relative source
+            # string is not a safe cache key. See :attr:`_indirect`.
+            return str(path)
+
         if self.changed:
             self.logger.info(f'Saved {self.display_name} data to {path}')
         else:
             self.logger.info(f'Found {self.display_name} data at {path}')
 
-        cache.clear_failure(self.cache_id)
-        if self._shared_cache:
-            cache.set(self.cache_id, path)
+        cache.set(self.cache_id, path)
         return str(path)
 
     def __resolve_env(self, path: str) -> str:
@@ -856,9 +868,8 @@ class KeyPathResolver(Resolver):
     `find_files` method of the root project object to locate the corresponding file.
     """
 
-    # The same keypath names a different file in every schema, so this cannot be
-    # shared through a cache keyed only by the source string.
-    _shared_cache: bool = False
+    # A keypath names something inside a schema, not a location of its own.
+    _indirect: bool = True
 
     def __init__(self, name: str, schema: "Project", source: str, reference: Optional[str] = None):
         super().__init__(name, schema, source, None)
@@ -894,10 +905,9 @@ class DatarootResolver(Resolver):
     A resolver for finding file paths stored with other dataroots.
     """
 
-    # A dataroot name is only meaningful within the schema that defines it, so
-    # this cannot be shared through a cache keyed only by the source string. The
-    # dataroot it points at is resolved by its own resolver, which still caches.
-    _shared_cache: bool = False
+    # A dataroot name is only meaningful within the schema that defines it, and
+    # the dataroot it points at is resolved by its own resolver.
+    _indirect: bool = True
 
     def __init__(self, name: str, schema: "Project", source: str, reference: Optional[str] = None):
         super().__init__(name, schema, source, None)

--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -21,17 +21,17 @@ import shutil
 import stat
 import time
 import threading
-import uuid
 
 import os.path
 
-from typing import Optional, List, Dict, Type, Union, TYPE_CHECKING, Final
+from typing import Optional, List, Dict, Type, Union, TYPE_CHECKING
 
 from fasteners import InterProcessLock
 from importlib.metadata import distributions, distribution
 from pathlib import Path, PureWindowsPath
 from urllib import parse as url_parse
 
+from siliconcompiler.package.cache import PathCache, DataRootResolutionError
 from siliconcompiler.utils import get_plugins, default_cache_dir
 from siliconcompiler.utils.paths import cwdirsafe
 from siliconcompiler.utils.multiprocessing import MPManager
@@ -57,7 +57,12 @@ class Resolver:
         source (str): The URI or path specifying the data source.
         reference (str): A version, commit hash, or tag for remote sources.
     """
-    __STORAGE: Final[str] = "__Resolver_cache_id"
+
+    #: Whether repeated failures to resolve this kind of source are tracked and
+    #: eventually abandoned. Only worth doing where an attempt is expensive, so
+    #: it is enabled for remote sources (see :class:`RemoteResolver`) and left
+    #: off for local ones, which fail instantly and identically every time.
+    _track_failures: bool = False
 
     def __init__(self, name: str,
                  schema: Optional[Union["Project", "BaseSchema"]],
@@ -229,103 +234,80 @@ class Resolver:
         """
         raise NotImplementedError("child class must implement this")
 
-    @staticmethod
-    def __get_root_id(root: Union["Project", "BaseSchema"]) -> str:
-        """Generates or retrieves a unique ID for a root object."""
-        if not getattr(root, Resolver.__STORAGE, None):
-            setattr(root, Resolver.__STORAGE, uuid.uuid4().hex)
-        return getattr(root, Resolver.__STORAGE)
-
-    @staticmethod
-    def get_cache(root: Optional[Union["Project", "BaseSchema"]], name: Optional[str] = None) \
-            -> Union[None, str, Dict[str, str]]:
+    @property
+    def cache(self) -> PathCache:
         """
-        Gets a cached path for a given root object and resolver name.
-
-        Args:
-            root: The root object (e.g., Project).
-            name (str, optional): The name of the resolver cache to retrieve.
-                If None, returns a copy of the entire cache for the root.
-
-        Returns:
-            str or dict or None: The cached path, a copy of the cache, or None.
+        :class:`~siliconcompiler.package.cache.PathCache`: The store of paths that
+        data sources have resolved to, shared by everything in this process.
         """
-        if root is None:
-            return None
+        return MPManager.get_path_cache()
 
-        cache_id = f"resolver-cache-{Resolver.__get_root_id(root)}"
-
-        settings = MPManager().get_transient_settings()
-
-        if name is not None:
-            return settings.get(cache_id, name, None)
-
-        return settings.get_category(cache_id)
-
-    @staticmethod
-    def set_cache(root: Optional[Union["Project", "BaseSchema"]],
-                  name: str,
-                  path: Union[Path, str]) -> None:
-        """
-        Sets a cached path for a given root object and resolver name.
-
-        Args:
-            root: The root object (e.g., Project).
-            name (str): The name of the resolver cache to set.
-            path (str): The path to cache.
-        """
-        if root is None:
-            return
-
-        cache_id = f"resolver-cache-{Resolver.__get_root_id(root)}"
-
-        settings = MPManager().get_transient_settings()
-
-        settings.set(cache_id, name, str(path))
-
-    @staticmethod
-    def reset_cache(root: Optional[Union["Project", "BaseSchema"]]) -> None:
-        """
-        Resets the entire cache for a given root object.
-
-        Args:
-            root: The root object whose cache will be cleared.
-        """
-        if root is None:
-            return
-        cache_id = f"resolver-cache-{Resolver.__get_root_id(root)}"
-
-        settings = MPManager().get_transient_settings()
-
-        settings.delete(cache_id)
+    def __abandoned_message(self, cache: PathCache) -> str:
+        """Builds the error text used when a data source is given up on."""
+        source = self.source
+        if self.reference:
+            source = f"{source} ({self.reference})"
+        return (f"Unable to resolve '{self.display_name}' from {source} after "
+                f"{cache.attempts(self.cache_id)} attempt(s), giving up. "
+                f"Last error: {cache.failure(self.cache_id)}")
 
     def get_path(self) -> str:
         """
         Resolves the data source and returns its local path.
 
-        This method first checks the in-memory cache. If not found, it calls
-        the `resolve()` method and caches the result.
+        This method first checks the cache of already resolved paths. If the
+        source is not cached, it calls `resolve()` and caches the result.
+
+        Each call makes at most one attempt at resolving the source. For sources
+        where an attempt is expensive (see :attr:`_track_failures`), failures are
+        counted in the shared :class:`~siliconcompiler.package.cache.PathCache`,
+        so the repeated lookups a run performs consume a bounded budget rather
+        than re-fetching indefinitely. Once the budget is spent, later calls fail
+        immediately without touching the network.
 
         Returns:
             str: The absolute path to the resolved data on the local filesystem.
 
         Raises:
             FileNotFoundError: If the resolved path does not exist.
+            DataRootResolutionError: If the source has already failed to resolve
+                :attr:`PathCache.max_attempts` times.
         """
-        cache_path: Optional[str] = Resolver.get_cache(self.__root, self.cache_id)
+        cache = self.cache
+
+        cache_path: Optional[str] = cache.get(self.cache_id)
         if cache_path:
             return cache_path
 
-        path = self.resolve()
-        if not os.path.exists(path):
-            raise FileNotFoundError(f"Unable to locate '{self.display_name}' at {path}")
+        if self._track_failures:
+            if cache.is_exhausted(self.cache_id):
+                raise DataRootResolutionError(self.__abandoned_message(cache))
+
+            # Back off before re-attempting a source that has already failed.
+            # Delays live in the cache so resolvers stay a single attempt each
+            # and no data source type has to implement its own retry policy.
+            cache.wait_before_retry(self.cache_id)
+
+        try:
+            path = self.resolve()
+            if not os.path.exists(path):
+                raise FileNotFoundError(f"Unable to locate '{self.display_name}' at {path}")
+        except Exception as e:
+            # Deliberately narrower than BaseException: a KeyboardInterrupt or
+            # SystemExit says nothing about whether the source is reachable, so
+            # it must not consume the budget or poison the cache.
+            if self._track_failures:
+                if cache.record_failure(self.cache_id, e) >= cache.max_attempts:
+                    self.logger.error(self.__abandoned_message(cache))
+            raise
 
         if self.changed:
             self.logger.info(f'Saved {self.display_name} data to {path}')
         else:
             self.logger.info(f'Found {self.display_name} data at {path}')
 
-        Resolver.set_cache(self.__root, self.cache_id, path)
+        cache.clear_failure(self.cache_id)
+        cache.set(self.cache_id, path)
         return str(path)
 
     def __resolve_env(self, path: str) -> str:
@@ -355,6 +337,11 @@ class RemoteResolver(Resolver):
     both thread-safe and process-safe locking to prevent race conditions when
     multiple SC instances try to download the same resource simultaneously.
     """
+
+    # Fetching a remote source is expensive, so give up on one that keeps
+    # failing instead of letting every caller re-download it.
+    _track_failures: bool = True
+
     def __init__(self, name: str,
                  schema: Optional[Union["Project", "BaseSchema"]],
                  source: str,
@@ -446,12 +433,14 @@ class RemoteResolver(Resolver):
         return self.cache_dir / f"{self.cache_name}.sc_lock"
 
     def thread_lock(self) -> threading.Lock:
-        """Gets a threading.Lock specific to this resolver instance."""
-        settings = MPManager().get_transient_settings()
-        locks = settings.get_category("resolver-remote-cache-locks")
-        if self.name not in locks:
-            settings.set("resolver-remote-cache-locks", self.name, threading.Lock(), keep=True)
-        return settings.get("resolver-remote-cache-locks", self.name)
+        """
+        Gets the download lock for this resolver's data source.
+
+        The lock is keyed by cache ID, matching the granularity of
+        :attr:`lock_file`, so two resolvers pointing at the same source share a
+        lock while resolvers for unrelated sources never contend.
+        """
+        return self.cache.thread_lock(self.cache_id)
 
     @contextlib.contextmanager
     def __thread_lock(self):
@@ -470,7 +459,11 @@ class RemoteResolver(Resolver):
             if lock_acquired:
                 yield
         finally:
-            if lock.locked():
+            # Only release a lock this context actually took. threading.Lock has
+            # no notion of an owner, so releasing on the strength of locked()
+            # would let a waiter that timed out free the holder's lock and admit
+            # a third thread into the download.
+            if lock_acquired:
                 lock.release()
 
         if not lock_acquired:

--- a/siliconcompiler/package/cache.py
+++ b/siliconcompiler/package/cache.py
@@ -312,7 +312,17 @@ class PathCache:
         if base <= 0:
             return 0.0
 
-        nominal = base * (backoff ** (attempts - 1))
+        # Cap the growth before raising it to a power. A high attempt budget, or a
+        # snapshot seeded with a large attempt count, otherwise pushes the
+        # exponential past the float range and raises OverflowError from inside
+        # path resolution rather than simply returning the capped delay.
+        try:
+            nominal = min(base * (backoff ** (attempts - 1)), PathCache.RETRY_MAX_DELAY)
+        except OverflowError:
+            nominal = PathCache.RETRY_MAX_DELAY
+
+        # Jitter still applies at the ceiling: workers that all reached the cap
+        # must not resume in lockstep either.
         jitter = PathCache.RETRY_JITTER
         delay = random.uniform(nominal * (1 - jitter), nominal * (1 + jitter))
 

--- a/siliconcompiler/package/cache.py
+++ b/siliconcompiler/package/cache.py
@@ -1,0 +1,443 @@
+"""
+Central store for resolved data source paths.
+
+Resolving a data source can be expensive: a remote data source may involve a
+network download of an entire git repository or archive. :class:`PathCache`
+gives a run one place to record
+
+* the local path a data source resolved to, so it is only ever resolved once,
+* how many times resolving it has *failed*, so a source that cannot be fetched
+  is retried a bounded number of times -- with a randomized, exponentially
+  growing delay between attempts -- and then abandoned with an actionable error
+  rather than re-downloaded by every caller, and
+* the per-source download mutex used to keep threads from fetching the same
+  source concurrently.
+
+There is one cache per process, owned by
+:class:`~siliconcompiler.utils.multiprocessing.MPManager` alongside the other
+shared resources and reachable through
+:meth:`~siliconcompiler.utils.multiprocessing.MPManager.get_path_cache`. Entries
+are keyed by a content hash of the source URI and its reference, so a single
+cache serves every project, library and design in the process: the same source
+at the same reference always resolves to the same path, and the number of
+entries is bounded by how many distinct sources a run touches.
+
+A ``fork`` worker inherits the cache as it stood when the worker was launched. A
+worker that cannot inherit it -- a ``spawn`` worker, or a node run out of
+process by the docker or slurm scheduler -- starts empty and reports what it
+resolved back to its parent, through :meth:`export` and :meth:`seed`.
+"""
+
+import math
+import random
+import threading
+import time
+
+from typing import Any, Dict, Optional, Tuple, Union
+
+from pathlib import Path
+
+
+class DataRootResolutionError(RuntimeError):
+    """
+    Raised when a data source could not be resolved within its attempt budget.
+
+    Once a source has failed :attr:`PathCache.max_attempts` times, further
+    attempts are abandoned and this error is raised instead of retrying, so a
+    broken or unreachable data source cannot be re-fetched indefinitely.
+    """
+
+
+class PathCache:
+    """
+    Cache of resolved data source paths and resolution failures.
+
+    Entries are keyed by a resolver's ``cache_id`` (a hash of the source URI and
+    its reference), so the same source shares one entry no matter which name it
+    was registered under, which schema asked for it, or how many resolver objects
+    are built for it.
+
+    Obtain the process cache with
+    :meth:`~siliconcompiler.utils.multiprocessing.MPManager.get_path_cache`
+    rather than constructing one.
+    """
+
+    #: Number of times a data source may fail to resolve before it is abandoned.
+    DEFAULT_MAX_ATTEMPTS: int = 3
+
+    #: Delay, in seconds, before the first retry of a failed source.
+    DEFAULT_RETRY_DELAY: float = 2.0
+
+    #: Factor each successive retry delay is multiplied by. With the default
+    #: delay this gives a ladder of roughly 2s, 5s, 10s, 23s, ...
+    DEFAULT_RETRY_BACKOFF: float = 2.25
+
+    #: Fraction the delay is randomly varied by, either side of its nominal
+    #: value. Spreads out workers that failed together instead of letting them
+    #: all retry the same unreachable source at the same moment.
+    RETRY_JITTER: float = 0.25
+
+    #: Ceiling on any single delay, so a large attempt budget cannot turn the
+    #: growing backoff into an effectively unbounded wait.
+    RETRY_MAX_DELAY: float = 60.0
+
+    def __init__(self):
+        self.__paths: Dict[str, str] = {}
+        self.__failures: Dict[str, Tuple[int, str]] = {}
+        self.__max_attempts: int = PathCache.DEFAULT_MAX_ATTEMPTS
+        self.__retry_delay: float = PathCache.DEFAULT_RETRY_DELAY
+        self.__retry_backoff: float = PathCache.DEFAULT_RETRY_BACKOFF
+
+        self.__lock = threading.RLock()
+        self.__download_locks: Dict[str, threading.Lock] = {}
+
+    # ------------------------------------------------------------------
+    # Resolved paths
+    # ------------------------------------------------------------------
+    def get(self, cache_id: str) -> Optional[str]:
+        """
+        Returns the cached path for a data source.
+
+        Args:
+            cache_id (str): The resolver cache ID of the data source.
+
+        Returns:
+            str or None: The resolved path, or None if it is not cached.
+        """
+        with self.__lock:
+            return self.__paths.get(cache_id, None)
+
+    def set(self, cache_id: str, path: Union[str, Path]) -> None:
+        """
+        Records the path a data source resolved to.
+
+        Args:
+            cache_id (str): The resolver cache ID of the data source.
+            path: The local path the source resolved to.
+        """
+        with self.__lock:
+            self.__paths[cache_id] = str(path)
+
+    # ------------------------------------------------------------------
+    # Failure tracking
+    # ------------------------------------------------------------------
+    def attempts(self, cache_id: str) -> int:
+        """
+        Returns how many times resolving a data source has failed.
+
+        Args:
+            cache_id (str): The resolver cache ID of the data source.
+
+        Returns:
+            int: The number of recorded failures.
+        """
+        with self.__lock:
+            attempts, _ = self.__failures.get(cache_id, (0, ""))
+            return attempts
+
+    def failure(self, cache_id: str) -> Optional[str]:
+        """
+        Returns the last recorded failure for a data source.
+
+        Args:
+            cache_id (str): The resolver cache ID of the data source.
+
+        Returns:
+            str or None: The last error, formatted as ``"<class>: <message>"``,
+                or None if the source has not failed.
+        """
+        with self.__lock:
+            if cache_id not in self.__failures:
+                return None
+            return self.__failures[cache_id][1]
+
+    def is_exhausted(self, cache_id: str) -> bool:
+        """
+        Returns True if a data source has used up its attempt budget.
+
+        Args:
+            cache_id (str): The resolver cache ID of the data source.
+
+        Returns:
+            bool: True if the source has failed :attr:`max_attempts` times.
+        """
+        return self.attempts(cache_id) >= self.max_attempts
+
+    def record_failure(self, cache_id: str, error: BaseException) -> int:
+        """
+        Records a failed attempt at resolving a data source.
+
+        The error is stored as text rather than as an exception object so that
+        the cache stays picklable and can be handed between processes.
+
+        Args:
+            cache_id (str): The resolver cache ID of the data source.
+            error (BaseException): The error that caused the failure.
+
+        Returns:
+            int: The total number of failures recorded for this source.
+        """
+        with self.__lock:
+            attempts, _ = self.__failures.get(cache_id, (0, ""))
+            attempts += 1
+            self.__failures[cache_id] = (attempts, f"{type(error).__name__}: {error}")
+            return attempts
+
+    def clear_failure(self, cache_id: str) -> None:
+        """
+        Forgets any recorded failures for a data source.
+
+        Args:
+            cache_id (str): The resolver cache ID of the data source.
+        """
+        with self.__lock:
+            self.__failures.pop(cache_id, None)
+
+    # ------------------------------------------------------------------
+    # Retry policy
+    # ------------------------------------------------------------------
+    @property
+    def max_attempts(self) -> int:
+        """int: Times a data source may fail to resolve before being abandoned."""
+        with self.__lock:
+            return self.__max_attempts
+
+    def set_max_attempts(self, value: int) -> None:
+        """
+        Sets how many times a data source may fail before being abandoned.
+
+        Args:
+            value (int): The maximum number of attempts. Must be at least 1.
+
+        Raises:
+            TypeError: If ``value`` is not a number.
+            ValueError: If ``value`` is less than 1.
+        """
+        try:
+            value = int(value)
+        except (TypeError, ValueError) as e:
+            raise type(e)(f"max_attempts must be an integer: {value!r}") from e
+        if value < 1:
+            raise ValueError("max_attempts must be greater than 0")
+        with self.__lock:
+            self.__max_attempts = value
+
+    @property
+    def retry_delay(self) -> float:
+        """float: Delay, in seconds, before the first retry of a failed source."""
+        with self.__lock:
+            return self.__retry_delay
+
+    def set_retry_delay(self, value: float) -> None:
+        """
+        Sets the delay applied before the first retry of a failed data source.
+
+        Later retries grow from this by :attr:`retry_backoff`.
+
+        Args:
+            value (float): The delay in seconds. Zero disables waiting.
+
+        Raises:
+            TypeError: If ``value`` is not a number.
+            ValueError: If ``value`` is negative, infinite, or not a number.
+        """
+        try:
+            value = float(value)
+        except (TypeError, ValueError) as e:
+            raise type(e)(f"retry_delay must be a number: {value!r}") from e
+        # nan and inf slip past a plain "< 0" test and would either wait forever
+        # or make time.sleep() raise from inside path resolution.
+        if not math.isfinite(value):
+            raise ValueError("retry_delay must be finite")
+        if value < 0:
+            raise ValueError("retry_delay must not be negative")
+        with self.__lock:
+            self.__retry_delay = value
+
+    @property
+    def retry_backoff(self) -> float:
+        """float: Factor each successive retry delay is multiplied by."""
+        with self.__lock:
+            return self.__retry_backoff
+
+    def set_retry_backoff(self, value: float) -> None:
+        """
+        Sets how sharply the retry delay grows with each failure.
+
+        Args:
+            value (float): The multiplier applied per retry. Must be at least 1;
+                exactly 1 keeps every delay at :attr:`retry_delay`.
+
+        Raises:
+            TypeError: If ``value`` is not a number.
+            ValueError: If ``value`` is less than 1, or is not finite.
+        """
+        try:
+            value = float(value)
+        except (TypeError, ValueError) as e:
+            raise type(e)(f"retry_backoff must be a number: {value!r}") from e
+        if not math.isfinite(value):
+            raise ValueError("retry_backoff must be finite")
+        if value < 1:
+            raise ValueError("retry_backoff must be at least 1")
+        with self.__lock:
+            self.__retry_backoff = value
+
+    def next_retry_delay(self, cache_id: str) -> float:
+        """
+        Returns how long to wait before the next attempt at a data source.
+
+        The delay grows exponentially with the number of failures already
+        recorded -- roughly 2s, 5s, 10s with the default settings -- and is
+        randomly varied by :attr:`RETRY_JITTER` either side of that. The jitter
+        matters as much as the growth: without it, workers that failed together
+        stay in lockstep and keep hammering the same unreachable source in
+        unison. Any single delay is capped at :attr:`RETRY_MAX_DELAY`.
+
+        Args:
+            cache_id (str): The resolver cache ID of the data source.
+
+        Returns:
+            float: Seconds to wait. Zero for a source that has not failed yet,
+                or when the delay has been configured away.
+        """
+        attempts = self.attempts(cache_id)
+        if not attempts:
+            return 0.0
+
+        with self.__lock:
+            base = self.__retry_delay
+            backoff = self.__retry_backoff
+
+        if base <= 0:
+            return 0.0
+
+        nominal = base * (backoff ** (attempts - 1))
+        jitter = PathCache.RETRY_JITTER
+        delay = random.uniform(nominal * (1 - jitter), nominal * (1 + jitter))
+
+        return min(delay, PathCache.RETRY_MAX_DELAY)
+
+    def wait_before_retry(self, cache_id: str) -> None:
+        """
+        Waits before retrying a data source that has already failed.
+
+        This is the only place a retry delay is applied. Individual resolvers
+        make a single attempt per call and never sleep themselves, so backoff
+        policy lives here rather than being reimplemented per data source type.
+        A source that has not failed yet is never delayed.
+
+        Args:
+            cache_id (str): The resolver cache ID of the data source.
+        """
+        delay = self.next_retry_delay(cache_id)
+        if delay > 0:
+            time.sleep(delay)
+
+    # ------------------------------------------------------------------
+    # Central seeding and export
+    # ------------------------------------------------------------------
+    def export(self) -> Dict[str, Any]:
+        """
+        Returns a serializable snapshot of the cache contents.
+
+        The result contains only strings and integers, so it can be sent over a
+        pipe or written to a command line.
+
+        Returns:
+            dict: A payload accepted by :meth:`seed`.
+        """
+        with self.__lock:
+            return {
+                "paths": dict(self.__paths),
+                "failures": {key: list(value) for key, value in self.__failures.items()}
+            }
+
+    def seed(self, payload: Optional[Dict[str, Any]], include_failures: bool = True) -> None:
+        """
+        Merges a snapshot produced by :meth:`export` into this cache.
+
+        Resolved paths are always merged. Failures are merged only when
+        ``include_failures`` is True; a caller that considers failures local to
+        the process that saw them (for example a scheduler merging results from
+        one node, where the next node may well succeed) can leave them behind.
+
+        A snapshot arrives from another process, over a pipe or a command line,
+        so every part of it is treated as untrusted: anything unrecognized is
+        skipped rather than raising, because a garbled message must never take
+        down the run that received it.
+
+        Args:
+            payload (dict): A snapshot from :meth:`export`. Ignored if it is not
+                a dictionary, so a truncated or unexpected message is harmless.
+            include_failures (bool): If True, also merge recorded failures.
+        """
+        if not isinstance(payload, dict):
+            return
+
+        paths = payload.get("paths", None)
+        with self.__lock:
+            if isinstance(paths, dict):
+                for key, value in paths.items():
+                    if isinstance(key, str) and value is not None:
+                        self.__paths[key] = str(value)
+
+            if not include_failures:
+                return
+
+            failures = payload.get("failures", None)
+            if not isinstance(failures, dict):
+                return
+
+            for key, value in failures.items():
+                if not isinstance(key, str):
+                    continue
+                # Accept only a real two-element sequence. A bare string would
+                # happily unpack into two characters, so reject anything that is
+                # not a list or tuple before looking at it.
+                if not isinstance(value, (list, tuple)) or len(value) != 2:
+                    continue
+                try:
+                    attempts = int(value[0])
+                except (TypeError, ValueError):
+                    continue
+                attempts = max(0, attempts)
+                # Keep whichever side has seen more failures so a merge can only
+                # ever tighten the remaining budget.
+                known, _ = self.__failures.get(key, (0, ""))
+                if attempts >= known:
+                    self.__failures[key] = (attempts, str(value[1]))
+
+    def clear(self) -> None:
+        """Removes all cached paths and recorded failures."""
+        with self.__lock:
+            self.__paths.clear()
+            self.__failures.clear()
+
+    # ------------------------------------------------------------------
+    # Download mutex
+    # ------------------------------------------------------------------
+    def thread_lock(self, cache_id: str) -> threading.Lock:
+        """
+        Returns the download lock for a data source, creating it if needed.
+
+        The lock is keyed by ``cache_id`` so it has the same granularity as the
+        inter-process lock file: threads fetching the same source contend, and
+        threads fetching unrelated sources do not.
+
+        Args:
+            cache_id (str): The resolver cache ID of the data source.
+
+        Returns:
+            threading.Lock: The lock guarding this source.
+        """
+        with self.__lock:
+            if cache_id not in self.__download_locks:
+                self.__download_locks[cache_id] = threading.Lock()
+            return self.__download_locks[cache_id]
+
+    def __repr__(self) -> str:
+        with self.__lock:
+            return (f"{type(self).__name__}(paths={len(self.__paths)}, "
+                    f"failures={len(self.__failures)}, "
+                    f"max_attempts={self.__max_attempts})")

--- a/siliconcompiler/scheduler/run_node.py
+++ b/siliconcompiler/scheduler/run_node.py
@@ -16,8 +16,8 @@ import tarfile
 import os.path
 
 from siliconcompiler import Project
-from siliconcompiler.package import Resolver
 from siliconcompiler.scheduler import SchedulerNode
+from siliconcompiler.utils.multiprocessing import MPManager
 from siliconcompiler._metadata import detailed_version
 
 
@@ -60,9 +60,9 @@ def main():
                         metavar='<directory>',
                         help="Option: user cache directory")
     parser.add_argument('-cachemap',
-                        metavar='<package>:<directory>',
+                        metavar='<cache_id>:<directory>',
                         nargs='+',
-                        help='Map of caches to prepopulate runner with')
+                        help='Map of resolved data source paths to prepopulate runner with')
     parser.add_argument('-step',
                         required=True,
                         metavar='<step>',
@@ -114,11 +114,17 @@ def main():
         for _, step, index in proj.option.scheduler.get('name', field=None).getvalues():
             proj.option.scheduler.unset('name', step=step, index=index)
 
-    # Pre-populate the package cache if a map is provided.
+    # Pre-populate the path cache if a map is provided. Keys are resolver cache
+    # IDs, which is what the cache is looked up by. A cache ID is a hex digest
+    # and so never contains a colon, while a path can (``C:\dir``), so the split
+    # is on the first colon and everything after it is the path.
     if args.cachemap:
+        cache = MPManager.get_path_cache()
         for cachepair in args.cachemap:
-            package, path = cachepair.split(':')
-            Resolver.set_cache(proj, package, path)
+            cache_id, sep, path = cachepair.partition(':')
+            if not cache_id or not sep or not path:
+                continue
+            cache.set(cache_id, path)
 
     # Instantiate the SchedulerNode for the specified step and index.
     error = True

--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -17,7 +17,7 @@ from siliconcompiler import utils, sc_open
 from siliconcompiler import NodeStatus
 from siliconcompiler.utils.logging import get_console_formatter, SCInRunLoggerFormatter
 
-from siliconcompiler.package import Resolver
+from siliconcompiler.utils.multiprocessing import MPManager
 from siliconcompiler.schema_support.record import RecordTime, RecordTool
 from siliconcompiler.schema import Journal, Parameter
 from siliconcompiler.scheduler import send_messages
@@ -378,6 +378,11 @@ class SchedulerNode:
         try:
             if msg:
                 self.logger.error(msg)
+
+            # Report resolved paths before exiting. A node that halts because a
+            # data source could not be fetched is exactly the node whose cache
+            # the parent needs, so this cannot wait for the end of run().
+            self._send_pathcache()
 
             self.__record.set("status", NodeStatus.ERROR, step=self.__step, index=self.__index)
             try:
@@ -893,8 +898,24 @@ class SchedulerNode:
         # Stop journaling
         journal.stop()
 
-        if self.__pipe:
-            self.__pipe.send(Resolver.get_cache(self.__project))
+        self._send_pathcache()
+
+    def _send_pathcache(self) -> None:
+        """
+        Sends this node's resolved data source paths back to the parent process.
+
+        A worker resolves data sources into its own copy of the cache, so the
+        results are handed back over the pipe for the parent to merge. Sending is
+        best effort: a broken or already closed pipe must never turn into a node
+        failure. Safe to call more than once.
+        """
+        if not self.__pipe:
+            return
+
+        try:
+            self.__pipe.send(MPManager.get_path_cache().export())
+        except (OSError, EOFError, BrokenPipeError, ConnectionResetError, ValueError):
+            pass
 
     @contextlib.contextmanager
     def __set_env(self):

--- a/siliconcompiler/scheduler/taskscheduler.py
+++ b/siliconcompiler/scheduler/taskscheduler.py
@@ -14,7 +14,6 @@ from siliconcompiler import NodeStatus
 from siliconcompiler import utils
 from siliconcompiler.flowgraph import RuntimeFlowgraph
 
-from siliconcompiler.package import Resolver
 from siliconcompiler.schema import Journal
 
 from siliconcompiler.utils.logging import SCBlankLoggerFormatter, \
@@ -324,10 +323,11 @@ class TaskScheduler:
                 # for a full second when a child died without writing.
                 if info["parent_pipe"] and info["parent_pipe"].poll(0):
                     try:
-                        packages = info["parent_pipe"].recv()
-                        if isinstance(packages, dict):
-                            for package, path in packages.items():
-                                Resolver.set_cache(self.__project, package, path)
+                        # Take the paths the node resolved, but not its failures:
+                        # a fetch that failed for one node may still succeed for
+                        # the next, so each node gets its own retry budget for now.
+                        MPManager.get_path_cache().seed(
+                            info["parent_pipe"].recv(), include_failures=False)
                     except:  # noqa E722
                         pass
 

--- a/siliconcompiler/utils/multiprocessing.py
+++ b/siliconcompiler/utils/multiprocessing.py
@@ -9,7 +9,7 @@ import warnings
 
 import os.path
 
-from typing import Iterator, Union, Optional
+from typing import Iterator, Union, Optional, TYPE_CHECKING
 
 from datetime import datetime
 from logging.handlers import QueueHandler
@@ -20,6 +20,9 @@ from siliconcompiler.utils.settings import SettingsManager
 from siliconcompiler.utils import default_sc_path, default_sc_system_path
 
 from siliconcompiler.report.dashboard.cli.board import Board
+
+if TYPE_CHECKING:
+    from siliconcompiler.package.cache import PathCache
 
 
 def get_process_context() -> BaseContext:
@@ -139,14 +142,21 @@ class _ManagerSingleton(type):
         If an instance of the class does not already exist, it creates one
         and stores it. Subsequent calls will return the existing instance.
         A special '_init_singleton' method is called on the first creation.
+
+        The instance is registered only once ``_init_singleton`` has finished.
+        The outer ``has_cls`` check deliberately skips the lock, so publishing
+        any earlier would hand a half-built instance to a second thread while
+        the first is still inside ``_init_singleton`` -- which, for
+        :class:`MPManager`, spends that time launching a manager process, a
+        wide window in which every attribute is still missing.
         """
         if not _ManagerSingleton.has_cls(cls):
             with _ManagerSingleton._lock:
                 if cls not in _ManagerSingleton._instances:
                     instance = super(_ManagerSingleton, cls).__call__(*args, **kwargs)
-                    _ManagerSingleton._instances[cls] = instance
                     # Custom initializer for the singleton instance
                     instance._init_singleton()
+                    _ManagerSingleton._instances[cls] = instance
         return _ManagerSingleton._instances[cls]
 
 
@@ -221,6 +231,12 @@ class MPManager(metaclass=_ManagerSingleton):
             default_sc_path("settings.json"), self.__logger,
             system_filepath=default_sc_system_path())
         self.__transient_settings = SettingsManager(None, self.__logger)
+
+        # Cache of paths that data sources have resolved to. Imported here rather
+        # than at module scope: siliconcompiler.package imports this module, so a
+        # top-level import would close a cycle.
+        from siliconcompiler.package.cache import PathCache
+        self.__path_cache = PathCache()
 
         # Register cleanup function to run at exit
         atexit.register(MPManager.stop)
@@ -368,6 +384,20 @@ class MPManager(metaclass=_ManagerSingleton):
             SettingsManager: The singleton transient settings instance.
         """
         return MPManager().__transient_settings
+
+    @staticmethod
+    def get_path_cache() -> "PathCache":
+        """
+        Provides access to the shared cache of resolved data source paths.
+
+        There is one cache per process. Entries are keyed by a content hash of a
+        data source's URI and reference, so a single cache serves every project,
+        library and design in the process without them colliding.
+
+        Returns:
+            PathCache: The singleton path cache instance.
+        """
+        return MPManager().__path_cache
 
     @staticmethod
     def get_dashboard() -> Board:

--- a/tests/package/test_cache.py
+++ b/tests/package/test_cache.py
@@ -1,0 +1,703 @@
+import contextlib
+import pytest
+import threading
+
+from unittest.mock import patch
+
+from siliconcompiler.package import PathCache
+from siliconcompiler.utils.multiprocessing import MPManager
+
+
+@contextlib.contextmanager
+def patch_sleep():
+    """Records sleep durations instead of waiting."""
+    sleeps = []
+    with patch("siliconcompiler.package.cache.time.sleep", side_effect=sleeps.append):
+        yield sleeps
+
+
+@contextlib.contextmanager
+def patch_nominal_jitter():
+    """Pins the randomized delay to the midpoint of its jitter band."""
+    with patch("siliconcompiler.package.cache.random.uniform",
+               side_effect=lambda low, high: (low + high) / 2):
+        yield
+
+
+def test_init_defaults():
+    cache = PathCache()
+
+    assert cache.max_attempts == PathCache.DEFAULT_MAX_ATTEMPTS
+    assert cache.max_attempts == 3
+    assert cache.retry_delay == PathCache.DEFAULT_RETRY_DELAY
+    assert cache.retry_backoff == PathCache.DEFAULT_RETRY_BACKOFF
+    assert cache.get("missing") is None
+    assert cache.attempts("missing") == 0
+    assert cache.failure("missing") is None
+    assert not cache.is_exhausted("missing")
+
+
+def test_set_get():
+    cache = PathCache()
+    cache.set("id", "/some/path")
+
+    assert cache.get("id") == "/some/path"
+
+
+def test_set_stringifies(tmp_path):
+    cache = PathCache()
+    cache.set("id", tmp_path)
+
+    assert cache.get("id") == str(tmp_path)
+    assert isinstance(cache.get("id"), str)
+
+
+def test_record_failure():
+    cache = PathCache()
+
+    assert cache.record_failure("id", ValueError("first")) == 1
+    assert cache.attempts("id") == 1
+    assert cache.failure("id") == "ValueError: first"
+    assert not cache.is_exhausted("id")
+
+    assert cache.record_failure("id", FileNotFoundError("second")) == 2
+    assert cache.record_failure("id", FileNotFoundError("third")) == 3
+    assert cache.attempts("id") == 3
+    assert cache.failure("id") == "FileNotFoundError: third"
+    assert cache.is_exhausted("id")
+
+
+def test_record_failure_is_per_id():
+    cache = PathCache()
+    cache.record_failure("id0", ValueError("nope"))
+
+    assert cache.attempts("id0") == 1
+    assert cache.attempts("id1") == 0
+
+
+def test_clear_failure():
+    cache = PathCache()
+    cache.record_failure("id", ValueError("nope"))
+    cache.clear_failure("id")
+
+    assert cache.attempts("id") == 0
+    assert cache.failure("id") is None
+
+    # Must not raise for an unknown id
+    cache.clear_failure("other")
+
+
+def test_set_max_attempts():
+    cache = PathCache()
+    cache.set_max_attempts(1)
+
+    assert cache.max_attempts == 1
+    assert not cache.is_exhausted("id")
+
+    cache.record_failure("id", ValueError("nope"))
+    assert cache.is_exhausted("id")
+
+
+@pytest.mark.parametrize("value", (0, -1))
+def test_set_max_attempts_invalid(value):
+    with pytest.raises(ValueError, match="^max_attempts must be greater than 0$"):
+        PathCache().set_max_attempts(value)
+
+
+def test_set_retry_delay():
+    cache = PathCache()
+    cache.set_retry_delay(0)
+
+    assert cache.retry_delay == 0
+
+
+def test_set_retry_delay_invalid():
+    with pytest.raises(ValueError, match="^retry_delay must not be negative$"):
+        PathCache().set_retry_delay(-1)
+
+
+def test_wait_before_retry_first_attempt():
+    """A source that has not failed yet is never delayed."""
+    cache = PathCache()
+    cache.set_retry_delay(30)
+
+    with patch_sleep() as sleeps:
+        cache.wait_before_retry("id")
+
+    assert sleeps == []
+
+
+def test_wait_before_retry_backs_off():
+    """Each delay grows by the backoff factor. Jitter is pinned to the nominal."""
+    cache = PathCache()
+    cache.set_retry_delay(2)
+    cache.set_retry_backoff(2)
+
+    seen = []
+    for _ in range(3):
+        cache.record_failure("id", ValueError("nope"))
+        with patch_nominal_jitter(), patch_sleep() as sleeps:
+            cache.wait_before_retry("id")
+        seen.extend(sleeps)
+
+    assert seen == [2, 4, 8]
+
+
+def test_default_retry_ladder():
+    """The shipped defaults give roughly 2s, 5s, 10s."""
+    cache = PathCache()
+
+    ladder = []
+    for _ in range(3):
+        cache.record_failure("id", ValueError("nope"))
+        with patch_nominal_jitter():
+            ladder.append(round(cache.next_retry_delay("id"), 1))
+
+    assert ladder == [2.0, 4.5, 10.1]
+
+
+def test_next_retry_delay_is_randomized():
+    """
+    Workers that failed together must not retry in unison, so the delay is
+    jittered either side of its nominal value.
+    """
+    cache = PathCache()
+    cache.set_retry_delay(10)
+    cache.record_failure("id", ValueError("nope"))
+
+    delays = {cache.next_retry_delay("id") for _ in range(50)}
+
+    # Actually varying, and inside the jitter band around the 10s nominal
+    assert len(delays) > 1
+    jitter = PathCache.RETRY_JITTER
+    assert all(10 * (1 - jitter) <= delay <= 10 * (1 + jitter) for delay in delays)
+
+
+def test_next_retry_delay_jitter_bounds():
+    """The band is exactly +/- RETRY_JITTER of nominal, at both extremes."""
+    cache = PathCache()
+    cache.set_retry_delay(8)
+    cache.set_retry_backoff(1)
+    cache.record_failure("id", ValueError("nope"))
+
+    with patch("siliconcompiler.package.cache.random.uniform",
+               side_effect=lambda low, high: low):
+        assert cache.next_retry_delay("id") == 8 * (1 - PathCache.RETRY_JITTER)
+
+    with patch("siliconcompiler.package.cache.random.uniform",
+               side_effect=lambda low, high: high):
+        assert cache.next_retry_delay("id") == 8 * (1 + PathCache.RETRY_JITTER)
+
+
+def test_next_retry_delay_is_capped():
+    """A large attempt budget must not turn the growth into an endless wait."""
+    cache = PathCache()
+    cache.set_max_attempts(50)
+    cache.set_retry_delay(2)
+
+    for _ in range(40):
+        cache.record_failure("id", ValueError("nope"))
+
+    assert cache.next_retry_delay("id") == PathCache.RETRY_MAX_DELAY
+
+
+def test_next_retry_delay_unknown_id():
+    assert PathCache().next_retry_delay("never-seen") == 0.0
+
+
+def test_next_retry_delay_zero_base():
+    cache = PathCache()
+    cache.set_retry_delay(0)
+    cache.record_failure("id", ValueError("nope"))
+
+    assert cache.next_retry_delay("id") == 0.0
+
+
+def test_set_retry_backoff():
+    cache = PathCache()
+    cache.set_retry_backoff(3)
+
+    assert cache.retry_backoff == 3
+
+
+def test_set_retry_backoff_of_one_is_constant():
+    cache = PathCache()
+    cache.set_retry_delay(5)
+    cache.set_retry_backoff(1)
+
+    ladder = []
+    for _ in range(3):
+        cache.record_failure("id", ValueError("nope"))
+        with patch_nominal_jitter():
+            ladder.append(cache.next_retry_delay("id"))
+
+    assert ladder == [5, 5, 5]
+
+
+def test_wait_before_retry_zero_delay():
+    cache = PathCache()
+    cache.set_retry_delay(0)
+    cache.record_failure("id", ValueError("nope"))
+
+    with patch_sleep() as sleeps:
+        cache.wait_before_retry("id")
+
+    assert sleeps == []
+
+
+def test_export():
+    cache = PathCache()
+    cache.set("id0", "/path0")
+    cache.record_failure("id1", ValueError("nope"))
+
+    assert cache.export() == {
+        "paths": {"id0": "/path0"},
+        "failures": {"id1": [1, "ValueError: nope"]}
+    }
+
+
+def test_export_is_a_copy():
+    cache = PathCache()
+    cache.set("id0", "/path0")
+
+    export = cache.export()
+    export["paths"]["id0"] = "/tampered"
+
+    assert cache.get("id0") == "/path0"
+
+
+def test_seed_roundtrip():
+    source = PathCache()
+    source.set("id0", "/path0")
+    source.record_failure("id1", ValueError("nope"))
+
+    dest = PathCache()
+    dest.seed(source.export())
+
+    assert dest.get("id0") == "/path0"
+    assert dest.attempts("id1") == 1
+    assert dest.failure("id1") == "ValueError: nope"
+
+
+def test_seed_ignore_failures():
+    source = PathCache()
+    source.set("id0", "/path0")
+    source.record_failure("id1", ValueError("nope"))
+
+    dest = PathCache()
+    dest.seed(source.export(), include_failures=False)
+
+    assert dest.get("id0") == "/path0"
+    assert dest.attempts("id1") == 0
+    assert dest.failure("id1") is None
+
+
+def test_seed_keeps_highest_attempt_count():
+    source = PathCache()
+    source.record_failure("id", ValueError("one"))
+
+    dest = PathCache()
+    dest.record_failure("id", ValueError("a"))
+    dest.record_failure("id", ValueError("b"))
+
+    # Merging may only ever tighten the remaining budget
+    dest.seed(source.export())
+    assert dest.attempts("id") == 2
+    assert dest.failure("id") == "ValueError: b"
+
+    source.record_failure("id", ValueError("two"))
+    source.record_failure("id", ValueError("three"))
+    dest.seed(source.export())
+    assert dest.attempts("id") == 3
+    assert dest.failure("id") == "ValueError: three"
+
+
+@pytest.mark.parametrize("payload", (None, "notadict", 5, [], {"paths": "notadict"},
+                                     {"failures": "notadict"}, {}))
+def test_seed_tolerates_junk(payload):
+    cache = PathCache()
+    cache.set("id", "/path")
+
+    cache.seed(payload)
+
+    assert cache.get("id") == "/path"
+
+
+def test_seed_tolerates_malformed_failures():
+    cache = PathCache()
+    cache.seed({"failures": {"id0": "nottuple", "id1": [2, "ValueError: nope"]}})
+
+    assert cache.attempts("id0") == 0
+    assert cache.attempts("id1") == 2
+
+
+def test_clear():
+    cache = PathCache()
+    cache.set("id0", "/path0")
+    cache.record_failure("id1", ValueError("nope"))
+
+    cache.clear()
+
+    assert cache.get("id0") is None
+    assert cache.attempts("id1") == 0
+
+
+def test_clear_keeps_policy():
+    cache = PathCache()
+    cache.set_max_attempts(7)
+    cache.set_retry_delay(0)
+    cache.set_retry_backoff(4)
+
+    cache.clear()
+
+    assert cache.max_attempts == 7
+    assert cache.retry_delay == 0
+    assert cache.retry_backoff == 4
+
+
+def test_thread_lock_is_stable():
+    cache = PathCache()
+
+    assert cache.thread_lock("id") is cache.thread_lock("id")
+
+
+def test_thread_lock_is_per_id():
+    cache = PathCache()
+
+    assert cache.thread_lock("id0") is not cache.thread_lock("id1")
+
+
+# ============================================================================
+# Ownership
+# ============================================================================
+
+def test_repr():
+    cache = PathCache()
+    cache.set("id0", "/path")
+    cache.record_failure("id1", ValueError("nope"))
+
+    assert repr(cache) == "PathCache(paths=1, failures=1, max_attempts=3)"
+
+
+def test_mpmanager_owns_one_cache():
+    cache = MPManager.get_path_cache()
+
+    assert isinstance(cache, PathCache)
+    assert MPManager.get_path_cache() is cache
+
+
+def test_cache_is_discarded_with_mpmanager():
+    """The cache belongs to the process, so it dies with the manager."""
+    cache = MPManager.get_path_cache()
+    cache.set("id", "/path")
+
+    MPManager.stop()
+
+    assert MPManager.get_path_cache() is not cache
+    assert MPManager.get_path_cache().get("id") is None
+
+
+def test_cache_is_shared_across_schemas():
+    """
+    Cache IDs are content hashes, so one cache serves every schema in the process:
+    the same source at the same reference always resolves to the same path.
+    """
+    from siliconcompiler import Design, Project
+
+    project = Project("testproj")
+    design = Design("testdesign")
+
+    MPManager.get_path_cache().set("id", "/path")
+
+    from siliconcompiler.package import Resolver
+    assert Resolver("n", project, "source://x").cache.get("id") == "/path"
+    assert Resolver("n", design, "source://x").cache.get("id") == "/path"
+    assert Resolver("n", None, "source://x").cache.get("id") == "/path"
+
+
+def test_cache_is_reachable_before_any_project_exists():
+    """A resolver with no schema context must still find the cache."""
+    from siliconcompiler.package import Resolver
+
+    assert Resolver("n", None, "source://x").cache is MPManager.get_path_cache()
+
+
+# ============================================================================
+# Poor inputs
+# ============================================================================
+
+@pytest.mark.parametrize("value", ("notanumber", None, [], {}, object()))
+def test_set_max_attempts_not_a_number(value):
+    cache = PathCache()
+
+    with pytest.raises((TypeError, ValueError), match="^max_attempts must be an integer"):
+        cache.set_max_attempts(value)
+
+    # Rejected input must leave the policy untouched
+    assert cache.max_attempts == PathCache.DEFAULT_MAX_ATTEMPTS
+
+
+def test_set_max_attempts_truncates_float():
+    cache = PathCache()
+    cache.set_max_attempts(2.9)
+
+    assert cache.max_attempts == 2
+
+
+def test_set_max_attempts_rejects_bool_false():
+    with pytest.raises(ValueError, match="^max_attempts must be greater than 0$"):
+        PathCache().set_max_attempts(False)
+
+
+@pytest.mark.parametrize("value", ("notanumber", None, [], {}, object()))
+def test_set_retry_delay_not_a_number(value):
+    cache = PathCache()
+
+    with pytest.raises((TypeError, ValueError), match="^retry_delay must be a number"):
+        cache.set_retry_delay(value)
+
+    assert cache.retry_delay == PathCache.DEFAULT_RETRY_DELAY
+
+
+@pytest.mark.parametrize("value", (float("nan"), float("inf"), float("-inf")))
+def test_set_retry_delay_rejects_non_finite(value):
+    """nan and inf slip past a plain "< 0" test and would break time.sleep()."""
+    cache = PathCache()
+
+    with pytest.raises(ValueError, match="^retry_delay must be finite$"):
+        cache.set_retry_delay(value)
+
+    assert cache.retry_delay == PathCache.DEFAULT_RETRY_DELAY
+
+
+@pytest.mark.parametrize("value", ("notanumber", None, [], {}, object()))
+def test_set_retry_backoff_not_a_number(value):
+    cache = PathCache()
+
+    with pytest.raises((TypeError, ValueError), match="^retry_backoff must be a number"):
+        cache.set_retry_backoff(value)
+
+    assert cache.retry_backoff == PathCache.DEFAULT_RETRY_BACKOFF
+
+
+@pytest.mark.parametrize("value", (float("nan"), float("inf"), float("-inf")))
+def test_set_retry_backoff_rejects_non_finite(value):
+    """inf would make the very first retry wait forever."""
+    cache = PathCache()
+
+    with pytest.raises(ValueError, match="^retry_backoff must be finite$"):
+        cache.set_retry_backoff(value)
+
+    assert cache.retry_backoff == PathCache.DEFAULT_RETRY_BACKOFF
+
+
+@pytest.mark.parametrize("value", (0, 0.5, -1))
+def test_set_retry_backoff_rejects_shrinking(value):
+    """A factor below 1 would shrink each delay, which is backwards."""
+    cache = PathCache()
+
+    with pytest.raises(ValueError, match="^retry_backoff must be at least 1$"):
+        cache.set_retry_backoff(value)
+
+    assert cache.retry_backoff == PathCache.DEFAULT_RETRY_BACKOFF
+
+
+def test_huge_backoff_is_still_capped():
+    """Even an absurd factor cannot produce an unbounded wait."""
+    cache = PathCache()
+    cache.set_retry_backoff(10 ** 6)
+    cache.record_failure("id", ValueError("nope"))
+    cache.record_failure("id", ValueError("nope"))
+
+    assert cache.next_retry_delay("id") == PathCache.RETRY_MAX_DELAY
+
+
+@pytest.mark.parametrize("cache_id", (None, 5, (), True))
+def test_hashable_but_odd_cache_ids(cache_id):
+    """Odd but hashable keys are stored without complaint or collision."""
+    cache = PathCache()
+    cache.set(cache_id, "/path")
+    cache.record_failure(cache_id, ValueError("nope"))
+
+    assert cache.get(cache_id) == "/path"
+    assert cache.attempts(cache_id) == 1
+    assert cache.get("other") is None
+
+
+@pytest.mark.parametrize("cache_id", ([], {}, set()))
+def test_unhashable_cache_ids(cache_id):
+    """An unhashable key raises where a key must be resolved."""
+    cache = PathCache()
+
+    for call in (lambda: cache.get(cache_id),
+                 lambda: cache.set(cache_id, "/path"),
+                 lambda: cache.attempts(cache_id),
+                 lambda: cache.failure(cache_id),
+                 lambda: cache.is_exhausted(cache_id),
+                 lambda: cache.record_failure(cache_id, ValueError("nope")),
+                 lambda: cache.thread_lock(cache_id)):
+        with pytest.raises(TypeError):
+            call()
+
+
+@pytest.mark.parametrize("cache_id", ([], {}, set()))
+def test_unhashable_cache_id_leaves_cache_usable(cache_id):
+    """
+    Whether an unhashable key raises or is quietly ignored, it must never leave
+    the cache damaged or holding its internal lock.
+    """
+    cache = PathCache()
+    cache.set("good", "/path")
+
+    # clear_failure is a no-op rather than an error while nothing has failed:
+    # dict.pop with a default skips hashing on an empty dict.
+    cache.clear_failure(cache_id)
+
+    cache.record_failure("good", ValueError("nope"))
+    with pytest.raises(TypeError):
+        cache.clear_failure(cache_id)
+
+    # Still fully usable, and the lock was released on every path
+    assert cache.get("good") == "/path"
+    cache.set("more", "/other")
+    assert cache.export() == {
+        "paths": {"good": "/path", "more": "/other"},
+        "failures": {"good": [1, "ValueError: nope"]}
+    }
+
+
+def test_record_failure_with_odd_errors():
+    """Errors carrying awkward messages must still be storable as text."""
+    cache = PathCache()
+
+    class Weird(Exception):
+        def __str__(self):
+            return "\x00binary\n\tmess"
+
+    cache.record_failure("id", Weird())
+    assert cache.failure("id") == "Weird: \x00binary\n\tmess"
+
+    cache.record_failure("id2", ValueError())
+    assert cache.failure("id2") == "ValueError: "
+
+
+def test_set_with_none_path():
+    """None is recorded as the string "None" rather than silently vanishing."""
+    cache = PathCache()
+    cache.set("id", None)
+
+    assert cache.get("id") == "None"
+
+
+@pytest.mark.parametrize("payload", (
+    {"paths": {5: "/path"}},
+    {"paths": {None: "/path"}},
+    {"paths": {(): "/path"}},
+))
+def test_seed_skips_non_string_path_keys(payload):
+    cache = PathCache()
+    cache.seed(payload)
+
+    assert cache.export()["paths"] == {}
+
+
+def test_seed_skips_none_path_values():
+    cache = PathCache()
+    cache.seed({"paths": {"id0": None, "id1": "/path"}})
+
+    assert cache.export()["paths"] == {"id1": "/path"}
+
+
+def test_seed_coerces_path_values():
+    cache = PathCache()
+    cache.seed({"paths": {"id0": 5, "id1": ["a"]}})
+
+    assert cache.get("id0") == "5"
+    assert cache.get("id1") == "['a']"
+
+
+@pytest.mark.parametrize("value", (
+    "ab",             # a 2-char string would unpack into two characters
+    [1],              # too short
+    [1, "msg", 3],    # too long
+    None,
+    5,
+    {"attempts": 1},
+    [object(), "msg"],
+    ["notanint", "msg"],
+))
+def test_seed_skips_malformed_failure_entries(value):
+    cache = PathCache()
+    cache.seed({"failures": {"id": value}})
+
+    assert cache.attempts("id") == 0
+    assert cache.failure("id") is None
+
+
+def test_seed_skips_non_string_failure_keys():
+    cache = PathCache()
+    cache.seed({"failures": {5: [1, "msg"]}})
+
+    assert cache.export()["failures"] == {}
+
+
+def test_seed_clamps_negative_attempts():
+    cache = PathCache()
+    cache.seed({"failures": {"id": [-5, "msg"]}})
+
+    assert cache.attempts("id") == 0
+    assert not cache.is_exhausted("id")
+
+
+def test_seed_coerces_failure_fields():
+    cache = PathCache()
+    cache.seed({"failures": {"id": ("2", 5)}})
+
+    assert cache.attempts("id") == 2
+    assert cache.failure("id") == "5"
+
+
+def test_seed_huge_attempt_count_exhausts():
+    cache = PathCache()
+    cache.seed({"failures": {"id": [10 ** 9, "msg"]}})
+
+    assert cache.is_exhausted("id")
+
+
+def test_seed_partial_payload_keeps_valid_entries():
+    """One bad entry must not discard the good ones alongside it."""
+    cache = PathCache()
+    cache.seed({
+        "paths": {"good": "/path", 5: "/skipped"},
+        "failures": {"good": [2, "msg"], "bad": "junk"}
+    })
+
+    assert cache.get("good") == "/path"
+    assert cache.attempts("good") == 2
+    assert cache.attempts("bad") == 0
+
+
+def test_wait_before_retry_unknown_id():
+    cache = PathCache()
+
+    with patch_sleep() as sleeps:
+        cache.wait_before_retry("never-seen")
+
+    assert sleeps == []
+
+
+def test_thread_safe_record_failure():
+    cache = PathCache()
+    cache.set_max_attempts(1000)
+
+    def hammer():
+        for _ in range(100):
+            cache.record_failure("id", ValueError("nope"))
+
+    threads = [threading.Thread(target=hammer) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert cache.attempts("id") == 800

--- a/tests/package/test_cache.py
+++ b/tests/package/test_cache.py
@@ -198,7 +198,49 @@ def test_next_retry_delay_is_capped():
     for _ in range(40):
         cache.record_failure("id", ValueError("nope"))
 
-    assert cache.next_retry_delay("id") == PathCache.RETRY_MAX_DELAY
+    # Jitter still applies at the ceiling, so the delay sits in the band below it
+    delay = cache.next_retry_delay("id")
+    assert PathCache.RETRY_MAX_DELAY * (1 - PathCache.RETRY_JITTER) <= delay
+    assert delay <= PathCache.RETRY_MAX_DELAY
+
+
+def test_next_retry_delay_at_ceiling_is_still_jittered():
+    """Workers that all reached the cap must not resume in lockstep."""
+    cache = PathCache()
+    cache.set_max_attempts(50)
+    cache.set_retry_delay(2)
+    for _ in range(40):
+        cache.record_failure("id", ValueError("nope"))
+
+    assert len({cache.next_retry_delay("id") for _ in range(50)}) > 1
+
+
+@pytest.mark.parametrize("attempts", (10 ** 3, 10 ** 6, 10 ** 9))
+def test_next_retry_delay_survives_huge_attempt_counts(attempts):
+    """
+    The exponential is capped before it is raised to a power. Left unguarded it
+    exceeds the float range and raises OverflowError from inside path resolution.
+    """
+    cache = PathCache()
+    cache.set_max_attempts(10 ** 12)
+    cache.seed({"failures": {"id": [attempts, "msg"]}})
+
+    delay = cache.next_retry_delay("id")
+
+    assert delay <= PathCache.RETRY_MAX_DELAY
+    assert delay > 0
+
+
+def test_wait_before_retry_survives_huge_attempt_counts():
+    cache = PathCache()
+    cache.set_max_attempts(10 ** 12)
+    cache.seed({"failures": {"id": [10 ** 9, "msg"]}})
+
+    with patch_sleep() as sleeps:
+        cache.wait_before_retry("id")
+
+    assert len(sleeps) == 1
+    assert sleeps[0] <= PathCache.RETRY_MAX_DELAY
 
 
 def test_next_retry_delay_unknown_id():
@@ -509,7 +551,18 @@ def test_huge_backoff_is_still_capped():
     cache.record_failure("id", ValueError("nope"))
     cache.record_failure("id", ValueError("nope"))
 
-    assert cache.next_retry_delay("id") == PathCache.RETRY_MAX_DELAY
+    delay = cache.next_retry_delay("id")
+    assert PathCache.RETRY_MAX_DELAY * (1 - PathCache.RETRY_JITTER) <= delay
+    assert delay <= PathCache.RETRY_MAX_DELAY
+
+
+def test_huge_backoff_with_huge_attempts_does_not_overflow():
+    cache = PathCache()
+    cache.set_max_attempts(10 ** 6)
+    cache.set_retry_backoff(10 ** 6)
+    cache.seed({"failures": {"id": [10 ** 5, "msg"]}})
+
+    assert cache.next_retry_delay("id") <= PathCache.RETRY_MAX_DELAY
 
 
 @pytest.mark.parametrize("cache_id", (None, 5, (), True))

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -1460,7 +1460,7 @@ def test_dataroot_resolver_does_not_share_cache():
 
     # Same source string, so the same cache ID: the entry cannot be shared
     assert res_a.cache_id == res_b.cache_id
-    assert not DatarootResolver._shared_cache
+    assert DatarootResolver._indirect
 
     assert res_a.get_path() == os.path.abspath("dataA")
     assert res_b.get_path() == os.path.abspath("dataB")
@@ -1482,18 +1482,61 @@ def test_keypath_resolver_does_not_share_cache():
     res_b = KeyPathResolver("k", design_b, "key://fileset,rtl,idir")
 
     assert res_a.cache_id == res_b.cache_id
-    assert not KeyPathResolver._shared_cache
+    assert KeyPathResolver._indirect
 
     assert res_a.get_path() == os.path.abspath("dataA")
     assert res_b.get_path() == os.path.abspath("dataB")
 
 
-def test_portable_sources_do_share_cache():
-    """A source that means the same thing everywhere is still cached once."""
-    assert Resolver._shared_cache
-    assert RemoteResolver._shared_cache
-    assert FileResolver._shared_cache
-    assert PythonPathResolver._shared_cache
+def test_direct_sources_are_cached():
+    """A source that names a location of its own is cached and announced."""
+    assert not Resolver._indirect
+    assert not RemoteResolver._indirect
+    assert not FileResolver._indirect
+    assert not PythonPathResolver._indirect
+
+
+def test_indirect_resolver_does_not_repeat_the_log():
+    """
+    An indirection resolves every time, so it must not announce the location on
+    every call -- and the resolver it delegates to already reported it once.
+    Without this, a fileset behind a dataroot:// emitted one line per file per
+    find_files call.
+    """
+    os.makedirs("data", exist_ok=True)
+    for num in range(10):
+        Path(f"data/f{num}.v").touch()
+
+    design = Design("testdesign")
+    design.set_dataroot("inner", os.path.abspath("data"))
+    design.set_dataroot("outer", "dataroot://inner")
+    with design.active_fileset("rtl"), design.active_dataroot("outer"):
+        for num in range(10):
+            design.add_file(f"f{num}.v")
+
+    messages = []
+
+    class Collect(logging.Handler):
+        def emit(self, record):
+            messages.append(record.getMessage())
+
+    # Resolvers log under the root "siliconcompiler" logger, which does not
+    # propagate, so attach directly rather than using caplog.
+    sc_logger = logging.getLogger("siliconcompiler")
+    handler = Collect()
+    sc_logger.addHandler(handler)
+    old_level = sc_logger.level
+    sc_logger.setLevel(logging.INFO)
+    try:
+        for _ in range(3):
+            found = design.find_files("fileset", "rtl", "file", "verilog")
+            assert len(found) == 10
+    finally:
+        sc_logger.removeHandler(handler)
+        sc_logger.setLevel(old_level)
+
+    # Exactly one announcement, from the dataroot the indirection points at
+    assert len([msg for msg in messages if "data at" in msg]) == 1
 
 
 # ============================================================================

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -971,11 +971,11 @@ def test_remote_lock_timeout_does_not_release_holder():
     with holder.lock():
         with pytest.raises(RuntimeError, match=r"Another thread is currently holding the lock\."):
             with waiter.lock():
-                assert False, "should not get here"
+                pytest.fail("should not get here")
 
         with pytest.raises(RuntimeError, match=r"Another thread is currently holding the lock\."):
             with intruder.lock():
-                assert False, "should not get here"
+                pytest.fail("should not get here")
 
 
 def test_remote_thread_lock_is_per_source():
@@ -1439,6 +1439,61 @@ def test_resolver_cache_shared_between_projects():
 
     res0.cache.set(res0.cache_id, "/resolved/once")
     assert res1.cache.get(res1.cache_id) == "/resolved/once"
+
+
+def test_dataroot_resolver_does_not_share_cache():
+    """
+    A dataroot name means something different in every schema, so two schemas
+    using one name must not collide in the process-wide cache and hand each other
+    the wrong path.
+    """
+    os.makedirs("dataA", exist_ok=True)
+    os.makedirs("dataB", exist_ok=True)
+
+    design_a = Design("designA")
+    design_a.set_dataroot("shared_name", os.path.abspath("dataA"))
+    design_b = Design("designB")
+    design_b.set_dataroot("shared_name", os.path.abspath("dataB"))
+
+    res_a = DatarootResolver("shared_name", design_a, "dataroot://shared_name")
+    res_b = DatarootResolver("shared_name", design_b, "dataroot://shared_name")
+
+    # Same source string, so the same cache ID: the entry cannot be shared
+    assert res_a.cache_id == res_b.cache_id
+    assert not DatarootResolver._shared_cache
+
+    assert res_a.get_path() == os.path.abspath("dataA")
+    assert res_b.get_path() == os.path.abspath("dataB")
+
+
+def test_keypath_resolver_does_not_share_cache():
+    """The same keypath names a different file in every schema."""
+    os.makedirs("dataA", exist_ok=True)
+    os.makedirs("dataB", exist_ok=True)
+
+    design_a = Design("designA")
+    with design_a.active_fileset("rtl"):
+        design_a.add_idir("dataA")
+    design_b = Design("designB")
+    with design_b.active_fileset("rtl"):
+        design_b.add_idir("dataB")
+
+    res_a = KeyPathResolver("k", design_a, "key://fileset,rtl,idir")
+    res_b = KeyPathResolver("k", design_b, "key://fileset,rtl,idir")
+
+    assert res_a.cache_id == res_b.cache_id
+    assert not KeyPathResolver._shared_cache
+
+    assert res_a.get_path() == os.path.abspath("dataA")
+    assert res_b.get_path() == os.path.abspath("dataB")
+
+
+def test_portable_sources_do_share_cache():
+    """A source that means the same thing everywhere is still cached once."""
+    assert Resolver._shared_cache
+    assert RemoteResolver._shared_cache
+    assert FileResolver._shared_cache
+    assert PythonPathResolver._shared_cache
 
 
 # ============================================================================

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -1460,7 +1460,7 @@ def test_dataroot_resolver_does_not_share_cache():
 
     # Same source string, so the same cache ID: the entry cannot be shared
     assert res_a.cache_id == res_b.cache_id
-    assert DatarootResolver._indirect
+    assert res_a.is_indirect
 
     assert res_a.get_path() == os.path.abspath("dataA")
     assert res_b.get_path() == os.path.abspath("dataB")
@@ -1482,18 +1482,29 @@ def test_keypath_resolver_does_not_share_cache():
     res_b = KeyPathResolver("k", design_b, "key://fileset,rtl,idir")
 
     assert res_a.cache_id == res_b.cache_id
-    assert KeyPathResolver._indirect
+    assert res_a.is_indirect
 
     assert res_a.get_path() == os.path.abspath("dataA")
     assert res_b.get_path() == os.path.abspath("dataB")
 
 
-def test_direct_sources_are_cached():
-    """A source that names a location of its own is cached and announced."""
-    assert not Resolver._indirect
-    assert not RemoteResolver._indirect
-    assert not FileResolver._indirect
-    assert not PythonPathResolver._indirect
+@pytest.mark.parametrize("build,indirect,retryable", (
+    (lambda p: Resolver("n", p, "source://x"), False, False),
+    (lambda p: FileResolver("n", p, os.path.abspath(".")), False, False),
+    (lambda p: PythonPathResolver("n", p, "python://siliconcompiler"), False, False),
+    (lambda p: RemoteResolver("n", p, "https://x", "ref"), False, True),
+    (lambda p: KeyPathResolver("n", p, "key://option,builddir"), True, False),
+    (lambda p: DatarootResolver("n", p, "dataroot://x"), True, False),
+), ids=("resolver", "file", "python", "remote", "keypath", "dataroot"))
+def test_resolver_kind_matrix(build, indirect, retryable):
+    """
+    Only an expensive source is worth retrying, and only an indirection opts out
+    of the cache and the announcement.
+    """
+    resolver = build(Project("testproj"))
+
+    assert resolver.is_indirect is indirect
+    assert resolver.is_retryable is retryable
 
 
 def test_indirect_resolver_does_not_repeat_the_log():

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -16,6 +16,8 @@ import siliconcompiler
 from siliconcompiler.package import Resolver, RemoteResolver
 from siliconcompiler.package import FileResolver, PythonPathResolver, \
     KeyPathResolver, DatarootResolver
+from siliconcompiler.package import DataRootResolutionError
+from siliconcompiler.utils.multiprocessing import MPManager
 from siliconcompiler.package import InterProcessLock as dut_ipl
 
 from siliconcompiler import Project, Design
@@ -425,7 +427,7 @@ def test_get_path_usecache(project_logger, caplog):
     proj.logger.setLevel(logging.INFO)
 
     resolver = AlwaysCache("alwayscache", proj, "notused", "notused")
-    Resolver.set_cache(proj, resolver.cache_id, "path")
+    MPManager.get_path_cache().set(resolver.cache_id, "path")
     assert resolver.get_path() == "path"
 
     assert caplog.text == ""
@@ -567,6 +569,272 @@ def test_remote_resolve_cached():
         resolve_remote.assert_not_called()
 
 
+class FailingResolver(RemoteResolver):
+    """A remote source that never resolves, counting each attempt."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.calls = 0
+
+    def check_cache(self):
+        return False
+
+    @property
+    def cache_path(self):
+        return Path(os.path.abspath("neverthere"))
+
+    def resolve_remote(self):
+        self.calls += 1
+        raise FileNotFoundError("simulated 404")
+
+
+@pytest.fixture
+def failing_resolver():
+    """Builds a failing remote resolver with retry delays disabled."""
+    def build(root=None, source="https://filepath", reference="ref"):
+        if root is None:
+            root = Project("testproj")
+            root.option.set_cachedir(".")
+        resolver = FailingResolver("thisname", root, source, reference)
+        resolver.cache.set_retry_delay(0)
+        return resolver
+
+    return build
+
+
+def test_get_path_failure_is_bounded(failing_resolver):
+    """Repeated lookups must consume a budget, not re-download forever."""
+    resolver = failing_resolver()
+
+    for _ in range(10):
+        with pytest.raises((FileNotFoundError, DataRootResolutionError)):
+            resolver.get_path()
+
+    assert resolver.calls == 3
+    assert resolver.cache.attempts(resolver.cache_id) == 3
+    assert resolver.cache.is_exhausted(resolver.cache_id)
+
+
+def test_get_path_failure_raises_original_until_exhausted(failing_resolver):
+    resolver = failing_resolver()
+
+    # Every real attempt reports the underlying error
+    for _ in range(3):
+        with pytest.raises(FileNotFoundError, match="^simulated 404$"):
+            resolver.get_path()
+
+    # After that the source is abandoned without another attempt
+    with pytest.raises(DataRootResolutionError):
+        resolver.get_path()
+    assert resolver.calls == 3
+
+
+def test_get_path_abandoned_message(failing_resolver):
+    resolver = failing_resolver()
+
+    for _ in range(3):
+        with pytest.raises(FileNotFoundError):
+            resolver.get_path()
+
+    with pytest.raises(DataRootResolutionError, match=(
+            r"^Unable to resolve 'thisname' from https://filepath \(ref\) after 3 attempt\(s\), "
+            r"giving up\. Last error: FileNotFoundError: simulated 404$")):
+        resolver.get_path()
+
+
+def test_get_path_abandoned_is_logged(failing_resolver, project_logger, caplog):
+    project = Project("testproj")
+    project.option.set_cachedir(".")
+    project_logger(project)
+    project.logger.setLevel(logging.INFO)
+
+    resolver = failing_resolver(root=project)
+    for _ in range(3):
+        with pytest.raises(FileNotFoundError):
+            resolver.get_path()
+
+    assert "Unable to resolve 'thisname' from https://filepath (ref) after 3 attempt(s)" \
+        in caplog.text
+
+
+def test_get_path_max_attempts_honored(failing_resolver):
+    resolver = failing_resolver()
+    resolver.cache.set_max_attempts(1)
+
+    with pytest.raises(FileNotFoundError):
+        resolver.get_path()
+    with pytest.raises(DataRootResolutionError):
+        resolver.get_path()
+
+    assert resolver.calls == 1
+
+
+def test_get_path_budget_is_shared_between_resolvers(failing_resolver):
+    """
+    The budget is tracked per source for the whole process, so two resolvers --
+    even ones belonging to different projects -- draw from one pool rather than
+    each getting their own three attempts.
+    """
+    first = failing_resolver(root=Project("testproj0"))
+    second = failing_resolver(root=Project("testproj1"))
+
+    for _ in range(2):
+        with pytest.raises(FileNotFoundError):
+            first.get_path()
+    with pytest.raises(FileNotFoundError):
+        second.get_path()
+
+    with pytest.raises(DataRootResolutionError):
+        second.get_path()
+
+    assert first.calls == 2
+    assert second.calls == 1
+
+
+def test_get_path_budget_is_per_source(failing_resolver):
+    project = Project("testproj")
+    project.option.set_cachedir(".")
+
+    first = failing_resolver(root=project, source="https://filepath")
+    second = failing_resolver(root=project, source="https://otherpath")
+
+    for _ in range(4):
+        with pytest.raises((FileNotFoundError, DataRootResolutionError)):
+            first.get_path()
+    with pytest.raises(FileNotFoundError):
+        second.get_path()
+
+    assert first.calls == 3
+    assert second.calls == 1
+
+
+def test_get_path_retries_wait(failing_resolver):
+    """Backoff grows exponentially and is skipped on the first try."""
+    resolver = failing_resolver()
+    resolver.cache.set_retry_delay(2)
+    resolver.cache.set_retry_backoff(2)
+
+    with patch("siliconcompiler.package.cache.random.uniform",
+               side_effect=lambda low, high: (low + high) / 2), \
+         patch("siliconcompiler.package.cache.time.sleep") as sleep:
+        for _ in range(3):
+            with pytest.raises(FileNotFoundError):
+                resolver.get_path()
+
+    # First attempt is immediate; the two retries back off
+    assert [call.args[0] for call in sleep.call_args_list] == [2, 4]
+
+
+def test_get_path_retry_waits_are_randomized(failing_resolver):
+    """Two workers that failed together must not retry at the same moment."""
+    delays = set()
+
+    # A distinct source per round, so each starts with a fresh budget: the cache
+    # is process-wide, so reusing one source would exhaust it on the first round.
+    for num in range(20):
+        resolver = failing_resolver(source=f"https://filepath{num}")
+        resolver.cache.set_retry_delay(10)
+
+        with patch("siliconcompiler.package.cache.time.sleep") as sleep:
+            with pytest.raises(FileNotFoundError):
+                resolver.get_path()
+            with pytest.raises(FileNotFoundError):
+                resolver.get_path()
+
+        delays.add(sleep.call_args_list[0].args[0])
+
+    assert len(delays) > 1
+
+
+def test_get_path_success_clears_failures(failing_resolver):
+    """A source that recovers is cached and never attempted again."""
+    resolver = failing_resolver()
+
+    def flaky():
+        resolver.calls += 1
+        if resolver.calls < 3:
+            raise FileNotFoundError("simulated 404")
+        os.makedirs("neverthere", exist_ok=True)
+
+    with patch.object(FailingResolver, "resolve_remote", side_effect=flaky):
+        for _ in range(2):
+            with pytest.raises(FileNotFoundError):
+                resolver.get_path()
+        assert resolver.cache.attempts(resolver.cache_id) == 2
+
+        assert resolver.get_path() == os.path.abspath("neverthere")
+        assert resolver.calls == 3
+        assert resolver.cache.attempts(resolver.cache_id) == 0
+
+        # Now cached, so no further attempts
+        assert resolver.get_path() == os.path.abspath("neverthere")
+        assert resolver.calls == 3
+
+
+@pytest.mark.parametrize("errorcls", (KeyboardInterrupt, SystemExit))
+def test_get_path_interrupt_does_not_consume_budget(failing_resolver, errorcls):
+    """An interrupt says nothing about whether a source is reachable."""
+    resolver = failing_resolver()
+
+    def interrupt():
+        resolver.calls += 1
+        raise errorcls("interrupted")
+
+    with patch("shutil.rmtree"), \
+         patch.object(FailingResolver, "resolve_remote", side_effect=interrupt):
+        for _ in range(5):
+            with pytest.raises(errorcls):
+                resolver.get_path()
+
+    assert resolver.calls == 5
+    assert resolver.cache.attempts(resolver.cache_id) == 0
+
+
+def test_get_path_local_failure_is_not_tracked():
+    """Local sources fail instantly, so there is nothing to budget."""
+    design = Design("testdesign")
+    design.set_dataroot("dataA", "dataroot://dataB")
+    design.set_dataroot("dataB", "dataroot://dataA")
+
+    resolver = DatarootResolver("thisname", design, "dataroot://dataA")
+
+    for _ in range(5):
+        with pytest.raises(RuntimeError, match="Circular dataroot reference detected"):
+            resolver.get_path()
+
+    assert resolver.cache.attempts(resolver.cache_id) == 0
+
+
+def test_find_files_failure_is_bounded():
+    """
+    A dataroot is resolved once per path entry, so a failing dataroot used to be
+    re-downloaded once per file, on every find_files call.
+    """
+    design = Design("testdesign")
+    design.set_dataroot("remote", "https://filepath", tag="ref")
+    with design.active_fileset("rtl"), design.active_dataroot("remote"):
+        for num in range(5):
+            design.add_file(f"file{num}.v")
+
+    MPManager.get_path_cache().set_retry_delay(0)
+
+    calls = []
+
+    def fail():
+        calls.append(1)
+        raise FileNotFoundError("simulated 404")
+
+    with patch("siliconcompiler.package.https.HTTPResolver.check_cache", return_value=False), \
+         patch("siliconcompiler.package.https.HTTPResolver.resolve_remote", side_effect=fail), \
+         patch("shutil.rmtree"):
+        for _ in range(3):
+            assert design.find_files("fileset", "rtl", "file", "verilog",
+                                     missing_ok=True) == [None] * 5
+
+    # Was 5 attempts per call (once per file), 15 in total
+    assert len(calls) == 3
+
+
 def test_remote_resolve():
     project = Project("testproj")
     project.option.set_cachedir(".")
@@ -658,6 +926,8 @@ def test_remote_lock_within_lock_thread():
     resolver1.set_timeout(1)
     assert resolver1.timeout == 1
 
+    thread_lock = resolver0.thread_lock()
+
     with resolver0.lock():
         assert os.path.exists(resolver0.lock_file)
         assert not os.path.exists(resolver0.sc_lock_file)
@@ -667,8 +937,66 @@ def test_remote_lock_within_lock_thread():
             with resolver1.lock():
                 assert False, "should not get here"
 
+        # The waiter timing out must not hand away the holder's lock
+        assert thread_lock.locked()
+
+    assert not thread_lock.locked()
+
     assert os.path.exists(resolver0.lock_file)
     assert not os.path.exists(resolver0.sc_lock_file)
+
+
+def test_remote_lock_timeout_does_not_release_holder():
+    """
+    A thread that gives up waiting must not release the lock. threading.Lock has
+    no owner, so releasing it would admit a third thread into the download.
+    """
+    project = Project("testproj")
+    project.option.set_cachedir(".")
+
+    holder = RemoteResolver("thisname", project, "https://filepath", "ref")
+    waiter = RemoteResolver("thisname", project, "https://filepath", "ref")
+    intruder = RemoteResolver("thisname", project, "https://filepath", "ref")
+
+    waiter.set_timeout(1)
+    intruder.set_timeout(1)
+
+    # Isolate the thread lock from the inter-process lock
+    @contextlib.contextmanager
+    def dummy_lock():
+        yield
+    for resolver in (holder, waiter, intruder):
+        object.__setattr__(resolver, "_RemoteResolver__file_lock", dummy_lock)
+
+    with holder.lock():
+        with pytest.raises(RuntimeError, match=r"Another thread is currently holding the lock\."):
+            with waiter.lock():
+                assert False, "should not get here"
+
+        with pytest.raises(RuntimeError, match=r"Another thread is currently holding the lock\."):
+            with intruder.lock():
+                assert False, "should not get here"
+
+
+def test_remote_thread_lock_is_per_source():
+    """Same name, different source: the two must not contend."""
+    project = Project("testproj")
+    project.option.set_cachedir(".")
+
+    resolver0 = RemoteResolver("thisname", project, "https://filepath", "ref")
+    resolver1 = RemoteResolver("thisname", project, "https://otherpath", "ref")
+
+    assert resolver0.thread_lock() is not resolver1.thread_lock()
+
+
+def test_remote_thread_lock_is_shared_per_source():
+    project = Project("testproj")
+    project.option.set_cachedir(".")
+
+    resolver0 = RemoteResolver("thisname", project, "https://filepath", "ref")
+    resolver1 = RemoteResolver("othername", project, "https://filepath", "ref")
+
+    assert resolver0.thread_lock() is resolver1.thread_lock()
 
 
 def test_remote_lock_within_lock_thread_multiple_tries(monkeypatch):
@@ -699,6 +1027,9 @@ def test_remote_lock_within_lock_thread_multiple_tries(monkeypatch):
                 if self.calls == 1:
                     return False
                 return True
+
+            def release(self):
+                self.released = True
 
             def locked(self):
                 return False
@@ -1081,85 +1412,33 @@ def test_keypath_resolver_no_root():
         resolver.resolve()
 
 
-def test_get_cache():
+def test_resolver_cache_property():
+    """Every resolver reads the one cache the process owns."""
     project = Project("testproj")
-    assert Resolver.get_cache(project) == {}
-    assert getattr(project, "__Resolver_cache_id")
+
+    assert Resolver("testpath", project, "source://this").cache \
+        is MPManager.get_path_cache()
 
 
-def test_get_cache_none():
-    with patch("siliconcompiler.package.Resolver._Resolver__get_root_id") as root:
-        assert Resolver.get_cache(None) is None
-        root.assert_not_called()
+def test_resolver_cache_property_no_root():
+    """A resolver without a schema context reaches the same cache."""
+    assert Resolver("testpath", None, "source://this").cache is MPManager.get_path_cache()
 
 
-def test_set_cache():
-    project = Project("testproj")
-    assert Resolver.get_cache(project) == {}
-    assert getattr(project, "__Resolver_cache_id")
-
-    Resolver.set_cache(project, "test", "path")
-    assert Resolver.get_cache(project) == {
-        "test": "path"
-    }
-    Resolver.set_cache(project, "test0", "path0")
-    assert Resolver.get_cache(project) == {
-        "test": "path",
-        "test0": "path0",
-    }
-
-
-def test_set_cache_none():
-    with patch("siliconcompiler.package.Resolver._Resolver__get_root_id") as root:
-        Resolver.set_cache(None, "test", "path")
-        root.assert_not_called()
-
-
-def test_set_cache_different_projects():
+def test_resolver_cache_shared_between_projects():
+    """
+    Cache IDs are content hashes, so two projects asking for the same source at
+    the same reference share the entry instead of each resolving it.
+    """
     project0 = Project("testproj")
     project1 = Project("testproj")
 
-    assert Resolver.get_cache(project0) == {}
-    assert Resolver.get_cache(project1) == {}
+    res0 = Resolver("name0", project0, "source://this", reference="ref")
+    res1 = Resolver("name1", project1, "source://this", reference="ref")
+    assert res0.cache_id == res1.cache_id
 
-    assert getattr(project0, "__Resolver_cache_id")
-    assert getattr(project1, "__Resolver_cache_id")
-
-    Resolver.set_cache(project0, "test", "path")
-    assert Resolver.get_cache(project0) == {
-        "test": "path"
-    }
-    assert Resolver.get_cache(project1) == {}
-
-    Resolver.set_cache(project1, "test0", "path0")
-    assert Resolver.get_cache(project0) == {
-        "test": "path"
-    }
-    assert Resolver.get_cache(project1) == {
-        "test0": "path0",
-    }
-
-
-def test_reset_cache():
-    project = Project("testproj")
-
-    assert Resolver.get_cache(project) == {}
-
-    Resolver.set_cache(project, "test", "path")
-    assert Resolver.get_cache(project) == {
-        "test": "path"
-    }
-
-    assert getattr(project, "__Resolver_cache_id")
-
-    Resolver.reset_cache(project)
-    assert Resolver.get_cache(project) == {}
-
-
-def test_reset_cache_none():
-    with patch("siliconcompiler.package.Resolver._Resolver__get_root_id") as root:
-        Resolver.reset_cache(None)
-        root.assert_not_called()
+    res0.cache.set(res0.cache_id, "/resolved/once")
+    assert res1.cache.get(res1.cache_id) == "/resolved/once"
 
 
 # ============================================================================

--- a/tests/scheduler/test_run_node.py
+++ b/tests/scheduler/test_run_node.py
@@ -1,0 +1,80 @@
+import pytest
+
+from unittest.mock import patch
+
+from siliconcompiler import Project, Flowgraph, Design
+from siliconcompiler.utils.multiprocessing import MPManager
+from siliconcompiler.scheduler import run_node
+from siliconcompiler.tools.builtin.nop import NOPTask
+
+
+@pytest.fixture
+def manifest():
+    """Writes a minimal manifest and returns its path."""
+    flow = Flowgraph("testflow")
+    flow.node("stepone", NOPTask())
+
+    design = Design("testdesign")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+
+    project = Project(design)
+    project.add_fileset("rtl")
+    project.set_flow(flow)
+
+    path = "manifest.pkg.json"
+    project.write_manifest(path)
+    return path
+
+
+def run_main(manifest, cachemap=None):
+    """Runs main() without executing the node."""
+    argv = ["run_node", "-cfg", manifest, "-cwd", ".", "-builddir", "build",
+            "-step", "stepone", "-index", "0"]
+    if cachemap:
+        argv.append("-cachemap")
+        argv.extend(cachemap)
+
+    with patch("sys.argv", argv), \
+         patch("siliconcompiler.scheduler.run_node.SchedulerNode"):
+        assert run_node.main() == 0
+
+
+def test_no_cachemap(manifest):
+    run_main(manifest)
+
+    assert MPManager.get_path_cache().export()["paths"] == {}
+
+
+def test_cachemap_seeds_paths(manifest):
+    run_main(manifest, ["abc123:/some/path", "def456:/other/path"])
+
+    assert MPManager.get_path_cache().get("abc123") == "/some/path"
+    assert MPManager.get_path_cache().get("def456") == "/other/path"
+
+
+def test_cachemap_path_with_colon(manifest):
+    """A cache ID is a hex digest, so everything after the first colon is path."""
+    run_main(manifest, [r"abc123:C:\data\thing"])
+
+    assert MPManager.get_path_cache().get("abc123") == r"C:\data\thing"
+
+
+def test_cachemap_path_with_many_colons(manifest):
+    run_main(manifest, ["abc123:/a:b:c/d"])
+
+    assert MPManager.get_path_cache().get("abc123") == "/a:b:c/d"
+
+
+@pytest.mark.parametrize("entry", ("noseparator", ":", ":/only/path", "abc123:", ""))
+def test_cachemap_malformed_entries_are_skipped(manifest, entry):
+    """A malformed entry must be ignored, not crash the node before it starts."""
+    run_main(manifest, [entry])
+
+    assert MPManager.get_path_cache().export()["paths"] == {}
+
+
+def test_cachemap_keeps_good_entries_alongside_bad(manifest):
+    run_main(manifest, ["noseparator", "abc123:/some/path", "abc123:"])
+
+    assert MPManager.get_path_cache().export()["paths"] == {"abc123": "/some/path"}

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -21,6 +21,7 @@ from siliconcompiler.tools.builtin.nop import NOPTask
 from siliconcompiler.tools.builtin.join import JoinTask
 from scheduler.tools.echo import EchoTask
 
+from siliconcompiler.utils.multiprocessing import MPManager
 from siliconcompiler.scheduler import SchedulerNode
 from siliconcompiler.scheduler.schedulernode import SchedulerFlowReset, \
     SchedulerNodeReset, SchedulerNodeResetSilent
@@ -285,6 +286,77 @@ def test_halt(project):
         node.halt()
     assert project.get("record", "status", step="steptwo", index="0") == NodeStatus.ERROR
     assert os.path.exists("build/testdesign/job0/steptwo/0/outputs/testdesign.pkg.json")
+
+
+def test_halt_sends_pathcache(project):
+    '''A node that halts because a data source could not be fetched is exactly
+    the node whose resolved paths the parent needs, so halt() must report them
+    before exiting.'''
+    node = SchedulerNode(project, "steptwo", "0")
+    node.task.setup_work_directory(node.workdir)
+
+    MPManager.get_path_cache().set("someid", "/some/path")
+    MPManager.get_path_cache().record_failure("otherid", ValueError("nope"))
+
+    sent = []
+
+    class DummyPipe:
+        def send(self, payload):
+            sent.append(payload)
+
+    node.set_queue(DummyPipe(), Queue())
+
+    with pytest.raises(SystemExit):
+        node.halt()
+
+    assert sent == [{
+        "paths": {"someid": "/some/path"},
+        "failures": {"otherid": [1, "ValueError: nope"]}
+    }]
+
+
+def test_halt_without_pipe(project):
+    '''Nothing to report to in a local run.'''
+    node = SchedulerNode(project, "steptwo", "0")
+    node.task.setup_work_directory(node.workdir)
+
+    with pytest.raises(SystemExit):
+        node.halt()
+
+
+@pytest.mark.parametrize("errorcls", (OSError, EOFError, BrokenPipeError,
+                                      ConnectionResetError, ValueError))
+def test_send_pathcache_swallows_pipe_errors(project, errorcls):
+    '''A broken or already closed pipe must never become a node failure.'''
+    node = SchedulerNode(project, "steptwo", "0")
+
+    class DeadPipe:
+        def send(self, payload):
+            raise errorcls("pipe is gone")
+
+    node.set_queue(DeadPipe(), Queue())
+
+    node._send_pathcache()
+
+
+def test_run_sends_pathcache(project):
+    node = SchedulerNode(project, "stepone", "0")
+
+    sent = []
+
+    class DummyPipe:
+        def send(self, payload):
+            sent.append(payload)
+
+    node.set_queue(DummyPipe(), Queue())
+    node.task.setup_work_directory(node.workdir)
+
+    MPManager.get_path_cache().set("someid", "/some/path")
+
+    with patch("siliconcompiler.scheduler.SchedulerNode.execute"):
+        node.run()
+
+    assert sent == [{"paths": {"someid": "/some/path"}, "failures": {}}]
 
 
 def test_halt_with_reason(project_logger, project, caplog):

--- a/tests/scheduler/test_taskscheduler.py
+++ b/tests/scheduler/test_taskscheduler.py
@@ -393,6 +393,64 @@ def test_process_completed_nodes_nonzero_exit_is_error(large_flow, make_tasks):
                           step=node[0], index=node[1]) == NodeStatus.ERROR
 
 
+def test_process_completed_nodes_merges_paths(large_flow, make_tasks):
+    '''A node resolves data sources in its own process, so the paths it found
+    must be merged back into the parent.'''
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+    node = ("stepone", "0")
+    _, pipe = _setup_completed_node(scheduler, node, exitcode=0, pipe_has_data=True)
+    pipe.recv.return_value = {
+        "paths": {"someid": "/some/path"},
+        "failures": {"otherid": [3, "FileNotFoundError: simulated 404"]}
+    }
+
+    scheduler._TaskScheduler__process_completed_nodes()
+
+    assert MPManager.get_path_cache().get("someid") == "/some/path"
+
+
+def test_process_completed_nodes_ignores_failures(large_flow, make_tasks):
+    '''A fetch that failed for one node may still succeed for the next, so each
+    node keeps its own retry budget for now.'''
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+    node = ("stepone", "0")
+    _, pipe = _setup_completed_node(scheduler, node, exitcode=0, pipe_has_data=True)
+    pipe.recv.return_value = {
+        "paths": {},
+        "failures": {"otherid": [3, "FileNotFoundError: simulated 404"]}
+    }
+
+    scheduler._TaskScheduler__process_completed_nodes()
+
+    assert MPManager.get_path_cache().attempts("otherid") == 0
+    assert not MPManager.get_path_cache().is_exhausted("otherid")
+
+
+def test_process_completed_nodes_tolerates_bad_payload(large_flow, make_tasks):
+    '''A garbled or truncated message must not take down the scheduler.'''
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+    node = ("stepone", "0")
+    large_flow.set("record", "status", NodeStatus.SUCCESS, step=node[0], index=node[1])
+    _, pipe = _setup_completed_node(scheduler, node, exitcode=0, pipe_has_data=True)
+    pipe.recv.return_value = "not a payload"
+
+    scheduler._TaskScheduler__process_completed_nodes()
+
+    assert large_flow.get("record", "status", step=node[0], index=node[1]) == NodeStatus.SUCCESS
+
+
+def test_process_completed_nodes_tolerates_recv_error(large_flow, make_tasks):
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+    node = ("stepone", "0")
+    large_flow.set("record", "status", NodeStatus.SUCCESS, step=node[0], index=node[1])
+    _, pipe = _setup_completed_node(scheduler, node, exitcode=0, pipe_has_data=True)
+    pipe.recv.side_effect = EOFError("pipe is gone")
+
+    scheduler._TaskScheduler__process_completed_nodes()
+
+    assert large_flow.get("record", "status", step=node[0], index=node[1]) == NodeStatus.SUCCESS
+
+
 def test_check(large_flow, make_tasks):
     scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
     large_flow.set("record", "status", NodeStatus.SUCCESS, step="jointhree", index="0")

--- a/tests/utils/test_multiprocessing.py
+++ b/tests/utils/test_multiprocessing.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 import warnings
 
 from multiprocessing.managers import RemoteError
@@ -43,6 +44,36 @@ def test_init_singleton():
     assert man0 is man1
 
     assert MPManager in _ManagerSingleton._instances
+
+
+def test_singleton_is_not_published_until_initialized():
+    '''The outer has_cls() check skips the lock, so publishing the instance
+    before _init_singleton() finishes hands a half-built object to any other
+    thread that asks for it meanwhile -- and _init_singleton() spends that
+    window launching a manager process.'''
+    errors = []
+    instances = []
+    barrier = threading.Barrier(8)
+
+    def race():
+        barrier.wait()
+        try:
+            manager = MPManager()
+            # Touch state that only exists after _init_singleton() has run
+            assert manager.get_transient_settings() is not None
+            instances.append(manager)
+        except Exception as e:  # noqa B902
+            errors.append(f"{type(e).__name__}: {e}")
+
+    threads = [threading.Thread(target=race) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert len(instances) == 8
+    assert len(set(id(manager) for manager in instances)) == 1
 
 
 def test_has_cls():

--- a/tests/utils/test_multiprocessing.py
+++ b/tests/utils/test_multiprocessing.py
@@ -51,6 +51,11 @@ def test_singleton_is_not_published_until_initialized():
     before _init_singleton() finishes hands a half-built object to any other
     thread that asks for it meanwhile -- and _init_singleton() spends that
     window launching a manager process.'''
+    # Guard against the test going vacuous: once the manager exists, every thread
+    # takes the fast path and _init_singleton() is never raced at all.
+    MPManager.stop()
+    assert not _ManagerSingleton.has_cls(MPManager)
+
     errors = []
     instances = []
     barrier = threading.Barrier(8)


### PR DESCRIPTION
Rework cache downloading to avoid attempting to redownload a failed download on every path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared caching for resolved package and data-source paths across processes and scheduler nodes.
  * Added configurable retry limits, exponential backoff, jitter, failure tracking, and clear errors for exhausted resolution attempts.
  * Added cache seeding and export support for distributed workflows.
  * Improved cache-map handling, including paths containing colons and graceful handling of malformed entries.

* **Bug Fixes**
  * Improved concurrent cache access and singleton initialization reliability.
  * Ensured successful resolution clears previous failure state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->