### PR TITLE
handle UTF-8 in manifest gracefully

### DIFF
--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -18,9 +18,11 @@ except ModuleNotFoundError:
 
 try:
     import orjson as json
+    import json as stdlib_json
     _has_orjson = True
 except ModuleNotFoundError:
     import json
+    stdlib_json = json
     _has_orjson = False
 
 import os.path
@@ -519,11 +521,26 @@ class BaseSchema:
                     return pathlib.PureWindowsPath(obj).as_posix()
                 raise TypeError
 
+            manifest = self.getdict()
             if _has_orjson:
-                manifest_str = json.dumps(self.getdict(), option=json.OPT_INDENT_2,
+                manifest_str = json.dumps(manifest, option=json.OPT_INDENT_2,
                                           default=default).decode()
+                # orjson emits UTF-8 and has no ensure_ascii; the stdlib escapes
+                # non-ASCII by default. Without this the manifest's encoding
+                # depends on which JSON library happened to be installed, and an
+                # ASCII manifest is the thing that lets any reader decode it
+                # whatever the host locale claims -- a server running under
+                # LANG=C failed a whole job on one Greek letter in a journal.
+                #
+                # Re-serializing rather than post-processing the string: only
+                # \uXXXX is a legal JSON escape, so backslashreplace (which works
+                # per byte, and yields \xNN) produces a manifest that will not
+                # parse. isascii() is a C-level scan, and the slow path only runs
+                # on the rare manifest that needs it.
+                if not manifest_str.isascii():
+                    manifest_str = stdlib_json.dumps(manifest, indent=2, default=default)
             else:
-                manifest_str = json.dumps(self.getdict(), indent=2, default=default)
+                manifest_str = json.dumps(manifest, indent=2, default=default)
             fout.write(manifest_str)
         finally:
             fout.close()

--- a/siliconcompiler/schema/journal.py
+++ b/siliconcompiler/schema/journal.py
@@ -168,7 +168,11 @@ class Journal:
             schema (:class:`BaseSchema`): schema to replay transactions to
             filepath (path): path to manifest
         '''
-        with open(filepath, "r") as fid:
+        # Manifests are written as UTF-8 (BaseSchema.__open_file); read them as
+        # UTF-8 rather than as whatever the host's locale happens to be. A
+        # server running under LANG=C decoded this as ASCII and failed the whole
+        # job on the first non-ASCII byte in a node's journal.
+        with open(filepath, "r", encoding="utf-8") as fid:
             data = json.load(fid)
         if "__journal__" not in data:
             return

--- a/siliconcompiler/schema/parametertype.py
+++ b/siliconcompiler/schema/parametertype.py
@@ -263,6 +263,34 @@ class NodeType:
         return None
 
     @staticmethod
+    def _tcl_ascii(value: str) -> str:
+        r'''Escape non-ASCII characters as Tcl ``\uXXXX``.
+
+        Tcl decodes a script using the *system* encoding, which follows the
+        host's locale. A manifest written as UTF-8 and read back under LANG=C
+        does not merely display oddly -- it decodes to a different string:
+        "café-Ω µm" comes back with a length of 12 instead of 9, so a path or a
+        design name silently stops matching. Escaping sidesteps the question,
+        because an ASCII file decodes the same way under every locale.
+
+        Must be applied *after* the backslash doubling in to_tcl, so that the
+        backslashes introduced here survive as escapes.
+        '''
+        out = []
+        for char in value:
+            point = ord(char)
+            if point < 0x80:
+                out.append(char)
+            elif point <= 0xFFFF:
+                out.append(f"\\u{point:04x}")
+            else:
+                # Tcl 8.6 has no \U; emit the surrogate pair it expects.
+                point -= 0x10000
+                out.append(f"\\u{0xD800 + (point >> 10):04x}"
+                           f"\\u{0xDC00 + (point & 0x3FF):04x}")
+        return "".join(out)
+
+    @staticmethod
     def to_tcl(value, sctype):
         '''
         Recursive helper function for converting Python values to safe TCL
@@ -315,7 +343,7 @@ class NodeType:
                                 .replace('[', '\\[')    # escape '[' to avoid command substitution
                                 .replace('$', '\\$')    # escape '$' to avoid variable substitution
                                 .replace('"', '\\"'))   # escape '"' to avoid string terminating
-            return '"' + escaped_val + '"'
+            return '"' + NodeType._tcl_ascii(escaped_val) + '"'
 
         if sctype == 'bool':
             return 'true' if value else 'false'
@@ -335,7 +363,7 @@ class NodeType:
                                                         # insert '\')
                                 .replace('[', '\\[')    # escape '[' to avoid command substitution
                                 .replace('"', '\\"'))   # escape '"' to avoid string terminating
-            return '"' + escaped_val + '"'
+            return '"' + NodeType._tcl_ascii(escaped_val) + '"'
 
         raise TypeError(f'{sctype} is not a supported type')
 

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -1136,10 +1136,17 @@ class Task(NamedSchema, PathSchema, DocsSchema):
         if suffix == "json":
             schema.write_manifest(manifest_path)
         else:
+            # Pin UTF-8 rather than taking the platform default. A design name
+            # or file path with a non-ASCII character would otherwise fail to
+            # write on any host whose locale is not UTF-8 -- LANG=C in a
+            # minimal container, or a Windows code page -- and it would fail
+            # mid-run, while writing the node's manifest. Python 3.15 makes
+            # UTF-8 the default and hides this; the versions SC supports today
+            # do not.
             fopen_args = {}
             if suffix == "csv":
                 fopen_args['newline'] = ''
-            with open(manifest_path, 'w', **fopen_args) as fout:
+            with open(manifest_path, 'w', encoding='UTF-8', **fopen_args) as fout:
                 if suffix == "yaml":
                     self.__write_yaml_manifest(fout, schema)
                 elif suffix == "tcl":

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import pytest
 
@@ -873,6 +874,40 @@ def test_write_manifest_stdjson(monkeypatch):
     assert not os.path.isfile("test.json")
     schema.write_manifest("test.json")
     assert os.path.isfile("test.json")
+
+
+@pytest.mark.parametrize("stdjson", (False, True))
+def test_write_manifest_non_ascii(monkeypatch, stdjson):
+    """The manifest must be pure ASCII whichever JSON library is installed.
+
+    ``json.dumps`` escapes non-ASCII by default (``ensure_ascii``); orjson has
+    no such option and emits UTF-8. That made the manifest's encoding depend on
+    which library happened to be present, and a server -- which has orjson --
+    read one back with a bare ``open()`` under ``LANG=C`` and failed the whole
+    job on 'ascii' codec can't decode byte 0xce. An ASCII manifest is decodable
+    by any reader, rather than relying on every reader remembering encoding=.
+    """
+    import json
+    if stdjson:
+        from siliconcompiler.schema import baseschema
+        monkeypatch.setattr(baseschema, 'json', json)
+        monkeypatch.setattr(baseschema, '_has_orjson', False)
+
+    schema = BaseSchema()
+    edit = EditableSchema(schema)
+    edit.insert("test0", "test1", Parameter("str"))
+    schema.set("test0", "test1", "µm_Ω")
+
+    schema.write_manifest("test.json")
+
+    raw = Path("test.json").read_bytes()
+    assert raw.isascii(), "manifest is not ASCII; a non-UTF-8 reader will fail on it"
+    assert b"\\u03a9" in raw
+
+    # Read it back the way the server did: no encoding= anywhere. The escapes
+    # must survive that, not merely be present in the file.
+    data = json.load(io.TextIOWrapper(io.BytesIO(raw), encoding="ascii"))
+    assert data["test0"]["test1"]["node"]["*"]["*"]["value"] == "µm_Ω"
 
 
 def test_write_manifest_path():

--- a/tests/schema/test_journal.py
+++ b/tests/schema/test_journal.py
@@ -1,5 +1,9 @@
 import json
+import os
 import pytest
+import subprocess
+import sys
+import textwrap
 
 from siliconcompiler.schema import BaseSchema
 from siliconcompiler.schema import EditableSchema
@@ -482,6 +486,49 @@ def test_replay_file():
     assert schema.get("test0", "test1") == []
     Journal.replay_file(schema, "replay.json")
     assert schema.get("test0", "test1") == ["hello"]
+
+
+def test_replay_file_non_ascii_under_c_locale():
+    """A UTF-8 manifest replays whatever encoding the host locale names.
+
+    Manifests are written as UTF-8, but this read them back with a bare
+    ``open()``, which decodes using the locale instead. A server running under
+    ``LANG=C`` failed a whole job on 'ascii' codec can't decode byte 0xce --
+    one Greek letter in a node's journal. SC now writes ASCII manifests, so
+    this covers the ones already on disk from earlier versions.
+
+    A subprocess is unavoidable: CPython resolves the locale encoding once at
+    interpreter startup, so patching :mod:`locale` in-process does not reach
+    ``open()`` and the test would pass with the fix reverted.
+    """
+    replay = [
+        {
+            "type": "add",
+            "key": ("test0", "test1"),
+            "value": "µm_Ω",
+            "field": "value",
+            "step": None,
+            "index": None
+        }
+    ]
+    with open("replay.json", "w", encoding="utf-8") as f:
+        json.dump({"__journal__": replay}, f, ensure_ascii=False)
+
+    script = textwrap.dedent("""
+        from siliconcompiler.schema import BaseSchema, EditableSchema, Parameter, Journal
+
+        schema = BaseSchema()
+        EditableSchema(schema).insert("test0", "test1", Parameter("[str]"))
+        Journal.replay_file(schema, "replay.json")
+        assert schema.get("test0", "test1") == ["\\u00b5m_\\u03a9"]
+    """)
+
+    env = dict(os.environ, LC_ALL="C", LANG="C")
+    env.pop("PYTHONUTF8", None)
+    # -X utf8=0 stops UTF-8 mode from overriding the locale we just set.
+    proc = subprocess.run([sys.executable, "-X", "utf8=0", "-c", script],
+                          capture_output=True, text=True, env=env)
+    assert proc.returncode == 0, proc.stderr
 
 
 def test_replay_file_empty():

--- a/tests/schema/test_parametertype.py
+++ b/tests/schema/test_parametertype.py
@@ -279,6 +279,18 @@ def test_normalize(type, value, expect):
         # File env-var substitution and bracket escaping (parallel to dir).
         ("file", "$TEST/test.txt", "\"$env(TEST)/test.txt\""),
         ("file", "/usr/test[0].txt", "\"/usr/test\\[0].txt\""),
+        # Non-ASCII is escaped to \uXXXX on every path that emits a quoted
+        # string, so the manifest is ASCII whatever encoding Tcl picks up from
+        # the locale. See test_tcl_ascii_* below.
+        ("str", "\u00b5m_\u03a9", "\"\\u00b5m_\\u03a9\""),
+        ("<a,\u03a9>", "\u03a9", "\"\\u03a9\""),
+        ("file", "/usr/\u00b5.txt", "\"/usr/\\u00b5.txt\""),
+        ("dir", "/usr/\u03a9[0]", "\"/usr/\\u03a9\\[0]\""),
+        ("[str]", ["\u03a9"], "[list \"\\u03a9\"]"),
+        # The escape runs after the backslash doubling, so a literal backslash
+        # is still doubled and the \u it introduces is not doubled with it.
+        ("str", "a\\\u03a9", "\"a\\\\\\u03a9\""),
+        ("dir", "/a\\\u03a9", "\"/a\\\\\\u03a9\""),
     ])
 def test_to_tcl(type, value, expect):
     assert NodeType.to_tcl(value, NodeType.parse(type)) == expect
@@ -287,6 +299,34 @@ def test_to_tcl(type, value, expect):
 def test_to_tcl_unsupported():
     with pytest.raises(TypeError, match=r"^invalid is not a supported type$"):
         NodeType.to_tcl(12, "invalid")
+
+
+@pytest.mark.parametrize(
+    "value,expect", [
+        ("", ""),
+        ("plain", "plain"),
+        # Boundaries of the ASCII passthrough. 0x7f is the last character that
+        # may be emitted literally; 0x80 is the first that may not.
+        ("\u007f", "\u007f"),
+        ("\u0080", "\\u0080"),
+        # Latin-1 and Greek: the characters that actually turned up in SC's own
+        # help text and design names.
+        ("µ", "\\u00b5"),
+        ("é", "\\u00e9"),
+        ("Ω", "\\u03a9"),
+        # Last character of the BMP, and the first that needs a surrogate pair.
+        ("￿", "\\uffff"),
+        ("\U00010000", "\\ud800\\udc00"),
+        ("\U0001f600", "\\ud83d\\ude00"),
+        ("\U0010ffff", "\\udbff\\udfff"),
+        # Mixed input keeps the ASCII run intact between escapes.
+        ("aΩb", "a\\u03a9b"),
+        ("naïve-Ω µm", "na\\u00efve-\\u03a9 \\u00b5m"),
+    ])
+def test_tcl_ascii(value, expect):
+    """Every branch of the escaper: ASCII, BMP, and astral."""
+    assert NodeType._tcl_ascii(value) == expect
+    assert NodeType._tcl_ascii(value).isascii()
 
 
 def test_normalize_value_enum():

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1193,7 +1193,7 @@ def test_write_task_manifest(running_node, suffix):
         assert os.listdir() == [f'sc_manifest.{suffix}']
 
 
-@pytest.mark.parametrize("suffix", ("tcl", "yaml"))
+@pytest.mark.parametrize("suffix", ("tcl", "yaml", "csv"))
 def test_write_task_manifest_specifies_encoding(running_node, monkeypatch, suffix):
     """The manifest writer must not take the platform's default encoding.
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,3 +1,4 @@
+import builtins
 import copy
 import csv
 import hashlib
@@ -1190,6 +1191,127 @@ def test_write_task_manifest(running_node, suffix):
     with running_node.task.runtime(running_node) as runtool:
         runtool.write_task_manifest('.')
         assert os.listdir() == [f'sc_manifest.{suffix}']
+
+
+@pytest.mark.parametrize("suffix", ("tcl", "yaml"))
+def test_write_task_manifest_specifies_encoding(running_node, monkeypatch, suffix):
+    """The manifest writer must not take the platform's default encoding.
+
+    Every format except json/gz went through a bare ``open(path, 'w')``. A
+    non-ASCII value then failed to write on any host whose locale is not UTF-8 --
+    LANG=C in a minimal container, or a Windows code page -- and it failed
+    mid-run, while writing a node's manifest.
+
+    Asserting on the encoding rather than on the written bytes is deliberate:
+    Python 3.15 makes UTF-8 the default, which would let a round-trip test pass
+    on a new interpreter while the bug was still live on a supported one.
+    """
+    opened = []
+    real_open = builtins.open
+
+    def spy(file, mode="r", *args, **kwargs):
+        if "w" in mode and "b" not in mode and str(file).endswith(f"sc_manifest.{suffix}"):
+            opened.append(kwargs.get("encoding"))
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", spy)
+
+    assert running_node.project.set("tool", "builtin", 'task', 'nop', "format", suffix)
+    with running_node.task.runtime(running_node) as runtool:
+        runtool.write_task_manifest('.')
+
+    assert opened, f"sc_manifest.{suffix} was never opened for writing"
+    assert all(enc and enc.lower().replace("-", "") == "utf8" for enc in opened), \
+        f"manifest opened with encoding={opened!r}; pass encoding='UTF-8' explicitly"
+
+
+def test_write_task_manifest_non_ascii_roundtrip(running_node):
+    """A non-ASCII value survives being written, as an escape.
+
+    Every format SC writes is ASCII: json escapes to \\uXXXX, PyYAML to \\xNN,
+    and tcl to \\uXXXX (test_write_task_manifest_tcl_is_ascii). That is what lets
+    a reader decode a manifest without knowing the host's locale.
+    """
+    suffix = "json"
+    assert running_node.project.set("tool", "builtin", 'task', 'nop', "format", suffix)
+    assert running_node.project.set("tool", "builtin", "task", "nop", "option",
+                                    ["--label=\u00b5m-\u03a9"])
+
+    with running_node.task.runtime(running_node) as runtool:
+        runtool.write_task_manifest('.')
+
+    with open(f"sc_manifest.{suffix}", "rb") as fobj:
+        raw = fobj.read()
+    # Escaped, not literal: SC's own manifests are written ASCII-only so that a
+    # reader with any encoding can decode them.
+    assert raw.isascii()
+    assert rb"\u00b5m-\u03a9" in raw
+
+
+def test_write_task_manifest_tcl_is_ascii(running_node):
+    """The Tcl manifest must contain no byte above 0x7f.
+
+    Tcl decodes a script with the *system* encoding, which follows the host's
+    locale. Raw UTF-8 read back under LANG=C does not merely display oddly, it
+    decodes to a different string -- a Greek/Latin mix comes back with a length of
+    12 instead of 9 -- so a path or a design name silently stops matching. An
+    ASCII file with \\uXXXX escapes decodes identically under every locale.
+    """
+    assert running_node.project.set("tool", "builtin", 'task', 'nop', "format", "tcl")
+    assert running_node.project.set("tool", "builtin", "task", "nop", "option",
+                                    ["--label=\u00b5m-\u03a9"])
+
+    with running_node.task.runtime(running_node) as runtool:
+        runtool.write_task_manifest('.')
+
+    with open("sc_manifest.tcl", "rb") as fobj:
+        raw = fobj.read()
+    assert raw.isascii(), "Tcl manifest is not ASCII; it will mis-decode under a non-UTF-8 locale"
+    assert b"\\u00b5m-\\u03a9" in raw
+
+
+@pytest.mark.parametrize("sysencoding", ("utf-8", "iso8859-1"))
+def test_write_task_manifest_tcl_non_ascii_roundtrip(running_node, sysencoding):
+    """Tcl reads a non-ASCII value back as the string SC wrote, under any locale.
+
+    ``encoding system`` is what Tcl decodes a sourced script with, and it
+    follows the host's locale: iso8859-1 under LANG=C, utf-8 otherwise. Setting
+    it directly covers both without a subprocess and without depending on the
+    locale the test happens to run under.
+
+    Written raw, the value comes back longer than it went in -- each non-ASCII
+    character split into its UTF-8 bytes -- so a path or a design name silently
+    stops matching, with no error to notice.
+    """
+    tkinter = pytest.importorskip("tkinter")
+
+    value = "naïve-Ω µm"
+    nop = running_node.project.get_nop()
+    nop.add_parameter("nonascii", "str", "non-ascii round-trip check")
+
+    assert running_node.project.set("tool", "builtin", "task", "nop", "format", "tcl")
+    assert running_node.project.set("tool", "builtin", "task", "nop", "var", "nonascii", value)
+
+    with running_node.task.runtime(running_node) as runtool:
+        runtool.write_task_manifest('.')
+
+    interp = tkinter.Tcl()
+    interp.eval(f"encoding system {sysencoding}")
+    # Tcl accepts forward slashes on every platform; backslashes in a Windows
+    # path would be read as escapes.
+    interp.eval("source {%s}" % os.path.abspath("sc_manifest.tcl").replace(os.sep, "/"))
+
+    # Compare code points rather than the decoded string: the value comes back
+    # through the same encoding machinery under test, so this pins what Tcl
+    # actually holds rather than how it chooses to hand it over.
+    codepoints = interp.eval(
+        'set v [dict get $sc_cfg tool builtin task nop var nonascii]\n'
+        'set out {}\n'
+        'foreach c [split $v ""] { lappend out [scan $c %c] }\n'
+        'return $out').split()
+
+    assert codepoints == [str(ord(char)) for char in value], \
+        "Tcl decoded the manifest to a different string than SC wrote"
 
 
 def test_write_task_manifest_abspath(running_node):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-ASCII characters in JSON, Tcl, journal, and task manifest files.
  * Ensured files consistently use UTF-8 encoding across system locales.
  * Added Unicode escaping for Tcl output, including characters outside the Basic Multilingual Plane.
  * Preserved Unicode values during manifest serialization and replay.

* **Tests**
  * Added coverage for Unicode serialization, encoding behavior, locale independence, and Tcl round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->