### PR TITLE
Included netlist with tie cells in write_data_physical.tcl

### DIFF
--- a/siliconcompiler/tools/openroad/_apr.py
+++ b/siliconcompiler/tools/openroad/_apr.py
@@ -2084,6 +2084,7 @@ class APRTask(OpenROADTask):
             self.add_output_file(ext="sdc")
         self.add_output_file(ext="vg")
         self.add_output_file(ext="lec.vg")
+        self.add_output_file(ext="sim.vg")
         self.add_output_file(ext="def.gz")
         self.add_output_file(ext="odb.gz")
 

--- a/siliconcompiler/tools/openroad/scripts/common/write_data_physical.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/write_data_physical.tcl
@@ -7,11 +7,21 @@ write_def "outputs/${sc_topmodule}.def.gz"
 puts "Writing netlist: outputs/${sc_topmodule}.vg"
 write_verilog -include_pwr_gnd "outputs/${sc_topmodule}.vg"
 
-set remove_cells []
+set remove_physical []
 foreach lib [sc_cfg_get asic asiclib] {
-    foreach celltype "decap tie filler tap endcap antenna physicalonly" {
-        lappend remove_cells {*}[sc_cfg_get library $lib asic cells $celltype]
+    foreach celltype "decap filler tap endcap antenna physicalonly" {
+        lappend remove_physical {*}[sc_cfg_get library $lib asic cells $celltype]
     }
 }
+
+set remove_tie []
+foreach lib [sc_cfg_get asic asiclib] {
+    lappend remove_tie {*}[sc_cfg_get library $lib asic cells tie]
+}
+
 puts "Writing LEC netlist: outputs/${sc_topmodule}.lec.vg"
-write_verilog -remove_cells $remove_cells "outputs/${sc_topmodule}.lec.vg"
+write_verilog -remove_cells [concat $remove_physical $remove_tie] \
+    "outputs/${sc_topmodule}.lec.vg"
+
+puts "Writing simulation netlist: outputs/${sc_topmodule}.sim.vg"
+write_verilog -remove_cells $remove_physical "outputs/${sc_topmodule}.sim.vg"

--- a/siliconcompiler/tools/slang/utils/macro.py
+++ b/siliconcompiler/tools/slang/utils/macro.py
@@ -531,8 +531,11 @@ def build_macro(project: ASIC, name: str) -> StdCellLibrary:
       multi-corner PDKs.
     * ``rtl`` -- the gate-level netlist as a *simulation* view, bundling the
       standard-cell Verilog models (as a dependency) so it simulates standalone.
-    * ``netlist`` -- the same gate-level netlist as a *structural* view for STA,
-      dependency-free (STA resolves cells from Liberty).
+      This takes the ``sim.vg`` flavour, which keeps the tie cells a simulator
+      needs.
+    * ``netlist`` -- the gate-level netlist as a *structural* view for STA,
+      dependency-free (STA resolves cells from Liberty) and taking the
+      constant-folded ``lec.vg``.
     * ``sdc`` -- the implementation-generated constraints (propagated clocks).
 
     The ``rtl`` view's cell-model dependency is serialized into the macro's
@@ -572,17 +575,24 @@ def build_macro(project: ASIC, name: str) -> StdCellLibrary:
             library.add_asic_libcornerfileset(corner, "nldm")
 
     # Gate-level netlist as two views, both topping out at the variant module.
-    netlist = project.find_result("lec.vg", step="write.views")
-    if netlist:
+    # They take different flavours because they need different things from the
+    # netlist: STA folds constants and resolves cells from Liberty, so the LEC
+    # netlist suits it, while a simulator needs the tie cells the LEC netlist
+    # drops or the nets they drove read x.
+    sim_netlist = project.find_result("sim.vg", step="write.views")
+    if sim_netlist:
         # 'rtl' (simulation): bundle the standard-cell Verilog models so the
         # netlist simulates standalone; the dependency is serialized into the
         # macro manifest and recovered on reload.
         with library.active_fileset("rtl"):
             library.set_topmodule(name)
-            library.add_file(netlist)
+            library.add_file(sim_netlist)
             mainlib = project.get_library(project.get("asic", "mainlib"))
             if mainlib is not None:
                 library.add_depfileset(mainlib, "rtl")
+
+    netlist = project.find_result("lec.vg", step="write.views")
+    if netlist:
         # 'netlist' (structural, for STA): dependency-free -- STA resolves cells
         # from Liberty, so no cell Verilog is bundled.
         with library.active_fileset("netlist"):


### PR DESCRIPTION
Added a new output "sim.vg" to write_data_physical.tcl that includes tie cells. Tie cells are needed for gate level sims to avoid X prop issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Place-and-route results now include a simulation-ready netlist by default.
  * Simulation netlists retain tie cells needed for accurate simulation, while structural netlists remain optimized for analysis.
* **Bug Fixes**
  * Improved gate-level macro generation by selecting the appropriate netlist for simulation and timing analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->