### PR TITLE
fix openroad fill registration

### DIFF
--- a/siliconcompiler/tools/openroad/__init__.py
+++ b/siliconcompiler/tools/openroad/__init__.py
@@ -619,3 +619,118 @@ class OpenROADTask(ASICTask):
         node = SchedulerNode(proj, "<step>", "<index>")
         node.setup()
         return node.task
+
+
+class OpenROADFillParameter(OpenROADTask):
+    """
+    Mixin class for tasks that insert metal fill.
+
+    The PDK ships its metal fill rules as a file of filetype ``fill`` in a
+    fileset registered under ``pdk, fill, runsetfileset, openroad, <name>``.
+    """
+    def __init__(self):
+        super().__init__()
+
+        self.add_parameter("fin_add_fill", "bool",
+                           "true/false, when true enables adding fill, "
+                           "if enabled by the PDK, to the design", defvalue=False)
+        self.add_parameter("fill_name", "str",
+                           "name of the metal fill deck to use, this is only required when "
+                           "the PDK ships more than one deck")
+
+    def set_openroad_addfill(self, enable: bool,
+                             step: Optional[str] = None, index: Optional[Union[int, str]] = None):
+        """
+        Enables or disables adding fill to the design.
+
+        Args:
+            enable (bool): True to enable fill, False to disable.
+            step (str, optional): The specific step to apply this configuration to.
+            index (str, optional): The specific index to apply this configuration to.
+        """
+        self.set("var", "fin_add_fill", enable, step=step, index=index)
+
+    def set_openroad_fillname(self, name: str,
+                              step: Optional[str] = None,
+                              index: Optional[Union[int, str]] = None):
+        """
+        Sets the name of the metal fill deck to use.
+
+        Args:
+            name (str): The name of the metal fill deck.
+            step (str, optional): The specific step to apply this configuration to.
+            index (str, optional): The specific index to apply this configuration to.
+        """
+        self.set("var", "fill_name", name, step=step, index=index)
+
+    def _get_fill_decks(self) -> List[str]:
+        """Return the names of the PDK metal fill decks that carry a fill file."""
+        if not self.pdk.valid("pdk", "fill", "runsetfileset", "openroad"):
+            return []
+
+        decks = []
+        for name in self.pdk.getkeys("pdk", "fill", "runsetfileset", "openroad"):
+            for fileset in self.pdk.get("pdk", "fill", "runsetfileset", "openroad", name):
+                if self.pdk.has_file(fileset=fileset, filetype="fill"):
+                    decks.append(name)
+                    break
+        return decks
+
+    def _resolve_fill_deck(self) -> Optional[str]:
+        """
+        Determine which metal fill deck to use.
+
+        A PDK that ships exactly one deck needs no configuration. When it ships
+        more than one, ``fill_name`` selects between them.
+
+        Raises:
+            ValueError: If the PDK ships several decks and none was selected, or
+                        if the selected deck does not exist.
+
+        Returns:
+            The deck name, or None if the PDK ships no metal fill rules.
+        """
+        decks = self._get_fill_decks()
+
+        name = self.get("var", "fill_name")
+        if name:
+            if name not in decks:
+                raise ValueError(f"{name} is not a metal fill deck provided by "
+                                 f"{self.pdk.name}, available decks are: "
+                                 f"{', '.join(sorted(decks)) if decks else 'none'}")
+            return name
+
+        if len(decks) > 1:
+            raise ValueError(f"{self.pdk.name} provides more than one metal fill deck, "
+                             f"select one with fill_name: {', '.join(sorted(decks))}")
+
+        return decks[0] if decks else None
+
+    def _setup_fill_deck(self) -> bool:
+        """
+        Declare the PDK metal fill deck required so it is hashed (cache) and
+        copied (remote runs), and record the resolved deck name for the script.
+
+        Returns:
+            True if metal fill rules are available.
+        """
+        name = self._resolve_fill_deck()
+
+        if name:
+            self.set("var", "fill_name", name)
+            self.add_required_key("var", "fill_name")
+            self.add_required_key(
+                self.pdk, "pdk", "fill", "runsetfileset", "openroad", name)
+            for fileset in self.pdk.get("pdk", "fill", "runsetfileset", "openroad", name):
+                if self.pdk.has_file(fileset=fileset, filetype="fill"):
+                    self.add_required_key(self.pdk, "fileset", fileset, "file", "fill")
+            return True
+
+        # Deprecated: PDKs used to register the fill rules in the OpenROAD APR tech
+        # fileset. Keep reading that until those PDKs move to the fill runset section.
+        found = False
+        for fileset in self.pdk.get("pdk", "aprtechfileset", "openroad"):
+            if self.pdk.has_file(fileset=fileset, filetype="fill"):
+                self.add_required_key(self.pdk, "fileset", fileset, "file", "fill")
+                found = True
+        return found

--- a/siliconcompiler/tools/openroad/fillmetal_insertion.py
+++ b/siliconcompiler/tools/openroad/fillmetal_insertion.py
@@ -1,34 +1,14 @@
-from typing import Optional, Union
-
+from siliconcompiler.tools.openroad import OpenROADFillParameter
 from siliconcompiler.tools.openroad._apr import APRTask
 from siliconcompiler.tools.openroad._apr import OpenROADSTAParameter
 
 from siliconcompiler import TaskSkip
 
 
-class FillMetalTask(APRTask, OpenROADSTAParameter):
+class FillMetalTask(APRTask, OpenROADSTAParameter, OpenROADFillParameter):
     '''
     Perform fill metal insertion
     '''
-    def __init__(self):
-        super().__init__()
-
-        self.add_parameter("fin_add_fill", "bool",
-                           "true/false, when true enables adding fill, "
-                           "if enabled by the PDK, to the design", defvalue=False)
-
-    def set_openroad_addfill(self, enable: bool,
-                             step: Optional[str] = None, index: Optional[Union[int, str]] = None):
-        """
-        Enables or disables adding fill to the design.
-
-        Args:
-            enable (bool): True to enable fill, False to disable.
-            step (str, optional): The specific step to apply this configuration to.
-            index (str, optional): The specific index to apply this configuration to.
-        """
-        self.set("var", "fin_add_fill", enable, step=step, index=index)
-
     def task(self):
         return "fillmetal_insertion"
 
@@ -73,15 +53,7 @@ class FillMetalTask(APRTask, OpenROADSTAParameter):
                 raise TaskSkip("metal fill is disabled")
             return
 
-        # The metal fill rules are shipped by the PDK as a fill file (filetype
-        # "fill") inside the OpenROAD APR tech fileset. Mark it required so it is
-        # hashed (cache) and copied (remote runs). If no PDK provides one, there
-        # is nothing to do and the task is skipped.
-        found = False
-        for fileset in self.pdk.get("pdk", "aprtechfileset", "openroad"):
-            if self.pdk.has_file(fileset=fileset, filetype="fill"):
-                self.add_required_key(self.pdk, "fileset", fileset, "file", "fill")
-                found = True
-
-        if not found and not has_scripts:
+        # If the PDK provides no metal fill rules there is nothing to do and the
+        # task is skipped.
+        if not self._setup_fill_deck() and not has_scripts:
             raise TaskSkip("no metal fill rules are available")

--- a/siliconcompiler/tools/openroad/pex.py
+++ b/siliconcompiler/tools/openroad/pex.py
@@ -16,10 +16,21 @@ class PEXBaseTask(OpenROADTask):
 
         super().setup()
 
-        # Tech LEF (routing layers) via the fileset the APR flow uses.
+        # Tech LEF (routing layers) via the fileset the APR flow uses. Only some of
+        # the APR tech filesets carry a LEF, the rest hold tracks, viarules and the
+        # like, so requiring one from every fileset would fail the run before it
+        # started.
         self.add_required_key(self.pdk, "pdk", "aprtechfileset", "openroad")
+        found = False
         for fileset in self.pdk.get("pdk", "aprtechfileset", "openroad"):
-            self.add_required_key(self.pdk, "fileset", fileset, "file", "lef")
+            if self.pdk.has_file(fileset=fileset, filetype="lef"):
+                self.add_required_key(self.pdk, "fileset", fileset, "file", "lef")
+                found = True
+
+        if not found:
+            # The bench generates its patterns from the routing layers, so without a
+            # tech LEF there is nothing to build and OpenROAD would fail later on.
+            raise ValueError(f"{self.pdk.name} does not provide a tech LEF for openroad")
 
 
 class PEXBenchTask(PEXBaseTask):

--- a/siliconcompiler/tools/openroad/rdlroute.py
+++ b/siliconcompiler/tools/openroad/rdlroute.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 from typing import Optional, Union
 
-from siliconcompiler.tools.openroad import OpenROADTask
+from siliconcompiler.tools.openroad import OpenROADFillParameter
 
 
-class RDLRouteTask(OpenROADTask):
+class RDLRouteTask(OpenROADFillParameter):
     '''
     Perform floorplanning, pin placements, macro placements and power grid generation
     '''
@@ -12,10 +12,6 @@ class RDLRouteTask(OpenROADTask):
         super().__init__()
 
         self.add_parameter("rdlroute", "[file]", "RDL routing scripts")
-
-        self.add_parameter("fin_add_fill", "bool",
-                           "true/false, when true enables adding fill, "
-                           "if enabled by the PDK, to the design", defvalue=False)
 
     def add_openroad_rdlroute(self, file: Union[str, Path], dataroot: Optional[str] = None,
                               step: Optional[str] = None, index: Optional[Union[int, str]] = None,
@@ -37,18 +33,6 @@ class RDLRouteTask(OpenROADTask):
                 self.set("var", "rdlroute", file, step=step, index=index)
             else:
                 self.add("var", "rdlroute", file, step=step, index=index)
-
-    def set_openroad_addfill(self, enable: bool,
-                             step: Optional[str] = None, index: Optional[Union[int, str]] = None):
-        """
-        Enables or disables adding fill to the design.
-
-        Args:
-            enable (bool): True to enable fill, False to disable.
-            step (str, optional): The specific step to apply this configuration to.
-            index (str, optional): The specific index to apply this configuration to.
-        """
-        self.set("var", "fin_add_fill", enable, step=step, index=index)
 
     def task(self):
         return "rdlroute"
@@ -89,6 +73,12 @@ class RDLRouteTask(OpenROADTask):
         if self.get("var", "rdlroute"):
             self.add_required_key("var", "rdlroute")
         self.add_required_key("var", "fin_add_fill")
+
+        # sc_rdlroute.tcl runs its own metal fill, so the deck has to be declared
+        # required here too. Unlike fillmetal_insertion this task has plenty else
+        # to do, so a PDK without fill rules is not a reason to skip it.
+        if self.get("var", "fin_add_fill"):
+            self._setup_fill_deck()
 
         # sc_rdlroute.tcl loads the PDK tech LEF and per-library LEFs; declare them
         # required so they are hashed (cache) and copied (remote runs).

--- a/siliconcompiler/tools/openroad/scripts/apr/sc_fillmetal_insertion.tcl
+++ b/siliconcompiler/tools/openroad/scripts/apr/sc_fillmetal_insertion.tcl
@@ -15,8 +15,7 @@ source "$sc_refdir/apr/preamble.tcl"
 # Do fill
 ###############################
 
-set sc_aprfileset [sc_cfg_get library $sc_pdk pdk aprtechfileset openroad]
-set sc_fillrules [sc_cfg_get_fileset $sc_pdk $sc_aprfileset fill]
+set sc_fillrules [sc_get_fill_rules $sc_pdk]
 
 if {
     [sc_cfg_tool_task_get var fin_add_fill] &&

--- a/siliconcompiler/tools/openroad/scripts/common/procs.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/procs.tcl
@@ -1686,3 +1686,27 @@ proc sc_setup_pex { args } {
         }
     }
 }
+
+proc sc_get_fill_rules { pdk } {
+    # Returns the PDK metal fill rules files, or an empty list when the PDK ships
+    # none. The task resolves which deck to use and records it in the fill_name
+    # variable, so only that one deck is read here.
+    if { [sc_cfg_tool_task_exists var fill_name] } {
+        set fill_name [sc_cfg_tool_task_get var fill_name]
+        if {
+            $fill_name != "" &&
+            [sc_cfg_exists library $pdk pdk fill runsetfileset openroad $fill_name]
+        } {
+            set fileset [sc_cfg_get library $pdk pdk fill runsetfileset openroad $fill_name]
+            return [sc_cfg_get_fileset $pdk $fileset fill]
+        }
+    }
+
+    # Deprecated: PDKs used to register the fill rules in the OpenROAD APR tech
+    # fileset. Keep reading that until those PDKs move to the fill runset section.
+    if { ![sc_cfg_exists library $pdk pdk aprtechfileset openroad] } {
+        return []
+    }
+    set aprfileset [sc_cfg_get library $pdk pdk aprtechfileset openroad]
+    return [sc_cfg_get_fileset $pdk $aprfileset fill]
+}

--- a/siliconcompiler/tools/openroad/scripts/sc_rdlroute.tcl
+++ b/siliconcompiler/tools/openroad/scripts/sc_rdlroute.tcl
@@ -128,7 +128,7 @@ foreach obstruction [[ord::get_db_block] getObstructions] {
 }
 utl::info FLW 1 "Deleted $removed_obs routing obstructions"
 
-set sc_fillrules [sc_cfg_get_fileset $sc_pdk $aprfileset fill]
+set sc_fillrules [sc_get_fill_rules $sc_pdk]
 if {
     [sc_cfg_tool_task_get var fin_add_fill] &&
     [llength $sc_fillrules] > 0

--- a/tests/tools/test_openroad.py
+++ b/tests/tools/test_openroad.py
@@ -8,6 +8,7 @@ from siliconcompiler import Flowgraph
 from siliconcompiler import TaskSkip
 
 from siliconcompiler.flows.asicflow import ASICFlow
+from siliconcompiler.flows.interposerflow import InterposerFlow
 from siliconcompiler.flows.openroad_pex import (
     GenerateOpenRCXFlow,
     GeneratePEXEstimateFlow,
@@ -1659,13 +1660,34 @@ def test_openroad_fillmetal_insertion_skips_when_disabled(asic_gcd):
         assert node.setup() is False
 
 
+def _add_fill_deck(pdk, tmp_path, name="beol", fileset=None, runset=True, aprtech=False):
+    """Register a metal fill deck on a PDK the way a PDK author would."""
+    fileset = fileset or f"openroad.fill.{name}"
+    rules = tmp_path / f"{name}.fill.json"
+    rules.write_text("{}")
+
+    pdk.set_dataroot("fill-pytest", str(tmp_path))
+    with pdk.active_dataroot("fill-pytest"), pdk.active_fileset(fileset):
+        pdk.add_file(rules.name, filetype="fill")
+        if runset:
+            pdk.add_runsetfileset("fill", "openroad", name)
+        if aprtech:
+            pdk.add_aprtechfileset("openroad")
+    return fileset
+
+
 def test_openroad_fillmetal_insertion_skips_without_pdk_rules(asic_gcd):
     """Fill enabled but no PDK fill file to work from still skips the node."""
     fillmetal_insertion.FillMetalTask.find_task(asic_gcd).set_openroad_addfill(True)
 
-    # Drop any fill rules the PDK ships so the skip is exercised regardless of
-    # what freepdk45 provides.
+    # Drop any fill rules the PDK ships, from both the fill runset section and the
+    # deprecated APR tech fileset, so the skip is exercised regardless of what
+    # freepdk45 provides.
     pdk = asic_gcd.get_library(asic_gcd.get("asic", "pdk"))
+    if pdk.valid("pdk", "fill", "runsetfileset", "openroad"):
+        for name in pdk.getkeys("pdk", "fill", "runsetfileset", "openroad"):
+            for fileset in pdk.get("pdk", "fill", "runsetfileset", "openroad", name):
+                pdk.unset("fileset", fileset, "file", "fill")
     for fileset in pdk.get("pdk", "aprtechfileset", "openroad"):
         pdk.unset("fileset", fileset, "file", "fill")
 
@@ -1675,6 +1697,86 @@ def test_openroad_fillmetal_insertion_skips_without_pdk_rules(asic_gcd):
         with pytest.raises(TaskSkip, match="^no metal fill rules are available$"):
             node.task.setup()
         assert node.setup() is False
+
+
+def test_openroad_fillmetal_insertion_uses_fill_runset(asic_gcd, tmp_path):
+    """A deck registered in the fill runset section is found and required."""
+    fillmetal_insertion.FillMetalTask.find_task(asic_gcd).set_openroad_addfill(True)
+
+    pdk = asic_gcd.get_library(asic_gcd.get("asic", "pdk"))
+    fileset = _add_fill_deck(pdk, tmp_path)
+
+    task = _setup_node(asic_gcd, "dfm.metal_fill")
+    require = task.get("require")
+
+    # The deck resolves without configuration when the PDK ships exactly one.
+    assert task.get("var", "fill_name", step="dfm.metal_fill", index="0") == "beol"
+    assert f"library,{pdk.name},pdk,fill,runsetfileset,openroad,beol" in require
+    assert f"library,{pdk.name},fileset,{fileset},file,fill" in require
+    # The deprecated APR tech fileset is not consulted when a deck resolves.
+    assert "tool,openroad,task,fillmetal_insertion,var,fill_name" in require
+
+
+def test_openroad_fillmetal_insertion_selects_named_deck(asic_gcd, tmp_path):
+    """fill_name picks between decks when the PDK ships more than one."""
+    task = fillmetal_insertion.FillMetalTask.find_task(asic_gcd)
+    task.set_openroad_addfill(True)
+    task.set_openroad_fillname("feol")
+
+    pdk = asic_gcd.get_library(asic_gcd.get("asic", "pdk"))
+    _add_fill_deck(pdk, tmp_path, name="beol")
+    feol = _add_fill_deck(pdk, tmp_path, name="feol")
+
+    require = _setup_node(asic_gcd, "dfm.metal_fill").get("require")
+
+    assert f"library,{pdk.name},pdk,fill,runsetfileset,openroad,feol" in require
+    assert f"library,{pdk.name},fileset,{feol},file,fill" in require
+    assert f"library,{pdk.name},pdk,fill,runsetfileset,openroad,beol" not in require
+
+
+def test_openroad_fillmetal_insertion_ambiguous_deck_errors(asic_gcd, tmp_path):
+    """Two decks and no selection is an error rather than an arbitrary pick."""
+    fillmetal_insertion.FillMetalTask.find_task(asic_gcd).set_openroad_addfill(True)
+
+    pdk = asic_gcd.get_library(asic_gcd.get("asic", "pdk"))
+    _add_fill_deck(pdk, tmp_path, name="beol")
+    _add_fill_deck(pdk, tmp_path, name="feol")
+
+    node = SchedulerNode(asic_gcd, "dfm.metal_fill", "0")
+    with node.runtime():
+        with pytest.raises(ValueError,
+                           match=r"provides more than one metal fill deck, "
+                                 r"select one with fill_name: beol, feol$"):
+            node.task.setup()
+
+
+def test_openroad_fillmetal_insertion_unknown_deck_errors(asic_gcd, tmp_path):
+    """A fill_name the PDK does not provide is reported, not silently ignored."""
+    task = fillmetal_insertion.FillMetalTask.find_task(asic_gcd)
+    task.set_openroad_addfill(True)
+    task.set_openroad_fillname("nope")
+
+    pdk = asic_gcd.get_library(asic_gcd.get("asic", "pdk"))
+    _add_fill_deck(pdk, tmp_path, name="beol")
+
+    node = SchedulerNode(asic_gcd, "dfm.metal_fill", "0")
+    with node.runtime():
+        with pytest.raises(ValueError,
+                           match=r"^nope is not a metal fill deck provided by .*, "
+                                 r"available decks are: beol$"):
+            node.task.setup()
+
+
+def test_openroad_fillmetal_insertion_aprtechfileset_fallback(asic_gcd, tmp_path):
+    """Deprecated: PDKs that still register fill in the APR tech fileset work."""
+    fillmetal_insertion.FillMetalTask.find_task(asic_gcd).set_openroad_addfill(True)
+
+    pdk = asic_gcd.get_library(asic_gcd.get("asic", "pdk"))
+    fileset = _add_fill_deck(pdk, tmp_path, runset=False, aprtech=True)
+
+    require = _setup_node(asic_gcd, "dfm.metal_fill").get("require")
+
+    assert f"library,{pdk.name},fileset,{fileset},file,fill" in require
 
 
 def test_openroad_fillmetal_insertion_disabled_still_runs_with_a_script(asic_gcd):
@@ -2367,6 +2469,39 @@ def test_openroad_pex_bench_extract_setup_requires_openrcx(asic_gcd):
         _setup_node(asic_gcd, "extract")
 
 
+def test_openroad_pex_bench_tolerates_non_lef_aprtechfileset(asic_gcd, tmp_path):
+    """An APR tech fileset without a LEF must not be required to carry one.
+
+    https://github.com/siliconcompiler/siliconcompiler/issues/5250 -- PDKs put
+    non-LEF filesets (fill rules, tracks, viarules) in aprtechfileset, and
+    requiring a LEF from each blocked the PEX bench before any tool ran.
+    """
+    asic_gcd.set_flow(GeneratePEXEstimateFlow())
+
+    pdk = asic_gcd.get_library(str(asic_gcd.get("asic", "pdk")))
+    fileset = _add_fill_deck(pdk, tmp_path, runset=False, aprtech=True)
+    assert fileset in pdk.get("pdk", "aprtechfileset", "openroad")
+
+    require = _setup_node(asic_gcd, "bench").get("require")
+
+    assert f"library,{pdk.name},fileset,{fileset},file,lef" not in require
+    # The filesets that do carry a tech LEF are still required.
+    assert any(r.endswith(",file,lef") for r in require)
+
+
+def test_openroad_pex_bench_requires_a_tech_lef(asic_gcd):
+    """No tech LEF anywhere means the bench cannot be built at all."""
+    asic_gcd.set_flow(GeneratePEXEstimateFlow())
+
+    pdk = asic_gcd.get_library(str(asic_gcd.get("asic", "pdk")))
+    for fileset in pdk.get("pdk", "aprtechfileset", "openroad"):
+        pdk.unset("fileset", fileset, "file", "lef")
+
+    with pytest.raises(ValueError,
+                       match=r"^freepdk45 does not provide a tech LEF for openroad$"):
+        _setup_node(asic_gcd, "bench")
+
+
 @pytest.mark.timeout(30)
 def test_openroad_calibrate_pex_setup(asic_gcd):
     asic_gcd.set_flow(PEXCalibrateFlow())
@@ -2550,6 +2685,46 @@ def test_openroad_rdlroute_parameter_add_fill():
     task.set_openroad_addfill(False, step='rdlroute', index='1')
     assert task.get("var", "fin_add_fill", step='rdlroute', index='1') is False
     assert task.get("var", "fin_add_fill") is True
+
+
+@pytest.mark.parametrize("task_cls", [
+    fillmetal_insertion.FillMetalTask,
+    rdlroute.RDLRouteTask,
+])
+def test_openroad_parameter_fill_name(task_cls):
+    task = task_cls()
+    task.set_openroad_fillname("beol")
+    assert task.get("var", "fill_name") == "beol"
+    task.set_openroad_fillname("feol", step=task.task(), index='1')
+    assert task.get("var", "fill_name", step=task.task(), index='1') == "feol"
+    assert task.get("var", "fill_name") == "beol"
+
+
+def test_openroad_rdlroute_requires_fill_deck(asic_gcd, tmp_path):
+    """sc_rdlroute.tcl runs its own fill, so the deck has to be hashed and copied."""
+    asic_gcd.set_flow(InterposerFlow())
+    rdlroute.RDLRouteTask.find_task(asic_gcd).set_openroad_addfill(True)
+
+    pdk = asic_gcd.get_library(str(asic_gcd.get("asic", "pdk")))
+    fileset = _add_fill_deck(pdk, tmp_path)
+
+    require = _setup_node(asic_gcd, "rdlroute").get("require")
+
+    assert f"library,{pdk.name},pdk,fill,runsetfileset,openroad,beol" in require
+    assert f"library,{pdk.name},fileset,{fileset},file,fill" in require
+
+
+def test_openroad_rdlroute_skips_fill_deck_when_disabled(asic_gcd, tmp_path):
+    """Fill off means the deck is neither resolved nor required."""
+    asic_gcd.set_flow(InterposerFlow())
+    rdlroute.RDLRouteTask.find_task(asic_gcd).set_openroad_addfill(False)
+
+    pdk = asic_gcd.get_library(str(asic_gcd.get("asic", "pdk")))
+    fileset = _add_fill_deck(pdk, tmp_path)
+
+    require = _setup_node(asic_gcd, "rdlroute").get("require")
+
+    assert f"library,{pdk.name},fileset,{fileset},file,fill" not in require
 
 
 def test_openroad_repair_design_parameter_tie_separation():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable metal-fill deck selection for OpenROAD fill-metal and RDL routing flows.
  * Supports enabling or disabling fill and selecting named PDK-provided fill decks.
  * Automatically discovers available decks and validates required or invalid selections.
  * Preserves compatibility with legacy APR technology fill configurations.

* **Bug Fixes**
  * Improved technology file handling for parasitic extraction by allowing APR filesets without LEF files when another valid technology LEF is available.
  * Improved fill-rule resolution across supported OpenROAD flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->