### PR TITLE
Changed lec.vg to include tie cells

### DIFF
--- a/siliconcompiler/tools/openroad/scripts/common/write_data_physical.tcl
+++ b/siliconcompiler/tools/openroad/scripts/common/write_data_physical.tcl
@@ -9,7 +9,7 @@ write_verilog -include_pwr_gnd "outputs/${sc_topmodule}.vg"
 
 set remove_cells []
 foreach lib [sc_cfg_get asic asiclib] {
-    foreach celltype "decap tie filler tap endcap antenna physicalonly" {
+    foreach celltype "decap filler tap endcap antenna physicalonly" {
         lappend remove_cells {*}[sc_cfg_get library $lib asic cells $celltype]
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tie cells are now retained in generated LEC netlists, improving the accuracy of downstream logical equivalence checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->