### PR TITLE
attempt to reduce docker image size

### DIFF
--- a/setup/docker/builder.py
+++ b/setup/docker/builder.py
@@ -281,10 +281,46 @@ def _get_tools(allow_skip=False):
     return tools
 
 
+def _get_subsumed_tools():
+    '''
+    Tools whose install prefix is already carried by another tool's image, and
+    which therefore do not need copying into sc_tools on their own.
+
+    tool.docker copies a dependency's whole $SC_PREFIX into the dependent before
+    building it, and installs the dependency's apt.txt there too, so sc_soda's
+    image contains everything sc_mlir installed and sc_nextpnr's contains
+    icepack -- prefix and packages both.
+
+    Copying the dependency into sc_tools as well is not merely redundant. COPY
+    never deletes at the destination, so if a dependent prunes what it inherited
+    (soda drops the LLVM/MLIR dev tree once soda-opt has linked against it) an
+    unpruned copy of the dependency landing first would survive underneath the
+    pruned one and the prune would save nothing.
+
+    A dependency is only subsumed when a dependent is actually being copied.
+    Under --include_tools the dependent may be filtered out, and then the
+    dependency has to carry itself.
+    '''
+    copied = {tool for tool, _ in _get_tools()}
+
+    subsumed = set()
+    for _, depends in _get_tools():
+        if not depends:
+            continue
+        if isinstance(depends, str):
+            depends = [depends]
+        for depend in depends:
+            if depend in copied:
+                subsumed.add(depend)
+
+    return subsumed
+
+
 def _get_tool_images(tool=None):
     '''
     Returns the image name for a tool.
-    If tool is not provided, return all image names in a dict
+    If tool is not provided, return the image names that sc_tools needs to copy,
+    which excludes any tool already carried by a dependent's image.
     '''
     tool_images = {}
     for tool_name, _ in _get_tools():
@@ -292,8 +328,9 @@ def _get_tool_images(tool=None):
 
     if tool:
         return tool_images[tool]
-    else:
-        return [tool_images[tool] for tool, _ in _get_tools()]
+
+    subsumed = _get_subsumed_tools()
+    return [tool_images[tool] for tool, _ in _get_tools() if tool not in subsumed]
 
 
 def _get_tool_versions():

--- a/setup/docker/builder.py
+++ b/setup/docker/builder.py
@@ -175,7 +175,11 @@ def make_tool_docker(tool, output_dir, reference_tool=None):
         'base_build_image': get_image_name(base_name, base_tag, False),
         'install_script': f'install-{tool}.sh',
         'extra_commands': extracmds,
-        'depends_tools': []
+        'depends_tools': [],
+        # Another tool builds against this prefix, so leave its symbols alone.
+        # The dependent copies this prefix in and strips it there, which is what
+        # reaches sc_tools, so nothing ships unstripped either way.
+        'strip_symbols': not _is_build_input(tool)
     }
 
     if reference_tool:
@@ -281,6 +285,28 @@ def _get_tools(allow_skip=False):
     return tools
 
 
+def _is_build_input(tool):
+    '''
+    True when another tool declares this one in docker-depends, which makes this
+    image a build input rather than only a shipping artifact.
+
+    Deliberately independent of --include_tools: whether an image is safe to
+    strip is a property of the tool graph, not of which subset is being built,
+    and making it vary with the filter would let a filtered build produce a
+    differently-stripped image under the same tag.
+    '''
+    for other in _tools.get_tools():
+        depends = _tools.get_field(other, 'docker-depends')
+        if not depends:
+            continue
+        if isinstance(depends, str):
+            depends = [depends]
+        if tool in depends:
+            return True
+
+    return False
+
+
 def _get_subsumed_tools():
     '''
     Tools whose install prefix is already carried by another tool's image, and
@@ -368,6 +394,11 @@ def _get_tool_image_check_tag(tool):
     if cmds:
         for cmd in cmds:
             hash.update(cmd.encode('utf-8'))
+
+    # Whether this image gets stripped depends on the tool graph around it, not
+    # only on this tool's own inputs, so a tool gaining or losing a dependent
+    # has to invalidate its image.
+    hash.update(str(_is_build_input(tool)).encode('utf-8'))
 
     extra_files = _tools.get_field(tool, 'docker-extra-files')
     if extra_files:

--- a/setup/docker/sc_local_runner.docker
+++ b/setup/docker/sc_local_runner.docker
@@ -1,3 +1,5 @@
+# Copyright (C) 2023-2026 Zero ASIC
+
 ARG SC_VERSION
 ARG SC_IMAGE=ghcr.io/siliconcompiler/sc_runner:v${SC_VERSION}
 FROM ${SC_IMAGE}

--- a/setup/docker/sc_runner.docker
+++ b/setup/docker/sc_runner.docker
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Zero ASIC
+# Copyright (C) 2023-2026 Zero ASIC
 
 FROM {{ sc_tools_build_image }}
 

--- a/setup/docker/sc_tools.docker
+++ b/setup/docker/sc_tools.docker
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Zero ASIC
+# Copyright (C) 2023-2026 Zero ASIC
 
 FROM ubuntu:24.04
 

--- a/setup/docker/tool.docker
+++ b/setup/docker/tool.docker
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Zero ASIC
+# Copyright (C) 2023-2026 Zero ASIC
 
 FROM {{ base_build_image }}
 
@@ -37,8 +37,13 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf $HOME/.cache
 
+{% if strip_symbols %}
 # Strip symbols from everything this tool installed.
 RUN . /_prereqs.sh && sc_strip_prefix $SC_PREFIX
+{% else %}
+# Not stripped: another tool builds against this prefix, and the dependent
+# strips it after copying it in, so nothing ships unstripped.
+{% endif %}
 
 # Run additional commands needed by tool build, if needed by tool
 {{ extra_commands }}

--- a/setup/docker/tool.docker
+++ b/setup/docker/tool.docker
@@ -37,8 +37,17 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf $HOME/.cache
 
-# Generate list of installed programs
-RUN apt list --installed | grep "\[installed\(.*\)\]" | sed 's/\/.*//' > $SC_PREFIX/apt.txt
+# Strip symbols from everything this tool installed.
+RUN . /_prereqs.sh && sc_strip_prefix $SC_PREFIX
 
 # Run additional commands needed by tool build, if needed by tool
 {{ extra_commands }}
+
+# Generate list of installed programs, which sc_tools reinstalls to provide the
+# runtime dependencies of this tool.
+#
+# This runs LAST, after extra_commands, so that a tool which drops its own build
+# dependencies there ("apt-get remove" in docker-cmds) is not listed as needing
+# them at runtime. Moving it earlier silently reinstates every build dependency
+# in the final image.
+RUN apt list --installed | grep "\[installed\(.*\)\]" | sed 's/\/.*//' > $SC_PREFIX/apt.txt

--- a/setup/docker/toolbase.docker
+++ b/setup/docker/toolbase.docker
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Zero ASIC
+# Copyright (C) 2023-2026 Zero ASIC
 
 FROM ubuntu:24.04
 

--- a/siliconcompiler/toolscripts/_prereqs.sh
+++ b/siliconcompiler/toolscripts/_prereqs.sh
@@ -238,9 +238,7 @@ install_prereq_group() {
 # /var/lib/apt/lists the only names apt recognises are the installed ones. So an
 # unfiltered remove list fails the build the moment a tool's dependency set
 # shifts and one of the names is no longer there.
-_sc_installed_pkgs() {
-    set +x
-
+_sc_installed_deb() {
     _sc_installed=""
     for _sc_pkg in "$@"; do
         if dpkg-query -W -f='${Status}' "$_sc_pkg" 2>/dev/null |
@@ -250,6 +248,35 @@ _sc_installed_pkgs() {
     done
 
     printf '%s' "$_sc_installed"
+}
+
+_sc_installed_rpm() {
+    _sc_installed=""
+    for _sc_pkg in "$@"; do
+        if rpm -q "$_sc_pkg" > /dev/null 2>&1; then
+            _sc_installed="$_sc_installed $_sc_pkg"
+        fi
+    done
+
+    printf '%s' "$_sc_installed"
+}
+
+_sc_installed_pkgs() {
+    set +x
+
+    # Same probe selection as _sc_missing_pkgs: whichever query tool is present
+    # decides, independently of which package manager will do the work. Without
+    # a probe nothing is reported installed, so nothing is removed -- the safe
+    # direction here, since the cost is an image that stays large.
+    # Word splitting of the package list is intended.
+    # shellcheck disable=SC2086
+    if command -v dpkg-query > /dev/null 2>&1; then
+        _sc_installed_deb "$@"
+    elif command -v rpm > /dev/null 2>&1; then
+        _sc_installed_rpm "$@"
+    else
+        printf '%s' ""
+    fi
 }
 
 # Remove packages a tool needed to build but does not need to run, skipping any
@@ -336,7 +363,13 @@ sc_strip_prefix() {
     # prefixes carry shell wrappers, Tcl, Python and the odd foreign-platform
     # binary, and "strip" on those either fails or corrupts them. Check the
     # magic number instead.
-    find "$_sc_strip_dir" -type f \( -perm -u+x -o -name '*.so' -o -name '*.so.*' \) \
+    # Static archives are excluded explicitly rather than left to chance. They
+    # are usually mode 644 and so would not match -perm -u+x anyway, but three
+    # tools ship an archive their runtime links against -- lib/ghdl/libgrt.a,
+    # lib/panda/*.a, lib/Bluesim/*.a -- and stripping one breaks linking against
+    # it, which is not a failure worth risking on a mode bit.
+    find "$_sc_strip_dir" -type f ! -name '*.a' \
+        \( -perm -u+x -o -name '*.so' -o -name '*.so.*' \) \
         -print 2>/dev/null | while IFS= read -r _sc_obj; do
         case "$(dd if="$_sc_obj" bs=4 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n')" in
             7f454c46) ;;

--- a/siliconcompiler/toolscripts/_prereqs.sh
+++ b/siliconcompiler/toolscripts/_prereqs.sh
@@ -231,3 +231,126 @@ install_prereq_group() {
     echo "Installing group (requires root): $_sc_group"
     $_sc_sudo $_sc_yum group install -y "$_sc_group"
 }
+
+# Echo the subset of "$@" that is installed. The mirror of _sc_missing_pkgs, and
+# the reason it exists is asymmetric with installing: "apt-get remove" exits 100
+# on a package name it does not recognise, and once tool.docker has cleaned
+# /var/lib/apt/lists the only names apt recognises are the installed ones. So an
+# unfiltered remove list fails the build the moment a tool's dependency set
+# shifts and one of the names is no longer there.
+_sc_installed_pkgs() {
+    set +x
+
+    _sc_installed=""
+    for _sc_pkg in "$@"; do
+        if dpkg-query -W -f='${Status}' "$_sc_pkg" 2>/dev/null |
+                grep -q '^install ok installed$'; then
+            _sc_installed="$_sc_installed $_sc_pkg"
+        fi
+    done
+
+    printf '%s' "$_sc_installed"
+}
+
+# Remove packages a tool needed to build but does not need to run, skipping any
+# that are not installed.
+#
+#     sc_remove_prereqs PKG...
+#
+# Where install_prereqs errs toward installing, this errs toward keeping: a name
+# the probe cannot confirm is installed is left alone rather than handed to the
+# package manager. The worst case is a package that stays in the image, which is
+# the behaviour this whole mechanism is trying to improve on rather than a
+# regression from it.
+#
+# Deliberately no "apt-get autoremove". These images keep runtime libraries that
+# arrived only as some build package's dependency -- libxcb-keysyms1 under
+# libxcb-keysyms1-dev, libgmp10 under ghc, libllvm18 under llvm-18-dev -- and
+# autoremove would take them along with the build packages, breaking the tool at
+# run time rather than at build time.
+sc_remove_prereqs() {
+    if [ "$#" -eq 0 ]; then
+        return 0
+    fi
+
+    _sc_drop=$(_sc_installed_pkgs "$@")
+
+    if [ -z "$_sc_drop" ]; then
+        echo "No build-only prerequisites to remove: $*"
+        return 0
+    fi
+
+    echo "Removing build-only prerequisites:$_sc_drop"
+
+    # Word splitting of the package list is intended.
+    case "$_sc_backend" in
+        deb)
+            # shellcheck disable=SC2086
+            $_sc_sudo apt-get remove -y --purge $_sc_drop
+            ;;
+        rpm)
+            # shellcheck disable=SC2086
+            $_sc_sudo $_sc_yum remove -y $_sc_drop
+            ;;
+        *)
+            echo "sc_remove_prereqs: no supported package manager found" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Remove symbol tables and debug sections from everything installed under a
+# prefix. Nothing in the flows reads them: they exist for debugging a tool build,
+# and they are a third of the size of an installed tool tree.
+#
+#     sc_strip_prefix [DIR]      strip DIR, defaulting to $PREFIX
+#
+# Measured across the 30-tool container prefix: 6,497MB -> 5,500MB. About 300MB
+# of that is .debug_* and 700MB is .symtab/.strtab, which is why this does a full
+# strip rather than the more commonly seen --strip-debug.
+#
+# Executables are stripped outright. Shared objects get --strip-unneeded, which
+# removes .symtab but keeps .dynsym -- the dynamic symbol table is what the
+# loader and dlopen() resolve against, so stripping it would break every plugin
+# in the tree (yosys' and bambu's included).
+#
+# Static archives are left alone. They are link-time only and stripping them
+# risks breaking a later build against this prefix; the container drops them
+# wholesale instead.
+sc_strip_prefix() {
+    _sc_strip_dir="${1:-${PREFIX:-}}"
+
+    if [ -z "$_sc_strip_dir" ] || [ ! -d "$_sc_strip_dir" ]; then
+        echo "sc_strip_prefix: no prefix to strip" >&2
+        return 0
+    fi
+
+    if ! command -v strip > /dev/null 2>&1; then
+        echo "sc_strip_prefix: strip not available, skipping" >&2
+        return 0
+    fi
+
+    echo "Stripping symbols from $_sc_strip_dir"
+
+    # Only ELF objects. A wrong guess from the filename is not enough -- the
+    # prefixes carry shell wrappers, Tcl, Python and the odd foreign-platform
+    # binary, and "strip" on those either fails or corrupts them. Check the
+    # magic number instead.
+    find "$_sc_strip_dir" -type f \( -perm -u+x -o -name '*.so' -o -name '*.so.*' \) \
+        -print 2>/dev/null | while IFS= read -r _sc_obj; do
+        case "$(dd if="$_sc_obj" bs=4 count=1 2>/dev/null | od -An -tx1 | tr -d ' \n')" in
+            7f454c46) ;;
+            *) continue ;;
+        esac
+
+        case "$_sc_obj" in
+            *.so|*.so.*) _sc_strip_args="--strip-unneeded" ;;
+            *)           _sc_strip_args="--strip-all" ;;
+        esac
+
+        # A refusal is not fatal. Some objects legitimately cannot be stripped,
+        # and a tool that builds is worth more than the bytes.
+        strip $_sc_strip_args --preserve-dates "$_sc_obj" 2>/dev/null || \
+            echo "  could not strip $_sc_obj" >&2
+    done
+}

--- a/siliconcompiler/toolscripts/_tools.json
+++ b/siliconcompiler/toolscripts/_tools.json
@@ -6,19 +6,41 @@
       "# Remove OR-Tools files",
       "RUN rm -f $SC_PREFIX/Makefile $SC_PREFIX/README.md",
       "# Remove OpenROAD Env file",
-      "RUN rm -f $SC_PREFIX/env.sh"
+      "RUN rm -f $SC_PREFIX/env.sh",
+      "# Drop the documentation toolchain and the -dev half of the GUI libraries.",
+      "# The matching runtime xcb libraries stay: they are separate packages, and",
+      "# sc_remove_prereqs does no autoremove, so they are not swept up.",
+      "RUN . /_prereqs.sh && sc_remove_prereqs pandoc groff bsdmainutils \\",
+      "    libxcb1-dev libxcb-util-dev libxcb-icccm4-dev libxcb-image0-dev \\",
+      "    libxcb-keysyms1-dev libxcb-randr0-dev libxcb-render-util0-dev \\",
+      "    libxcb-xinerama0-dev libxcb-xkb-dev"
     ],
     "auto-update": true
   },
   "surelog": {
     "git-url": "https://github.com/chipsalliance/Surelog.git",
     "git-commit": "v1.87",
-    "auto-update": true
+    "auto-update": true,
+    "docker-cmds": [
+      "# Link-time only: surelog and the uhdm tools are what run.",
+      "RUN rm -f $SC_PREFIX/lib/libsurelog.a $SC_PREFIX/lib/libuhdm*.a \\",
+      "    $SC_PREFIX/lib/libantlr*.a",
+      "# Drop the build toolchain. The JRE here runs ANTLR's parser generator at",
+      "# build time only -- install-chisel.sh declares its own JRE, so removing",
+      "# this one no longer leaves sbt without a java to run.",
+      "RUN . /_prereqs.sh && sc_remove_prereqs default-jre default-jre-headless \\",
+      "    cmake swig uuid-dev libgoogle-perftools-dev python3-dev lcov \\",
+      "    pkg-config"
+    ]
   },
   "opensta": {
     "git-url": "https://github.com/parallaxsw/OpenSTA.git",
     "git-commit": "737b52f33b66e4c2ccc3e3ef22c3adfe9aec8d09",
-    "auto-update": true
+    "auto-update": true,
+    "docker-cmds": [
+      "# libOpenSTA.a is link-time only: the sta binary is what runs. 86MB.",
+      "RUN rm -f $SC_PREFIX/lib/libOpenSTA.a"
+    ]
   },
   "netgen": {
     "git-url": "https://github.com/RTimothyEdwards/netgen.git",
@@ -28,7 +50,18 @@
   "ghdl": {
     "git-url": "https://github.com/ghdl/ghdl.git",
     "git-commit": "v5.1.1",
-    "auto-update": false
+    "auto-update": false,
+    "docker-cmds": [
+      "# Drop the LLVM headers and the Ada compiler. libllvm18 and libgnat-13",
+      "# stay: ghdl1-llvm links both at runtime (ldd confirms) and ghdl shells out",
+      "# to no compiler of its own.",
+      "#",
+      "# libz-dev and lib/ghdl/libgrt.a both stay: every \"ghdl -e\" links -lz and",
+      "# libgrt.a into the elaborated design.",
+      "RUN . /_prereqs.sh && sc_remove_prereqs llvm-18-dev llvm-18 llvm-18-tools \\",
+      "    libclang-18-dev clang clang-18 libclang-cpp18 libclang1-18 gnat \\",
+      "    gnat-13 gnat-13-x86-64-linux-gnu"
+    ]
   },
   "magic": {
     "git-url": "https://github.com/RTimothyEdwards/magic.git",
@@ -38,7 +71,15 @@
   "bluespec": {
     "git-url": "https://github.com/B-Lang-org/bsc.git",
     "git-commit": "2024.07",
-    "auto-update": false
+    "auto-update": false,
+    "docker-cmds": [
+      "# Drop the Haskell toolchain. bsc and bluetcl are compiled binaries whose",
+      "# runtime needs are libgmp10, libffi8 and libtcl8.6 -- separate packages,",
+      "# and no autoremove means they stay. lib/Bluesim/*.a stays too: \"bsc -sim\"",
+      "# links it.",
+      "RUN . /_prereqs.sh && sc_remove_prereqs ghc libghc-regex-compat-dev \\",
+      "    libghc-syb-dev libghc-old-time-dev libghc-split-dev tcl-dev pkg-config"
+    ]
   },
   "klayout": {
     "version": "0.30.12",
@@ -61,7 +102,17 @@
   "verilator": {
     "git-url": "https://github.com/verilator/verilator.git",
     "git-commit": "v5.038",
-    "auto-update": true
+    "auto-update": true,
+    "docker-cmds": [
+      "# Drop the debug builds. verilator_bin_dbg is 88MB against",
+      "# verilator_bin's 17MB and nothing in the flows selects it.",
+      "#",
+      "# g++, make, perl and zlib1g-dev all stay: they are what compiles the",
+      "# generated model at run time, and --trace-fst links -lz into it.",
+      "RUN rm -f $SC_PREFIX/bin/*_dbg $SC_PREFIX/share/verilator/bin/*_dbg",
+      "RUN . /_prereqs.sh && sc_remove_prereqs libfl-dev libgoogle-perftools-dev \\",
+      "    perl-doc help2man autoconf"
+    ]
   },
   "bambu": {
     "git-url": "https://github.com/ferrandi/PandA-bambu.git",
@@ -71,13 +122,30 @@
       "# Remove ORFS Stuff",
       "RUN rm -rf $SC_PREFIX/share/panda/asap7",
       "RUN rm -rf $SC_PREFIX/share/panda/nangate45",
-      "RUN rm -rf $SC_PREFIX/share/panda/scripts"
+      "RUN rm -rf $SC_PREFIX/share/panda/scripts",
+      "# Drop the clang and boost build APIs. bambu shells out to clang-16,",
+      "# clang++-16 and llvm-link-16 at runtime, so the clang *runtime* packages",
+      "# stay; only the headers and static libraries go. libboost-all-dev is a",
+      "# metapackage, so removing it takes its whole -dev set with it.",
+      "#",
+      "# gcc-multilib, g++-multilib and libc6-dev are NOT removable: bambu",
+      "# compiles its 32-bit MDPI simulation runtime at run time. Neither is",
+      "# lib/panda/*.a, which it links into generated designs.",
+      "RUN . /_prereqs.sh && sc_remove_prereqs llvm-16-dev libclang-16-dev \\",
+      "    libboost-all-dev doxygen graphviz libsuitesparse-dev libglpk-dev \\",
+      "    libbdd-dev libmpfi-dev libmpc-dev libmpfr-dev libxml2-dev liblzma-dev \\",
+      "    libicu-dev autoconf-archive libfl-dev"
     ]
   },
   "vpr": {
     "git-url": "https://github.com/verilog-to-routing/vtr-verilog-to-routing.git",
     "git-commit": "fe77ace273b3f0558763e0e91d409b2d13344eff",
-    "auto-update": false
+    "auto-update": false,
+    "docker-cmds": [
+      "# vpr's build installs its intermediate archives into bin/ alongside the",
+      "# executables. Link-time only. 168MB.",
+      "RUN rm -f $SC_PREFIX/bin/*.a"
+    ]
   },
   "icepack": {
     "git-url": "https://github.com/YosysHQ/icestorm.git",
@@ -109,7 +177,12 @@
     "git-url": "https://github.com/Xyce/Xyce.git",
     "git-commit": "Release-7.10.0",
     "version-prefix": "Release-",
-    "auto-update": true
+    "auto-update": true,
+    "docker-cmds": [
+      "# Trilinos is linked into the Xyce binary and libxyce.so; the archives it",
+      "# was linked from are not needed to run either. 299MB.",
+      "RUN rm -f $SC_PREFIX/trilinos/lib/*.a"
+    ]
   },
   "xdm": {
     "version": "2.7.0",
@@ -125,7 +198,9 @@
     "docker-cmds": [
       "COPY slurm $SC_PREFIX/slurm_cfg",
       "RUN mv $SC_PREFIX/slurm_cfg/install-slurm.sh $SC_PREFIX/",
-      "RUN chmod +x $SC_PREFIX/install-slurm.sh"
+      "RUN chmod +x $SC_PREFIX/install-slurm.sh",
+      "# Slurm loads its plugins as .so; these are the static variants. 298MB.",
+      "RUN rm -f $SC_PREFIX/lib/libslurm.a $SC_PREFIX/lib/slurm/*.a"
     ]
   },
   "montage": {
@@ -199,6 +274,27 @@
     "git-url": "https://github.com/pnnl/soda-opt.git",
     "git-commit": "af0f8779949643ae3791f053449509de0a633aa9",
     "auto-update": false,
-    "docker-depends": "mlir"
+    "docker-depends": "mlir",
+    "docker-cmds": [
+      "# Drop the LLVM/MLIR dev tree now that soda-opt is linked. \"ldd soda-opt\"",
+      "# reports libstdc++, libm, libgcc_s and libc and nothing else -- it is",
+      "# statically linked, so none of this has a runtime consumer.",
+      "#",
+      "# Named by prefix rather than a blanket \"find -name '*.a' -delete\". This",
+      "# image's prefix holds only mlir and soda, but three tools elsewhere ship",
+      "# static archives their runtime links against -- lib/ghdl/libgrt.a for",
+      "# \"ghdl -e\", lib/panda/*.a for bambu's generated designs, lib/Bluesim/*.a",
+      "# for \"bsc -sim\" -- so a blanket delete is the wrong habit to establish in",
+      "# a prefix that is shared whenever PREFIX is set.",
+      "RUN rm -f $SC_PREFIX/lib/libLLVM*.a $SC_PREFIX/lib/libMLIR*.a \\",
+      "    $SC_PREFIX/lib/libclang*.a $SC_PREFIX/lib/libLTO*.a \\",
+      "    $SC_PREFIX/lib/libRemarks*.a $SC_PREFIX/lib/libPolly*.a \\",
+      "    $SC_PREFIX/lib/libbenchmark*.a $SC_PREFIX/lib/libgtest*.a",
+      "RUN rm -rf $SC_PREFIX/include $SC_PREFIX/lib/cmake $SC_PREFIX/lib/pkgconfig",
+      "# libclang-cpp.so and libclang.so are only loaded by c-index-test, which",
+      "# install-mlir.sh no longer installs.",
+      "RUN rm -f $SC_PREFIX/lib/libclang-cpp.so* $SC_PREFIX/lib/libclang.so* \\",
+      "    $SC_PREFIX/lib/libLTO.so* $SC_PREFIX/lib/libRemarks.so*"
+    ]
   }
 }

--- a/siliconcompiler/toolscripts/rhel8/install-chisel.sh
+++ b/siliconcompiler/toolscripts/rhel8/install-chisel.sh
@@ -17,6 +17,13 @@ fi
 
 install_prereqs wget
 
+# sbt is a launcher script for a JVM tool, so a JRE is a runtime requirement and
+# not just a build one. It used to arrive by accident: install-surelog.sh pulls a
+# JRE in to run ANTLR's parser generator, and that leaked into the container
+# image through apt.txt. Declare it here so that dropping surelog's build-time
+# JRE cannot leave chisel without a java to run.
+install_prereqs java-11-openjdk-headless
+
 mkdir -p deps
 cd deps
 
@@ -29,7 +36,31 @@ if [ ! -z ${PREFIX} ]; then
     args="-C $PREFIX --strip-components 1"
 fi
 
-$SUDO_INSTALL tar xvf sbt.tgz $args
+# sbt ships a native "sbtn" client for every platform it supports, so the
+# tarball carries macOS, Windows and aarch64 binaries that will never run here
+# -- about 127MB of the install. Skip them at extraction time rather than
+# deleting them afterwards: PREFIX is often a shared prefix (sc-install defaults
+# to ~/.local) and this script should never remove a file it did not write.
+#
+# An unrecognised machine keeps every launcher, and a platform sbt adds later is
+# extracted rather than dropped. Both cost size only.
+case "$(uname -m)" in
+    x86_64|amd64)  keep_sbtn=sbtn-x86_64-pc-linux ;;
+    aarch64|arm64) keep_sbtn=sbtn-aarch64-pc-linux ;;
+    *)             keep_sbtn= ;;
+esac
+
+sbtn_excludes=
+if [ -n "${keep_sbtn}" ]; then
+    for sbtn in sbtn-x86_64-pc-linux sbtn-aarch64-pc-linux \
+                sbtn-universal-apple-darwin sbtn-x86_64-pc-win32.exe; do
+        if [ "${sbtn}" != "${keep_sbtn}" ]; then
+            sbtn_excludes="${sbtn_excludes} --exclude=*/${sbtn}"
+        fi
+    done
+fi
+
+$SUDO_INSTALL tar xvf sbt.tgz $sbtn_excludes $args
 
 cd -
 

--- a/siliconcompiler/toolscripts/rhel9/install-chisel.sh
+++ b/siliconcompiler/toolscripts/rhel9/install-chisel.sh
@@ -17,6 +17,13 @@ fi
 
 install_prereqs wget
 
+# sbt is a launcher script for a JVM tool, so a JRE is a runtime requirement and
+# not just a build one. It used to arrive by accident: install-surelog.sh pulls a
+# JRE in to run ANTLR's parser generator, and that leaked into the container
+# image through apt.txt. Declare it here so that dropping surelog's build-time
+# JRE cannot leave chisel without a java to run.
+install_prereqs java-11-openjdk-headless
+
 mkdir -p deps
 cd deps
 
@@ -29,7 +36,31 @@ if [ ! -z ${PREFIX} ]; then
     args="-C $PREFIX --strip-components 1"
 fi
 
-$SUDO_INSTALL tar xvf sbt.tgz $args
+# sbt ships a native "sbtn" client for every platform it supports, so the
+# tarball carries macOS, Windows and aarch64 binaries that will never run here
+# -- about 127MB of the install. Skip them at extraction time rather than
+# deleting them afterwards: PREFIX is often a shared prefix (sc-install defaults
+# to ~/.local) and this script should never remove a file it did not write.
+#
+# An unrecognised machine keeps every launcher, and a platform sbt adds later is
+# extracted rather than dropped. Both cost size only.
+case "$(uname -m)" in
+    x86_64|amd64)  keep_sbtn=sbtn-x86_64-pc-linux ;;
+    aarch64|arm64) keep_sbtn=sbtn-aarch64-pc-linux ;;
+    *)             keep_sbtn= ;;
+esac
+
+sbtn_excludes=
+if [ -n "${keep_sbtn}" ]; then
+    for sbtn in sbtn-x86_64-pc-linux sbtn-aarch64-pc-linux \
+                sbtn-universal-apple-darwin sbtn-x86_64-pc-win32.exe; do
+        if [ "${sbtn}" != "${keep_sbtn}" ]; then
+            sbtn_excludes="${sbtn_excludes} --exclude=*/${sbtn}"
+        fi
+    done
+fi
+
+$SUDO_INSTALL tar xvf sbt.tgz $sbtn_excludes $args
 
 cd -
 

--- a/siliconcompiler/toolscripts/ubuntu20/install-chisel.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-chisel.sh
@@ -17,6 +17,13 @@ fi
 
 install_prereqs wget
 
+# sbt is a launcher script for a JVM tool, so a JRE is a runtime requirement and
+# not just a build one. It used to arrive by accident: install-surelog.sh pulls a
+# JRE in to run ANTLR's parser generator, and that leaked into the container
+# image through apt.txt. Declare it here so that dropping surelog's build-time
+# JRE cannot leave chisel without a java to run.
+install_prereqs default-jre-headless
+
 mkdir -p deps
 cd deps
 
@@ -29,7 +36,31 @@ if [ ! -z ${PREFIX} ]; then
     args="-C $PREFIX --strip-components 1"
 fi
 
-$SUDO_INSTALL tar xvf sbt.tgz $args
+# sbt ships a native "sbtn" client for every platform it supports, so the
+# tarball carries macOS, Windows and aarch64 binaries that will never run here
+# -- about 127MB of the install. Skip them at extraction time rather than
+# deleting them afterwards: PREFIX is often a shared prefix (sc-install defaults
+# to ~/.local) and this script should never remove a file it did not write.
+#
+# An unrecognised machine keeps every launcher, and a platform sbt adds later is
+# extracted rather than dropped. Both cost size only.
+case "$(uname -m)" in
+    x86_64|amd64)  keep_sbtn=sbtn-x86_64-pc-linux ;;
+    aarch64|arm64) keep_sbtn=sbtn-aarch64-pc-linux ;;
+    *)             keep_sbtn= ;;
+esac
+
+sbtn_excludes=
+if [ -n "${keep_sbtn}" ]; then
+    for sbtn in sbtn-x86_64-pc-linux sbtn-aarch64-pc-linux \
+                sbtn-universal-apple-darwin sbtn-x86_64-pc-win32.exe; do
+        if [ "${sbtn}" != "${keep_sbtn}" ]; then
+            sbtn_excludes="${sbtn_excludes} --exclude=*/${sbtn}"
+        fi
+    done
+fi
+
+$SUDO_INSTALL tar xvf sbt.tgz $sbtn_excludes $args
 
 cd -
 

--- a/siliconcompiler/toolscripts/ubuntu20/install-mlir.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-mlir.sh
@@ -91,8 +91,15 @@ fi
 #   siliconcompiler/tools/{mlir,soda}/)
 #
 #   install-soda.sh then builds soda-opt against this tree, which needs the
-#   headers, the static libraries and the cmake exports of all three projects,
-#   plus llvm-lit for -DLLVM_EXTERNAL_LIT
+#   headers, the static libraries and the cmake exports of all three projects
+#
+# Note that llvm-lit is deliberately absent even though install-soda.sh passes
+# -DLLVM_EXTERNAL_LIT=${mlir_prefix}/bin/llvm-lit. llvm-lit has no install rule
+# at all -- llvm/utils/llvm-lit only configure_file()s it into the build tree --
+# so that path has never existed in the prefix, under this install or the plain
+# "install" target before it. cmake only reads LLVM_EXTERNAL_LIT to run the lit
+# suite, which this build does not, so the dangling path is harmless. Listing
+# llvm-lit as a component is not: it fails configure outright.
 #
 # A name with no install target is a configure-time SEND_ERROR from
 # LLVMDistributionSupport.cmake naming the component, so a mistake here fails in
@@ -103,7 +110,7 @@ distribution_components="${distribution_components};llvm-headers;llvm-libraries;
 distribution_components="${distribution_components};clang-headers;clang-libraries;clang-cmake-exports"
 distribution_components="${distribution_components};clang-resource-headers"
 distribution_components="${distribution_components};mlir-headers;mlir-libraries;mlir-cmake-exports"
-distribution_components="${distribution_components};llvm-lit;FileCheck;count;not"
+distribution_components="${distribution_components};FileCheck;count;not"
 
 cmake -G Ninja \
     -S llvm-project/llvm \

--- a/siliconcompiler/toolscripts/ubuntu20/install-mlir.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-mlir.sh
@@ -91,7 +91,25 @@ fi
 #   siliconcompiler/tools/{mlir,soda}/)
 #
 #   install-soda.sh then builds soda-opt against this tree, which needs the
-#   headers, the static libraries and the cmake exports of all three projects
+#   headers, the static libraries and the cmake exports of all three projects,
+#   plus the tablegen tools -- soda-opt is an out-of-tree dialect and generates
+#   its headers from .td files. MLIRConfig.cmake names exactly three
+#   executables, and these are they:
+#
+#       MLIR_TABLEGEN_EXE             mlir-tblgen
+#       MLIR_PDLL_TABLEGEN_EXE        mlir-pdll
+#       MLIR_SRC_SHARDER_TABLEGEN_EXE mlir-src-sharder   (not installable)
+#
+#   The first two are here. mlir-src-sharder is not: it has no install target at
+#   all, so naming it fails configure -- the same quirk as llvm-lit above, where
+#   MLIRConfig advertises a path the install never provides.
+#
+#   Leaving mlir-tblgen out does not fail configure, which is what made its
+#   absence expensive to find: MLIRConfig sets the variable to a bare name
+#   either way, and the build only falls over later, when ninja looks for a file
+#   called "mlir-tblgen" next to the generated header. mlir-pdll is included on
+#   the same reasoning; soda does not use PDLL today, and a project that did
+#   would break the same silent way.
 #
 # Note that llvm-lit is deliberately absent even though install-soda.sh passes
 # -DLLVM_EXTERNAL_LIT=${mlir_prefix}/bin/llvm-lit. llvm-lit has no install rule
@@ -106,6 +124,7 @@ fi
 # seconds rather than after the build. If a future LLVM bump drops one of these,
 # that error says which.
 distribution_components="clang;opt;llvm-link;mlir-opt;mlir-translate;llvm-config"
+distribution_components="${distribution_components};mlir-tblgen;mlir-pdll"
 distribution_components="${distribution_components};llvm-headers;llvm-libraries;cmake-exports"
 distribution_components="${distribution_components};clang-headers;clang-libraries;clang-cmake-exports"
 distribution_components="${distribution_components};clang-resource-headers"

--- a/siliconcompiler/toolscripts/ubuntu20/install-mlir.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-mlir.sh
@@ -8,10 +8,18 @@
 # MLIR's C++ libraries, so it has to be built against this exact release --
 # a distro llvm/mlir package will not do.
 #
-# The full LLVM install tree is what "sc-install soda" then builds against, so
-# this script runs the "install" target rather than only building the four
-# binaries the flow calls. That also installs the MLIR test-pass libraries
-# (MLIRLinalgTestPasses and friends) which soda-opt links against.
+# The LLVM dev tree -- headers, static libraries and cmake exports -- is what
+# "sc-install soda" then builds against, so the install has to carry more than
+# the five binaries the flow calls. It does not have to carry everything, and it
+# no longer does: LLVM_DISTRIBUTION_COMPONENTS below declares the set, which is
+# what trims 2.1GB of unused tools out of the install tree. See the comment on
+# that variable.
+#
+# One thing to watch across LLVM bumps: soda-opt links against the MLIR
+# test-pass libraries (MLIRLinalgTestPasses and friends), which are built
+# because LLVM_INCLUDE_TESTS defaults on. If a bump stops the mlir-libraries
+# component covering them, soda-opt fails to link and the fix is to name those
+# libraries in the component list.
 #
 # clang is built alongside mlir because the flow compiles the MLIR runtime
 # helpers to LLVM IR before linking them into a kernel, and that IR has to be
@@ -70,6 +78,33 @@ if command -v ld.lld > /dev/null 2>&1; then
     lld_args=-DLLVM_ENABLE_LLD=ON
 fi
 
+# What gets installed. LLVM_DISTRIBUTION_COMPONENTS narrows the install to a
+# declared set and generates an "install-distribution" target for it, which is
+# how LLVM itself expects a packager to trim an install tree -- rather than
+# installing everything and deleting afterwards, which would mean this script
+# removing files from a prefix it may share with every other SC tool.
+#
+# Two groups, for the project's two consumers:
+#
+#   the flow drives clang, opt, llvm-link, mlir-opt and mlir-translate, and
+#   nothing else (each is named in a set_exe call under
+#   siliconcompiler/tools/{mlir,soda}/)
+#
+#   install-soda.sh then builds soda-opt against this tree, which needs the
+#   headers, the static libraries and the cmake exports of all three projects,
+#   plus llvm-lit for -DLLVM_EXTERNAL_LIT
+#
+# A name with no install target is a configure-time SEND_ERROR from
+# LLVMDistributionSupport.cmake naming the component, so a mistake here fails in
+# seconds rather than after the build. If a future LLVM bump drops one of these,
+# that error says which.
+distribution_components="clang;opt;llvm-link;mlir-opt;mlir-translate;llvm-config"
+distribution_components="${distribution_components};llvm-headers;llvm-libraries;cmake-exports"
+distribution_components="${distribution_components};clang-headers;clang-libraries;clang-cmake-exports"
+distribution_components="${distribution_components};clang-resource-headers"
+distribution_components="${distribution_components};mlir-headers;mlir-libraries;mlir-cmake-exports"
+distribution_components="${distribution_components};llvm-lit;FileCheck;count;not"
+
 cmake -G Ninja \
     -S llvm-project/llvm \
     -B build \
@@ -85,6 +120,7 @@ cmake -G Ninja \
     -DLLVM_PARALLEL_LINK_JOBS=2 \
     -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
     -DLLVM_INSTALL_UTILS=ON \
+    -DLLVM_DISTRIBUTION_COMPONENTS="${distribution_components}" \
     ${lld_args}
 
 # The tools the SODA flow drives directly, built first so a failure in one of
@@ -92,8 +128,11 @@ cmake -G Ninja \
 cmake --build build --target opt llvm-link clang mlir-opt mlir-translate \
     -j${NPROC:-$(nproc)}
 
-# Everything soda-opt needs to configure and link against.
-cmake --build build --target install -j${NPROC:-$(nproc)}
+# Install only the declared distribution. The plain "install" target ships 111
+# binaries beyond the five the flow drives -- clang-repl at 141MB,
+# mlir-cpu-runner at 110MB, mlir-lsp-server at 95MB, bugpoint, lli, llvm-lto and
+# the rest, 2.1GB in total -- and none of them is ever invoked.
+cmake --build build --target install-distribution -j${NPROC:-$(nproc)}
 
 cd -
 

--- a/siliconcompiler/toolscripts/ubuntu22/install-chisel.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-chisel.sh
@@ -17,6 +17,13 @@ fi
 
 install_prereqs wget
 
+# sbt is a launcher script for a JVM tool, so a JRE is a runtime requirement and
+# not just a build one. It used to arrive by accident: install-surelog.sh pulls a
+# JRE in to run ANTLR's parser generator, and that leaked into the container
+# image through apt.txt. Declare it here so that dropping surelog's build-time
+# JRE cannot leave chisel without a java to run.
+install_prereqs default-jre-headless
+
 mkdir -p deps
 cd deps
 
@@ -29,7 +36,31 @@ if [ ! -z ${PREFIX} ]; then
     args="-C $PREFIX --strip-components 1"
 fi
 
-$SUDO_INSTALL tar xvf sbt.tgz $args
+# sbt ships a native "sbtn" client for every platform it supports, so the
+# tarball carries macOS, Windows and aarch64 binaries that will never run here
+# -- about 127MB of the install. Skip them at extraction time rather than
+# deleting them afterwards: PREFIX is often a shared prefix (sc-install defaults
+# to ~/.local) and this script should never remove a file it did not write.
+#
+# An unrecognised machine keeps every launcher, and a platform sbt adds later is
+# extracted rather than dropped. Both cost size only.
+case "$(uname -m)" in
+    x86_64|amd64)  keep_sbtn=sbtn-x86_64-pc-linux ;;
+    aarch64|arm64) keep_sbtn=sbtn-aarch64-pc-linux ;;
+    *)             keep_sbtn= ;;
+esac
+
+sbtn_excludes=
+if [ -n "${keep_sbtn}" ]; then
+    for sbtn in sbtn-x86_64-pc-linux sbtn-aarch64-pc-linux \
+                sbtn-universal-apple-darwin sbtn-x86_64-pc-win32.exe; do
+        if [ "${sbtn}" != "${keep_sbtn}" ]; then
+            sbtn_excludes="${sbtn_excludes} --exclude=*/${sbtn}"
+        fi
+    done
+fi
+
+$SUDO_INSTALL tar xvf sbt.tgz $sbtn_excludes $args
 
 cd -
 

--- a/siliconcompiler/toolscripts/ubuntu22/install-mlir.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-mlir.sh
@@ -91,8 +91,15 @@ fi
 #   siliconcompiler/tools/{mlir,soda}/)
 #
 #   install-soda.sh then builds soda-opt against this tree, which needs the
-#   headers, the static libraries and the cmake exports of all three projects,
-#   plus llvm-lit for -DLLVM_EXTERNAL_LIT
+#   headers, the static libraries and the cmake exports of all three projects
+#
+# Note that llvm-lit is deliberately absent even though install-soda.sh passes
+# -DLLVM_EXTERNAL_LIT=${mlir_prefix}/bin/llvm-lit. llvm-lit has no install rule
+# at all -- llvm/utils/llvm-lit only configure_file()s it into the build tree --
+# so that path has never existed in the prefix, under this install or the plain
+# "install" target before it. cmake only reads LLVM_EXTERNAL_LIT to run the lit
+# suite, which this build does not, so the dangling path is harmless. Listing
+# llvm-lit as a component is not: it fails configure outright.
 #
 # A name with no install target is a configure-time SEND_ERROR from
 # LLVMDistributionSupport.cmake naming the component, so a mistake here fails in
@@ -103,7 +110,7 @@ distribution_components="${distribution_components};llvm-headers;llvm-libraries;
 distribution_components="${distribution_components};clang-headers;clang-libraries;clang-cmake-exports"
 distribution_components="${distribution_components};clang-resource-headers"
 distribution_components="${distribution_components};mlir-headers;mlir-libraries;mlir-cmake-exports"
-distribution_components="${distribution_components};llvm-lit;FileCheck;count;not"
+distribution_components="${distribution_components};FileCheck;count;not"
 
 cmake -G Ninja \
     -S llvm-project/llvm \

--- a/siliconcompiler/toolscripts/ubuntu22/install-mlir.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-mlir.sh
@@ -91,7 +91,25 @@ fi
 #   siliconcompiler/tools/{mlir,soda}/)
 #
 #   install-soda.sh then builds soda-opt against this tree, which needs the
-#   headers, the static libraries and the cmake exports of all three projects
+#   headers, the static libraries and the cmake exports of all three projects,
+#   plus the tablegen tools -- soda-opt is an out-of-tree dialect and generates
+#   its headers from .td files. MLIRConfig.cmake names exactly three
+#   executables, and these are they:
+#
+#       MLIR_TABLEGEN_EXE             mlir-tblgen
+#       MLIR_PDLL_TABLEGEN_EXE        mlir-pdll
+#       MLIR_SRC_SHARDER_TABLEGEN_EXE mlir-src-sharder   (not installable)
+#
+#   The first two are here. mlir-src-sharder is not: it has no install target at
+#   all, so naming it fails configure -- the same quirk as llvm-lit above, where
+#   MLIRConfig advertises a path the install never provides.
+#
+#   Leaving mlir-tblgen out does not fail configure, which is what made its
+#   absence expensive to find: MLIRConfig sets the variable to a bare name
+#   either way, and the build only falls over later, when ninja looks for a file
+#   called "mlir-tblgen" next to the generated header. mlir-pdll is included on
+#   the same reasoning; soda does not use PDLL today, and a project that did
+#   would break the same silent way.
 #
 # Note that llvm-lit is deliberately absent even though install-soda.sh passes
 # -DLLVM_EXTERNAL_LIT=${mlir_prefix}/bin/llvm-lit. llvm-lit has no install rule
@@ -106,6 +124,7 @@ fi
 # seconds rather than after the build. If a future LLVM bump drops one of these,
 # that error says which.
 distribution_components="clang;opt;llvm-link;mlir-opt;mlir-translate;llvm-config"
+distribution_components="${distribution_components};mlir-tblgen;mlir-pdll"
 distribution_components="${distribution_components};llvm-headers;llvm-libraries;cmake-exports"
 distribution_components="${distribution_components};clang-headers;clang-libraries;clang-cmake-exports"
 distribution_components="${distribution_components};clang-resource-headers"

--- a/siliconcompiler/toolscripts/ubuntu22/install-mlir.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-mlir.sh
@@ -8,10 +8,18 @@
 # MLIR's C++ libraries, so it has to be built against this exact release --
 # a distro llvm/mlir package will not do.
 #
-# The full LLVM install tree is what "sc-install soda" then builds against, so
-# this script runs the "install" target rather than only building the four
-# binaries the flow calls. That also installs the MLIR test-pass libraries
-# (MLIRLinalgTestPasses and friends) which soda-opt links against.
+# The LLVM dev tree -- headers, static libraries and cmake exports -- is what
+# "sc-install soda" then builds against, so the install has to carry more than
+# the five binaries the flow calls. It does not have to carry everything, and it
+# no longer does: LLVM_DISTRIBUTION_COMPONENTS below declares the set, which is
+# what trims 2.1GB of unused tools out of the install tree. See the comment on
+# that variable.
+#
+# One thing to watch across LLVM bumps: soda-opt links against the MLIR
+# test-pass libraries (MLIRLinalgTestPasses and friends), which are built
+# because LLVM_INCLUDE_TESTS defaults on. If a bump stops the mlir-libraries
+# component covering them, soda-opt fails to link and the fix is to name those
+# libraries in the component list.
 #
 # clang is built alongside mlir because the flow compiles the MLIR runtime
 # helpers to LLVM IR before linking them into a kernel, and that IR has to be
@@ -70,6 +78,33 @@ if command -v ld.lld > /dev/null 2>&1; then
     lld_args=-DLLVM_ENABLE_LLD=ON
 fi
 
+# What gets installed. LLVM_DISTRIBUTION_COMPONENTS narrows the install to a
+# declared set and generates an "install-distribution" target for it, which is
+# how LLVM itself expects a packager to trim an install tree -- rather than
+# installing everything and deleting afterwards, which would mean this script
+# removing files from a prefix it may share with every other SC tool.
+#
+# Two groups, for the project's two consumers:
+#
+#   the flow drives clang, opt, llvm-link, mlir-opt and mlir-translate, and
+#   nothing else (each is named in a set_exe call under
+#   siliconcompiler/tools/{mlir,soda}/)
+#
+#   install-soda.sh then builds soda-opt against this tree, which needs the
+#   headers, the static libraries and the cmake exports of all three projects,
+#   plus llvm-lit for -DLLVM_EXTERNAL_LIT
+#
+# A name with no install target is a configure-time SEND_ERROR from
+# LLVMDistributionSupport.cmake naming the component, so a mistake here fails in
+# seconds rather than after the build. If a future LLVM bump drops one of these,
+# that error says which.
+distribution_components="clang;opt;llvm-link;mlir-opt;mlir-translate;llvm-config"
+distribution_components="${distribution_components};llvm-headers;llvm-libraries;cmake-exports"
+distribution_components="${distribution_components};clang-headers;clang-libraries;clang-cmake-exports"
+distribution_components="${distribution_components};clang-resource-headers"
+distribution_components="${distribution_components};mlir-headers;mlir-libraries;mlir-cmake-exports"
+distribution_components="${distribution_components};llvm-lit;FileCheck;count;not"
+
 cmake -G Ninja \
     -S llvm-project/llvm \
     -B build \
@@ -85,6 +120,7 @@ cmake -G Ninja \
     -DLLVM_PARALLEL_LINK_JOBS=2 \
     -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
     -DLLVM_INSTALL_UTILS=ON \
+    -DLLVM_DISTRIBUTION_COMPONENTS="${distribution_components}" \
     ${lld_args}
 
 # The tools the SODA flow drives directly, built first so a failure in one of
@@ -92,8 +128,11 @@ cmake -G Ninja \
 cmake --build build --target opt llvm-link clang mlir-opt mlir-translate \
     -j${NPROC:-$(nproc)}
 
-# Everything soda-opt needs to configure and link against.
-cmake --build build --target install -j${NPROC:-$(nproc)}
+# Install only the declared distribution. The plain "install" target ships 111
+# binaries beyond the five the flow drives -- clang-repl at 141MB,
+# mlir-cpu-runner at 110MB, mlir-lsp-server at 95MB, bugpoint, lli, llvm-lto and
+# the rest, 2.1GB in total -- and none of them is ever invoked.
+cmake --build build --target install-distribution -j${NPROC:-$(nproc)}
 
 cd -
 

--- a/siliconcompiler/toolscripts/ubuntu24/install-chisel.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-chisel.sh
@@ -17,6 +17,13 @@ fi
 
 install_prereqs wget
 
+# sbt is a launcher script for a JVM tool, so a JRE is a runtime requirement and
+# not just a build one. It used to arrive by accident: install-surelog.sh pulls a
+# JRE in to run ANTLR's parser generator, and that leaked into the container
+# image through apt.txt. Declare it here so that dropping surelog's build-time
+# JRE cannot leave chisel without a java to run.
+install_prereqs default-jre-headless
+
 mkdir -p deps
 cd deps
 
@@ -29,7 +36,31 @@ if [ ! -z ${PREFIX} ]; then
     args="-C $PREFIX --strip-components 1"
 fi
 
-$SUDO_INSTALL tar xvf sbt.tgz $args
+# sbt ships a native "sbtn" client for every platform it supports, so the
+# tarball carries macOS, Windows and aarch64 binaries that will never run here
+# -- about 127MB of the install. Skip them at extraction time rather than
+# deleting them afterwards: PREFIX is often a shared prefix (sc-install defaults
+# to ~/.local) and this script should never remove a file it did not write.
+#
+# An unrecognised machine keeps every launcher, and a platform sbt adds later is
+# extracted rather than dropped. Both cost size only.
+case "$(uname -m)" in
+    x86_64|amd64)  keep_sbtn=sbtn-x86_64-pc-linux ;;
+    aarch64|arm64) keep_sbtn=sbtn-aarch64-pc-linux ;;
+    *)             keep_sbtn= ;;
+esac
+
+sbtn_excludes=
+if [ -n "${keep_sbtn}" ]; then
+    for sbtn in sbtn-x86_64-pc-linux sbtn-aarch64-pc-linux \
+                sbtn-universal-apple-darwin sbtn-x86_64-pc-win32.exe; do
+        if [ "${sbtn}" != "${keep_sbtn}" ]; then
+            sbtn_excludes="${sbtn_excludes} --exclude=*/${sbtn}"
+        fi
+    done
+fi
+
+$SUDO_INSTALL tar xvf sbt.tgz $sbtn_excludes $args
 
 cd -
 

--- a/siliconcompiler/toolscripts/ubuntu24/install-mlir.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-mlir.sh
@@ -91,8 +91,15 @@ fi
 #   siliconcompiler/tools/{mlir,soda}/)
 #
 #   install-soda.sh then builds soda-opt against this tree, which needs the
-#   headers, the static libraries and the cmake exports of all three projects,
-#   plus llvm-lit for -DLLVM_EXTERNAL_LIT
+#   headers, the static libraries and the cmake exports of all three projects
+#
+# Note that llvm-lit is deliberately absent even though install-soda.sh passes
+# -DLLVM_EXTERNAL_LIT=${mlir_prefix}/bin/llvm-lit. llvm-lit has no install rule
+# at all -- llvm/utils/llvm-lit only configure_file()s it into the build tree --
+# so that path has never existed in the prefix, under this install or the plain
+# "install" target before it. cmake only reads LLVM_EXTERNAL_LIT to run the lit
+# suite, which this build does not, so the dangling path is harmless. Listing
+# llvm-lit as a component is not: it fails configure outright.
 #
 # A name with no install target is a configure-time SEND_ERROR from
 # LLVMDistributionSupport.cmake naming the component, so a mistake here fails in
@@ -103,7 +110,7 @@ distribution_components="${distribution_components};llvm-headers;llvm-libraries;
 distribution_components="${distribution_components};clang-headers;clang-libraries;clang-cmake-exports"
 distribution_components="${distribution_components};clang-resource-headers"
 distribution_components="${distribution_components};mlir-headers;mlir-libraries;mlir-cmake-exports"
-distribution_components="${distribution_components};llvm-lit;FileCheck;count;not"
+distribution_components="${distribution_components};FileCheck;count;not"
 
 cmake -G Ninja \
     -S llvm-project/llvm \

--- a/siliconcompiler/toolscripts/ubuntu24/install-mlir.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-mlir.sh
@@ -91,7 +91,25 @@ fi
 #   siliconcompiler/tools/{mlir,soda}/)
 #
 #   install-soda.sh then builds soda-opt against this tree, which needs the
-#   headers, the static libraries and the cmake exports of all three projects
+#   headers, the static libraries and the cmake exports of all three projects,
+#   plus the tablegen tools -- soda-opt is an out-of-tree dialect and generates
+#   its headers from .td files. MLIRConfig.cmake names exactly three
+#   executables, and these are they:
+#
+#       MLIR_TABLEGEN_EXE             mlir-tblgen
+#       MLIR_PDLL_TABLEGEN_EXE        mlir-pdll
+#       MLIR_SRC_SHARDER_TABLEGEN_EXE mlir-src-sharder   (not installable)
+#
+#   The first two are here. mlir-src-sharder is not: it has no install target at
+#   all, so naming it fails configure -- the same quirk as llvm-lit above, where
+#   MLIRConfig advertises a path the install never provides.
+#
+#   Leaving mlir-tblgen out does not fail configure, which is what made its
+#   absence expensive to find: MLIRConfig sets the variable to a bare name
+#   either way, and the build only falls over later, when ninja looks for a file
+#   called "mlir-tblgen" next to the generated header. mlir-pdll is included on
+#   the same reasoning; soda does not use PDLL today, and a project that did
+#   would break the same silent way.
 #
 # Note that llvm-lit is deliberately absent even though install-soda.sh passes
 # -DLLVM_EXTERNAL_LIT=${mlir_prefix}/bin/llvm-lit. llvm-lit has no install rule
@@ -106,6 +124,7 @@ fi
 # seconds rather than after the build. If a future LLVM bump drops one of these,
 # that error says which.
 distribution_components="clang;opt;llvm-link;mlir-opt;mlir-translate;llvm-config"
+distribution_components="${distribution_components};mlir-tblgen;mlir-pdll"
 distribution_components="${distribution_components};llvm-headers;llvm-libraries;cmake-exports"
 distribution_components="${distribution_components};clang-headers;clang-libraries;clang-cmake-exports"
 distribution_components="${distribution_components};clang-resource-headers"

--- a/siliconcompiler/toolscripts/ubuntu24/install-mlir.sh
+++ b/siliconcompiler/toolscripts/ubuntu24/install-mlir.sh
@@ -8,10 +8,18 @@
 # MLIR's C++ libraries, so it has to be built against this exact release --
 # a distro llvm/mlir package will not do.
 #
-# The full LLVM install tree is what "sc-install soda" then builds against, so
-# this script runs the "install" target rather than only building the four
-# binaries the flow calls. That also installs the MLIR test-pass libraries
-# (MLIRLinalgTestPasses and friends) which soda-opt links against.
+# The LLVM dev tree -- headers, static libraries and cmake exports -- is what
+# "sc-install soda" then builds against, so the install has to carry more than
+# the five binaries the flow calls. It does not have to carry everything, and it
+# no longer does: LLVM_DISTRIBUTION_COMPONENTS below declares the set, which is
+# what trims 2.1GB of unused tools out of the install tree. See the comment on
+# that variable.
+#
+# One thing to watch across LLVM bumps: soda-opt links against the MLIR
+# test-pass libraries (MLIRLinalgTestPasses and friends), which are built
+# because LLVM_INCLUDE_TESTS defaults on. If a bump stops the mlir-libraries
+# component covering them, soda-opt fails to link and the fix is to name those
+# libraries in the component list.
 #
 # clang is built alongside mlir because the flow compiles the MLIR runtime
 # helpers to LLVM IR before linking them into a kernel, and that IR has to be
@@ -70,6 +78,33 @@ if command -v ld.lld > /dev/null 2>&1; then
     lld_args=-DLLVM_ENABLE_LLD=ON
 fi
 
+# What gets installed. LLVM_DISTRIBUTION_COMPONENTS narrows the install to a
+# declared set and generates an "install-distribution" target for it, which is
+# how LLVM itself expects a packager to trim an install tree -- rather than
+# installing everything and deleting afterwards, which would mean this script
+# removing files from a prefix it may share with every other SC tool.
+#
+# Two groups, for the project's two consumers:
+#
+#   the flow drives clang, opt, llvm-link, mlir-opt and mlir-translate, and
+#   nothing else (each is named in a set_exe call under
+#   siliconcompiler/tools/{mlir,soda}/)
+#
+#   install-soda.sh then builds soda-opt against this tree, which needs the
+#   headers, the static libraries and the cmake exports of all three projects,
+#   plus llvm-lit for -DLLVM_EXTERNAL_LIT
+#
+# A name with no install target is a configure-time SEND_ERROR from
+# LLVMDistributionSupport.cmake naming the component, so a mistake here fails in
+# seconds rather than after the build. If a future LLVM bump drops one of these,
+# that error says which.
+distribution_components="clang;opt;llvm-link;mlir-opt;mlir-translate;llvm-config"
+distribution_components="${distribution_components};llvm-headers;llvm-libraries;cmake-exports"
+distribution_components="${distribution_components};clang-headers;clang-libraries;clang-cmake-exports"
+distribution_components="${distribution_components};clang-resource-headers"
+distribution_components="${distribution_components};mlir-headers;mlir-libraries;mlir-cmake-exports"
+distribution_components="${distribution_components};llvm-lit;FileCheck;count;not"
+
 cmake -G Ninja \
     -S llvm-project/llvm \
     -B build \
@@ -85,6 +120,7 @@ cmake -G Ninja \
     -DLLVM_PARALLEL_LINK_JOBS=2 \
     -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
     -DLLVM_INSTALL_UTILS=ON \
+    -DLLVM_DISTRIBUTION_COMPONENTS="${distribution_components}" \
     ${lld_args}
 
 # The tools the SODA flow drives directly, built first so a failure in one of
@@ -92,8 +128,11 @@ cmake -G Ninja \
 cmake --build build --target opt llvm-link clang mlir-opt mlir-translate \
     -j${NPROC:-$(nproc)}
 
-# Everything soda-opt needs to configure and link against.
-cmake --build build --target install -j${NPROC:-$(nproc)}
+# Install only the declared distribution. The plain "install" target ships 111
+# binaries beyond the five the flow drives -- clang-repl at 141MB,
+# mlir-cpu-runner at 110MB, mlir-lsp-server at 95MB, bugpoint, lli, llvm-lto and
+# the rest, 2.1GB in total -- and none of them is ever invoked.
+cmake --build build --target install-distribution -j${NPROC:-$(nproc)}
 
 cd -
 

--- a/siliconcompiler/toolscripts/ubuntu26/install-chisel.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-chisel.sh
@@ -17,6 +17,13 @@ fi
 
 install_prereqs wget
 
+# sbt is a launcher script for a JVM tool, so a JRE is a runtime requirement and
+# not just a build one. It used to arrive by accident: install-surelog.sh pulls a
+# JRE in to run ANTLR's parser generator, and that leaked into the container
+# image through apt.txt. Declare it here so that dropping surelog's build-time
+# JRE cannot leave chisel without a java to run.
+install_prereqs default-jre-headless
+
 mkdir -p deps
 cd deps
 
@@ -29,7 +36,31 @@ if [ ! -z ${PREFIX} ]; then
     args="-C $PREFIX --strip-components 1"
 fi
 
-$SUDO_INSTALL tar xvf sbt.tgz $args
+# sbt ships a native "sbtn" client for every platform it supports, so the
+# tarball carries macOS, Windows and aarch64 binaries that will never run here
+# -- about 127MB of the install. Skip them at extraction time rather than
+# deleting them afterwards: PREFIX is often a shared prefix (sc-install defaults
+# to ~/.local) and this script should never remove a file it did not write.
+#
+# An unrecognised machine keeps every launcher, and a platform sbt adds later is
+# extracted rather than dropped. Both cost size only.
+case "$(uname -m)" in
+    x86_64|amd64)  keep_sbtn=sbtn-x86_64-pc-linux ;;
+    aarch64|arm64) keep_sbtn=sbtn-aarch64-pc-linux ;;
+    *)             keep_sbtn= ;;
+esac
+
+sbtn_excludes=
+if [ -n "${keep_sbtn}" ]; then
+    for sbtn in sbtn-x86_64-pc-linux sbtn-aarch64-pc-linux \
+                sbtn-universal-apple-darwin sbtn-x86_64-pc-win32.exe; do
+        if [ "${sbtn}" != "${keep_sbtn}" ]; then
+            sbtn_excludes="${sbtn_excludes} --exclude=*/${sbtn}"
+        fi
+    done
+fi
+
+$SUDO_INSTALL tar xvf sbt.tgz $sbtn_excludes $args
 
 cd -
 

--- a/siliconcompiler/toolscripts/ubuntu26/install-mlir.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-mlir.sh
@@ -8,10 +8,18 @@
 # MLIR's C++ libraries, so it has to be built against this exact release --
 # a distro llvm/mlir package will not do.
 #
-# The full LLVM install tree is what "sc-install soda" then builds against, so
-# this script runs the "install" target rather than only building the four
-# binaries the flow calls. That also installs the MLIR test-pass libraries
-# (MLIRLinalgTestPasses and friends) which soda-opt links against.
+# The LLVM dev tree -- headers, static libraries and cmake exports -- is what
+# "sc-install soda" then builds against, so the install has to carry more than
+# the five binaries the flow calls. It does not have to carry everything, and it
+# no longer does: LLVM_DISTRIBUTION_COMPONENTS below declares the set, which is
+# what trims 2.1GB of unused tools out of the install tree. See the comment on
+# that variable.
+#
+# One thing to watch across LLVM bumps: soda-opt links against the MLIR
+# test-pass libraries (MLIRLinalgTestPasses and friends), which are built
+# because LLVM_INCLUDE_TESTS defaults on. If a bump stops the mlir-libraries
+# component covering them, soda-opt fails to link and the fix is to name those
+# libraries in the component list.
 #
 # clang is built alongside mlir because the flow compiles the MLIR runtime
 # helpers to LLVM IR before linking them into a kernel, and that IR has to be
@@ -70,6 +78,33 @@ if command -v ld.lld > /dev/null 2>&1; then
     lld_args=-DLLVM_ENABLE_LLD=ON
 fi
 
+# What gets installed. LLVM_DISTRIBUTION_COMPONENTS narrows the install to a
+# declared set and generates an "install-distribution" target for it, which is
+# how LLVM itself expects a packager to trim an install tree -- rather than
+# installing everything and deleting afterwards, which would mean this script
+# removing files from a prefix it may share with every other SC tool.
+#
+# Two groups, for the project's two consumers:
+#
+#   the flow drives clang, opt, llvm-link, mlir-opt and mlir-translate, and
+#   nothing else (each is named in a set_exe call under
+#   siliconcompiler/tools/{mlir,soda}/)
+#
+#   install-soda.sh then builds soda-opt against this tree, which needs the
+#   headers, the static libraries and the cmake exports of all three projects,
+#   plus llvm-lit for -DLLVM_EXTERNAL_LIT
+#
+# A name with no install target is a configure-time SEND_ERROR from
+# LLVMDistributionSupport.cmake naming the component, so a mistake here fails in
+# seconds rather than after the build. If a future LLVM bump drops one of these,
+# that error says which.
+distribution_components="clang;opt;llvm-link;mlir-opt;mlir-translate;llvm-config"
+distribution_components="${distribution_components};llvm-headers;llvm-libraries;cmake-exports"
+distribution_components="${distribution_components};clang-headers;clang-libraries;clang-cmake-exports"
+distribution_components="${distribution_components};clang-resource-headers"
+distribution_components="${distribution_components};mlir-headers;mlir-libraries;mlir-cmake-exports"
+distribution_components="${distribution_components};llvm-lit;FileCheck;count;not"
+
 # ubuntu26 defaults to gcc 15, which no longer pulls <cstdint> in transitively
 # from the other standard headers. LLVM 19.1.5 predates that and does not include
 # it where it uses int64_t, so the build dies in the affine dialect with
@@ -93,6 +128,7 @@ cmake -G Ninja \
     -DLLVM_PARALLEL_LINK_JOBS=2 \
     -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
     -DLLVM_INSTALL_UTILS=ON \
+    -DLLVM_DISTRIBUTION_COMPONENTS="${distribution_components}" \
     ${lld_args}
 
 # The tools the SODA flow drives directly, built first so a failure in one of
@@ -100,8 +136,11 @@ cmake -G Ninja \
 cmake --build build --target opt llvm-link clang mlir-opt mlir-translate \
     -j${NPROC:-$(nproc)}
 
-# Everything soda-opt needs to configure and link against.
-cmake --build build --target install -j${NPROC:-$(nproc)}
+# Install only the declared distribution. The plain "install" target ships 111
+# binaries beyond the five the flow drives -- clang-repl at 141MB,
+# mlir-cpu-runner at 110MB, mlir-lsp-server at 95MB, bugpoint, lli, llvm-lto and
+# the rest, 2.1GB in total -- and none of them is ever invoked.
+cmake --build build --target install-distribution -j${NPROC:-$(nproc)}
 
 cd -
 

--- a/siliconcompiler/toolscripts/ubuntu26/install-mlir.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-mlir.sh
@@ -91,7 +91,25 @@ fi
 #   siliconcompiler/tools/{mlir,soda}/)
 #
 #   install-soda.sh then builds soda-opt against this tree, which needs the
-#   headers, the static libraries and the cmake exports of all three projects
+#   headers, the static libraries and the cmake exports of all three projects,
+#   plus the tablegen tools -- soda-opt is an out-of-tree dialect and generates
+#   its headers from .td files. MLIRConfig.cmake names exactly three
+#   executables, and these are they:
+#
+#       MLIR_TABLEGEN_EXE             mlir-tblgen
+#       MLIR_PDLL_TABLEGEN_EXE        mlir-pdll
+#       MLIR_SRC_SHARDER_TABLEGEN_EXE mlir-src-sharder   (not installable)
+#
+#   The first two are here. mlir-src-sharder is not: it has no install target at
+#   all, so naming it fails configure -- the same quirk as llvm-lit above, where
+#   MLIRConfig advertises a path the install never provides.
+#
+#   Leaving mlir-tblgen out does not fail configure, which is what made its
+#   absence expensive to find: MLIRConfig sets the variable to a bare name
+#   either way, and the build only falls over later, when ninja looks for a file
+#   called "mlir-tblgen" next to the generated header. mlir-pdll is included on
+#   the same reasoning; soda does not use PDLL today, and a project that did
+#   would break the same silent way.
 #
 # Note that llvm-lit is deliberately absent even though install-soda.sh passes
 # -DLLVM_EXTERNAL_LIT=${mlir_prefix}/bin/llvm-lit. llvm-lit has no install rule
@@ -106,6 +124,7 @@ fi
 # seconds rather than after the build. If a future LLVM bump drops one of these,
 # that error says which.
 distribution_components="clang;opt;llvm-link;mlir-opt;mlir-translate;llvm-config"
+distribution_components="${distribution_components};mlir-tblgen;mlir-pdll"
 distribution_components="${distribution_components};llvm-headers;llvm-libraries;cmake-exports"
 distribution_components="${distribution_components};clang-headers;clang-libraries;clang-cmake-exports"
 distribution_components="${distribution_components};clang-resource-headers"

--- a/siliconcompiler/toolscripts/ubuntu26/install-mlir.sh
+++ b/siliconcompiler/toolscripts/ubuntu26/install-mlir.sh
@@ -91,8 +91,15 @@ fi
 #   siliconcompiler/tools/{mlir,soda}/)
 #
 #   install-soda.sh then builds soda-opt against this tree, which needs the
-#   headers, the static libraries and the cmake exports of all three projects,
-#   plus llvm-lit for -DLLVM_EXTERNAL_LIT
+#   headers, the static libraries and the cmake exports of all three projects
+#
+# Note that llvm-lit is deliberately absent even though install-soda.sh passes
+# -DLLVM_EXTERNAL_LIT=${mlir_prefix}/bin/llvm-lit. llvm-lit has no install rule
+# at all -- llvm/utils/llvm-lit only configure_file()s it into the build tree --
+# so that path has never existed in the prefix, under this install or the plain
+# "install" target before it. cmake only reads LLVM_EXTERNAL_LIT to run the lit
+# suite, which this build does not, so the dangling path is harmless. Listing
+# llvm-lit as a component is not: it fails configure outright.
 #
 # A name with no install target is a configure-time SEND_ERROR from
 # LLVMDistributionSupport.cmake naming the component, so a mistake here fails in
@@ -103,7 +110,7 @@ distribution_components="${distribution_components};llvm-headers;llvm-libraries;
 distribution_components="${distribution_components};clang-headers;clang-libraries;clang-cmake-exports"
 distribution_components="${distribution_components};clang-resource-headers"
 distribution_components="${distribution_components};mlir-headers;mlir-libraries;mlir-cmake-exports"
-distribution_components="${distribution_components};llvm-lit;FileCheck;count;not"
+distribution_components="${distribution_components};FileCheck;count;not"
 
 # ubuntu26 defaults to gcc 15, which no longer pulls <cstdint> in transitively
 # from the other standard headers. LLVM 19.1.5 predates that and does not include

--- a/tests/toolscripts/test_prereqs.py
+++ b/tests/toolscripts/test_prereqs.py
@@ -69,6 +69,19 @@ ALLOWED_SUDO = {
 }
 
 
+# strip <args> <file>. Records the invocation so a test can assert which flags a
+# given kind of object got, and refuses the one file the real strip refuses, so
+# the helper's "a refusal is not fatal" path is exercised.
+STRIP_STUB = """#!/bin/sh
+for arg in "$@"; do
+    case "$arg" in
+        *unstrippable*) echo "strip: $arg: file format not recognized" >&2; exit 1 ;;
+    esac
+done
+echo "strip $*" >> "$SC_TEST_LOG"
+"""
+
+
 # Stand-ins for the three commands install_prereqs reaches for. Everything the
 # helper does is recorded in $SC_TEST_LOG, so a test asserts on what it ran (and,
 # just as importantly, on what it did not run).
@@ -83,6 +96,7 @@ exec "$@"
     "id": """#!/bin/sh
 echo "${SC_TEST_UID:-1000}"
 """,
+    "strip": STRIP_STUB,
 }
 
 DEB_STUBS = {
@@ -118,6 +132,7 @@ def _manager_stub(name):
 
 RPM_STUBS = {"rpm": RPM_QUERY_STUB, "yum": _manager_stub("yum")}
 
+
 # RHEL 8 and 9 both ship yum as an alias for dnf, but a dnf-only system has to
 # work too: the helper picks whichever command is actually there.
 DNF_STUBS = {"rpm": RPM_QUERY_STUB, "dnf": _manager_stub("dnf")}
@@ -127,7 +142,9 @@ BACKEND_STUBS = {"deb": DEB_STUBS, "rpm": RPM_STUBS, "dnf": DNF_STUBS}
 # The backend is chosen by which package manager is on PATH, so each case runs
 # with a PATH holding nothing but its own stubs plus the few real tools the
 # helper shells out to.
-REAL_TOOLS = ("grep",)
+# sc_strip_prefix walks the prefix and reads each file's ELF magic, so it needs a
+# few more real tools than install_prereqs does.
+REAL_TOOLS = ("grep", "find", "dd", "od", "tr", "basename")
 
 
 @pytest.fixture
@@ -388,3 +405,207 @@ def test_script_sudo_is_on_the_allowlist(script):
                 continue
             assert line in allowed, \
                 f"{script}:{lineno}: unexpected sudo, use install_prereqs instead: {line!r}"
+
+# ---------------------------------------------------------------------------
+# sc_remove_prereqs
+#
+# The mirror of install_prereqs, and asymmetric with it on purpose. Installing
+# errs toward acting: an unrecognised name is handed to the package manager.
+# Removing errs toward leaving things alone, because "apt-get remove" exits 100
+# on a name it does not recognise -- and tool.docker cleans /var/lib/apt/lists
+# before docker-cmds run, so the only names apt recognises there are the
+# installed ones. An unfiltered remove list fails the image build outright.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_remove_drops_installed_packages(run_prereqs):
+    """The straightforward case: everything named is installed, so all of it goes."""
+    log = run_prereqs("sc_remove_prereqs present-ghc present-tcl-dev")
+
+    assert log == [
+        "sudo apt-get remove -y --purge present-ghc present-tcl-dev",
+        "apt-get remove -y --purge present-ghc present-tcl-dev",
+    ]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_remove_of_nothing_installed_runs_no_package_manager(run_prereqs):
+    """The build-breaking case. Not installed means the package manager is never
+    called, because calling it would exit 100 and fail the image build."""
+    assert run_prereqs("sc_remove_prereqs llvm-18-tools clang-18 libz-dev") == []
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_remove_filters_to_the_installed_subset(run_prereqs):
+    """A partly-stale list removes what is there and says nothing about the rest."""
+    log = run_prereqs(
+        "sc_remove_prereqs absent-llvm-18-dev present-pandoc absent-gnat present-groff")
+
+    assert log == [
+        "sudo apt-get remove -y --purge present-pandoc present-groff",
+        "apt-get remove -y --purge present-pandoc present-groff",
+    ]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_remove_never_autoremoves(run_prereqs):
+    """No autoremove, ever.
+
+    These images keep runtime libraries that arrived only as a build package's
+    dependency -- libxcb-keysyms1 under libxcb-keysyms1-dev, libgmp10 under ghc,
+    libllvm18 under llvm-18-dev. An autoremove would take them along with the
+    build packages and break the tool at run time rather than at build time.
+    """
+    log = run_prereqs("sc_remove_prereqs present-ghc")
+
+    assert not any("autoremove" in line for line in log)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_remove_empty_list_is_a_noop(run_prereqs):
+    assert run_prereqs("sc_remove_prereqs") == []
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_remove_configfiles_state_is_not_removed_again(run_prereqs):
+    """Already removed, config files left behind. Nothing to do."""
+    assert run_prereqs("sc_remove_prereqs configfiles-tcl-dev") == []
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_remove_as_root_drops_sudo(run_prereqs):
+    """The container builds run as root, where sudo may not be installed."""
+    log = run_prereqs("sc_remove_prereqs present-ghc", root=True)
+
+    assert log == ["apt-get remove -y --purge present-ghc"]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+@pytest.mark.parametrize("backend,manager", [("rpm", "yum"), ("dnf", "dnf")])
+def test_remove_on_rpm_uses_the_right_manager(run_prereqs, backend, manager):
+    log = run_prereqs("sc_remove_prereqs present-ghc absent-gnat", backend=backend)
+
+    assert log == [
+        f"sudo {manager} remove -y present-ghc",
+        f"{manager} remove -y present-ghc",
+    ]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_remove_on_rpm_with_nothing_installed_is_a_noop(run_prereqs):
+    assert run_prereqs("sc_remove_prereqs absent-gnat", backend="rpm") == []
+
+
+# ---------------------------------------------------------------------------
+# sc_strip_prefix
+# ---------------------------------------------------------------------------
+
+ELF_MAGIC = b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 8
+
+
+def _make_prefix(root, files):
+    """Build a fake install prefix. A file whose content is ELF magic is treated
+    as an object to strip; anything else stands in for a script or data file."""
+    for relpath, elf in files.items():
+        path = os.path.join(root, relpath)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(ELF_MAGIC if elf else b"#!/bin/sh\necho hello\n")
+        os.chmod(path, 0o755)
+    return root
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_strip_uses_strip_all_on_executables_and_strip_unneeded_on_libraries(
+        run_prereqs, tmp_path):
+    """The distinction that matters.
+
+    A shared object keeps .dynsym, which is what the loader and dlopen() resolve
+    against -- strip it and every plugin in the tree stops loading. An
+    executable has no such constraint, so it gets the full strip.
+    """
+    prefix = _make_prefix(str(tmp_path / "px"), {
+        "bin/yosys": True,
+        "lib/libyosys.so": True,
+        "lib/libghdl-5_1_1.so.1": True,
+    })
+
+    log = run_prereqs(f"sc_strip_prefix {prefix}")
+    flags = {line.rsplit("/", 1)[-1]: line for line in log}
+
+    assert "--strip-all" in flags["yosys"]
+    assert "--strip-unneeded" in flags["libyosys.so"]
+    assert "--strip-unneeded" in flags["libghdl-5_1_1.so.1"]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_strip_leaves_static_archives_alone(run_prereqs, tmp_path):
+    """Static archives are skipped, and not as an oversight.
+
+    Three tools link an archive from their own prefix at run time --
+    lib/ghdl/libgrt.a into every elaborated design, lib/panda/*.a into bambu's
+    generated designs, lib/Bluesim/*.a for "bsc -sim" -- and stripping an
+    archive breaks linking against it. The container drops the archives it does
+    not need by name instead.
+    """
+    prefix = _make_prefix(str(tmp_path / "pa"), {
+        "lib/ghdl/libgrt.a": True,
+        "lib/panda/libbambu_clang16.a": True,
+        "bin/ghdl": True,
+    })
+
+    log = run_prereqs(f"sc_strip_prefix {prefix}")
+
+    assert not any(".a" in line for line in log)
+    assert any(line.endswith("/ghdl") for line in log)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_strip_skips_non_elf_files(run_prereqs, tmp_path):
+    """The prefixes are full of executable shell, Tcl and Python. The helper
+    checks the magic number rather than trusting the mode bit."""
+    prefix = _make_prefix(str(tmp_path / "pn"), {
+        "bin/sc-install": False,
+        "bin/verilator": False,
+        "bin/verilator_bin": True,
+    })
+
+    log = run_prereqs(f"sc_strip_prefix {prefix}")
+
+    assert len(log) == 1
+    assert log[0].endswith("/verilator_bin")
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_strip_survives_an_object_it_cannot_strip(run_prereqs, tmp_path):
+    """A refusal is not fatal: a tool that builds is worth more than the bytes.
+
+    The install scripts run under "set -e", so a non-zero strip would otherwise
+    abort the whole install.
+    """
+    prefix = _make_prefix(str(tmp_path / "pu"), {
+        "bin/unstrippable-thing": True,
+        "bin/openroad": True,
+    })
+
+    log = run_prereqs(f"sc_strip_prefix {prefix}")
+
+    assert [line.rsplit("/", 1)[-1] for line in log] == ["openroad"]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_strip_of_a_missing_prefix_is_a_noop(run_prereqs, tmp_path):
+    assert run_prereqs(f"sc_strip_prefix {tmp_path}/not-there") == []
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_strip_with_no_argument_falls_back_to_prefix(run_prereqs, tmp_path):
+    """tool.docker passes $SC_PREFIX explicitly, but the install scripts export
+    PREFIX, so a bare call has to work too."""
+    prefix = _make_prefix(str(tmp_path / "pp"), {"bin/sta": True})
+
+    log = run_prereqs(f"PREFIX={prefix}\nexport PREFIX\nsc_strip_prefix")
+
+    assert len(log) == 1
+    assert log[0].endswith("/sta")


### PR DESCRIPTION
Requires a full daily run to merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Docker tool images now exclude build-only files, symbols, debug data, and unused dependencies, resulting in smaller images.
  - Chisel installations include the required Java runtime and retain only native `sbtn` launchers for the host architecture.
  - MLIR installations include only components required by supported flows.

- **Bug Fixes**
  - Runtime dependency detection avoids packages removed during image creation.
  - Docker image validation reflects changes in tool dependency relationships.
  - Prerequisite cleanup safely handles unavailable packages and unsupported package managers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->