### PR TITLE
use encode/decode to speed up serilization

### DIFF
--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -4,6 +4,7 @@
 # SC dependencies outside of its directory, since it may be used by tool drivers
 # that have isolated Python environments.
 
+import codecs
 import contextlib
 import copy
 import importlib
@@ -37,6 +38,28 @@ from .journal import Journal
 from ._metadata import version
 
 TSchema = TypeVar('TSchema', bound='BaseSchema')
+
+
+def _json_escape_error(exc: UnicodeEncodeError) -> Tuple[str, int]:
+    r'''Replace a run of non-ASCII characters with their JSON ``\uXXXX`` escapes.
+
+    ``encode_basestring_ascii`` is the C escaper :func:`json.dumps` itself uses,
+    so an astral character comes out as the surrogate pair JSON requires. It
+    returns a quoted string literal; the quotes are dropped because the run is
+    being spliced back into one.
+    '''
+    return stdlib_json.encoder.encode_basestring_ascii(
+        exc.object[exc.start:exc.end])[1:-1], exc.end
+
+
+# codecs keeps one process-wide registry of error handlers, so this name has to
+# be unlikely to collide with another package's. Deriving it from __name__ gets
+# that for free and keeps the module from naming the package around it -- this
+# file is loaded by tool drivers in isolated environments and cannot assume it
+# is sitting inside siliconcompiler.
+_JSON_ASCII_ERRORS = f"{__name__}.jsonescape"
+
+codecs.register_error(_JSON_ASCII_ERRORS, _json_escape_error)
 
 
 class SchemaFrozenError(RuntimeError):
@@ -532,13 +555,19 @@ class BaseSchema:
                 # whatever the host locale claims -- a server running under
                 # LANG=C failed a whole job on one Greek letter in a journal.
                 #
-                # Re-serializing rather than post-processing the string: only
-                # \uXXXX is a legal JSON escape, so backslashreplace (which works
-                # per byte, and yields \xNN) produces a manifest that will not
-                # parse. isascii() is a C-level scan, and the slow path only runs
-                # on the rare manifest that needs it.
+                # Escape in place rather than re-serializing with the stdlib:
+                # json.dumps skips its C encoder whenever indent is set, so the
+                # fallback would push the whole manifest -- megabytes of it --
+                # through the pure-Python encoder. One Greek letter in a help
+                # string made the manifest non-ASCII and cost 45% of a test
+                # suite's runtime. Only \uXXXX is a legal JSON escape, so this
+                # cannot use backslashreplace, which works per byte and yields
+                # \xNN. isascii() is a C-level scan, so ASCII manifests (the
+                # overwhelming majority) pay nothing.
                 if not manifest_str.isascii():
-                    manifest_str = stdlib_json.dumps(manifest, indent=2, default=default)
+                    manifest_str = manifest_str \
+                        .encode("ascii", _JSON_ASCII_ERRORS) \
+                        .decode("ascii")
             else:
                 manifest_str = json.dumps(manifest, indent=2, default=default)
             fout.write(manifest_str)

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -910,6 +910,43 @@ def test_write_manifest_non_ascii(monkeypatch, stdjson):
     assert data["test0"]["test1"]["node"]["*"]["*"]["value"] == "µm_Ω"
 
 
+def test_write_manifest_non_ascii_escapes_in_place(monkeypatch):
+    """Making the manifest ASCII must not re-serialize it.
+
+    ``json.dumps`` skips its C encoder whenever ``indent`` is set, so falling
+    back to the stdlib pushes the entire manifest -- megabytes of it, thousands
+    of times over a run -- through the pure-Python encoder. A single Greek
+    letter in one tool's help string cost 45% of a test suite's runtime that
+    way, because it made every manifest take the slow path.
+
+    Astral characters are the reason this is not simply ``backslashreplace``:
+    that escapes per byte and emits ``\\xNN``, which is not legal JSON.
+    """
+    import json
+    from siliconcompiler.schema import baseschema
+    if not baseschema._has_orjson:
+        pytest.skip("without orjson the stdlib encoder is the only path")
+
+    def reserialized(*args, **kwargs):
+        raise AssertionError("manifest was re-serialized with the pure-Python encoder")
+
+    monkeypatch.setattr(baseschema.stdlib_json, "dumps", reserialized)
+
+    schema = BaseSchema()
+    edit = EditableSchema(schema)
+    edit.insert("test0", "test1", Parameter("str"))
+    schema.set("test0", "test1", "µm_Ω_\U0001F600")
+
+    schema.write_manifest("test.json")
+
+    raw = Path("test.json").read_bytes()
+    assert raw.isascii()
+    # The astral character must be the surrogate pair, not \U0001f600.
+    assert b"\\ud83d\\ude00" in raw
+    data = json.load(io.TextIOWrapper(io.BytesIO(raw), encoding="ascii"))
+    assert data["test0"]["test1"]["node"]["*"]["*"]["value"] == "µm_Ω_\U0001F600"
+
+
 def test_write_manifest_path():
     from siliconcompiler.schema.baseschema import _has_orjson
     assert _has_orjson


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manifest files now consistently escape non-ASCII characters as Unicode sequences when written.
  * Improved handling of characters outside the basic multilingual range, including emoji and other astral symbols.

* **Tests**
  * Added coverage to verify Unicode escaping works without affecting manifest output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->