### PR TITLE
set require keys for etch files for klayout

### DIFF
--- a/siliconcompiler/tools/klayout/__init__.py
+++ b/siliconcompiler/tools/klayout/__init__.py
@@ -148,6 +148,50 @@ class KLayoutTask(ASICTask):
         # KLayout 0.26.11
         return stdout.split()[1]
 
+    def _add_hidelayers_required_keys(self) -> None:
+        """
+        Declares the layer visibility keys read by show() in klayout_show.py.
+
+        The layers to hide are the union of the PDK and task settings, so both keys are
+        declared when they hold a value.
+        """
+        if self.get("var", "hide_layers"):
+            self.add_required_key("var", "hide_layers")
+        if self.pdk.get("tool", "klayout", "hide_layers"):
+            self.add_required_key(self.pdk, "tool", "klayout", "hide_layers")
+
+    def _add_technology_files(self) -> None:
+        """
+        Declares the files read by technology() in klayout_utils.py.
+
+        The technology (.lyt) and layer properties (.lyp) files written by a previous node
+        take precedence over the PDK files, but are only available when an input node
+        provides them, so they are declared as inputs only in that case. The PDK files
+        used when they are not available are declared required so they are hashed (cache)
+        and copied (remote runs).
+        """
+        input_files = self.get_files_from_input_nodes()
+        for ext in ("lyt", "lyp"):
+            if f"{self.design_topmodule}.{ext}" in input_files:
+                self.add_input_file(ext=ext)
+
+        if self.pdk.valid("pdk", "layermapfileset", "klayout", "def", "klayout") and \
+                self.pdk.get("pdk", "layermapfileset", "klayout", "def", "klayout"):
+            self.add_required_key(self.pdk, "pdk", "layermapfileset", "klayout", "def", "klayout")
+            for fileset in self.pdk.get("pdk", "layermapfileset", "klayout", "def", "klayout"):
+                if self.pdk.has_file(fileset=fileset, filetype="layermap"):
+                    self.add_required_key(self.pdk, "fileset", fileset, "file", "layermap")
+
+        if self.pdk.valid("pdk", "displayfileset", "klayout") and \
+                self.pdk.get("pdk", "displayfileset", "klayout"):
+            self.add_required_key(self.pdk, "pdk", "displayfileset", "klayout")
+            for fileset in self.pdk.get("pdk", "displayfileset", "klayout"):
+                if self.pdk.has_file(fileset=fileset, filetype="display"):
+                    self.add_required_key(self.pdk, "fileset", fileset, "file", "display")
+
+        if self.pdk.get("tool", "klayout", "units"):
+            self.add_required_key(self.pdk, "tool", "klayout", "units")
+
     def setup(self):
         super().setup()
 

--- a/siliconcompiler/tools/klayout/export.py
+++ b/siliconcompiler/tools/klayout/export.py
@@ -50,6 +50,8 @@ class ExportTask(KLayoutStreamTask, ScreenshotParams):
         self.add_output_file(ext="lyt")
         self.add_output_file(ext="lyp")
 
+        self._add_technology_files()
+
         sc_stream_order = self._get_klayout_streamorder()
         req_set = False
         for s in sc_stream_order:

--- a/siliconcompiler/tools/klayout/img2stream.py
+++ b/siliconcompiler/tools/klayout/img2stream.py
@@ -177,6 +177,8 @@ class Img2StreamTask(KLayoutTask):
         self.add_output_file(ext=f"{default_stream}.gz")
         self.add_output_file(ext="lef")
 
+        self._add_technology_files()
+
         if f"{self.design_topmodule}.{imageformat}" in self.get_files_from_input_nodes():
             self.add_input_file(ext=imageformat)
         else:

--- a/siliconcompiler/tools/klayout/merge.py
+++ b/siliconcompiler/tools/klayout/merge.py
@@ -105,3 +105,5 @@ class Merge(KLayoutTask):
                 self.add_required_key("library", lib_name, "fileset", fileset, "file", "gds")
 
         self.add_output_file(ext="gds.gz")
+
+        self._add_technology_files()

--- a/siliconcompiler/tools/klayout/operations.py
+++ b/siliconcompiler/tools/klayout/operations.py
@@ -1232,5 +1232,7 @@ class OperationsTask(KLayoutStreamTask):
         self._add_stream_input_file()
         self._add_stream_output_file()
 
+        self._add_technology_files()
+
         for op in operations:
             op.setup(self)

--- a/siliconcompiler/tools/klayout/screenshot.py
+++ b/siliconcompiler/tools/klayout/screenshot.py
@@ -91,8 +91,7 @@ class ScreenshotParams(Task):
         super().setup()
 
         # consumed by show(), which every screenshot goes through
-        if self.get("var", "hide_layers"):
-            self.add_required_key("var", "hide_layers")
+        self._add_hidelayers_required_keys()
 
         self.add_required_key("var", "show_resolution")
         self.add_required_key("var", "show_bins")

--- a/siliconcompiler/tools/klayout/show.py
+++ b/siliconcompiler/tools/klayout/show.py
@@ -15,8 +15,8 @@ class ShowTask(ShowTask, KLayoutTask):
 
         self.set_script("klayout_show.py")
 
-        if self.get("var", "hide_layers"):
-            self.add_required_key("var", "hide_layers")
+        self._add_hidelayers_required_keys()
+        self._add_technology_files()
 
         if f"{self.design_topmodule}.gds.gz" in self.get_files_from_input_nodes():
             self.add_input_file(ext="gds.gz")

--- a/siliconcompiler/tools/klayout/stream2lef.py
+++ b/siliconcompiler/tools/klayout/stream2lef.py
@@ -117,6 +117,8 @@ class Stream2LefTask(KLayoutTask):
 
         self.add_output_file(ext="lef")
 
+        self._add_technology_files()
+
         sc_stream_order = [default_stream, *[s for s in ("gds", "oas") if s != default_stream]]
         for s in sc_stream_order:
             if self.pdk.valid("pdk", "layermapfileset", "klayout", "def", s):

--- a/tests/tools/test_klayout.py
+++ b/tests/tools/test_klayout.py
@@ -957,3 +957,62 @@ def test_drc_runset_required(setup_pdk_test):
     assert f"library,{pdk_name},pdk,drc,runsetfileset,klayout,drc" in requires, requires
     assert any(r.startswith(f"library,{pdk_name},fileset,") and r.endswith("file,drc")
                for r in requires), requires
+
+
+def test_technology_files_required():
+    # Regression guard: the technology files read by technology() must be declared, the
+    # .lyt/.lyp from a previous node as inputs so they are copied into the node, and the
+    # PDK files used when they are missing as required so they are hashed and copied.
+    design = Design("heartbeat")
+    with design.active_fileset("layout"):
+        design.set_topmodule("heartbeat")
+
+    proj = ASIC(design)
+    proj.add_fileset("layout")
+    freepdk45_demo(proj)
+
+    flow = Flowgraph("testflow")
+    flow.node("export", export.ExportTask())
+    flow.node("screenshot", screenshot.ScreenshotTask())
+    flow.edge("export", "screenshot")
+    proj.set_flow(flow)
+
+    # the export node declares the technology files it writes
+    export_node = SchedulerNode(proj, "export", "0")
+    with export_node.runtime():
+        assert export_node.setup() is True
+
+    node = SchedulerNode(proj, "screenshot", "0")
+    with node.runtime():
+        assert node.setup() is True
+        requires = node.task.get("require")
+        inputs = node.task.get("input")
+
+    assert "heartbeat.lyt" in inputs, inputs
+    assert "heartbeat.lyp" in inputs, inputs
+
+    pdk_name = proj.get("asic", "pdk")
+    assert f"library,{pdk_name},pdk,layermapfileset,klayout,def,klayout" in requires, requires
+    assert any(r.startswith(f"library,{pdk_name},fileset,") and r.endswith("file,layermap")
+               for r in requires), requires
+    assert f"library,{pdk_name},pdk,displayfileset,klayout" in requires, requires
+    assert any(r.startswith(f"library,{pdk_name},fileset,") and r.endswith("file,display")
+               for r in requires), requires
+
+
+def test_hide_layers_required(asic_heartbeat_screenshot):
+    # Regression guard: show() hides the union of the PDK and task layers, so both keys
+    # must be declared required.
+    proj, task = asic_heartbeat_screenshot
+
+    task.add_klayout_hidelayers("metal9")
+    pdk = proj.get_library(proj.get("asic", "pdk"))
+    pdk.add_klayout_hidelayers("metal10")
+
+    node = SchedulerNode(proj, "screenshot", "0")
+    with node.runtime():
+        assert node.setup() is True
+        requires = node.task.get("require")
+
+    assert "tool,klayout,task,screenshot,var,hide_layers" in requires, requires
+    assert f"library,{proj.get('asic', 'pdk')},tool,klayout,hide_layers" in requires, requires


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KLayout task configuration to consistently recognize technology, display, layer-map, and stream-unit files.
  * Ensured hidden-layer settings are correctly applied at both task and PDK levels.
  * Improved handling of technology files across export, merge, screenshot, stream conversion, and related workflows.

* **Tests**
  * Added regression coverage for technology files, display files, and hidden-layer settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->