### PR TITLE
add report_logic_depth_histogram

### DIFF
--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -2264,7 +2264,9 @@ class APRTask(OpenROADTask):
                 "design/registers.rpt"
             ],
             "logicdepth": [
-                "design/logic_depth.rpt"
+                "design/logic_depth.rpt",
+                "design/logic_depth.histogram.rpt",
+                "design/logic_depth.histogram.comboonly.rpt"
             ],
             "unconstrained": [
                 "timing/unconstrained.rpt",

--- a/siliconcompiler/tools/openroad/scripts/common/reports.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/reports.tcl
@@ -233,8 +233,18 @@ if { [llength [all_clocks]] > 0 } {
 
 # get logic depth of design
 if { [sc_cfg_tool_task_check_in_list logicdepth var reports] } {
+    sc_report_banner "Logic depth" \
+        reports/design/logic_depth.rpt \
+        reports/design/logic_depth.histogram.rpt \
+        reports/design/logic_depth.histogram.comboonly.rpt
     utl::metric_int "design__logic__depth" \
         [sc_count_logic_depth -report reports/design/logic_depth.rpt]
+    if { [sc_check_version 24 3 4812] } {
+        tee -file "reports/design/logic_depth.histogram.rpt" \
+            {report_logic_depth_histogram -num_bins 20}
+        tee -quiet -file "reports/design/logic_depth.histogram.comboonly.rpt" \
+            {report_logic_depth_histogram -num_bins 20 -exclude_buffers}
+    }
 }
 
 if { [sc_cfg_tool_task_check_in_list power var reports] } {

--- a/siliconcompiler/tools/openroad/scripts/common/reports.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/reports.tcl
@@ -233,10 +233,15 @@ if { [llength [all_clocks]] > 0 } {
 
 # get logic depth of design
 if { [sc_cfg_tool_task_check_in_list logicdepth var reports] } {
+    set ld_reports []
+    if { [sc_check_version 24 3 4812] } {
+        lappend ld_reports reports/design/logic_depth.histogram.rpt
+        lappend ld_reports reports/design/logic_depth.histogram.comboonly.rpt
+    }
+
     sc_report_banner "Logic depth" \
         reports/design/logic_depth.rpt \
-        reports/design/logic_depth.histogram.rpt \
-        reports/design/logic_depth.histogram.comboonly.rpt
+        {*}$ld_reports
     utl::metric_int "design__logic__depth" \
         [sc_count_logic_depth -report reports/design/logic_depth.rpt]
     if { [sc_check_version 24 3 4812] } {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standard and buffer-excluded logic-depth histogram reports when supported by OpenROAD version 24.3.4812 or later.
  * Logic-depth report summaries now include links to the available histogram reports.
  * Histogram reports are listed only when they are generated, providing accurate report information.
  * Existing logic-depth metrics and reports remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->