### PR TITLE
fix tets build and clock name vs port

### DIFF
--- a/setup/rhel8/Docker.testbuild
+++ b/setup/rhel8/Docker.testbuild
@@ -34,6 +34,7 @@ ENV CPLUS_INCLUDE_PATH="$SC_PREFIX/include"
 COPY setup/build_tools.sh $SC_BUILD/
 COPY siliconcompiler/toolscripts/_tools.py $SC_BUILD/..
 COPY siliconcompiler/toolscripts/_tools.json $SC_BUILD/..
+COPY siliconcompiler/toolscripts/_prereqs.sh $SC_BUILD/..
 COPY siliconcompiler/toolscripts/rhel8 $SC_BUILD
 
 WORKDIR $SC_BUILD

--- a/setup/rhel9/Docker.testbuild
+++ b/setup/rhel9/Docker.testbuild
@@ -34,6 +34,7 @@ ENV CPLUS_INCLUDE_PATH="$SC_PREFIX/include"
 COPY setup/build_tools.sh $SC_BUILD/
 COPY siliconcompiler/toolscripts/_tools.py $SC_BUILD/..
 COPY siliconcompiler/toolscripts/_tools.json $SC_BUILD/..
+COPY siliconcompiler/toolscripts/_prereqs.sh $SC_BUILD/..
 COPY siliconcompiler/toolscripts/rhel9 $SC_BUILD
 
 WORKDIR $SC_BUILD

--- a/setup/ubuntu20/Docker.testbuild
+++ b/setup/ubuntu20/Docker.testbuild
@@ -43,6 +43,7 @@ ENV CPLUS_INCLUDE_PATH="$SC_PREFIX/include"
 COPY setup/build_tools.sh $SC_BUILD/
 COPY siliconcompiler/toolscripts/_tools.py $SC_BUILD/..
 COPY siliconcompiler/toolscripts/_tools.json $SC_BUILD/..
+COPY siliconcompiler/toolscripts/_prereqs.sh $SC_BUILD/..
 COPY siliconcompiler/toolscripts/ubuntu20 $SC_BUILD
 
 WORKDIR $SC_BUILD

--- a/setup/ubuntu22/Docker.testbuild
+++ b/setup/ubuntu22/Docker.testbuild
@@ -44,6 +44,7 @@ ENV CPLUS_INCLUDE_PATH="$SC_PREFIX/include"
 COPY setup/build_tools.sh $SC_BUILD/
 COPY siliconcompiler/toolscripts/_tools.py $SC_BUILD/..
 COPY siliconcompiler/toolscripts/_tools.json $SC_BUILD/..
+COPY siliconcompiler/toolscripts/_prereqs.sh $SC_BUILD/..
 COPY siliconcompiler/toolscripts/ubuntu22 $SC_BUILD
 
 WORKDIR $SC_BUILD

--- a/setup/ubuntu24/Docker.testbuild
+++ b/setup/ubuntu24/Docker.testbuild
@@ -44,6 +44,7 @@ ENV CPLUS_INCLUDE_PATH="$SC_PREFIX/include"
 COPY setup/build_tools.sh $SC_BUILD/
 COPY siliconcompiler/toolscripts/_tools.py $SC_BUILD/..
 COPY siliconcompiler/toolscripts/_tools.json $SC_BUILD/..
+COPY siliconcompiler/toolscripts/_prereqs.sh $SC_BUILD/..
 COPY siliconcompiler/toolscripts/ubuntu24 $SC_BUILD
 
 WORKDIR $SC_BUILD

--- a/setup/ubuntu26/Docker.testbuild
+++ b/setup/ubuntu26/Docker.testbuild
@@ -44,6 +44,7 @@ ENV CPLUS_INCLUDE_PATH="$SC_PREFIX/include"
 COPY setup/build_tools.sh $SC_BUILD/
 COPY siliconcompiler/toolscripts/_tools.py $SC_BUILD/..
 COPY siliconcompiler/toolscripts/_tools.json $SC_BUILD/..
+COPY siliconcompiler/toolscripts/_prereqs.sh $SC_BUILD/..
 COPY siliconcompiler/toolscripts/ubuntu26 $SC_BUILD
 
 WORKDIR $SC_BUILD

--- a/siliconcompiler/asic.py
+++ b/siliconcompiler/asic.py
@@ -745,8 +745,15 @@ class ASICTask(Task):
 
         return [command for command in commands if command.strip()]
 
-    def __parse_sdc_clock(self, file: str) -> Tuple[str, float]:
+    def __parse_sdc_clock(self, file: str) -> Tuple[str, str, float]:
+        """Finds the fastest clock a single SDC file defines.
+
+        Returns:
+            The name, the port and the period of the fastest ``create_clock`` in the
+            file, each None when the file does not give it.
+        """
         name = None
+        port = None
         period = None
         with sc_open(file) as f:
             lines = self.__join_continuations(f.read().splitlines())
@@ -765,11 +772,18 @@ class ASICTask(Task):
         # a command substitution, a list, or a quoted string
         re_word = r"[^\s\[\]{}\"]+"
         sdc_vars = {}
+        # The whole right-hand side, kept separately because a port is regularly held
+        # in a variable that a bare word cannot express, as in
+        # "set clk_port [get_ports clk]".
+        sdc_exprs = {}
         for command in commands:
             tcl_variable = re.findall(fr"^\s*set\s+({re_var})\s+({re_word})", command)
             if tcl_variable:
                 var_name, var_value = tcl_variable[0]
                 sdc_vars[f'${var_name}'] = var_value
+            tcl_expr = re.match(fr"^\s*set\s+({re_var})\s+(\S.*)$", command)
+            if tcl_expr:
+                sdc_exprs[f'${tcl_expr.group(1)}'] = tcl_expr.group(2).strip()
 
         def resolve(value: str) -> Optional[str]:
             """Substitutes TCL variables until a literal is reached, returning None if
@@ -781,6 +795,43 @@ class ASICTask(Task):
                 seen.add(value)
                 value = sdc_vars[value]
             return value
+
+        def expand(command: str) -> str:
+            """Substitutes every variable this parser collected, so that a port reached
+            through one is visible to the port match below. Bounded by the number of
+            variables, which is what stops a variable defined in terms of itself."""
+            for _ in range(len(sdc_exprs) + 1):
+                expanded = re.sub(fr"\${re_var}",
+                                  lambda match: sdc_exprs.get(match.group(0), match.group(0)),
+                                  command)
+                if expanded == command:
+                    break
+                command = expanded
+            return command
+
+        # The flags of create_clock that take a value, so that what is left over is the
+        # object the clock is attached to.
+        flags_with_value = ("-name", "-period", "-waveform", "-comment")
+
+        def find_port(command: str) -> Optional[str]:
+            """Finds the port a create_clock is attached to, None for a virtual clock,
+            which is attached to nothing."""
+            command = expand(command)
+
+            ports = re.findall(fr"get_ports?\s+\{{?\s*({re_word})", command)
+            if ports:
+                return ports[0]
+
+            # No [get_ports ...], so the object list names the port directly.
+            skip = False
+            for token in command.replace("{", " ").replace("}", " ").split():
+                if skip:
+                    skip = False
+                elif token in flags_with_value:
+                    skip = True
+                elif not token.startswith("-"):
+                    return token
+            return None
 
         for command in commands:
             # A create_clock inside a comment or a quoted string is not a clock
@@ -808,11 +859,12 @@ class ASICTask(Task):
 
                 period = new_period
                 # A create_clock without -name takes its name from the port it is
-                # attached to, which this parser does not resolve.
+                # attached to.
                 clock_name = re.findall(fr"-name\s+({re_word})", command)
-                name = resolve(clock_name[0]) if clock_name else None
+                port = find_port(command)
+                name = resolve(clock_name[0]) if clock_name else port
 
-        return name, period
+        return name, port, period
 
     def __get_timing_modes(self) -> List[BaseSchema]:
         """Collects the timing modes of the scenarios that run at this step and index.
@@ -890,6 +942,27 @@ class ASICTask(Task):
                 if lib.has_file(fileset=fileset, filetype="sdc"):
                     self.add_required_key(lib, "fileset", fileset, "file", "sdc")
 
+    def __find_clock(self) -> Tuple[str, str, float]:
+        """Finds the fastest clock across the SDC files that apply at this node.
+
+        Returns:
+            The name, the port and the period of that clock, each None when the SDC
+            files do not give it.
+        """
+        name = None
+        port = None
+        period = None
+
+        for sdc in self.__get_sdcs():
+            new_name, new_port, new_period = self.__parse_sdc_clock(sdc)
+            if new_period is not None:
+                if period is None or new_period < period:
+                    period = new_period
+                    name = new_name
+                    port = new_port
+
+        return name, port, period
+
     def get_clock(self, clock_units_multiplier: float = 1.0) -> Tuple[str, float]:
         """Finds the fastest clock the SDC files of this node define.
 
@@ -900,20 +973,28 @@ class ASICTask(Task):
             The name and period of the fastest clock, either of which is None when the
             SDC files do not give it.
         """
-        name = None
-        period = None
-
-        for sdc in self.__get_sdcs():
-            new_name, new_period = self.__parse_sdc_clock(sdc)
-            if new_period is not None:
-                if period is None or new_period < period:
-                    period = new_period
-                    name = new_name
+        name, _, period = self.__find_clock()
 
         if period is not None:
             period *= clock_units_multiplier
 
         return name, period
+
+    def get_clock_port(self) -> Optional[str]:
+        """Finds the port the fastest clock of this node is attached to.
+
+        This is the name the clock carries in the design, which is not the name of the
+        clock itself: ``create_clock -name core_clock [get_ports clock]`` names a clock
+        ``core_clock`` on a port ``clock``. A tool that has to agree with the SDC on
+        what the clock pin is called -- one generating the RTL the SDC constrains, say
+        -- wants this and not :meth:`get_clock`.
+
+        Returns:
+            The port name, None when the SDC files do not give it or the fastest clock
+            is virtual and so attached to no port.
+        """
+        _, port, _ = self.__find_clock()
+        return port
 
 
 class CellArea:

--- a/siliconcompiler/tools/bambu/convert.py
+++ b/siliconcompiler/tools/bambu/convert.py
@@ -115,15 +115,21 @@ class ConvertTask(ASICTask, Task):
         if mem_channels > 0:
             options.append(f'--channels-number={mem_channels}')
 
-        clk_name, clk_period = self.get_clock()
+        _, clk_period = self.get_clock()
         if clk_period is not None:
-            if self.mainlib.valid("var", "bambu_clock_multiplier"):
+            clock_multiplier = 1.0
+            # the multiplier is a property of the main library, which a project that
+            # only runs the conversion need not have selected
+            if self.project.valid("asic", "mainlib") and \
+                    self.mainlib.valid("var", "bambu_clock_multiplier"):
                 clock_multiplier = self.mainlib.get("var", "bambu_clock_multiplier")
-            else:
-                clock_multiplier = 1.0
             clk_period *= clock_multiplier
-            if clk_name:
-                options.append(f'--clock-name={clk_name}')
+            # --clock-name names the clock port of the generated RTL, which the SDC
+            # then constrains, so it has to be the port the SDC creates its clock on
+            # and not the name of that clock.
+            clk_port = self.get_clock_port()
+            if clk_port:
+                options.append(f'--clock-name={clk_port}')
             options.append(f'--clock-period={clk_period}')
 
         options.append('--disable-function-proxy')

--- a/tests/data/asic/sdc_bare_port.sdc
+++ b/tests/data/asic/sdc_bare_port.sdc
@@ -1,0 +1,3 @@
+current_design aes_cipher_top
+
+create_clock -period 10 clk

--- a/tests/data/asic/sdc_virtual_clock.sdc
+++ b/tests/data/asic/sdc_virtual_clock.sdc
@@ -1,0 +1,3 @@
+current_design aes_cipher_top
+
+create_clock -name vclk -period 10

--- a/tests/test_asic.py
+++ b/tests/test_asic.py
@@ -869,30 +869,36 @@ def test_asic_set_asic_var_from_pdk_as_list(running_node):
 
 
 @pytest.mark.parametrize(
-    "sdc_file,scale,period,clock",
+    "sdc_file,scale,period,clock,port",
     [
-        ("sdc_with_variable.sdc", 1, 10, "clk"),
-        ("sdc_with_nested.sdc", 1, 10, "clk"),
-        ("sdc_with_number0.sdc", 1, 10, "clk"),
-        ("sdc_with_number1.sdc", 1, 10.5, "clk"),
-        ("sdc_with_variable.sdc", 1e-12, 10e-12, "clk"),
-        ("sdc_with_number0.sdc", 1e-12, 10e-12, "clk"),
-        ("sdc_with_number1.sdc", 1e-12, 10.5e-12, "clk"),
-        ("sdc_with_nested.sdc", 1e-9, 10e-9, "clk"),
+        ("sdc_with_variable.sdc", 1, 10, "clk", "clk"),
+        ("sdc_with_nested.sdc", 1, 10, "clk", "clk"),
+        ("sdc_with_number0.sdc", 1, 10, "clk", "clk"),
+        ("sdc_with_number1.sdc", 1, 10.5, "clk", "clk"),
+        ("sdc_with_variable.sdc", 1e-12, 10e-12, "clk", "clk"),
+        ("sdc_with_number0.sdc", 1e-12, 10e-12, "clk", "clk"),
+        ("sdc_with_number1.sdc", 1e-12, 10.5e-12, "clk", "clk"),
+        ("sdc_with_nested.sdc", 1e-9, 10e-9, "clk", "clk"),
         # a create_clock split over several lines
-        ("sdc_with_continuation.sdc", 1, 10, "clk"),
-        # the fastest clock in the file, and its name
-        ("sdc_with_multiple.sdc", 1, 5, "fast_clk"),
-        # a create_clock that takes its name from the port it is attached to
-        ("sdc_without_name.sdc", 1, 10, None),
+        ("sdc_with_continuation.sdc", 1, 10, "clk", "clk"),
+        # the fastest clock in the file, its name, and the port it sits on, which is
+        # not the same string
+        ("sdc_with_multiple.sdc", 1, 5, "fast_clk", "clk_fast"),
+        # a create_clock without -name takes its name from the port it is attached to
+        ("sdc_without_name.sdc", 1, 10, "clk", "clk"),
+        # an object list that names the port directly instead of via get_ports
+        ("sdc_bare_port.sdc", 1, 10, "clk", "clk"),
+        # a virtual clock is attached to no port
+        ("sdc_virtual_clock.sdc", 1, 10, "vclk", None),
         # a commented-out create_clock is not a clock definition
-        ("sdc_with_comment.sdc", 1, 10, "clk"),
+        ("sdc_with_comment.sdc", 1, 10, "clk", "clk"),
         # commands separated by a semicolon are still commands
-        ("sdc_with_semicolon.sdc", 1, 10, "clk"),
+        ("sdc_with_semicolon.sdc", 1, 10, "clk", "clk"),
         # a zero period is not the fastest clock, it is not a clock
-        ("sdc_with_zero_period.sdc", 1, 10, "clk"),
+        ("sdc_with_zero_period.sdc", 1, 10, "clk", "clk"),
     ])
-def test_get_clock_sdc(datadir, sdc_file, scale, period, clock, running_project, running_node):
+def test_get_clock_sdc(datadir, sdc_file, scale, period, clock, port,
+                       running_project, running_node):
     task = ASICTask()
     EditableSchema(running_project).insert("tool", "dummy", "task", "asic", task)
 
@@ -903,9 +909,11 @@ def test_get_clock_sdc(datadir, sdc_file, scale, period, clock, running_project,
 
     with task.runtime(running_node) as runtool:
         name, sdc_period = runtool.get_clock(scale)
+        sdc_port = runtool.get_clock_port()
 
     assert name == clock
     assert sdc_period == period
+    assert sdc_port == port
 
 
 def test_get_clock_sdc_from_constraints(datadir, running_project, running_node):
@@ -987,9 +995,11 @@ def test_get_clock_none(running_project, running_node):
 
     with task.runtime(running_node) as runtool:
         name, sdc_period = runtool.get_clock()
+        sdc_port = runtool.get_clock_port()
 
     assert name is None
     assert sdc_period is None
+    assert sdc_port is None
 
 
 def test_snapshot_info_empty():

--- a/tests/tools/test_bambu.py
+++ b/tests/tools/test_bambu.py
@@ -76,6 +76,27 @@ def test_runtime_args(gcd_design, datadir):
         ]
 
 
+def test_runtime_args_clock(gcd_design):
+    """--clock-name is the clock port of the generated RTL, so it has to come from the
+    port the SDC creates its clock on and not from the name of that clock. gcd.sdc says
+    "create_clock -name core_clock ... [get_ports clk]"; naming the port core_clock
+    would leave the SDC constraining a port that does not exist."""
+    proj = Project(gcd_design)
+    proj.add_fileset(["rtl", "sdc"])
+
+    flow = Flowgraph("testflow")
+    flow.node("convert", convert.ConvertTask())
+    proj.set_flow(flow)
+
+    node = SchedulerNode(proj, "convert", "0")
+    with node.runtime():
+        assert node.setup() is True
+        arguments = node.task.get_runtime_arguments()
+
+    assert '--clock-name=clk' in arguments
+    assert '--clock-period=2.0' in arguments
+
+
 def test_parameter_memorychannels():
     task = convert.ConvertTask()
     task.set_bambu_memorychannels(2)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SDC clock handling to identify associated clock ports, including ports referenced through common constraint commands.
  * Added access to the detected clock port for downstream tools.
  * Bambu runtime arguments now use the detected clock port and period when available.

* **Bug Fixes**
  * Improved compatibility with conversion-only projects that do not define a main ASIC library.

* **Chores**
  * Updated supported Docker test-build images to include prerequisite setup files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->