### PR TITLE
try 2 for bambu sim

### DIFF
--- a/siliconcompiler/toolscripts/ubuntu20/install-bambu.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-bambu.sh
@@ -26,14 +26,20 @@ install_prereqs \
     gfortran-8 gfortran-8-multilib \
     clang-8 libclang-8-dev
 
-# gcc-multilib ships /usr/include/asm, the unprefixed compatibility symlink that
-# the versioned gcc-N-multilib packages do not provide. bambu's MDPI simulation
-# runtime compiles against <linux/errno.h>, which includes <asm/errno.h> without
-# the multiarch prefix, and builds it with a compiler that has no multiarch
-# include path -- so without this, "bambu --simulate" fails with
-#   /usr/include/linux/errno.h:1:10: fatal error: 'asm/errno.h' file not found
-# and only that step fails, well after synthesis has succeeded.
-install_prereqs gcc-multilib
+# bambu's MDPI simulation runtime is built 32-bit, by whichever compiler is the
+# distribution default -- not by the versioned gcc-N/g++-N pinned above. So it
+# needs the unversioned multilib metapackages, which track that default:
+#
+#   gcc-multilib  ships /usr/include/asm, the unprefixed compatibility symlink
+#                 the gcc-N-multilib packages do not provide. Without it:
+#                   linux/errno.h:1:10: fatal error: 'asm/errno.h' file not found
+#   g++-multilib  ships the 32-bit libstdc++ headers. Without it:
+#                   c++/13/cstdio:41:10: fatal error: 'bits/c++config.h' file not found
+#
+# Pinning g++-11-multilib is not enough on a distribution whose default is newer
+# (ubuntu24 defaults to 13), and only "bambu --simulate" fails -- well after
+# synthesis has already succeeded.
+install_prereqs gcc-multilib g++-multilib
 
 install_prereqs git build-essential
 

--- a/siliconcompiler/toolscripts/ubuntu24/install-bambu.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-bambu.sh
@@ -25,14 +25,20 @@ install_prereqs \
     llvm-16 llvm-16-dev libllvm16 \
     clang-16 libclang-16-dev
 
-# gcc-multilib ships /usr/include/asm, the unprefixed compatibility symlink that
-# the versioned gcc-N-multilib packages do not provide. bambu's MDPI simulation
-# runtime compiles against <linux/errno.h>, which includes <asm/errno.h> without
-# the multiarch prefix, and builds it with a compiler that has no multiarch
-# include path -- so without this, "bambu --simulate" fails with
-#   /usr/include/linux/errno.h:1:10: fatal error: 'asm/errno.h' file not found
-# and only that step fails, well after synthesis has succeeded.
-install_prereqs gcc-multilib
+# bambu's MDPI simulation runtime is built 32-bit, by whichever compiler is the
+# distribution default -- not by the versioned gcc-N/g++-N pinned above. So it
+# needs the unversioned multilib metapackages, which track that default:
+#
+#   gcc-multilib  ships /usr/include/asm, the unprefixed compatibility symlink
+#                 the gcc-N-multilib packages do not provide. Without it:
+#                   linux/errno.h:1:10: fatal error: 'asm/errno.h' file not found
+#   g++-multilib  ships the 32-bit libstdc++ headers. Without it:
+#                   c++/13/cstdio:41:10: fatal error: 'bits/c++config.h' file not found
+#
+# Pinning g++-11-multilib is not enough on a distribution whose default is newer
+# (ubuntu24 defaults to 13), and only "bambu --simulate" fails -- well after
+# synthesis has already succeeded.
+install_prereqs gcc-multilib g++-multilib
 
 install_prereqs git build-essential
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bambu installation prerequisites on Ubuntu 20 and Ubuntu 24.
  * Added required 32-bit compiler and C++ compatibility packages to support MDPI simulation runtime builds.
  * Enhanced installation guidance for required compatibility headers and libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->