### PR TITLE
RTL is a clocked flow of data

### DIFF
--- a/docs/user_guide/glossary.rst
+++ b/docs/user_guide/glossary.rst
@@ -249,9 +249,9 @@ output.
        for real interconnect delay rather than estimates.
 
     RTL
-       Register Transfer Level -- a description of hardware in terms of data
-       flow between registers, written in a language such as Verilog, VHDL, or
-       SystemVerilog. The usual starting point of a compilation.
+       Register Transfer Level -- a description of hardware in terms of a
+       clocked flow of data between registers, written in a language such as 
+       Verilog, VHDL, or SystemVerilog. The usual starting point of a compilation.
 
     SDC
        Synopsys Design Constraints -- the de facto standard format for


### PR DESCRIPTION
Clarify the definition of RTL by specifying 'a clocked flow of data'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the RTL glossary entry to clarify that RTL describes clocked data flow between registers.
  * Preserved the existing language examples and supporting explanation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->