### PR TITLE
ensure bambu can simulate

### DIFF
--- a/siliconcompiler/toolscripts/ubuntu20/install-bambu.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-bambu.sh
@@ -26,6 +26,15 @@ install_prereqs \
     gfortran-8 gfortran-8-multilib \
     clang-8 libclang-8-dev
 
+# gcc-multilib ships /usr/include/asm, the unprefixed compatibility symlink that
+# the versioned gcc-N-multilib packages do not provide. bambu's MDPI simulation
+# runtime compiles against <linux/errno.h>, which includes <asm/errno.h> without
+# the multiarch prefix, and builds it with a compiler that has no multiarch
+# include path -- so without this, "bambu --simulate" fails with
+#   /usr/include/linux/errno.h:1:10: fatal error: 'asm/errno.h' file not found
+# and only that step fails, well after synthesis has succeeded.
+install_prereqs gcc-multilib
+
 install_prereqs git build-essential
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu22/install-bambu.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-bambu.sh
@@ -26,6 +26,15 @@ install_prereqs \
     gfortran-10 gfortran-10-multilib \
     clang-11 libclang-11-dev
 
+# gcc-multilib ships /usr/include/asm, the unprefixed compatibility symlink that
+# the versioned gcc-N-multilib packages do not provide. bambu's MDPI simulation
+# runtime compiles against <linux/errno.h>, which includes <asm/errno.h> without
+# the multiarch prefix, and builds it with a compiler that has no multiarch
+# include path -- so without this, "bambu --simulate" fails with
+#   /usr/include/linux/errno.h:1:10: fatal error: 'asm/errno.h' file not found
+# and only that step fails, well after synthesis has succeeded.
+install_prereqs gcc-multilib
+
 install_prereqs git build-essential
 
 mkdir -p deps

--- a/siliconcompiler/toolscripts/ubuntu24/install-bambu.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-bambu.sh
@@ -25,6 +25,15 @@ install_prereqs \
     llvm-16 llvm-16-dev libllvm16 \
     clang-16 libclang-16-dev
 
+# gcc-multilib ships /usr/include/asm, the unprefixed compatibility symlink that
+# the versioned gcc-N-multilib packages do not provide. bambu's MDPI simulation
+# runtime compiles against <linux/errno.h>, which includes <asm/errno.h> without
+# the multiarch prefix, and builds it with a compiler that has no multiarch
+# include path -- so without this, "bambu --simulate" fails with
+#   /usr/include/linux/errno.h:1:10: fatal error: 'asm/errno.h' file not found
+# and only that step fails, well after synthesis has succeeded.
+install_prereqs gcc-multilib
+
 install_prereqs git build-essential
 
 mkdir -p deps


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Bambu installation prerequisites across supported Ubuntu versions.
  - Prevented simulation runtime compilation failures caused by missing Linux header compatibility links.
  - Improved reliability of `bambu --simulate` after synthesis completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->