### PR TITLE
avoid starting a manager for each test during entire pytest lifetime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ markers = [
     "nocpulimit: don't limit cpu count for this test.",
     "docker: test requires docker",
     "nocache: don't automatically set the cache directory",
+    "isolated_manager: give this test an MPManager server of its own instead of the session-wide one. Needed only by tests that assert on the manager's own lifecycle.",
 ]
 pythonpath = [
     "tests"

--- a/tests/apps/test_sc_show.py
+++ b/tests/apps/test_sc_show.py
@@ -752,6 +752,7 @@ def test_sc_show_with_tool_task_and_extension(monkeypatch, make_manifests, asic_
                                      tool='openroad/timing', open=False)
 
 
+@pytest.mark.timeout(90)
 @pytest.mark.parametrize('flags', [
     ['-ext', 'gds'],
     ['-design', 'gcd', '-ext', 'gds'],
@@ -929,6 +930,7 @@ def _capture_show_run(monkeypatch):
     return captured
 
 
+@pytest.mark.timeout(90)
 def test_sc_show_does_not_call_reset_job_params(monkeypatch, make_manifests, asic_gcd, tmp_path):
     '''show() must mark the copied project to skip __reset_job_params before run().'''
     make_manifests(asic_gcd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,6 +206,16 @@ def isolate_statics_in_testing(monkeypatch, request, shared_manager_server):
 
     isolated = 'isolated_manager' in request.keywords
 
+    if not isolated:
+        # Clean up after the previous test here rather than in this fixture's
+        # own teardown. Teardown runs while the finishing test's monkeypatches
+        # are still in place -- monkeypatch is a dependency, so it is undone
+        # only once this fixture has finalized -- and talking to the manager
+        # under them is not safe: a test that fakes sys.platform makes
+        # multiprocessing reject the real address family ("Family AF_PIPE is
+        # not recognized" on Windows). By setup time every such patch is gone.
+        shared_manager_server.reset()
+
     monkeypatch.setattr(MPManager, "_MPManager__ENABLE_LOGGER", False)
     monkeypatch.setattr(MPManager, "_MPManager__address",
                         None if isolated else shared_manager_server.address)
@@ -218,9 +228,6 @@ def isolate_statics_in_testing(monkeypatch, request, shared_manager_server):
 
         # Cleanup afterwards
         MPManager.stop()
-
-    if not isolated:
-        shared_manager_server.reset()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,14 +107,108 @@ def limit_cpus(monkeypatch, request):
     monkeypatch.setattr(utils, 'get_cores', limit_cpu)
 
 
+class _SharedManagerServer:
+    '''
+    The session-wide manager server, see shared_manager_server().
+    '''
+
+    def __init__(self):
+        self.__start()
+
+    def __start(self) -> None:
+        # Collecting some test modules builds a Project, which leaves an
+        # MPManager behind. Drop it, or MPManager() below would hand that one
+        # back without running _init_singleton() and there would be no address
+        # to share.
+        MPManager.stop()
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(MPManager, "_MPManager__ENABLE_LOGGER", False)
+            monkeypatch.setattr(MPManager, "_MPManager__address", None)
+            MPManager()
+
+        self.__manager = MPManager.get_manager()
+        self.address = self.__manager.address
+        assert self.address is not None, "manager server did not report an address"
+        self.__baseline = self.__manager._number_of_objects()
+
+    def __is_pristine(self) -> bool:
+        '''Is the server up and holding nothing a test put there?'''
+        process = getattr(self.__manager, "_process", None)
+        if process is None or not process.is_alive():
+            return False
+        try:
+            return self.__manager._number_of_objects() == self.__baseline
+        except OSError:
+            # Socket gone: a hard-killed server whose address still resolves.
+            return False
+
+    def reset(self) -> None:
+        '''Hand the next test a server as clean as a freshly started one.
+
+        Normally there is nothing to do -- a test's proxies are released when
+        its MPManager singleton is dropped. What survives is the occasional
+        stranded server-side refcount, from a node worker killed before it
+        could decref, plus a proxy here and there whose release has not been
+        collected yet. Rather than unpicking the server's object table by hand,
+        throw the server away and start another: measured at ~20 restarts
+        across a full run, against the ~2000 this fixture exists to avoid.
+
+        Also covers a test that shut the server down outright, which is why
+        no test needs to declare that it might.
+        '''
+        if self.__is_pristine():
+            return
+        self.stop()
+        self.__start()
+
+    def stop(self) -> None:
+        MPManager.stop()
+
+
+@pytest.fixture(autouse=True, scope="session")
+def shared_manager_server():
+    '''
+    Run one manager server process for the whole session.
+
+    isolate_statics_in_testing() drops the MPManager singleton after every
+    test, so without a pre-existing server every test that builds a Project
+    would start one of its own: ~2000 manager processes over a full run. On
+    Linux that is a fork and costs ~10ms, but macOS and Windows use spawn (see
+    get_process_context()), which boots a fresh interpreter every time. That is
+    slow on average and has a very long tail on a saturated CI runner -- long
+    enough that SyncManager.start() alone has blown the pytest timeout while
+    waiting on the new process to report its address.
+
+    Handing the tests an address up front sends them down _init_singleton()'s
+    connect() branch instead, which is a socket handshake against this one
+    server, and reset() keeps that server as clean between tests as a fresh one
+    would be. Everything else a test might dirty -- settings, the path cache,
+    the board, the logger -- is in-process state that the singleton teardown
+    already rebuilds from scratch.
+
+    A test that needs to own its manager rather than connect to this one -- one
+    asserting on the manager's own lifecycle -- opts out with
+    @pytest.mark.isolated_manager.
+    '''
+    server = _SharedManagerServer()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
 @pytest.fixture(autouse=True)
-def isolate_statics_in_testing(monkeypatch):
+def isolate_statics_in_testing(monkeypatch, request, shared_manager_server):
     '''
     Isolate static instances for testing
     '''
 
+    isolated = 'isolated_manager' in request.keywords
+
     monkeypatch.setattr(MPManager, "_MPManager__ENABLE_LOGGER", False)
-    monkeypatch.setattr(MPManager, "_MPManager__address", None)
+    monkeypatch.setattr(MPManager, "_MPManager__address",
+                        None if isolated else shared_manager_server.address)
 
     BaseSchema._BaseSchema__get_child_classes.cache_clear()
     BaseSchema._BaseSchema__load_schema_class.cache_clear()
@@ -124,6 +218,9 @@ def isolate_statics_in_testing(monkeypatch):
 
         # Cleanup afterwards
         MPManager.stop()
+
+    if not isolated:
+        shared_manager_server.reset()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/report/dashboard/test_cli_dashboard.py
+++ b/tests/report/dashboard/test_cli_dashboard.py
@@ -433,7 +433,12 @@ def test_stop_without_force_does_not_dump_log(dashboard):
         board._log_handler.add_line(f"log line {i}")
 
     io_file = io.StringIO()
-    board._console = Console(file=io_file, width=120)
+    # Pin the height, not just the width: the log panel sizes itself from the
+    # console and the buffer holds 120 lines, so on a terminal taller than ~40
+    # rows "log line 0" is legitimately on screen and the assertion below stops
+    # meaning "a full dump happened". fake_console forces is_terminal True, so
+    # an unpinned height comes from whatever terminal pytest is running in.
+    board._console = Console(file=io_file, width=120, height=25)
 
     class FakeThread:
         def is_alive(self):

--- a/tests/utils/test_multiprocessing.py
+++ b/tests/utils/test_multiprocessing.py
@@ -282,6 +282,10 @@ def test_stop_swallows_keyboard_interrupt_in_board_stop():
     assert _ManagerSingleton.has_cls(MPManager) is False
 
 
+# Needs a manager it owns: shutdown() is bound by BaseManager.start(), so a
+# manager that merely connected to conftest's shared server has no such
+# attribute for patch.object to replace.
+@pytest.mark.isolated_manager
 def test_stop_swallows_keyboard_interrupt_in_manager_shutdown():
     '''A KeyboardInterrupt raised while shutting down the multiprocessing
     manager must not escape.'''


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation and lifecycle validation with shared and independently managed test servers.
  * Added clearer handling for tests requiring isolated manager instances.
  * Increased timeouts for extension and project-reset scenarios.
  * Stabilized dashboard log assertions with a fixed console size.
  * Added documentation for the new test marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->