### PR TITLE
add zstd to tools image since its used in caching

### DIFF
--- a/setup/docker/sc_tools.docker
+++ b/setup/docker/sc_tools.docker
@@ -15,12 +15,16 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 RUN echo "APT::Install-Recommends \"false\";" >> /etc/apt/apt.conf
 RUN echo "APT::Install-Suggests \"false\";" >> /etc/apt/apt.conf
 
-# Install minimum tools needed by SC and support scripts
+# Install minimum tools needed by SC and support scripts.
+# zstd is needed by actions/cache: it hashes the compression method into the
+# cache version, so without the zstd binary here a cache saved by a job on the
+# runner (which has zstd) never matches on restore inside this container.
 RUN apt-get update && \
     apt-get install -y sudo \
                        git \
                        python3 python3-pip \
                        xvfb \
+                       zstd \
                        munge libmunge-dev build-essential libmariadb-dev lbzip2 libjson-c-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `zstd` support to the Docker image for improved compatibility with GitHub Actions caching.
  * Preserved the existing package installation and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->