### PR TITLE
compute core or die area from margin when one or the other is not provided

### DIFF
--- a/siliconcompiler/constraints/asic_floorplan.py
+++ b/siliconcompiler/constraints/asic_floorplan.py
@@ -1,3 +1,5 @@
+import math
+
 from typing import Union, List, Tuple, Optional
 
 from siliconcompiler.schema import BaseSchema, EditableSchema, Parameter, PerNode, Scope
@@ -558,6 +560,234 @@ class ASICAreaConstraint(BaseSchema):
             Tuple[float, float]: A tuple containing the width and height of the core area.
         """
         return self._calc_size(self.get_coreboundingbox(step=step, index=index))
+
+    @staticmethod
+    def _calc_polygon_vertices(points: List[Tuple[float, float]]) \
+            -> List[Tuple[float, float]]:
+        """
+        Reduces an outline to the vertices that give it its shape.
+
+        Repeated points have no edge direction, and a point in the middle of a
+        straight edge does not turn the outline, so neither survives.
+
+        Args:
+            points (List[Tuple[float, float]]): The outline points, without a
+                                                repeated closing point.
+
+        Returns:
+            List[Tuple[float, float]]: The corners of the outline, in the order
+                                       they were given.
+        """
+        unique = []
+        for point in points:
+            point = tuple(point)
+            if not unique or point != unique[-1]:
+                unique.append(point)
+        if len(unique) > 1 and unique[0] == unique[-1]:
+            unique.pop()
+
+        if len(unique) < 3:
+            return unique
+
+        corners = []
+        for index, (x, y) in enumerate(unique):
+            x0, y0 = unique[index - 1]
+            x1, y1 = unique[(index + 1) % len(unique)]
+
+            # cross product of the incoming and outgoing edges
+            if (x - x0) * (y1 - y) != (y - y0) * (x1 - x):
+                corners.append((x, y))
+
+        return corners
+
+    @staticmethod
+    def _calc_signed_area(points: List[Tuple[float, float]]) -> float:
+        """
+        Computes the signed area of a closed polygon with the shoelace formula.
+
+        Args:
+            points (List[Tuple[float, float]]): The polygon vertices, without a
+                                                repeated closing vertex.
+
+        Returns:
+            float: The signed area. Positive for a counter-clockwise outline and
+                   negative for a clockwise one.
+        """
+        area = 0.0
+        for index, (x0, y0) in enumerate(points):
+            x1, y1 = points[(index + 1) % len(points)]
+            area += x0 * y1 - x1 * y0
+        return area / 2.0
+
+    @classmethod
+    def _calc_offset_polygon(cls, points: List[Tuple[float, float]], offset: float) \
+            -> List[Tuple[float, float]]:
+        """
+        Offsets a closed polygon by sliding every edge along its inward normal.
+
+        Each vertex of the result is the intersection of its two offset edges, so
+        a rectilinear outline stays rectilinear and concave corners are offset
+        into the shape rather than away from it. Mitering a concave corner keeps
+        the result inside the outline it was offset from, which is what matters
+        for a core area, but it does trim slightly more than the offset distance
+        right at that corner.
+
+        Args:
+            points (List[Tuple[float, float]]): The polygon vertices, optionally
+                                                repeating the first vertex to
+                                                close the outline.
+            offset (float): The distance to move each edge. A positive offset
+                            shrinks the polygon and a negative one grows it.
+
+        Raises:
+            ValueError: If the outline is not a polygon, or if the offset
+                        collapses or inverts it.
+
+        Returns:
+            List[Tuple[float, float]]: The offset polygon, closed the same way
+                                       the input was.
+        """
+        closed = len(points) > 1 and tuple(points[0]) == tuple(points[-1])
+        vertices = cls._calc_polygon_vertices(points[:-1] if closed else points)
+
+        if len(vertices) < 3:
+            raise ValueError("outline must have at least three vertices")
+
+        area = cls._calc_signed_area(vertices)
+        if area == 0.0:
+            raise ValueError("outline does not enclose an area")
+
+        # A counter-clockwise outline keeps its interior to the left of each edge.
+        winding = 1.0 if area > 0.0 else -1.0
+
+        # Slide every edge along its inward normal, keeping it as a point plus a
+        # unit direction so the offset vertices can be solved for below.
+        edges = []
+        for index, (x0, y0) in enumerate(vertices):
+            x1, y1 = vertices[(index + 1) % len(vertices)]
+            dx, dy = x1 - x0, y1 - y0
+            length = math.hypot(dx, dy)
+            dx, dy = dx / length, dy / length
+            edges.append((x0 - offset * winding * dy, y0 + offset * winding * dx, dx, dy))
+
+        # Every vertex becomes the intersection of the two edges that meet there.
+        offset_vertices = []
+        for index, (qx, qy, vx, vy) in enumerate(edges):
+            px, py, ux, uy = edges[index - 1]
+
+            # sin() of the angle the outline turns through at this vertex
+            turn = ux * vy - uy * vx
+            if abs(turn) < 1e-9:
+                raise ValueError("outline doubles back on itself")
+
+            distance = ((qx - px) * vy - (qy - py) * vx) / turn
+            offset_vertices.append((px + distance * ux, py + distance * uy))
+
+        # A big enough offset folds the outline over itself, which shows up as an edge
+        # that now runs backwards. Checking the direction of every edge catches that
+        # even when the folded outline keeps its winding and encloses a smaller area.
+        for index, (_, _, dx, dy) in enumerate(edges):
+            x0, y0 = offset_vertices[index]
+            x1, y1 = offset_vertices[(index + 1) % len(offset_vertices)]
+            if (x1 - x0) * dx + (y1 - y0) * dy <= 0.0:
+                raise ValueError("offset is too large for the outline")
+
+        if closed:
+            offset_vertices.append(offset_vertices[0])
+
+        return offset_vertices
+
+    def calc_floorplan_areas(self, step: Optional[str] = None,
+                             index: Optional[Union[str, int]] = None) \
+            -> Optional[Tuple[List[Tuple[float, float]], List[Tuple[float, float]]]]:
+        """
+        Resolves the die and core areas used to initialize a floorplan.
+
+        Floorplanning tools need both a die and a core outline, but only one of
+        them has to be specified since the other can be derived from the core
+        margin:
+
+        * die area and core area: both are used as specified.
+        * die area only: the core area is the die area inset by the core margin.
+        * core area only: the die area is the core area outset by the core
+          margin. The core keeps the coordinates it was given so that component
+          placements remain valid, which means the core area has to sit at least
+          one core margin away from the origin.
+
+        Rectilinear outlines are offset edge by edge, so a polygonal die yields a
+        polygonal core that follows it rather than its bounding box.
+
+        A core margin of zero is assumed when the margin has not been set.
+
+        Args:
+            step (str, optional): The step in a workflow to retrieve from.
+                                  Defaults to None.
+            index (Union[str, int], optional): The index within a step to
+                                               retrieve from. Defaults to None.
+
+        Raises:
+            ValueError: If the core margin does not leave a core area with a
+                        positive width and height, or if it places the die area
+                        at a negative coordinate.
+
+        Returns:
+            Optional[Tuple[List[Tuple[float, float]], List[Tuple[float, float]]]]:
+            The die and core areas, or None if neither area has been specified,
+            in which case the floorplan must be sized from the density and
+            aspect ratio.
+        """
+        diearea = self.get_diearea(step=step, index=index)
+        corearea = self.get_corearea(step=step, index=index)
+
+        if diearea and corearea:
+            return diearea, corearea
+
+        if not diearea and not corearea:
+            return None
+
+        coremargin = self.get_coremargin(step=step, index=index)
+        if coremargin is None:
+            coremargin = 0.0
+
+        if diearea:
+            if len(diearea) == 2:
+                # Two points are the lower left and upper right of a rectangle.
+                (die_x0, die_y0), (die_x1, die_y1) = self._calc_boundingbox(diearea)
+
+                if 2 * coremargin >= (die_x1 - die_x0):
+                    raise ValueError("core margin is greater than or equal to the die width")
+                if 2 * coremargin >= (die_y1 - die_y0):
+                    raise ValueError("core margin is greater than or equal to the die height")
+
+                corearea = [
+                    (die_x0 + coremargin, die_y0 + coremargin),
+                    (die_x1 - coremargin, die_y1 - coremargin)]
+            else:
+                try:
+                    corearea = self._calc_offset_polygon(diearea, coremargin)
+                except ValueError as e:
+                    raise ValueError(f"core margin does not fit in the die area: {e}") from e
+        else:
+            if len(corearea) == 2:
+                (core_x0, core_y0), (core_x1, core_y1) = self._calc_boundingbox(corearea)
+
+                diearea = [
+                    (core_x0 - coremargin, core_y0 - coremargin),
+                    (core_x1 + coremargin, core_y1 + coremargin)]
+            else:
+                try:
+                    diearea = self._calc_offset_polygon(corearea, -coremargin)
+                except ValueError as e:
+                    raise ValueError(f"core margin cannot be applied to the core area: {e}") from e
+
+            # OpenROAD rejects a die area with negative coordinates.
+            (die_x0, die_y0), _ = self._calc_boundingbox(diearea)
+            if die_x0 < 0.0:
+                raise ValueError("core margin places the die area at a negative x coordinate")
+            if die_y0 < 0.0:
+                raise ValueError("core margin places the die area at a negative y coordinate")
+
+        return diearea, corearea
 
     def calc_diearea(self, step: Optional[str] = None, index: Optional[Union[str, int]] = None) \
             -> float:

--- a/siliconcompiler/tools/openroad/init_floorplan.py
+++ b/siliconcompiler/tools/openroad/init_floorplan.py
@@ -272,6 +272,17 @@ class InitFloorplanTask(APRTask,
             self.add_required_key(self.mainlib, "asic", "site")
 
             area = self.project.constraint.area
+
+            # sc_init_floorplan.tcl reads the two corners of a rectangle, and OpenROAD's
+            # polygonal floorplan support is not usable yet, so refuse a polygon rather
+            # than silently floorplanning its first two points.
+            for name, points in (("die", area.get_diearea(step=self.step, index=self.index)),
+                                 ("core", area.get_corearea(step=self.step, index=self.index))):
+                if points and len(points) != 2:
+                    raise ValueError(
+                        f"openroad does not support a polygonal {name} area yet, "
+                        f"the {name} area must be given as two points")
+
             floorplan_areas = area.calc_floorplan_areas(step=self.step, index=self.index)
             if floorplan_areas:
                 # sc_init_floorplan.tcl needs both an explicit die and core area, so record

--- a/siliconcompiler/tools/openroad/init_floorplan.py
+++ b/siliconcompiler/tools/openroad/init_floorplan.py
@@ -270,14 +270,31 @@ class InitFloorplanTask(APRTask,
         # area/site floorplanning keys are only required when initializing from scratch.
         if not floorplan_def:
             self.add_required_key(self.mainlib, "asic", "site")
-            if self.project.constraint.area.get_diearea(step=self.step, index=self.index) and \
-                    self.project.constraint.area.get_corearea(step=self.step, index=self.index):
-                self.add_required_key(self.project.constraint.area, "diearea")
-                self.add_required_key(self.project.constraint.area, "corearea")
+
+            area = self.project.constraint.area
+            floorplan_areas = area.calc_floorplan_areas(step=self.step, index=self.index)
+            if floorplan_areas:
+                # sc_init_floorplan.tcl needs both an explicit die and core area, so record
+                # the area that was derived from the core margin.
+                diearea, corearea = floorplan_areas
+                from_coremargin = False
+                if not area.get_diearea(step=self.step, index=self.index):
+                    area.set_diearea(diearea, step=self.step, index=self.index)
+                    from_coremargin = True
+                if not area.get_corearea(step=self.step, index=self.index):
+                    area.set_corearea(corearea, step=self.step, index=self.index)
+                    from_coremargin = True
+
+                self.add_required_key(area, "diearea")
+                self.add_required_key(area, "corearea")
+                if from_coremargin:
+                    # One of the areas was computed from the core margin, so a change to
+                    # the margin has to invalidate this node.
+                    self.add_required_key(area, "coremargin")
             else:
-                self.add_required_key(self.project.constraint.area, "aspectratio")
-                self.add_required_key(self.project.constraint.area, "density")
-                self.add_required_key(self.project.constraint.area, "coremargin")
+                self.add_required_key(area, "aspectratio")
+                self.add_required_key(area, "density")
+                self.add_required_key(area, "coremargin")
 
         if self.mainlib.get("tool", "openroad", "tracks"):
             self.add_required_key(self.mainlib, "tool", "openroad", "tracks")

--- a/tests/constraints/test_asic_floorplan.py
+++ b/tests/constraints/test_asic_floorplan.py
@@ -1,3 +1,4 @@
+import math
 import pytest
 
 from siliconcompiler.schema import PerNode, Scope
@@ -440,3 +441,195 @@ def test_calc_area_with_step_index(shape, expect):
 
     assert schema.calc_diearea() == 10000
     assert schema.calc_diearea(step="step", index="index") == expect
+
+
+def test_calc_floorplan_areas_unset():
+    # Nothing to resolve, the floorplan has to be sized from density/aspectratio.
+    assert ASICAreaConstraint().calc_floorplan_areas() is None
+
+
+def test_calc_floorplan_areas_both_set():
+    schema = ASICAreaConstraint()
+    schema.set_diearea_rectangle(100.0, 150.0, 2.0)
+    schema.set_coremargin(25.0)
+
+    # An explicit core area wins over the core margin.
+    assert schema.calc_floorplan_areas() == (
+        [(0.0, 0.0), (150.0, 100.0)],
+        [(2.0, 2.0), (148.0, 98.0)])
+
+
+def test_calc_floorplan_areas_die_with_margin():
+    schema = ASICAreaConstraint()
+    schema.set_diearea_rectangle(500.0, 500.0)
+    schema.set_coremargin(1.0)
+
+    assert schema.calc_floorplan_areas() == (
+        [(0.0, 0.0), (500.0, 500.0)],
+        [(1.0, 1.0), (499.0, 499.0)])
+
+
+def test_calc_floorplan_areas_die_without_margin():
+    schema = ASICAreaConstraint()
+    schema.set_diearea_rectangle(500.0, 500.0)
+
+    # An unset core margin is a zero margin, the die area is still honored.
+    assert schema.calc_floorplan_areas() == (
+        [(0.0, 0.0), (500.0, 500.0)],
+        [(0.0, 0.0), (500.0, 500.0)])
+
+
+def test_calc_floorplan_areas_die_polygon_with_margin():
+    schema = ASICAreaConstraint()
+    # An L shape, wound clockwise, missing its top right corner.
+    schema.set_diearea([(0, 0), (0, 200), (200, 200), (200, 100), (300, 100), (300, 0)])
+    schema.set_coremargin(5.0)
+
+    # The core follows the die outline. A bounding box inset would have put the
+    # core over the missing corner, outside the die.
+    assert schema.calc_floorplan_areas() == (
+        [(0.0, 0.0), (0.0, 200.0), (200.0, 200.0), (200.0, 100.0), (300.0, 100.0), (300.0, 0.0)],
+        [(5.0, 5.0), (5.0, 195.0), (195.0, 195.0), (195.0, 95.0), (295.0, 95.0), (295.0, 5.0)])
+
+
+def test_calc_floorplan_areas_die_polygon_counterclockwise():
+    schema = ASICAreaConstraint()
+    # The same L shape wound the other way, the core must still be inside it.
+    schema.set_diearea([(0, 0), (300, 0), (300, 100), (200, 100), (200, 200), (0, 200)])
+    schema.set_coremargin(5.0)
+
+    _, corearea = schema.calc_floorplan_areas()
+    assert corearea == [
+        (5.0, 5.0), (295.0, 5.0), (295.0, 95.0), (195.0, 95.0), (195.0, 195.0), (5.0, 195.0)]
+
+
+def test_calc_floorplan_areas_die_polygon_closed():
+    schema = ASICAreaConstraint()
+    # A repeated first vertex closes the outline, the core is closed the same way.
+    schema.set_diearea([(0, 0), (0, 100), (100, 100), (100, 0), (0, 0)])
+    schema.set_coremargin(10.0)
+
+    _, corearea = schema.calc_floorplan_areas()
+    assert corearea == [
+        (10.0, 10.0), (10.0, 90.0), (90.0, 90.0), (90.0, 10.0), (10.0, 10.0)]
+
+
+def test_calc_floorplan_areas_die_polygon_collinear_vertex():
+    schema = ASICAreaConstraint()
+    # (50, 0) adds no shape, so it drops out of the offset outline.
+    schema.set_diearea([(0, 0), (0, 100), (100, 100), (100, 0), (50, 0)])
+    schema.set_coremargin(10.0)
+
+    _, corearea = schema.calc_floorplan_areas()
+    assert corearea == [(10.0, 10.0), (10.0, 90.0), (90.0, 90.0), (90.0, 10.0)]
+
+
+def test_calc_floorplan_areas_die_polygon_diagonal():
+    schema = ASICAreaConstraint()
+    schema.set_diearea([(0, 0), (0, 100), (100, 0)])
+    schema.set_coremargin(5.0)
+
+    _, corearea = schema.calc_floorplan_areas()
+    # The diagonal edge is mitered, so its corners sit back by 5 * (1 + sqrt(2)).
+    miter = 100.0 - 5.0 * (1 + math.sqrt(2))
+    assert corearea == [
+        pytest.approx((5.0, 5.0)),
+        pytest.approx((5.0, miter)),
+        pytest.approx((miter, 5.0))]
+
+
+def test_calc_floorplan_areas_die_polygon_margin_too_large():
+    schema = ASICAreaConstraint()
+    schema.set_diearea([(0, 0), (0, 200), (200, 200), (200, 100), (300, 100), (300, 0)])
+    schema.set_coremargin(200.0)
+
+    with pytest.raises(ValueError,
+                       match=r"^core margin does not fit in the die area: "
+                             r"offset is too large for the outline$"):
+        schema.calc_floorplan_areas()
+
+
+def test_calc_floorplan_areas_core_polygon_with_margin():
+    schema = ASICAreaConstraint()
+    schema.set_corearea([(10, 10), (10, 210), (210, 210), (210, 110), (310, 110), (310, 10)])
+    schema.set_coremargin(5.0)
+
+    diearea, corearea = schema.calc_floorplan_areas()
+    # The die grows around the core and keeps the same outline. Growing it shrinks
+    # the notch, so the reflex corner moves to (215, 115) rather than (215, 105).
+    assert diearea == [
+        (5.0, 5.0), (5.0, 215.0), (215.0, 215.0), (215.0, 115.0), (315.0, 115.0), (315.0, 5.0)]
+    assert corearea == [
+        (10.0, 10.0), (10.0, 210.0), (210.0, 210.0), (210.0, 110.0), (310.0, 110.0), (310.0, 10.0)]
+
+
+def test_calc_floorplan_areas_core_at_origin_with_margin():
+    schema = ASICAreaConstraint()
+    schema.set_corearea([(0.0, 10.0), (100.0, 110.0)])
+    schema.set_coremargin(5.0)
+
+    # Growing the die would put it at x = -5, which OpenROAD rejects.
+    with pytest.raises(ValueError,
+                       match=r"^core margin places the die area at a negative x coordinate$"):
+        schema.calc_floorplan_areas()
+
+
+def test_calc_floorplan_areas_core_below_origin_with_margin():
+    schema = ASICAreaConstraint()
+    schema.set_corearea([(10.0, 0.0), (110.0, 100.0)])
+    schema.set_coremargin(5.0)
+
+    with pytest.raises(ValueError,
+                       match=r"^core margin places the die area at a negative y coordinate$"):
+        schema.calc_floorplan_areas()
+
+
+def test_calc_floorplan_areas_core_with_margin():
+    schema = ASICAreaConstraint()
+    schema.set_corearea([(10.0, 10.0), (110.0, 60.0)])
+    schema.set_coremargin(5.0)
+
+    # The core coordinates are preserved so component placements stay valid.
+    assert schema.calc_floorplan_areas() == (
+        [(5.0, 5.0), (115.0, 65.0)],
+        [(10.0, 10.0), (110.0, 60.0)])
+
+
+def test_calc_floorplan_areas_core_without_margin():
+    schema = ASICAreaConstraint()
+    schema.set_corearea([(0.0, 0.0), (100.0, 100.0)])
+
+    assert schema.calc_floorplan_areas() == (
+        [(0.0, 0.0), (100.0, 100.0)],
+        [(0.0, 0.0), (100.0, 100.0)])
+
+
+def test_calc_floorplan_areas_margin_exceeds_die_width():
+    schema = ASICAreaConstraint()
+    schema.set_diearea_rectangle(500.0, 100.0)
+    schema.set_coremargin(50.0)
+
+    with pytest.raises(ValueError,
+                       match=r"^core margin is greater than or equal to the die width$"):
+        schema.calc_floorplan_areas()
+
+
+def test_calc_floorplan_areas_margin_exceeds_die_height():
+    schema = ASICAreaConstraint()
+    schema.set_diearea_rectangle(100.0, 500.0)
+    schema.set_coremargin(50.0)
+
+    with pytest.raises(ValueError,
+                       match=r"^core margin is greater than or equal to the die height$"):
+        schema.calc_floorplan_areas()
+
+
+def test_calc_floorplan_areas_step_index():
+    schema = ASICAreaConstraint()
+    schema.set_coremargin(1.0)
+    schema.set_diearea_rectangle(500.0, 500.0, step="step0", index="0")
+
+    assert schema.calc_floorplan_areas() is None
+    assert schema.calc_floorplan_areas(step="step0", index="0") == (
+        [(0.0, 0.0), (500.0, 500.0)],
+        [(1.0, 1.0), (499.0, 499.0)])

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -1810,6 +1810,22 @@ def test_openroad_init_floorplan_derives_corearea_no_coremargin(asic_gcd):
     assert "constraint,area,coremargin" in require
 
 
+@pytest.mark.parametrize("area,expect", [
+    ("diearea", "die"),
+    ("corearea", "core"),
+])
+def test_openroad_init_floorplan_rejects_polygon(asic_gcd, area, expect):
+    # sc_init_floorplan.tcl floorplans the first two points of an outline, so a polygon has
+    # to be refused until OpenROAD's polygonal floorplan support is usable.
+    getattr(asic_gcd.constraint.area, f"set_{area}")(
+        [(0, 0), (0, 200), (200, 200), (200, 100), (300, 100), (300, 0)])
+
+    with pytest.raises(ValueError,
+                       match=rf"^openroad does not support a polygonal {expect} area yet, "
+                             rf"the {expect} area must be given as two points$"):
+        _setup_node(asic_gcd, "floorplan.init")
+
+
 def test_openroad_init_floorplan_density_sizing(asic_gcd):
     # Without a die or core area the floorplan is still sized from density.
     require = _setup_node(asic_gcd, "floorplan.init").get("require")

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -1744,6 +1744,85 @@ def _setup_node(project, step):
         return node.task
 
 
+def test_openroad_init_floorplan_derives_corearea_from_coremargin(asic_gcd):
+    # sc_init_floorplan.tcl only honors an explicit die area when a core area
+    # goes with it, so a die area on its own used to silently fall back to
+    # density driven sizing and discard the requested die.
+    # https://github.com/siliconcompiler/siliconcompiler/issues/5217
+    area = asic_gcd.constraint.area
+    area.set_diearea_rectangle(500, 500)
+    assert area.get_coremargin() == 1.0, "freepdk45 must supply a core margin"
+
+    require = _setup_node(asic_gcd, "floorplan.init").get("require")
+
+    assert area.get_diearea(step="floorplan.init", index="0") == [(0.0, 0.0), (500.0, 500.0)]
+    assert area.get_corearea(step="floorplan.init", index="0") == [(1.0, 1.0), (499.0, 499.0)]
+
+    assert "constraint,area,diearea" in require
+    assert "constraint,area,corearea" in require
+    # The core area was computed from the margin, so the margin is part of the node.
+    assert "constraint,area,coremargin" in require
+    assert "constraint,area,density" not in require
+
+
+def test_openroad_init_floorplan_derives_diearea_from_coremargin(asic_gcd):
+    area = asic_gcd.constraint.area
+    area.set_corearea([(10, 10), (410, 260)])
+
+    require = _setup_node(asic_gcd, "floorplan.init").get("require")
+
+    # The die grows around the core, the core keeps the coordinates it was given.
+    assert area.get_diearea(step="floorplan.init", index="0") == [(9.0, 9.0), (411.0, 261.0)]
+    assert area.get_corearea(step="floorplan.init", index="0") == [(10.0, 10.0), (410.0, 260.0)]
+
+    assert "constraint,area,diearea" in require
+    assert "constraint,area,corearea" in require
+    assert "constraint,area,coremargin" in require
+
+
+def test_openroad_init_floorplan_explicit_areas(asic_gcd):
+    area = asic_gcd.constraint.area
+    area.set_diearea_rectangle(500, 500, coremargin=10)
+
+    require = _setup_node(asic_gcd, "floorplan.init").get("require")
+
+    assert area.get_diearea(step="floorplan.init", index="0") == [(0.0, 0.0), (500.0, 500.0)]
+    assert area.get_corearea(step="floorplan.init", index="0") == [(10.0, 10.0), (490.0, 490.0)]
+
+    assert "constraint,area,diearea" in require
+    assert "constraint,area,corearea" in require
+    # Nothing was derived, so the margin does not affect this node.
+    assert "constraint,area,coremargin" not in require
+
+
+def test_openroad_init_floorplan_derives_corearea_no_coremargin(asic_gcd):
+    area = asic_gcd.constraint.area
+    area.set_diearea_rectangle(500, 500)
+    area.unset("coremargin")
+
+    require = _setup_node(asic_gcd, "floorplan.init").get("require")
+
+    assert area.get_diearea(step="floorplan.init", index="0") == [(0.0, 0.0), (500.0, 500.0)]
+    assert area.get_corearea(step="floorplan.init", index="0") == [(0.0, 0.0), (500.0, 500.0)]
+
+    assert "constraint,area,diearea" in require
+    assert "constraint,area,corearea" in require
+    assert "constraint,area,coremargin" in require
+
+
+def test_openroad_init_floorplan_density_sizing(asic_gcd):
+    # Without a die or core area the floorplan is still sized from density.
+    require = _setup_node(asic_gcd, "floorplan.init").get("require")
+
+    assert asic_gcd.constraint.area.get_diearea(step="floorplan.init", index="0") == []
+    assert asic_gcd.constraint.area.get_corearea(step="floorplan.init", index="0") == []
+
+    assert "constraint,area,aspectratio" in require
+    assert "constraint,area,density" in require
+    assert "constraint,area,coremargin" in require
+    assert "constraint,area,diearea" not in require
+
+
 @pytest.mark.parametrize("task_cls", [
     pex.PEXBenchTask,
     pex.PEXBenchExtractTask,


### PR DESCRIPTION
Closes #5217 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically derives missing die or core floorplan areas from available dimensions and margins.
  - Supports rectangular and polygonal outlines with inward and outward margin calculations.
  - Preserves explicitly provided areas while resolving missing values when possible.
- **Bug Fixes**
  - Strengthened validation for invalid margins, degenerate outlines, inconsistent dimensions, and unsupported polygonal configurations.
  - OpenROAD floorplan initialization now enforces required constraints consistently.
- **Tests**
  - Added comprehensive coverage for floorplan calculations and initialization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->