### PR TITLE
ensure IHP130 extracts and avoid pointless retries

### DIFF
--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -19,19 +19,21 @@ import re
 import site
 import shutil
 import stat
+import tarfile
 import time
 import threading
 
 import os.path
 
-from typing import Optional, List, Dict, Type, Union, TYPE_CHECKING
+from typing import Optional, List, Dict, Tuple, Type, Union, TYPE_CHECKING
 
 from fasteners import InterProcessLock
 from importlib.metadata import distributions, distribution
 from pathlib import Path, PureWindowsPath
 from urllib import parse as url_parse
 
-from siliconcompiler.package.cache import PathCache, DataRootResolutionError
+from siliconcompiler.package.cache import PathCache, DataRootResolutionError, \
+    PermanentResolutionError
 from siliconcompiler.utils import get_plugins, default_cache_dir
 from siliconcompiler.utils.paths import cwdirsafe
 from siliconcompiler.utils.multiprocessing import MPManager
@@ -40,6 +42,12 @@ if TYPE_CHECKING:
     from siliconcompiler.project import Project
     from siliconcompiler.schema_support.pathschema import PathSchema
     from siliconcompiler.schema import BaseSchema
+
+
+#: The extraction filters, and so the errors they raise, only exist on Python
+#: releases carrying the PEP 706 backport.
+_TAR_FILTER_ERRORS: Tuple[Type[BaseException], ...] = \
+    (tarfile.FilterError,) if hasattr(tarfile, "FilterError") else ()
 
 
 class Resolver:
@@ -163,6 +171,39 @@ class Resolver:
         """
         return False
 
+    def is_permanent_failure(self, error: BaseException) -> bool:
+        """
+        True if ``error`` will recur identically however many times it is retried.
+
+        The attempt budget is for failures a second try might survive: a dropped
+        connection, a truncated transfer, a server having a bad minute. It is
+        wasted on a failure that is settled the moment it happens, and the waste
+        is not free -- abandoning a source takes
+        :attr:`PathCache.max_attempts` fetches of the same data, plus the backoff
+        between them, to arrive at the answer the first attempt already had.
+
+        Two kinds of error are treated as settled:
+
+        * :class:`~siliconcompiler.package.cache.PermanentResolutionError`, raised
+          by a resolver that has itself established the answer will not change --
+          an HTTP status saying the data is not there, for instance.
+        * ``tarfile.FilterError``, raised when the extraction filter refuses a
+          member of a downloaded archive. That verdict is a property of the
+          archive's contents, so a fresh copy of the same archive earns it again.
+
+        Anything else counts as transient, deliberately: this decides how much
+        effort a failure is worth, and treating a retryable error as settled costs
+        a run that would have recovered, while the reverse costs some bandwidth.
+        Subclasses may widen this for errors specific to how they fetch.
+
+        Args:
+            error (BaseException): The error a resolution attempt raised.
+
+        Returns:
+            bool: True if the source should be abandoned without further attempts.
+        """
+        return isinstance(error, (PermanentResolutionError, *_TAR_FILTER_ERRORS))
+
     @property
     def is_indirect(self) -> bool:
         """
@@ -277,6 +318,12 @@ class Resolver:
         source = self.source
         if self.reference:
             source = f"{source} ({self.reference})"
+        if cache.is_permanent(self.cache_id):
+            # Say why one attempt was enough, so the single try does not read as a
+            # retry budget that failed to apply.
+            return (f"Unable to resolve '{self.display_name}' from {source}, and "
+                    f"retrying cannot change the outcome, giving up. "
+                    f"Error: {cache.failure(self.cache_id)}")
         return (f"Unable to resolve '{self.display_name}' from {source} after "
                 f"{cache.attempts(self.cache_id)} attempt(s), giving up. "
                 f"Last error: {cache.failure(self.cache_id)}")
@@ -292,8 +339,9 @@ class Resolver:
         where an attempt is expensive (see :attr:`is_retryable`), failures are
         counted in the shared :class:`~siliconcompiler.package.cache.PathCache`,
         so the repeated lookups a run performs consume a bounded budget rather
-        than re-fetching indefinitely. Once the budget is spent, later calls fail
-        immediately without touching the network.
+        than re-fetching indefinitely. A failure that a retry could not fix (see
+        :meth:`is_permanent_failure`) spends the whole budget at once. Once the
+        budget is spent, later calls fail immediately without touching the network.
 
         Returns:
             str: The absolute path to the resolved data on the local filesystem.
@@ -301,7 +349,7 @@ class Resolver:
         Raises:
             FileNotFoundError: If the resolved path does not exist.
             DataRootResolutionError: If the source has already failed to resolve
-                :attr:`PathCache.max_attempts` times.
+                :attr:`PathCache.max_attempts` times, or has failed permanently.
         """
         cache = self.cache
 
@@ -328,7 +376,10 @@ class Resolver:
             # SystemExit says nothing about whether the source is reachable, so
             # it must not consume the budget or poison the cache.
             if self.is_retryable:
-                if cache.record_failure(self.cache_id, e) >= cache.max_attempts:
+                if self.is_permanent_failure(e):
+                    cache.record_permanent_failure(self.cache_id, e)
+                    self.logger.error(self.__abandoned_message(cache))
+                elif cache.record_failure(self.cache_id, e) >= cache.max_attempts:
                     self.logger.error(self.__abandoned_message(cache))
             raise
 

--- a/siliconcompiler/package/cache.py
+++ b/siliconcompiler/package/cache.py
@@ -68,10 +68,14 @@ class DataSourceUnavailableError(PermanentResolutionError, FileNotFoundError):
     """
     Raised when a data source answers, but with an answer no retry will change.
 
-    An HTTP 404 or 403 is a complete answer: the source is telling us the thing
-    is not there, or is not ours to fetch. Also a ``FileNotFoundError``, because
-    that is what a missing data source has always raised and callers still catch
-    it.
+    An HTTP 404 is a complete answer: the source is telling us the thing is not
+    there. Which answers count is the fetching resolver's judgement, not this
+    class's -- see
+    :data:`siliconcompiler.package.https._TERMINAL_STATUSES` for the HTTP list, and
+    note that a refusal which a credential could lift (401, 403) is not on it.
+
+    Also a ``FileNotFoundError``, because that is what a missing data source has
+    always raised and callers still catch it.
     """
 
 

--- a/siliconcompiler/package/cache.py
+++ b/siliconcompiler/package/cache.py
@@ -439,7 +439,8 @@ class PathCache:
         them were permanent, are merged only when ``include_failures`` is True; a
         caller that considers failures local to the process that saw them (for
         example a scheduler merging results from one node, where the next node may
-        well succeed) can leave them behind.
+        well succeed) can leave them behind. A permanent mark is kept only for a
+        source that has a failure to go with it, in this payload or already here.
 
         A snapshot arrives from another process, over a pipe or a command line,
         so every part of it is treated as untrusted: anything unrecognized is
@@ -464,32 +465,36 @@ class PathCache:
             if not include_failures:
                 return
 
+            failures = payload.get("failures", None)
+            if isinstance(failures, dict):
+                for key, value in failures.items():
+                    if not isinstance(key, str):
+                        continue
+                    # Accept only a real two-element sequence. A bare string would
+                    # happily unpack into two characters, so reject anything that is
+                    # not a list or tuple before looking at it.
+                    if not isinstance(value, (list, tuple)) or len(value) != 2:
+                        continue
+                    try:
+                        attempts = int(value[0])
+                    except (TypeError, ValueError):
+                        continue
+                    attempts = max(0, attempts)
+                    # Keep whichever side has seen more failures so a merge can only
+                    # ever tighten the remaining budget.
+                    known, _ = self.__failures.get(key, (0, ""))
+                    if attempts >= known:
+                        self.__failures[key] = (attempts, str(value[1]))
+
+            # Merged after the failures, and only for a source one of them
+            # accounts for. A mark on its own would exhaust a source with no error
+            # to report it by, so a truncated payload could retire a data source
+            # for the rest of the process and leave the abandonment message with
+            # nothing to say.
             permanent = payload.get("permanent", None)
             if isinstance(permanent, (list, tuple, set)):
-                self.__permanent.update(key for key in permanent if isinstance(key, str))
-
-            failures = payload.get("failures", None)
-            if not isinstance(failures, dict):
-                return
-
-            for key, value in failures.items():
-                if not isinstance(key, str):
-                    continue
-                # Accept only a real two-element sequence. A bare string would
-                # happily unpack into two characters, so reject anything that is
-                # not a list or tuple before looking at it.
-                if not isinstance(value, (list, tuple)) or len(value) != 2:
-                    continue
-                try:
-                    attempts = int(value[0])
-                except (TypeError, ValueError):
-                    continue
-                attempts = max(0, attempts)
-                # Keep whichever side has seen more failures so a merge can only
-                # ever tighten the remaining budget.
-                known, _ = self.__failures.get(key, (0, ""))
-                if attempts >= known:
-                    self.__failures[key] = (attempts, str(value[1]))
+                self.__permanent.update(key for key in permanent
+                                        if isinstance(key, str) and key in self.__failures)
 
     def clear(self) -> None:
         """Removes all cached paths and recorded failures."""

--- a/siliconcompiler/package/cache.py
+++ b/siliconcompiler/package/cache.py
@@ -9,7 +9,8 @@ gives a run one place to record
 * how many times resolving it has *failed*, so a source that cannot be fetched
   is retried a bounded number of times -- with a randomized, exponentially
   growing delay between attempts -- and then abandoned with an actionable error
-  rather than re-downloaded by every caller, and
+  rather than re-downloaded by every caller, immediately where the failure is one
+  no retry could fix (see :class:`PermanentResolutionError`), and
 * the per-source download mutex used to keep threads from fetching the same
   source concurrently.
 
@@ -33,7 +34,7 @@ import random
 import threading
 import time
 
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Set, Tuple, Union
 
 from pathlib import Path
 
@@ -45,6 +46,32 @@ class DataRootResolutionError(RuntimeError):
     Once a source has failed :attr:`PathCache.max_attempts` times, further
     attempts are abandoned and this error is raised instead of retrying, so a
     broken or unreachable data source cannot be re-fetched indefinitely.
+    """
+
+
+class PermanentResolutionError(Exception):
+    """
+    Base for a resolution failure that means the *answer* is wrong, not the
+    connection.
+
+    A retry budget exists for failures that a second attempt might survive: a
+    dropped connection, a truncated download, a server having a bad minute. Some
+    failures are settled on the first attempt instead -- an archive whose
+    contents the extraction filter refuses, a URL the server says does not exist
+    -- and re-fetching one only spends the same bandwidth to reach the same
+    conclusion. Resolvers raise this, or any subclass, to say so; see
+    :meth:`~siliconcompiler.package.Resolver.is_permanent_failure`.
+    """
+
+
+class DataSourceUnavailableError(PermanentResolutionError, FileNotFoundError):
+    """
+    Raised when a data source answers, but with an answer no retry will change.
+
+    An HTTP 404 or 403 is a complete answer: the source is telling us the thing
+    is not there, or is not ours to fetch. Also a ``FileNotFoundError``, because
+    that is what a missing data source has always raised and callers still catch
+    it.
     """
 
 
@@ -84,6 +111,7 @@ class PathCache:
     def __init__(self):
         self.__paths: Dict[str, str] = {}
         self.__failures: Dict[str, Tuple[int, str]] = {}
+        self.__permanent: Set[str] = set()
         self.__max_attempts: int = PathCache.DEFAULT_MAX_ATTEMPTS
         self.__retry_delay: float = PathCache.DEFAULT_RETRY_DELAY
         self.__retry_backoff: float = PathCache.DEFAULT_RETRY_BACKOFF
@@ -151,17 +179,35 @@ class PathCache:
                 return None
             return self.__failures[cache_id][1]
 
-    def is_exhausted(self, cache_id: str) -> bool:
+    def is_permanent(self, cache_id: str) -> bool:
         """
-        Returns True if a data source has used up its attempt budget.
+        Returns True if a data source failed in a way no retry could fix.
 
         Args:
             cache_id (str): The resolver cache ID of the data source.
 
         Returns:
-            bool: True if the source has failed :attr:`max_attempts` times.
+            bool: True if the source's last failure was recorded through
+                :meth:`record_permanent_failure`.
         """
-        return self.attempts(cache_id) >= self.max_attempts
+        with self.__lock:
+            return cache_id in self.__permanent
+
+    def is_exhausted(self, cache_id: str) -> bool:
+        """
+        Returns True if a data source has used up its attempt budget.
+
+        A permanent failure exhausts the budget on the spot, however many
+        attempts are left: see :class:`PermanentResolutionError`.
+
+        Args:
+            cache_id (str): The resolver cache ID of the data source.
+
+        Returns:
+            bool: True if the source has failed permanently, or has failed
+                :attr:`max_attempts` times.
+        """
+        return self.is_permanent(cache_id) or self.attempts(cache_id) >= self.max_attempts
 
     def record_failure(self, cache_id: str, error: BaseException) -> int:
         """
@@ -183,6 +229,26 @@ class PathCache:
             self.__failures[cache_id] = (attempts, f"{type(error).__name__}: {error}")
             return attempts
 
+    def record_permanent_failure(self, cache_id: str, error: BaseException) -> int:
+        """
+        Records a failure that leaves nothing for a retry to accomplish.
+
+        The failure is counted like any other, so the attempt total stays an
+        honest record of what was tried, and the source is additionally marked
+        exhausted: :meth:`is_exhausted` is True from here on no matter how much
+        budget was left.
+
+        Args:
+            cache_id (str): The resolver cache ID of the data source.
+            error (BaseException): The error that caused the failure.
+
+        Returns:
+            int: The total number of failures recorded for this source.
+        """
+        with self.__lock:
+            self.__permanent.add(cache_id)
+            return self.record_failure(cache_id, error)
+
     def clear_failure(self, cache_id: str) -> None:
         """
         Forgets any recorded failures for a data source.
@@ -192,6 +258,7 @@ class PathCache:
         """
         with self.__lock:
             self.__failures.pop(cache_id, None)
+            self.__permanent.discard(cache_id)
 
     # ------------------------------------------------------------------
     # Retry policy
@@ -360,17 +427,19 @@ class PathCache:
         with self.__lock:
             return {
                 "paths": dict(self.__paths),
-                "failures": {key: list(value) for key, value in self.__failures.items()}
+                "failures": {key: list(value) for key, value in self.__failures.items()},
+                "permanent": sorted(self.__permanent)
             }
 
     def seed(self, payload: Optional[Dict[str, Any]], include_failures: bool = True) -> None:
         """
         Merges a snapshot produced by :meth:`export` into this cache.
 
-        Resolved paths are always merged. Failures are merged only when
-        ``include_failures`` is True; a caller that considers failures local to
-        the process that saw them (for example a scheduler merging results from
-        one node, where the next node may well succeed) can leave them behind.
+        Resolved paths are always merged. Failures, and the marks saying which of
+        them were permanent, are merged only when ``include_failures`` is True; a
+        caller that considers failures local to the process that saw them (for
+        example a scheduler merging results from one node, where the next node may
+        well succeed) can leave them behind.
 
         A snapshot arrives from another process, over a pipe or a command line,
         so every part of it is treated as untrusted: anything unrecognized is
@@ -394,6 +463,10 @@ class PathCache:
 
             if not include_failures:
                 return
+
+            permanent = payload.get("permanent", None)
+            if isinstance(permanent, (list, tuple, set)):
+                self.__permanent.update(key for key in permanent if isinstance(key, str))
 
             failures = payload.get("failures", None)
             if not isinstance(failures, dict):
@@ -423,6 +496,7 @@ class PathCache:
         with self.__lock:
             self.__paths.clear()
             self.__failures.clear()
+            self.__permanent.clear()
 
     # ------------------------------------------------------------------
     # Download mutex

--- a/siliconcompiler/package/https.py
+++ b/siliconcompiler/package/https.py
@@ -20,12 +20,18 @@ from siliconcompiler.package import RemoteResolver
 from siliconcompiler.package.cache import DataSourceUnavailableError
 from siliconcompiler.utils import tar_extract_kwargs
 
-#: HTTP statuses that describe the request rather than the server's health, and so
-#: mean the same thing however often they are asked -- excepting the two that ask
-#: for exactly that: 408 (the request took too long) and 429 (too many requests).
-#: A 5xx is left retryable: a server having a bad minute may not be having a bad
-#: hour.
-_RETRYABLE_CLIENT_ERRORS = (408, 429)
+#: HTTP statuses that answer the request completely enough that asking again can
+#: only collect the same answer: the data is not there (404, 410) or the request
+#: itself is one no server will accept (400, 405, 414, 451).
+#:
+#: An allowlist rather than "any 4xx", because plenty of 4xx responses do change:
+#: 408 and 429 ask to be retried outright, 409/421/423/425 describe a passing
+#: condition, and 401/403 turn into a 200 as soon as a token is granted -- GitHub
+#: also answers 403 for rate limiting. Since the attempt budget is shared by cache
+#: ID, which covers only the source and its reference, retiring one of those would
+#: also block a later resolver that does have credentials. A 5xx stays retryable
+#: too: a server having a bad minute may not be having a bad hour.
+_TERMINAL_STATUSES = (400, 404, 405, 410, 414, 451)
 
 
 def get_resolver() -> Dict[str, Type["HTTPResolver"]]:
@@ -109,10 +115,11 @@ class HTTPResolver(RemoteResolver):
         directory that GitHub often includes in its source archives.
 
         Raises:
-            FileNotFoundError: If the download fails. A status that will not change
-                on a retry (a 404, say) raises the
+            FileNotFoundError: If the download fails. One of the
+                :data:`_TERMINAL_STATUSES` raises the
                 :class:`~siliconcompiler.package.cache.DataSourceUnavailableError`
-                subclass, so the source is abandoned rather than re-requested.
+                subclass, so the source is abandoned rather than re-requested;
+                every other status, including 401 and 403, stays retryable.
         """
         data_url = self.download_url
 
@@ -138,9 +145,8 @@ class HTTPResolver(RemoteResolver):
         response = requests.get(data_url, stream=True, headers=headers)
         if not response.ok:
             status = response.status_code
-            error = FileNotFoundError
-            if 400 <= status < 500 and status not in _RETRYABLE_CLIENT_ERRORS:
-                error = DataSourceUnavailableError
+            error = DataSourceUnavailableError if status in _TERMINAL_STATUSES \
+                else FileNotFoundError
             raise error(f'Failed to download {self.display_name} data source from '
                         f'{data_url}. Status code: {status}')
 

--- a/siliconcompiler/package/https.py
+++ b/siliconcompiler/package/https.py
@@ -17,7 +17,15 @@ from io import BytesIO
 from urllib.parse import urlparse
 
 from siliconcompiler.package import RemoteResolver
+from siliconcompiler.package.cache import DataSourceUnavailableError
 from siliconcompiler.utils import tar_extract_kwargs
+
+#: HTTP statuses that describe the request rather than the server's health, and so
+#: mean the same thing however often they are asked -- excepting the two that ask
+#: for exactly that: 408 (the request took too long) and 429 (too many requests).
+#: A 5xx is left retryable: a server having a bad minute may not be having a bad
+#: hour.
+_RETRYABLE_CLIENT_ERRORS = (408, 429)
 
 
 def get_resolver() -> Dict[str, Type["HTTPResolver"]]:
@@ -101,7 +109,10 @@ class HTTPResolver(RemoteResolver):
         directory that GitHub often includes in its source archives.
 
         Raises:
-            FileNotFoundError: If the download fails (e.g., 404 error).
+            FileNotFoundError: If the download fails. A status that will not change
+                on a retry (a 404, say) raises the
+                :class:`~siliconcompiler.package.cache.DataSourceUnavailableError`
+                subclass, so the source is abandoned rather than re-requested.
         """
         data_url = self.download_url
 
@@ -126,8 +137,12 @@ class HTTPResolver(RemoteResolver):
 
         response = requests.get(data_url, stream=True, headers=headers)
         if not response.ok:
-            raise FileNotFoundError(f'Failed to download {self.display_name} data source from '
-                                    f'{data_url}. Status code: {response.status_code}')
+            status = response.status_code
+            error = FileNotFoundError
+            if 400 <= status < 500 and status not in _RETRYABLE_CLIENT_ERRORS:
+                error = DataSourceUnavailableError
+            raise error(f'Failed to download {self.display_name} data source from '
+                        f'{data_url}. Status code: {status}')
 
         os.makedirs(self.cache_path, exist_ok=True)
 

--- a/siliconcompiler/utils/__init__.py
+++ b/siliconcompiler/utils/__init__.py
@@ -1,4 +1,5 @@
 import contextlib
+import functools
 import logging
 import re
 import pathlib
@@ -37,7 +38,86 @@ if TYPE_CHECKING:
     from siliconcompiler.project import Project
 
 
-def tar_extract_kwargs(filter: str = "data") -> Dict[str, str]:
+@functools.lru_cache(maxsize=None)
+def _data_filter_mishandles_symlinks() -> bool:
+    """Reports whether this interpreter's ``data`` filter misjudges symlinks.
+
+    The first PEP 706 backport -- Python 3.8.17, 3.9.17, 3.10.12 and 3.11.4 --
+    resolved a symlink's target from the extraction root rather than from the
+    directory the link lives in, so ``filter="data"`` rejects an ordinary
+    relative symlink. Real archives trip over this: the IHP130 PDK ships
+    ``ihp-sg13g2/libs.tech/ngspice/install.py -> ../xschem/install.py``, which
+    the broken check reads as pointing a level *above* the destination. CPython
+    fixed it in gh-107845, released in the next point release of every branch,
+    but ``requires-python`` admits the broken ones.
+
+    The defect only ever rejects a safe link, never accepts an unsafe one:
+    prepending the link's own directory can only move the target deeper into the
+    destination. So this detects a false positive, not a missing check.
+
+    Returns:
+        bool: True if relative symlink targets are resolved from the wrong
+            directory.
+    """
+    probe = tarfile.TarInfo("dir/link")
+    probe.type = tarfile.SYMTYPE
+    # Points at 'dir/target', a sibling of the link, and so is always safe.
+    probe.linkname = f"..{os.sep}dir{os.sep}target"
+
+    # Two levels deep, so a single '..' escaping the destination has somewhere to
+    # land: with the filesystem root as the destination it would not.
+    dest = os.path.join(os.path.abspath(os.sep), "sc_filter_probe", "dest")
+    try:
+        tarfile.data_filter(probe, dest)
+    except tarfile.LinkOutsideDestinationError:
+        return True
+    except tarfile.FilterError:  # pragma: no cover - the probe is safe otherwise
+        return False
+    return False
+
+
+def _symlink_safe_data_filter(member: tarfile.TarInfo,
+                              dest_path: str) -> Optional[tarfile.TarInfo]:
+    """Applies the ``data`` extraction filter with its symlink check corrected.
+
+    Used in place of the plain ``"data"`` filter on the releases
+    :func:`_data_filter_mishandles_symlinks` identifies, so a valid archive still
+    extracts there.
+
+    The correction is to hand the filter a link target that is already relative
+    to ``dest_path``, which is where the broken check resolves from. It then
+    computes the same target the fixed filter would, and every other part of the
+    ``data`` filter -- name containment, permission clamping, special file
+    rejection -- stays exactly as CPython wrote it, including its rejection of a
+    link that really does escape. The archive's own link target is put back
+    afterwards, since that is what gets written to disk.
+
+    Only relative symlinks are rerouted. A hard link's target genuinely is
+    relative to the archive root, and an absolute target is rejected by the
+    filter itself, so both go straight through.
+
+    Args:
+        member (tarfile.TarInfo): The archive member about to be extracted.
+        dest_path (str): The directory being extracted into.
+
+    Returns:
+        tarfile.TarInfo: The member to extract, or None to skip it.
+    """
+    # Matches how the filter itself arrives at a relative name before it uses one.
+    name = member.name.lstrip("/" + os.sep)
+    if not member.issym() or os.path.isabs(name) or os.path.isabs(member.linkname):
+        return tarfile.data_filter(member, dest_path)
+
+    linkname = os.path.normpath(member.linkname)
+    from_dest = os.path.normpath(os.path.join(os.path.dirname(name), linkname))
+
+    checked = tarfile.data_filter(member.replace(linkname=from_dest, deep=False), dest_path)
+    if checked is None:
+        return None
+    return checked.replace(linkname=linkname, deep=False)
+
+
+def tar_extract_kwargs(filter: str = "data") -> Dict[str, Union[str, Callable]]:
     """Returns keyword arguments selecting a PEP 706 extraction filter.
 
     ``TarFile.extractall``/``extract`` gained the ``filter`` argument in Python
@@ -49,14 +129,22 @@ def tar_extract_kwargs(filter: str = "data") -> Dict[str, str]:
     ``TypeError``; those versions also predate the warning, so return no kwargs
     and let the legacy default apply.
 
+    Where the requested filter is ``"data"`` and this interpreter is one of the
+    releases that misreads relative symlinks (see
+    :func:`_data_filter_mishandles_symlinks`), a corrected equivalent is returned
+    instead of the filter's name. The filter is not weakened to do it: the same
+    ``data`` checks run, on the target the link actually points at.
+
     Args:
         filter (str): The extraction filter to request (``"data"``, ``"tar"`` or
             ``"fully_trusted"``). Defaults to ``"data"``, the safest option and
             the Python 3.14 default.
     """
-    if hasattr(tarfile, "data_filter"):
-        return {"filter": filter}
-    return {}
+    if not hasattr(tarfile, "data_filter"):
+        return {}
+    if filter == "data" and _data_filter_mishandles_symlinks():
+        return {"filter": _symlink_safe_data_filter}
+    return {"filter": filter}
 
 
 def link_symlink_copy(srcfile, dstfile):

--- a/siliconcompiler/utils/__init__.py
+++ b/siliconcompiler/utils/__init__.py
@@ -57,8 +57,12 @@ def _data_filter_mishandles_symlinks() -> bool:
 
     Returns:
         bool: True if relative symlink targets are resolved from the wrong
-            directory.
+            directory. False on a release with no extraction filter at all, which
+            has no such check to get wrong.
     """
+    if not hasattr(tarfile, "data_filter"):
+        return False
+
     probe = tarfile.TarInfo("dir/link")
     probe.type = tarfile.SYMTYPE
     # Points at 'dir/target', a sibling of the link, and so is always safe.
@@ -92,6 +96,14 @@ def _symlink_safe_data_filter(member: tarfile.TarInfo,
     link that really does escape. The archive's own link target is put back
     afterwards, since that is what gets written to disk.
 
+    That rerouted target is joined and deliberately left unnormalized. Collapsing
+    ``a/b/../t`` to ``a/t`` would settle the link's fate textually while the check
+    that follows resolves it for real: if ``a/b`` is itself a link the archive
+    planted earlier, the two answers differ, and the textual one can be walked out
+    of the destination. Leaving the ``..`` in place makes the path that gets checked
+    the same expression the kernel will follow, so the link that is validated is
+    the link that is created.
+
     Only relative symlinks are rerouted. A hard link's target genuinely is
     relative to the archive root, and an absolute target is rejected by the
     filter itself, so both go straight through.
@@ -108,13 +120,12 @@ def _symlink_safe_data_filter(member: tarfile.TarInfo,
     if not member.issym() or os.path.isabs(name) or os.path.isabs(member.linkname):
         return tarfile.data_filter(member, dest_path)
 
-    linkname = os.path.normpath(member.linkname)
-    from_dest = os.path.normpath(os.path.join(os.path.dirname(name), linkname))
+    from_dest = os.path.join(os.path.dirname(name), member.linkname)
 
     checked = tarfile.data_filter(member.replace(linkname=from_dest, deep=False), dest_path)
     if checked is None:
         return None
-    return checked.replace(linkname=linkname, deep=False)
+    return checked.replace(linkname=member.linkname, deep=False)
 
 
 def tar_extract_kwargs(filter: str = "data") -> Dict[str, Union[str, Callable]]:

--- a/siliconcompiler/utils/__init__.py
+++ b/siliconcompiler/utils/__init__.py
@@ -102,7 +102,14 @@ def _symlink_safe_data_filter(member: tarfile.TarInfo,
     planted earlier, the two answers differ, and the textual one can be walked out
     of the destination. Leaving the ``..`` in place makes the path that gets checked
     the same expression the kernel will follow, so the link that is validated is
-    the link that is created.
+    the link that is created. (On Windows the two cannot diverge in the first
+    place, because ``ntpath.realpath`` collapses ``..`` before it resolves a
+    reparse point, but the check does not need to know that.)
+
+    The one thing changed about the target is its separators, since a Windows
+    symlink cannot hold a forward slash: extracting an archive's ``../a/b``
+    verbatim there yields a link the OS will not follow. The structure is left
+    alone, so this is a no-op wherever ``/`` is already the separator.
 
     Only relative symlinks are rerouted. A hard link's target genuinely is
     relative to the archive root, and an absolute target is rejected by the
@@ -120,12 +127,13 @@ def _symlink_safe_data_filter(member: tarfile.TarInfo,
     if not member.issym() or os.path.isabs(name) or os.path.isabs(member.linkname):
         return tarfile.data_filter(member, dest_path)
 
-    from_dest = os.path.join(os.path.dirname(name), member.linkname)
+    linkname = member.linkname.replace("/", os.sep)
+    from_dest = os.path.join(os.path.dirname(name), linkname)
 
     checked = tarfile.data_filter(member.replace(linkname=from_dest, deep=False), dest_path)
     if checked is None:
         return None
-    return checked.replace(linkname=member.linkname, deep=False)
+    return checked.replace(linkname=linkname, deep=False)
 
 
 def tar_extract_kwargs(filter: str = "data") -> Dict[str, Union[str, Callable]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -569,10 +569,17 @@ def broken_tarfile_data_filter(monkeypatch):
     workaround in :func:`siliconcompiler.utils.tar_extract_kwargs` has to be
     exercised somewhere other than on them.
 
+    A release older still -- anything before the backport -- has no extraction
+    filter to stand in for, and extracts the link without complaint, so there is
+    nothing for these tests to exercise there.
+
     Yields:
         The stand-in filter, for a test that wants to pass it to ``extractall``
         directly rather than through ``tar_extract_kwargs``.
     """
+    if not hasattr(tarfile, "data_filter"):
+        pytest.skip("release predates the PEP 706 extraction filters")
+
     real = tarfile.data_filter
 
     def broken(member, dest_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import shutil
 import socket
 import subprocess
 import sys
+import tarfile
 import time
 
 import os.path
@@ -553,3 +554,46 @@ def disable_mp_process():
          patch("siliconcompiler.scheduler.scheduler.get_process_context",
                return_value=fake_ctx):
         yield
+
+
+@pytest.fixture
+def broken_tarfile_data_filter(monkeypatch):
+    """
+    Makes this interpreter look like one that misreads relative symlinks.
+
+    Python 3.8.17, 3.9.17, 3.10.12 and 3.11.4 shipped the first PEP 706 backport,
+    which resolved a symlink's target from the extraction root instead of from the
+    directory holding the link (fixed by CPython gh-107845). A relative symlink
+    into a sibling directory -- as the IHP130 PDK ships -- looked to them like an
+    escape from the destination. ``requires-python`` admits those releases, so the
+    workaround in :func:`siliconcompiler.utils.tar_extract_kwargs` has to be
+    exercised somewhere other than on them.
+
+    Yields:
+        The stand-in filter, for a test that wants to pass it to ``extractall``
+        directly rather than through ``tar_extract_kwargs``.
+    """
+    real = tarfile.data_filter
+
+    def broken(member, dest_path):
+        # Only the containment checks are reproduced, in the order the old filter
+        # ran them -- a member's own name before its link target. Everything else
+        # is left to the real filter.
+        dest = os.path.realpath(dest_path)
+
+        name = member.name.lstrip("/" + os.sep)
+        target = os.path.realpath(os.path.join(dest, name))
+        if os.path.commonpath([target, dest]) != dest:
+            raise tarfile.OutsideDestinationError(member, target)
+
+        if (member.issym() or member.islnk()) and not os.path.isabs(member.linkname):
+            target = os.path.realpath(os.path.join(dest, member.linkname))
+            if os.path.commonpath([target, dest]) != dest:
+                raise tarfile.LinkOutsideDestinationError(member, target)
+
+        return real(member, dest_path)
+
+    monkeypatch.setattr(tarfile, "data_filter", broken)
+    utils._data_filter_mishandles_symlinks.cache_clear()
+    yield broken
+    utils._data_filter_mishandles_symlinks.cache_clear()

--- a/tests/package/test_cache.py
+++ b/tests/package/test_cache.py
@@ -427,6 +427,37 @@ def test_seed_tolerates_malformed_permanent_entries(payload):
     assert cache.export()["permanent"] == []
 
 
+@pytest.mark.parametrize("payload", (
+    {"permanent": ["id"]},                              # no failures at all
+    {"permanent": ["id"], "failures": "notadict"},      # failures unusable
+    {"permanent": ["id"], "failures": {"id": [1]}},     # failure record malformed
+    {"permanent": ["id"], "failures": {"other": [1, "ValueError: nope"]}},
+))
+def test_seed_skips_permanent_without_a_failure(payload):
+    """
+    A mark with no failure behind it would retire the source for the rest of the
+    process and leave the abandonment message with nothing to report, so a
+    truncated payload must not be able to plant one.
+    """
+    cache = PathCache()
+    cache.seed(payload)
+
+    assert not cache.is_permanent("id")
+    assert not cache.is_exhausted("id")
+    assert cache.failure("id") is None
+
+
+def test_seed_permanent_backed_by_a_local_failure():
+    """A mark for a source this process has already seen fail does count."""
+    cache = PathCache()
+    cache.record_failure("id", ValueError("nope"))
+
+    cache.seed({"permanent": ["id"]})
+
+    assert cache.is_permanent("id")
+    assert cache.failure("id") == "ValueError: nope"
+
+
 def test_seed_keeps_highest_attempt_count():
     source = PathCache()
     source.record_failure("id", ValueError("one"))

--- a/tests/package/test_cache.py
+++ b/tests/package/test_cache.py
@@ -75,6 +75,40 @@ def test_record_failure_is_per_id():
     assert cache.attempts("id1") == 0
 
 
+def test_record_permanent_failure():
+    """A failure no retry could fix leaves no budget behind."""
+    cache = PathCache()
+
+    assert cache.record_permanent_failure("id", ValueError("settled")) == 1
+
+    # Counted like any other failure, so the record of what was tried stays honest
+    assert cache.attempts("id") == 1
+    assert cache.failure("id") == "ValueError: settled"
+    # ... but with none of the budget left
+    assert cache.is_permanent("id")
+    assert cache.is_exhausted("id")
+
+
+def test_record_permanent_failure_is_per_id():
+    cache = PathCache()
+    cache.record_permanent_failure("id0", ValueError("settled"))
+    cache.record_failure("id1", ValueError("nope"))
+
+    assert cache.is_permanent("id0")
+    assert not cache.is_permanent("id1")
+    assert not cache.is_permanent("id2")
+    assert not cache.is_exhausted("id1")
+
+
+def test_record_permanent_failure_after_transient_ones():
+    """A source that starts failing transiently and then settles is settled."""
+    cache = PathCache()
+    cache.record_failure("id", TimeoutError("slow"))
+
+    assert cache.record_permanent_failure("id", ValueError("settled")) == 2
+    assert cache.is_exhausted("id")
+
+
 def test_clear_failure():
     cache = PathCache()
     cache.record_failure("id", ValueError("nope"))
@@ -85,6 +119,25 @@ def test_clear_failure():
 
     # Must not raise for an unknown id
     cache.clear_failure("other")
+
+
+def test_clear_failure_forgets_permanence():
+    """A source that resolved on a later look is no longer a settled failure."""
+    cache = PathCache()
+    cache.record_permanent_failure("id", ValueError("settled"))
+    cache.clear_failure("id")
+
+    assert not cache.is_permanent("id")
+    assert not cache.is_exhausted("id")
+
+
+def test_permanent_failure_ignores_max_attempts():
+    """Raising the budget cannot revive a source whose answer will not change."""
+    cache = PathCache()
+    cache.set_max_attempts(10)
+    cache.record_permanent_failure("id", ValueError("settled"))
+
+    assert cache.is_exhausted("id")
 
 
 def test_set_max_attempts():
@@ -294,18 +347,35 @@ def test_export():
 
     assert cache.export() == {
         "paths": {"id0": "/path0"},
-        "failures": {"id1": [1, "ValueError: nope"]}
+        "failures": {"id1": [1, "ValueError: nope"]},
+        "permanent": []
     }
+
+
+def test_export_permanent_failures():
+    cache = PathCache()
+    cache.record_permanent_failure("id1", ValueError("settled"))
+    cache.record_failure("id0", ValueError("nope"))
+
+    export = cache.export()
+    assert export["failures"] == {
+        "id1": [1, "ValueError: settled"],
+        "id0": [1, "ValueError: nope"]
+    }
+    assert export["permanent"] == ["id1"]
 
 
 def test_export_is_a_copy():
     cache = PathCache()
     cache.set("id0", "/path0")
+    cache.record_permanent_failure("id1", ValueError("settled"))
 
     export = cache.export()
     export["paths"]["id0"] = "/tampered"
+    export["permanent"].append("id2")
 
     assert cache.get("id0") == "/path0"
+    assert not cache.is_permanent("id2")
 
 
 def test_seed_roundtrip():
@@ -321,10 +391,22 @@ def test_seed_roundtrip():
     assert dest.failure("id1") == "ValueError: nope"
 
 
+def test_seed_roundtrip_permanent_failure():
+    source = PathCache()
+    source.record_permanent_failure("id", ValueError("settled"))
+
+    dest = PathCache()
+    dest.seed(source.export())
+
+    assert dest.is_permanent("id")
+    assert dest.is_exhausted("id")
+
+
 def test_seed_ignore_failures():
     source = PathCache()
     source.set("id0", "/path0")
     source.record_failure("id1", ValueError("nope"))
+    source.record_permanent_failure("id2", ValueError("settled"))
 
     dest = PathCache()
     dest.seed(source.export(), include_failures=False)
@@ -332,6 +414,17 @@ def test_seed_ignore_failures():
     assert dest.get("id0") == "/path0"
     assert dest.attempts("id1") == 0
     assert dest.failure("id1") is None
+    # Permanence is a kind of failure, so it stays behind with the rest
+    assert not dest.is_permanent("id2")
+
+
+@pytest.mark.parametrize("payload", ("notalist", 5, {"id": True}, [5, None, ()]))
+def test_seed_tolerates_malformed_permanent_entries(payload):
+    cache = PathCache()
+    cache.seed({"permanent": payload})
+
+    assert not cache.is_permanent("id")
+    assert cache.export()["permanent"] == []
 
 
 def test_seed_keeps_highest_attempt_count():
@@ -377,11 +470,13 @@ def test_clear():
     cache = PathCache()
     cache.set("id0", "/path0")
     cache.record_failure("id1", ValueError("nope"))
+    cache.record_permanent_failure("id2", ValueError("settled"))
 
     cache.clear()
 
     assert cache.get("id0") is None
     assert cache.attempts("id1") == 0
+    assert not cache.is_permanent("id2")
 
 
 def test_clear_keeps_policy():
@@ -588,6 +683,7 @@ def test_unhashable_cache_ids(cache_id):
                  lambda: cache.failure(cache_id),
                  lambda: cache.is_exhausted(cache_id),
                  lambda: cache.record_failure(cache_id, ValueError("nope")),
+                 lambda: cache.record_permanent_failure(cache_id, ValueError("nope")),
                  lambda: cache.thread_lock(cache_id)):
         with pytest.raises(TypeError):
             call()
@@ -602,9 +698,11 @@ def test_unhashable_cache_id_leaves_cache_usable(cache_id):
     cache = PathCache()
     cache.set("good", "/path")
 
-    # clear_failure is a no-op rather than an error while nothing has failed:
-    # dict.pop with a default skips hashing on an empty dict.
-    cache.clear_failure(cache_id)
+    # While nothing has failed, clear_failure may raise or quietly do nothing,
+    # depending on the key: an empty dict.pop skips hashing altogether, and a set
+    # is looked up in a set as its frozen equivalent rather than rejected.
+    with contextlib.suppress(TypeError):
+        cache.clear_failure(cache_id)
 
     cache.record_failure("good", ValueError("nope"))
     with pytest.raises(TypeError):
@@ -615,7 +713,8 @@ def test_unhashable_cache_id_leaves_cache_usable(cache_id):
     cache.set("more", "/other")
     assert cache.export() == {
         "paths": {"good": "/path", "more": "/other"},
-        "failures": {"good": [1, "ValueError: nope"]}
+        "failures": {"good": [1, "ValueError: nope"]},
+        "permanent": []
     }
 
 

--- a/tests/package/test_https.py
+++ b/tests/package/test_https.py
@@ -11,6 +11,8 @@ from io import BytesIO
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+from siliconcompiler.package import DataRootResolutionError
+from siliconcompiler.package.cache import DataSourceUnavailableError
 from siliconcompiler.package.https import HTTPResolver
 from siliconcompiler import Project
 
@@ -67,6 +69,87 @@ def test_dependency_path_download_http_failed():
                        match=r"^Failed to download sc-data data source from "
                              r"https://.*\.tar\.gz\. Status code: 400$"):
         resolver.resolve()
+
+
+def _failing_resolver(status):
+    """A resolver aimed at a URL that answers with `status` and nothing else."""
+    responses.add(responses.GET, re.compile(r".*"), status=status)
+
+    proj = Project("testproj")
+    proj.option.set_cachedir(".")
+    resolver = HTTPResolver("sc-data", proj, "https://example.com/data.tar.gz", "ref")
+    resolver.cache.set_retry_delay(0)
+    return resolver
+
+
+@pytest.mark.parametrize("status", (400, 401, 403, 404, 410, 451))
+@responses.activate
+def test_download_status_is_not_retried(status):
+    """
+    A 4xx describes the request, not the server's health, so asking again just
+    collects the same answer -- at the cost of the whole attempt budget.
+    """
+    resolver = _failing_resolver(status)
+
+    with pytest.raises(DataSourceUnavailableError):
+        resolver.get_path()
+
+    for _ in range(3):
+        with pytest.raises(DataRootResolutionError):
+            resolver.get_path()
+
+    assert len(responses.calls) == 1
+    assert resolver.cache.is_permanent(resolver.cache_id)
+
+
+@pytest.mark.parametrize("status", (408, 429, 500, 503))
+@responses.activate
+def test_download_status_is_retried(status):
+    """A server having a bad minute may not be having a bad hour."""
+    resolver = _failing_resolver(status)
+
+    for _ in range(5):
+        with pytest.raises((FileNotFoundError, DataRootResolutionError)):
+            resolver.get_path()
+
+    assert len(responses.calls) == resolver.cache.max_attempts
+    assert not resolver.cache.is_permanent(resolver.cache_id)
+
+
+def test_resolve_remote_relative_symlink(broken_tarfile_data_filter, tmpdir):
+    """
+    A PDK that ships a relative symlink -- IHP130 ships exactly one -- has to
+    unpack even on the releases whose extraction filter misreads one.
+    """
+    project = Project("testproj")
+    project.set("option", "cachedir", str(tmpdir))
+
+    resolver = HTTPResolver("test", project, "https://example.com/data.tar.gz", "v1.0")
+
+    tar_buffer = BytesIO()
+    with tarfile.open(fileobj=tar_buffer, mode='w:gz') as tar:
+        info = tarfile.TarInfo(name="libs.tech/xschem/install.py")
+        info.size = 5
+        tar.addfile(info, BytesIO(b"hello"))
+
+        link = tarfile.TarInfo(name="libs.tech/ngspice/install.py")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../xschem/install.py"
+        tar.addfile(link)
+
+    import siliconcompiler.package.https as https_module
+    with patch.object(https_module, "requests") as mock_requests:
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.content = tar_buffer.getvalue()
+        mock_requests.get.return_value = mock_response
+
+        resolver.resolve_remote()
+
+    installer = os.path.join(str(resolver.cache_path), "libs.tech", "ngspice", "install.py")
+    assert os.path.islink(installer)
+    with open(installer, "rb") as f:
+        assert f.read() == b"hello"
 
 
 # ============================================================================

--- a/tests/package/test_https.py
+++ b/tests/package/test_https.py
@@ -82,12 +82,13 @@ def _failing_resolver(status):
     return resolver
 
 
-@pytest.mark.parametrize("status", (400, 401, 403, 404, 410, 451))
+@pytest.mark.parametrize("status", (400, 404, 405, 410, 414, 451))
 @responses.activate
 def test_download_status_is_not_retried(status):
     """
-    A 4xx describes the request, not the server's health, so asking again just
-    collects the same answer -- at the cost of the whole attempt budget.
+    These answer the request completely -- the data is not there, or the request is
+    one no server will accept -- so asking again just collects the same answer, at
+    the cost of the whole attempt budget.
     """
     resolver = _failing_resolver(status)
 
@@ -102,10 +103,16 @@ def test_download_status_is_not_retried(status):
     assert resolver.cache.is_permanent(resolver.cache_id)
 
 
-@pytest.mark.parametrize("status", (408, 429, 500, 503))
+@pytest.mark.parametrize("status", (401, 403, 408, 409, 421, 423, 425, 429, 500, 503))
 @responses.activate
 def test_download_status_is_retried(status):
-    """A server having a bad minute may not be having a bad hour."""
+    """
+    A server having a bad minute may not be having a bad hour, and the rest of
+    these describe a passing condition too: 401 and 403 turn into a 200 once a
+    token is granted, and GitHub answers 403 for rate limiting. Retiring one would
+    also block a later resolver for the same source that does have credentials,
+    since the budget is keyed by source and reference alone.
+    """
     resolver = _failing_resolver(status)
 
     for _ in range(5):

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -5,6 +5,8 @@ import pytest
 import shutil
 import stat
 import sys
+import tarfile
+import zipfile
 
 import os.path
 
@@ -17,6 +19,7 @@ from siliconcompiler.package import Resolver, RemoteResolver
 from siliconcompiler.package import FileResolver, PythonPathResolver, \
     KeyPathResolver, DatarootResolver
 from siliconcompiler.package import DataRootResolutionError
+from siliconcompiler.package.cache import PermanentResolutionError, DataSourceUnavailableError
 from siliconcompiler.utils.multiprocessing import MPManager
 from siliconcompiler.package import InterProcessLock as dut_ipl
 
@@ -572,9 +575,10 @@ def test_remote_resolve_cached():
 class FailingResolver(RemoteResolver):
     """A remote source that never resolves, counting each attempt."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, error=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.calls = 0
+        self.error = error if error else FileNotFoundError("simulated 404")
 
     def check_cache(self):
         return False
@@ -585,21 +589,125 @@ class FailingResolver(RemoteResolver):
 
     def resolve_remote(self):
         self.calls += 1
-        raise FileNotFoundError("simulated 404")
+        raise self.error
 
 
 @pytest.fixture
 def failing_resolver():
     """Builds a failing remote resolver with retry delays disabled."""
-    def build(root=None, source="https://filepath", reference="ref"):
+    def build(root=None, source="https://filepath", reference="ref", error=None):
         if root is None:
             root = Project("testproj")
             root.option.set_cachedir(".")
-        resolver = FailingResolver("thisname", root, source, reference)
+        resolver = FailingResolver("thisname", root, source, reference, error=error)
         resolver.cache.set_retry_delay(0)
         return resolver
 
     return build
+
+
+def _rejected_link():
+    """The error a downloaded archive earns by holding a link out of bounds."""
+    return tarfile.LinkOutsideDestinationError(tarfile.TarInfo("pkg/link"), "/elsewhere")
+
+
+@pytest.mark.parametrize("error,permanent", (
+    (FileNotFoundError("404"), False),
+    (ConnectionError("reset by peer"), False),
+    (TimeoutError("no answer"), False),
+    (tarfile.ReadError("truncated"), False),
+    (zipfile.BadZipFile("truncated"), False),
+    (TypeError("neither tar nor zip"), False),
+    (PermanentResolutionError("settled"), True),
+    (DataSourceUnavailableError("no such release"), True),
+    (tarfile.LinkOutsideDestinationError(tarfile.TarInfo("pkg/link"), "/elsewhere"), True),
+    (tarfile.AbsoluteLinkError(tarfile.TarInfo("pkg/link")), True),
+    (tarfile.SpecialFileError(tarfile.TarInfo("pkg/dev")), True),
+))
+def test_is_permanent_failure(error, permanent):
+    """
+    A transfer that broke may work next time; an archive whose contents the
+    extraction filter refuses will be refused just as firmly on a fresh copy.
+    """
+    resolver = Resolver("thisname", Project("testproj"), "https://filepath", "ref")
+
+    assert resolver.is_permanent_failure(error) is permanent
+
+
+def test_get_path_permanent_failure_is_not_retried(failing_resolver):
+    """One attempt is all a settled failure gets, whatever the budget allows."""
+    resolver = failing_resolver(error=_rejected_link())
+
+    with pytest.raises(tarfile.LinkOutsideDestinationError):
+        resolver.get_path()
+
+    for _ in range(5):
+        with pytest.raises(DataRootResolutionError):
+            resolver.get_path()
+
+    assert resolver.calls == 1
+    assert resolver.cache.attempts(resolver.cache_id) == 1
+    assert resolver.cache.is_permanent(resolver.cache_id)
+
+
+def test_get_path_permanent_failure_does_not_wait(failing_resolver):
+    """Nothing is gained by backing off before a retry that will not happen."""
+    resolver = failing_resolver(error=_rejected_link())
+    resolver.cache.set_retry_delay(30)
+
+    with patch("siliconcompiler.package.cache.time.sleep") as sleep:
+        with pytest.raises(tarfile.LinkOutsideDestinationError):
+            resolver.get_path()
+        with pytest.raises(DataRootResolutionError):
+            resolver.get_path()
+
+    sleep.assert_not_called()
+
+
+def test_get_path_permanent_abandoned_message(failing_resolver):
+    resolver = failing_resolver(error=_rejected_link())
+
+    with pytest.raises(tarfile.LinkOutsideDestinationError):
+        resolver.get_path()
+
+    with pytest.raises(DataRootResolutionError, match=(
+            r"^Unable to resolve 'thisname' from https://filepath \(ref\), and retrying "
+            r"cannot change the outcome, giving up\. Error: LinkOutsideDestinationError: "
+            r"'pkg/link' would link to '/elsewhere', which is outside the destination$")):
+        resolver.get_path()
+
+
+def test_get_path_permanent_abandoned_is_logged(failing_resolver, project_logger, caplog):
+    project = Project("testproj")
+    project.option.set_cachedir(".")
+    project_logger(project)
+    project.logger.setLevel(logging.INFO)
+
+    resolver = failing_resolver(root=project, error=_rejected_link())
+    with pytest.raises(tarfile.LinkOutsideDestinationError):
+        resolver.get_path()
+
+    # Reported on the attempt that settled it, not on some later lookup
+    assert "and retrying cannot change the outcome, giving up" in caplog.text
+
+
+def test_get_path_permanent_failure_of_a_local_source(failing_resolver):
+    """
+    A source that is not worth retrying is not worth bookkeeping either: it fails
+    the same way every time whether or not the failure was recorded.
+    """
+    class Failing(Resolver):
+        def resolve(self):
+            raise PermanentResolutionError("settled")
+
+    resolver = Failing("thisname", Project("testproj"), "source://x")
+    assert not resolver.is_retryable
+
+    for _ in range(3):
+        with pytest.raises(PermanentResolutionError):
+            resolver.get_path()
+
+    assert not resolver.cache.is_permanent(resolver.cache_id)
 
 
 def test_get_path_failure_is_bounded(failing_resolver):

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -606,11 +606,6 @@ def failing_resolver():
     return build
 
 
-def _rejected_link():
-    """The error a downloaded archive earns by holding a link out of bounds."""
-    return tarfile.LinkOutsideDestinationError(tarfile.TarInfo("pkg/link"), "/elsewhere")
-
-
 @pytest.mark.parametrize("error,permanent", (
     (FileNotFoundError("404"), False),
     (ConnectionError("reset by peer"), False),
@@ -620,25 +615,41 @@ def _rejected_link():
     (TypeError("neither tar nor zip"), False),
     (PermanentResolutionError("settled"), True),
     (DataSourceUnavailableError("no such release"), True),
-    (tarfile.LinkOutsideDestinationError(tarfile.TarInfo("pkg/link"), "/elsewhere"), True),
-    (tarfile.AbsoluteLinkError(tarfile.TarInfo("pkg/link")), True),
-    (tarfile.SpecialFileError(tarfile.TarInfo("pkg/dev")), True),
 ))
 def test_is_permanent_failure(error, permanent):
     """
-    A transfer that broke may work next time; an archive whose contents the
-    extraction filter refuses will be refused just as firmly on a fresh copy.
+    A transfer that broke may work next time; a source that has answered has
+    already said everything it is going to say.
     """
     resolver = Resolver("thisname", Project("testproj"), "https://filepath", "ref")
 
     assert resolver.is_permanent_failure(error) is permanent
 
 
+# The extraction filters, and so their errors, only exist on releases carrying the
+# PEP 706 backport; an older one has no such error to classify.
+@pytest.mark.skipif(not hasattr(tarfile, "FilterError"),
+                    reason="release predates the PEP 706 extraction filters")
+@pytest.mark.parametrize("build", (
+    lambda: tarfile.LinkOutsideDestinationError(tarfile.TarInfo("pkg/link"), "/elsewhere"),
+    lambda: tarfile.AbsoluteLinkError(tarfile.TarInfo("pkg/link")),
+    lambda: tarfile.SpecialFileError(tarfile.TarInfo("pkg/dev")),
+), ids=("link-outside", "absolute-link", "special-file"))
+def test_is_permanent_failure_for_archive_contents(build):
+    """
+    An archive the extraction filter refuses will be refused just as firmly on a
+    fresh copy, so re-downloading it settles nothing.
+    """
+    resolver = Resolver("thisname", Project("testproj"), "https://filepath", "ref")
+
+    assert resolver.is_permanent_failure(build()) is True
+
+
 def test_get_path_permanent_failure_is_not_retried(failing_resolver):
     """One attempt is all a settled failure gets, whatever the budget allows."""
-    resolver = failing_resolver(error=_rejected_link())
+    resolver = failing_resolver(error=PermanentResolutionError("settled"))
 
-    with pytest.raises(tarfile.LinkOutsideDestinationError):
+    with pytest.raises(PermanentResolutionError):
         resolver.get_path()
 
     for _ in range(5):
@@ -652,11 +663,11 @@ def test_get_path_permanent_failure_is_not_retried(failing_resolver):
 
 def test_get_path_permanent_failure_does_not_wait(failing_resolver):
     """Nothing is gained by backing off before a retry that will not happen."""
-    resolver = failing_resolver(error=_rejected_link())
+    resolver = failing_resolver(error=PermanentResolutionError("settled"))
     resolver.cache.set_retry_delay(30)
 
     with patch("siliconcompiler.package.cache.time.sleep") as sleep:
-        with pytest.raises(tarfile.LinkOutsideDestinationError):
+        with pytest.raises(PermanentResolutionError):
             resolver.get_path()
         with pytest.raises(DataRootResolutionError):
             resolver.get_path()
@@ -665,15 +676,15 @@ def test_get_path_permanent_failure_does_not_wait(failing_resolver):
 
 
 def test_get_path_permanent_abandoned_message(failing_resolver):
-    resolver = failing_resolver(error=_rejected_link())
+    resolver = failing_resolver(error=DataSourceUnavailableError("no such release"))
 
-    with pytest.raises(tarfile.LinkOutsideDestinationError):
+    with pytest.raises(DataSourceUnavailableError):
         resolver.get_path()
 
     with pytest.raises(DataRootResolutionError, match=(
             r"^Unable to resolve 'thisname' from https://filepath \(ref\), and retrying "
-            r"cannot change the outcome, giving up\. Error: LinkOutsideDestinationError: "
-            r"'pkg/link' would link to '/elsewhere', which is outside the destination$")):
+            r"cannot change the outcome, giving up\. Error: DataSourceUnavailableError: "
+            r"no such release$")):
         resolver.get_path()
 
 
@@ -683,8 +694,8 @@ def test_get_path_permanent_abandoned_is_logged(failing_resolver, project_logger
     project_logger(project)
     project.logger.setLevel(logging.INFO)
 
-    resolver = failing_resolver(root=project, error=_rejected_link())
-    with pytest.raises(tarfile.LinkOutsideDestinationError):
+    resolver = failing_resolver(root=project, error=PermanentResolutionError("settled"))
+    with pytest.raises(PermanentResolutionError):
         resolver.get_path()
 
     # Reported on the attempt that settled it, not on some later lookup

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -311,7 +311,8 @@ def test_halt_sends_pathcache(project):
 
     assert sent == [{
         "paths": {"someid": "/some/path"},
-        "failures": {"otherid": [1, "ValueError: nope"]}
+        "failures": {"otherid": [1, "ValueError: nope"]},
+        "permanent": []
     }]
 
 
@@ -356,7 +357,7 @@ def test_run_sends_pathcache(project):
     with patch("siliconcompiler.scheduler.SchedulerNode.execute"):
         node.run()
 
-    assert sent == [{"paths": {"someid": "/some/path"}, "failures": {}}]
+    assert sent == [{"paths": {"someid": "/some/path"}, "failures": {}, "permanent": []}]
 
 
 def test_halt_with_reason(project_logger, project, caplog):

--- a/tests/scheduler/test_taskscheduler.py
+++ b/tests/scheduler/test_taskscheduler.py
@@ -417,12 +417,14 @@ def test_process_completed_nodes_ignores_failures(large_flow, make_tasks):
     _, pipe = _setup_completed_node(scheduler, node, exitcode=0, pipe_has_data=True)
     pipe.recv.return_value = {
         "paths": {},
-        "failures": {"otherid": [3, "FileNotFoundError: simulated 404"]}
+        "failures": {"otherid": [3, "FileNotFoundError: simulated 404"]},
+        "permanent": ["otherid"]
     }
 
     scheduler._TaskScheduler__process_completed_nodes()
 
     assert MPManager.get_path_cache().attempts("otherid") == 0
+    assert not MPManager.get_path_cache().is_permanent("otherid")
     assert not MPManager.get_path_cache().is_exhausted("otherid")
 
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -962,18 +962,36 @@ def _extract(archive, **kwargs):
     return os.path.join(dest, "pkg", "libs.tech", "ngspice", "install.py")
 
 
+#: Both of these hold on the interpreter actually running the suite, whatever it
+#: is. The tests below that describe another release fake it with the
+#: broken_tarfile_data_filter fixture or by removing the filter, so these are
+#: snapshotted here, before any of that.
+_HAS_FILTERS = hasattr(tarfile, "data_filter")
+_MISHANDLES_SYMLINKS = utils._data_filter_mishandles_symlinks()
+
+needs_filters = pytest.mark.skipif(
+    not _HAS_FILTERS, reason="release predates the PEP 706 extraction filters")
+needs_working_filters = pytest.mark.skipif(
+    not _HAS_FILTERS or _MISHANDLES_SYMLINKS,
+    reason="release either predates the extraction filters or predates CPython gh-107845, "
+           "so tar_extract_kwargs answers with something other than the filter's name")
+
+
+@needs_working_filters
 def test_tar_extract_kwargs():
     assert tar_extract_kwargs() == {"filter": "data"}
 
 
+@needs_filters
 @pytest.mark.parametrize("filter", ("tar", "fully_trusted"))
 def test_tar_extract_kwargs_other_filters(filter):
+    """Neither filter checks link targets, so neither is ever substituted."""
     assert tar_extract_kwargs(filter) == {"filter": filter}
 
 
 def test_tar_extract_kwargs_legacy_python(monkeypatch):
     """A release predating PEP 706 has no filter argument to pass."""
-    monkeypatch.delattr(tarfile, "data_filter")
+    monkeypatch.delattr(tarfile, "data_filter", raising=False)
     utils._data_filter_mishandles_symlinks.cache_clear()
 
     assert tar_extract_kwargs() == {}
@@ -981,9 +999,24 @@ def test_tar_extract_kwargs_legacy_python(monkeypatch):
     utils._data_filter_mishandles_symlinks.cache_clear()
 
 
-def test_data_filter_symlinks_not_mishandled():
-    """The interpreter running the tests must carry CPython gh-107845."""
-    assert utils._data_filter_mishandles_symlinks() is False
+@needs_filters
+def test_data_filter_symlinks_probe_agrees_with_the_filter():
+    """
+    The probe has to report what this interpreter's filter actually does, so ask
+    the filter the same question directly -- from a different destination, since a
+    probe that only works against its own is no probe at all.
+    """
+    member = tarfile.TarInfo("dir/link")
+    member.type = tarfile.SYMTYPE
+    member.linkname = os.path.join(os.pardir, "dir", "target")
+
+    rejected = False
+    try:
+        tarfile.data_filter(member, os.path.abspath("dest"))
+    except tarfile.LinkOutsideDestinationError:
+        rejected = True
+
+    assert utils._data_filter_mishandles_symlinks() is rejected
 
 
 def test_data_filter_mishandled_symlinks_detected(broken_tarfile_data_filter):
@@ -1007,18 +1040,27 @@ def test_data_filter_rejects_valid_symlink(broken_tarfile_data_filter, symlink_a
 def test_corrected_filter_extracts_valid_symlink(broken_tarfile_data_filter, symlink_archive):
     link = _extract(symlink_archive("../xschem/install.py"), **tar_extract_kwargs())
 
-    # Written as the archive stored it, and pointing at the real file
+    # Written as the archive stored it -- separators aside, since Windows keeps its
+    # own -- and pointing at the real file
     assert os.path.islink(link)
-    assert os.readlink(link) == os.path.join("..", "xschem", "install.py")
+    assert os.readlink(link).replace(os.sep, "/") == "../xschem/install.py"
     with open(link, "rb") as f:
         assert f.read() == b"installer\n"
 
 
-def test_corrected_filter_normalizes_linkname(broken_tarfile_data_filter, symlink_archive):
-    """Matching what a fixed data filter does with a redundant link target."""
-    link = _extract(symlink_archive("../xschem/./install.py"), **tar_extract_kwargs())
+def test_corrected_filter_preserves_linkname(broken_tarfile_data_filter):
+    """
+    The link is passed on exactly as the archive stored it, redundant components
+    and all. Tidying it up would be a guess about what the archive meant, and it
+    would also decide the link textually while the check resolves it -- see
+    test_corrected_filter_still_rejects_a_link_through_a_planted_directory.
+    """
+    member = tarfile.TarInfo("pkg/libs.tech/ngspice/install.py")
+    member.type = tarfile.SYMTYPE
+    member.linkname = "../xschem/./install.py"
 
-    assert os.readlink(link) == os.path.join("..", "xschem", "install.py")
+    filtered = utils._symlink_safe_data_filter(member, os.path.abspath("dest"))
+    assert filtered.linkname == "../xschem/./install.py"
 
 
 @pytest.mark.parametrize("linkname", (
@@ -1034,7 +1076,11 @@ def test_corrected_filter_still_rejects_escaping_symlink(broken_tarfile_data_fil
 
 def test_corrected_filter_still_rejects_absolute_symlink(broken_tarfile_data_filter,
                                                          symlink_archive):
-    with pytest.raises(tarfile.AbsoluteLinkError):
+    # AbsoluteLinkError where '/etc/passwd' is an absolute path, and
+    # LinkOutsideDestinationError on Windows, where a drive-less path is not one and
+    # gets read as a relative climb out of the destination instead. Either way the
+    # filter is the one refusing it.
+    with pytest.raises(tarfile.FilterError):
         _extract(symlink_archive("/etc/passwd"), **tar_extract_kwargs())
 
 
@@ -1044,6 +1090,31 @@ def test_corrected_filter_still_rejects_escaping_name(broken_tarfile_data_filter
     with pytest.raises(tarfile.OutsideDestinationError):
         _extract(symlink_archive("install.py", linkpath="../evil/install.py"),
                  **tar_extract_kwargs())
+
+
+def test_corrected_filter_still_rejects_a_link_through_a_planted_directory(
+        broken_tarfile_data_filter):
+    """
+    An archive can leave a symlinked directory behind and then route a later link
+    through it, so that the same '..' means one thing textually and another on
+    disk. 'here' resolves to the destination itself, which makes 'here/inside' one
+    level deep, not two -- so '../..' climbs out even though counting the
+    components of the name says it cannot. The check has to resolve the path, not
+    count it.
+    """
+    dest = os.path.abspath("dest")
+    os.makedirs(os.path.join(dest, "inside"), exist_ok=True)
+    try:
+        os.symlink(".", os.path.join(dest, "here"), target_is_directory=True)
+    except OSError as e:  # pragma: no cover - Windows without the symlink privilege
+        pytest.skip(f"cannot plant a symlinked directory here: {e}")
+
+    member = tarfile.TarInfo("here/inside/link")
+    member.type = tarfile.SYMTYPE
+    member.linkname = os.path.join(os.pardir, os.pardir, "escaped")
+
+    with pytest.raises(tarfile.LinkOutsideDestinationError):
+        utils._symlink_safe_data_filter(member, dest)
 
 
 def test_corrected_filter_passes_through_non_symlinks(broken_tarfile_data_filter):
@@ -1057,13 +1128,19 @@ def test_corrected_filter_passes_through_non_symlinks(broken_tarfile_data_filter
 
 
 def test_corrected_filter_passes_through_hard_links(broken_tarfile_data_filter):
-    """A hard link's target really is relative to the archive root."""
-    member = tarfile.TarInfo("dir/link")
-    member.type = tarfile.LNKTYPE
-    member.linkname = "dir/target"
+    """
+    A hard link's target really is relative to the archive root, so it goes to the
+    filter unrerouted and whatever the filter makes of it stands.
+    """
+    def member():
+        hardlink = tarfile.TarInfo("dir/link")
+        hardlink.type = tarfile.LNKTYPE
+        hardlink.linkname = "dir/target"
+        return hardlink
 
-    filtered = utils._symlink_safe_data_filter(member, os.getcwd())
-    assert filtered.linkname == "dir/target"
+    dest = os.path.abspath("dest")
+    assert utils._symlink_safe_data_filter(member(), dest).linkname == \
+        tarfile.data_filter(member(), dest).linkname
 
 
 def test_corrected_filter_honors_a_skipped_member(broken_tarfile_data_filter, monkeypatch):

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -5,15 +5,17 @@ import os
 import os.path
 import psutil
 import sys
+import tarfile
 import types
 
 from importlib.metadata import entry_points
+from io import BytesIO
 from unittest.mock import patch
 
 from siliconcompiler import utils
 from siliconcompiler.utils import \
     truncate_text, safecompare, get_cores, grep, \
-    get_plugins, \
+    get_plugins, tar_extract_kwargs, \
     default_sc_dir, default_credentials_file, default_cache_dir, \
     default_email_credentials_file, default_sc_path, default_sc_system_path
 from siliconcompiler.utils import (
@@ -921,3 +923,155 @@ def test_check_python_dependencies_isolates_per_project(
         "good environment is out of sync with pyproject.toml; "
         "run 'pip install -e .' to update",
     ]
+
+
+# ============================================================================
+# tarfile extraction filter
+# ============================================================================
+
+@pytest.fixture
+def symlink_archive():
+    """
+    Builds a tarball shaped like the IHP130 PDK: a file, and a symlink reaching
+    it from a sibling directory.
+    """
+    def build(linkname, linkpath="pkg/libs.tech/ngspice/install.py"):
+        buf = BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            data = b"installer\n"
+            info = tarfile.TarInfo("pkg/libs.tech/xschem/install.py")
+            info.size = len(data)
+            tar.addfile(info, BytesIO(data))
+
+            link = tarfile.TarInfo(linkpath)
+            link.type = tarfile.SYMTYPE
+            link.linkname = linkname
+            tar.addfile(link)
+        buf.seek(0)
+        return buf
+
+    return build
+
+
+def _extract(archive, **kwargs):
+    """Extracts into a directory of the test's own, returning the link it holds."""
+    dest = os.path.abspath("dest")
+    os.makedirs(dest, exist_ok=True)
+    with tarfile.open(fileobj=archive, mode="r:gz") as tar:
+        tar.extractall(path=dest, **kwargs)
+    return os.path.join(dest, "pkg", "libs.tech", "ngspice", "install.py")
+
+
+def test_tar_extract_kwargs():
+    assert tar_extract_kwargs() == {"filter": "data"}
+
+
+@pytest.mark.parametrize("filter", ("tar", "fully_trusted"))
+def test_tar_extract_kwargs_other_filters(filter):
+    assert tar_extract_kwargs(filter) == {"filter": filter}
+
+
+def test_tar_extract_kwargs_legacy_python(monkeypatch):
+    """A release predating PEP 706 has no filter argument to pass."""
+    monkeypatch.delattr(tarfile, "data_filter")
+    utils._data_filter_mishandles_symlinks.cache_clear()
+
+    assert tar_extract_kwargs() == {}
+
+    utils._data_filter_mishandles_symlinks.cache_clear()
+
+
+def test_data_filter_symlinks_not_mishandled():
+    """The interpreter running the tests must carry CPython gh-107845."""
+    assert utils._data_filter_mishandles_symlinks() is False
+
+
+def test_data_filter_mishandled_symlinks_detected(broken_tarfile_data_filter):
+    assert utils._data_filter_mishandles_symlinks() is True
+
+
+def test_tar_extract_kwargs_substitutes_corrected_filter(broken_tarfile_data_filter):
+    """Only the 'data' filter checks link targets, so only it needs correcting."""
+    assert tar_extract_kwargs() == {"filter": utils._symlink_safe_data_filter}
+    assert tar_extract_kwargs("tar") == {"filter": "tar"}
+
+
+def test_data_filter_rejects_valid_symlink(broken_tarfile_data_filter, symlink_archive):
+    """The failure being worked around, so the workaround is shown to be needed."""
+    with pytest.raises(tarfile.LinkOutsideDestinationError,
+                       match=r"^'pkg/libs\.tech/ngspice/install\.py' would link to .*"
+                             r"which is outside the destination$"):
+        _extract(symlink_archive("../xschem/install.py"), filter=broken_tarfile_data_filter)
+
+
+def test_corrected_filter_extracts_valid_symlink(broken_tarfile_data_filter, symlink_archive):
+    link = _extract(symlink_archive("../xschem/install.py"), **tar_extract_kwargs())
+
+    # Written as the archive stored it, and pointing at the real file
+    assert os.path.islink(link)
+    assert os.readlink(link) == os.path.join("..", "xschem", "install.py")
+    with open(link, "rb") as f:
+        assert f.read() == b"installer\n"
+
+
+def test_corrected_filter_normalizes_linkname(broken_tarfile_data_filter, symlink_archive):
+    """Matching what a fixed data filter does with a redundant link target."""
+    link = _extract(symlink_archive("../xschem/./install.py"), **tar_extract_kwargs())
+
+    assert os.readlink(link) == os.path.join("..", "xschem", "install.py")
+
+
+@pytest.mark.parametrize("linkname", (
+    "../../../../../etc/passwd",       # climbs out of the destination
+    "../../../..",                     # climbs out to a directory
+))
+def test_corrected_filter_still_rejects_escaping_symlink(broken_tarfile_data_filter,
+                                                         symlink_archive, linkname):
+    """Correcting a false positive must not cost the check itself."""
+    with pytest.raises(tarfile.LinkOutsideDestinationError):
+        _extract(symlink_archive(linkname), **tar_extract_kwargs())
+
+
+def test_corrected_filter_still_rejects_absolute_symlink(broken_tarfile_data_filter,
+                                                         symlink_archive):
+    with pytest.raises(tarfile.AbsoluteLinkError):
+        _extract(symlink_archive("/etc/passwd"), **tar_extract_kwargs())
+
+
+def test_corrected_filter_still_rejects_escaping_name(broken_tarfile_data_filter,
+                                                      symlink_archive):
+    """A member whose own name escapes is rejected before its link is looked at."""
+    with pytest.raises(tarfile.OutsideDestinationError):
+        _extract(symlink_archive("install.py", linkpath="../evil/install.py"),
+                 **tar_extract_kwargs())
+
+
+def test_corrected_filter_passes_through_non_symlinks(broken_tarfile_data_filter):
+    """A member with no link target is handed to the filter untouched."""
+    member = tarfile.TarInfo("file.txt")
+    member.size = 5
+
+    filtered = utils._symlink_safe_data_filter(member, os.getcwd())
+    assert filtered.name == "file.txt"
+    assert filtered.linkname == ""
+
+
+def test_corrected_filter_passes_through_hard_links(broken_tarfile_data_filter):
+    """A hard link's target really is relative to the archive root."""
+    member = tarfile.TarInfo("dir/link")
+    member.type = tarfile.LNKTYPE
+    member.linkname = "dir/target"
+
+    filtered = utils._symlink_safe_data_filter(member, os.getcwd())
+    assert filtered.linkname == "dir/target"
+
+
+def test_corrected_filter_honors_a_skipped_member(broken_tarfile_data_filter, monkeypatch):
+    """A filter that skips a member returns None, which must be passed along."""
+    monkeypatch.setattr(tarfile, "data_filter", lambda member, dest: None)
+
+    member = tarfile.TarInfo("dir/link")
+    member.type = tarfile.SYMTYPE
+    member.linkname = "../dir/target"
+
+    assert utils._symlink_safe_data_filter(member, os.getcwd()) is None

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -983,10 +983,10 @@ def test_tar_extract_kwargs():
 
 
 @needs_filters
-@pytest.mark.parametrize("filter", ("tar", "fully_trusted"))
-def test_tar_extract_kwargs_other_filters(filter):
+@pytest.mark.parametrize("extraction_filter", ("tar", "fully_trusted"))
+def test_tar_extract_kwargs_other_filters(extraction_filter):
     """Neither filter checks link targets, so neither is ever substituted."""
-    assert tar_extract_kwargs(filter) == {"filter": filter}
+    assert tar_extract_kwargs(extraction_filter) == {"filter": extraction_filter}
 
 
 def test_tar_extract_kwargs_legacy_python(monkeypatch):
@@ -1050,17 +1050,20 @@ def test_corrected_filter_extracts_valid_symlink(broken_tarfile_data_filter, sym
 
 def test_corrected_filter_preserves_linkname(broken_tarfile_data_filter):
     """
-    The link is passed on exactly as the archive stored it, redundant components
-    and all. Tidying it up would be a guess about what the archive meant, and it
-    would also decide the link textually while the check resolves it -- see
-    test_corrected_filter_still_rejects_a_link_through_a_planted_directory.
+    The link is passed on with the structure the archive gave it, redundant
+    components and all -- only its separators are localized. Tidying the structure
+    up would be a guess about what the archive meant, and it would also decide the
+    link textually while the check resolves it, as
+    test_corrected_filter_still_rejects_a_link_through_a_planted_directory shows.
     """
     member = tarfile.TarInfo("pkg/libs.tech/ngspice/install.py")
     member.type = tarfile.SYMTYPE
     member.linkname = "../xschem/./install.py"
 
     filtered = utils._symlink_safe_data_filter(member, os.path.abspath("dest"))
-    assert filtered.linkname == "../xschem/./install.py"
+    # Both halves matter: the structure is the archive's, and the separators are
+    # this platform's, which is what keeps the link followable on Windows.
+    assert filtered.linkname == "../xschem/./install.py".replace("/", os.sep)
 
 
 @pytest.mark.parametrize("linkname", (
@@ -1092,6 +1095,10 @@ def test_corrected_filter_still_rejects_escaping_name(broken_tarfile_data_filter
                  **tar_extract_kwargs())
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="ntpath.realpath collapses '..' before it resolves a reparse point, so a "
+           "symlinked directory cannot change what the path above it means")
 def test_corrected_filter_still_rejects_a_link_through_a_planted_directory(
         broken_tarfile_data_filter):
     """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package resolution by identifying permanent failures and stopping unnecessary retries.
  - Added clearer error reporting for unavailable data sources and non-retryable HTTP responses.
  - Preserved safe relative symlinks when extracting archives on affected Python versions.
  - Continued rejecting unsafe archive paths, absolute links, and traversal attempts.

- **Improvements**
  - Permanent failure status is retained across cache export and import operations.
  - Resolution and retry documentation now distinguish permanent failures from temporary failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->