### PR TITLE
add guard of sbt download failures in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,9 @@ include-package-data = true
 find = {namespaces = false}  # Disable implicit namespaces
 
 [tool.pytest.ini_options]
+# -rfEs: the pytest default short summary (failed + errored) plus every skipped
+# test and its reason, so CI logs show what was skipped and why.
+addopts = "-rfEs"
 markers = [
     "eda: this test requires EDA tools installed to run. By default these tests will be run nightly, not on push.",
     "quick: always run this test on push, even if it requires EDA tools.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 import pytest
 import glob
 import json
+import re
 import multiprocessing
 import platform
 import shutil
@@ -439,10 +440,9 @@ def sbt_download_guard(request):
     '''Returns a context manager that converts an sbt dependency download
     failure into a skip.
 
-    Wrap the run of any Chisel-based flow in it. If the wrapped code fails and
-    any log under the working directory shows sbt failing to fetch its
-    dependencies, the test is skipped; every other failure propagates
-    unchanged.'''
+    Wrap the run of any Chisel-based flow in it. If the run fails and the log of
+    a node that failed shows sbt failing to fetch its dependencies, the test is
+    skipped; every other failure propagates unchanged.'''
 
     # sbt resolves its own launcher and the Chisel jars from Maven Central (and
     # friends) on every run, so a rate limit (HTTP 429) or a network hiccup
@@ -456,17 +456,24 @@ def sbt_download_guard(request):
     def guard():
         try:
             yield
-        except Exception:
-            for log in glob.glob(os.path.join("**", "*.log"), recursive=True):
-                try:
-                    with open(log, errors="ignore") as f:
-                        text = f.read()
-                except OSError:
-                    continue
-                for error in errors:
-                    if error in text:
-                        pytest.skip(f"{request.node.nodeid}: sbt failed to download its "
-                                    f"dependencies ({error}) in {log}")
+        except Exception as e:
+            # Only the logs of the nodes that actually failed count: coursier
+            # reports the same download errors for mirrors it then successfully
+            # falls back from, so those messages also sit in the logs of nodes
+            # that ran fine and must not mask an unrelated failure.
+            failed = re.search(r"due to errors in: (.*)", str(e))
+            for node in failed.group(1).split(",") if failed else []:
+                step, _, index = node.strip().partition("/")
+                for log in glob.glob(os.path.join("**", step, index, "*.log"), recursive=True):
+                    try:
+                        with open(log, errors="ignore") as f:
+                            text = f.read()
+                    except OSError:
+                        continue
+                    for error in errors:
+                        if error in text:
+                            pytest.skip(f"{request.node.nodeid}: sbt failed to download its "
+                                        f"dependencies ({error}) in {log}")
             raise
 
     return guard

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import pytest
+import glob
 import json
 import multiprocessing
 import platform
@@ -12,6 +13,7 @@ import time
 
 import os.path
 
+from contextlib import contextmanager
 from uuid import uuid4
 from pathlib import Path
 from pyvirtualdisplay import Display
@@ -430,6 +432,44 @@ def run_cli():
         return proc
 
     return run
+
+
+@pytest.fixture
+def sbt_download_guard(request):
+    '''Returns a context manager that converts an sbt dependency download
+    failure into a skip.
+
+    Wrap the run of any Chisel-based flow in it. If the wrapped code fails and
+    any log under the working directory shows sbt failing to fetch its
+    dependencies, the test is skipped; every other failure propagates
+    unchanged.'''
+
+    # sbt resolves its own launcher and the Chisel jars from Maven Central (and
+    # friends) on every run, so a rate limit (HTTP 429) or a network hiccup
+    # fails the convert node for reasons unrelated to SiliconCompiler.
+    errors = (
+        "download error: Caught java.io.IOException",
+        "could not retrieve sbt",
+    )
+
+    @contextmanager
+    def guard():
+        try:
+            yield
+        except Exception:
+            for log in glob.glob(os.path.join("**", "*.log"), recursive=True):
+                try:
+                    with open(log, errors="ignore") as f:
+                        text = f.read()
+                except OSError:
+                    continue
+                for error in errors:
+                    if error in text:
+                        pytest.skip(f"{request.node.nodeid}: sbt failed to download its "
+                                    f"dependencies ({error}) in {log}")
+            raise
+
+    return guard
 
 
 @pytest.fixture

--- a/tests/examples/test_gcd.py
+++ b/tests/examples/test_gcd.py
@@ -425,9 +425,10 @@ def test_py_gcd_hls():
 
 @pytest.mark.eda
 @pytest.mark.timeout(300)
-def test_py_gcd_chisel():
+def test_py_gcd_chisel(sbt_download_guard):
     from gcd import gcd_chisel
-    gcd_chisel.main()
+    with sbt_download_guard():
+        gcd_chisel.main()
 
     assert os.path.isfile('build/gcd/job0/write.gds/0/outputs/GCD.gds.gz')
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,0 +1,52 @@
+import pytest
+
+import os.path
+
+
+def write_log(step, index, text):
+    logdir = os.path.join("build", "gcd", "job0", step, index)
+    os.makedirs(logdir, exist_ok=True)
+    with open(os.path.join(logdir, f"{step}.log"), "w") as f:
+        f.write(text)
+
+
+DOWNLOAD_FAILURE = """
+[info] [launcher] getting org.scala-sbt sbt 1.11.6  (this may take some time)...
+[error] [launcher] ...coursier.error.ResolutionError$CantDownloadModule:
+  download error: Caught java.io.IOException (Server returned HTTP response code: \
+429 for URL: https://repo1.maven.org/...) while downloading ...
+[error] [launcher] could not retrieve sbt 1.11.6
+"""
+
+
+def test_sbt_download_guard_pass_through(sbt_download_guard):
+    with sbt_download_guard():
+        assert True
+
+
+def test_sbt_download_guard_skips(sbt_download_guard):
+    write_log("convert", "0", DOWNLOAD_FAILURE)
+
+    with pytest.raises(pytest.skip.Exception, match="sbt failed to download"):
+        with sbt_download_guard():
+            raise RuntimeError("Run failed: Could not run final steps (convert) "
+                               "due to errors in: convert/0")
+
+
+def test_sbt_download_guard_reraises(sbt_download_guard):
+    with pytest.raises(RuntimeError, match="boom"):
+        with sbt_download_guard():
+            raise RuntimeError("boom")
+
+
+def test_sbt_download_guard_reraises_unrelated_node(sbt_download_guard):
+    '''A download error that sbt recovered from sits in the log of a node that
+    ran fine, so it must not turn an unrelated failure into a skip.'''
+
+    write_log("convert", "0", DOWNLOAD_FAILURE)
+    write_log("route.detailed", "0", "[ERROR DRT-0073] no available Rtree.\n")
+
+    with pytest.raises(RuntimeError, match="route.detailed"):
+        with sbt_download_guard():
+            raise RuntimeError("Run failed: Could not run final steps (write.gds) "
+                               "due to errors in: route.detailed/0")

--- a/tests/tools/test_chisel.py
+++ b/tests/tools/test_chisel.py
@@ -27,7 +27,7 @@ def test_version(gcd_design):
 @pytest.mark.eda
 @pytest.mark.quick
 @pytest.mark.timeout(300)
-def test_chisel(datadir):
+def test_chisel(datadir, sbt_download_guard):
     design = Design("gcd")
     design.set_dataroot("root", datadir)
     with design.active_dataroot("root"), design.active_fileset("rtl"):
@@ -41,7 +41,8 @@ def test_chisel(datadir):
     flow.node("convert", convert.ConvertTask())
     proj.set_flow(flow)
 
-    assert proj.run()
+    with sbt_download_guard():
+        assert proj.run()
 
     # check that compilation succeeded
     assert proj.find_result('v', step='convert') == \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reporting to show failed, errored, and skipped tests with reasons.
  * Tests involving unavailable SBT dependencies now skip gracefully when downloads fail, while unrelated failures continue to be reported normally.
  * Added coverage for dependency-download handling and failure propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->