### PR TITLE
Fix race in concurrent resolver population

### DIFF
--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -50,6 +50,28 @@ _TAR_FILTER_ERRORS: Tuple[Type[BaseException], ...] = \
     (tarfile.FilterError,) if hasattr(tarfile, "FilterError") else ()
 
 
+#: Registry key marking resolver population as *complete*, written only once
+#: every scheme is in place.
+#:
+#: The registry cannot use "the category is non-empty" as its populated test:
+#: the category becomes non-empty on the very first write, so a caller could
+#: return early believing the registry was ready and then fail to find a scheme
+#: that had not been registered yet. The remote schemes (``https``, ``git``,
+#: ``github``, ``scp``) are registered last and so had the widest exposure,
+#: which is why an ordinary GitHub tarball could be reported as an unsupported
+#: URI while a ``file://`` path never was.
+#:
+#: Other threads are kept out by holding the category (see
+#: :meth:`~siliconcompiler.utils.settings.SettingsManager.lock_category`), but
+#: the marker is what a *forked child* has to go on: it inherits whatever the
+#: registry held at the instant of the fork, with no lock left to wait on.
+#:
+#: The leading underscores keep the marker out of the scheme namespace:
+#: :func:`urllib.parse.urlparse` only recognises a scheme that starts with a
+#: letter, so no source URI can ever resolve to this key.
+_RESOLVERS_POPULATED: str = "__populated__"
+
+
 class Resolver:
     """
     Abstract base class for all data source resolvers.
@@ -96,26 +118,37 @@ class Resolver:
         built-in resolvers (file, key, python, http, git, github, scp) and any
         resolvers provided by external plugins. Built-ins are registered first,
         so a plugin claiming the same scheme takes precedence.
+
+        Population is atomic. Several threads reach here at once whenever a
+        process resolves data sources in parallel, so the registry is held for
+        the length of the build and a thread that arrives mid-population waits
+        rather than looking up a scheme that is registered but not yet written
+        (see :data:`_RESOLVERS_POPULATED`).
         """
         # Imported here because each of these modules imports RemoteResolver from
         # this module.
         from siliconcompiler.package import git, github, https, scp
 
         settings = MPManager().get_transient_settings()
-        if settings.get_category("resolvers"):
-            # Already populated
-            return
+        with settings.lock_category("resolvers"):
+            if settings.get("resolvers", _RESOLVERS_POPULATED, False):
+                # Already populated
+                return
 
-        settings.set("resolvers", "", FileResolver)
-        settings.set("resolvers", "file", FileResolver)
-        settings.set("resolvers", "key", KeyPathResolver)
-        settings.set("resolvers", "python", PythonPathResolver)
-        settings.set("resolvers", "dataroot", DatarootResolver)
+            settings.set("resolvers", "", FileResolver)
+            settings.set("resolvers", "file", FileResolver)
+            settings.set("resolvers", "key", KeyPathResolver)
+            settings.set("resolvers", "python", PythonPathResolver)
+            settings.set("resolvers", "dataroot", DatarootResolver)
 
-        builtins = (https.get_resolver, git.get_resolver, github.get_resolver, scp.get_resolver)
-        for resolver in (*builtins, *get_plugins("path_resolver")):
-            for scheme, res in resolver().items():
-                settings.set("resolvers", scheme, res)
+            builtins = (https.get_resolver, git.get_resolver, github.get_resolver,
+                        scp.get_resolver)
+            for resolver in (*builtins, *get_plugins("path_resolver")):
+                for scheme, res in resolver().items():
+                    settings.set("resolvers", scheme, res)
+
+            # Written last, once the registry above is complete.
+            settings.set("resolvers", _RESOLVERS_POPULATED, True)
 
     @staticmethod
     def find_resolver(source: str) -> Type["Resolver"]:

--- a/siliconcompiler/utils/settings.py
+++ b/siliconcompiler/utils/settings.py
@@ -1,15 +1,46 @@
+import contextlib
 import json
 import os
 import logging
 import threading
+import weakref
 
 import os.path
 
-from typing import Optional
+from typing import Generator, Optional
 
 from fasteners import InterProcessLock
 
 from siliconcompiler import sc_open
+
+
+#: Every live SettingsManager, so a forked child can rebuild their locks.
+_managers: "weakref.WeakSet[SettingsManager]" = weakref.WeakSet()
+
+
+def _reset_locks_after_fork() -> None:
+    """
+    Rebuilds every manager's locks in a freshly forked child.
+
+    A child inherits each lock in the state it had at the instant of the fork,
+    and a lock held by a thread that does not exist in the child is never
+    released. SiliconCompiler forks its scheduler workers (see
+    :func:`~siliconcompiler.utils.multiprocessing.get_process_context`) out of a
+    process that may well have another thread inside
+    :meth:`SettingsManager.lock_category` at the time.
+
+    Discarding the locks is safe precisely because the child has one thread: no
+    update can be in progress in it. What the child *may* have inherited is a
+    category left half-written by the parent, which is why a category built in
+    steps needs a completion marker rather than a lock alone -- see
+    :meth:`SettingsManager.lock_category`.
+    """
+    for manager in list(_managers):
+        manager._reset_locks()
+
+
+if hasattr(os, "register_at_fork"):  # absent on Windows, which has no fork
+    os.register_at_fork(after_in_child=_reset_locks_after_fork)
 
 
 class SettingsManager:
@@ -68,7 +99,15 @@ class SettingsManager:
         self.__filepath = filepath
         if self.__filepath is not None:
             self.__lock = InterProcessLock(self.__filepath + ".lock")
+        # Two levels of lock, always taken category-first: a category lock is
+        # held for as long as a caller is building that category (see
+        # lock_category), while __settings_lock is held only for the dict
+        # operations themselves. Whole-file work (_load, save) takes just
+        # __settings_lock, so there is no cycle to deadlock on.
         self.__settings_lock = threading.Lock()
+        self.__category_locks = {}
+        self.__category_locks_lock = threading.Lock()
+        _managers.add(self)
         self.__timeout = timeout
         self.__logger = logger.getChild("settings")
         self.__settings = {}
@@ -205,6 +244,53 @@ class SettingsManager:
         """
         return key in self.__priority.get(category, ())
 
+    def _reset_locks(self) -> None:
+        """
+        Replaces every lock with a fresh one. See :func:`_reset_locks_after_fork`.
+        """
+        self.__settings_lock = threading.Lock()
+        self.__category_locks = {}
+        self.__category_locks_lock = threading.Lock()
+
+    def _category_lock(self, category: str) -> threading.RLock:
+        """
+        Return the lock guarding one category, creating it on first use.
+
+        Re-entrant by design: every accessor takes this lock, so the thread
+        holding a category open under :meth:`lock_category` has to be able to
+        take it again to do the work it opened the category for.
+        """
+        with self.__category_locks_lock:
+            if category not in self.__category_locks:
+                self.__category_locks[category] = threading.RLock()
+            return self.__category_locks[category]
+
+    @contextlib.contextmanager
+    def lock_category(self, category: str) -> Generator[None, None, None]:
+        """
+        Hold a category for the length of a multi-step update.
+
+        A category assembled one :meth:`set` at a time is readable while it is
+        still being assembled: another thread sees the keys written so far and
+        has nothing to tell it the rest is still coming. Hold the category while
+        writing it and every other thread's access to *that* category waits for
+        the release. Other categories are unaffected, and the holder's own
+        :meth:`get`, :meth:`set` and :meth:`delete` calls run normally -- the
+        lock excludes other threads, not the one doing the work.
+
+        Note this is a lock, not a completion record, and the two are not the
+        same thing across a ``fork``: a child forked mid-update inherits the
+        half-written category with nothing held (see
+        :func:`_reset_locks_after_fork`). A category built in steps should
+        therefore still write a marker key last and test *that*, rather than
+        reading "the category is non-empty" as "the category is finished".
+
+        Args:
+            category (str): The group name to hold.
+        """
+        with self._category_lock(category):
+            yield
+
     def save(self):
         """
         Save the current settings to the disk in JSON format.
@@ -241,13 +327,14 @@ class SettingsManager:
                                   "overridden. Ignoring.")
             return
 
-        with self.__settings_lock:
-            if category not in self.__settings:
-                self.__settings[category] = {}
+        with self._category_lock(category):
+            with self.__settings_lock:
+                if category not in self.__settings:
+                    self.__settings[category] = {}
 
-            if keep and key in self.__settings[category]:
-                return
-            self.__settings[category][key] = value
+                if keep and key in self.__settings[category]:
+                    return
+                self.__settings[category][key] = value
 
     def get(self, category: str, key: str, default=None):
         """
@@ -270,14 +357,15 @@ class SettingsManager:
         Returns:
             The stored value or the default.
         """
-        with self.__settings_lock:
-            if self._has_priority(category, key):
+        with self._category_lock(category):
+            with self.__settings_lock:
+                if self._has_priority(category, key):
+                    return self.__system_settings.get(category, {}).get(key, default)
+
+                if category in self.__settings and key in self.__settings[category]:
+                    return self.__settings[category][key]
+
                 return self.__system_settings.get(category, {}).get(key, default)
-
-            if category in self.__settings and key in self.__settings[category]:
-                return self.__settings[category][key]
-
-            return self.__system_settings.get(category, {}).get(key, default)
 
     def get_category(self, category: str):
         """
@@ -289,8 +377,9 @@ class SettingsManager:
         the system file does not define them). Returns an empty dict if the
         category exists in neither layer.
         """
-        with self.__settings_lock:
-            return self._merge_category(category)
+        with self._category_lock(category):
+            with self.__settings_lock:
+                return self._merge_category(category)
 
     def _merge_category(self, category: str):
         """
@@ -324,13 +413,14 @@ class SettingsManager:
                                   "removed. Ignoring.")
             return
 
-        with self.__settings_lock:
-            if category in self.__settings:
-                if key:
-                    if key in self.__settings[category]:
-                        del self.__settings[category][key]
-                        # Clean up empty categories
-                        if not self.__settings[category]:
-                            del self.__settings[category]
-                else:
-                    del self.__settings[category]
+        with self._category_lock(category):
+            with self.__settings_lock:
+                if category in self.__settings:
+                    if key:
+                        if key in self.__settings[category]:
+                            del self.__settings[category][key]
+                            # Clean up empty categories
+                            if not self.__settings[category]:
+                                del self.__settings[category]
+                    else:
+                        del self.__settings[category]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import re
 import platform
 import psutil
 import shutil
+import signal
 import socket
 import subprocess
 import sys
@@ -21,7 +22,7 @@ from pathlib import Path
 from pyvirtualdisplay import Display
 from unittest.mock import patch
 
-from typing import Optional
+from typing import Optional, Tuple
 
 from siliconcompiler import utils, ASIC, Design, Project
 from siliconcompiler.tools.openroad._apr import APRTask
@@ -292,6 +293,38 @@ def fake_plugins(monkeypatch):
     monkeypatch.setattr(utils, "entry_points", fake_entry_points)
 
     return register
+
+
+@pytest.fixture
+def wait_for_child():
+    '''
+    Wait on a forked child, as ``(exited, exited_cleanly)``.
+
+    Any child still running at the deadline is killed and reaped in teardown, so
+    a test whose child deadlocks fails on its own assertions instead of wedging
+    the run: a forked child holds the session's file descriptors open, and
+    pytest will not finish while one of them is stuck.
+
+    Returns a callable taking the pid and an optional timeout in seconds.
+    '''
+    running = []
+
+    def wait(pid: int, timeout: float = 10) -> Tuple[bool, bool]:
+        running.append(pid)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            waited, status = os.waitpid(pid, os.WNOHANG)
+            if waited:
+                running.remove(pid)
+                return True, os.waitstatus_to_exitcode(status) == 0
+            time.sleep(0.05)
+        return False, False
+
+    yield wait
+
+    for pid in running:
+        os.kill(pid, signal.SIGKILL)
+        os.waitpid(pid, 0)
 
 
 @pytest.fixture

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -6,6 +6,8 @@ import shutil
 import stat
 import sys
 import tarfile
+import threading
+import time
 import zipfile
 
 import os.path
@@ -14,14 +16,17 @@ from pathlib import Path
 from unittest.mock import patch
 
 import siliconcompiler
+import siliconcompiler.package.https
 
 from siliconcompiler.package import Resolver, RemoteResolver
 from siliconcompiler.package import FileResolver, PythonPathResolver, \
     KeyPathResolver, DatarootResolver
+from siliconcompiler.package import _RESOLVERS_POPULATED
+from siliconcompiler.package.https import HTTPResolver
 from siliconcompiler.package import DataRootResolutionError
 from siliconcompiler.package.cache import PermanentResolutionError, DataSourceUnavailableError
 from siliconcompiler import utils
-from siliconcompiler.utils.multiprocessing import MPManager
+from siliconcompiler.utils.multiprocessing import MPManager, forking
 from siliconcompiler.package import InterProcessLock as dut_ipl
 
 from siliconcompiler import Project, Design
@@ -218,6 +223,120 @@ def test_find_resolver_plugin(fake_plugins):
     assert Resolver.find_resolver("https://host/file") is PluginResolver
     # Schemes the plugin does not claim keep their built-in resolver
     assert Resolver.find_resolver("scp://host/file").__name__ == "SCPResolver"
+
+
+def test_populate_resolvers_marker_written_last(fake_plugins):
+    """The registry is not marked populated until every scheme is registered."""
+    midway = {}
+
+    def get_resolver():
+        # Plugins are loaded at the tail of population, so the registry is as
+        # complete here as it ever gets before the marker lands.
+        settings = MPManager().get_transient_settings()
+        midway["marked"] = settings.get("resolvers", _RESOLVERS_POPULATED, False)
+        midway["https"] = settings.get("resolvers", "https", None)
+        return {}
+
+    fake_plugins("path_resolver", "probe", get_resolver)
+
+    Resolver.find_resolver("https://host/file")
+
+    assert midway["marked"] is False, "marked populated while population was still running"
+    assert midway["https"] is not None, "marker check ran before https was registered"
+    assert MPManager().get_transient_settings().get("resolvers", _RESOLVERS_POPULATED) is True
+
+
+def test_find_resolver_concurrent_population(monkeypatch):
+    """
+    A thread arriving mid-population must not be told a good URI is unsupported.
+
+    The first write to the registry makes it non-empty, and the remote schemes
+    are registered last, so a second thread that treats "non-empty" as
+    "populated" looks up https before it exists. Widen that window by stalling
+    the https registration and send a crowd of threads through it.
+    """
+    real_get_resolver = siliconcompiler.package.https.get_resolver
+
+    def slow_get_resolver():
+        time.sleep(0.5)
+        return real_get_resolver()
+
+    monkeypatch.setattr(siliconcompiler.package.https, "get_resolver", slow_get_resolver)
+
+    barrier = threading.Barrier(8)
+    results = []
+
+    def resolve():
+        barrier.wait(timeout=10)
+        try:
+            results.append(Resolver.find_resolver("https://host/archive.tar.gz"))
+        except Exception as e:
+            # Recorded rather than raised: an exception in a thread would
+            # otherwise only reach stderr and the test would pass.
+            results.append(e)
+
+    threads = [threading.Thread(target=resolve) for _ in range(barrier.parties)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+        assert not thread.is_alive(), "population deadlocked"
+
+    assert len(results) == barrier.parties
+    assert all(result is HTTPResolver for result in results), results
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+def test_find_resolver_after_fork_mid_population(monkeypatch, wait_for_child):
+    """
+    A child forked mid-population rebuilds instead of trusting what it inherited.
+
+    This is the case the category lock cannot cover, and the reason the marker
+    exists alongside it. The lock keeps other *threads* out, but a fork copies
+    the registry and leaves the child no lock to wait on: it gets the schemes
+    written so far and nothing to say the rest never arrived. SC forks its
+    scheduler workers, so a fork landing inside the population window is exactly
+    the shape of the original bug -- and reading "non-empty" as "finished" there
+    breaks the child permanently, not just for one lookup.
+    """
+    real_get_resolver = siliconcompiler.package.https.get_resolver
+    stalled = threading.Event()
+    release = threading.Event()
+
+    def stalling_get_resolver():
+        # Population has written the local schemes by now, but no remote one.
+        stalled.set()
+        release.wait(timeout=10)
+        return real_get_resolver()
+
+    monkeypatch.setattr(siliconcompiler.package.https, "get_resolver", stalling_get_resolver)
+
+    thread = threading.Thread(
+        target=lambda: Resolver.find_resolver("https://host/archive.tar.gz"))
+    thread.start()
+    assert stalled.wait(timeout=10), "population never reached the https registration"
+
+    with forking():
+        pid = os.fork()
+    if pid == 0:
+        # The child inherits the stall too, and would hang on its own rebuild.
+        siliconcompiler.package.https.get_resolver = real_get_resolver
+        try:
+            found = Resolver.find_resolver("https://host/archive.tar.gz")
+            os._exit(0 if found is HTTPResolver else 1)
+        except BaseException:
+            os._exit(1)
+
+    try:
+        exited, resolved = wait_for_child(pid)
+    finally:
+        # Always let the stalled thread finish, or it outlives the test and
+        # trips over the torn-down MPManager.
+        release.set()
+        thread.join(timeout=10)
+
+    assert exited, "forked child hung instead of rebuilding the registry"
+    assert resolved, "forked child trusted the half-written registry it inherited"
 
 
 def test_file_env_var():

--- a/tests/utils/test_settings.py
+++ b/tests/utils/test_settings.py
@@ -2,11 +2,14 @@ import pytest
 import os
 import json
 import logging
+import threading
+import time
 
 import os.path
 
 from unittest.mock import patch
 
+from siliconcompiler.utils.multiprocessing import forking
 from siliconcompiler.utils.settings import SettingsManager
 
 
@@ -402,3 +405,123 @@ def test_mixed_priority_and_plain_in_category(settings_file, system_file):
 
     # Save should be a safe no-op
     manager.save()
+
+
+def test_lock_category_blocks_other_threads(settings_file):
+    """A category held open is not readable by another thread until released."""
+    manager = SettingsManager(settings_file, logging.getLogger())
+
+    holding = threading.Event()
+    observed = []
+
+    def reader():
+        holding.wait(timeout=10)
+        observed.append(manager.get_category("a"))
+
+    thread = threading.Thread(target=reader)
+    with manager.lock_category("a"):
+        thread.start()
+        manager.set("a", "first", 1)
+        holding.set()
+        # The reader is now blocked on the category; give it every chance to
+        # slip in and read the half-built category before the second write.
+        time.sleep(0.5)
+        manager.set("a", "second", 2)
+
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+    assert observed == [{"first": 1, "second": 2}]
+
+
+def test_lock_category_reentrant_for_holder(settings_file):
+    """The holder can still read and write the category it is holding."""
+    manager = SettingsManager(settings_file, logging.getLogger())
+
+    with manager.lock_category("a"):
+        manager.set("a", "key", 1)
+        assert manager.get("a", "key") == 1
+        assert manager.get_category("a") == {"key": 1}
+        with manager.lock_category("a"):  # nesting is fine too
+            manager.set("a", "key", 2)
+        manager.delete("a", "key")
+        assert manager.get_category("a") == {}
+
+
+def test_lock_category_leaves_other_categories_alone(settings_file):
+    """Holding one category does not block access to any other."""
+    manager = SettingsManager(settings_file, logging.getLogger())
+    manager.set("b", "key", 1)
+
+    done = threading.Event()
+
+    def reader():
+        assert manager.get("b", "key") == 1
+        done.set()
+
+    with manager.lock_category("a"):
+        thread = threading.Thread(target=reader)
+        thread.start()
+        assert done.wait(timeout=10), "read of an unheld category blocked"
+        thread.join(timeout=10)
+
+
+def test_lock_category_released_on_exception(settings_file):
+    """An exception inside the block still releases the category."""
+    manager = SettingsManager(settings_file, logging.getLogger())
+
+    with pytest.raises(RuntimeError, match="^boom$"):
+        with manager.lock_category("a"):
+            manager.set("a", "key", 1)
+            raise RuntimeError("boom")
+
+    released = threading.Event()
+
+    def reader():
+        manager.get_category("a")
+        released.set()
+
+    thread = threading.Thread(target=reader)
+    thread.start()
+    assert released.wait(timeout=10), "category still held after an exception"
+    thread.join(timeout=10)
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+def test_locks_reset_after_fork(settings_file, wait_for_child):
+    """
+    A child forked while a category was held does not inherit the wait.
+
+    The lock was taken by a thread that does not exist in the child, so nothing
+    will ever release it; the child gets fresh locks instead.
+    """
+    manager = SettingsManager(settings_file, logging.getLogger())
+    manager.set("a", "key", 1)
+
+    holding = threading.Event()
+    release = threading.Event()
+
+    def holder():
+        with manager.lock_category("a"):
+            holding.set()
+            release.wait(timeout=10)
+
+    thread = threading.Thread(target=holder)
+    thread.start()
+    assert holding.wait(timeout=10)
+
+    with forking():
+        pid = os.fork()
+    if pid == 0:
+        try:
+            manager.get_category("a")
+            os._exit(0)
+        except BaseException:
+            os._exit(1)
+
+    try:
+        exited, _ = wait_for_child(pid)
+    finally:
+        release.set()
+        thread.join(timeout=10)
+
+    assert exited, "forked child blocked on a lock held by a thread it does not have"

--- a/tests/utils/test_settings.py
+++ b/tests/utils/test_settings.py
@@ -519,9 +519,10 @@ def test_locks_reset_after_fork(settings_file, wait_for_child):
             os._exit(1)
 
     try:
-        exited, _ = wait_for_child(pid)
+        exited, read_ok = wait_for_child(pid)
     finally:
         release.set()
         thread.join(timeout=10)
 
     assert exited, "forked child blocked on a lock held by a thread it does not have"
+    assert read_ok, "forked child failed to read the category"


### PR DESCRIPTION
## Problem

`Resolver.populate_resolvers()` was a check-then-act. It treated a non-empty `resolvers` category as "already populated", but the category becomes non-empty on the **first** write:

```python
if settings.get_category("resolvers"):   # non-empty from the first set() below
    return
settings.set("resolvers", "", FileResolver)   # <- makes it non-empty
...
builtins = (https.get_resolver, git.get_resolver, github.get_resolver, scp.get_resolver)
for resolver in (*builtins, *get_plugins("path_resolver")):   # <- remote schemes land last
```

A second thread arriving inside that window returned early and then looked up a scheme the first thread had not registered yet. The remote schemes are registered last, so they had the widest exposure — which is why an ordinary GitHub tarball came back as

```
ValueError: Source URI 'https://github.com/.../archive/<sha>.tar.gz' is not supported
```

while a `file://` path never did. The message does not mean the URI is malformed; it means the registry had no entry for `https` at that instant.

Observed on a cold cache with 8 parallel workers, where it lost a variant or two at random. Every symptom fits: t=0 only, parallel only, a subset of workers, the *same* dataroot resolving fine in another worker at that moment, and a clean serial re-run.

## Fix

The broken invariant — *a category assembled one `set()` at a time must not be readable half-built* — belongs to the settings store, not to each caller that happens to build a category in steps. So the lock went there.

**`SettingsManager.lock_category(category)`** holds one category for a multi-step update:

- Per-category `threading.RLock`, taken by `get`, `set`, `get_category` and `delete`. Another thread touching *that* category waits; other categories are unaffected.
- Re-entrant by necessity, not convenience: every accessor takes the lock, so a plain `Lock` would deadlock the writer on its own first `set()`. It excludes other threads, not the one doing the work.
- Lock order is category → settings; `_load`/`save` take only the settings lock, so there is no cycle.
- `os.register_at_fork` rebuilds every live manager's locks in a forked child: a lock held by a thread the child does not have is never released. Holding a category across a caller's work is a far wider fork window than the dict operations were exposed to before, and SC forks its scheduler workers.

**`populate_resolvers()`** now runs under that lock and writes `__populated__` **last**; that marker, not "the category is non-empty", is what the early return tests. Leading underscores keep it out of the scheme namespace — `urlparse` only recognises a scheme starting with a letter, so no source URI can collide with it.

### Why the marker as well as the lock

A lock is not a completion record, and the difference shows up across a `fork`. A child forked mid-population inherits the half-written category with **nothing held**, so under the old "non-empty" test it was broken *permanently* — convinced the registry was complete while `https` was missing from it, for the whole life of that worker. With the marker it sees nothing and rebuilds.

This was verified rather than assumed. With the marker removed and the lock kept, the 8-thread race test still passes and only the fork test fails.

The alternative — dropping locked categories in the at-fork handler instead — needs to probe `RLock` state to tell "was locked at fork time", and that probe is wrong when the forking thread is itself the owner. The marker has no such hole.

## Tests

Each was verified to fail against the code it guards.

`tests/package/test_package.py`
- `test_find_resolver_concurrent_population` — stalls `https.get_resolver` to widen the window, then sends 8 barrier-synchronised threads through `find_resolver`. Against the old code it reproduces the reported error verbatim for 7 of the 8.
- `test_find_resolver_after_fork_mid_population` — forks mid-population; the child must rebuild rather than trust what it inherited.
- `test_populate_resolvers_marker_written_last` — pins the ordering invariant without threads.

`tests/utils/test_settings.py` — `lock_category` blocks other threads, stays re-entrant for the holder, leaves other categories alone, releases on an exception, and does not wedge a forked child.

`tests/conftest.py` — new `wait_for_child` fixture returning `(exited, exited_cleanly)` and killing/reaping any survivor in teardown, so a deadlocking child fails its own test instead of wedging the run (a forked child holds the session's file descriptors open, and pytest will not finish while one is stuck).

## Verification

1569 tests pass across `tests/utils`, `tests/package`, `tests/scheduler` and `tests/test_tool.py`. `flake8` and `codespell` clean.

Two things I could not run in my environment, both pre-existing gaps rather than anything this branch touches: `tests/package/test_https.py` does not collect (`responses` not installed), and the docs build stops in `docs/_ext/requirements.py` on missing `pip-licenses` / `sc-dashboard` binaries. `SettingsManager` is autodoc'd with `:members:`, so the new `lock_category` docstring will be rendered — worth a look at that CI job. Sphinx is not in nitpicky mode here, so unresolved roles degrade to plain text.

## Not included

`OpenTask.__populate_tasks` (`siliconcompiler/tool.py:2777`) has the identical check-then-act. Same defect, much lower stakes — a racing thread gets a partial or mis-ordered viewer list once, so `get_task` can pick the wrong viewer or none. It is now a two-line fix with this primitive in place, but it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when settings are accessed or updated concurrently.
  * Prevented incomplete resolver registrations from being used during startup or parallel operations.
  * Improved behavior in forked processes by avoiding inherited partial state and lock issues.

* **New Features**
  * Added category-level locking for coordinating multi-step settings updates.

* **Tests**
  * Expanded coverage for concurrency, resolver initialization, exception handling, and forked processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->