### PR TITLE
fix show ordering

### DIFF
--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -1471,8 +1471,12 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
             extension (str, optional): The specific file extension to search for when
                                        automatically finding a file (e.g., 'gds', 'lef').
                                        Used only if `filename` is None. Defaults to None.
-            tool (str, optional): The name of the specific showtool to use for displaying the file.
-                                  If not provided, the tool is selected based on the file extension.
+            tool (str, optional): The specific showtool to use for displaying the file, as
+                                  ``"tool"`` or ``"tool/task"``. If not provided, the tool is
+                                  selected based on the file extension. If provided but not
+                                  usable for the file (unknown tool, or a tool that does not
+                                  support the extension), an error is logged and None is
+                                  returned rather than falling back to a different tool.
             open (bool): If True, the file is opened with an `OpenTask` (e.g. an interactive
                          tool session) instead of being rendered with a `ShowTask`.
                          Mutually exclusive with `screenshot`. Defaults to False.
@@ -1527,8 +1531,14 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
             # Use the shared extension map so the preferred tool for each
             # extension matches what sc-show -list reports. The map preserves
             # registration order, so higher-priority tools are tried first.
+            # A user-supplied tool is a hard requirement, so the search is
+            # restricted to the extensions that tool can actually handle.
             ext_map = tool_cls.get_extension_map(tool=tool)
             search_exts = list(ext_map.keys())
+
+            if tool and not search_exts:
+                self.logger.error(f"No registered tasks matched tool '{tool}'.")
+                return None
 
             if extension:
                 if extension not in search_exts:
@@ -1569,10 +1579,17 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         task = tool_cls.get_task(ext=filetype, tool=tool)
         if task is None:
             if tool:
-                self.logger.error(f"Filetype '{filetype}' not available for {tool}.")
-            else:
-                self.logger.error(
-                    f"Filetype '{filetype}' not available in the registered showtools.")
+                # get_task() honors a named tool or nothing, so this is the
+                # requested tool being unusable, not the extension being
+                # unsupported outright.
+                self.logger.error(f"Filetype '{filetype}' not available for '{tool}'.")
+                available = tool_cls._get_tasks_for_extension(filetype)
+                if available:
+                    names = ', '.join(f"{t.tool()}/{t.task()}" for t in available)
+                    self.logger.error(f"Tasks supporting '{filetype}': {names}")
+                    return None
+            self.logger.error(
+                f"Filetype '{filetype}' not available in the registered showtools.")
             return None
 
         # Create copy of project to avoid changing user project

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -3304,6 +3304,17 @@ class OpenTask(Task):
         """
         Registers a new show task class for dynamic discovery.
 
+        Registration order is priority order: later registrations outrank
+        earlier ones (see :meth:`get_task`). Re-registering an already known
+        task therefore moves it to the end -- :meth:`SettingsManager.set
+        <siliconcompiler.utils.settings.SettingsManager.set>` appends on every
+        write. Were it to stay where it first landed, whoever imported a viewer
+        module first would fix its priority for the life of the process, and
+        the deliberate ordering in
+        :func:`~siliconcompiler.utils.showtools.showtasks` would be silently
+        ignored for any module already pulled in by user code, a plugin, or the
+        subclass recursion in ``__build_tasks``.
+
         Args:
             task: The show task class to register.
 
@@ -3388,10 +3399,10 @@ class OpenTask(Task):
         # Register the built-in viewers, in the order showtools prefers.
         #
         # Imported here rather than at module scope because showtools imports from
-        # siliconcompiler, which imports this module. The import must also stay below the
-        # recursion above: it is what pulls the viewer modules in, and if it ran first the
-        # recursion would register them in module-path order and showtools could no longer
-        # influence which one wins (re-registering a task does not reorder it).
+        # siliconcompiler, which imports this module. Priority no longer depends on
+        # this running after the recursion above -- register_task() re-orders on
+        # re-registration -- but it is still what pulls the viewer modules in, so the
+        # recursion alone cannot be relied on to discover them.
         from siliconcompiler.utils.showtools import showtasks
         showtasks()
 
@@ -3414,15 +3425,22 @@ class OpenTask(Task):
         settings file (~/.sc/settings.json) under the 'showtask' category for a preferred tool.
         If no tool is requested and no preference is found, it falls back to automatic discovery.
 
+        Every lookup walks the registry in reverse registration order, so a
+        later-registered task (a plugin, or a built-in listed later in
+        :func:`~siliconcompiler.utils.showtools.showtasks`) wins over an earlier
+        one. This holds for the ``tool`` hint and the user-settings preference
+        as well as for automatic discovery, so narrowing a lookup with a
+        tool-only hint like ``"openroad"`` cannot select a lower-priority task
+        than the unhinted lookup would.
+
         Args:
             ext (str): The file extension to find a viewer for.
-            tool (str, optional): A tool/task hint, not a strict filter. Format
-                can be ``"tool"`` to prefer any task from that tool, or
-                ``"tool/task"`` to prefer a specific task. If the hint cannot be
-                resolved for ``ext`` (e.g. the named tool doesn't support that
-                extension), resolution falls back to the user-settings
-                preference and then to automatic discovery, so a non-None
-                result does not guarantee the returned task matches the hint.
+            tool (str, optional): The tool/task to use, as ``"tool"`` for any
+                task of that tool or ``"tool/task"`` for a specific one. This
+                is a requirement, not a hint: if it cannot be resolved for
+                ``ext`` -- an unknown tool, or one that does not support that
+                extension -- None is returned rather than quietly running
+                something else. Leave it unset to let ``ext`` decide.
 
         Returns:
             An instance of a compatible ShowTask subclass, or None if
@@ -3445,7 +3463,12 @@ class OpenTask(Task):
             spec_tool = spec_parts[0]
             spec_task = spec_parts[1] if len(spec_parts) > 1 else None
 
-            for task_cls in tasks:
+            # Iterate in reverse, matching the automatic-discovery fallback below:
+            # later registrations take precedence. Walking forward here would make a
+            # tool-only spec resolve to the *lowest*-priority task of that tool, so
+            # e.g. "openroad" would pick openroad/web over openroad/show even though
+            # showtasks() registers web first precisely so show wins.
+            for task_cls in reversed(tasks):
                 try:
                     task_inst = task_cls()
                     # Check if this task matches the specification
@@ -3473,11 +3496,11 @@ class OpenTask(Task):
         if ext is None:
             return tasks
 
-        # 1. Check for requested tool first (if provided)
+        # 1. An explicitly requested tool wins, and is the only thing tried:
+        # the caller named it, so falling through to another one would silently
+        # launch the wrong viewer.
         if tool:
-            result = find_task_by_spec(tool, ext, tasks)
-            if result:
-                return result
+            return find_task_by_spec(tool, ext, tasks)
 
         # 2. Check User Settings for Preference
         if issubclass(cls, ShowTask):
@@ -3485,6 +3508,9 @@ class OpenTask(Task):
         else:
             preference = MPManager.get_settings().get("opentask", ext)
 
+        # Unlike an explicit request, a stale preference degrades quietly: a
+        # setting left over from an uninstalled viewer should not make show()
+        # stop working.
         if preference:
             result = find_task_by_spec(preference, ext, tasks)
             if result:
@@ -3520,11 +3546,10 @@ class OpenTask(Task):
         :meth:`get_supported_task_extentions`).
 
         Args:
-            tool (str, optional): A tool/task preference hint in ``"tool"`` or
-                ``"tool/task"`` form, forwarded to :meth:`get_task`. It biases
-                the preferred task per extension but is not a strict filter:
-                extensions the hint cannot resolve still appear in the map
-                with whichever task :meth:`get_task` falls back to.
+            tool (str, optional): Restrict the map to one tool/task, in
+                ``"tool"`` or ``"tool/task"`` form, forwarded to
+                :meth:`get_task`. Extensions that tool cannot handle are
+                omitted, so the result describes only what it can show.
 
         Returns:
             A dictionary mapping each supported extension to the preferred
@@ -3554,6 +3579,32 @@ class OpenTask(Task):
             if preferred is not None:
                 ext_map[ext] = preferred
         return ext_map
+
+    @classmethod
+    def _get_tasks_for_extension(cls: Type[TOpenTask], ext: str) -> List[TOpenTask]:
+        """
+        Returns every registered task that declares support for an extension.
+
+        Args:
+            ext (str): The file extension to look up.
+
+        Returns:
+            A list of task instances supporting ``ext``, most-preferred first
+            (reverse registration order, matching :meth:`get_task`).
+        """
+        tasks = cls.get_task(None)
+        if not tasks:
+            return []
+
+        found: List[TOpenTask] = []
+        for task_cls in reversed(tasks):
+            try:
+                task_inst = task_cls()
+                if ext in task_inst.get_supported_task_extentions():
+                    found.append(task_inst)
+            except NotImplementedError:
+                continue
+        return found
 
 
 class ShowTask(OpenTask):

--- a/siliconcompiler/utils/settings.py
+++ b/siliconcompiler/utils/settings.py
@@ -316,11 +316,21 @@ class SettingsManager:
         """
         Set a specific setting within a category.
 
+        A write always places the key last within its category, so a category's
+        iteration order is the order its keys were most recently written.
+        Categories looked up by key do not care, but the ones whose order
+        carries meaning depend on it -- see
+        :meth:`~siliconcompiler.tool.OpenTask.register_task`, where a later
+        registration has to outrank an earlier one. Leaving a re-written key at
+        its original position would silently pin priority to whoever wrote it
+        first.
+
         Args:
             category (str): The group name (e.g., 'showtools', 'options').
             key (str): The specific setting name.
             value: The value to store (must be JSON serializable).
-            keep (bool): If True, do not overwrite existing value.
+            keep (bool): If True, do not overwrite existing value (and so also
+                leave its position alone).
         """
         if self._has_priority(category, key):
             self.__logger.warning(f"Setting '{category}.{key}' has system priority and cannot be "
@@ -334,6 +344,9 @@ class SettingsManager:
 
                 if keep and key in self.__settings[category]:
                     return
+                # Plain assignment keeps an existing key at its original
+                # position; drop it first so the write appends.
+                self.__settings[category].pop(key, None)
                 self.__settings[category][key] = value
 
     def get(self, category: str, key: str, default=None):

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -3799,7 +3799,7 @@ def test_get_task_with_tool_parameter_valid(isolated_tasks):
 
 
 def test_get_task_with_tool_parameter_invalid(isolated_tasks):
-    """Test that requesting a non-existent tool falls back to defaults."""
+    """Requesting a non-existent tool is refused, not quietly substituted."""
     ShowTask.register_task(ToolA)
     ShowTask.register_task(ToolB)
 
@@ -3812,9 +3812,9 @@ def test_get_task_with_tool_parameter_invalid(isolated_tasks):
         # Request a tool that doesn't exist
         task = ShowTask.get_task("ext", tool="nonexistent")
 
-        # Should fall back to default discovery
-        assert task is not None
-        assert task.tool() in ["toola", "toolb"]
+        # Falling back to toola/toolb here would run a viewer the caller did
+        # not ask for, and a typo would look like success.
+        assert task is None
 
 
 def test_get_task_with_tool_priority_over_preference(isolated_tasks):
@@ -3843,7 +3843,7 @@ def test_get_task_with_tool_priority_over_preference(isolated_tasks):
 
 
 def test_get_task_with_tool_unsupported_extension(isolated_tasks):
-    """Test that tool param doesn't force unsupported extensions."""
+    """A tool that cannot read the extension is refused, not swapped out."""
 
     class ToolC(ShowTask):
         def tool(self):
@@ -3867,9 +3867,8 @@ def test_get_task_with_tool_unsupported_extension(isolated_tasks):
         # Try to use ToolC for 'ext' (which it doesn't support)
         task = ShowTask.get_task("ext", tool="toolc")
 
-        # Should fall back to ToolA since ToolC doesn't support 'ext'
-        assert task is not None
-        assert task.tool() == "toola"
+        # ToolA supports 'ext', but the caller asked for toolc.
+        assert task is None
 
 
 def test_get_task_with_tool_multiple_tasks_same_tool(isolated_tasks):
@@ -3990,10 +3989,10 @@ def test_get_task_with_tool_case_sensitive(isolated_tasks):
         # Try with different case
         task = ShowTask.get_task("ext", tool="ToolA")
 
-        # Should not match since tool names are case-sensitive
-        # Should fall back to default
-        assert task is not None
-        assert task.tool() in ["toola", "toolb"]
+        # Tool names are case-sensitive, so "ToolA" names nothing and is
+        # refused rather than resolving to toola or toolb.
+        assert task is None
+        assert ShowTask.get_task("ext", tool="toola").tool() == "toola"
 
 
 def test_get_task_with_tool_empty_string(isolated_tasks):
@@ -4080,9 +4079,8 @@ def test_get_task_with_tool_task_format_invalid_task(isolated_tasks):
         # Request non-existent task
         task = ShowTask.get_task("txt", tool="toolh/mode_b")
 
-        # Should fall back to default discovery
-        assert task is not None
-        assert task.tool() == "toolh"
+        # toolh/mode_a is right there, but "mode_b" is what was asked for.
+        assert task is None
 
 
 def test_get_task_tool_task_format_priority_over_preference(isolated_tasks):
@@ -4225,12 +4223,13 @@ def test_get_extension_map_respects_user_preference(isolated_tasks):
 
 
 def test_get_extension_map_tool_filter_matches_get_task(isolated_tasks):
-    """tool= behavior in get_extension_map mirrors get_task: it's a hint, not a strict filter.
+    """tool= behavior in get_extension_map mirrors get_task: it is a filter.
 
-    For extensions the requested tool supports, the requested tool is preferred.
-    For extensions it does not, get_task falls back to whatever tool can handle
-    them, and get_extension_map reflects that same fallback. This matches how
-    Project.show resolves a tool for the eventual file extension.
+    For extensions the requested tool supports, the requested tool is the
+    preferred one. Extensions it cannot handle are dropped rather than mapped
+    to a fallback, matching get_task refusing to substitute a tool the caller
+    did not name. This is what Project.show relies on to keep its search to
+    files the requested tool can actually open.
     """
 
     class ToolOnlyXyz(ShowTask):
@@ -4256,9 +4255,12 @@ def test_get_extension_map_tool_filter_matches_get_task(isolated_tasks):
 
         # ToolA wins for "ext" because the requested tool actually supports it.
         assert isinstance(ext_map["ext"], ToolA)
-        # "xyz" still falls back to ToolOnlyXyz — matching get_task's behavior
-        # when the requested tool can't handle the extension.
-        assert isinstance(ext_map["xyz"], ToolOnlyXyz)
+        # "xyz" is dropped: ToolOnlyXyz handles it, but toola is what was asked
+        # for, and get_task returns None there.
+        assert "xyz" not in ext_map
+        assert ShowTask.get_task("xyz", tool="toola") is None
+        # Unfiltered, "xyz" is present.
+        assert isinstance(ShowTask.get_extension_map()["xyz"], ToolOnlyXyz)
 
         # Every entry must equal what get_task would return for that ext.
         for ext, preferred in ext_map.items():
@@ -4402,6 +4404,160 @@ def test_get_extension_map_matches_get_task_resolution(isolated_tasks):
             assert type(resolved) is type(preferred), \
                 f"ext={ext}: map gave {type(preferred).__name__}, " \
                 f"get_task gave {type(resolved).__name__}"
+
+
+class _PriorityLow(ShowTask):
+    """Registered first, so the registration-order convention makes it lose."""
+    def tool(self):
+        return "prio"
+
+    def task(self):
+        return "low"
+
+    def get_supported_task_extentions(self):
+        return ["prio_ext"]
+
+
+class _PriorityHigh(ShowTask):
+    """Registered last, so it is the preferred task of tool "prio"."""
+    def tool(self):
+        return "prio"
+
+    def task(self):
+        return "high"
+
+    def get_supported_task_extentions(self):
+        return ["prio_ext"]
+
+
+@pytest.fixture
+def priority_tasks(isolated_tasks):
+    """Two tasks of one tool, registered lowest-priority first."""
+    ShowTask.register_task(_PriorityLow)
+    ShowTask.register_task(_PriorityHigh)
+
+    with patch('siliconcompiler.utils.multiprocessing.MPManager.get_settings') \
+            as mock_settings_cls:
+        mock_settings = MagicMock()
+        mock_settings.get.return_value = None  # No preference
+        mock_settings_cls.return_value = mock_settings
+        yield
+
+
+def test_get_task_tool_only_hint_matches_unhinted_priority(priority_tasks):
+    """A tool-only hint must not select a lower-priority task than no hint at all.
+
+    Registration order is "later wins" (see showtasks()), so a tool that
+    registers its fallback viewer first and its preferred viewer second must
+    resolve to the preferred one either way. Walking the registry forward here
+    used to return the first match, i.e. exactly the task the ordering was set
+    up to lose -- e.g. "openroad" gave openroad/web instead of openroad/show.
+    """
+    unhinted = ShowTask.get_task("prio_ext")
+    hinted = ShowTask.get_task("prio_ext", tool="prio")
+
+    assert isinstance(unhinted, _PriorityHigh)
+    assert isinstance(hinted, _PriorityHigh), \
+        f"tool-only hint downgraded to {hinted.task()}"
+
+
+def test_get_task_tool_task_hint_still_reaches_lower_priority(priority_tasks):
+    """The full "tool/task" form can still pin the lower-priority task."""
+    task = ShowTask.get_task("prio_ext", tool="prio/low")
+
+    assert isinstance(task, _PriorityLow)
+
+
+def test_get_task_preference_matches_unhinted_priority(priority_tasks):
+    """A tool-only user-settings preference resolves the same way as the hint."""
+    with patch('siliconcompiler.utils.multiprocessing.MPManager.get_settings') \
+            as mock_settings_cls:
+        mock_settings = MagicMock()
+
+        def get_side_effect(category, key, default=None):
+            if category == "showtask" and key == "prio_ext":
+                return "prio"
+            return default
+
+        mock_settings.get.side_effect = get_side_effect
+        mock_settings_cls.return_value = mock_settings
+
+        assert isinstance(ShowTask.get_task("prio_ext"), _PriorityHigh)
+
+
+def test_get_extension_map_tool_only_hint_matches_unhinted(priority_tasks):
+    """get_extension_map inherits the corrected hint resolution."""
+    assert isinstance(ShowTask.get_extension_map()["prio_ext"], _PriorityHigh)
+    assert isinstance(ShowTask.get_extension_map(tool="prio")["prio_ext"], _PriorityHigh)
+
+
+def test_get_task_unknown_tool_returns_none(priority_tasks):
+    """A misspelled tool or task is refused rather than substituted.
+
+    "prioo" and "prio/nosuchtask" used to fall through to automatic discovery
+    and quietly launch whatever else handled the extension.
+    """
+    assert ShowTask.get_task("prio_ext", tool="prioo") is None
+    assert ShowTask.get_task("prio_ext", tool="prio/nosuchtask") is None
+
+
+def test_get_task_tool_without_extension_returns_none(priority_tasks):
+    """A real tool that cannot handle the extension is also refused."""
+
+    class ToolOther(ShowTask):
+        def tool(self):
+            return "other"
+
+        def task(self):
+            return "show"
+
+        def get_supported_task_extentions(self):
+            return ["other_ext"]
+
+    ShowTask.register_task(ToolOther)
+
+    assert ShowTask.get_task("prio_ext", tool="other") is None
+
+
+def test_get_task_resolvable_tool_is_unaffected(priority_tasks):
+    """Refusing the unresolvable case does not disturb the resolvable one."""
+    assert isinstance(ShowTask.get_task("prio_ext", tool="prio"), _PriorityHigh)
+    assert isinstance(ShowTask.get_task("prio_ext", tool="prio/low"), _PriorityLow)
+    assert isinstance(ShowTask.get_task("prio_ext"), _PriorityHigh)
+    assert ShowTask.get_task("nosuchext") is None
+
+
+def test_get_extension_map_tool_drops_unhandled_extensions(priority_tasks):
+    """A tool argument narrows the map to what that tool can handle."""
+
+    class ToolOther(ShowTask):
+        def tool(self):
+            return "other"
+
+        def task(self):
+            return "show"
+
+        def get_supported_task_extentions(self):
+            return ["other_ext"]
+
+    ShowTask.register_task(ToolOther)
+
+    assert set(ShowTask.get_extension_map().keys()) == {"prio_ext", "other_ext"}
+    assert set(ShowTask.get_extension_map(tool="prio").keys()) == {"prio_ext"}
+    assert isinstance(ShowTask.get_extension_map(tool="prio")["prio_ext"], _PriorityHigh)
+
+
+def test_get_extension_map_unknown_tool_is_empty(priority_tasks):
+    """An unknown tool leaves nothing in the map."""
+    assert ShowTask.get_extension_map(tool="prioo") == {}
+
+
+def test_tasks_for_extension_priority_order(priority_tasks):
+    """_get_tasks_for_extension lists supporting tasks most-preferred first."""
+    found = ShowTask._get_tasks_for_extension("prio_ext")
+
+    assert [t.task() for t in found] == ["high", "low"]
+    assert ShowTask._get_tasks_for_extension("nosuchext") == []
 
 
 def test_task_py_logging_output_different_files(gcd_design):

--- a/tests/utils/test_settings.py
+++ b/tests/utils/test_settings.py
@@ -102,6 +102,106 @@ def test_get_category(settings_file):
     assert manager.get_category('missing') == {}
 
 
+def test_set_appends_new_keys_in_write_order(settings_file):
+    """A category iterates in the order its keys were written."""
+    manager = SettingsManager(settings_file, logging.getLogger())
+    manager.set('order', 'first', 1)
+    manager.set('order', 'second', 2)
+    manager.set('order', 'third', 3)
+
+    assert list(manager.get_category('order')) == ['first', 'second', 'third']
+
+
+def test_set_moves_rewritten_key_to_the_end(settings_file):
+    """Re-writing a key re-positions it, it does not update it in place.
+
+    Callers that read a category as an ordered list treat position as
+    precedence -- see OpenTask.register_task, where a later registration has to
+    outrank an earlier one. Plain dict assignment keeps an existing key where
+    it first landed, which would pin precedence to whoever wrote it first.
+    """
+    manager = SettingsManager(settings_file, logging.getLogger())
+    manager.set('order', 'first', 1)
+    manager.set('order', 'second', 2)
+    manager.set('order', 'third', 3)
+
+    manager.set('order', 'first', 'rewritten')
+
+    assert list(manager.get_category('order')) == ['second', 'third', 'first']
+    assert manager.get('order', 'first') == 'rewritten'
+
+
+def test_set_reorders_even_when_value_is_unchanged(settings_file):
+    """Writing the same value still counts as a fresh write."""
+    manager = SettingsManager(settings_file, logging.getLogger())
+    manager.set('order', 'a', 'x')
+    manager.set('order', 'b', 'x')
+
+    manager.set('order', 'a', 'x')
+
+    assert list(manager.get_category('order')) == ['b', 'a']
+
+
+def test_set_keep_does_not_reorder(settings_file):
+    """keep=True skips the write entirely, position included."""
+    manager = SettingsManager(settings_file, logging.getLogger())
+    manager.set('order', 'a', 1)
+    manager.set('order', 'b', 2)
+
+    manager.set('order', 'a', 99, keep=True)
+
+    assert list(manager.get_category('order')) == ['a', 'b']
+    assert manager.get('order', 'a') == 1
+
+
+def test_set_ordering_is_per_category(settings_file):
+    """Re-writing a key in one category leaves other categories alone."""
+    manager = SettingsManager(settings_file, logging.getLogger())
+    manager.set('one', 'a', 1)
+    manager.set('one', 'b', 2)
+    manager.set('two', 'a', 1)
+    manager.set('two', 'b', 2)
+
+    manager.set('one', 'a', 3)
+
+    assert list(manager.get_category('one')) == ['b', 'a']
+    assert list(manager.get_category('two')) == ['a', 'b']
+
+
+def test_set_ordering_survives_save_and_reload(settings_file):
+    """The persisted file keeps the order, so a reload resolves the same way."""
+    manager = SettingsManager(settings_file, logging.getLogger())
+    manager.set('order', 'first', 1)
+    manager.set('order', 'second', 2)
+    manager.set('order', 'first', 3)
+    manager.save()
+
+    with open(settings_file, encoding='utf-8') as f:
+        assert list(json.load(f)['order']) == ['second', 'first']
+
+    reloaded = SettingsManager(settings_file, logging.getLogger())
+    assert list(reloaded.get_category('order')) == ['second', 'first']
+
+
+def test_set_ordering_with_system_layer(settings_file, system_file):
+    """System defaults lead; a user key that shadows one keeps the system slot.
+
+    get_category() builds the system layer first and updates it with the user
+    layer, so re-writing a shadowing key moves it within the user dict but not
+    within the merged view. Only categories with no system layer -- such as the
+    in-memory transient registry -- can rely on the merged order.
+    """
+    _write_json(system_file, {'order': {'sys_a': 1, 'sys_b': 2}})
+    manager = SettingsManager(settings_file, logging.getLogger(),
+                              system_filepath=system_file)
+
+    manager.set('order', 'user_a', 3)
+    manager.set('order', 'sys_a', 4)
+
+    assert list(manager.get_category('order')) == ['sys_a', 'sys_b', 'user_a']
+    assert manager.get('order', 'sys_a') == 4
+
+
 def test_delete_setting(settings_file):
     """Test deleting settings and cleaning up empty categories."""
     manager = SettingsManager(settings_file, logging.getLogger())

--- a/tests/utils/test_showtools.py
+++ b/tests/utils/test_showtools.py
@@ -325,3 +325,212 @@ def test_vcd_viewer_preference(available, expected):
                           capture_output=True, text=True)
     assert proc.returncode == 0, proc.stderr
     assert proc.stdout.strip() == expected
+
+
+# ---------------------------------------------------------------------------
+# Tool-hint resolution against the real built-in registry.
+#
+# showtasks() registers OpenROADWeb *before* OpenROADShow so that the
+# "later registration wins" rule makes openroad/show the default viewer for
+# odb/def/vg. These pin that the -tool hint agrees with the default instead of
+# inverting it.
+# ---------------------------------------------------------------------------
+
+OPENROAD_SHOW_EXTS = ["odb", "def", "vg"]
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("ext", OPENROAD_SHOW_EXTS)
+def test_openroad_default_viewer_is_show_not_web(ext):
+    """The unhinted default for OpenROAD's extensions is the GUI, not the webviewer."""
+    task = ShowTask.get_task(ext)
+
+    assert (task.tool(), task.task()) == ("openroad", "show")
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("ext", OPENROAD_SHOW_EXTS)
+def test_openroad_tool_only_hint_matches_default(ext):
+    """"-tool openroad" must not downgrade the choice to openroad/web.
+
+    Regression: find_task_by_spec() walked the registry forward while the
+    automatic fallback walked it backward, so naming the tool selected the
+    task the registration order was set up to lose.
+    """
+    task = ShowTask.get_task(ext, tool="openroad")
+
+    assert (task.tool(), task.task()) == ("openroad", "show"), \
+        f"-tool openroad picked openroad/{task.task()} for '{ext}'"
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("ext", OPENROAD_SHOW_EXTS)
+@pytest.mark.parametrize("task_name", ["show", "web"])
+def test_openroad_tool_task_hint_is_exact(ext, task_name):
+    """The full "tool/task" form still reaches either viewer."""
+    task = ShowTask.get_task(ext, tool=f"openroad/{task_name}")
+
+    assert (task.tool(), task.task()) == ("openroad", task_name)
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_openroad_3dblox_tool_only_hint_matches_default():
+    """The same ordering holds for the 3dbx pair."""
+    assert ShowTask.get_task("3dbx").task() == "show3dblox"
+    assert ShowTask.get_task("3dbx", tool="openroad").task() == "show3dblox"
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_klayout_tool_only_hint_matches_default():
+    """A tool with a single task is unaffected by the reversed walk."""
+    task = ShowTask.get_task("gds", tool="klayout")
+
+    assert (task.tool(), task.task()) == ("klayout", "show")
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_extension_map_tool_hint_matches_default():
+    """sc-show -list stars the same task the hint resolves to."""
+    default_map = ShowTask.get_extension_map()
+    hinted_map = ShowTask.get_extension_map(tool="openroad")
+
+    for ext in OPENROAD_SHOW_EXTS:
+        assert type(default_map[ext]) is type(hinted_map[ext])
+        assert hinted_map[ext].task() == "show"
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("bad_tool", ["openrroad", "openrroad/web", "openroad/wbe"])
+def test_misspelled_tool_is_refused_not_substituted(bad_tool):
+    """A typo must not silently resolve to some other viewer."""
+    assert ShowTask.get_task("odb", tool=bad_tool) is None
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_tool_without_extension_support_is_refused():
+    """klayout cannot read odb, so asking for it is an error, not a fallback."""
+    assert ShowTask.get_task("odb", tool="klayout") is None
+    assert ShowTask.get_task("gds", tool="openroad") is None
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_tasks_for_extension_reports_openroad_viewers():
+    """The candidate list backing the error message is in priority order."""
+    names = [f"{t.tool()}/{t.task()}" for t in ShowTask._get_tasks_for_extension("odb")]
+
+    assert names == ["openroad/show", "openroad/web"]
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("bad_tool", ["openrroad/web", "klayout"])
+def test_project_show_refuses_unusable_tool(bad_tool, monkeypatch, caplog, gcd_design):
+    """Project.show() reports the bad tool instead of running a different one."""
+    proj = Project(gcd_design)
+    proj.add_fileset("rtl")
+    proj.logger.setLevel("INFO")
+
+    monkeypatch.setattr("os.path.exists", lambda x: True)
+    monkeypatch.setattr("os.path.abspath", lambda x: x)
+
+    def no_run(self):
+        raise AssertionError("show() ran a flow despite an unusable -tool")
+
+    monkeypatch.setattr(Project, "run", no_run)
+
+    assert proj.show("/path/to/design.odb", tool=bad_tool) is None
+
+    assert f"Filetype 'odb' not available for '{bad_tool}'." in caplog.text
+    assert "Tasks supporting 'odb': openroad/show, openroad/web" in caplog.text
+
+
+@pytest.mark.quick
+@pytest.mark.timeout(300)
+def test_project_show_tool_hint_selects_default_task(monkeypatch, gcd_design):
+    """Project.show() with "-tool openroad" builds a flow around openroad/show."""
+    proj = Project(gcd_design)
+    proj.add_fileset("rtl")
+
+    monkeypatch.setattr("os.path.exists", lambda x: True)
+    monkeypatch.setattr("os.path.abspath", lambda x: x)
+
+    picked = []
+
+    def capture_run(self):
+        flow = self.get_flow(self.option.get_flow())
+        for step, index in flow.get_nodes():
+            task = flow.get_task_module(step, index)()
+            picked.append(f"{task.tool()}/{task.task()}")
+
+    monkeypatch.setattr(Project, "run", capture_run)
+
+    proj.show("/path/to/design.odb", tool="openroad")
+
+    assert picked == ["openroad/show"]
+
+
+# An early import of a viewer module lets the subclass recursion in
+# __build_tasks register it before showtasks() gets a say. register_task()
+# re-orders on re-registration so showtools still decides, but that has to be
+# checked in a fresh interpreter -- this module imports openroad.show at the
+# top, so the "early" case is already baked in by the time a test runs here.
+IMPORT_ORDER_PROBE = """
+import sys
+if len(sys.argv) > 1 and sys.argv[1] == "early":
+    import siliconcompiler.tools.openroad.show  # noqa: F401
+
+from unittest.mock import patch
+import siliconcompiler.utils as utils
+with patch.object(utils, "entry_points", lambda group: []):
+    from siliconcompiler import ShowTask
+    order = []
+    for cls in ShowTask.get_task(None):
+        try:
+            inst = cls()
+            order.append(inst.tool() + "/" + inst.task())
+        except NotImplementedError:
+            continue
+    print(",".join(order))
+    for hint in (None, "openroad"):
+        task = ShowTask.get_task("odb", tool=hint)
+        print(task.tool() + "/" + task.task())
+"""
+
+
+@pytest.mark.parametrize("when", ["late", "early"])
+def test_registry_order_independent_of_viewer_import_order(when):
+    """showtools decides priority even if a viewer module was imported first.
+
+    Regression: register_task() wrote through to a dict, and assigning an
+    existing key leaves it in place. Importing openroad.show before the first
+    get_task() therefore let the module-path-sorted subclass recursion pin
+    WebTask after ShowTask, making openroad/web the default for odb.
+    """
+    proc = subprocess.run([sys.executable, "-c", IMPORT_ORDER_PROBE, when],
+                          capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+
+    order, unhinted, hinted = proc.stdout.strip().splitlines()
+
+    assert order.split(",") == [
+        "klayout/show",
+        "openroad/web",
+        "openroad/show",
+        "openroad/web3dblox",
+        "openroad/show3dblox",
+        "graphviz/show",
+        "vpr/show",
+        "gtkwave/show",
+        "surfer/show",
+    ]
+    assert unhinted == "openroad/show"
+    assert hinted == "openroad/show"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Viewer selection now respects explicitly chosen tools and tasks without silently switching to alternatives.
  - Unsupported, unknown, or misspelled tool requests are rejected clearly.
  - File discovery now considers only formats supported by the selected tool.
  - Viewer task priorities are applied consistently, including default and preference-based selections.

- **Improvements**
  - Extension listings now exclude formats unsupported by the selected tool.
  - Settings updates preserve predictable ordering, with rewritten entries moving to the end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->