### PR TITLE
remove unneeded unset

### DIFF
--- a/siliconcompiler/scheduler/taskscheduler.py
+++ b/siliconcompiler/scheduler/taskscheduler.py
@@ -416,9 +416,6 @@ class TaskScheduler:
 
                 if os.path.exists(manifest):
                     Journal.replay_file(self.__schema, manifest)
-                    # TODO: once tool is fixed this can go away
-                    self.__schema.unset("arg", "step")
-                    self.__schema.unset("arg", "index")
 
                 # The child either sent the package cache before exiting or
                 # it never will. poll(0) avoids blocking the scheduler loop


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved step and index settings after replaying a manifest, preventing them from being unexpectedly cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->