### PR TITLE
add support for zstd archives on packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ dependencies = [
 
     "fasteners >= 0.20",
     "tomli >= 2.0.0; python_version < '3.11'",
+    # Zstandard entered the stdlib in 3.14 (PEP 784); older releases need the backport.
+    "backports.zstd >= 1.6.0, < 2.0.0; python_version < '3.14'",
     "pandas >= 1.1.5",
     "psutil >= 5.8.0",
     "Jinja2 >= 2.11.3",

--- a/siliconcompiler/package/https.py
+++ b/siliconcompiler/package/https.py
@@ -34,15 +34,19 @@ from siliconcompiler.utils import is_zstd, open_zstd_stream, tar_extract_kwargs,
 #: too: a server having a bad minute may not be having a bad hour.
 _TERMINAL_STATUSES = (400, 404, 405, 410, 414, 451)
 
-#: Suffixes naming a compressed tar, stripped from a GitHub archive's filename to
-#: recover the release reference its top-level directory is named after.
+#: Archive suffixes stripped from a GitHub archive's filename to recover the
+#: release reference its top-level directory is named after.
 #:
 #: The fallback for a name matching none of these gives up at the first '.', which
 #: truncates any release carrying a dotted version -- 'v1.0.2.tar.zst' would look
 #: for 'repo-1' rather than 'repo-1.0.2'. No entry is a suffix of another, so the
 #: first match is the whole extension.
-_TAR_SUFFIXES = (".tar.gz", ".tar.bz2", ".tar.xz", ".tar.zst",
-                 ".tgz", ".tbz2", ".txz", ".tzst")
+#:
+#: One format is deliberately absent: a plain, uncompressed '.tar' is not among the
+#: formats :func:`_archive_formats` can read, so an archive named that way never
+#: reaches the flattening this table serves.
+_ARCHIVE_SUFFIXES = (".tar.gz", ".tar.bz2", ".tar.xz", ".tar.zst",
+                     ".tgz", ".tbz2", ".txz", ".tzst", ".zip")
 
 
 def _extract_tar(fileobj: IO[bytes], path: str, mode: str) -> None:
@@ -276,7 +280,7 @@ class HTTPResolver(RemoteResolver):
             if repo.endswith('.git'):
                 gh_ref = self.reference
             else:
-                for suffix in _TAR_SUFFIXES:
+                for suffix in _ARCHIVE_SUFFIXES:
                     if gh_ref.endswith(suffix):
                         gh_ref = gh_ref[0:-len(suffix)]
                         break

--- a/siliconcompiler/package/https.py
+++ b/siliconcompiler/package/https.py
@@ -11,14 +11,15 @@ import zipfile
 
 import os.path
 
-from typing import Dict, Type
+from typing import Callable, Dict, IO, List, Tuple, Type
 
 from io import BytesIO
 from urllib.parse import urlparse
 
 from siliconcompiler.package import RemoteResolver
-from siliconcompiler.package.cache import DataSourceUnavailableError
-from siliconcompiler.utils import tar_extract_kwargs
+from siliconcompiler.package.cache import DataSourceUnavailableError, PermanentResolutionError
+from siliconcompiler.utils import is_zstd, open_zstd_stream, tar_extract_kwargs, \
+    zstd_available, zstd_errors, zstd_unavailable_message
 
 #: HTTP statuses that answer the request completely enough that asking again can
 #: only collect the same answer: the data is not there (404, 410) or the request
@@ -32,6 +33,107 @@ from siliconcompiler.utils import tar_extract_kwargs
 #: also block a later resolver that does have credentials. A 5xx stays retryable
 #: too: a server having a bad minute may not be having a bad hour.
 _TERMINAL_STATUSES = (400, 404, 405, 410, 414, 451)
+
+#: Suffixes naming a compressed tar, stripped from a GitHub archive's filename to
+#: recover the release reference its top-level directory is named after.
+#:
+#: The fallback for a name matching none of these gives up at the first '.', which
+#: truncates any release carrying a dotted version -- 'v1.0.2.tar.zst' would look
+#: for 'repo-1' rather than 'repo-1.0.2'. No entry is a suffix of another, so the
+#: first match is the whole extension.
+_TAR_SUFFIXES = (".tar.gz", ".tar.bz2", ".tar.xz", ".tar.zst",
+                 ".tgz", ".tbz2", ".txz", ".tzst")
+
+
+def _extract_tar(fileobj: IO[bytes], path: str, mode: str) -> None:
+    """Extracts a tar archive, applying the PEP 706 extraction filter."""
+    with tarfile.open(fileobj=fileobj, mode=mode) as tar_ref:
+        tar_ref.extractall(path=path, **tar_extract_kwargs())
+
+
+def _extract_zstd_tar(fileobj: IO[bytes], path: str) -> None:
+    """Extracts a Zstandard-compressed tar archive.
+
+    Decompression and extraction are separate steps here, rather than the single
+    ``mode="r:zst"`` that Python 3.14 offers, so that one ``tarfile`` reads the
+    archive on every supported release. See
+    :func:`siliconcompiler.utils.open_zstd_stream` for why that matters.
+    """
+    with open_zstd_stream(fileobj) as stream:
+        _extract_tar(stream, path, "r:")
+
+
+def _extract_zip(fileobj: IO[bytes], path: str) -> None:
+    """Extracts a zip archive."""
+    with zipfile.ZipFile(fileobj) as zip_ref:
+        zip_ref.extractall(path=path)
+
+
+def _archive_formats() -> List[Tuple[str, Callable[[IO[bytes], str], None]]]:
+    """The archive formats an HTTP download may arrive in, in the order tried.
+
+    A download is identified by attempting it, not by reading its URL, because the
+    URL is under the server's control and an archive's name is free to disagree
+    with its contents. Order between formats is otherwise immaterial -- each is
+    ruled out by its own magic number within the first few bytes -- so the
+    long-standing formats keep their long-standing precedence.
+
+    Zstandard appears only where the bindings for it do; the format is recognized
+    either way, so a download that needs them still gets an error saying so rather
+    than being called invalid (see :func:`_extract_archive`).
+
+    Returns:
+        list: ``(name, extract)`` pairs, where ``extract`` takes the downloaded
+            stream and the destination directory.
+    """
+    formats: List[Tuple[str, Callable[[IO[bytes], str], None]]] = [
+        ("gzip tar", lambda fileobj, path: _extract_tar(fileobj, path, "r:gz")),
+        ("bzip2 tar", lambda fileobj, path: _extract_tar(fileobj, path, "r:bz2")),
+        ("xz tar", lambda fileobj, path: _extract_tar(fileobj, path, "r:xz")),
+    ]
+    if zstd_available():
+        formats.append(("zstd tar", _extract_zstd_tar))
+    formats.append(("zip", _extract_zip))
+    return formats
+
+
+def _extract_archive(fileobj: IO[bytes], path: str, data_url: str) -> str:
+    """Unpacks a downloaded archive, identifying its format by trial.
+
+    Args:
+        fileobj (IO[bytes]): The downloaded archive, open and seekable.
+        path (str): The directory to extract into.
+        data_url (str): Where the archive came from, for error messages.
+
+    Returns:
+        str: The name of the format that read the archive.
+
+    Raises:
+        PermanentResolutionError: If the archive is Zstandard and this environment
+            has no bindings to read it with. Settled rather than transient: the
+            download worked and what is missing is local, so retrying would spend a
+            second full transfer -- hundreds of megabytes, for a PDK artifact -- to
+            re-learn that a package is not installed.
+        TypeError: If the archive is in no format known here.
+        tarfile.FilterError: If the extraction filter refuses a member.
+    """
+    for name, extract in _archive_formats():
+        fileobj.seek(0)
+        try:
+            extract(fileobj, path)
+        except (tarfile.ReadError, zipfile.BadZipFile, *zstd_errors()):
+            # Not this format: the next one gets the same bytes from the start.
+            continue
+        return name
+
+    fileobj.seek(0)
+    header = fileobj.read(8)
+    if not zstd_available() and is_zstd(header):
+        raise PermanentResolutionError(f"Could not extract file from {data_url}. "
+                                       f"{zstd_unavailable_message()}")
+
+    raise TypeError(f"Could not extract file from {data_url}. File is not a valid "
+                    "tar (gzip, bzip2, xz or zstd) or zip archive.")
 
 
 def get_resolver() -> Dict[str, Type["HTTPResolver"]]:
@@ -54,10 +156,10 @@ class HTTPResolver(RemoteResolver):
     """
     A resolver for fetching and unpacking data from HTTP/HTTPS URLs.
 
-    This class downloads a file from a URL, automatically determines if it's a
-    gzipped tarball or a zip file, and extracts its contents into the local
-    cache. It also includes special handling to flatten the directory structure
-    of archives downloaded from GitHub.
+    This class downloads a file from a URL, determines from its contents whether
+    it is a tarball (gzip, bzip2, xz or Zstandard compressed) or a zip file, and
+    extracts it into the local cache. It also includes special handling to flatten
+    the directory structure of archives downloaded from GitHub.
     """
 
     def check_cache(self) -> bool:
@@ -110,9 +212,10 @@ class HTTPResolver(RemoteResolver):
         """
         Fetches the remote archive, unpacks it, and stores it in the cache.
 
-        This method downloads the file, detects the archive type (tar.gz or zip),
-        and extracts it. It includes special logic to handle the extra top-level
-        directory that GitHub often includes in its source archives.
+        This method downloads the file, detects the archive type (a tar compressed
+        with gzip, bzip2, xz or Zstandard, or a zip), and extracts it. It includes
+        special logic to handle the extra top-level directory that GitHub often
+        includes in its source archives.
 
         Raises:
             FileNotFoundError: If the download fails. One of the
@@ -120,6 +223,9 @@ class HTTPResolver(RemoteResolver):
                 :class:`~siliconcompiler.package.cache.DataSourceUnavailableError`
                 subclass, so the source is abandoned rather than re-requested;
                 every other status, including 401 and 403, stays retryable.
+            TypeError: If what arrives is in no archive format known here.
+            PermanentResolutionError: If it arrives in one this environment lacks
+                the bindings to unpack, which no retry can change.
         """
         data_url = self.download_url
 
@@ -155,23 +261,8 @@ class HTTPResolver(RemoteResolver):
         # Download content into an in-memory buffer
         fileobj = BytesIO(response.content)
 
-        # Attempt to extract as a tarball, fall back to zip
-        try:
-            with tarfile.open(fileobj=fileobj, mode='r:gz') as tar_ref:
-                tar_ref.extractall(path=self.cache_path, **tar_extract_kwargs())
-        except tarfile.ReadError:
-            fileobj.seek(0)
-            try:
-                with tarfile.open(fileobj=fileobj, mode='r:bz2') as tar_ref:
-                    tar_ref.extractall(path=self.cache_path, **tar_extract_kwargs())
-            except tarfile.ReadError:
-                fileobj.seek(0)
-                try:
-                    with zipfile.ZipFile(fileobj) as zip_ref:
-                        zip_ref.extractall(path=self.cache_path)
-                except zipfile.BadZipFile:
-                    raise TypeError(f"Could not extract file from {data_url}. "
-                                    "File is not a valid tar.gz or zip archive.")
+        archive_format = _extract_archive(fileobj, self.cache_path, data_url)
+        self.logger.debug(f'Unpacked {self.display_name} data as a {archive_format} archive')
 
         # --- GitHub-specific directory flattening ---
         # GitHub archives often have a single top-level directory like 'repo-v1.0'.
@@ -184,12 +275,15 @@ class HTTPResolver(RemoteResolver):
             gh_ref = gh_url.path.split('/')[-1]
             if repo.endswith('.git'):
                 gh_ref = self.reference
-            elif gh_ref.endswith('.tar.gz'):
-                gh_ref = gh_ref[0:-7]
-            elif gh_ref.endswith('.tgz'):
-                gh_ref = gh_ref[0:-4]
             else:
-                gh_ref = gh_ref.split('.')[0]
+                for suffix in _TAR_SUFFIXES:
+                    if gh_ref.endswith(suffix):
+                        gh_ref = gh_ref[0:-len(suffix)]
+                        break
+                else:
+                    # An unrecognized name keeps the long-standing guess, which
+                    # gives up at its first '.' and so truncates a dotted release.
+                    gh_ref = gh_ref.split('.')[0]
 
             if gh_ref.startswith('v'):
                 gh_ref = gh_ref[1:]

--- a/siliconcompiler/utils/__init__.py
+++ b/siliconcompiler/utils/__init__.py
@@ -16,7 +16,7 @@ from io import StringIO
 from pathlib import Path
 from jinja2 import Environment, FileSystemLoader, Template
 
-from typing import Dict, Optional, Union, Callable, List, TYPE_CHECKING
+from typing import IO, Dict, Optional, Tuple, Type, Union, Callable, List, cast, TYPE_CHECKING
 
 import importlib.util
 from importlib.metadata import distributions, entry_points
@@ -31,6 +31,14 @@ except ImportError:  # Python < 3.11
         import tomli as tomllib
     except ImportError:  # pragma: no cover - only when tomli is not yet installed
         tomllib = None
+
+try:
+    if sys.version_info >= (3, 14):  # PEP 784 put Zstandard in the standard library
+        from compression import zstd as _zstd
+    else:
+        from backports import zstd as _zstd
+except ImportError:  # pragma: no cover - a build or install without Zstandard
+    _zstd = None
 
 from siliconcompiler.utils.paths import builddir
 
@@ -164,6 +172,101 @@ def tar_extract_kwargs(filter: str = "data") -> Dict[str, Union[str, Callable]]:
     if filter == "data" and _data_filter_mishandles_symlinks():
         return {"filter": _symlink_safe_data_filter}
     return {"filter": filter}
+
+
+def zstd_available() -> bool:
+    """Reports whether this interpreter can read Zstandard streams.
+
+    Returns:
+        bool: True if :func:`open_zstd_stream` will work.
+    """
+    return _zstd is not None
+
+
+def is_zstd(data: bytes) -> bool:
+    """Reports whether ``data`` begins a Zstandard frame.
+
+    Recognizing the format is independent of being able to *read* it, which is the
+    point: this is what separates "not an archive we know" from "an archive this
+    environment is missing the bindings for". That is also why the magic number is
+    written out here rather than taken from the bindings -- the question is asked
+    precisely when they could not be imported.
+
+    Only the frame magic of RFC 8878 section 3.1.1 is matched, not the skippable
+    frame magics: an archive opening with one of those carries no data of its own.
+
+    Args:
+        data (bytes): The start of the stream to identify. Fewer bytes than the
+            magic number is simply not a match.
+
+    Returns:
+        bool: True if the data starts with the Zstandard frame magic.
+    """
+    return data.startswith(b"\x28\xb5\x2f\xfd")
+
+
+def zstd_errors() -> Tuple[Type[BaseException], ...]:
+    """The errors a Zstandard stream raises over data it cannot decompress.
+
+    Returned as a tuple for splatting into an ``except`` clause, empty where the
+    bindings are missing, so a caller identifying an archive by trial can write one
+    handler that holds either way.
+
+    Returns:
+        tuple: Exception types signalling the data is not readable Zstandard.
+    """
+    if _zstd is None:
+        return ()
+    return (_zstd.ZstdError,)
+
+
+def zstd_unavailable_message() -> str:
+    """An actionable account of why this interpreter cannot read Zstandard.
+
+    Returns:
+        str: The reason, naming what would fix it.
+    """
+    version = ".".join(str(part) for part in sys.version_info[0:3])
+    if sys.version_info >= (3, 14):
+        return f"Python {version} was built without Zstandard support, so " \
+               "'compression.zstd' is unavailable."
+    return f"Zstandard support on Python {version} requires the 'backports.zstd' " \
+           "package, which is not installed."
+
+
+def open_zstd_stream(fileobj: IO[bytes]) -> IO[bytes]:
+    """Wraps a Zstandard-compressed stream in a readable, seekable decompressor.
+
+    Only the decompressor is taken from the Zstandard bindings, deliberately.
+    ``backports.zstd`` also ships a backported ``tarfile``, whose ``r:zst`` mode is
+    the obvious way to read a ``.tar.zst`` -- but that is a *different module
+    object* from the stdlib ``tarfile`` on the releases that need the backport,
+    with its own ``TarInfo``, its own ``data_filter`` and its own exception
+    classes. Extraction here depends on both: :func:`tar_extract_kwargs` may
+    substitute a filter that calls stdlib ``tarfile.data_filter``, and the resolver
+    retry logic decides whether a failure is worth retrying by matching stdlib
+    ``tarfile.FilterError``. Feeding either one a backported member would make the
+    substitution a duck-typed guess and leave a refused archive misclassified as a
+    transient failure -- re-downloaded in full, to be refused again. Handing a
+    plain decompressed stream to ``mode="r:"`` keeps one ``tarfile`` on every
+    supported release, and streams rather than materializing the whole archive.
+
+    Args:
+        fileobj (IO[bytes]): The compressed stream, positioned at the frame start.
+
+    Returns:
+        IO[bytes]: The decompressed contents, as a file object to read and seek.
+            Closing it does not close ``fileobj``.
+
+    Raises:
+        ModuleNotFoundError: If this interpreter has no Zstandard bindings.
+    """
+    if _zstd is None:
+        raise ModuleNotFoundError(zstd_unavailable_message())
+
+    # A ZstdFile is a BufferedIOBase, which is everything tarfile asks of a
+    # fileobj, but typeshed does not declare it as an IO[bytes].
+    return cast(IO[bytes], _zstd.ZstdFile(fileobj))
 
 
 def link_symlink_copy(srcfile, dstfile):

--- a/siliconcompiler/utils/__init__.py
+++ b/siliconcompiler/utils/__init__.py
@@ -192,17 +192,24 @@ def is_zstd(data: bytes) -> bool:
     written out here rather than taken from the bindings -- the question is asked
     precisely when they could not be imported.
 
-    Only the frame magic of RFC 8878 section 3.1.1 is matched, not the skippable
-    frame magics: an archive opening with one of those carries no data of its own.
+    Both of RFC 8878's magic numbers count: the Zstandard frame of section 3.1.1,
+    and the skippable frames of section 3.1.2, which a stream may legally lead
+    with. A skippable frame carries no compressed payload, but a file that opens
+    with one -- a tool prefixing its archives with metadata, say -- is a file zstd
+    reads end to end, so it is a file to report as Zstandard.
 
     Args:
-        data (bytes): The start of the stream to identify. Fewer bytes than the
-            magic number is simply not a match.
+        data (bytes): The start of the stream to identify. Fewer bytes than a magic
+            number is simply not a match.
 
     Returns:
-        bool: True if the data starts with the Zstandard frame magic.
+        bool: True if the data starts with a Zstandard frame magic.
     """
-    return data.startswith(b"\x28\xb5\x2f\xfd")
+    if len(data) < 4:
+        return False
+
+    magic = int.from_bytes(data[0:4], "little")
+    return magic == 0xFD2FB528 or 0x184D2A50 <= magic <= 0x184D2A5F
 
 
 def zstd_errors() -> Tuple[Type[BaseException], ...]:

--- a/tests/package/test_https.py
+++ b/tests/package/test_https.py
@@ -30,8 +30,7 @@ from siliconcompiler import Project
      '5440a5a4d2cd71bc')
 ])
 @responses.activate
-def test_dependency_path_download_http(project_logger, datadir, path, ref, cache_id, tmp_path,
-                                       caplog):
+def test_dependency_path_download_http(project_logger, datadir, path, ref, cache_id, caplog):
     with open(os.path.join(datadir, 'https.tar.gz'), "rb") as f:
         responses.add(
             responses.GET,
@@ -42,19 +41,19 @@ def test_dependency_path_download_http(project_logger, datadir, path, ref, cache
         )
 
     proj = Project("testproj")
-    proj.set("option", "cachedir", tmp_path)
+    proj.option.set_cachedir(".")
     project_logger(proj)
     proj.logger.setLevel(logging.INFO)
 
     resolver = HTTPResolver("sc-data", proj, path, ref)
-    assert resolver.resolve() == Path(os.path.join(tmp_path, f"sc-data-{ref[0:16]}-{cache_id}"))
-    assert os.path.isfile(
-        os.path.join(tmp_path, f"sc-data-{ref[0:16]}-{cache_id}", "pyproject.toml"))
+    cache_dir = os.path.abspath(f"sc-data-{ref[0:16]}-{cache_id}")
+    assert resolver.resolve() == Path(cache_dir)
+    assert os.path.isfile(os.path.join(cache_dir, "pyproject.toml"))
     assert "Downloading sc-data data from " in caplog.text
 
 
 @responses.activate
-def test_dependency_path_download_http_zstd(project_logger, datadir, tmp_path, caplog):
+def test_dependency_path_download_http_zstd(project_logger, datadir, caplog):
     """
     A Zstandard artifact resolves end to end, over the real transfer stack.
 
@@ -77,13 +76,13 @@ def test_dependency_path_download_http_zstd(project_logger, datadir, tmp_path, c
     )
 
     proj = Project("testproj")
-    proj.set("option", "cachedir", tmp_path)
+    proj.option.set_cachedir(".")
     project_logger(proj)
     proj.logger.setLevel(logging.INFO)
 
     resolver = HTTPResolver("sc-data", proj, "https://example.com/sky130_fd_sc_hd.tar.zst",
                             "v1.0.2")
-    cache_dir = os.path.join(tmp_path, "sc-data-v1.0.2-2b8a7556f743e2a4")
+    cache_dir = os.path.abspath("sc-data-v1.0.2-2b8a7556f743e2a4")
 
     assert resolver.resolve() == Path(cache_dir)
     assert os.path.isfile(os.path.join(cache_dir, "pyproject.toml"))
@@ -164,13 +163,13 @@ def test_download_status_is_retried(status):
     assert not resolver.cache.is_permanent(resolver.cache_id)
 
 
-def test_resolve_remote_relative_symlink(broken_tarfile_data_filter, tmpdir):
+def test_resolve_remote_relative_symlink(broken_tarfile_data_filter):
     """
     A PDK that ships a relative symlink -- IHP130 ships exactly one -- has to
     unpack even on the releases whose extraction filter misreads one.
     """
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, "https://example.com/data.tar.gz", "v1.0")
 
@@ -247,10 +246,10 @@ def test_http_resolver_download_url_complex():
     assert resolver.download_url == "https://user:pass@example.com/path/ref.tar.gz"
 
 
-def test_http_resolver_resolve_remote_tarball(monkeypatch, tmpdir):
+def test_http_resolver_resolve_remote_tarball(monkeypatch):
     """Test resolve_remote extracts tar.gz correctly."""
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, "https://example.com/data.tar.gz", "v1.0")
 
@@ -276,12 +275,12 @@ def test_http_resolver_resolve_remote_tarball(monkeypatch, tmpdir):
         assert os.path.exists(os.path.join(str(resolver.cache_path), "test_file.txt"))
 
 
-def test_http_resolver_resolve_remote_with_auth_token(monkeypatch, tmpdir):
+def test_http_resolver_resolve_remote_with_auth_token(monkeypatch):
     """Test resolve_remote uses GIT_TOKEN for authentication."""
     monkeypatch.setenv("GIT_TOKEN", "test_token_123")
 
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, "https://example.com/data.tar.gz", "v1.0")
 
@@ -307,10 +306,10 @@ def test_http_resolver_resolve_remote_with_auth_token(monkeypatch, tmpdir):
         assert mock_requests.get.called
 
 
-def test_http_resolver_resolve_remote_github_header(tmpdir):
+def test_http_resolver_resolve_remote_github_header():
     """Test resolve_remote sets GitHub-specific Accept header."""
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project,
                             "https://github.com/owner/repo/releases/download/v1.0/file.tar.gz",
@@ -352,10 +351,10 @@ def test_http_resolver_resolve_remote_download_failed():
             resolver.resolve_remote()
 
 
-def test_http_resolver_resolve_remote_invalid_archive(tmpdir):
+def test_http_resolver_resolve_remote_invalid_archive():
     """Test resolve_remote raises error for invalid archive."""
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, "https://example.com/invalid.tar.gz", "v1.0")
 
@@ -372,10 +371,10 @@ def test_http_resolver_resolve_remote_invalid_archive(tmpdir):
             resolver.resolve_remote()
 
 
-def test_http_resolver_resolve_remote_zip_file(tmpdir):
+def test_http_resolver_resolve_remote_zip_file():
     """Test resolve_remote extracts zip files correctly."""
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, "https://example.com/data.zip", "v1.0")
 
@@ -398,10 +397,10 @@ def test_http_resolver_resolve_remote_zip_file(tmpdir):
         assert os.path.exists(os.path.join(str(resolver.cache_path), "test_file.txt"))
 
 
-def test_http_resolver_resolve_remote_github_flatten(tmpdir):
+def test_http_resolver_resolve_remote_github_flatten():
     """Test resolve_remote flattens GitHub archive structure."""
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project,
                             "https://github.com/owner/repo/archive/refs/tags/v1.0.tar.gz", "v1.0")
@@ -428,10 +427,10 @@ def test_http_resolver_resolve_remote_github_flatten(tmpdir):
         assert not os.path.exists(os.path.join(str(resolver.cache_path), "repo-1.0"))
 
 
-def test_http_resolver_resolve_remote_bz2_tarball(tmpdir):
+def test_http_resolver_resolve_remote_bz2_tarball():
     """Test resolve_remote extracts bz2 tarballs."""
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, "https://example.com/data.tar.bz2", "v1.0")
 
@@ -455,10 +454,10 @@ def test_http_resolver_resolve_remote_bz2_tarball(tmpdir):
         assert os.path.exists(os.path.join(str(resolver.cache_path), "test.txt"))
 
 
-def test_http_resolver_resolve_remote_github_flatten_tgz(tmpdir):
+def test_http_resolver_resolve_remote_github_flatten_tgz():
     """Test resolve_remote flattens GitHub archive structure with .tgz extension."""
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project,
                             "https://github.com/owner/repo/archive/refs/tags/v1.0.tgz", "v1.0")

--- a/tests/package/test_https.py
+++ b/tests/package/test_https.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 import re
 import responses
+import struct
 import sys
 import tarfile
 import zipfile
@@ -538,6 +539,11 @@ def _tarball(members, compression):
     return raw.getvalue()
 
 
+def _skippable_frame(content=b"metadata"):
+    """Builds an RFC 8878 section 3.1.2 skippable frame, which a stream may lead with."""
+    return struct.pack("<II", 0x184D2A50, len(content)) + content
+
+
 def _resolve_with_content(resolver, content):
     """Runs resolve_remote against a download that answers with ``content``."""
     import siliconcompiler.package.https as https_module
@@ -551,10 +557,10 @@ def _resolve_with_content(resolver, content):
 
 
 @pytest.mark.parametrize("suffix,compression", _COMPRESSIONS)
-def test_http_resolver_resolve_remote_compressed_tarball(tmpdir, suffix, compression):
+def test_http_resolver_resolve_remote_compressed_tarball(suffix, compression):
     """Every compression SiliconCompiler claims to accept unpacks."""
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, f"https://example.com/data{suffix}", "v1.0")
 
@@ -569,7 +575,7 @@ def test_http_resolver_resolve_remote_compressed_tarball(tmpdir, suffix, compres
     ("xz", "xz tar"),
     ("zst", "zstd tar"),
 ))
-def test_extract_archive_reports_the_format_it_found(tmp_path, compression, expected):
+def test_extract_archive_reports_the_format_it_found(compression, expected):
     """
     The format that read an archive is reported back, and logged.
 
@@ -578,19 +584,19 @@ def test_extract_archive_reports_the_format_it_found(tmp_path, compression, expe
     """
     archive = BytesIO(_tarball({"test.txt": b"test"}, compression))
 
-    assert _extract_archive(archive, str(tmp_path), "https://example.com/data") == expected
+    assert _extract_archive(archive, ".", "https://example.com/data") == expected
 
 
-def test_extract_archive_reports_zip(tmp_path):
+def test_extract_archive_reports_zip():
     """A zip is named as a zip, not as a tar of some compression."""
     archive = BytesIO()
     with zipfile.ZipFile(archive, 'w') as zf:
         zf.writestr("test.txt", "test")
 
-    assert _extract_archive(archive, str(tmp_path), "https://example.com/data") == "zip"
+    assert _extract_archive(archive, ".", "https://example.com/data") == "zip"
 
 
-def test_http_resolver_resolve_remote_zstd_identified_by_contents(tmpdir):
+def test_http_resolver_resolve_remote_zstd_identified_by_contents():
     """
     A zstd archive is unpacked on its contents, not its name.
 
@@ -598,7 +604,7 @@ def test_http_resolver_resolve_remote_zstd_identified_by_contents(tmpdir):
     is the frame magic, as it already did for the other compressions.
     """
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, "https://example.com/data.tar.gz", "v1.0")
 
@@ -607,7 +613,24 @@ def test_http_resolver_resolve_remote_zstd_identified_by_contents(tmpdir):
     assert os.path.isfile(os.path.join(str(resolver.cache_path), "test.txt"))
 
 
-def test_http_resolver_resolve_remote_zstd_nested_layout(tmpdir):
+def test_http_resolver_resolve_remote_zstd_with_leading_skippable_frame():
+    """
+    An archive that opens with a skippable frame unpacks like any other.
+
+    A stream is free to lead with metadata that carries no compressed payload, and
+    the decompressor reads straight past it.
+    """
+    project = Project("testproj")
+    project.option.set_cachedir(".")
+
+    resolver = HTTPResolver("test", project, "https://example.com/data.tar.zst", "v1.0")
+
+    _resolve_with_content(resolver, _skippable_frame() + _tarball({"test.txt": b"test"}, "zst"))
+
+    assert os.path.isfile(os.path.join(str(resolver.cache_path), "test.txt"))
+
+
+def test_http_resolver_resolve_remote_zstd_nested_layout():
     """
     A zstd archive with a real PDK's directory depth unpacks whole.
 
@@ -615,7 +638,7 @@ def test_http_resolver_resolve_remote_zstd_nested_layout(tmpdir):
     library's views, several directories deep and thousands of members long.
     """
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, "https://example.com/sky130_fd_sc_hd.tar.zst", "v1.0")
 
@@ -630,7 +653,9 @@ def test_http_resolver_resolve_remote_zstd_nested_layout(tmpdir):
         assert os.path.isfile(os.path.join(str(resolver.cache_path), *name.split("/")))
 
 
-def test_http_resolver_resolve_remote_zstd_applies_extraction_filter(tmpdir):
+@pytest.mark.skipif(not hasattr(tarfile, "FilterError"),
+                    reason="release predates the PEP 706 extraction filters")
+def test_http_resolver_resolve_remote_zstd_applies_extraction_filter():
     """
     The extraction filter covers the zstd path too, and its verdict still settles.
 
@@ -639,7 +664,7 @@ def test_http_resolver_resolve_remote_zstd_applies_extraction_filter(tmpdir):
     one, and the refusal it raises is the class the retry logic knows to stop on.
     """
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, "https://example.com/data.tar.zst", "v1.0")
 
@@ -648,9 +673,11 @@ def test_http_resolver_resolve_remote_zstd_applies_extraction_filter(tmpdir):
     with pytest.raises(tarfile.OutsideDestinationError):
         _resolve_with_content(resolver, archive)
 
-    assert not os.path.exists(os.path.join(str(tmpdir), "escape.txt"))
+    assert not os.path.exists("escape.txt")
 
 
+@pytest.mark.skipif(not hasattr(tarfile, "FilterError"),
+                    reason="release predates the PEP 706 extraction filters")
 def test_http_resolver_zstd_filter_refusal_is_permanent():
     """A member the filter refuses is refused again on a fresh copy, so it settles."""
     resolver = HTTPResolver("test", Project("testproj"),
@@ -661,7 +688,7 @@ def test_http_resolver_zstd_filter_refusal_is_permanent():
     assert resolver.is_permanent_failure(error) is True
 
 
-def test_http_resolver_resolve_remote_zstd_that_is_not_a_tar(tmpdir):
+def test_http_resolver_resolve_remote_zstd_that_is_not_a_tar():
     """
     A readable zstd frame holding something other than a tar is not an archive.
 
@@ -669,7 +696,7 @@ def test_http_resolver_resolve_remote_zstd_that_is_not_a_tar(tmpdir):
     decompressor's own exception to the caller.
     """
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, "https://example.com/data.tar.zst", "v1.0")
 
@@ -679,7 +706,7 @@ def test_http_resolver_resolve_remote_zstd_that_is_not_a_tar(tmpdir):
 
 
 @pytest.mark.parametrize("compression", ("gz", "zst"))
-def test_http_resolver_resolve_remote_truncated_tarball_stays_retryable(tmpdir, compression):
+def test_http_resolver_resolve_remote_truncated_tarball_stays_retryable(compression):
     """
     A half-transferred archive is a transfer that broke, not an answer.
 
@@ -690,7 +717,7 @@ def test_http_resolver_resolve_remote_truncated_tarball_stays_retryable(tmpdir, 
     environment missing the zstd bindings, which no retry can change.
     """
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, f"https://example.com/data.tar.{compression}", "v1.0")
 
@@ -704,7 +731,9 @@ def test_http_resolver_resolve_remote_truncated_tarball_stays_retryable(tmpdir, 
     assert resolver.is_permanent_failure(excinfo.value) is False
 
 
-def test_http_resolver_resolve_remote_zstd_without_bindings(tmpdir, monkeypatch):
+@pytest.mark.parametrize("prefix", (b"", _skippable_frame()),
+                         ids=("plain", "leading-skippable-frame"))
+def test_http_resolver_resolve_remote_zstd_without_bindings(monkeypatch, prefix):
     """
     An environment that cannot read zstd says so, and stops asking.
 
@@ -712,13 +741,17 @@ def test_http_resolver_resolve_remote_zstd_without_bindings(tmpdir, monkeypatch)
     for a PDK artifact, hundreds of megabytes to re-learn that a package is
     missing -- so the source is abandoned on the first attempt with an error
     naming what would fix it.
+
+    A stream leading with a skippable frame has to reach the same verdict: it is
+    just as much a zstd archive, and telling the user it is invalid would send them
+    looking for a corrupt download instead of a missing package.
     """
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, "https://example.com/data.tar.zst", "v1.0")
 
-    archive = _tarball({"test.txt": b"test"}, "zst")
+    archive = prefix + _tarball({"test.txt": b"test"}, "zst")
     monkeypatch.setattr(utils, "_zstd", None)
 
     expected = "compression.zstd" if sys.version_info >= (3, 14) else "backports.zstd"
@@ -728,10 +761,10 @@ def test_http_resolver_resolve_remote_zstd_without_bindings(tmpdir, monkeypatch)
     assert resolver.is_permanent_failure(excinfo.value) is True
 
 
-def test_http_resolver_resolve_remote_unknown_format_is_not_blamed_on_zstd(tmpdir, monkeypatch):
+def test_http_resolver_resolve_remote_unknown_format_is_not_blamed_on_zstd(monkeypatch):
     """Missing bindings explain a zstd download, and only a zstd download."""
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver("test", project, "https://example.com/data.tar.zst", "v1.0")
 
@@ -743,7 +776,7 @@ def test_http_resolver_resolve_remote_unknown_format_is_not_blamed_on_zstd(tmpdi
 
 
 @pytest.mark.parametrize("suffix,compression", _COMPRESSIONS)
-def test_http_resolver_resolve_remote_github_flatten_compressed(tmpdir, suffix, compression):
+def test_http_resolver_resolve_remote_github_flatten_compressed(suffix, compression):
     """
     The GitHub flattening recovers a dotted release from every archive suffix.
 
@@ -751,13 +784,37 @@ def test_http_resolver_resolve_remote_github_flatten_compressed(tmpdir, suffix, 
     first '.', which would look for 'repo-1' here and quietly skip the flatten.
     """
     project = Project("testproj")
-    project.set("option", "cachedir", str(tmpdir))
+    project.option.set_cachedir(".")
 
     resolver = HTTPResolver(
         "test", project,
         f"https://github.com/owner/repo/archive/refs/tags/v1.0.2{suffix}", "v1.0.2")
 
     _resolve_with_content(resolver, _tarball({"repo-1.0.2/test.txt": b"test"}, compression))
+
+    assert os.path.isfile(os.path.join(str(resolver.cache_path), "test.txt"))
+    assert not os.path.exists(os.path.join(str(resolver.cache_path), "repo-1.0.2"))
+
+
+def test_http_resolver_resolve_remote_github_flatten_zip():
+    """
+    A GitHub source zip flattens like the tarballs do.
+
+    ``github://`` builds these itself, as '<release>.zip' -- so the dotted release
+    that defeats the fallback guess is the normal case, not an exotic one.
+    """
+    project = Project("testproj")
+    project.option.set_cachedir(".")
+
+    resolver = HTTPResolver(
+        "test", project,
+        "https://github.com/owner/repo/archive/refs/tags/v1.0.2.zip", "v1.0.2")
+
+    archive = BytesIO()
+    with zipfile.ZipFile(archive, 'w') as zf:
+        zf.writestr("repo-1.0.2/test.txt", "test")
+
+    _resolve_with_content(resolver, archive.getvalue())
 
     assert os.path.isfile(os.path.join(str(resolver.cache_path), "test.txt"))
     assert not os.path.exists(os.path.join(str(resolver.cache_path), "repo-1.0.2"))

--- a/tests/package/test_https.py
+++ b/tests/package/test_https.py
@@ -1,7 +1,9 @@
+import gzip
 import logging
 import pytest
 import re
 import responses
+import sys
 import tarfile
 import zipfile
 import os
@@ -11,9 +13,10 @@ from io import BytesIO
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+from siliconcompiler import utils
 from siliconcompiler.package import DataRootResolutionError
-from siliconcompiler.package.cache import DataSourceUnavailableError
-from siliconcompiler.package.https import HTTPResolver
+from siliconcompiler.package.cache import DataSourceUnavailableError, PermanentResolutionError
+from siliconcompiler.package.https import HTTPResolver, _extract_archive
 from siliconcompiler import Project
 
 
@@ -46,6 +49,43 @@ def test_dependency_path_download_http(project_logger, datadir, path, ref, cache
     assert resolver.resolve() == Path(os.path.join(tmp_path, f"sc-data-{ref[0:16]}-{cache_id}"))
     assert os.path.isfile(
         os.path.join(tmp_path, f"sc-data-{ref[0:16]}-{cache_id}", "pyproject.toml"))
+    assert "Downloading sc-data data from " in caplog.text
+
+
+@responses.activate
+def test_dependency_path_download_http_zstd(project_logger, datadir, tmp_path, caplog):
+    """
+    A Zstandard artifact resolves end to end, over the real transfer stack.
+
+    The unit tests above hand :meth:`resolve_remote` a mocked response; this goes
+    through ``resolve()`` and an actual ``requests`` download, which is where a
+    binary body could still be mangled in transit before any decompressor sees it.
+    Ciel publishes its PDK artifacts this way, which is what brought zstd here, so
+    the archive is the existing fixture recompressed rather than a second copy
+    checked in.
+    """
+    with open(os.path.join(datadir, 'https.tar.gz'), "rb") as f:
+        body = _zstd_compress(gzip.decompress(f.read()))
+
+    responses.add(
+        responses.GET,
+        "https://example.com/sky130_fd_sc_hd.tar.zst",
+        body=body,
+        status=200,
+        content_type="application/zstd"
+    )
+
+    proj = Project("testproj")
+    proj.set("option", "cachedir", tmp_path)
+    project_logger(proj)
+    proj.logger.setLevel(logging.INFO)
+
+    resolver = HTTPResolver("sc-data", proj, "https://example.com/sky130_fd_sc_hd.tar.zst",
+                            "v1.0.2")
+    cache_dir = os.path.join(tmp_path, "sc-data-v1.0.2-2b8a7556f743e2a4")
+
+    assert resolver.resolve() == Path(cache_dir)
+    assert os.path.isfile(os.path.join(cache_dir, "pyproject.toml"))
     assert "Downloading sc-data data from " in caplog.text
 
 
@@ -326,7 +366,8 @@ def test_http_resolver_resolve_remote_invalid_archive(tmpdir):
         mock_response.content = b"not a valid archive"
         mock_requests.get.return_value = mock_response
 
-        with pytest.raises(TypeError, match="not a valid tar.gz or zip archive"):
+        with pytest.raises(TypeError,
+                           match=r"not a valid tar \(gzip, bzip2, xz or zstd\) or zip archive"):
             resolver.resolve_remote()
 
 
@@ -441,6 +482,285 @@ def test_http_resolver_resolve_remote_github_flatten_tgz(tmpdir):
         # Verify file was moved to cache root
         assert os.path.exists(os.path.join(str(resolver.cache_path), "test.txt"))
         assert not os.path.exists(os.path.join(str(resolver.cache_path), "repo-1.0"))
+
+
+# ============================================================================
+# Compressed archive handling
+#
+# Every fixture below is built with the same bindings the resolver reads it back
+# with, so these run unchanged on an interpreter using the stdlib
+# ``compression.zstd`` (3.14+) and on one using the ``backports.zstd`` package
+# (3.10-3.13), exercising whichever the shim selected.
+# ============================================================================
+
+#: Tar compressions the resolver accepts, as (archive suffix, tarfile mode
+#: suffix). "zst" is not a mode stdlib tarfile can write before 3.14, and is
+#: special-cased by :func:`_tarball`.
+_COMPRESSIONS = (
+    (".tar.gz", "gz"),
+    (".tgz", "gz"),
+    (".tar.bz2", "bz2"),
+    (".tbz2", "bz2"),
+    (".tar.xz", "xz"),
+    (".txz", "xz"),
+    (".tar.zst", "zst"),
+    (".tzst", "zst"),
+)
+
+
+def _zstd_compress(data):
+    """Compresses with the bindings :mod:`siliconcompiler.utils` selected.
+
+    Reaching for the module the shim resolved, rather than importing one here,
+    keeps a test fixture and the code under test on the same implementation -- and
+    fails loudly if the shim found none, which is the whole point of declaring the
+    backport as a dependency.
+    """
+    assert utils.zstd_available(), utils.zstd_unavailable_message()
+    return utils._zstd.compress(data)
+
+
+def _tarball(members, compression):
+    """Builds an in-memory tarball of ``{name: contents}`` in the given compression."""
+    # Before 3.14 stdlib tarfile cannot write zstd at all, so the tar is built
+    # uncompressed and the frame wrapped around it afterwards.
+    mode = "w:" if compression == "zst" else f"w:{compression}"
+
+    raw = BytesIO()
+    with tarfile.open(fileobj=raw, mode=mode) as tar:
+        for name, content in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(content)
+            tar.addfile(info, BytesIO(content))
+
+    if compression == "zst":
+        return _zstd_compress(raw.getvalue())
+    return raw.getvalue()
+
+
+def _resolve_with_content(resolver, content):
+    """Runs resolve_remote against a download that answers with ``content``."""
+    import siliconcompiler.package.https as https_module
+    with patch.object(https_module, "requests") as mock_requests:
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.content = content
+        mock_requests.get.return_value = mock_response
+
+        resolver.resolve_remote()
+
+
+@pytest.mark.parametrize("suffix,compression", _COMPRESSIONS)
+def test_http_resolver_resolve_remote_compressed_tarball(tmpdir, suffix, compression):
+    """Every compression SiliconCompiler claims to accept unpacks."""
+    project = Project("testproj")
+    project.set("option", "cachedir", str(tmpdir))
+
+    resolver = HTTPResolver("test", project, f"https://example.com/data{suffix}", "v1.0")
+
+    _resolve_with_content(resolver, _tarball({"test.txt": b"test"}, compression))
+
+    assert os.path.isfile(os.path.join(str(resolver.cache_path), "test.txt"))
+
+
+@pytest.mark.parametrize("compression,expected", (
+    ("gz", "gzip tar"),
+    ("bz2", "bzip2 tar"),
+    ("xz", "xz tar"),
+    ("zst", "zstd tar"),
+))
+def test_extract_archive_reports_the_format_it_found(tmp_path, compression, expected):
+    """
+    The format that read an archive is reported back, and logged.
+
+    Which one answered is the first thing worth knowing when a download unpacks
+    into something unexpected, since the name it arrived under does not decide it.
+    """
+    archive = BytesIO(_tarball({"test.txt": b"test"}, compression))
+
+    assert _extract_archive(archive, str(tmp_path), "https://example.com/data") == expected
+
+
+def test_extract_archive_reports_zip(tmp_path):
+    """A zip is named as a zip, not as a tar of some compression."""
+    archive = BytesIO()
+    with zipfile.ZipFile(archive, 'w') as zf:
+        zf.writestr("test.txt", "test")
+
+    assert _extract_archive(archive, str(tmp_path), "https://example.com/data") == "zip"
+
+
+def test_http_resolver_resolve_remote_zstd_identified_by_contents(tmpdir):
+    """
+    A zstd archive is unpacked on its contents, not its name.
+
+    The extension is the server's to choose and is routinely wrong -- what decides
+    is the frame magic, as it already did for the other compressions.
+    """
+    project = Project("testproj")
+    project.set("option", "cachedir", str(tmpdir))
+
+    resolver = HTTPResolver("test", project, "https://example.com/data.tar.gz", "v1.0")
+
+    _resolve_with_content(resolver, _tarball({"test.txt": b"test"}, "zst"))
+
+    assert os.path.isfile(os.path.join(str(resolver.cache_path), "test.txt"))
+
+
+def test_http_resolver_resolve_remote_zstd_nested_layout(tmpdir):
+    """
+    A zstd archive with a real PDK's directory depth unpacks whole.
+
+    Shaped after a Ciel artifact, which is what brought zstd here: a tarball of a
+    library's views, several directories deep and thousands of members long.
+    """
+    project = Project("testproj")
+    project.set("option", "cachedir", str(tmpdir))
+
+    resolver = HTTPResolver("test", project, "https://example.com/sky130_fd_sc_hd.tar.zst", "v1.0")
+
+    members = {
+        f"sky130_fd_sc_hd/{view}/cell_{index}.{view}": f"cell {index}".encode()
+        for view in ("lef", "lib", "gds")
+        for index in range(4)
+    }
+    _resolve_with_content(resolver, _tarball(members, "zst"))
+
+    for name in members:
+        assert os.path.isfile(os.path.join(str(resolver.cache_path), *name.split("/")))
+
+
+def test_http_resolver_resolve_remote_zstd_applies_extraction_filter(tmpdir):
+    """
+    The extraction filter covers the zstd path too, and its verdict still settles.
+
+    This is what the decompress-then-extract split buys: one stdlib ``tarfile``
+    reads every archive, so the filter that guards a gzip download guards a zstd
+    one, and the refusal it raises is the class the retry logic knows to stop on.
+    """
+    project = Project("testproj")
+    project.set("option", "cachedir", str(tmpdir))
+
+    resolver = HTTPResolver("test", project, "https://example.com/data.tar.zst", "v1.0")
+
+    archive = _tarball({"safe.txt": b"ok", "../escape.txt": b"bad"}, "zst")
+
+    with pytest.raises(tarfile.OutsideDestinationError):
+        _resolve_with_content(resolver, archive)
+
+    assert not os.path.exists(os.path.join(str(tmpdir), "escape.txt"))
+
+
+def test_http_resolver_zstd_filter_refusal_is_permanent():
+    """A member the filter refuses is refused again on a fresh copy, so it settles."""
+    resolver = HTTPResolver("test", Project("testproj"),
+                            "https://example.com/data.tar.zst", "v1.0")
+
+    error = tarfile.OutsideDestinationError(tarfile.TarInfo("../escape.txt"), "dest")
+
+    assert resolver.is_permanent_failure(error) is True
+
+
+def test_http_resolver_resolve_remote_zstd_that_is_not_a_tar(tmpdir):
+    """
+    A readable zstd frame holding something other than a tar is not an archive.
+
+    It must land on the ordinary "unknown format" error rather than leaking the
+    decompressor's own exception to the caller.
+    """
+    project = Project("testproj")
+    project.set("option", "cachedir", str(tmpdir))
+
+    resolver = HTTPResolver("test", project, "https://example.com/data.tar.zst", "v1.0")
+
+    with pytest.raises(TypeError,
+                       match=r"not a valid tar \(gzip, bzip2, xz or zstd\) or zip archive"):
+        _resolve_with_content(resolver, _zstd_compress(b"this is not a tar file"))
+
+
+@pytest.mark.parametrize("compression", ("gz", "zst"))
+def test_http_resolver_resolve_remote_truncated_tarball_stays_retryable(tmpdir, compression):
+    """
+    A half-transferred archive is a transfer that broke, not an answer.
+
+    Truncation is what the attempt budget exists for, and zstd reports it the way
+    gzip has all along -- the decompressor runs out of input rather than rejecting
+    the format -- so both are parametrized here to keep them answering alike. What
+    matters either way is that neither is mistaken for the settled case: an
+    environment missing the zstd bindings, which no retry can change.
+    """
+    project = Project("testproj")
+    project.set("option", "cachedir", str(tmpdir))
+
+    resolver = HTTPResolver("test", project, f"https://example.com/data.tar.{compression}", "v1.0")
+
+    # Padded well past a tar block, so half of it is a genuinely partial archive
+    # rather than a header the reader can still make sense of.
+    archive = _tarball({"test.txt": b"x" * 4096}, compression)
+
+    with pytest.raises((EOFError, TypeError)) as excinfo:
+        _resolve_with_content(resolver, archive[0:len(archive) // 2])
+
+    assert resolver.is_permanent_failure(excinfo.value) is False
+
+
+def test_http_resolver_resolve_remote_zstd_without_bindings(tmpdir, monkeypatch):
+    """
+    An environment that cannot read zstd says so, and stops asking.
+
+    Retrying would re-download the whole archive to reach the same conclusion --
+    for a PDK artifact, hundreds of megabytes to re-learn that a package is
+    missing -- so the source is abandoned on the first attempt with an error
+    naming what would fix it.
+    """
+    project = Project("testproj")
+    project.set("option", "cachedir", str(tmpdir))
+
+    resolver = HTTPResolver("test", project, "https://example.com/data.tar.zst", "v1.0")
+
+    archive = _tarball({"test.txt": b"test"}, "zst")
+    monkeypatch.setattr(utils, "_zstd", None)
+
+    expected = "compression.zstd" if sys.version_info >= (3, 14) else "backports.zstd"
+    with pytest.raises(PermanentResolutionError, match=expected) as excinfo:
+        _resolve_with_content(resolver, archive)
+
+    assert resolver.is_permanent_failure(excinfo.value) is True
+
+
+def test_http_resolver_resolve_remote_unknown_format_is_not_blamed_on_zstd(tmpdir, monkeypatch):
+    """Missing bindings explain a zstd download, and only a zstd download."""
+    project = Project("testproj")
+    project.set("option", "cachedir", str(tmpdir))
+
+    resolver = HTTPResolver("test", project, "https://example.com/data.tar.zst", "v1.0")
+
+    monkeypatch.setattr(utils, "_zstd", None)
+
+    with pytest.raises(TypeError,
+                       match=r"not a valid tar \(gzip, bzip2, xz or zstd\) or zip archive"):
+        _resolve_with_content(resolver, b"not an archive in any format")
+
+
+@pytest.mark.parametrize("suffix,compression", _COMPRESSIONS)
+def test_http_resolver_resolve_remote_github_flatten_compressed(tmpdir, suffix, compression):
+    """
+    The GitHub flattening recovers a dotted release from every archive suffix.
+
+    A name the suffix table misses falls back to a guess that gives up at the
+    first '.', which would look for 'repo-1' here and quietly skip the flatten.
+    """
+    project = Project("testproj")
+    project.set("option", "cachedir", str(tmpdir))
+
+    resolver = HTTPResolver(
+        "test", project,
+        f"https://github.com/owner/repo/archive/refs/tags/v1.0.2{suffix}", "v1.0.2")
+
+    _resolve_with_content(resolver, _tarball({"repo-1.0.2/test.txt": b"test"}, compression))
+
+    assert os.path.isfile(os.path.join(str(resolver.cache_path), "test.txt"))
+    assert not os.path.exists(os.path.join(str(resolver.cache_path), "repo-1.0.2"))
 
 
 # ============================================================================

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -20,6 +20,7 @@ from siliconcompiler.package import FileResolver, PythonPathResolver, \
     KeyPathResolver, DatarootResolver
 from siliconcompiler.package import DataRootResolutionError
 from siliconcompiler.package.cache import PermanentResolutionError, DataSourceUnavailableError
+from siliconcompiler import utils
 from siliconcompiler.utils.multiprocessing import MPManager
 from siliconcompiler.package import InterProcessLock as dut_ipl
 
@@ -613,6 +614,8 @@ def failing_resolver():
     (tarfile.ReadError("truncated"), False),
     (zipfile.BadZipFile("truncated"), False),
     (TypeError("neither tar nor zip"), False),
+    (EOFError("compressed file ended early"), False),
+    (utils.zstd_errors()[0]("corrupt frame"), False),
     (PermanentResolutionError("settled"), True),
     (DataSourceUnavailableError("no such release"), True),
 ))

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -615,7 +615,9 @@ def failing_resolver():
     (zipfile.BadZipFile("truncated"), False),
     (TypeError("neither tar nor zip"), False),
     (EOFError("compressed file ended early"), False),
-    (utils.zstd_errors()[0]("corrupt frame"), False),
+    # Splatted rather than indexed: with no Zstandard bindings the tuple is empty,
+    # and subscripting it would fail the whole module's collection.
+    *[(error("corrupt frame"), False) for error in utils.zstd_errors()],
     (PermanentResolutionError("settled"), True),
     (DataSourceUnavailableError("no such release"), True),
 ))

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -4,6 +4,7 @@ import pytest
 import os
 import os.path
 import psutil
+import struct
 import sys
 import tarfile
 import types
@@ -1275,6 +1276,12 @@ def test_zstd_errors_reports_the_decompressor_error():
 @pytest.mark.parametrize("data,expected", (
     (b"\x28\xb5\x2f\xfd", True),
     (b"\x28\xb5\x2f\xfd\x00\x48\x65", True),
+    # Skippable frames (RFC 8878 3.1.2) span 0x184D2A50-0x184D2A5F, little-endian,
+    # so it is the first byte that varies. A stream may lead with one.
+    (b"\x50\x2a\x4d\x18", True),       # 0x184D2A50, the bottom of the range
+    (b"\x5f\x2a\x4d\x18", True),       # 0x184D2A5F, the top of it
+    (b"\x4f\x2a\x4d\x18", False),      # 0x184D2A4F, just below
+    (b"\x60\x2a\x4d\x18", False),      # 0x184D2A60, just above
     (b"\x1f\x8b\x08\x00", False),      # gzip
     (b"BZh9", False),                  # bzip2
     (b"\xfd7zXZ\x00", False),          # xz
@@ -1285,6 +1292,20 @@ def test_zstd_errors_reports_the_decompressor_error():
 def test_is_zstd(data, expected):
     """The frame magic identifies zstd, and identifies nothing else as zstd."""
     assert utils.is_zstd(data) is expected
+
+
+def test_is_zstd_accepts_a_leading_skippable_frame():
+    """
+    A stream that opens with a skippable frame is still Zstandard.
+
+    Built the way a writer would rather than from a magic constant, so this stays
+    honest about what the decompressor accepts: it must read the same bytes back.
+    """
+    frame = struct.pack("<II", 0x184D2A50, 4) + b"meta" + utils._zstd.compress(b"payload")
+
+    assert utils.is_zstd(frame) is True
+    with utils.open_zstd_stream(BytesIO(frame)) as stream:
+        assert stream.read() == b"payload"
 
 
 def test_is_zstd_recognizes_what_it_cannot_read(monkeypatch):

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1159,3 +1159,142 @@ def test_corrected_filter_honors_a_skipped_member(broken_tarfile_data_filter, mo
     member.linkname = "../dir/target"
 
     assert utils._symlink_safe_data_filter(member, os.getcwd()) is None
+
+
+#############################
+# Zstandard bindings
+#
+# Zstandard entered the stdlib in Python 3.14 (PEP 784) and is carried to 3.10-3.13
+# by the 'backports.zstd' dependency, so which module answers below depends on the
+# interpreter. Nothing here names one: the point is that every supported release
+# reaches a working implementation.
+#############################
+def test_zstd_available():
+    """
+    Every supported interpreter can read Zstandard.
+
+    The one test that fails if the dependency declaration is wrong -- a marker that
+    misfires, or a bound that excludes the release under test -- and it fails on the
+    release it is wrong for, rather than at the first PDK download that needs it.
+    """
+    assert utils.zstd_available() is True, utils.zstd_unavailable_message()
+
+
+def test_zstd_module_matches_interpreter():
+    """The stdlib module is used where it exists, and the backport only below it."""
+    expected = "compression.zstd" if sys.version_info >= (3, 14) else "backports.zstd"
+
+    assert utils._zstd.__name__ == expected
+
+
+def test_open_zstd_stream_round_trip():
+    """A compressed frame reads back byte for byte."""
+    payload = b"the quick brown fox" * 1000
+
+    with utils.open_zstd_stream(BytesIO(utils._zstd.compress(payload))) as stream:
+        assert stream.read() == payload
+
+
+def test_open_zstd_stream_is_seekable():
+    """
+    The decompressed stream can be seeked, which is what tarfile needs of it.
+
+    Reading a tar means jumping between headers and member data; a stream that only
+    moves forward would need ``mode="r|"`` and would give up random access to the
+    archive.
+    """
+    with utils.open_zstd_stream(BytesIO(utils._zstd.compress(b"0123456789"))) as stream:
+        assert stream.seekable() is True
+        stream.seek(4)
+        assert stream.read(3) == b"456"
+        stream.seek(0)
+        assert stream.read(2) == b"01"
+
+
+def test_open_zstd_stream_reads_multiple_frames():
+    """
+    Concatenated frames read as one continuous stream.
+
+    Zstandard files are free to be multi-frame, and a compressor that splits its
+    output would otherwise appear to produce a truncated archive.
+    """
+    blob = utils._zstd.compress(b"first") + utils._zstd.compress(b"second")
+
+    with utils.open_zstd_stream(BytesIO(blob)) as stream:
+        assert stream.read() == b"firstsecond"
+
+
+def test_open_zstd_stream_rejects_other_data():
+    """Data that is not Zstandard raises one of the errors zstd_errors() reports."""
+    with pytest.raises(utils.zstd_errors()):
+        with utils.open_zstd_stream(BytesIO(b"not compressed with zstd")) as stream:
+            stream.read()
+
+
+def test_open_zstd_stream_leaves_the_source_open():
+    """
+    Closing the decompressor does not close what it was reading from.
+
+    The caller owns the downloaded buffer and may still need to hand it to another
+    reader -- which is exactly what identifying an archive by trial does.
+    """
+    source = BytesIO(utils._zstd.compress(b"payload"))
+
+    with utils.open_zstd_stream(source) as stream:
+        stream.read()
+
+    assert source.closed is False
+
+
+def test_open_zstd_stream_without_bindings(monkeypatch):
+    """Asked for zstd it cannot provide, the shim names what would fix it."""
+    monkeypatch.setattr(utils, "_zstd", None)
+
+    expected = "compression.zstd" if sys.version_info >= (3, 14) else "backports.zstd"
+    with pytest.raises(ModuleNotFoundError, match=expected):
+        utils.open_zstd_stream(BytesIO(b""))
+
+
+def test_zstd_errors_without_bindings(monkeypatch):
+    """
+    With no bindings there is no error class to catch, and the empty tuple says so.
+
+    An ``except`` clause splatting it then matches nothing, which is right: the
+    caller never opened a zstd stream to fail.
+    """
+    monkeypatch.setattr(utils, "_zstd", None)
+
+    assert utils.zstd_errors() == ()
+
+
+def test_zstd_errors_reports_the_decompressor_error():
+    """The reported error is the one the selected bindings actually raise."""
+    assert utils.zstd_errors() == (utils._zstd.ZstdError,)
+
+
+@pytest.mark.parametrize("data,expected", (
+    (b"\x28\xb5\x2f\xfd", True),
+    (b"\x28\xb5\x2f\xfd\x00\x48\x65", True),
+    (b"\x1f\x8b\x08\x00", False),      # gzip
+    (b"BZh9", False),                  # bzip2
+    (b"\xfd7zXZ\x00", False),          # xz
+    (b"PK\x03\x04", False),            # zip
+    (b"\x28\xb5\x2f", False),          # a short read is not a match
+    (b"", False),
+))
+def test_is_zstd(data, expected):
+    """The frame magic identifies zstd, and identifies nothing else as zstd."""
+    assert utils.is_zstd(data) is expected
+
+
+def test_is_zstd_recognizes_what_it_cannot_read(monkeypatch):
+    """
+    Recognizing the format does not depend on being able to decompress it.
+
+    That separation is what lets a download on an interpreter without the bindings
+    be reported as unsupported rather than as unrecognized.
+    """
+    blob = utils._zstd.compress(b"payload")
+    monkeypatch.setattr(utils, "_zstd", None)
+
+    assert utils.is_zstd(blob) is True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for downloading and extracting Zstandard-compressed archives.
  * Archive handling now supports gzip, bzip2, xz, Zstandard, and ZIP formats.
  * Improved archive detection, including content-based identification and nested extraction.
  * GitHub archive downloads now recognize additional compressed tarball formats.

* **Bug Fixes**
  * Improved error messages and failure handling for invalid archives and unavailable Zstandard support.
  * Maintained compatibility across supported Python versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->