### PR TITLE
port over pre_placement option for opts.

### DIFF
--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -557,7 +557,7 @@ class OpenROADRSZTimingParameter(OpenROADTask):
         self.add_parameter("rsz_skip_final_sizing", "bool",
                            "true/false, skip the greedy gate resizing pass that runs at the end "
                            "of setup repair to pick up any slack the main optimization left",
-                           defvalue=False)
+                           defvalue=self._default_skip_final_sizing())
         self.add_parameter("rsz_skip_size_down", "bool",
                            "true/false, skip down-sizing gates that are not on the critical path",
                            defvalue=False)
@@ -570,7 +570,7 @@ class OpenROADRSZTimingParameter(OpenROADTask):
         self.add_parameter("rsz_sequence", f"[<{','.join(RSZ_MOVES)}>]",
                            "explicit order of setup optimization moves, an empty list uses the "
                            "tool default",
-                           defvalue=[])
+                           defvalue=self._default_sequence())
         self.add_parameter("rsz_phases", f"[<{','.join(RSZ_PHASES)}>]",
                            "explicit order of setup optimization phases, an empty list uses the "
                            "tool default, note the tool appends its critical threshold voltage "
@@ -598,6 +598,12 @@ class OpenROADRSZTimingParameter(OpenROADTask):
         self.add_parameter("rsz_max_buffer_percent", "float<0.0..100.0>",
                            "maximum number of buffers hold repair may insert, as a percentage of "
                            "the instance count, unset uses the tool default")
+
+    def _default_skip_final_sizing(self) -> bool:
+        return False
+
+    def _default_sequence(self) -> List[str]:
+        return []
 
     def set_openroad_rszsetupslackmargin(self, margin: float,
                                          step: Optional[str] = None, index: Optional[str] = None):

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_cleanup_synth.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_cleanup_synth.tcl
@@ -28,6 +28,21 @@ if { [sc_cfg_tool_task_get var remove_dead_logic] } {
 }
 
 ###############################
+# Repair timing on the synthesized netlist
+###############################
+
+# No placement exists yet, so check_parasitics falls back to wire load models. That is
+# adequate for the gate sizing this is here to correct and not for wire delay, hence the
+# restricted default move sequence. dont_use is already applied by the preamble.
+if { [sc_cfg_tool_task_get var repair_synth_timing] } {
+    set repair_args [sc_repair_timing_args setup]
+    sc_report_args -command repair_timing -args $repair_args
+    repair_timing -setup \
+        -setup_margin [sc_cfg_tool_task_get var rsz_setup_slack_margin] \
+        {*}$repair_args
+}
+
+###############################
 # Task Postamble
 ###############################
 

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_cleanup_synth.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_cleanup_synth.tcl
@@ -39,6 +39,7 @@ if { [sc_cfg_tool_task_get var repair_synth_timing] } {
     sc_report_args -command repair_timing -args $repair_args
     repair_timing -setup \
         -setup_margin [sc_cfg_tool_task_get var rsz_setup_slack_margin] \
+        -repair_tns [sc_cfg_tool_task_get var rsz_repair_tns] \
         {*}$repair_args
 }
 

--- a/siliconcompiler/tools/openroad/synth_cleanup.py
+++ b/siliconcompiler/tools/openroad/synth_cleanup.py
@@ -20,6 +20,9 @@ class CleanupSynthTask(APRTask, OpenROADSTAParameter,
     off in a way a liberty-accurate pass can correct, and correcting it here means
     placement is given cells that are already close to their final size. The pass is
     off by default because it moves the quality of results of every design.
+
+    Buffer removal and timing repair are alternatives rather than additive, so enabling
+    both is rejected during setup.
     """
     def __init__(self):
         super().__init__()
@@ -111,6 +114,17 @@ class CleanupSynthTask(APRTask, OpenROADSTAParameter,
             "logicdepth"
         ])
         self.set_openroad_enableimages(False)
+
+        # Removing the buffers and then repairing timing is the one combination that is
+        # worse than either alone: the buffering is deleted, and the repair is then asked
+        # to recover from that with a move sequence that deliberately cannot insert
+        # buffers. Upstream treats the two as alternatives for the same reason.
+        if self.get("var", "remove_synth_buffers") and self.get("var", "repair_synth_timing"):
+            raise ValueError(
+                "remove_synth_buffers and repair_synth_timing are alternatives, not "
+                "additive: removing the synthesis buffers discards the buffering the "
+                "repair pass would otherwise refine, and the repair cannot insert "
+                "buffers to replace them. Enable one or neither.")
 
         self.add_required_key("var", "remove_synth_buffers")
         self.add_required_key("var", "remove_dead_logic")

--- a/siliconcompiler/tools/openroad/synth_cleanup.py
+++ b/siliconcompiler/tools/openroad/synth_cleanup.py
@@ -1,13 +1,25 @@
-from typing import Optional
+from typing import List, Optional
 
 from siliconcompiler.tools.openroad._apr import APRTask
 from siliconcompiler.tools.openroad._apr import OpenROADSTAParameter
+from siliconcompiler.tools.openroad._apr import OpenROADRSZDRVParameter
+from siliconcompiler.tools.openroad._apr import OpenROADRSZTimingParameter
 
 
-class CleanupSynthTask(APRTask, OpenROADSTAParameter):
+# Both resizer mixins, matching RepairTimingTask: sc_repair_timing_args reads
+# rsz_match_cell_footprint and rsz_max_utilization, which live on the DRV mixin because
+# they apply to repair_design as well.
+class CleanupSynthTask(APRTask, OpenROADSTAParameter,
+                       OpenROADRSZDRVParameter, OpenROADRSZTimingParameter):
     """
     A task for cleaning up synthesized netlists using OpenROAD.
     Mainly used to remove buffers and dead logic inserted during synthesis from yosys.
+
+    Can also run a setup repair pass over the synthesized netlist. Synthesis optimizes
+    against a simple delay and capacitance model, so its gate sizing is systematically
+    off in a way a liberty-accurate pass can correct, and correcting it here means
+    placement is given cells that are already close to their final size. The pass is
+    off by default because it moves the quality of results of every design.
     """
     def __init__(self):
         super().__init__()
@@ -16,6 +28,32 @@ class CleanupSynthTask(APRTask, OpenROADSTAParameter):
                            "remove buffers inserted by synthesis", defvalue=True)
         self.add_parameter("remove_dead_logic", "bool",
                            "remove logic which does not drive a primary output", defvalue=True)
+        self.add_parameter("repair_synth_timing", "bool",
+                           "true/false, perform setup timing repair on the synthesized netlist. "
+                           "No placement exists yet, so this runs on wire load models and is "
+                           "most useful for correcting gate sizing rather than wire delay",
+                           defvalue=False)
+
+    def _default_sequence(self) -> List[str]:
+        """
+        Restricts the pass to the moves that are meaningful before placement.
+
+        Gate resizing is what a pre-placement pass can justify: it corrects synthesis
+        sizing using real liberty delays, which needs no placement. Buffer insertion,
+        cloning and load splitting are all wire-delay driven and there is no wire
+        length to drive them with yet.
+        """
+        return ["unbuffer", "sizeup"]
+
+    def _default_skip_final_sizing(self) -> bool:
+        """
+        Skips the greedy final sizing pass, which is expensive for what it returns here.
+
+        Upstream reports the same conclusion the other way round: its guidance when
+        pre-placement repair takes too long is to skip this pass or bound the repair
+        with a slack margin.
+        """
+        return True
 
     def set_openroad_removebuffers(self, enable: bool,
                                    step: Optional[str] = None, index: Optional[str] = None):
@@ -41,6 +79,19 @@ class CleanupSynthTask(APRTask, OpenROADSTAParameter):
         """
         self.set("var", "remove_dead_logic", enable, step=step, index=index)
 
+    def set_openroad_repairsynthtiming(self, enable: bool,
+                                       step: Optional[str] = None,
+                                       index: Optional[str] = None):
+        """
+        Enables or disables setup timing repair on the synthesized netlist.
+
+        Args:
+            enable: True to repair timing, False to leave the netlist as synthesized.
+            step: The specific step to apply this configuration to.
+            index: The specific index to apply this configuration to.
+        """
+        self.set("var", "repair_synth_timing", enable, step=step, index=index)
+
     def task(self):
         return "cleanup_synth"
 
@@ -63,3 +114,4 @@ class CleanupSynthTask(APRTask, OpenROADSTAParameter):
 
         self.add_required_key("var", "remove_synth_buffers")
         self.add_required_key("var", "remove_dead_logic")
+        self.add_required_key("var", "repair_synth_timing")

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -1758,8 +1758,8 @@ def test_openroad_cleanup_synth_rejects_remove_plus_repair(asic_gcd, remove, rep
             assert node.setup() is True
         else:
             with pytest.raises(ValueError,
-                               match="^remove_synth_buffers and repair_synth_timing are "
-                                     "alternatives, not additive: .* Enable one or neither\\.$"):
+                               match=r"^remove_synth_buffers and repair_synth_timing are "
+                                     r"alternatives, not additive: .* Enable one or neither\.$"):
                 node.task.setup()
 
 

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -1718,6 +1718,37 @@ def test_openroad_cleanup_synth_parameter_remove_dead_logic():
     assert task.get("var", "remove_dead_logic") is True
 
 
+def test_openroad_cleanup_synth_parameter_repair_synth_timing():
+    task = synth_cleanup.CleanupSynthTask()
+    # Off by default: enabling it moves the quality of results of every design.
+    assert task.get("var", "repair_synth_timing") is False
+    task.set_openroad_repairsynthtiming(True)
+    assert task.get("var", "repair_synth_timing") is True
+    task.set_openroad_repairsynthtiming(False, step='cleanup_synth', index='1')
+    assert task.get("var", "repair_synth_timing", step='cleanup_synth', index='1') is False
+    assert task.get("var", "repair_synth_timing") is True
+
+
+def test_openroad_cleanup_synth_restricts_the_move_sequence():
+    """Only the moves a pre-placement pass can justify, and no final sizing pass.
+
+    Buffer insertion, cloning and load splitting are wire-delay driven and there is no
+    wire length yet, so the default sequence is deliberately narrower than the tool's.
+    """
+    task = synth_cleanup.CleanupSynthTask()
+    assert task.get("var", "rsz_sequence") == ["unbuffer", "sizeup"]
+    assert task.get("var", "rsz_skip_final_sizing") is True
+
+
+def test_openroad_cleanup_synth_defaults_do_not_leak_to_repair_timing():
+    """The narrowed defaults are per-task, so the resizer tasks keep the tool defaults."""
+    for task in (repair_timing.RepairTimingTask(), repair_design.RepairDesignTask()):
+        if task.valid("var", "rsz_sequence"):
+            assert task.get("var", "rsz_sequence") == [], task.task()
+        if task.valid("var", "rsz_skip_final_sizing"):
+            assert task.get("var", "rsz_skip_final_sizing") is False, task.task()
+
+
 def test_openroad_init_floorplan_parameter_padring_fileset():
     task = init_floorplan.InitFloorplanTask()
     task.add_openroad_padringfileset('fileset1')

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -1740,6 +1740,29 @@ def test_openroad_cleanup_synth_restricts_the_move_sequence():
     assert task.get("var", "rsz_skip_final_sizing") is True
 
 
+@pytest.mark.parametrize("remove,repair,legal", [
+    (True, False, True),      # the shipped default
+    (False, True, True),      # keep the buffers and refine them
+    (False, False, True),     # leave the netlist as synthesized
+    (True, True, False),      # delete the buffering, then forbid replacing it
+])
+def test_openroad_cleanup_synth_rejects_remove_plus_repair(asic_gcd, remove, repair, legal):
+    """Buffer removal and timing repair are alternatives; one or neither is legal."""
+    task = synth_cleanup.CleanupSynthTask.find_task(asic_gcd)
+    task.set_openroad_removebuffers(remove)
+    task.set_openroad_repairsynthtiming(repair)
+
+    node = SchedulerNode(asic_gcd, "cleanup.clean", "0")
+    with node.runtime():
+        if legal:
+            assert node.setup() is True
+        else:
+            with pytest.raises(ValueError,
+                               match="^remove_synth_buffers and repair_synth_timing are "
+                                     "alternatives, not additive: .* Enable one or neither\\.$"):
+                node.task.setup()
+
+
 def test_openroad_cleanup_synth_defaults_do_not_leak_to_repair_timing():
     """The narrowed defaults are per-task, so the resizer tasks keep the tool defaults."""
     for task in (repair_timing.RepairTimingTask(), repair_design.RepairDesignTask()):


### PR DESCRIPTION
Synthesis optimizes against a simple delay and capacitance model, so its gate
sizing is systematically off in a way a liberty-accurate pass corrects, and
correcting it before placement means placement is handed cells already close to
their final size. SC had no way to run that pass; ORFS runs the equivalent in
its floorplan stage by default.

CleanupSynthTask gains the two resizer mixins and a repair_synth_timing var,
and sc_cleanup_synth.tcl runs repair_timing -setup when it is set. Both mixins
are needed, matching RepairTimingTask: sc_repair_timing_args reads
rsz_match_cell_footprint and rsz_max_utilization from the DRV mixin. Found by
running it -- the timing mixin alone fails on the missing key.

Off by default, so this commit moves no quality of results. The defaults that
apply once it is enabled are narrowed through the _default_ hooks rather than
set at setup time: rsz_sequence is unbuffer,sizeup because buffer insertion,
cloning and load splitting are wire-delay driven and there is no wire length
yet, and rsz_skip_final_sizing is true because upstream's own guidance when
pre-placement repair runs long is to skip that pass. Both hooks are new on
OpenROADRSZTimingParameter and default to the previous values, so the resizer
tasks are unchanged -- pinned by a test.

Measured on aes/freepdk45 at 0.8ns with synthesis buffers kept, openroad
26Q3-1094, cleanup.clean:

  off     cellarea 14084  WNS -0.10637   TNS -5.840   154 violating endpoints
  on      cellarea 14158  WNS -0.022874  TNS -0.0631   11 violating endpoints

99% of TNS for +0.5% area, 134 gates resized and no buffers removed -- which is
the expected shape if synthesis sizing is the error being corrected. Carried to
route.detailed it is worth -14% TNS, -2.1% cell area and -10% buffers against
the same netlist without the pass.

Not turned on by default because the evidence is one design on one PDK, and
gcd -- 254 cells against aes's 9849 -- pointed the other way. That needs a
gallery run, along with the related question of whether remove_synth_buffers
should still default true.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional synthesized-netlist timing repair during cleanup.
  * Added configurable resizer and timing-repair settings, including setup slack margins and repair sequences.
  * Added validation to prevent conflicting buffer-removal and timing-repair options.
  * Added pre-placement repair defaults for more controlled cleanup behavior.

* **Bug Fixes**
  * Improved default handling for resizer timing settings across cleanup workflows.

* **Tests**
  * Added coverage for timing-repair configuration, defaults, and conflicting options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->