### PR TITLE
docs: correct what AGENTS.md says about cocotb and the docs build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ the four are easy not to know about. Details in
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ```sh
-pip install -e .[test,lint,docs]
+pip install -e .[test,lint,docs,cocotb]
 
 flake8 --statistics .                              # 1. Python
 tclfmt --check . && tclint .                       # 2. TCL
@@ -196,11 +196,16 @@ pytest -m "not eda"                                # tests, no EDA tools needed
 cd docs && make html                               # warnings are errors
 ```
 
-The docs build needs **Python 3.13 or older**. It documents the cocotb tasks, and
-generating a task's documentation runs its `setup()`, which for those needs `cocotb`
-importable. The `docs` extra pulls it in, but `cocotb` is pinned to
-`python_version <= '3.13'`, so on 3.14 it resolves to nothing and the build fails on
-the first cocotb task. Everything else in the list is fine on 3.14.
+**`cocotb` is in that list, and the docs build needs it.** It is its own extra, not
+part of `docs`: the build documents the cocotb tasks, generating a task's
+documentation runs its `setup()`, and theirs needs `cocotb` importable. Install
+`docs` alone and the build fails on the first cocotb task.
+`.github/workflows/docs.yml` installs `.[docs,cocotb]` for the same reason.
+
+That also makes the docs build the one gate needing **Python 3.13 or older**, because
+`cocotb` is pinned to `python_version <= '3.13'`; above that it resolves to nothing
+and the extra installs successfully but empty. Everything else in the list is fine on
+3.14.
 
 The fourth gate is **Verilog**, and it is the sharpest edge: it needs
 [Verible](https://github.com/chipsalliance/verible) (not a Python package), and

--- a/tests/docs/test_agents_md.py
+++ b/tests/docs/test_agents_md.py
@@ -44,6 +44,10 @@ AGENTS = os.path.join(docs.sc_root, "AGENTS.md")
 PREAMBLE = os.path.join(docs.sc_root, "docs", "_llms", "preamble.md")
 PYPROJECT = os.path.join(docs.sc_root, "pyproject.toml")
 LINT_WORKFLOW = os.path.join(docs.sc_root, ".github", "workflows", "lint.yml")
+DOCS_WORKFLOW = os.path.join(docs.sc_root, ".github", "workflows", "docs.yml")
+
+# ``pip install -e .[a,b,c]`` in a shell block, in either file.
+PIP_EXTRAS = re.compile(r"pip install\s+(?:-e\s+)?\.\[([a-z0-9,._-]+)\]")
 
 
 def _read(path):
@@ -193,6 +197,46 @@ def test_lint_gates_match_ci(agents):
         assert tools[job] in agents, (
             f"CI runs the {job} gate with {tools[job]}, which AGENTS.md does "
             "not mention")
+
+
+@needs_toml
+def test_install_command_extras_exist(agents):
+    """Every extra the install line names has to be declared."""
+    match = PIP_EXTRAS.search(agents)
+    assert match, "AGENTS.md no longer contains a 'pip install -e .[...]' command"
+
+    with open(PYPROJECT, "rb") as f:
+        declared = set(tomllib.load(f)["project"]["optional-dependencies"])
+
+    named = set(match.group(1).split(","))
+    assert named <= declared, (
+        f"AGENTS.md tells contributors to install extras {sorted(named - declared)}, "
+        "which pyproject.toml does not declare")
+
+
+def test_install_command_covers_the_docs_build(agents):
+    """The install line has to be enough to run the gates listed under it.
+
+    The docs build is the gate this keeps getting wrong, because its dependencies
+    are split across two extras and only one of them is named ``docs``. AGENTS.md
+    claimed for a while that the ``docs`` extra pulled ``cocotb`` in; it never did,
+    so a contributor following the file exactly could not build the docs on any
+    Python version. ``docs.yml`` is the authority on what the build needs.
+    """
+    workflow = _read(DOCS_WORKFLOW)
+    needed = set()
+    for match in PIP_EXTRAS.finditer(workflow):
+        needed.update(match.group(1).split(","))
+    assert needed, "could not read any 'pip install .[...]' extras out of docs.yml"
+
+    match = PIP_EXTRAS.search(agents)
+    assert match, "AGENTS.md no longer contains a 'pip install -e .[...]' command"
+
+    listed = set(match.group(1).split(","))
+    assert needed <= listed, (
+        f"docs.yml installs extras {sorted(needed - listed)} to build the docs, "
+        "which AGENTS.md's install command omits -- following AGENTS.md exactly "
+        "would fail the docs build gate")
 
 
 def test_example_command_is_runnable(orientation):


### PR DESCRIPTION
AGENTS.md said the docs extra pulls cocotb in. It does not -- cocotb is its own extra, and docs.yml installs .[docs,cocotb] explicitly. So the gate list's own command, .[test,lint,docs], could not build the docs on any Python version, not just on 3.14 as the paragraph claimed.

Add cocotb to the install command, say where the dependency actually comes from, and pin both claims with tests: every extra the install line names has to be declared in pyproject.toml, and it has to cover whatever docs.yml installs to build the docs. The second test fails on the wording this replaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to include the dependencies required for documentation builds.
  * Clarified supported Python versions for documentation generation and other checks.
  * Documented the documentation workflow’s dependency installation requirements.

* **Tests**
  * Added validation to ensure setup instructions reference valid optional dependencies.
  * Added coverage checks confirming documentation requirements are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->