### PR TITLE
cleanup simulator parameter

### DIFF
--- a/siliconcompiler/tools/bambu/convert.py
+++ b/siliconcompiler/tools/bambu/convert.py
@@ -24,10 +24,9 @@ class ConvertTask(ASICTask, Task):
                            "counts; without it bambu reports area and timing estimates "
                            "only. Needs a testbench.",
                            defvalue=False)
-        self.add_parameter("simulator", "str",
-                           "simulator bambu drives when 'simulate' is set "
-                           "(MODELSIM, XSIM or VERILATOR)",
-                           defvalue="VERILATOR")
+        self.add_parameter("simulator", "<modelsim,xsim,verilator>",
+                           "simulator bambu drives when 'simulate' is set",
+                           defvalue="verilator")
         self.add_parameter("testbench_fileset", "[(str,str)]",
                            "filesets holding the testbench to simulate against: either a "
                            "testbench XML, or a C/C++ file whose main() calls the "
@@ -72,7 +71,9 @@ class ConvertTask(ASICTask, Task):
         """Sets the simulator bambu drives.
 
         Args:
-            simulator: One of MODELSIM, XSIM or VERILATOR.
+            simulator: One of 'modelsim', 'xsim' or 'verilator'. bambu names
+                these in upper case on its command line; the conversion happens
+                on the way out.
             step: The step to associate with this setting. Defaults to None.
             index: The index to associate with this setting. Defaults to None.
         """
@@ -237,7 +238,9 @@ class ConvertTask(ASICTask, Task):
             for testbench in distinct(testbenches):
                 options.append(f'--generate-tb={testbench}')
             options.append('--simulate')
-            options.append(f'--simulator={self.get("var", "simulator")}')
+            # bambu spells these in upper case; the schema holds them lower so
+            # the accepted set reads like every other enum in the tree.
+            options.append(f'--simulator={self.get("var", "simulator").upper()}')
 
         _, clk_period = self.get_clock()
         if clk_period is not None:

--- a/tests/tools/test_bambu.py
+++ b/tests/tools/test_bambu.py
@@ -417,13 +417,29 @@ def test_simulator_setter(gcd_design, datadir):
 
     task = convert.ConvertTask.find_task(proj)
     task.set_bambu_simulate(True)
-    task.set_bambu_simulator("MODELSIM")
+    task.set_bambu_simulator("modelsim")
     task.add_bambu_testbenchfileset("gcd", "testbench")
 
     node = SchedulerNode(proj, "convert", "0")
     with node.runtime():
         assert node.setup() is True
+        # Held lower case, spelled the way bambu wants on the way out.
         assert "--simulator=MODELSIM" in node.task.get_runtime_arguments()
+
+
+def test_simulator_is_an_enum():
+    """bambu accepts exactly three, and rejects anything else itself."""
+    task = convert.ConvertTask()
+    assert task.get("var", "simulator") == "verilator"
+
+    for simulator in ("modelsim", "xsim", "verilator"):
+        task.set_bambu_simulator(simulator)
+        assert task.get("var", "simulator") == simulator
+
+    # Including the upper case bambu itself uses, so there is one spelling.
+    for rejected in ("VERILATOR", "icarus"):
+        with pytest.raises(ValueError):
+            task.set_bambu_simulator(rejected)
 
 
 @pytest.mark.eda


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Bambu simulator settings now use lowercase values: `modelsim`, `xsim`, or `verilator`.
  * Selected simulator names continue to be translated correctly for command-line execution.
  * Invalid simulator values are rejected with clear validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->