### PR TITLE
fix missing reports and make per scenario reports

### DIFF
--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -2153,9 +2153,23 @@ class APRTask(OpenROADTask):
         '''
 
         scenario_corners = self.project.getkeys('constraint', 'timing', 'scenario')
+
+        def scenario_reports(name, unconstrained=False):
+            # Per-scene reports, written only when more than one scene is defined
+            variants = ("", "topN.") if unconstrained else ("", "topN.", "failing.", "endpoints.")
+            return [f"timing/scenarios/{corner}/{name}.{corner}.{variant}rpt"
+                    for corner in scenario_corners
+                    for variant in variants]
+
+        def scenario_files(name):
+            # A single per-scene report, e.g. worst_slack.setup
+            return [f"timing/scenarios/{corner}/{name}.{corner}.rpt"
+                    for corner in scenario_corners]
+
         metric_reports = {
             "setuptns": [
                 "timing/total_negative_slack.setup.rpt",
+                *scenario_files("total_negative_slack.setup"),
                 "timing/setup.rpt",
                 "timing/setup.failing.rpt",
                 "timing/setup.histogram.rpt",
@@ -2163,12 +2177,12 @@ class APRTask(OpenROADTask):
             ],
             "setupslack": [
                 "timing/worst_slack.setup.rpt",
+                *scenario_files("worst_slack.setup"),
                 "timing/setup.rpt",
                 "timing/setup.topN.rpt",
                 "timing/setup.failing.rpt",
                 "timing/setup.endpoints.rpt",
-                *[f"timing/setup.{corner}.rpt" for corner in scenario_corners],
-                *[f"timing/setup.topN.{corner}.rpt" for corner in scenario_corners],
+                *scenario_reports("setup"),
                 "timing/setup.histogram.rpt",
                 "images/timing/setup.histogram.png"
             ],
@@ -2183,13 +2197,13 @@ class APRTask(OpenROADTask):
                 "timing/setup.topN.rpt",
                 "timing/setup.failing.rpt",
                 "timing/setup.endpoints.rpt",
-                *[f"timing/setup.{corner}.rpt" for corner in scenario_corners],
-                *[f"timing/setup.topN.{corner}.rpt" for corner in scenario_corners],
+                *scenario_reports("setup"),
                 "timing/setup.histogram.rpt",
                 "images/timing/setup.histogram.png"
             ],
             "holdtns": [
                 "timing/total_negative_slack.hold.rpt",
+                *scenario_files("total_negative_slack.hold"),
                 "timing/hold.rpt",
                 "timing/hold.failing.rpt",
                 "timing/hold.histogram.rpt",
@@ -2197,12 +2211,12 @@ class APRTask(OpenROADTask):
             ],
             "holdslack": [
                 "timing/worst_slack.hold.rpt",
+                *scenario_files("worst_slack.hold"),
                 "timing/hold.rpt",
                 "timing/hold.topN.rpt",
                 "timing/hold.failing.rpt",
                 "timing/hold.endpoints.rpt",
-                *[f"timing/hold.{corner}.rpt" for corner in scenario_corners],
-                *[f"timing/hold.topN.{corner}.rpt" for corner in scenario_corners],
+                *scenario_reports("hold"),
                 "timing/hold.histogram.rpt",
                 "images/timing/hold.histogram.png"
             ],
@@ -2217,8 +2231,7 @@ class APRTask(OpenROADTask):
                 "timing/hold.topN.rpt",
                 "timing/hold.failing.rpt",
                 "timing/hold.endpoints.rpt",
-                *[f"timing/hold.{corner}.rpt" for corner in scenario_corners],
-                *[f"timing/hold.topN.{corner}.rpt" for corner in scenario_corners],
+                *scenario_reports("hold"),
                 "timing/hold.histogram.rpt",
                 "images/timing/hold.histogram.png"
             ],
@@ -2230,7 +2243,8 @@ class APRTask(OpenROADTask):
             ],
             "unconstrained": [
                 "timing/unconstrained.rpt",
-                "timing/unconstrained.topN.rpt"
+                "timing/unconstrained.topN.rpt",
+                *scenario_reports("unconstrained", unconstrained=True)
             ],
             "peakpower": [
                 *[f"power/{corner}.rpt"

--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -1284,12 +1284,20 @@ proc sc_report_check_timing { } {
     }
 }
 
+proc sc_write_report_line { file line } {
+    puts "report: $file"
+    set fid [open $file w]
+    puts $fid $line
+    close $fid
+}
+
 proc sc_report_scene_timing { args } {
     sta::parse_key_args "sc_report_scene_timing" args \
         keys {-delay -name -fields -top_paths} \
-        flags {}
+        flags {-unconstrained}
 
     global sc_scenarios
+    global sta_report_default_digits
 
     if { [sc_has_sta_mcmm_support] } {
         set scenes $sc_scenarios
@@ -1307,15 +1315,69 @@ proc sc_report_scene_timing { args } {
         return
     }
 
+    # Mirror the combined reports exactly, adding only the scene selector. Each scene gets
+    # its own directory, so the file names match their combined counterparts. Unconstrained
+    # paths have no failing/endpoints counterpart, so they stop after topN.
+    set unconstrained [info exists flags(-unconstrained)]
+    if { $unconstrained } {
+        set path_sel "-unconstrained"
+        set full_extra "-path_group unconstrained"
+    } else {
+        set path_sel "-path_delay $keys(-delay)"
+        set full_extra ""
+    }
+
+    # Worst slack and TNS have no public report command that accepts a scene, so mirror
+    # report_worst_slack / report_tns output using the scene-aware accessors. These only
+    # exist in builds carrying the scene timing model.
+    set has_scene_slack [expr { [info commands sta::worst_slack_scene] ne "" }]
+
+    # The scene is repeated in the file name, not just the directory, so reports gathered
+    # from several scenes into one place stay unique without renaming.
     foreach scene $scenes {
-        puts "report: reports/timing/$keys(-name).${scene}.rpt"
-        tee -quiet -file reports/timing/$keys(-name).${scene}.rpt \
-            "report_checks -sort_by_slack -fields $keys(-fields) -path_delay $keys(-delay) \
-            -format full_clock_expanded $scene_arg $scene"
-        puts "report: reports/timing/$keys(-name).topN.${scene}.rpt"
-        tee -quiet -file reports/timing/$keys(-name).topN.${scene}.rpt \
-            "report_checks -sort_by_slack -fields $keys(-fields) -path_delay $keys(-delay) \
+        set dir "reports/timing/scenarios/${scene}"
+        file mkdir $dir
+        set base "${dir}/$keys(-name).${scene}"
+
+        puts "report: ${base}.rpt"
+        tee -quiet -file ${base}.rpt \
+            "report_checks -sort_by_slack -fields $keys(-fields) $path_sel \
+            -format full_clock_expanded $full_extra $scene_arg $scene"
+
+        puts "report: ${base}.topN.rpt"
+        tee -quiet -file ${base}.topN.rpt \
+            "report_checks -sort_by_slack -fields $keys(-fields) $path_sel \
             -group_path_count $keys(-top_paths) $scene_arg $scene"
+
+        if { $unconstrained } {
+            continue
+        }
+
+        puts "report: ${base}.failing.rpt"
+        tee -quiet -file ${base}.failing.rpt \
+            "report_checks -sort_by_slack $path_sel -slack_max 0 -endpoint_path_count 1 \
+            -group_path_count $keys(-top_paths) -format short $scene_arg $scene"
+
+        puts "report: ${base}.endpoints.rpt"
+        tee -quiet -file ${base}.endpoints.rpt \
+            "report_checks -sort_by_slack $path_sel -endpoint_path_count 1 \
+            -group_path_count $keys(-top_paths) -format end $scene_arg $scene"
+
+        if { !$has_scene_slack } {
+            continue
+        }
+
+        set scene_obj [sta::find_scene $scene]
+        set scene_slack [sta::format_time \
+            [sta::worst_slack_scene $scene_obj $keys(-delay)] $sta_report_default_digits]
+        set scene_tns [sta::format_time \
+            [sta::total_negative_slack_scene_cmd $scene_obj $keys(-delay)] \
+            $sta_report_default_digits]
+
+        sc_write_report_line ${dir}/worst_slack.$keys(-name).${scene}.rpt \
+            "worst slack $keys(-delay) $scene_slack"
+        sc_write_report_line ${dir}/total_negative_slack.$keys(-name).${scene}.rpt \
+            "tns $keys(-delay) $scene_tns"
     }
 }
 

--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -1285,10 +1285,66 @@ proc sc_report_check_timing { } {
 }
 
 proc sc_write_report_line { file line } {
-    puts "report: $file"
     set fid [open $file w]
     puts $fid $line
     close $fid
+}
+
+proc sc_timing_scenes { } {
+    global sc_scenarios
+
+    if { [sc_has_sta_mcmm_support] } {
+        set scenes $sc_scenarios
+    } else {
+        set scenes []
+        foreach corner [sta::corners] {
+            lappend scenes [$corner name]
+        }
+    }
+
+    # A single scene would just duplicate the combined timing reports
+    if { [llength $scenes] <= 1 } {
+        return []
+    }
+
+    return $scenes
+}
+
+# Worst slack and TNS have no public report command that accepts a scene, so they are
+# mirrored from the scene-aware accessors, which only exist in builds carrying the scene
+# timing model.
+proc sc_has_scene_slack { } {
+    return [expr { [info commands sta::worst_slack_scene] ne "" }]
+}
+
+# The reports sc_report_scene_timing will write, so the section banner can name them all
+# up front instead of announcing them one by one after the combined output.
+proc sc_scene_timing_reports { args } {
+    sta::parse_key_args "sc_scene_timing_reports" args \
+        keys {-name} \
+        flags {-unconstrained}
+
+    set reports []
+    foreach scene [sc_timing_scenes] {
+        set dir "reports/timing/scenarios/${scene}"
+        set base "${dir}/$keys(-name).${scene}"
+
+        lappend reports ${base}.rpt ${base}.topN.rpt
+
+        if { [info exists flags(-unconstrained)] } {
+            continue
+        }
+
+        lappend reports ${base}.failing.rpt ${base}.endpoints.rpt
+
+        if { [sc_has_scene_slack] } {
+            lappend reports \
+                ${dir}/worst_slack.$keys(-name).${scene}.rpt \
+                ${dir}/total_negative_slack.$keys(-name).${scene}.rpt
+        }
+    }
+
+    return $reports
 }
 
 proc sc_report_scene_timing { args } {
@@ -1296,23 +1352,17 @@ proc sc_report_scene_timing { args } {
         keys {-delay -name -fields -top_paths} \
         flags {-unconstrained}
 
-    global sc_scenarios
     global sta_report_default_digits
 
-    if { [sc_has_sta_mcmm_support] } {
-        set scenes $sc_scenarios
-        set scene_arg "-scenes"
-    } else {
-        set scenes []
-        foreach corner [sta::corners] {
-            lappend scenes [$corner name]
-        }
-        set scene_arg "-corner"
+    set scenes [sc_timing_scenes]
+    if { [llength $scenes] == 0 } {
+        return
     }
 
-    # A single scene would just duplicate the combined timing reports
-    if { [llength $scenes] <= 1 } {
-        return
+    if { [sc_has_sta_mcmm_support] } {
+        set scene_arg "-scenes"
+    } else {
+        set scene_arg "-corner"
     }
 
     # Mirror the combined reports exactly, adding only the scene selector. Each scene gets
@@ -1327,11 +1377,6 @@ proc sc_report_scene_timing { args } {
         set full_extra ""
     }
 
-    # Worst slack and TNS have no public report command that accepts a scene, so mirror
-    # report_worst_slack / report_tns output using the scene-aware accessors. These only
-    # exist in builds carrying the scene timing model.
-    set has_scene_slack [expr { [info commands sta::worst_slack_scene] ne "" }]
-
     # The scene is repeated in the file name, not just the directory, so reports gathered
     # from several scenes into one place stay unique without renaming.
     foreach scene $scenes {
@@ -1339,12 +1384,10 @@ proc sc_report_scene_timing { args } {
         file mkdir $dir
         set base "${dir}/$keys(-name).${scene}"
 
-        puts "report: ${base}.rpt"
         tee -quiet -file ${base}.rpt \
             "report_checks -sort_by_slack -fields $keys(-fields) $path_sel \
             -format full_clock_expanded $full_extra $scene_arg $scene"
 
-        puts "report: ${base}.topN.rpt"
         tee -quiet -file ${base}.topN.rpt \
             "report_checks -sort_by_slack -fields $keys(-fields) $path_sel \
             -group_path_count $keys(-top_paths) $scene_arg $scene"
@@ -1353,17 +1396,15 @@ proc sc_report_scene_timing { args } {
             continue
         }
 
-        puts "report: ${base}.failing.rpt"
         tee -quiet -file ${base}.failing.rpt \
             "report_checks -sort_by_slack $path_sel -slack_max 0 -endpoint_path_count 1 \
             -group_path_count $keys(-top_paths) -format short $scene_arg $scene"
 
-        puts "report: ${base}.endpoints.rpt"
         tee -quiet -file ${base}.endpoints.rpt \
             "report_checks -sort_by_slack $path_sel -endpoint_path_count 1 \
             -group_path_count $keys(-top_paths) -format end $scene_arg $scene"
 
-        if { !$has_scene_slack } {
+        if { ![sc_has_scene_slack] } {
             continue
         }
 

--- a/siliconcompiler/tools/openroad/scripts/common/reports.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/reports.tcl
@@ -57,7 +57,7 @@ if { [sc_cfg_tool_task_check_in_list hold var reports] } {
         reports/timing/hold.endpoints.rpt \
         reports/timing/worst_slack.hold.rpt \
         reports/timing/total_negative_slack.hold.rpt
-    tee -quiet -file reports/timing/hold.rpt \
+    tee -file reports/timing/hold.rpt \
         "report_checks -sort_by_slack -fields $fields -path_delay min -format full_clock_expanded"
     tee -file reports/timing/hold.topN.rpt -quiet \
         "report_checks -sort_by_slack -fields $fields -path_delay min \
@@ -117,7 +117,7 @@ if {
 if { [sc_cfg_tool_task_check_in_list drv_violations var reports] } {
     sc_report_banner "DRV violators" \
         reports/checks/drv_violators.rpt
-    tee -quiet -file reports/checks/drv_violators.rpt \
+    tee -file reports/checks/drv_violators.rpt \
         "report_check_types -max_slew -max_capacitance -max_fanout -violators"
     report_erc_metrics
 }

--- a/siliconcompiler/tools/openroad/scripts/common/reports.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/reports.tcl
@@ -97,6 +97,9 @@ if { [sc_cfg_tool_task_check_in_list unconstrained var reports] } {
     tee -file reports/timing/unconstrained.topN.rpt -quiet \
         "report_checks -sort_by_slack -fields $fields -unconstrained \
         -group_path_count $sta_top_n_paths"
+
+    sc_report_scene_timing -unconstrained -name unconstrained \
+        -fields $fields -top_paths $sta_top_n_paths
 }
 
 if {

--- a/siliconcompiler/tools/openroad/scripts/common/reports.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/reports.tcl
@@ -12,13 +12,20 @@ if { [sc_cfg_tool_task_check_in_list scenarios var reports] } {
 }
 
 if { [sc_cfg_tool_task_check_in_list setup var reports] } {
-    sc_report_banner "Setup timing" \
+    set setup_histogram [expr { [sc_check_version 24 3 3932] && [llength [all_clocks]] > 0 }]
+    set setup_reports [list \
         reports/timing/setup.rpt \
         reports/timing/setup.topN.rpt \
         reports/timing/setup.failing.rpt \
         reports/timing/setup.endpoints.rpt \
         reports/timing/worst_slack.setup.rpt \
-        reports/timing/total_negative_slack.setup.rpt
+        reports/timing/total_negative_slack.setup.rpt]
+    if { $setup_histogram } {
+        lappend setup_reports reports/timing/setup.histogram.rpt
+    }
+    lappend setup_reports {*}[sc_scene_timing_reports -name setup]
+    sc_report_banner "Setup timing" {*}$setup_reports
+
     tee -file reports/timing/setup.rpt \
         "report_checks -sort_by_slack -fields $fields -path_delay max -format full_clock_expanded"
     tee -file reports/timing/setup.topN.rpt -quiet \
@@ -39,8 +46,7 @@ if { [sc_cfg_tool_task_check_in_list setup var reports] } {
         "report_tns"
     report_tns_metric -setup
 
-    if { [sc_check_version 24 3 3932] && [llength [all_clocks]] > 0 } {
-        puts "report: reports/timing/setup.histogram.rpt"
+    if { $setup_histogram } {
         tee -quiet -file reports/timing/setup.histogram.rpt \
             "report_timing_histogram -num_bins 20 -setup"
     }
@@ -50,13 +56,20 @@ if { [sc_cfg_tool_task_check_in_list setup var reports] } {
 }
 
 if { [sc_cfg_tool_task_check_in_list hold var reports] } {
-    sc_report_banner "Hold timing" \
+    set hold_histogram [expr { [sc_check_version 24 3 3932] && [llength [all_clocks]] > 0 }]
+    set hold_reports [list \
         reports/timing/hold.rpt \
         reports/timing/hold.topN.rpt \
         reports/timing/hold.failing.rpt \
         reports/timing/hold.endpoints.rpt \
         reports/timing/worst_slack.hold.rpt \
-        reports/timing/total_negative_slack.hold.rpt
+        reports/timing/total_negative_slack.hold.rpt]
+    if { $hold_histogram } {
+        lappend hold_reports reports/timing/hold.histogram.rpt
+    }
+    lappend hold_reports {*}[sc_scene_timing_reports -name hold]
+    sc_report_banner "Hold timing" {*}$hold_reports
+
     tee -file reports/timing/hold.rpt \
         "report_checks -sort_by_slack -fields $fields -path_delay min -format full_clock_expanded"
     tee -file reports/timing/hold.topN.rpt -quiet \
@@ -77,8 +90,7 @@ if { [sc_cfg_tool_task_check_in_list hold var reports] } {
         "report_tns -min"
     report_tns_metric -hold
 
-    if { [sc_check_version 24 3 3932] && [llength [all_clocks]] > 0 } {
-        puts "report: reports/timing/hold.histogram.rpt"
+    if { $hold_histogram } {
         tee -quiet -file reports/timing/hold.histogram.rpt \
             "report_timing_histogram -num_bins 20 -hold"
     }
@@ -88,9 +100,13 @@ if { [sc_cfg_tool_task_check_in_list hold var reports] } {
 }
 
 if { [sc_cfg_tool_task_check_in_list unconstrained var reports] } {
-    sc_report_banner "Unconstrained paths" \
+    set unconstrained_reports [list \
         reports/timing/unconstrained.rpt \
-        reports/timing/unconstrained.topN.rpt
+        reports/timing/unconstrained.topN.rpt]
+    lappend unconstrained_reports \
+        {*}[sc_scene_timing_reports -unconstrained -name unconstrained]
+    sc_report_banner "Unconstrained paths" {*}$unconstrained_reports
+
     tee -file reports/timing/unconstrained.rpt \
         "report_checks -sort_by_slack -fields $fields -unconstrained -format full_clock_expanded \
         -path_group unconstrained"

--- a/siliconcompiler/tools/opensta/scripts/sc_procs.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_procs.tcl
@@ -116,7 +116,7 @@ proc sc_report_corner_timing { args } {
             -format full_clock_expanded -corner $corner \
             > reports/timing/$keys(-name).${corner}.rpt
         puts "report: reports/timing/$keys(-name).topN.${corner}.rpt"
-        report_checks -sort_by_slack -path_delay $keys(-delay) \
+        report_checks -sort_by_slack -fields $keys(-fields) -path_delay $keys(-delay) \
             -group_path_count $keys(-top_paths) -corner $corner \
             > reports/timing/$keys(-name).topN.${corner}.rpt
     }

--- a/siliconcompiler/tools/opensta/scripts/sc_procs.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_procs.tcl
@@ -98,27 +98,91 @@ proc sc_report_check_timing { } {
     }
 }
 
+proc sc_write_report_line { file line } {
+    puts "report: $file"
+    set fid [open $file w]
+    puts $fid $line
+    close $fid
+}
+
 proc sc_report_corner_timing { args } {
     sta::parse_key_args "sc_report_corner_timing" args \
         keys {-delay -name -fields -top_paths} \
-        flags {}
+        flags {-unconstrained}
 
     global sc_scenarios
+    global sta_report_default_digits
 
     # A single corner would just duplicate the combined timing reports
     if { [llength $sc_scenarios] <= 1 } {
         return
     }
 
+    # Mirror the combined reports exactly, adding only the corner selector. Each corner gets
+    # its own directory, so the file names match their combined counterparts. Unconstrained
+    # paths have no failing/endpoints counterpart, so they stop after topN.
+    # $path_sel and $full_extra must be {*}-expanded: report_checks is invoked directly
+    # here, so an unexpanded "-path_delay max" would arrive as a single argument.
+    set unconstrained [info exists flags(-unconstrained)]
+    if { $unconstrained } {
+        set path_sel "-unconstrained"
+        set full_extra "-path_group unconstrained"
+    } else {
+        set path_sel "-path_delay $keys(-delay)"
+        set full_extra ""
+    }
+
+    # Worst slack and TNS have no public report command that accepts a corner, so mirror
+    # report_worst_slack / report_tns output using the scene-aware accessors. These only
+    # exist in builds carrying the scene timing model.
+    set has_scene_slack [expr { [info commands sta::worst_slack_scene] ne "" }]
+
+    # The corner is repeated in the file name, not just the directory, so reports gathered
+    # from several corners into one place stay unique without renaming.
     foreach corner $sc_scenarios {
-        puts "report: reports/timing/$keys(-name).${corner}.rpt"
-        report_checks -sort_by_slack -fields $keys(-fields) -path_delay $keys(-delay) \
-            -format full_clock_expanded -corner $corner \
-            > reports/timing/$keys(-name).${corner}.rpt
-        puts "report: reports/timing/$keys(-name).topN.${corner}.rpt"
-        report_checks -sort_by_slack -fields $keys(-fields) -path_delay $keys(-delay) \
+        set dir "reports/timing/scenarios/${corner}"
+        file mkdir $dir
+        set base "${dir}/$keys(-name).${corner}"
+
+        puts "report: ${base}.rpt"
+        report_checks -sort_by_slack -fields $keys(-fields) {*}$path_sel \
+            -format full_clock_expanded {*}$full_extra -corner $corner \
+            > ${base}.rpt
+
+        puts "report: ${base}.topN.rpt"
+        report_checks -sort_by_slack -fields $keys(-fields) {*}$path_sel \
             -group_path_count $keys(-top_paths) -corner $corner \
-            > reports/timing/$keys(-name).topN.${corner}.rpt
+            > ${base}.topN.rpt
+
+        if { $unconstrained } {
+            continue
+        }
+
+        puts "report: ${base}.failing.rpt"
+        report_checks -sort_by_slack {*}$path_sel -slack_max 0 -endpoint_path_count 1 \
+            -group_path_count $keys(-top_paths) -format short -corner $corner \
+            > ${base}.failing.rpt
+
+        puts "report: ${base}.endpoints.rpt"
+        report_checks -sort_by_slack {*}$path_sel -endpoint_path_count 1 \
+            -group_path_count $keys(-top_paths) -format end -corner $corner \
+            > ${base}.endpoints.rpt
+
+        if { !$has_scene_slack } {
+            continue
+        }
+
+        set scene_obj [sta::find_scene $corner]
+        set scene_slack [sta::format_time \
+            [sta::worst_slack_scene $scene_obj $keys(-delay)] $sta_report_default_digits]
+        set scene_tns [sta::format_time \
+            [sta::total_negative_slack_scene_cmd $scene_obj $keys(-delay)] \
+            $sta_report_default_digits]
+
+        sc_write_report_line ${dir}/worst_slack.$keys(-name).${corner}.rpt \
+            "worst slack $keys(-delay) $scene_slack"
+        sc_write_report_line ${dir}/total_negative_slack.$keys(-name).${corner}.rpt \
+            "tns $keys(-delay) $scene_tns"
     }
 }
 

--- a/siliconcompiler/tools/opensta/scripts/sc_procs.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_procs.tcl
@@ -99,10 +99,57 @@ proc sc_report_check_timing { } {
 }
 
 proc sc_write_report_line { file line } {
-    puts "report: $file"
     set fid [open $file w]
     puts $fid $line
     close $fid
+}
+
+proc sc_timing_corners { } {
+    global sc_scenarios
+
+    # A single corner would just duplicate the combined timing reports
+    if { [llength $sc_scenarios] <= 1 } {
+        return []
+    }
+
+    return $sc_scenarios
+}
+
+# Worst slack and TNS have no public report command that accepts a corner, so they are
+# mirrored from the scene-aware accessors, which only exist in builds carrying the scene
+# timing model.
+proc sc_has_scene_slack { } {
+    return [expr { [info commands sta::worst_slack_scene] ne "" }]
+}
+
+# The reports sc_report_corner_timing will write, so the section banner can name them all
+# up front instead of announcing them one by one after the combined output.
+proc sc_corner_timing_reports { args } {
+    sta::parse_key_args "sc_corner_timing_reports" args \
+        keys {-name} \
+        flags {-unconstrained}
+
+    set reports []
+    foreach corner [sc_timing_corners] {
+        set dir "reports/timing/scenarios/${corner}"
+        set base "${dir}/$keys(-name).${corner}"
+
+        lappend reports ${base}.rpt ${base}.topN.rpt
+
+        if { [info exists flags(-unconstrained)] } {
+            continue
+        }
+
+        lappend reports ${base}.failing.rpt ${base}.endpoints.rpt
+
+        if { [sc_has_scene_slack] } {
+            lappend reports \
+                ${dir}/worst_slack.$keys(-name).${corner}.rpt \
+                ${dir}/total_negative_slack.$keys(-name).${corner}.rpt
+        }
+    }
+
+    return $reports
 }
 
 proc sc_report_corner_timing { args } {
@@ -110,11 +157,10 @@ proc sc_report_corner_timing { args } {
         keys {-delay -name -fields -top_paths} \
         flags {-unconstrained}
 
-    global sc_scenarios
     global sta_report_default_digits
 
-    # A single corner would just duplicate the combined timing reports
-    if { [llength $sc_scenarios] <= 1 } {
+    set corners [sc_timing_corners]
+    if { [llength $corners] == 0 } {
         return
     }
 
@@ -132,24 +178,17 @@ proc sc_report_corner_timing { args } {
         set full_extra ""
     }
 
-    # Worst slack and TNS have no public report command that accepts a corner, so mirror
-    # report_worst_slack / report_tns output using the scene-aware accessors. These only
-    # exist in builds carrying the scene timing model.
-    set has_scene_slack [expr { [info commands sta::worst_slack_scene] ne "" }]
-
     # The corner is repeated in the file name, not just the directory, so reports gathered
     # from several corners into one place stay unique without renaming.
-    foreach corner $sc_scenarios {
+    foreach corner $corners {
         set dir "reports/timing/scenarios/${corner}"
         file mkdir $dir
         set base "${dir}/$keys(-name).${corner}"
 
-        puts "report: ${base}.rpt"
         report_checks -sort_by_slack -fields $keys(-fields) {*}$path_sel \
             -format full_clock_expanded {*}$full_extra -corner $corner \
             > ${base}.rpt
 
-        puts "report: ${base}.topN.rpt"
         report_checks -sort_by_slack -fields $keys(-fields) {*}$path_sel \
             -group_path_count $keys(-top_paths) -corner $corner \
             > ${base}.topN.rpt
@@ -158,17 +197,15 @@ proc sc_report_corner_timing { args } {
             continue
         }
 
-        puts "report: ${base}.failing.rpt"
         report_checks -sort_by_slack {*}$path_sel -slack_max 0 -endpoint_path_count 1 \
             -group_path_count $keys(-top_paths) -format short -corner $corner \
             > ${base}.failing.rpt
 
-        puts "report: ${base}.endpoints.rpt"
         report_checks -sort_by_slack {*}$path_sel -endpoint_path_count 1 \
             -group_path_count $keys(-top_paths) -format end -corner $corner \
             > ${base}.endpoints.rpt
 
-        if { !$has_scene_slack } {
+        if { ![sc_has_scene_slack] } {
             continue
         }
 

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -325,7 +325,8 @@ if { [sc_cfg_tool_task_check_in_list setup var reports] } {
         -format full_clock_expanded \
         > reports/timing/setup.rpt
     sc_display_report reports/timing/setup.rpt
-    report_checks -sort_by_slack -path_delay max -group_path_count $opensta_top_n_paths \
+    report_checks -sort_by_slack -fields $fields -path_delay max \
+        -group_path_count $opensta_top_n_paths \
         > reports/timing/setup.topN.rpt
     report_checks -sort_by_slack -path_delay max -slack_max 0 -endpoint_path_count 1 \
         -group_path_count $opensta_top_n_paths -format short \
@@ -361,7 +362,8 @@ if { [sc_cfg_tool_task_check_in_list hold var reports] } {
         -format full_clock_expanded \
         > reports/timing/hold.rpt
     sc_display_report reports/timing/hold.rpt
-    report_checks -sort_by_slack -path_delay min -group_path_count $opensta_top_n_paths \
+    report_checks -sort_by_slack -fields $fields -path_delay min \
+        -group_path_count $opensta_top_n_paths \
         > reports/timing/hold.topN.rpt
     report_checks -sort_by_slack -path_delay min -slack_max 0 -endpoint_path_count 1 \
         -group_path_count $opensta_top_n_paths -format short \
@@ -392,7 +394,8 @@ if { [sc_cfg_tool_task_check_in_list unconstrained var reports] } {
         -format full_clock_expanded \
         -path_group unconstrained > reports/timing/unconstrained.rpt
     sc_display_report reports/timing/unconstrained.rpt
-    report_checks -sort_by_slack -unconstrained -group_path_count $opensta_top_n_paths \
+    report_checks -sort_by_slack -fields $fields -unconstrained \
+        -group_path_count $opensta_top_n_paths \
         > reports/timing/unconstrained.topN.rpt
 }
 

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -360,6 +360,7 @@ if { [sc_cfg_tool_task_check_in_list hold var reports] } {
     report_checks -sort_by_slack -fields $fields -path_delay min \
         -format full_clock_expanded \
         > reports/timing/hold.rpt
+    sc_display_report reports/timing/hold.rpt
     report_checks -sort_by_slack -path_delay min -group_path_count $opensta_top_n_paths \
         > reports/timing/hold.topN.rpt
     report_checks -sort_by_slack -path_delay min -slack_max 0 -endpoint_path_count 1 \
@@ -380,7 +381,7 @@ if { [sc_cfg_tool_task_check_in_list hold var reports] } {
 
     puts "$PREFIX holdtns"
     report_tns -min > reports/timing/total_negative_slack.hold.rpt
-    puts "tns [sta::time_sta_ui [sta::total_negative_slack_cmd min]]"
+    sc_display_report reports/timing/total_negative_slack.hold.rpt
 }
 
 if { [sc_cfg_tool_task_check_in_list unconstrained var reports] } {
@@ -416,6 +417,7 @@ if { [sc_cfg_tool_task_check_in_list drv_violations var reports] } {
     puts "$PREFIX drvs"
     report_check_types -max_slew -max_capacitance -max_fanout -violators -no_line_splits \
         > reports/checks/drv_violators.rpt
+    sc_display_report reports/checks/drv_violators.rpt
 }
 
 if { [sc_cfg_tool_task_check_in_list fmax var reports] } {

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -316,13 +316,16 @@ if { [sc_cfg_tool_task_check_in_list check_setup var reports] } {
 }
 
 if { [sc_cfg_tool_task_check_in_list setup var reports] } {
-    sc_report_banner "Setup timing" \
+    set setup_reports [list \
         reports/timing/setup.rpt \
         reports/timing/setup.topN.rpt \
         reports/timing/setup.failing.rpt \
         reports/timing/setup.endpoints.rpt \
         reports/timing/worst_slack.setup.rpt \
-        reports/timing/total_negative_slack.setup.rpt
+        reports/timing/total_negative_slack.setup.rpt]
+    lappend setup_reports {*}[sc_corner_timing_reports -name setup]
+    sc_report_banner "Setup timing" {*}$setup_reports
+
     puts "$PREFIX report_checks -path_delay max"
     report_checks -sort_by_slack -fields $fields -path_delay max \
         -format full_clock_expanded \
@@ -353,13 +356,16 @@ if { [sc_cfg_tool_task_check_in_list setup var reports] } {
 }
 
 if { [sc_cfg_tool_task_check_in_list hold var reports] } {
-    sc_report_banner "Hold timing" \
+    set hold_reports [list \
         reports/timing/hold.rpt \
         reports/timing/hold.topN.rpt \
         reports/timing/hold.failing.rpt \
         reports/timing/hold.endpoints.rpt \
         reports/timing/worst_slack.hold.rpt \
-        reports/timing/total_negative_slack.hold.rpt
+        reports/timing/total_negative_slack.hold.rpt]
+    lappend hold_reports {*}[sc_corner_timing_reports -name hold]
+    sc_report_banner "Hold timing" {*}$hold_reports
+
     puts "$PREFIX report_checks -path_delay min"
     report_checks -sort_by_slack -fields $fields -path_delay min \
         -format full_clock_expanded \
@@ -390,9 +396,13 @@ if { [sc_cfg_tool_task_check_in_list hold var reports] } {
 }
 
 if { [sc_cfg_tool_task_check_in_list unconstrained var reports] } {
-    sc_report_banner "Unconstrained paths" \
+    set unconstrained_reports [list \
         reports/timing/unconstrained.rpt \
-        reports/timing/unconstrained.topN.rpt
+        reports/timing/unconstrained.topN.rpt]
+    lappend unconstrained_reports \
+        {*}[sc_corner_timing_reports -unconstrained -name unconstrained]
+    sc_report_banner "Unconstrained paths" {*}$unconstrained_reports
+
     report_checks -sort_by_slack -fields $fields -unconstrained \
         -format full_clock_expanded \
         -path_group unconstrained > reports/timing/unconstrained.rpt

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -400,6 +400,8 @@ if { [sc_cfg_tool_task_check_in_list unconstrained var reports] } {
     report_checks -sort_by_slack -fields $fields -unconstrained \
         -group_path_count $opensta_top_n_paths \
         > reports/timing/unconstrained.topN.rpt
+    sc_report_corner_timing -unconstrained -name unconstrained \
+        -fields $fields -top_paths $opensta_top_n_paths
 }
 
 if {

--- a/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
+++ b/siliconcompiler/tools/opensta/scripts/sc_timing.tcl
@@ -296,7 +296,10 @@ file mkdir \
 
 set opensta_top_n_paths [sc_cfg_tool_task_get var top_n_paths]
 
-set fields "{capacitance slew input_pins hierarcial_pins net fanout}"
+# Must be a flat list: report_checks is invoked directly here, so the value reaches
+# parse_report_path_options as-is. The braced-string form used by the OpenROAD scripts
+# only works there because tee re-evaluates the command string.
+set fields {capacitance slew input_pins hierarcial_pins net fanout}
 set PREFIX "SC_METRIC:"
 
 puts "$PREFIX timeunit"

--- a/siliconcompiler/tools/opensta/timing.py
+++ b/siliconcompiler/tools/opensta/timing.py
@@ -357,33 +357,47 @@ class TimingTaskBase(OpenSTATask):
     def __report_map(self, metric):
         corners = self.project.getkeys('constraint', 'timing', 'scenario')
         power_reports = [f"reports/power/{corner}.rpt" for corner in corners]
+
+        def scenario_reports(name, unconstrained=False):
+            # Per-corner reports, written only when more than one corner is defined
+            variants = ("", "topN.") if unconstrained else ("", "topN.", "failing.", "endpoints.")
+            return [f"reports/timing/scenarios/{corner}/{name}.{corner}.{variant}rpt"
+                    for corner in corners
+                    for variant in variants]
+
+        def scenario_files(name):
+            # A single per-corner report, e.g. worst_slack.setup
+            return [f"reports/timing/scenarios/{corner}/{name}.{corner}.rpt"
+                    for corner in corners]
+
         setup_reports = [
             "reports/timing/setup.rpt",
             "reports/timing/setup.topN.rpt",
             "reports/timing/setup.failing.rpt",
             "reports/timing/setup.endpoints.rpt",
-            *[f"reports/timing/setup.{corner}.rpt" for corner in corners],
-            *[f"reports/timing/setup.topN.{corner}.rpt" for corner in corners]
+            *scenario_reports("setup")
         ]
         hold_reports = [
             "reports/timing/hold.rpt",
             "reports/timing/hold.topN.rpt",
             "reports/timing/hold.failing.rpt",
             "reports/timing/hold.endpoints.rpt",
-            *[f"reports/timing/hold.{corner}.rpt" for corner in corners],
-            *[f"reports/timing/hold.topN.{corner}.rpt" for corner in corners]
+            *scenario_reports("hold")
         ]
         mapping = {
             "peakpower": power_reports,
             "leakagepower": power_reports,
             "unconstrained": ["reports/timing/unconstrained.rpt",
-                              "reports/timing/unconstrained.topN.rpt"],
+                              "reports/timing/unconstrained.topN.rpt",
+                              *scenario_reports("unconstrained", unconstrained=True)],
             "setuppaths": setup_reports,
             "holdpaths": hold_reports,
-            "holdslack": hold_reports,
-            "setupslack": setup_reports,
-            "setuptns": ["reports/timing/total_negative_slack.setup.rpt", *setup_reports],
-            "holdtns": ["reports/timing/total_negative_slack.hold.rpt", *hold_reports],
+            "holdslack": [*hold_reports, *scenario_files("worst_slack.hold")],
+            "setupslack": [*setup_reports, *scenario_files("worst_slack.setup")],
+            "setuptns": ["reports/timing/total_negative_slack.setup.rpt", *setup_reports,
+                         *scenario_files("total_negative_slack.setup")],
+            "holdtns": ["reports/timing/total_negative_slack.hold.rpt", *hold_reports,
+                        *scenario_files("total_negative_slack.hold")],
             "setupskew": ["reports/clocks/skew.setup.rpt", *setup_reports],
             "holdskew": ["reports/clocks/skew.hold.rpt", *hold_reports],
             "fmax": ["reports/clocks/fmax.rpt"],

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -113,6 +113,52 @@ def test_metrics_task(asic_gcd):
     assert asic_gcd.history("job0").get('metric', 'totalarea', step='metrics', index='0') is not \
         None
 
+    # A single scenario duplicates the combined reports, so none are written
+    assert not os.path.exists(os.path.join(
+        workdir(asic_gcd, step="metrics", index="0"), "reports", "timing", "scenarios"))
+
+
+@pytest.mark.eda
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_metrics_task_scenario_reports(asic_gcd):
+    '''Per-scene timing reports are only written when more than one scene exists.'''
+    # freepdk45_demo defines only "typical"; add a second scenario so the
+    # per-scene reports are generated.
+    scenario = asic_gcd.constraint.timing.make_scenario("extra")
+    scenario.add_libcorner(["typical", "generic"])
+    scenario.set_pexcorner("typical")
+    scenario.add_check(["setup", "hold"])
+
+    flow = ASICFlow("testflow")
+    flow.node("metrics", metrics.MetricsTask())
+    flow.edge('floorplan.init', 'metrics')
+
+    asic_gcd.set_flow(flow)
+    asic_gcd.set('option', 'to', 'metrics')
+    assert asic_gcd.run()
+
+    reports = os.path.join(
+        workdir(asic_gcd, step="metrics", index="0"), "reports", "timing", "scenarios")
+    # One directory per scene, each holding the same report set. The scene is repeated in
+    # the file name so the reports stay unique if gathered into one place.
+    assert set(os.listdir(reports)) == {"typical", "extra"}
+    for scene in ("typical", "extra"):
+        expected = set()
+        for delay in ("setup", "hold"):
+            for variant in ("", "topN.", "failing.", "endpoints."):
+                expected.add(f"{delay}.{scene}.{variant}rpt")
+            expected.add(f"worst_slack.{delay}.{scene}.rpt")
+            expected.add(f"total_negative_slack.{delay}.{scene}.rpt")
+        for variant in ("", "topN."):
+            expected.add(f"unconstrained.{scene}.{variant}rpt")
+
+        scene_dir = os.path.join(reports, scene)
+        assert set(os.listdir(scene_dir)) == expected
+
+        for report in expected:
+            assert os.path.getsize(os.path.join(scene_dir, report)) > 0, f"{scene}/{report}"
+
 
 @pytest.mark.eda
 @pytest.mark.quick

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -159,6 +159,21 @@ def test_metrics_task_scenario_reports(asic_gcd):
         for report in expected:
             assert os.path.getsize(os.path.join(scene_dir, report)) > 0, f"{scene}/{report}"
 
+    # The section banner must name every per-scene report that gets written, so the log
+    # section stays one block instead of announcing files after the combined output.
+    written = set()
+    for scene in os.listdir(reports):
+        for report in os.listdir(os.path.join(reports, scene)):
+            written.add(f"reports/timing/scenarios/{scene}/{report}")
+
+    logfile = os.path.join(workdir(asic_gcd, step="metrics", index="0"), "metrics.log")
+    prefix = "== report: reports/timing/scenarios/"
+    with open(logfile) as f:
+        announced = {line.strip()[len("== report: "):] for line in f
+                     if line.startswith(prefix)}
+
+    assert announced == written
+
 
 @pytest.mark.eda
 @pytest.mark.quick

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -169,10 +169,12 @@ def test_metrics_task_scenario_reports(asic_gcd):
     logfile = os.path.join(workdir(asic_gcd, step="metrics", index="0"), "metrics.log")
     prefix = "== report: reports/timing/scenarios/"
     with open(logfile) as f:
-        announced = {line.strip()[len("== report: "):] for line in f
-                     if line.startswith(prefix)}
+        announced = [line.strip()[len("== report: "):] for line in f
+                     if line.startswith(prefix)]
 
-    assert announced == written
+    # Kept as a list so a report announced twice is caught rather than deduplicated away
+    assert len(announced) == len(set(announced))
+    assert set(announced) == written
 
 
 @pytest.mark.eda

--- a/tests/tools/test_opensta.py
+++ b/tests/tools/test_opensta.py
@@ -112,6 +112,21 @@ def test_opensta_scenario_reports(datadir):
         for report in expected:
             assert os.path.getsize(os.path.join(corner_dir, report)) > 0, f"{corner}/{report}"
 
+    # The section banner must name every per-corner report that gets written, so the log
+    # section stays one block instead of announcing files after the combined output.
+    written = set()
+    for corner in os.listdir(reports):
+        for report in os.listdir(os.path.join(reports, corner)):
+            written.add(f"reports/timing/scenarios/{corner}/{report}")
+
+    logfile = os.path.join("build", "testdesign", "job0", "opensta", "0", "opensta.log")
+    prefix = "== report: reports/timing/scenarios/"
+    with open(logfile) as f:
+        announced = {line.strip()[len("== report: "):] for line in f
+                     if line.startswith(prefix)}
+
+    assert announced == written
+
     # Metrics are still recorded, and now cite the per-scenario reports
     assert proj.history("job0").get('metric', 'setupslack', step='opensta', index='0') == -0.220
     assert proj.history("job0").get('metric', 'holdslack', step='opensta', index='0') == 0.050

--- a/tests/tools/test_opensta.py
+++ b/tests/tools/test_opensta.py
@@ -122,10 +122,12 @@ def test_opensta_scenario_reports(datadir):
     logfile = os.path.join("build", "testdesign", "job0", "opensta", "0", "opensta.log")
     prefix = "== report: reports/timing/scenarios/"
     with open(logfile) as f:
-        announced = {line.strip()[len("== report: "):] for line in f
-                     if line.startswith(prefix)}
+        announced = [line.strip()[len("== report: "):] for line in f
+                     if line.startswith(prefix)]
 
-    assert announced == written
+    # Kept as a list so a report announced twice is caught rather than deduplicated away
+    assert len(announced) == len(set(announced))
+    assert set(announced) == written
 
     # Metrics are still recorded, and now cite the per-scenario reports
     assert proj.history("job0").get('metric', 'setupslack', step='opensta', index='0') == -0.220

--- a/tests/tools/test_opensta.py
+++ b/tests/tools/test_opensta.py
@@ -55,6 +55,67 @@ def test_opensta(datadir):
     assert proj.history("job0").get('metric', 'setupslack', step='opensta', index='0') == -0.220
     assert proj.history("job0").get('metric', 'holdslack', step='opensta', index='0') == 0.050
 
+    # A single scenario duplicates the combined reports, so none are written
+    assert not os.path.exists(
+        os.path.join("build", "testdesign", "job0", "opensta", "0",
+                     "reports", "timing", "scenarios"))
+
+
+@pytest.mark.eda
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_opensta_scenario_reports(datadir):
+    '''Per-scenario timing reports are only written when more than one scenario exists.'''
+    design = Design("testdesign")
+    design.set_dataroot("root", datadir)
+    with design.active_dataroot("root"), design.active_fileset("rtl"):
+        design.set_topmodule("foo")
+        design.add_file(os.path.join("lec", "foo.vg"))
+    with design.active_dataroot("root"), design.active_fileset("sdc"):
+        design.add_file(os.path.join("lec", "foo.sdc"))
+    proj = ASIC(design)
+    proj.add_fileset(["rtl", "sdc"])
+    freepdk45_demo(proj)
+
+    # freepdk45_demo defines only "typical"; add a second scenario so the
+    # per-scenario reports are generated.
+    scenario = proj.constraint.timing.make_scenario("extra")
+    scenario.add_libcorner(["typical", "generic"])
+    scenario.set_pexcorner("typical")
+    scenario.add_check(["setup", "hold"])
+
+    flow = Flowgraph("timing")
+    flow.node("opensta", timing.TimingTask())
+    proj.set_flow(flow)
+
+    assert proj.run()
+
+    reports = os.path.join("build", "testdesign", "job0", "opensta", "0",
+                           "reports", "timing", "scenarios")
+    # One directory per corner, each holding the same report set. The corner is repeated in
+    # the file name so the reports stay unique if gathered into one place.
+    assert set(os.listdir(reports)) == {"typical", "extra"}
+    for corner in ("typical", "extra"):
+        expected = set()
+        for delay in ("setup", "hold"):
+            for variant in ("", "topN.", "failing.", "endpoints."):
+                expected.add(f"{delay}.{corner}.{variant}rpt")
+            expected.add(f"worst_slack.{delay}.{corner}.rpt")
+            expected.add(f"total_negative_slack.{delay}.{corner}.rpt")
+        for variant in ("", "topN."):
+            expected.add(f"unconstrained.{corner}.{variant}rpt")
+
+        corner_dir = os.path.join(reports, corner)
+        assert set(os.listdir(corner_dir)) == expected
+
+        # The reports must have content, not just exist
+        for report in expected:
+            assert os.path.getsize(os.path.join(corner_dir, report)) > 0, f"{corner}/{report}"
+
+    # Metrics are still recorded, and now cite the per-scenario reports
+    assert proj.history("job0").get('metric', 'setupslack', step='opensta', index='0') == -0.220
+    assert proj.history("job0").get('metric', 'holdslack', step='opensta', index='0') == 0.050
+
 
 @pytest.mark.eda
 @pytest.mark.quick


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timing reports organized by scenario or corner for setup, hold, and unconstrained paths.
  * Added detailed reports for failing paths, endpoints, worst slack, and total negative slack where supported.
  * Preserved aggregate timing reports alongside scenario-specific results.
* **Bug Fixes**
  * Improved timing metric collection and report discovery across multi-scenario analyses.
  * Avoided creating redundant scenario reports for single-scenario runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->