### PR TITLE
move tools build to 24

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -94,7 +94,7 @@ jobs:
   daily_tests_job:
     needs: [cache, docker_image, test_setup]
     timeout-minutes: 150
-    runs-on: ubuntu-22.04 # Match ubuntu version with container
+    runs-on: ubuntu-24.04 # Match ubuntu version with container
     container:
       image: ${{ needs.docker_image.outputs.sc_tool }}
 

--- a/setup/docker/builder.py
+++ b/setup/docker/builder.py
@@ -17,7 +17,7 @@ from siliconcompiler.toolscripts import _tools
 _file_path = os.path.dirname(__file__)
 _builder_path = os.path.abspath(os.path.join(_file_path, '..'))
 _tools_path = os.path.abspath(os.path.dirname(_tools.__file__))
-_install_script_path = os.path.join(_tools_path, 'ubuntu22')
+_install_script_path = os.path.join(_tools_path, 'ubuntu24')
 # Sourced by every install script, so it has to travel into the image with them
 # and feed the tool image tag the same way the install script itself does.
 _prereqs_script = '_prereqs.sh'

--- a/setup/docker/sc_tools.docker
+++ b/setup/docker/sc_tools.docker
@@ -1,6 +1,6 @@
 # Copyright (C) 2023 Zero ASIC
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.source="https://github.com/siliconcompiler/siliconcompiler"
 LABEL org.opencontainers.image.description="SiliconCompiler container with all supported OpenSource tools"

--- a/setup/docker/toolbase.docker
+++ b/setup/docker/toolbase.docker
@@ -1,6 +1,6 @@
 # Copyright (C) 2023 Zero ASIC
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.source="https://github.com/siliconcompiler/siliconcompiler"
 LABEL org.opencontainers.image.description="Base tool builder image for SiliconCompiler tools"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated daily testing environments to Ubuntu 24.04.
  - Upgraded tool container environments from Ubuntu 22.04 to Ubuntu 24.04.
  - Updated installation tooling to use Ubuntu 24.04-compatible setup scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->