### PR TITLE
ensure unsupported schedulers are correctly rejected

### DIFF
--- a/siliconcompiler/scheduler/scheduler.py
+++ b/siliconcompiler/scheduler/scheduler.py
@@ -120,6 +120,10 @@ class Scheduler:
                 node_cls = SlurmSchedulerNode
             elif node_scheduler == 'docker':
                 node_cls = DockerSchedulerNode
+            elif node_scheduler is None:
+                pass
+            else:
+                raise SCRuntimeError(f"Unsupported scheduler '{node_scheduler}' for node {step}/{index}")
             self.__tasks[(step, index)] = node_cls(self.__project, step, index)
             if self.__flow.get(step, index, "tool") == "builtin":
                 self.__tasks[(step, index)].set_builtin()

--- a/siliconcompiler/scheduler/scheduler.py
+++ b/siliconcompiler/scheduler/scheduler.py
@@ -123,7 +123,8 @@ class Scheduler:
             elif node_scheduler is None:
                 pass
             else:
-                raise SCRuntimeError(f"Unsupported scheduler '{node_scheduler}' for node {step}/{index}")
+                raise SCRuntimeError(
+                    f"Unsupported scheduler '{node_scheduler}' for node {step}/{index}")
             self.__tasks[(step, index)] = node_cls(self.__project, step, index)
             if self.__flow.get(step, index, "tool") == "builtin":
                 self.__tasks[(step, index)].set_builtin()

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -13,7 +13,8 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from siliconcompiler import Project, Flowgraph, Design, NodeStatus
-from siliconcompiler.scheduler import Scheduler, SCRuntimeError, SlurmSchedulerNode
+from siliconcompiler.scheduler import Scheduler, SCRuntimeError, SchedulerNode, \
+    SlurmSchedulerNode, DockerSchedulerNode
 from siliconcompiler.schema import EditableSchema, Parameter
 
 from siliconcompiler.tools.builtin.nop import NOPTask
@@ -268,6 +269,55 @@ def test_init_flow_runtime_not_valid(basic_project):
         with pytest.raises(SCRuntimeError,
                            match=r"^test flowgraph contains errors and cannot be run\.$"):
             Scheduler(basic_project)
+
+
+def test_init_node_cls_local(basic_project):
+    # No scheduler set, so the local node class is used
+    scheduler = Scheduler(basic_project)
+    assert type(scheduler._Scheduler__tasks[("stepone", "0")]) is SchedulerNode
+
+
+@pytest.mark.parametrize("scheduler_name,node_cls", [
+    ("slurm", SlurmSchedulerNode),
+    ("docker", DockerSchedulerNode)])
+def test_init_node_cls(basic_project, scheduler_name, node_cls):
+    basic_project.option.scheduler.set_name(scheduler_name)
+
+    scheduler = Scheduler(basic_project)
+    assert type(scheduler._Scheduler__tasks[("stepone", "0")]) is node_cls
+
+
+@pytest.mark.parametrize("scheduler_name", ("lsf", "sge"))
+def test_init_node_cls_not_implemented(basic_project, scheduler_name):
+    basic_project.option.scheduler.set_name(scheduler_name)
+
+    with pytest.raises(SCRuntimeError,
+                       match=rf"^Unsupported scheduler '{scheduler_name}' for node stepone/0$"):
+        Scheduler(basic_project)
+
+
+@pytest.mark.parametrize("scheduler_name,node_cls", [
+    ("slurm", SlurmSchedulerNode),
+    ("docker", DockerSchedulerNode)])
+def test_init_node_cls_per_node(gcd_nop_project, scheduler_name, node_cls):
+    # Only some nodes are scheduled, the rest fall back to local execution
+    gcd_nop_project.option.scheduler.set_name(scheduler_name, step="stepone")
+    gcd_nop_project.option.scheduler.set_name(scheduler_name, step="stepthree")
+
+    tasks = Scheduler(gcd_nop_project)._Scheduler__tasks
+    assert type(tasks[("stepone", "0")]) is node_cls
+    assert type(tasks[("steptwo", "0")]) is SchedulerNode
+    assert type(tasks[("stepthree", "0")]) is node_cls
+    assert type(tasks[("stepfour", "0")]) is SchedulerNode
+
+
+@pytest.mark.parametrize("scheduler_name", ("lsf", "sge"))
+def test_init_node_cls_per_node_not_implemented(gcd_nop_project, scheduler_name):
+    gcd_nop_project.option.scheduler.set_name(scheduler_name, step="stepthree")
+
+    with pytest.raises(SCRuntimeError,
+                       match=rf"^Unsupported scheduler '{scheduler_name}' for node stepthree/0$"):
+        Scheduler(gcd_nop_project)
 
 
 def test_check_display_run(basic_project):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unsupported scheduler configurations now produce a clear runtime error.
  * Local execution remains available when no scheduler is configured.
  * Scheduler-specific node handling now correctly supports Slurm and Docker settings.
  * Added validation for unsupported LSF and SGE configurations, helping identify invalid setup choices earlier.
  * Scheduler selection now consistently respects both global settings and per-node configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->