### PR TITLE
ensure check_manifest is running on the same corrections that init_run will perform

### DIFF
--- a/docs/user_guide/tutorials/debug.rst
+++ b/docs/user_guide/tutorials/debug.rst
@@ -129,12 +129,10 @@ Checking configuration without running
 
    project.check_manifest()
 
-.. warning::
-   Run this **after** :meth:`.Project.run()`. Library dependency resolution
-   happens inside ``run()``, so a call before it reports errors about a
-   configuration that is actually correct -- it is not a usable pre-flight
-   check. To validate a configuration before building, use
-   ``design.check_filepaths()`` above.
+The check runs against the configuration :meth:`.Project.run()` would execute, so
+values a run infers for you -- the design fileset, the ASIC main library -- are
+reported as warnings rather than errors, and your project is left unmodified. To
+also confirm that the source files resolve, use ``design.check_filepaths()`` above.
 
 Asking for help
 ===============

--- a/siliconcompiler/asic.py
+++ b/siliconcompiler/asic.py
@@ -217,12 +217,12 @@ class ASIC(Project):
 
         self._import_dep(obj)
 
-    def check_manifest(self) -> bool:
+    def _check_manifest(self) -> bool:
         """
         Performs a comprehensive check of the ASIC project's manifest
         for consistency and validity, extending the base Project checks.
 
-        This method first calls the :meth:`.Project.check_manifest()` method.
+        This method first calls the :meth:`.Project._check_manifest()` method.
         Then, it performs additional ASIC-specific validations:
 
             - Asserts that :keypath:`ASIC,asic,pdk` is set and refers to a
@@ -237,7 +237,7 @@ class ASIC(Project):
         Returns:
             bool: True if the manifest is valid and all checks pass, False otherwise.
         """
-        error = not super().check_manifest()
+        error = not super()._check_manifest()
 
         pdk = self.get("asic", "pdk")
         if not pdk:

--- a/siliconcompiler/fpga.py
+++ b/siliconcompiler/fpga.py
@@ -229,7 +229,7 @@ class FPGA(Project):
 
         return self.set("fpga", "device", fpga)
 
-    def check_manifest(self) -> bool:
+    def _check_manifest(self) -> bool:
         """
         Validate the project manifest for FPGA configuration and library availability.
 
@@ -240,7 +240,7 @@ class FPGA(Project):
         Returns:
             bool: `True` if the manifest is valid, `False` otherwise.
         """
-        error = not super().check_manifest()
+        error = not super()._check_manifest()
 
         if not self.get("fpga", "device"):
             self.logger.error("[fpga,device] has not been set.")

--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -452,6 +452,38 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         Performs a comprehensive check of the project's manifest (configuration)
         for consistency and validity.
 
+        The checks are performed against a resolved copy of this project, so the
+        configuration that :meth:`.Project.run()` would actually execute is what
+        gets validated. Values that a run would infer, such as the design fileset
+        or the ASIC main library, are therefore not reported as errors, but the
+        inference itself is still reported as a warning. This project is left
+        unmodified.
+
+        Returns:
+            bool: True if the manifest is valid and all checks pass, False otherwise.
+        """
+        # Resolve the manifest on a throwaway copy so the checks see the same
+        # configuration a run would, without modifying this project.
+        proj = self.copy()
+
+        # Preserve logger instance so messages are reported against this project
+        proj.__logger = self.__logger
+
+        # The copy is short lived and never runs, so it has no use for a dashboard
+        proj.__dashboard = None
+
+        try:
+            proj._init_run()
+        except Exception as e:
+            self.logger.error(f"Failed to resolve manifest for checking: {e}")
+            return False
+
+        return proj._check_manifest()
+
+    def _check_manifest(self) -> bool:
+        """
+        Implements the manifest checks for this project.
+
         This method verifies that essential options like 'design', 'fileset',
         and 'flow' are properly set. It also checks if the specified design
         and flowgraph are loaded, and if filesets within the selected design
@@ -459,6 +491,9 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         any defined fileset aliases, ensuring that source and destination
         libraries and filesets exist. Error messages are logged for any
         detected inconsistencies.
+
+        This is called after :meth:`.Project._init_run()`, so implementations can
+        rely on the manifest having been resolved.
 
         Returns:
             bool: True if the manifest is valid and all checks pass, False otherwise.
@@ -546,8 +581,12 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
 
     def _init_run(self):
         """
-        Method called before :meth:`.Project.check_manifest()` to provide a mechanism to
+        Method called before :meth:`.Project._check_manifest()` to provide a mechanism to
         setup the project correctly for a run.
+
+        Any inference made here must be reported to the user, since
+        :meth:`.Project.check_manifest()` relies on these messages to explain
+        differences between the manifest as configured and the manifest as run.
         """
         # Automatically select fileset if only one is available in the design
         if not self.option.get_fileset() and self.option.get_design() and \

--- a/siliconcompiler/scheduler/scheduler.py
+++ b/siliconcompiler/scheduler/scheduler.py
@@ -177,7 +177,9 @@ class Scheduler:
             bool: True if the manifest is valid, False otherwise.
         """
         self.__logger.info("Checking manifest before running.")
-        return self.__project.check_manifest()
+        # _init_run() has already been called on the project, so check it directly
+        # instead of resolving a copy again.
+        return self.__project._check_manifest()
 
     def run_core(self) -> None:
         """

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -567,6 +567,18 @@ def test_check_manifest_pass(basic_project):
         call.assert_called_once()
 
 
+def test_check_manifest_checks_project_directly(basic_project):
+    # _init_run() has already run on the project, so the checks must not
+    # resolve and check a copy again
+    scheduler = Scheduler(basic_project)
+    with patch("siliconcompiler.Project._check_manifest", autospec=True) as check, \
+            patch("siliconcompiler.Project.check_manifest", autospec=True) as public_check:
+        check.return_value = True
+        assert scheduler.check_manifest() is True
+        check.assert_called_once_with(basic_project)
+        public_check.assert_not_called()
+
+
 def test_check_manifest_fail(basic_project):
     scheduler = Scheduler(basic_project)
     with patch("siliconcompiler.scheduler.Scheduler.check_manifest",

--- a/tests/test_asic.py
+++ b/tests/test_asic.py
@@ -249,9 +249,9 @@ def test_check_manifest_empty(project_logger, caplog):
     project_logger(proj)
     proj.logger.setLevel(logging.INFO)
 
-    with patch("siliconcompiler.Project.check_manifest") as check_manifest:
+    with patch("siliconcompiler.Project._check_manifest") as check_manifest:
         check_manifest.return_value = True
-        assert proj.check_manifest() is False
+        assert proj._check_manifest() is False
 
     assert "[asic,pdk] has not been set" in caplog.text
     assert "[asic,mainlib] has not been set, this will be inferred" in caplog.text
@@ -266,9 +266,9 @@ def test_check_manifest_missing_pdk(project_logger, caplog):
 
     proj.set("asic", "pdk", "thispdk")
 
-    with patch("siliconcompiler.Project.check_manifest") as check_manifest:
+    with patch("siliconcompiler.Project._check_manifest") as check_manifest:
         check_manifest.return_value = True
-        assert proj.check_manifest() is False
+        assert proj._check_manifest() is False
 
     assert "thispdk library has not been loaded" in caplog.text
     assert "[asic,mainlib] has not been set, this will be inferred" in caplog.text
@@ -284,9 +284,9 @@ def test_check_manifest_incorrect_type_pdk(project_logger, caplog):
     proj.add_dep(StdCellLibrary("thislib"))
     proj.set("asic", "pdk", "thislib")
 
-    with patch("siliconcompiler.Project.check_manifest") as check_manifest:
+    with patch("siliconcompiler.Project._check_manifest") as check_manifest:
         check_manifest.return_value = True
-        assert proj.check_manifest() is False
+        assert proj._check_manifest() is False
 
     assert "thislib must be a PDK" in caplog.text
     assert "[asic,mainlib] has not been set, this will be inferred" in caplog.text
@@ -302,9 +302,9 @@ def test_check_manifest_main_libmissing(project_logger, caplog):
     proj.set_pdk(PDK("thispdk"))
     proj.set("asic", "mainlib", "thislib")
 
-    with patch("siliconcompiler.Project.check_manifest") as check_manifest:
+    with patch("siliconcompiler.Project._check_manifest") as check_manifest:
         check_manifest.return_value = True
-        assert proj.check_manifest() is False
+        assert proj._check_manifest() is False
 
     assert "thislib library has not been loaded" in caplog.text
     assert "[asic,asiclib] does not contain any libraries" in caplog.text
@@ -320,9 +320,9 @@ def test_check_manifest_asiclib_missing(project_logger, caplog):
     proj.set_pdk(PDK("thispdk"))
     proj.set("asic", "asiclib", "thislib")
 
-    with patch("siliconcompiler.Project.check_manifest") as check_manifest:
+    with patch("siliconcompiler.Project._check_manifest") as check_manifest:
         check_manifest.return_value = True
-        assert proj.check_manifest() is False
+        assert proj._check_manifest() is False
 
     assert "[asic,mainlib] has not been set, this will be inferred" in caplog.text
     assert "thislib library has not been loaded" in caplog.text
@@ -339,9 +339,9 @@ def test_check_manifest_pass(project_logger, caplog):
     proj.add_asiclib("thislib")
     proj.set_asic_delaymodel("nldm")
 
-    with patch("siliconcompiler.Project.check_manifest") as check_manifest:
+    with patch("siliconcompiler.Project._check_manifest") as check_manifest:
         check_manifest.return_value = True
-        assert proj.check_manifest() is True
+        assert proj._check_manifest() is True
 
     assert caplog.text == ""
 
@@ -355,11 +355,34 @@ def test_check_manifest_pass_missing_mainlib(project_logger, caplog):
     proj.add_asiclib(StdCellLibrary("thislib"))
     proj.set_asic_delaymodel("nldm")
 
-    with patch("siliconcompiler.Project.check_manifest") as check_manifest:
+    with patch("siliconcompiler.Project._check_manifest") as check_manifest:
+        check_manifest.return_value = True
+        assert proj._check_manifest() is True
+
+    assert "[asic,mainlib] has not been set, this will be inferred" in caplog.text
+
+
+def test_check_manifest_mainlib_not_in_asiclib(project_logger, caplog):
+    # https://github.com/siliconcompiler/siliconcompiler/issues/5220
+    proj = ASIC()
+    project_logger(proj)
+    proj.logger.setLevel(logging.INFO)
+
+    proj.set_pdk(PDK("thispdk"))
+    proj.set_mainlib(StdCellLibrary("thislib"))
+    proj.set_asic_delaymodel("nldm")
+
+    with patch("siliconcompiler.Project._check_manifest") as check_manifest:
         check_manifest.return_value = True
         assert proj.check_manifest() is True
 
-    assert "[asic,mainlib] has not been set, this will be inferred" in caplog.text
+    # a run adds mainlib to asiclib, so this is reported as an inference, not an error
+    assert "Adding thislib to [asic,asiclib]" in caplog.text
+    assert "thislib library must be added to [asic,asiclib]" not in caplog.text
+    assert "[asic,asiclib] does not contain any libraries" not in caplog.text
+
+    # the check must not modify the project
+    assert proj.get("asic", "asiclib") == []
 
 
 def test_init_run_set_mainlib(project_logger, caplog):

--- a/tests/test_fpga.py
+++ b/tests/test_fpga.py
@@ -131,9 +131,9 @@ def test_project_check_manifest_empty(project_logger, caplog):
     project_logger(proj)
     proj.logger.setLevel(logging.INFO)
 
-    with patch("siliconcompiler.Project.check_manifest") as check_manifest:
+    with patch("siliconcompiler.Project._check_manifest") as check_manifest:
         check_manifest.return_value = True
-        assert proj.check_manifest() is False
+        assert proj._check_manifest() is False
 
     assert "[fpga,device] has not been set." in caplog.text
 
@@ -145,9 +145,9 @@ def test_project_check_manifest_missing_fpga(project_logger, caplog):
 
     proj.set_fpga("thisfpga")
 
-    with patch("siliconcompiler.Project.check_manifest") as check_manifest:
+    with patch("siliconcompiler.Project._check_manifest") as check_manifest:
         check_manifest.return_value = True
-        assert proj.check_manifest() is False
+        assert proj._check_manifest() is False
 
     assert "FPGA library 'thisfpga' has not been loaded." in caplog.text
 
@@ -159,9 +159,9 @@ def test_project_check_manifest_pass(project_logger, caplog):
 
     proj.set_fpga(FPGADevice("thisfpga"))
 
-    with patch("siliconcompiler.Project.check_manifest") as check_manifest:
+    with patch("siliconcompiler.Project._check_manifest") as check_manifest:
         check_manifest.return_value = True
-        assert proj.check_manifest() is True
+        assert proj._check_manifest() is True
 
     assert caplog.text == ""
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1685,6 +1685,81 @@ def test_check_manifest_with_alias_duplicate_target(project_logger, caplog):
     assert "alias points to the same library and fileset: testdesign/rtl" in caplog.text
 
 
+def test_check_manifest_resolves_manifest(project_logger, caplog):
+    design = Design("testdesign")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+        design.add_file("top.v")
+    flow = Flowgraph("testflow")
+    proj = Project(design)
+    proj.set_flow(flow)
+
+    project_logger(proj)
+    proj.logger.setLevel(logging.INFO)
+
+    # fileset is not set, but a run would infer it, so this is not an error
+    assert proj.check_manifest() is True
+    assert "Setting design fileset to: rtl" in caplog.text
+    assert "[option,fileset] has not been set" not in caplog.text
+
+    # the check must not modify the project
+    assert proj.option.get_fileset() == []
+
+
+def test_check_manifest_does_not_modify_project():
+    design = Design("testdesign")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+        design.add_file("top.v")
+    proj = Project(design)
+    proj.set_flow(Flowgraph("testflow"))
+
+    with patch("siliconcompiler.Project._check_manifest", autospec=True) as check:
+        check.return_value = True
+        assert proj.check_manifest() is True
+        check.assert_called_once()
+
+        # checks are performed on a copy, not on this project
+        assert check.call_args.args[0] is not proj
+
+
+def test_check_manifest_init_run_called_on_copy():
+    design = Design("testdesign")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+        design.add_file("top.v")
+    proj = Project(design)
+    proj.set_flow(Flowgraph("testflow"))
+
+    with patch("siliconcompiler.Project._init_run", autospec=True) as init_run, \
+            patch("siliconcompiler.Project._check_manifest", autospec=True) as check:
+        check.return_value = True
+        assert proj.check_manifest() is True
+        init_run.assert_called_once()
+
+    # the manifest is resolved on a copy of this project, not on this project
+    resolved = init_run.call_args.args[0]
+    assert isinstance(resolved, Project)
+    assert resolved is not proj
+    assert resolved.getdict() == proj.getdict()
+
+    # and it is that same copy that gets checked
+    assert check.call_args.args[0] is resolved
+
+
+def test_check_manifest_init_run_failure(project_logger, caplog):
+    proj = Project(Design("testdesign"))
+
+    project_logger(proj)
+    proj.logger.setLevel(logging.INFO)
+
+    with patch("siliconcompiler.Project._init_run", autospec=True) as init_run:
+        init_run.side_effect = ValueError("something went wrong")
+        assert proj.check_manifest() is False
+
+    assert "Failed to resolve manifest for checking: something went wrong" in caplog.text
+
+
 def test_init_run(project_logger, caplog):
     design = Design("testdesign")
     with design.active_fileset("rtl"):


### PR DESCRIPTION
Closes #5220 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Manifest checks now resolve inferred run settings before validation.
  - Validation runs on a project copy, preventing changes to the original project.
  - Configuration issues and inferred values are reported clearly, while file-path checks remain separate.
  - Scheduler manifest checks now use the resolved project configuration directly.

- **Bug Fixes**
  - Manifest resolution failures now return a failure result and provide a logged error.

- **Documentation**
  - Updated debugging guidance to reflect the revised manifest-checking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->