### PR TITLE
add missing csv option to tools

### DIFF
--- a/siliconcompiler/schema/CHANGELOG.rst
+++ b/siliconcompiler/schema/CHANGELOG.rst
@@ -14,6 +14,12 @@ from the code diffs, not the commit messages). Dates are the git commit dates of
 the version bump. Version numbering was not strictly linear during early
 development, so a few dates are non-monotonic relative to the semver ordering.
 
+0.57.1 — 2026-08-10
+===================
+- Added ``csv`` to the accepted values of ``tool,<tool>,task,<task>,format``
+  (``<json,tcl,yaml>`` → ``<csv,json,tcl,yaml>``). The CSV writer already existed in
+  ``write_task_manifest`` but could never be selected through the schema.
+
 0.57.0 — 2026-07-21
 ===================
 - Removed the standalone ``Schematic`` schema class (``schematic,*`` section) and its

--- a/siliconcompiler/schema/_metadata.py
+++ b/siliconcompiler/schema/_metadata.py
@@ -1,2 +1,2 @@
 # Version number following semver standard.
-version = '0.57.0'
+version = '0.57.1'

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -1,7 +1,6 @@
 import contextlib
 import copy
 import csv
-import gzip
 import json
 import logging
 import os
@@ -1026,6 +1025,12 @@ class Task(NamedSchema, PathSchema, DocsSchema):
         class YamlIndentDumper(yaml.Dumper):
             def increase_indent(self, flow=False, indentless=False):
                 return super().increase_indent(flow=flow, indentless=indentless)
+
+        # Emit tuples, such as the (step, index) pairs in the flowgraph, as plain
+        # sequences. The default representer tags them '!!python/tuple', which
+        # only a python reader can load.
+        YamlIndentDumper.add_representer(
+            tuple, lambda dumper, data: dumper.represent_list(list(data)))
 
         fout.write(yaml.dump(manifest.getdict(), Dumper=YamlIndentDumper,
                              default_flow_style=False))

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -1128,27 +1128,21 @@ class Task(NamedSchema, PathSchema, DocsSchema):
         # Generate a schema with absolute paths for the manifest
         schema = self.__abspath_schema()
 
-        if re.search(r'\.json(\.gz)?$', manifest_path):
+        if suffix == "json":
             schema.write_manifest(manifest_path)
         else:
-            # Format-specific dumping
-            if manifest_path.endswith('.gz'):
-                fout = gzip.open(manifest_path, 'wt', encoding='UTF-8')
-            elif re.search(r'\.csv$', manifest_path):
-                fout = open(manifest_path, 'w', newline='')
-            else:
-                fout = open(manifest_path, 'w')
-            try:
-                if re.search(r'(\.yaml|\.yml)(\.gz)?$', manifest_path):
+            fopen_args = {}
+            if suffix == "csv":
+                fopen_args['newline'] = ''
+            with open(manifest_path, 'w', **fopen_args) as fout:
+                if suffix == "yaml":
                     self.__write_yaml_manifest(fout, schema)
-                elif re.search(r'\.tcl(\.gz)?$', manifest_path):
+                elif suffix == "tcl":
                     self.__write_tcl_manifest(fout, schema)
-                elif re.search(r'\.csv(\.gz)?$', manifest_path):
+                elif suffix == "csv":
                     self.__write_csv_manifest(fout, schema)
                 else:
                     raise ValueError(f"{manifest_path} is not a recognized path type")
-            finally:
-                fout.close()
 
     def __abspath_schema(self) -> "Project":
         """
@@ -3139,7 +3133,7 @@ def schema_task(schema):
     schema.insert(
         'format',
         Parameter(
-            '<json,tcl,yaml>',
+            '<json,tcl,yaml,csv>',
             scope=Scope.JOB,
             pernode=PerNode.OPTIONAL,
             shorthelp="Tool: file format",

--- a/tests/data/defaults.json
+++ b/tests/data/defaults.json
@@ -17,7 +17,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.57.0",
+              "value": "0.57.1",
               "signature": null
             }
           }
@@ -2989,7 +2989,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.57.0",
+              "value": "0.57.1",
               "signature": null
             }
           }
@@ -6759,7 +6759,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.57.0",
+              "value": "0.57.1",
               "signature": null
             }
           }
@@ -11415,7 +11415,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.57.0",
+              "value": "0.57.1",
               "signature": null
             }
           }
@@ -14387,7 +14387,7 @@
         "node": {
           "default": {
             "default": {
-              "value": "0.57.0",
+              "value": "0.57.1",
               "signature": null
             }
           }

--- a/tests/data/defaults.json
+++ b/tests/data/defaults.json
@@ -1488,7 +1488,7 @@
                 }
               },
               "format": {
-                "type": "<json,tcl,yaml>",
+                "type": "<csv,json,tcl,yaml>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -5148,7 +5148,7 @@
                 }
               },
               "format": {
-                "type": "<json,tcl,yaml>",
+                "type": "<csv,json,tcl,yaml>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -9150,7 +9150,7 @@
                 }
               },
               "format": {
-                "type": "<json,tcl,yaml>",
+                "type": "<csv,json,tcl,yaml>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -12886,7 +12886,7 @@
                 }
               },
               "format": {
-                "type": "<json,tcl,yaml>",
+                "type": "<csv,json,tcl,yaml>",
                 "require": false,
                 "scope": "job",
                 "lock": false,
@@ -15858,7 +15858,7 @@
                 }
               },
               "format": {
-                "type": "<json,tcl,yaml>",
+                "type": "<csv,json,tcl,yaml>",
                 "require": false,
                 "scope": "job",
                 "lock": false,

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1181,7 +1181,7 @@ def test_write_task_manifest_none(running_node):
         assert os.listdir() == []
 
 
-@pytest.mark.parametrize("suffix", ("tcl", "json", "yaml"))
+@pytest.mark.parametrize("suffix", ("tcl", "json", "yaml", "csv"))
 def test_write_task_manifest(running_node, suffix):
     assert running_node.project.set("tool", "builtin", 'task', 'nop', "format", suffix)
     with running_node.task.runtime(running_node) as runtool:

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,4 +1,5 @@
 import copy
+import csv
 import hashlib
 import logging
 import pathlib
@@ -7,6 +8,7 @@ import sys
 import pytest
 import os
 import time
+import yaml
 
 import os.path
 
@@ -19,6 +21,7 @@ from siliconcompiler.schema_support.record import RecordSchema
 from siliconcompiler import Task
 from siliconcompiler import Design, Project
 from siliconcompiler.schema import BaseSchema, EditableSchema, Parameter, SafeSchema
+from siliconcompiler.schema._metadata import version as schema_version
 from siliconcompiler.schema.parameter import PerNode, Scope
 from siliconcompiler.tool import TaskExecutableNotFound, TaskError, TaskTimeout, \
     TaskOutOfMemoryError
@@ -1210,6 +1213,107 @@ def test_write_task_manifest_relative(running_node):
 
     check = SafeSchema.from_manifest(filepath="sc_manifest.json")
     assert check.get("tool", "builtin", "task", "nop", "refdir") == ["."]
+
+
+@pytest.fixture
+def manifest_quoting(running_node):
+    """Factory writing a task manifest in the requested format, with task
+    variables holding a quoting-sensitive value. Returns that value.
+
+        value = manifest_quoting("yaml")
+    """
+    def _write(suffix):
+        # Exercises the quoting rules of every manifest format: spaces, Tcl
+        # substitution characters, a CSV separator and a YAML flow-style separator.
+        value = 'a b [c] {d} "e" $f,g'
+
+        nop = running_node.project.get_nop()
+        nop.add_parameter("quoting", "str", "scalar quoting check")
+        nop.add_parameter("quotinglist", "[str]", "list quoting check")
+
+        assert running_node.project.set("tool", "builtin", "task", "nop", "var", "quoting",
+                                        value)
+        assert running_node.project.set("tool", "builtin", "task", "nop", "var", "quotinglist",
+                                        ["one item", value])
+        assert running_node.project.set("tool", "builtin", "task", "nop", "format", suffix)
+
+        with running_node.task.runtime(running_node) as runtool:
+            runtool.write_task_manifest('.')
+
+        assert os.listdir() == [f'sc_manifest.{suffix}']
+
+        return value
+
+    return _write
+
+
+def test_write_task_manifest_yaml_format(manifest_quoting):
+    """The yaml manifest must be loadable and preserve values verbatim."""
+    value = manifest_quoting("yaml")
+
+    with open("sc_manifest.yaml") as f:
+        manifest = yaml.safe_load(f)
+
+    assert isinstance(manifest, dict)
+    assert manifest["schemaversion"]["node"]["default"]["default"]["value"] == schema_version
+    assert manifest["option"]["design"]["node"]["*"]["*"]["value"] == "testdesign"
+
+    var = manifest["tool"]["builtin"]["task"]["nop"]["var"]
+    assert var["quoting"]["node"]["*"]["*"]["value"] == value
+    assert var["quotinglist"]["node"]["*"]["*"]["value"] == ["one item", value]
+
+    # (step, index) tuples must be plain sequences, not '!!python/tuple' tags,
+    # which safe_load above would have rejected.
+    flow_input = manifest["flowgraph"]["testflow"]["notrunning"]["0"]["input"]
+    assert flow_input["node"]["*"]["*"]["value"] == [["running", "0"]]
+
+
+def test_write_task_manifest_tcl_format(manifest_quoting):
+    """The tcl manifest must be sourceable and preserve values verbatim."""
+    tkinter = pytest.importorskip("tkinter")
+
+    value = manifest_quoting("tcl")
+
+    interp = tkinter.Tcl()
+    # Tcl accepts forward slashes on every platform; backslashes in a Windows
+    # path would be read as escapes.
+    interp.eval("source {%s}" % os.path.abspath("sc_manifest.tcl").replace(os.sep, "/"))
+
+    # Tool variables emitted alongside the manifest dictionary
+    assert interp.getvar("sc_tool") == "builtin"
+    assert interp.getvar("sc_task") == "nop"
+    assert interp.getvar("sc_topmodule") == "designtop"
+    assert interp.getvar("sc_designlib") == "testdesign"
+
+    assert interp.eval("dict get $sc_cfg option design") == "testdesign"
+    assert interp.eval("dict get $sc_cfg tool builtin task nop var quoting") == value
+    assert interp.eval(
+        "llength [dict get $sc_cfg tool builtin task nop var quotinglist]") == "2"
+    assert interp.eval(
+        "lindex [dict get $sc_cfg tool builtin task nop var quotinglist] 1") == value
+
+    # Default keys must not leak into the manifest
+    assert interp.eval("dict exists $sc_cfg library testdesign fileset default") == "0"
+
+
+def test_write_task_manifest_csv_format(manifest_quoting):
+    """The csv manifest must be parseable and preserve values verbatim."""
+    value = manifest_quoting("csv")
+
+    with open("sc_manifest.csv", newline='') as f:
+        rows = list(csv.reader(f))
+
+    assert rows[0] == ["Keypath", "Value"]
+    assert all(len(row) == 2 for row in rows)
+
+    values = {}
+    for keypath, keyvalue in rows[1:]:
+        values.setdefault(keypath, []).append(keyvalue)
+
+    assert values["option,design"] == ["testdesign"]
+    assert values["tool,builtin,task,nop,var,quoting"] == [value]
+    # List values are expanded into one row per item
+    assert values["tool,builtin,task,nop,var,quotinglist"] == ["one item", value]
 
 
 def test_write_task_manifest_with_backup(running_node):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task manifests can now be written in CSV format alongside JSON, Tcl, and YAML.
  * CSV output preserves values, special characters, metadata, and tool settings accurately.

* **Bug Fixes**
  * YAML manifests now serialize sequence values more consistently.

* **Changes**
  * Compressed `.gz` manifest variants are no longer supported.

* **Chores**
  * Updated the package version to 0.57.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->