### PR TITLE
use abspaths in pyslang

### DIFF
--- a/siliconcompiler/tools/slang/__init__.py
+++ b/siliconcompiler/tools/slang/__init__.py
@@ -10,7 +10,6 @@ Sources: https://github.com/MikePopoloski/slang
 
 Installation: https://sv-lang.com/building.html
 '''
-import os
 import shlex
 
 try:
@@ -20,6 +19,30 @@ except ModuleNotFoundError:
 
 from siliconcompiler import Task
 from siliconcompiler.tools._common import distinct
+
+
+def report_diagnostics(source_manager, diagnostics):
+    """
+    Format diagnostics into text, reporting absolute file paths.
+
+    This mirrors :meth:`pyslang.DiagnosticEngine.reportAll`, which always emits
+    paths relative to the current working directory.
+
+    Args:
+        source_manager (pyslang.SourceManager): source manager the diagnostics came from.
+        diagnostics (list of pyslang.Diagnostic): diagnostics to report.
+    """
+
+    client = pyslang.TextDiagnosticClient()
+    client.showAbsPaths(True)
+
+    engine = pyslang.DiagnosticEngine(source_manager)
+    engine.addClient(client)
+
+    for diag in diagnostics:
+        engine.issue(diag)
+
+    return client.getString()
 
 
 class SlangTask(Task):
@@ -208,15 +231,9 @@ class SlangTask(Task):
                 report_level = "error"
 
             if report_level:
-                for n, line in enumerate(
-                        diags.reportAll(self._driver.sourceManager, [diag]).splitlines()):
+                for line in report_diagnostics(
+                        self._driver.sourceManager, [diag]).splitlines():
                     if line.strip():
-                        if n == 0:
-                            line_parts = line.split(":")
-                            if os.path.exists(line_parts[0]):
-                                line_parts[0] = os.path.abspath(line_parts[0])
-                            line = ":".join(line_parts)
-
                         report[report_level].append(line)
 
         if report["warning"]:

--- a/siliconcompiler/tools/slang/utils/uniquify.py
+++ b/siliconcompiler/tools/slang/utils/uniquify.py
@@ -24,7 +24,7 @@ import re
 import shlex
 from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
-from siliconcompiler.tools.slang import pyslang
+from siliconcompiler.tools.slang import pyslang, report_diagnostics
 from siliconcompiler.tools._common import distinct
 
 if TYPE_CHECKING:
@@ -413,7 +413,7 @@ def build_compilation(sources: List[str], top: str,
         severity = driver.diagEngine.getSeverity(diag.code, diag.location)
         if severity in (pyslang.DiagnosticSeverity.Error,
                         pyslang.DiagnosticSeverity.Fatal):
-            errors.append(driver.diagEngine.reportAll(driver.sourceManager, [diag]))
+            errors.append(report_diagnostics(driver.sourceManager, [diag]))
     if errors:
         message = "elaboration reported errors:\n" + "\n".join(errors)
         if any("not a valid top-level module" in err for err in errors):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic messages for Slang-related errors.
  * Diagnostic paths are now consistently displayed as absolute paths.
  * Standardized error reporting across compilation and elaboration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->