### PR TITLE
add docs for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,13 +51,14 @@ the target and flow you want will not fit it.
 
 Top-level exports, in full: `Design`, `Project`, `ASIC`, `FPGA`, `Lint`, `Sim`,
 `PDK`, `StdCellLibrary`, `FPGADevice`, `Flowgraph`, `Checklist`, `Task`,
-`TaskSkip`, `OpenTask`, `ShowTask`, `ScreenshotTask`, `NodeStatus`, `sc_open`.
+`TaskSkip`, `OpenTask`, `ShowTask`, `ScreenshotTask`, `NodeStatus`, `sc_open`,
+`__version__`.
 
 ## Five things generated code gets wrong
 
 **1. `Chip` does not exist.** `Chip('design')`, `chip.set(...)`,
 `chip.use(...)`, `chip.input(...)`, `chip.register_source(...)` and
-`chip.load_target(...)` were removed in **v0.35.0** (August 2025) and replaced by
+`chip.load_target(...)` were removed in **v0.35.0** (October 2025) and replaced by
 `Design` + `Project`. If you are about to write `Chip`, you are writing the old
 API. See [Migrating from the Chip API](docs/user_guide/migration.rst) for the
 old-to-new table.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,207 @@
+# AGENTS.md
+
+Orientation for coding agents working in this repository, and for anyone writing
+SiliconCompiler build scripts. It is deliberately the same file humans read: a
+separate AI-only document would rot.
+
+Read this before generating SiliconCompiler code. Most of it is about avoiding
+one specific failure -- confidently emitting an API that was removed in 2025 and
+still dominates the training data, forum answers and search results.
+
+## What SiliconCompiler is
+
+A modular hardware build system -- "make for silicon". It compiles RTL to GDSII
+(ASIC) or a bitstream (FPGA) by driving pluggable flows over open-source and
+commercial EDA tools. Everything is configuration in a single, versioned schema;
+the Python API is a typed surface over that schema.
+
+## The API, in one working example
+
+This is the current idiom. It is
+[`examples/heartbeat/heartbeat.py`](examples/heartbeat/heartbeat.py), which runs.
+
+```python
+from siliconcompiler import ASIC, Design
+from siliconcompiler.targets import skywater130_demo
+
+design = Design("heartbeat")                        # what to build
+design.set_dataroot("heartbeat", __file__)          # where its files are rooted
+design.set_topmodule("heartbeat", fileset="rtl")
+design.add_file("heartbeat.v", dataroot="heartbeat", fileset="rtl")
+design.add_file("heartbeat.sdc", dataroot="heartbeat", fileset="sdc")
+
+project = ASIC(design)                              # how to build it
+project.add_fileset(["rtl", "sdc"])                 # which filesets to compile
+skywater130_demo(project)                           # PDK, libraries, flow
+project.run()
+project.summary()
+```
+
+The split matters: a **`Design`** describes source code and is reusable across
+builds; a **project** describes one compilation of it.
+
+**Use one of the named project classes -- `ASIC`, `FPGA`, `Lint`, `Sim` -- not
+the bare `Project`.** Choosing the class is how you say what kind of build this
+is, and each named class brings the schema, constraints and metrics for its
+domain: `ASIC` carries the `asic,*` parameters and floorplan constraints, `Lint`
+carries neither and needs no PDK. `Project` is the base class they extend. It is
+the right choice only when writing code that must work across project types, and
+the wrong choice for a build script -- a bare `Project` has no domain schema, so
+the target and flow you want will not fit it.
+
+Top-level exports, in full: `Design`, `Project`, `ASIC`, `FPGA`, `Lint`, `Sim`,
+`PDK`, `StdCellLibrary`, `FPGADevice`, `Flowgraph`, `Checklist`, `Task`,
+`TaskSkip`, `OpenTask`, `ShowTask`, `ScreenshotTask`, `NodeStatus`, `sc_open`.
+
+## Five things generated code gets wrong
+
+**1. `Chip` does not exist.** `Chip('design')`, `chip.set(...)`,
+`chip.use(...)`, `chip.input(...)`, `chip.register_source(...)` and
+`chip.load_target(...)` were removed in **v0.35.0** (August 2025) and replaced by
+`Design` + `Project`. If you are about to write `Chip`, you are writing the old
+API. See [Migrating from the Chip API](docs/user_guide/migration.rst) for the
+old-to-new table.
+
+**2. There is no `sc` command.** The entry points are `sc-dashboard`, `sc-issue`,
+`sc-remote`, `sc-server`, `sc-show`, `sc-install` and `smake` -- that is the whole
+list, from `[project.scripts]` in `pyproject.toml`. A bare `sc -target ...`
+invocation is from the pre-0.35 CLI and will fail with `command not found`. To
+run something from the shell, use a Python script, `smake`, or the demos:
+
+```sh
+python3 -m siliconcompiler.demos.asic_demo      # ASIC, remote by default
+python3 -m siliconcompiler.demos.fpga_demo      # FPGA
+```
+
+**3. Prefer typed accessors over raw keypaths.** `project.option.add_fileset('rtl')`
+and `project.get('option', 'fileset')` reach the same stored value, but the
+accessor is the supported, self-documenting interface and is what the tutorials
+and `examples/` use. Reach for a keypath only when no accessor exists -- most
+often reading metrics and records, which are keyed per flowgraph node:
+
+```python
+project.get('metric', 'cellarea', step='synthesis', index='0')
+```
+
+Do not use a keypath for a parameter that has an accessor.
+
+**4. Files go into filesets, not a flat list.** A `fileset` is a named group of
+files with a role -- `rtl`, `sdc`, `xdc`, `testbench`. `Design.add_file` puts a
+file in one; `Project.add_fileset` selects which ones this compilation uses. A
+design can carry filesets it does not compile every time, which is the point.
+
+**5. Paths are rooted at a `dataroot`, not the current directory.**
+`design.set_dataroot("name", __file__)` anchors a design's files to the script
+that defines them, so it works regardless of where it is run from. An
+environment-variable dataroot (`set_dataroot("foundry", "$FOUNDRY_ROOT/...")`)
+is how foundry data is referenced without committing it.
+
+## Where new code goes
+
+Answer this before writing a module -- the wrong destination is the most common
+reason a contribution has to be restarted. Full table with links:
+[docs/development_guide/contribution.rst](docs/development_guide/contribution.rst).
+
+| What you have | Where it goes |
+|---|---|
+| Open-source PDK or standard cell library | the separate [`lambdapdk`](https://github.com/siliconcompiler/lambdapdk) package -- **not** this repo |
+| Closed or proprietary PDK, or unpublishable IP | your own `pip`-installable package; foundry data referenced through env-var dataroots, never committed |
+| Tool driver, flow, or target | in-tree, under `siliconcompiler/` |
+
+**Do not create `siliconcompiler/pdks/` or `siliconcompiler/libs/`.** They do not
+exist, and a stale guide told people to make them for years. In-tree module
+directories are `siliconcompiler/tools/`, `flows/`, `targets/`, `checklists/`.
+
+## Repo layout
+
+| Path | Contents |
+|---|---|
+| `siliconcompiler/schema/` | the schema itself; `CHANGELOG.rst` records every parameter change under its own semver |
+| `siliconcompiler/tools/` | one directory per EDA tool driver |
+| `siliconcompiler/flows/`, `targets/` | pre-defined flowgraphs and target bundles |
+| `siliconcompiler/apps/` | the seven CLI entry points |
+| `siliconcompiler/toolscripts/` | per-OS tool install scripts, indexed by `_tools.json` |
+| `examples/` | working, tested designs -- the entry script is `make.py` or `<dirname>.py` |
+| `docs/` | Sphinx sources; `_ext/` holds build-time generators |
+| `tests/` | pytest suite; `-m "not eda"` skips anything needing a tool |
+
+Build output goes to
+`build/<design>/<jobname>/<step>/<index>/{inputs,outputs,reports}/`. Manifests
+are `.pkg.json` -- a `.cfg` path is from a much older era and is always stale.
+Caches, credentials and system defaults live under `~/.sc/`. All of it is
+documented in
+[docs/user_guide/directories.rst](docs/user_guide/directories.rst).
+
+Two independent version numbers: the **package** version (`0.38.x`) and the
+**schema** version (`schemaversion`, `0.57.x`), which is what a manifest records
+and what `siliconcompiler/schema/CHANGELOG.rst` tracks.
+
+## Adding an example
+
+`examples/` is enumerated at docs build time, so an example that does not
+describe itself **fails the build**. Give the entry script -- `make.py`, or
+`<dirname>.py` -- a module docstring whose first line is a one-line summary, and
+end it with a `Requires:` line naming the tools it needs:
+
+```python
+"""Formal property checking with SymbiYosys.
+
+Proves the SVA assertions carried by a small FIFO.
+
+Requires: sby, yosys
+"""
+```
+
+## Before you open a PR
+
+Every PR is gated on **four** lint jobs plus the test suite and the docs build.
+Agents fail these at the same rate humans do, and for the same reason: three of
+the four are easy not to know about. Details in
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+```sh
+pip install -e .[test,lint,docs]
+
+flake8 --statistics .                              # 1. Python
+tclfmt --check . && tclint .                       # 2. TCL
+codespell                                          # 3. spelling -- prose included
+pytest -m "not eda"                                # tests, no EDA tools needed
+cd docs && make html                               # warnings are errors
+```
+
+The fourth gate is **Verilog**, and it is the sharpest edge: it needs
+[Verible](https://github.com/chipsalliance/verible) (not a Python package), and
+the format check *rewrites* files and then fails if anything changed. Run it
+before committing and include whatever it reformats:
+
+```sh
+./.github/workflows/bin/format_verilog.sh > files.txt
+git diff --exit-code
+verible-verilog-lint --rules_config .github/workflows/config/verible.rules `cat files.txt`
+```
+
+Two rules that are not obvious from reading the tree:
+
+- **The docs build treats warnings as errors** (`-W --keep-going`, plus
+  `fail_on_warning` on Read the Docs). A broken cross-reference fails your PR.
+- **`:lines:` is banned in `docs/`.** Address included code by name --
+  `:pyobject:`, `:start-at:`/`:end-at:` -- because a line range silently shifts
+  when the file above it changes, and the page then renders the wrong code with a
+  green build. It has already happened. Conventions:
+  [docs/README.md](docs/README.md).
+
+## Where to look things up
+
+| Question | Source |
+|---|---|
+| What a parameter does | [Schema reference](https://docs.siliconcompiler.com/en/latest/reference_manual/schema.html) |
+| Method signatures | [Python API](https://docs.siliconcompiler.com/en/latest/reference_manual/schema_api.html) |
+| What was removed or renamed, and when | `siliconcompiler/schema/CHANGELOG.rst` |
+| Porting a pre-0.35 script | [docs/user_guide/migration.rst](docs/user_guide/migration.rst) |
+| "How do I ...?" | [docs/user_guide/howto.rst](docs/user_guide/howto.rst) |
+| Vocabulary | [docs/user_guide/glossary.rst](docs/user_guide/glossary.rst) |
+| Working code | `examples/`, and the [gallery](https://docs.siliconcompiler.com/en/latest/user_guide/examples.html) |
+
+If a claim in this file disagrees with the code, the code is right -- and the
+disagreement is a bug worth fixing here. `tests/docs/test_agents_md.py` checks
+the parts of it that can be checked mechanically.

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,34 @@ those pages means editing the generator or the docstrings behind them, not the
 directory, so tutorials can pull real, tested code in with `literalinclude`
 instead of pasting snippets that drift out of date.
 
+Three files are written to the root of the built site for machine consumers
+rather than for browsers:
+
+| File | Written by | Contents |
+|---|---|---|
+| `llms.txt` | `_ext/llmstxt.py` | Curated preamble — current API, what no longer exists, module placement — plus a generated index of every page |
+| `llms-full.txt` | `_ext/llmstxt.py` | The same preamble plus the full text of every hand-written page, rendered to Markdown |
+| `schema.json` | `_ext/schemadump.py` | Every schema parameter for every documented class, keyed by keypath |
+
+The preamble is the one hand-written part, at `_llms/preamble.md`, because
+stating which API is current and which names are gone is editorial work that
+cannot be generated. The rest is derived: the page index from the toctree, and
+the schema roots from the `:root:` options on `reference_manual/schema.rst`, so
+neither can drift from the site.
+
+All three are written by the **`html` builder only** — `latexpdf`, `linkcheck`
+and the rest have nowhere to publish them. Rendering every page for
+`llms-full.txt` costs about ten seconds, so if you are rebuilding repeatedly
+while editing one page, skip it:
+
+```sh
+SC_DOCS_SKIP_ARTIFACTS=1 make html
+```
+
+That is an environment variable rather than a Sphinx setting on purpose: changing
+a config value invalidates the cache and forces a full rebuild, costing more than
+it saves. Leave it unset for anything you intend to publish.
+
 ## Writing
 
 Pages are written in

--- a/docs/_ext/llmstxt.py
+++ b/docs/_ext/llmstxt.py
@@ -253,7 +253,7 @@ class _Markdown:
     def _table(self, node):
         rows = []
         header = 0
-        for group in node.traverse(nodes.tgroup):
+        for group in node.findall(nodes.tgroup):
             for part in group.children:
                 if isinstance(part, (nodes.thead, nodes.tbody)):
                     for row in part.children:
@@ -264,7 +264,24 @@ class _Markdown:
                         header = len(rows)
         if not rows:
             return
+
+        # A table whose every cell renders empty carries nothing. This is not
+        # hypothetical: `list-table`s used purely to lay out screenshots side by
+        # side (tutorials/emails.rst) lose all their content here, because images
+        # are skipped, and would otherwise emit rows of bare pipes.
+        if not any(cell for row in rows for cell in row):
+            return
+
         width = max(len(row) for row in rows)
+
+        # Markdown requires a delimiter row, and a table built by `list-table`
+        # without `:header-rows:` has no thead to put one after. Synthesise an
+        # empty header rather than promoting the first data row, which would
+        # silently relabel content as a heading.
+        if not header:
+            self._emit("| " + " | ".join([""] * width) + " |")
+            self._emit("|" + "|".join([" --- "] * width) + "|")
+
         for index, row in enumerate(rows):
             padded = row + [""] * (width - len(row))
             self._emit("| " + " | ".join(padded) + " |")

--- a/docs/_ext/llmstxt.py
+++ b/docs/_ext/llmstxt.py
@@ -1,0 +1,435 @@
+"""Generate ``llms.txt`` and ``llms-full.txt`` at build time.
+
+Two audiences read this documentation and only one of them was designed for.
+A code assistant asked "how do I compile a chip with SiliconCompiler?" answers
+from whatever it absorbed during training, which is dominated by the pre-0.35
+``Chip`` API -- and the site offers it nothing authoritative and cheap to fetch
+that says otherwise. `llms.txt <https://llmstxt.org>`_ is the convention for
+that: one small file at a predictable URL that states what the project is, what
+the current idiom is, and where the rest lives.
+
+Two files are written to the output root:
+
+``llms.txt``
+    A curated preamble followed by a generated index of every page, grouped by
+    section, with absolute URLs. Small enough to fetch speculatively.
+
+``llms-full.txt``
+    The same preamble followed by the full text of every prose page, rendered to
+    Markdown. One fetch instead of forty.
+
+The preamble is hand-written -- ``docs/_llms/preamble.md`` -- because its value
+is editorial: it is where the project says which API is current and, more
+usefully, which names no longer exist. Negative information is what stops a
+model emitting ``Chip()``, and nothing can generate it. The index and the body
+are generated so they cannot drift from the site.
+
+The generated reference tree is **linked but not inlined** in ``llms-full.txt``.
+The schema reference alone is larger than the entire prose corpus and is far
+better served by the machine-readable dump (``schema.json``, written by
+``schemadump.py``) than by paragraphs of prose about parameters. The prose/
+generated split is the same one ``searchrank.py`` uses for search ranking, and is
+imported from there rather than repeated.
+"""
+
+import os
+import posixpath
+import urllib.parse
+
+from docutils import nodes
+
+from sphinx import addnodes
+from sphinx.util import logging
+
+from searchrank import is_generated
+
+logger = logging.getLogger(__name__)
+
+# Escape hatch for local iteration, honoured by schemadump.py too. Rendering every
+# page costs around ten seconds, which is worth paying on a release build and not
+# worth paying on the twentieth rebuild while editing one paragraph.
+#
+# An environment variable rather than a Sphinx config value on purpose: changing a
+# config value invalidates the build cache and forces a full rebuild, which would
+# cost far more than it saved.
+SKIP_ENV = "SC_DOCS_SKIP_ARTIFACTS"
+
+# Fallback when the builder has no canonical URL, i.e. every local build. Read
+# the Docs sets html_baseurl per version, which is what the published files use.
+FALLBACK_BASEURL = "https://docs.siliconcompiler.com/en/latest/"
+
+PREAMBLE = os.path.join("_llms", "preamble.md")
+
+# Human-readable names for the top-level sections, keyed by docname prefix.
+# Anything not matched is grouped under "Other".
+SECTIONS = (
+    ("user_guide/tutorials/", "Tutorials"),
+    ("user_guide/", "User guide"),
+    ("development_guide/", "Advanced guide: building your own modules"),
+    ("reference_manual/", "Reference (generated from the source tree)"),
+)
+
+
+def _section_of(docname):
+    for prefix, title in SECTIONS:
+        if docname.startswith(prefix):
+            return title
+    return "Other"
+
+
+class _Markdown:
+    """Render a resolved doctree to Markdown.
+
+    Deliberately hand-rolled rather than borrowing Sphinx's ``TextBuilder``:
+    constructing a second builder inside a running build means reaching into
+    internals that carry no compatibility promise, and the output would be plain
+    text where the consumers of these files expect Markdown.
+
+    Every node type SiliconCompiler's prose actually uses is handled below.
+    Anything else falls back to ``astext()``, so an unrecognised directive
+    degrades to its own text rather than vanishing or raising.
+    """
+
+    # Nodes carrying no reader-facing text, or whose text is an artifact of the
+    # build rather than content. ``index`` is Sphinx's, not docutils'.
+    SKIP = (nodes.comment, nodes.system_message, nodes.raw, nodes.image,
+            nodes.target, nodes.substitution_definition, nodes.problematic,
+            addnodes.index, addnodes.highlightlang)
+
+    def __init__(self, pageurl):
+        # Sphinx writes internal link targets relative to the page they appear
+        # on, so resolving them against that page's URL is what a browser does.
+        self._pageurl = pageurl
+        self._out = []
+
+    # -- inline ----------------------------------------------------------
+
+    def _inline(self, node):
+        """Return the Markdown for a node's inline content."""
+        if isinstance(node, nodes.Text):
+            return node.astext()
+        if isinstance(node, self.SKIP):
+            return ""
+        if isinstance(node, (nodes.literal, addnodes.literal_strong,
+                             addnodes.literal_emphasis)):
+            text = node.astext()
+            # A backtick inside the text needs a longer fence around it.
+            fence = "``" if "`" in text else "`"
+            return f"{fence}{text}{fence}"
+        if isinstance(node, nodes.strong):
+            return f"**{self._children(node)}**"
+        if isinstance(node, nodes.emphasis):
+            return f"*{self._children(node)}*"
+        if isinstance(node, nodes.reference):
+            text = self._children(node)
+            uri = node.get("refuri")
+            if not uri:
+                return text
+            return f"[{text}]({self._absolute(uri)})"
+        if isinstance(node, nodes.footnote_reference):
+            return ""
+        return self._children(node)
+
+    def _children(self, node):
+        return "".join(self._inline(child) for child in node.children)
+
+    def _absolute(self, uri):
+        """Turn a page-relative URI into an absolute one.
+
+        ``urljoin`` handles every case the same way a browser does: already
+        absolute URLs and ``mailto:`` pass through, ``../`` segments resolve, and
+        a bare ``#anchor`` gains the page it was written on -- which matters here
+        because these files concatenate pages and an orphaned fragment would
+        point at nothing.
+        """
+        return urllib.parse.urljoin(self._pageurl, uri)
+
+    # -- block -----------------------------------------------------------
+
+    def _emit(self, text=""):
+        self._out.append(text)
+
+    def render(self, node, depth=1):
+        """Walk a section-bearing node, emitting Markdown for its children."""
+        for child in node.children:
+            self._block(child, depth)
+        return "\n".join(self._out).strip() + "\n"
+
+    def _block(self, node, depth):
+        if isinstance(node, self.SKIP):
+            return
+
+        if isinstance(node, nodes.section):
+            for child in node.children:
+                self._block(child, depth + 1)
+            return
+
+        if isinstance(node, nodes.title):
+            # Markdown has six heading levels; deeper nesting flattens onto the
+            # last one rather than emitting an invalid run of hashes.
+            self._emit(f"\n{'#' * min(depth, 6)} {self._children(node)}\n")
+            return
+
+        if isinstance(node, nodes.literal_block):
+            language = node.get("language", "")
+            if language in ("default", "none"):
+                language = ""
+            self._emit(f"```{language}\n{node.astext()}\n```\n")
+            return
+
+        if isinstance(node, (nodes.bullet_list, nodes.enumerated_list)):
+            self._list(node, depth, ordered=isinstance(node, nodes.enumerated_list))
+            self._emit()
+            return
+
+        if isinstance(node, nodes.definition_list):
+            for item in node.children:
+                term = "".join(self._children(c) for c in item.children
+                               if isinstance(c, nodes.term))
+                self._emit(f"**{term}**\n")
+                for c in item.children:
+                    if isinstance(c, nodes.definition):
+                        self._indented(c, depth)
+            return
+
+        if isinstance(node, nodes.table):
+            self._table(node)
+            return
+
+        if isinstance(node, (nodes.note, nodes.warning, nodes.tip,
+                             nodes.important, nodes.caution, nodes.admonition,
+                             nodes.attention, nodes.hint, addnodes.seealso)):
+            self._admonition(node, depth)
+            return
+
+        # ``compact_paragraph`` is a paragraph subclass, and resolved toctrees are
+        # built from them, so this branch renders the nav lists too.
+        if isinstance(node, (nodes.paragraph, nodes.line_block)):
+            text = self._children(node).strip()
+            if text:
+                self._emit(f"{text}\n")
+            return
+
+        if isinstance(node, (nodes.compound, nodes.block_quote, nodes.container,
+                             nodes.topic, nodes.sidebar, nodes.field_list,
+                             nodes.field, nodes.field_body, nodes.line,
+                             nodes.rubric, nodes.transition, nodes.list_item,
+                             nodes.definition, nodes.entry)):
+            for child in node.children:
+                self._block(child, depth)
+            return
+
+        # Unrecognised: keep the words rather than dropping them.
+        text = node.astext().strip()
+        if text:
+            self._emit(f"{text}\n")
+
+    def _list(self, node, depth, ordered):
+        for number, item in enumerate(node.children, start=1):
+            marker = f"{number}." if ordered else "-"
+            body = _Markdown(self._pageurl).render(item, depth).strip()
+            if not body:
+                continue
+            lines = body.splitlines()
+            self._emit(f"{marker} {lines[0]}")
+            for line in lines[1:]:
+                self._emit(f"  {line}" if line else "")
+
+    def _indented(self, node, depth):
+        body = _Markdown(self._pageurl).render(node, depth).strip()
+        for line in body.splitlines():
+            self._emit(f"  {line}" if line else "")
+        self._emit()
+
+    def _admonition(self, node, depth):
+        label = node.get("names") or [type(node).__name__]
+        body = _Markdown(self._pageurl).render(node, depth).strip()
+        # Blockquote the whole thing so the boundary survives concatenation.
+        self._emit(f"> **{str(label[0]).capitalize()}**")
+        for line in body.splitlines():
+            self._emit(f"> {line}" if line else ">")
+        self._emit()
+
+    def _table(self, node):
+        rows = []
+        header = 0
+        for group in node.traverse(nodes.tgroup):
+            for part in group.children:
+                if isinstance(part, (nodes.thead, nodes.tbody)):
+                    for row in part.children:
+                        cells = [" ".join(self._cell(entry).split())
+                                 for entry in row.children]
+                        rows.append(cells)
+                    if isinstance(part, nodes.thead):
+                        header = len(rows)
+        if not rows:
+            return
+        width = max(len(row) for row in rows)
+        for index, row in enumerate(rows):
+            padded = row + [""] * (width - len(row))
+            self._emit("| " + " | ".join(padded) + " |")
+            if index + 1 == header:
+                self._emit("|" + "|".join([" --- "] * width) + "|")
+        self._emit()
+
+    def _cell(self, entry):
+        return _Markdown(self._pageurl).render(entry).strip()
+
+
+def _pageurl(baseurl, docname):
+    """Absolute URL of a built page."""
+    return posixpath.join(baseurl, f"{docname}.html")
+
+
+def _ordered_docnames(env):
+    """Every reachable docname, in navigation order.
+
+    Depth-first over the toctrees from the root document, which is the order a
+    reader meets the pages. Falls back to appending anything unreachable, so a
+    page missing from the nav still appears rather than being silently dropped.
+    """
+    seen = []
+
+    def walk(docname):
+        if docname in seen:
+            return
+        seen.append(docname)
+        for child in env.toctree_includes.get(docname, []):
+            walk(child)
+
+    walk(env.config.root_doc)
+    for docname in sorted(env.all_docs):
+        if docname not in seen:
+            seen.append(docname)
+    return seen
+
+
+def _title(env, docname):
+    title = env.titles.get(docname)
+    return title.astext() if title else docname
+
+
+def _summary(doctree):
+    """First sentence of a page's first real paragraph, or ``None``."""
+    for paragraph in doctree.traverse(nodes.paragraph):
+        text = " ".join(paragraph.astext().split())
+        if len(text) < 20:
+            continue
+        # Cut at the first sentence end that is not an abbreviation or a
+        # version number.
+        for index in range(len(text) - 1):
+            if text[index] == "." and text[index + 1] == " " \
+                    and not text[index - 1].isdigit():
+                return text[:index + 1]
+        return text if len(text) <= 300 else text[:297].rsplit(" ", 1)[0] + "..."
+    return None
+
+
+# Sphinx's smartquotes transform rewrites straight quotes and ``--`` into
+# typographic characters, which is right for a rendered page and wrong for a
+# plain-text file: consumers of these files diff them, grep them, and paste
+# snippets out of them, and a curly apostrophe in a code-adjacent string is a
+# small trap for no benefit.
+#
+# Only the substitutions smartquotes makes are undone. Box-drawing characters
+# (the directory trees in ``directories.rst``), arrows and Greek letters are
+# content the author chose, they appear inside literal blocks that smartquotes
+# never touches, and mangling them would corrupt the page.
+_TYPOGRAPHIC = {
+    "‘": "'", "’": "'",           # single quotes
+    "“": '"', "”": '"',           # double quotes
+    "–": "--", "—": "--",         # en and em dash, both from ``--``
+    "…": "...",                        # ellipsis
+    " ": " ",                          # non-breaking space
+    "‑": "-",                          # non-breaking hyphen
+}
+
+_ASCII = str.maketrans(_TYPOGRAPHIC)
+
+
+def _write(outdir, name, text):
+    path = os.path.join(outdir, name)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text.translate(_ASCII))
+    return path
+
+
+def generate(app, exception):
+    # HTML only: these files are published from the site root, so a latex,
+    # linkcheck or dummy build has nowhere to put them and no reason to pay for
+    # them. Note this is the builder *name*, so switching the site to `dirhtml`
+    # would need this updated.
+    if exception is not None or app.builder.name != "html":
+        return
+    if os.environ.get(SKIP_ENV):
+        logger.info("skipping llms.txt (%s is set)", SKIP_ENV)
+        return
+
+    baseurl = app.config.html_baseurl or FALLBACK_BASEURL
+    if not baseurl.endswith("/"):
+        baseurl += "/"
+
+    preamble_path = os.path.join(app.srcdir, PREAMBLE)
+    if not os.path.exists(preamble_path):
+        logger.warning("llms.txt preamble is missing: %s", preamble_path)
+        return
+    with open(preamble_path, encoding="utf-8") as f:
+        preamble = f.read().rstrip()
+
+    docnames = _ordered_docnames(app.env)
+
+    index = {}
+    bodies = []
+    for docname in docnames:
+        page_url = _pageurl(baseurl, docname)
+        try:
+            doctree = app.env.get_and_resolve_doctree(docname, app.builder)
+        except Exception as e:                                 # pragma: no cover
+            logger.warning("llms.txt could not read %s: %s", docname, e)
+            continue
+
+        title = _title(app.env, docname)
+        entry = f"- [{title}]({page_url})"
+        summary = _summary(doctree)
+        if summary:
+            entry += f": {summary}"
+        index.setdefault(_section_of(docname), []).append(entry)
+
+        # The generated reference is linked from llms.txt but not inlined: it is
+        # larger than everything else combined and schema.json serves it better.
+        if not is_generated(docname):
+            body = _Markdown(page_url).render(doctree)
+            bodies.append(f"\n\n---\n\nSource: {page_url}\n\n{body}")
+
+    listing = []
+    seen = set()
+    for _, section in SECTIONS + (("", "Other"),):
+        entries = index.get(section)
+        if not entries or section in seen:
+            continue
+        seen.add(section)
+        listing.append(f"\n## {section}\n\n" + "\n".join(entries))
+
+    short = f"{preamble}\n\n" + "\n".join(listing) + "\n"
+    _write(app.outdir, "llms.txt", short)
+
+    full = (f"{preamble}\n\n"
+            "The remainder of this file is the full text of every hand-written "
+            "page on the documentation site. The generated reference -- the "
+            "schema, the Python API, the CLI apps and the module catalogues -- "
+            f"is not included; see {posixpath.join(baseurl, 'schema.json')} for "
+            "the machine-readable schema and the links above for the rest.\n"
+            + "".join(bodies) + "\n")
+    _write(app.outdir, "llms-full.txt", full)
+
+    logger.info("wrote llms.txt (%d pages indexed) and llms-full.txt (%d pages, %.0f kB)",
+                len(docnames), len(bodies), len(full) / 1024)
+
+
+def setup(app):
+    app.connect("build-finished", generate)
+    return {
+        "version": "1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/_ext/schemadump.py
+++ b/docs/_ext/schemadump.py
@@ -1,0 +1,184 @@
+"""Write a machine-readable dump of the schema to ``schema.json`` at build time.
+
+The schema is the whole configuration surface of SiliconCompiler, and the only
+published form of it is the HTML reference: eight hundred parameters rendered as
+nested sections. That is the right shape for a person looking one up and the
+wrong shape for anything else. Editor tooling, validators, code assistants and
+scripts that want to know whether a keypath exists all end up scraping HTML, or
+guessing.
+
+This writes the same information as one JSON document at a predictable URL, keyed
+by keypath:
+
+.. code-block:: json
+
+   {
+     "Project": {
+       "description": "...",
+       "parameters": {
+         "option,fileset": {
+           "type": "[str]",
+           "pernode": "never",
+           "scope": "global",
+           "shorthelp": "Option: Selected design filesets",
+           "help": "List of filesets to use from the selected design library",
+           "defvalue": []
+         }
+       }
+     }
+   }
+
+**Which classes are dumped is read out of the reference page itself.** Rather
+than keeping a second list of schema roots in sync by hand -- the failure mode
+this documentation set has hit repeatedly -- ``reference_manual/schema.rst`` is
+parsed for its ``:root:`` options, so the dump covers exactly what the reference
+covers, and adding a class to one adds it to the other.
+
+Keypaths are joined with commas, matching the ``:keypath:`option,fileset``` role
+and the ``project.get('option', 'fileset')`` call. ``default`` appears as a
+literal path segment where the schema takes an arbitrary name -- ``tool,default,
+task,default,warningoff`` -- which is how the schema expresses "any tool, any
+task".
+"""
+
+import enum
+import importlib
+import inspect
+import json
+import os
+import re
+
+from sphinx.util import logging
+
+import llmstxt
+
+from siliconcompiler.schema import BaseSchema, DocsSchema
+
+logger = logging.getLogger(__name__)
+
+OUTPUT = "schema.json"
+
+# The page whose :root: options define what gets dumped.
+REFERENCE = os.path.join("reference_manual", "schema.rst")
+
+_ROOT_OPTION = re.compile(r"^\s*:root:\s*(\S+)\s*$", re.MULTILINE)
+
+# Fields worth publishing. The per-node value tree is deliberately excluded:
+# it describes one populated instance rather than the schema, and its defaults
+# are already covered by ``defvalue``.
+FIELDS = ("type", "scope", "require", "pernode", "switch", "shorthelp", "help",
+          "notes", "unit", "copy", "hashalgo", "lock", "example")
+
+
+def _plain(value):
+    """Make a field value JSON-serializable without losing meaning."""
+    if isinstance(value, enum.Enum):
+        return value.value
+    if isinstance(value, (list, tuple)):
+        return [_plain(item) for item in value]
+    if isinstance(value, set):
+        return sorted(_plain(item) for item in value)
+    if isinstance(value, dict):
+        return {str(k): _plain(v) for k, v in value.items()}
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _roots(srcdir):
+    """Schema roots named by the reference page, as ``module/Class`` strings."""
+    path = os.path.join(srcdir, REFERENCE)
+    with open(path, encoding="utf-8") as f:
+        found = _ROOT_OPTION.findall(f.read())
+    # Preserve document order, drop duplicates.
+    roots = list(dict.fromkeys(found))
+    if not roots:
+        raise ValueError(f"no ':root:' options found in {REFERENCE}; "
+                         "schema.json would be empty")
+    return roots
+
+
+def _instances(root):
+    """Instantiate a ``module/Class`` root the way the reference renders it."""
+    module, name = root.split("/")
+    cls = getattr(importlib.import_module(module), name)
+    if not (inspect.isclass(cls) and issubclass(cls, BaseSchema)):
+        raise TypeError(f"{root} is not a BaseSchema subclass")
+    if issubclass(cls, DocsSchema):
+        made = cls.make_docs()
+        return cls, (made if isinstance(made, list) else [made])
+    return cls, [cls()]
+
+
+def _parameters(schema):
+    out = {}
+    for keypath in sorted(schema.allkeys()):
+        parameter = schema.get(*keypath, field=None)
+        entry = {}
+        for field in FIELDS:
+            try:
+                value = parameter.get(field=field)
+            except (KeyError, ValueError, TypeError):
+                continue
+            value = _plain(value)
+            # Skip fields that carry no information for this parameter, so a
+            # reader is not wading through nulls.
+            if value in (None, [], {}, False):
+                continue
+            entry[field] = value
+        try:
+            entry["defvalue"] = _plain(parameter.get())
+        except Exception:                                      # pragma: no cover
+            pass
+        out[",".join(keypath)] = entry
+    return out
+
+
+def generate(app, exception):
+    # HTML only, for the same reason as llmstxt.py: the file is published from the
+    # site root, so no other builder has anywhere to put it.
+    if exception is not None or app.builder.name != "html":
+        return
+    if os.environ.get(llmstxt.SKIP_ENV):
+        logger.info("skipping %s (%s is set)", OUTPUT, llmstxt.SKIP_ENV)
+        return
+
+    dump = {}
+    for root in _roots(app.srcdir):
+        cls, instances = _instances(root)
+        docstring = inspect.getdoc(cls) or ""
+        for instance in instances:
+            name = cls.__name__ if len(instances) == 1 else \
+                f"{cls.__name__}/{instances.index(instance)}"
+            dump[name] = {
+                "module": cls.__module__,
+                "class": f"{cls.__module__}.{cls.__qualname__}",
+                "description": docstring.strip().split("\n\n")[0].replace("\n", " "),
+                "parameters": _parameters(instance),
+            }
+
+    from siliconcompiler import Project, __version__
+    document = {
+        "$comment": "Generated dump of the SiliconCompiler schema. "
+                    "See https://docs.siliconcompiler.com for prose.",
+        "sc_version": __version__,
+        "schemaversion": Project().get("schemaversion"),
+        "classes": dump,
+    }
+
+    path = os.path.join(app.outdir, OUTPUT)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(document, f, separators=(",", ":"), sort_keys=False)
+
+    parameters = sum(len(cls["parameters"]) for cls in dump.values())
+    logger.info("wrote %s (%d classes, %d parameters, %.0f kB)",
+                OUTPUT, len(dump), parameters, os.path.getsize(path) / 1024)
+
+
+def setup(app):
+    app.connect("build-finished", generate)
+    return {
+        "version": "1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/_llms/preamble.md
+++ b/docs/_llms/preamble.md
@@ -1,0 +1,119 @@
+# SiliconCompiler
+
+> A modular hardware build system -- "make for silicon". It compiles RTL to GDSII
+> (ASIC) or a bitstream (FPGA) by driving pluggable flows over open-source and
+> commercial EDA tools. Everything is configuration in a single versioned schema,
+> and the Python API is a typed surface over that schema.
+
+This file follows the [llms.txt](https://llmstxt.org) convention. It exists
+because most of the material written about SiliconCompiler describes an API that
+was removed in 2025, so an assistant answering from memory will usually be
+wrong. The sections below state what is current; the index that follows links
+every page on the documentation site.
+
+## The current API
+
+Import from `siliconcompiler`. A **`Design`** describes source code and is
+reusable; a **project** describes one compilation of it.
+
+Use one of the named project classes -- **`ASIC`, `FPGA`, `Lint` or `Sim`** --
+rather than the bare `Project`. Choosing the class is how you say what kind of
+build this is, and each named class carries the schema, constraints and metrics
+for its domain. `Project` is only the base class they extend; a build script
+written against it has no domain schema and will not fit the target or flow you
+want.
+
+```python
+from siliconcompiler import ASIC, Design
+from siliconcompiler.targets import skywater130_demo
+
+design = Design("heartbeat")
+design.set_dataroot("heartbeat", __file__)          # root paths are resolved against
+design.set_topmodule("heartbeat", fileset="rtl")
+design.add_file("heartbeat.v", dataroot="heartbeat", fileset="rtl")
+design.add_file("heartbeat.sdc", dataroot="heartbeat", fileset="sdc")
+
+project = ASIC(design)
+project.add_fileset(["rtl", "sdc"])                 # which filesets to compile
+skywater130_demo(project)                           # PDK, libraries and flow
+project.run()
+project.summary()
+```
+
+Four conventions this example encodes:
+
+- **Files live in named filesets** (`rtl`, `sdc`, `xdc`, `testbench`) rather than
+  one flat list. `Design.add_file` assigns one; `Project.add_fileset` selects
+  which the run uses.
+- **Paths are rooted at a dataroot**, not the working directory. An environment
+  variable dataroot (`set_dataroot("foundry", "$FOUNDRY_ROOT/...")`) is how
+  foundry data is referenced without committing it.
+- **Prefer typed accessors to raw keypaths.** `project.option.set_remote(True)`
+  and `project.set('option', 'remote', True)` reach the same value; the accessor
+  is the supported interface. Use a keypath when no accessor exists, which mostly
+  means reading metrics and records: `project.get('metric', 'cellarea',
+  step='synthesis', index='0')`.
+- **A target is a function you call** with the project. Flows, tool tasks,
+  libraries and PDKs are classes you subclass.
+
+Full top-level export list: `Design`, `Project`, `ASIC`, `FPGA`, `Lint`, `Sim`,
+`PDK`, `StdCellLibrary`, `FPGADevice`, `Flowgraph`, `Checklist`, `Task`,
+`TaskSkip`, `OpenTask`, `ShowTask`, `ScreenshotTask`, `NodeStatus`, `sc_open`.
+
+## What no longer exists
+
+This section is the reason the file is worth fetching.
+
+- **There is no `Chip` class.** `Chip('design')`, `chip.set(...)`,
+  `chip.input(...)`, `chip.use(...)`, `chip.register_source(...)` and
+  `chip.load_target(...)` were removed in **v0.35.0** (August 2025). They are
+  what most training data contains. The replacement is `Design` + a project
+  class; every old name is mapped in the migration guide linked below.
+- **There is no `sc` command.** The console scripts are `sc-dashboard`,
+  `sc-issue`, `sc-remote`, `sc-server`, `sc-show`, `sc-install` and `smake` --
+  that is the complete list. A `sc -target asic_demo` invocation is from the
+  pre-0.35 CLI and fails with `command not found`. To run something from a
+  shell, use a Python script, `smake`, or
+  `python3 -m siliconcompiler.demos.asic_demo`.
+- **`FPGA` changed meaning.** It used to be the FPGA device class; it is now the
+  FPGA *project* class. The device is `FPGADevice`.
+- **Manifests are `.pkg.json`**, not `.cfg`. The `.cfg` extension predates
+  v0.20 and any script or command using it is stale.
+- **`package=` is now `dataroot=`** on every path parameter (schema 0.52.0).
+- **The `option,mode` parameter is gone** -- pick the project class instead.
+
+## Where new code goes
+
+A frequent request is "add a PDK to SiliconCompiler", and the answer is usually
+that it does not go in this repository:
+
+- **Open-source PDKs and standard cell libraries** go in the separate
+  [`lambdapdk`](https://github.com/siliconcompiler/lambdapdk) package.
+- **Closed or proprietary PDKs and IP** go in your own pip-installable package,
+  with foundry data referenced through environment-variable dataroots and never
+  committed.
+- **Tool drivers, flows and targets** go in-tree, under `siliconcompiler/`.
+
+`siliconcompiler/pdks/` and `siliconcompiler/libs/` do not exist and should not
+be created. In-tree module directories are `tools/`, `flows/`, `targets/` and
+`checklists/`.
+
+## Two version numbers
+
+The package version and the schema version are independent. The schema version
+(`schemaversion`) is recorded in every manifest and has its own changelog, which
+is the authoritative record of what was added, renamed or removed at each
+version -- see "Schema Changes" in the index below.
+
+## Machine-readable schema
+
+`schema.json` at the root of this site is a generated dump of the schema for each
+project class: every parameter with its keypath, type, default, scope and help
+text. Prefer it over scraping the HTML reference.
+
+## Repository
+
+Source, issues and discussions:
+<https://github.com/siliconcompiler/siliconcompiler>. The repository root carries
+an `AGENTS.md` with the same orientation aimed at editing the code rather than
+using it. Working, tested designs are under `examples/`.

--- a/docs/_llms/preamble.md
+++ b/docs/_llms/preamble.md
@@ -28,7 +28,7 @@ from siliconcompiler import ASIC, Design
 from siliconcompiler.targets import skywater130_demo
 
 design = Design("heartbeat")
-design.set_dataroot("heartbeat", __file__)          # root paths are resolved against
+design.set_dataroot("heartbeat", __file__)          # the root for files below
 design.set_topmodule("heartbeat", fileset="rtl")
 design.add_file("heartbeat.v", dataroot="heartbeat", fileset="rtl")
 design.add_file("heartbeat.sdc", dataroot="heartbeat", fileset="sdc")
@@ -45,9 +45,11 @@ Four conventions this example encodes:
 - **Files live in named filesets** (`rtl`, `sdc`, `xdc`, `testbench`) rather than
   one flat list. `Design.add_file` assigns one; `Project.add_fileset` selects
   which the run uses.
-- **Paths are rooted at a dataroot**, not the working directory. An environment
-  variable dataroot (`set_dataroot("foundry", "$FOUNDRY_ROOT/...")`) is how
-  foundry data is referenced without committing it.
+- **Paths are rooted at a dataroot**, not the working directory. Passing
+  `__file__` roots them at the directory holding the script -- a file path is
+  accepted and its parent directory used -- so the build works from anywhere. An
+  environment variable dataroot (`set_dataroot("foundry", "$FOUNDRY_ROOT/...")`)
+  is how foundry data is referenced without committing it.
 - **Prefer typed accessors to raw keypaths.** `project.option.set_remote(True)`
   and `project.set('option', 'remote', True)` reach the same value; the accessor
   is the supported interface. Use a keypath when no accessor exists, which mostly
@@ -56,9 +58,10 @@ Four conventions this example encodes:
 - **A target is a function you call** with the project. Flows, tool tasks,
   libraries and PDKs are classes you subclass.
 
-Full top-level export list: `Design`, `Project`, `ASIC`, `FPGA`, `Lint`, `Sim`,
+Top-level exports, in full: `Design`, `Project`, `ASIC`, `FPGA`, `Lint`, `Sim`,
 `PDK`, `StdCellLibrary`, `FPGADevice`, `Flowgraph`, `Checklist`, `Task`,
-`TaskSkip`, `OpenTask`, `ShowTask`, `ScreenshotTask`, `NodeStatus`, `sc_open`.
+`TaskSkip`, `OpenTask`, `ShowTask`, `ScreenshotTask`, `NodeStatus`, `sc_open`,
+`__version__`.
 
 ## What no longer exists
 
@@ -66,7 +69,7 @@ This section is the reason the file is worth fetching.
 
 - **There is no `Chip` class.** `Chip('design')`, `chip.set(...)`,
   `chip.input(...)`, `chip.use(...)`, `chip.register_source(...)` and
-  `chip.load_target(...)` were removed in **v0.35.0** (August 2025). They are
+  `chip.load_target(...)` were removed in **v0.35.0** (October 2025). They are
   what most training data contains. The replacement is `Design` + a project
   class; every old name is mapped in the migration guide linked below.
 - **There is no `sc` command.** The console scripts are `sc-dashboard`,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,9 @@ extensions = [
     'requirements',
     'installgen',
     'graphgen',
-    'examplegen'
+    'examplegen',
+    'llmstxt',
+    'schemadump'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/reference_manual/appendix/machine_readable.rst
+++ b/docs/reference_manual/appendix/machine_readable.rst
@@ -1,0 +1,98 @@
+.. _machine_readable:
+
+.. index:: ! llms.txt, ! schema.json, ! machine-readable documentation
+
+Machine-readable documentation
+==============================
+
+Three files are published alongside this site for programs rather than people:
+editor tooling, validators, scripts, and code assistants answering questions about
+SiliconCompiler. They hold the same content as the pages you are reading, in forms
+that do not require parsing HTML.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 20 58
+
+   * - File
+     - Format
+     - Contents
+   * - `llms.txt <../../llms.txt>`_
+     - Markdown
+     - The current API, the names that no longer exist, where a new module
+       belongs, and a linked index of every page on this site. Small enough to
+       fetch speculatively. Follows the `llmstxt.org <https://llmstxt.org>`_
+       convention.
+   * - `llms-full.txt <../../llms-full.txt>`_
+     - Markdown
+     - The full text of every hand-written page on this site in one file, with
+       cross-references resolved to absolute URLs. The generated reference is
+       linked rather than included.
+   * - `schema.json <../../schema.json>`_
+     - JSON
+     - Every parameter of every documented schema class, keyed by
+       :term:`keypath`.
+
+Versions
+--------
+
+The files are generated during each documentation build, so the copy served from
+a version describes that version:
+
+.. code-block:: text
+
+   https://docs.siliconcompiler.com/en/stable/llms.txt     # current release
+   https://docs.siliconcompiler.com/en/latest/llms.txt     # development branch
+   https://docs.siliconcompiler.com/en/v0.38.3/llms.txt    # a specific release
+
+This matters more for SiliconCompiler than it would for most projects: the API
+changed substantially at v0.35.0, so a file describing "the current API" is only
+meaningful next to a version. Prefer ``stable`` unless you specifically want
+unreleased behaviour.
+
+The schema dump
+---------------
+
+``schema.json`` is organised by class, then by keypath, with keypath segments
+joined by commas -- the same notation as the :ref:`Schema Reference <schema>` and
+as a ``get()`` call. ``default`` appears as a literal segment where the schema
+accepts an arbitrary name:
+
+.. code-block:: json
+
+   {
+     "sc_version": "0.38.3",
+     "schemaversion": "0.57.1",
+     "classes": {
+       "ASIC": {
+         "description": "The ASIC class extends the base Project class ...",
+         "parameters": {
+           "option,fileset": {
+             "type": "[str]",
+             "scope": "global",
+             "pernode": "never",
+             "shorthelp": "Option: Selected design filesets",
+             "help": "List of filesets to use from the selected design library",
+             "defvalue": []
+           },
+           "tool,default,task,default,warningoff": {"...": "..."}
+         }
+       }
+     }
+   }
+
+The classes covered are the ones documented in the :ref:`Schema Reference
+<schema>`, and the per-parameter fields are the ones defined at the top of that
+page. The per-node value tree is omitted, because it describes one populated
+project rather than the schema; ``defvalue`` carries the default.
+
+Two version numbers appear at the top level, and they are independent:
+``sc_version`` is the package release and ``schemaversion`` is the schema's own
+semver, which is what a :term:`manifest` records. :ref:`Schema Changes
+<schema_changelog>` tracks the latter.
+
+.. note::
+   These files are a convenience, not a stable API. The content tracks the
+   documentation, so it changes when the documentation changes. If you are
+   building something that depends on the schema long-term, pin a version in the
+   URL and read :ref:`Schema Changes <schema_changelog>` before moving.

--- a/docs/reference_manual/index.rst
+++ b/docs/reference_manual/index.rst
@@ -45,4 +45,5 @@ To learn how to use SiliconCompiler, see the :ref:`user guide <user_guide>`.
    appendix/licenses
    appendix/changelog
    appendix/schema_changelog
+   appendix/machine_readable
    appendix/dashboard_how_to_guide

--- a/docs/user_guide/faq.rst
+++ b/docs/user_guide/faq.rst
@@ -315,6 +315,19 @@ Nothing stops you writing your own driver for a proprietary tool and keeping it
 in your own package -- see :ref:`Setting up a Tool <dev_tools>` and
 :ref:`Packaging an External Library <dev_external_libraries>`.
 
+.. index:: ! old script, ! Chip, ! porting a script, ! legacy API
+
+I have an old script that uses ``Chip()``. How do I port it?
+------------------------------------------------------------
+
+``Chip`` was removed in v0.35.0 and split into a :term:`design` and a project.
+:ref:`Migrating from the Chip API <migration_guide>` maps the old names onto the
+new ones, method by method, and shows the same build written both ways.
+
+If a code assistant wrote the script you are porting, this is the most likely
+explanation: the ``Chip`` API is what most of the material written about
+SiliconCompiler still describes.
+
 Still stuck?
 ============
 

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -73,3 +73,4 @@ You will also want to look at API References for details.
    glossary
    Frequently asked questions <faq>
    How do I…? <howto>
+   Migrating from the Chip API <migration>

--- a/docs/user_guide/migration.rst
+++ b/docs/user_guide/migration.rst
@@ -1,0 +1,347 @@
+.. _migration_guide:
+
+.. index:: ! Chip, ! migration, ! porting an old script, ! legacy API
+
+###################################
+Migrating from the ``Chip`` API
+###################################
+
+If you have a script that starts like this, you are using an API that no longer
+exists:
+
+.. code-block:: python
+
+   from siliconcompiler import Chip
+
+   chip = Chip('heartbeat')
+   chip.input('heartbeat.v')
+   chip.load_target('freepdk45_demo')
+   chip.run()
+
+The ``Chip`` class was removed in **v0.35.0** (August 2025) and replaced by a
+:class:`.Design` object plus a project object. This page maps the
+old names onto the new ones.
+
+.. note::
+   This page is kept indefinitely, and deliberately spells out the old names in
+   full. Years of tutorials, papers, forum answers and blog posts use the
+   ``Chip`` API, search engines still surface documentation for releases that
+   predate the change, and code assistants trained on all of it will happily
+   write ``Chip('mydesign')`` today. If you arrived here from one of those, you
+   are in the right place.
+
+   Parameter-level changes -- keys added, renamed or removed inside the schema
+   itself -- are recorded separately in :ref:`Schema Changes <schema_changelog>`.
+
+Why it changed
+==============
+
+``Chip`` was one object holding two unrelated things: *what* you are building
+and *how* this particular build is configured. That made a design impossible to
+reuse -- to build the same RTL for two processes, or reuse a block inside a
+larger chip, you rebuilt the object from scratch.
+
+The replacement separates them:
+
+* A :class:`.Design` describes source code: files, grouped into
+  :term:`filesets <fileset>`, with a top module and include paths. It says
+  nothing about a process or a flow, so the same ``Design`` can be built many
+  ways, and one design can depend on another.
+* A **project** describes one compilation of a design. Use the class that
+  matches the job -- :class:`.ASIC`, :class:`.FPGA`, :class:`.Lint` or
+  :class:`.Sim` -- which is what replaces the old ``option,mode`` flag. Each one
+  brings the schema, constraints and metrics for its domain, so an ``ASIC``
+  carries the ``asic,*`` parameters that a ``Lint`` has no use for.
+  :class:`.Project` is the base class they extend, and is not the one to write a
+  build script against: it has no domain section, so an ASIC target applied to a
+  bare ``Project`` fails with ``AttributeError``.
+
+The second change is that configuration moved from string keypaths to **typed
+accessors** -- ``project.option.set_remote(True)`` rather than
+``chip.set('option', 'remote', True)``. Keypaths still work and are still the
+layer underneath; see :ref:`Working with the Schema <schema_access>` for when to
+use which.
+
+The same script, before and after
+=================================
+
+The old form, from the ``heartbeat`` example as it shipped in v0.34.3:
+
+.. code-block:: python
+
+   from siliconcompiler import Chip
+   from siliconcompiler.targets import freepdk45_demo
+
+   chip = Chip('heartbeat')
+   chip.register_source("heartbeat-example", __file__)
+   chip.input("heartbeat.v", package="heartbeat-example")
+   chip.input("heartbeat.sdc", package="heartbeat-example")
+   chip.use(freepdk45_demo)
+   chip.run()
+   chip.summary()
+   chip.show()
+
+The same build today. It is pulled in from ``examples/heartbeat/heartbeat.py``,
+so it is exercised by the test suite rather than transcribed here:
+
+.. literalinclude:: tutorials/examples/heartbeat/heartbeat.py
+   :language: python
+   :start-at: design = Design
+   :end-at: project.show()
+   :dedent: 4
+
+Four differences to notice, because they account for most of the porting work:
+
+#. **Two objects instead of one.** ``Design`` for the sources, ``ASIC`` for the
+   build.
+#. **Files carry a fileset.** ``input()`` guessed a file's role from its
+   extension; ``add_file()`` requires you to name it, and the project then
+   selects which filesets to compile with ``add_fileset()``.
+#. **The top module is explicit.** It used to be inferred from the ``Chip`` name.
+#. **A target is called, not "used".** ``skywater130_demo(project)`` instead of
+   ``chip.use(...)`` or ``chip.load_target(...)``.
+
+Objects and imports
+===================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Removed
+     - Use instead
+   * - ``Chip``
+     - :class:`.Design` for the sources, plus one of
+       :class:`.ASIC` / :class:`.FPGA` / :class:`.Lint` / :class:`.Sim` for the
+       build (:class:`.Project` is their base class, not a substitute for them)
+   * - ``ASICProject``
+     - :class:`.ASIC`
+   * - ``Library``, ``LibrarySchema``
+     - :class:`.Design`. Since schema 0.54.0 a library *is* a
+       design; :class:`.StdCellLibrary` adds the standard-cell
+       specifics
+   * - ``Flow``, ``FlowgraphSchema``
+     - :class:`.Flowgraph`
+   * - ``Schema`` (top-level export)
+     - Nothing to import. A project *is* a schema -- ``get``, ``set``,
+       ``getkeys`` and ``write_manifest`` are methods on it
+   * - ``DesignSchema``, ``PDKSchema``, ``ASICSchema``, ``MetricSchema``, …
+     - The ``…Schema`` suffix is gone from the public names:
+       :class:`.Design`, :class:`.PDK`,
+       :class:`.Checklist`, :class:`.Task`
+   * - ``SiliconCompilerError``
+     - Standard Python exceptions
+
+.. warning::
+   ``FPGA`` still exists and **means something different**. It used to be the
+   FPGA *device* class; it is now the FPGA *project* class. The device is
+   :class:`.FPGADevice`. Old code reading
+   ``FPGA('mydevice')`` needs ``FPGADevice('mydevice')``.
+
+Setting up a design
+===================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Old
+     - New
+   * - ``Chip('mydesign')``
+     - ``Design('mydesign')``
+   * - ``chip.set('design', 'top')``
+     - ``design.set_topmodule('top', fileset='rtl')``
+   * - ``chip.top()``
+     - ``design.get_topmodule(fileset='rtl')``
+   * - ``chip.input('f.v')``
+     - ``design.add_file('f.v', fileset='rtl')`` -- the fileset is explicit
+       rather than guessed from the extension
+   * - ``chip.output(...)``
+     - Outputs are produced by tasks, not declared on the design
+   * - ``chip.register_source('name', __file__)``
+     - ``design.set_dataroot('name', __file__)``
+   * - ``package='name'`` keyword
+     - ``dataroot='name'``. The schema field was renamed in schema 0.52.0, along
+       with the ``find_files`` and ``check_filepaths`` arguments
+   * - ``chip.add('option', 'idir', 'include')``
+     - ``design.add_idir('include', fileset='rtl')``
+   * - ``chip.add('option', 'define', 'SYNTHESIS')``
+     - ``design.add_define('SYNTHESIS', fileset='rtl')``
+   * - ``chip.import_flist('files.f')``
+     - ``design.read_fileset('files.f', fileset='rtl')``
+   * - ``chip.clock('clk', period=1.0)``
+     - Removed with no direct equivalent -- the ``datasheet`` pin timing
+       parameters it wrote are gone. Define clocks in an SDC file and add it to
+       an ``sdc`` fileset
+   * - ``chip.use(mylib)`` for a library
+     - ``project.add_dep(mylib)``, or list its filesets through
+       ``design.add_depfileset()``
+   * - ``chip.swap_library(old, new)``
+     - ``project.add_alias(old_dep, old_fileset, new_dep, new_fileset)``
+
+Configuring and running
+=======================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Old
+     - New
+   * - ``chip.use(freepdk45_demo)``
+     - ``freepdk45_demo(project)`` -- targets are still plain functions, and are
+       called with the project
+   * - ``chip.load_target('freepdk45_demo')``
+     - Import the target and call it. The string form, and the ``option,target``
+       parameter behind it, are both gone
+   * - ``chip.set('option', 'mode', 'asic')``
+     - Use the :class:`.ASIC` project class. ``option,mode`` was
+       removed in schema 0.42.7
+   * - ``chip.set('option', 'remote', True)``
+     - ``project.option.set_remote(True)``
+   * - ``chip.set('option', 'builddir', 'out')``
+     - ``project.option.set_builddir('out')``
+   * - ``chip.set('option', 'jobname', 'run1')``
+     - ``project.option.set_jobname('run1')``
+   * - ``chip.set('option', 'quiet', True)``
+     - ``project.option.set_quiet(True)``
+   * - ``chip.set('option', 'to', 'syn')``
+     - ``project.option.add_to('syn')``; likewise ``add_from`` and ``add_prune``
+   * - ``chip.set('option', 'flow', 'asicflow')``
+     - ``project.set_flow(ASICFlow())``, or let the target set it
+   * - ``chip.run()``, ``chip.summary()``, ``chip.show()``
+     - Unchanged -- same names on the project
+   * - ``chip.check_manifest()``
+     - ``project.check_manifest()``, but call it **after** ``run()``: library
+       dependencies are resolved during the run, so a pre-run call reports
+       failures on a correct configuration
+   * - ``chip.dashboard()``
+     - The CLI dashboard now runs during ``run()`` automatically; disable it with
+       ``project.option.set_nodashboard(True)``. For the web dashboard, use the
+       ``sc-dashboard`` command
+   * - ``chip.check_checklist()``
+     - ``Checklist.check()`` -- see :ref:`Checklists and signoff <checklists>`
+   * - ``chip.create_cmdline()``
+     - Unchanged in name, now provided by ``CommandLineSchema`` on the project
+   * - ``chip.error('message')``
+     - Raise an exception, or log through ``project.logger``
+
+Reading results and paths
+=========================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Old
+     - New
+   * - ``chip.get('metric', 'cellarea', step=…, index=…)``
+     - Unchanged, but read it from the object ``run()`` returns: job metrics are
+       reset on the live project when a run completes
+   * - ``chip.getworkdir()``
+     - ``siliconcompiler.utils.paths.workdir(project, step=…, index=…)``
+   * - ``chip.getbuilddir()``
+     - ``siliconcompiler.utils.paths.builddir(project)``
+   * - ``chip.collect()``, ``chip.archive()``
+     - ``siliconcompiler.utils.curation.collect(project)`` and
+       ``archive(project)``
+   * - ``chip.find_result(...)``, ``chip.snapshot()``
+     - Unchanged -- same names on the project
+   * - ``chip.find_node_file(...)``
+     - ``project.find_result(...)``
+   * - ``chip.hash_files(...)``, ``chip.check_filepaths()``
+     - Unchanged in name, now schema methods; ``hash_files`` takes ``dataroot``
+       where it took ``package``
+   * - ``chip.help('option', 'remote')``
+     - Removed. Parameter help text is in the
+       :ref:`Schema Reference <schema>`, or ``project.getdict()``
+   * - ``<design>.cfg``
+     - ``<design>.pkg.json``. Manifests have been JSON with a ``.pkg.json``
+       extension since well before the ``Chip`` removal; a ``.cfg`` path in a
+       script or a ``sc-dashboard -cfg`` invocation is stale
+
+Building flows, tools and libraries
+===================================
+
+Module-style setup functions became classes. Old flows, tool tasks, PDKs and
+libraries were modules exposing a ``setup(chip)`` function plus a ``make_docs``
+hook, discovered by import:
+
+.. code-block:: python
+
+   # old: siliconcompiler/flows/myflow.py
+   def make_docs(chip):
+       return setup()
+
+   def setup(flowname='myflow'):
+       flow = siliconcompiler.Flow(flowname)
+       flow.node(flowname, 'import', parse)
+       flow.node(flowname, 'syn', syn_asic)
+       flow.edge(flowname, 'import', 'syn')
+       return flow
+
+Now each is a class, and ``make_docs`` is gone -- the documentation is generated
+from the class and its docstring:
+
+.. code-block:: python
+
+   # new
+   from siliconcompiler import Flowgraph
+
+   class MyFlow(Flowgraph):
+       '''One-line summary, which becomes the description in the docs.'''
+       def __init__(self):
+           super().__init__("myflow")
+           self.node("elaborate", Elaborate())
+           self.node("synthesis", ASICSynthesis())
+           self.edge("elaborate", "synthesis")
+
+The same shape applies elsewhere: a tool task subclasses
+:class:`.Task` instead of exposing ``setup(chip)``,
+``pre_process(chip)`` and ``post_process(chip)`` module functions; a standard
+cell library subclasses :class:`.StdCellLibrary`; a PDK
+subclasses :class:`.PDK`. Nodes take a task *instance* rather
+than a module reference, and ``node()``/``edge()`` are methods on the flowgraph
+rather than on the chip.
+
+Targets are the exception: they are still functions taking a project, because a
+target's job is to configure one.
+
+See the :ref:`Advanced Guide <advanced_guide>` for how to write each of these, and
+:ref:`Where your module belongs <module_placement>` before you decide which
+repository it goes in -- that answer also changed.
+
+The command line
+================
+
+There is **no** ``sc`` command, and there never was one after v0.35.0. The
+entry points are ``sc-dashboard``, ``sc-issue``, ``sc-remote``, ``sc-server``,
+``sc-show``, ``sc-install`` and ``smake``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Old
+     - New
+   * - ``sc heartbeat.v -target freepdk45_demo``
+     - Write a Python script -- see the example above -- or use ``smake`` with a
+       ``make.py``
+   * - ``sc -target asic_demo``
+     - ``python3 -m siliconcompiler.demos.asic_demo``
+   * - ``sc -target asic_demo -remote``
+     - ``python3 -m siliconcompiler.demos.asic_demo -remote``
+
+Everything else -- ``sc-show``, ``sc-issue``, ``sc-remote`` and the rest --
+kept its name and its arguments.
+
+Still stuck?
+============
+
+If a symbol is not listed here, two places are worth checking before asking:
+:ref:`Schema Changes <schema_changelog>` for anything that looks like a schema
+key, and the :ref:`Python API <schema_api>` for a method name. Failing that, ask
+in `Discussions
+<https://github.com/siliconcompiler/siliconcompiler/discussions>`_ -- and please
+say which version the old script targeted, because it tells us which era of the
+API to translate from.

--- a/docs/user_guide/migration.rst
+++ b/docs/user_guide/migration.rst
@@ -18,7 +18,7 @@ exists:
    chip.load_target('freepdk45_demo')
    chip.run()
 
-The ``Chip`` class was removed in **v0.35.0** (August 2025) and replaced by a
+The ``Chip`` class was removed in **v0.35.0** (October 2025) and replaced by a
 :class:`.Design` object plus a project object. This page maps the
 old names onto the new ones.
 

--- a/tests/docs/test_agents_md.py
+++ b/tests/docs/test_agents_md.py
@@ -14,19 +14,31 @@ contributor to run match the ones CI actually runs.
 
 import os.path
 import re
-import tomllib
 
 import pytest
 import yaml
 
 import siliconcompiler
 from siliconcompiler.schema import docs
+# ``tomllib`` is stdlib only from 3.11, and SiliconCompiler supports 3.10, where
+# the declared ``tomli`` dependency stands in for it. Reuse the shim the package
+# already has rather than repeating the fallback: importing ``tomllib`` directly
+# here would be an ImportError at *collection* time on 3.10, failing the whole
+# session rather than this file.
+from siliconcompiler.utils import tomllib
 
 
 if not os.path.abspath(__file__).startswith(docs.sc_root):
     pytest.skip(reason="test for docs only possible in editable install",
                 allow_module_level=True)
 
+
+# The shim is None only in a tree where neither stdlib tomllib nor tomli is
+# importable. Skip rather than let the tests fail on a NoneType attribute error,
+# which says nothing about the cause.
+needs_toml = pytest.mark.skipif(
+    tomllib is None,
+    reason="no TOML reader: Python < 3.11 without the tomli dependency installed")
 
 AGENTS = os.path.join(docs.sc_root, "AGENTS.md")
 PREAMBLE = os.path.join(docs.sc_root, "docs", "_llms", "preamble.md")
@@ -60,10 +72,12 @@ def test_exported_symbols_exist(orientation):
 
     The failure this guards against is the file outliving a rename, which is
     exactly what happened to the class names it is warning the reader about.
+
+    This is a one-way check over every capitalized code span in the file, so it
+    catches a name that stops existing. It cannot catch an export the file never
+    mentioned -- that is ``test_export_list_is_complete``.
     """
     name, text = orientation
-    # The full export list both files quote, as a comma-separated run of
-    # backticked names.
     quoted = set(re.findall(r"`([A-Z][A-Za-z]+)`", text))
     # Names the files quote as *removed* are expected to be absent.
     removed = {"Chip", "ASICProject", "Library", "LibrarySchema", "Flow",
@@ -76,6 +90,35 @@ def test_exported_symbols_exist(orientation):
         f"{missing}")
 
 
+# Both files introduce their export list with this exact phrase, and the list runs
+# to the end of the paragraph. Keeping the wording identical is what lets one test
+# check both.
+EXPORT_LIST = re.compile(r"Top-level exports, in full:(.*?)\n\s*\n", re.DOTALL)
+
+
+def test_export_list_is_complete(orientation):
+    """The list says "in full", so it has to match ``__all__`` exactly.
+
+    Both directions matter. A name that disappears from the package leaves the
+    file describing an API that is gone; a name added to ``__all__`` and not here
+    leaves the file quietly incomplete while claiming otherwise. The second is the
+    one that actually happened -- ``__version__`` was missing from both files and
+    the existence check above passed anyway.
+    """
+    name, text = orientation
+    match = EXPORT_LIST.search(text)
+    assert match, (
+        f"{name} no longer contains a paragraph starting 'Top-level exports, in "
+        "full:'; this test parses that phrase to find the list")
+
+    listed = set(re.findall(r"`([A-Za-z_][A-Za-z0-9_]*)`", match.group(1)))
+    expected = set(siliconcompiler.__all__)
+    assert listed == expected, (
+        f"{name}'s export list does not match siliconcompiler.__all__.\n"
+        f"  missing from the file: {sorted(expected - listed)}\n"
+        f"  no longer exported:    {sorted(listed - expected)}")
+
+
 def test_removed_symbols_are_still_removed(orientation):
     """The negative claims have to stay true, or they mislead in reverse."""
     name, text = orientation
@@ -86,6 +129,7 @@ def test_removed_symbols_are_still_removed(orientation):
             "the file needs updating")
 
 
+@needs_toml
 def test_console_scripts_match_pyproject(orientation):
     """The entry point list is quoted as complete, so it must be."""
     name, text = orientation
@@ -98,6 +142,7 @@ def test_console_scripts_match_pyproject(orientation):
         f"declares {sorted(declared)}")
 
 
+@needs_toml
 def test_no_sc_entry_point():
     """The single most repeated wrong instruction in the project's history."""
     with open(PYPROJECT, "rb") as f:
@@ -108,9 +153,9 @@ def test_no_sc_entry_point():
 
 
 def test_in_tree_module_directories_exist(orientation):
-    """The placement policy names four in-tree directories."""
+    """The placement policy names four in-tree directories, so check four."""
     name, text = orientation
-    for directory in ("tools", "flows", "targets"):
+    for directory in ("tools", "flows", "targets", "checklists"):
         assert f"`{directory}/`" in text or f"siliconcompiler/{directory}" in text, \
             f"{name} no longer mentions siliconcompiler/{directory}/"
         assert os.path.isdir(os.path.join(docs.sc_root, "siliconcompiler", directory))

--- a/tests/docs/test_agents_md.py
+++ b/tests/docs/test_agents_md.py
@@ -1,0 +1,207 @@
+"""Check the claims ``AGENTS.md`` and the llms.txt preamble make about the code.
+
+Both files exist to tell a reader -- usually a code assistant -- which API is
+current and which names no longer exist. That makes them the two documents in the
+repository with the most to lose from going stale: a confidently-worded, wrong
+orientation file is worse than none, because it will be believed.
+
+Neither can be generated, because the useful part is editorial. So instead of
+generating them, this asserts the mechanically checkable claims: that the symbols
+they name exist, that the ones they say are gone are gone, that the console
+scripts they list match ``pyproject.toml``, and that the lint gates they tell a
+contributor to run match the ones CI actually runs.
+"""
+
+import os.path
+import re
+import tomllib
+
+import pytest
+import yaml
+
+import siliconcompiler
+from siliconcompiler.schema import docs
+
+
+if not os.path.abspath(__file__).startswith(docs.sc_root):
+    pytest.skip(reason="test for docs only possible in editable install",
+                allow_module_level=True)
+
+
+AGENTS = os.path.join(docs.sc_root, "AGENTS.md")
+PREAMBLE = os.path.join(docs.sc_root, "docs", "_llms", "preamble.md")
+PYPROJECT = os.path.join(docs.sc_root, "pyproject.toml")
+LINT_WORKFLOW = os.path.join(docs.sc_root, ".github", "workflows", "lint.yml")
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+@pytest.fixture
+def agents():
+    return _read(AGENTS)
+
+
+@pytest.fixture
+def preamble():
+    return _read(PREAMBLE)
+
+
+@pytest.fixture(params=[AGENTS, PREAMBLE], ids=["AGENTS.md", "llms_preamble"])
+def orientation(request):
+    """Both orientation files, checked against the same claims."""
+    return os.path.relpath(request.param, docs.sc_root), _read(request.param)
+
+
+def test_exported_symbols_exist(orientation):
+    """Every ``siliconcompiler.X`` name presented as current must import.
+
+    The failure this guards against is the file outliving a rename, which is
+    exactly what happened to the class names it is warning the reader about.
+    """
+    name, text = orientation
+    # The full export list both files quote, as a comma-separated run of
+    # backticked names.
+    quoted = set(re.findall(r"`([A-Z][A-Za-z]+)`", text))
+    # Names the files quote as *removed* are expected to be absent.
+    removed = {"Chip", "ASICProject", "Library", "LibrarySchema", "Flow",
+               "FlowgraphSchema", "DesignSchema", "PDKSchema", "ASICSchema",
+               "MetricSchema", "Schema", "SiliconCompilerError"}
+    missing = sorted(symbol for symbol in quoted - removed
+                     if not hasattr(siliconcompiler, symbol))
+    assert not missing, (
+        f"{name} names symbols that are not exported from siliconcompiler: "
+        f"{missing}")
+
+
+def test_removed_symbols_are_still_removed(orientation):
+    """The negative claims have to stay true, or they mislead in reverse."""
+    name, text = orientation
+    assert "Chip" in text, f"{name} should keep warning that Chip is gone"
+    for symbol in ("Chip", "ASICProject"):
+        assert not hasattr(siliconcompiler, symbol), (
+            f"{name} says {symbol} was removed, but it is exported again -- "
+            "the file needs updating")
+
+
+def test_console_scripts_match_pyproject(orientation):
+    """The entry point list is quoted as complete, so it must be."""
+    name, text = orientation
+    with open(PYPROJECT, "rb") as f:
+        declared = set(tomllib.load(f)["project"]["scripts"])
+
+    quoted = set(re.findall(r"`(sc-[a-z]+|smake)`", text))
+    assert quoted == declared, (
+        f"{name} lists console scripts {sorted(quoted)} but pyproject.toml "
+        f"declares {sorted(declared)}")
+
+
+def test_no_sc_entry_point():
+    """The single most repeated wrong instruction in the project's history."""
+    with open(PYPROJECT, "rb") as f:
+        scripts = tomllib.load(f)["project"]["scripts"]
+    assert "sc" not in scripts, (
+        "a bare 'sc' entry point now exists, so AGENTS.md, the llms.txt "
+        "preamble and the migration guide all need correcting")
+
+
+def test_in_tree_module_directories_exist(orientation):
+    """The placement policy names four in-tree directories."""
+    name, text = orientation
+    for directory in ("tools", "flows", "targets"):
+        assert f"`{directory}/`" in text or f"siliconcompiler/{directory}" in text, \
+            f"{name} no longer mentions siliconcompiler/{directory}/"
+        assert os.path.isdir(os.path.join(docs.sc_root, "siliconcompiler", directory))
+
+
+def test_directories_it_says_do_not_exist(orientation):
+    """``siliconcompiler/pdks/`` and ``libs/`` are the stale-guide trap."""
+    name, _ = orientation
+    for directory in ("pdks", "libs"):
+        assert not os.path.isdir(os.path.join(docs.sc_root, "siliconcompiler",
+                                              directory)), \
+            (f"siliconcompiler/{directory}/ now exists, but {name} tells readers "
+             "it does not -- the placement policy changed")
+
+
+def test_lint_gates_match_ci(agents):
+    """AGENTS.md claims four lint gates; CI is the authority on how many.
+
+    Contributors and agents fail the gates they do not know about, which is the
+    whole reason the list is in the file. A fifth job landing in CI without a
+    line here recreates that gap.
+    """
+    with open(LINT_WORKFLOW, encoding="utf-8") as f:
+        jobs = list(yaml.safe_load(f)["jobs"])
+    assert jobs, "could not read job names out of lint.yml"
+
+    tools = {"lint_python": "flake8", "lint_tcl": "tclint", "spelling": "codespell",
+             "lint_verilog": "verible-verilog-lint"}
+    unknown = sorted(set(jobs) - set(tools))
+    assert not unknown, (
+        f"lint.yml has new jobs {unknown}; add them to AGENTS.md and "
+        "CONTRIBUTING.md, then to the mapping in this test")
+
+    for job in jobs:
+        assert tools[job] in agents, (
+            f"CI runs the {job} gate with {tools[job]}, which AGENTS.md does "
+            "not mention")
+
+
+def test_example_command_is_runnable(orientation):
+    """The demo module both files point at has to be importable."""
+    name, text = orientation
+    assert "siliconcompiler.demos.asic_demo" in text
+    module = os.path.join(docs.sc_root, "siliconcompiler", "demos", "asic_demo.py")
+    assert os.path.isfile(module), f"{name} points at a demo that does not exist"
+
+
+def test_named_project_classes_carry_domain_schema():
+    """The reason both files say to prefer the named classes over ``Project``.
+
+    The advice is only worth giving while it is true: a named class exists to
+    bring its domain's parameters, and the base class deliberately has none of
+    them. If ``Project`` ever grew an ``asic`` section the guidance would need
+    rewording.
+    """
+    from siliconcompiler import ASIC, Design, Lint, Project
+
+    design = Design("t")
+    design.set_topmodule("t", fileset="rtl")
+
+    assert "asic" in ASIC(design).getkeys(), \
+        "ASIC no longer carries an 'asic' schema section"
+    for cls in (Project, Lint):
+        instance = cls(design) if cls is not Project else cls()
+        assert "asic" not in instance.getkeys(), (
+            f"{cls.__name__} now carries an 'asic' section, so the advice to "
+            "prefer the named project classes needs rewording")
+
+
+def test_orientation_files_are_ascii(orientation):
+    """Keep these two plain ASCII.
+
+    The preamble is copied verbatim into ``llms.txt`` and ``llms-full.txt``, which
+    are plain-text files people grep, diff and paste snippets out of. A curly
+    apostrophe next to code is a small trap for no benefit, and the same argument
+    applies to ``AGENTS.md``. The llms.txt generator strips the typographic
+    characters Sphinx introduces; nothing strips the ones an author types, so
+    they are rejected here instead.
+    """
+    name, text = orientation
+    offenders = sorted({character for character in text if ord(character) > 127})
+    assert not offenders, (
+        f"{name} contains non-ASCII characters {offenders}; use \"--\" for a "
+        "dash, straight quotes, and \"...\" for an ellipsis")
+
+
+def test_agents_md_references_resolve(agents):
+    """Relative links in AGENTS.md are read on GitHub, where they must resolve."""
+    broken = []
+    for target in re.findall(r"\]\((?!https?://|#)([^)]+)\)", agents):
+        path = os.path.join(docs.sc_root, target.split("#")[0])
+        if not os.path.exists(path):
+            broken.append(target)
+    assert not broken, f"AGENTS.md links to paths that do not exist: {broken}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for replacing the removed `Chip` API with the `Design` and project model.
  * Added FAQ guidance and navigation for migration resources.
  * Documented machine-readable artifacts, version-pinning guidance, repository practices, and an LLM-oriented documentation preamble.

* **New Features**
  * HTML documentation builds now generate `llms.txt`, `llms-full.txt`, and `schema.json`.
  * Added an option to skip artifact generation during iterative builds.

* **Tests**
  * Added checks for documentation accuracy, links, examples, API references, and repository guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->