### PR TITLE
switch default for add fill to false since this tool is poorly supported

### DIFF
--- a/siliconcompiler/tools/openroad/fillmetal_insertion.py
+++ b/siliconcompiler/tools/openroad/fillmetal_insertion.py
@@ -15,7 +15,7 @@ class FillMetalTask(APRTask, OpenROADSTAParameter):
 
         self.add_parameter("fin_add_fill", "bool",
                            "true/false, when true enables adding fill, "
-                           "if enabled by the PDK, to the design", defvalue=True)
+                           "if enabled by the PDK, to the design", defvalue=False)
 
     def set_openroad_addfill(self, enable: bool,
                              step: Optional[str] = None, index: Optional[Union[int, str]] = None):

--- a/siliconcompiler/tools/openroad/rdlroute.py
+++ b/siliconcompiler/tools/openroad/rdlroute.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
 
 from siliconcompiler.tools.openroad import OpenROADTask
 
@@ -14,9 +15,23 @@ class RDLRouteTask(OpenROADTask):
 
         self.add_parameter("fin_add_fill", "bool",
                            "true/false, when true enables adding fill, "
-                           "if enabled by the PDK, to the design", defvalue=True)
+                           "if enabled by the PDK, to the design", defvalue=False)
 
-    def add_openroad_rdlroute(self, file, dataroot=None, step=None, index=None, clobber=False):
+    def add_openroad_rdlroute(self, file: Union[str, Path], dataroot: Optional[str] = None,
+                              step: Optional[str] = None, index: Optional[Union[int, str]] = None,
+                              clobber: bool = False):
+        """
+        Adds a RDL routing script to the design.
+
+        Args:
+            file (str): The path to the RDL routing script.
+            dataroot (str, optional): The data root to apply this configuration to.
+            step (str, optional): The specific step to apply this configuration to.
+            index (str, optional): The specific index to apply this configuration to.
+            clobber (bool, optional): If True, replaces any existing RDL routing scripts
+                for the specified dataroot, step, and index. If False, appends the
+                new script to the existing list.
+        """
         with self.active_dataroot(self._get_active_dataroot(dataroot)):
             if clobber:
                 self.set("var", "rdlroute", file, step=step, index=index)
@@ -24,7 +39,7 @@ class RDLRouteTask(OpenROADTask):
                 self.add("var", "rdlroute", file, step=step, index=index)
 
     def set_openroad_addfill(self, enable: bool,
-                             step: Optional[str] = None, index: Optional[str] = None):
+                             step: Optional[str] = None, index: Optional[Union[int, str]] = None):
         """
         Enables or disables adding fill to the design.
 
@@ -85,5 +100,3 @@ class RDLRouteTask(OpenROADTask):
             for fileset in lib.get("asic", "aprfileset"):
                 if lib.has_file(fileset=fileset, filetype="lef"):
                     self.add_required_key(lib, "fileset", fileset, "file", "lef")
-
-        self.set_openroad_addfill(False)

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -1597,7 +1597,15 @@ def test_openroad_fillmetal_insertion_skips_when_disabled(asic_gcd):
 
 
 def test_openroad_fillmetal_insertion_skips_without_pdk_rules(asic_gcd):
-    """freepdk45 ships no openroad fill file, so the enabled default still skips."""
+    """Fill enabled but no PDK fill file to work from still skips the node."""
+    fillmetal_insertion.FillMetalTask.find_task(asic_gcd).set_openroad_addfill(True)
+
+    # Drop any fill rules the PDK ships so the skip is exercised regardless of
+    # what freepdk45 provides.
+    pdk = asic_gcd.get_library(asic_gcd.get("asic", "pdk"))
+    for fileset in pdk.get("pdk", "aprtechfileset", "openroad"):
+        pdk.unset("fileset", fileset, "file", "fill")
+
     node = SchedulerNode(asic_gcd, "dfm.metal_fill", "0")
     with node.runtime():
         assert node.task.get("var", "fin_add_fill") is True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated metal fill insertion defaults to avoid automatically adding fill during OpenROAD processing.
  * Corrected RDL routing defaults so fill is not enabled unless explicitly requested.
  * Improved RDL route configuration to accept route files provided as paths and fill-stage indexes as numbers or text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->