### PR TITLE
remove server CI test

### DIFF
--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -501,32 +501,3 @@ jobs:
     needs: [build_sc_tools, tools_changed_check]
     if: always() && !cancelled() && needs.tools_changed_check.outputs.asic_changed == 'Yes'
     uses: ./.github/workflows/daily_ci.yml
-
-  server_tests:
-    needs: build_sc_tools
-    if: always() && !cancelled()
-    name: Test server
-    timeout-minutes: 90
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check for Secret availability
-        id: secret-check
-        # perform secret check & put boolean result as an output
-        shell: bash
-        run: |
-          if [ "${{ secrets.ZA_TOKEN }}" != '' ]; then
-            echo "available=true" >> $GITHUB_OUTPUT;
-          else
-            echo "available=false" >> $GITHUB_OUTPUT;
-          fi
-      - name: Trigger server tests
-        if: ${{ steps.secret-check.outputs.available == 'true' }}
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        with:
-          github_token: ${{ secrets.ZA_TOKEN }}
-          owner: ${{ secrets.SERVER_OWNER }}
-          repo: ${{ secrets.SERVER_REPO }}
-          workflow_file_name: containers.yml
-          client_payload: '{"sc-ref": "${{ github.ref }}"}'
-          wait_interval: 60
-          ref: ${{ vars.SERVER_BRANCH }}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ SiliconCompiler is a modular hardware build system ("make for silicon"). The pro
 
 SiliconCompiler is available as wheel packages on PyPI for macOS, Windows and
 Linux platforms. For working Python 3.10-3.14 environment, just use pip.
-On Windows, use remote or Docker execution — local tool flows are supported on Linux and macOS.
+On Windows, use Docker or remote execution — local tool flows are supported on Linux and macOS.
 
 ```sh
 pip install --upgrade siliconcompiler
@@ -50,7 +50,7 @@ design.add_file("heartbeat.sdc", fileset="sdc")        # add input sources
 project = ASIC(design)                                 # create project
 project.add_fileset(["rtl", "sdc"])                    # enable filesets
 skywater130_demo(project)                              # load a pre-defined target
-project.option.set_remote(True)                        # enable remote execution
+project.option.scheduler.set_name("docker")            # run the tools in containers
 project.run()                                          # run compilation
 project.summary()                                      # print summary
 project.show()                                         # show layout
@@ -72,10 +72,10 @@ project class is what decides what happens to it:
 
 Linting is the quickest way to see SiliconCompiler work: the default linter ships
 as a Python package, so it needs no EDA tools installed at all. For a complete
-FPGA build with nothing installed locally, the demo runs remotely:
+FPGA build with no EDA tools installed locally, the demo runs in containers:
 
 ```sh
-python3 -m siliconcompiler.demos.fpga_demo -remote
+python3 -m siliconcompiler.demos.fpga_demo -scheduler docker
 ```
 
 # Why SiliconCompiler?
@@ -83,7 +83,7 @@ python3 -m siliconcompiler.demos.fpga_demo -remote
 * **Ease-of-use**: Programmable with a simple [Python API](https://docs.siliconcompiler.com/en/latest/reference_manual/schema_api.html)
 * **Portability:** Powerful dynamic JSON [schema](https://docs.siliconcompiler.com/en/latest/reference_manual/schema.html) supports ASIC and FPGA design and simulation
 * **Speed:** Flowgraph [execution model](https://docs.siliconcompiler.com/en/latest/user_guide/execution_model.html) enables cloud scale execution.
-* **Friction-less:** [Remote execution model](https://docs.siliconcompiler.com/en/latest/user_guide/remote_processing.html) enables "zero install" compilation
+* **Friction-less:** [Containerized execution](https://docs.siliconcompiler.com/en/latest/user_guide/docker.html) enables "zero install" compilation, and a [remote execution model](https://docs.siliconcompiler.com/en/latest/user_guide/remote_processing.html) offloads builds to a server you operate
 * **Modularity:** [Tool abstraction layer](https://docs.siliconcompiler.com/en/latest/development_guide/tools.html) makes it easy to add/port new tools to the project.
 * **Provenance:** [Compilation manifests](https://docs.siliconcompiler.com/en/latest/user_guide/data_model.html) created automatically during execution.
 * **Documented:** An extensive set of auto-generated high quality [reference documents](https://docs.siliconcompiler.com/).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,7 +80,7 @@ Get something running
 Run it somewhere else
 ---------------------
 
-* :ref:`Run remotely, with nothing installed locally <remote_processing>` -- compile against a server.
+* :ref:`Run remotely <remote_processing>` -- compile against a server you or your organization operates.
 * :ref:`Run inside a container <docker>` -- the supported route on Windows.
 * :ref:`Run steps in parallel <parallel_execution>` -- more than one node at a time.
 * :ref:`Run on a cluster <cluster_tutorial>` -- Slurm and friends.

--- a/docs/user_guide/faq.rst
+++ b/docs/user_guide/faq.rst
@@ -20,61 +20,33 @@ Getting started
 Do I need to install EDA tools, or can I just try it?
 -----------------------------------------------------
 
-You can try it with nothing but ``pip install siliconcompiler``, by running in
-the cloud:
-
-.. code-block:: python
-
-   project.option.set_remote(True)
-
-A local run needs four tools -- :ref:`Yosys <tool-yosys>`,
-:ref:`OpenROAD <tool-openroad>`, :ref:`OpenSTA <tool-opensta>` and
-:ref:`KLayout <tool-klayout>` -- or the
-:ref:`Docker image <docker>`, which needs none of them installed.
-:ref:`Where the compilation runs <choose_run_mode>` compares the options.
-
-.. index:: ! confidential, ! proprietary IP, ! public server, ! privacy
-
-Is my design confidential if I use the public server?
------------------------------------------------------
-
-Your design is uploaded to a server operated by SiliconCompiler, under
-`these terms <https://www.siliconcompiler.com/terms>`_. The client prints this
-before every remote run, and it is worth taking literally:
-
-   This public service, provided by SiliconCompiler, is not intended to process
-   proprietary IP.
-
-For anything you cannot publish, run locally or stand up a
-:ref:`private server <private-server>`. You are also responsible for having the
-right to distribute any IP contained in what you upload.
-
-.. index:: ! server down, ! server busy, ! 500 error
-
-What if the public server is down or busy?
-------------------------------------------
-
-**Please report it.** The server is not self-monitoring from your side of the
-connection, and a
-`bug report <https://github.com/siliconcompiler/siliconcompiler/issues/new/choose>`_
-is how an outage gets noticed and fixed. Include the error and roughly when it
-happened.
-
-Meanwhile, the fastest way to keep working is the
-:ref:`Docker image <docker>`, which runs the flow locally without installing any
-EDA tools:
+You can try it with nothing but Docker and ``pip install siliconcompiler``, by
+running the tools in containers:
 
 .. code-block:: bash
 
    python -m siliconcompiler.demos.asic_demo -scheduler docker
 
-Installing the tools natively is the better answer if you expect to keep
-building, but it is not a five-minute detour, so it is not the one to start on
-while you are blocked. Either way the script is unchanged apart from
-:ref:`how the run is dispatched <choose_run_mode>`.
+Running them natively needs four tools -- :ref:`Yosys <tool-yosys>`,
+:ref:`OpenROAD <tool-openroad>`, :ref:`OpenSTA <tool-opensta>` and
+:ref:`KLayout <tool-klayout>`. It is the better answer if you expect to keep
+building, but it is not a five-minute detour, so it is not the one to start on.
+:ref:`Where the compilation runs <choose_run_mode>` compares the two, and
+:ref:`Using SiliconCompiler with Docker <docker>` sets the container path up.
 
-A remote run depends on the server staying healthy for its whole duration,
-which is worth knowing before you rely on it for something time-critical.
+.. index:: ! confidential, ! proprietary IP, ! privacy
+
+Does my design leave my machine?
+--------------------------------
+
+Not on a local or :ref:`Docker <docker>` run -- both read and write your working
+directory and nothing else.
+
+It does on a :ref:`remote run <remote_processing>`, which uploads the design to
+the server named in your ``credentials`` file. SiliconCompiler does not host a
+server for you, so that is a machine you or your organization operates, under
+whatever terms that operator sets. You are responsible for having the right to
+distribute any IP contained in what you upload.
 
 .. index:: ! Windows, ! WSL
 
@@ -85,7 +57,8 @@ The package installs and runs on Windows, and is tested there on every commit,
 but that testing does not cover running EDA tools. There are no tool install
 scripts for Windows and local flows are not supported on it.
 
-From Windows, use a remote run, the :ref:`Docker image <docker>`, or WSL.
+From Windows, use the :ref:`Docker image <docker>`, WSL, or a
+:ref:`remote run <remote_processing>`.
 KLayout is worth installing natively so :ref:`sc-show <app-sc-show>` can display
 results. See :ref:`External Tools <external_tools>`.
 

--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -192,17 +192,18 @@ Finally, to clone and install SiliconCompiler, run the following:
 
 ASIC Demo
 ---------
-Now that you have installed SiliconCompiler, you can test your installation by running a quick demo through the ASIC design flow in the cloud.
+Now that you have installed SiliconCompiler, you can test your installation by running a quick demo through the ASIC design flow.
+The demo runs the EDA tools in containers with the :ref:`Docker scheduler <docker>`, so nothing beyond Docker and SiliconCompiler needs to be installed -- see :ref:`Using SiliconCompiler with Docker <docker>` if Docker is not running on your machine yet.
 
 .. code-block:: bash
 
-    python -m siliconcompiler.demos.asic_demo -remote
+    python -m siliconcompiler.demos.asic_demo -scheduler docker
 
 ``python`` rather than ``python3``: a virtual environment provides both on every
 platform, and Windows has only ``python``. Outside an activated environment on
 Linux or macOS, use ``python3``.
 
-Your remote job should only take a few minutes to run if the servers aren't too busy.
+The first run also pulls the container image, so it takes a few minutes.
 It should end with a results directory where you can find ``png`` file which displays your results.
 It should look something like this:
 
@@ -215,7 +216,7 @@ See :ref:`Quickstart guide <quickstart_guide>` next to go through the design and
 External Tools
 --------------
 
-If you wish to run on your machine instead of remotely in the cloud as in the quick :ref:`asic demo <asic_demo>` target above, there will be some tools you need to install first.
+If you wish to run the tools natively instead of in containers as in the quick :ref:`asic demo <asic_demo>` target above, there will be some tools you need to install first.
 You can use the provided :ref:`sc-install <app-sc-install>` application to install the tools or view the scripts directly in the list below.
 
 .. note::

--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -252,7 +252,7 @@ Coverage is not uniform, and the gaps matter for the ASIC flow:
 * **RHEL 8 and Ubuntu 20.04** have scripts for KLayout only. There are no
   scripts for Yosys, OpenROAD or OpenSTA on those platforms, so the ASIC flow
   cannot be installed this way -- use a newer distribution, the
-  :ref:`Docker image <docker>`, or a :ref:`remote run <choose_run_mode>`.
+  :ref:`Docker image <docker>`, or a :ref:`remote run <remote_processing>`.
 
 .. installscripts::
 
@@ -262,7 +262,7 @@ Coverage is not uniform, and the gaps matter for the ASIC flow:
    tools. No install scripts are provided for Windows and the local flows are
    not supported on it.
 
-   To compile a design from Windows, use a :ref:`remote run <choose_run_mode>`,
+   To compile a design from Windows, use a :ref:`remote run <remote_processing>`,
    the :ref:`Docker image <docker>`, or WSL. KLayout is the exception worth
    installing natively: it has Windows builds, and :ref:`sc-show <app-sc-show>`
    will use it to view results downloaded from a remote run.

--- a/docs/user_guide/quickstart.rst
+++ b/docs/user_guide/quickstart.rst
@@ -87,7 +87,7 @@ The following code snippet below shows how the :ref:`demo design <asic_demo>` wa
         project = ASIC(design)                                 # create project
         project.add_fileset(["rtl", "sdc"])                    # enable filesets
         skywater130_demo(project)                              # load a pre-defined target
-        project.option.set_remote(True)                        # enable remote execution
+        project.option.scheduler.set_name("docker")            # run the tools in containers
         project.run()                                          # run compilation
         project.summary()                                      # print summary
         project.show()                                         # show layout
@@ -141,14 +141,14 @@ This is the line that chooses between the two modes described :ref:`above <choos
 
 .. code-block:: python
 
-    project.option.set_remote(True)     # compile in the cloud
+    project.option.scheduler.set_name("docker")   # run the tools in containers
 
-Delete it -- or set it to ``False`` -- and the identical script compiles on your
-own machine instead:
+Delete it and the identical script runs the tools installed natively on your own
+machine instead:
 
 .. code-block:: python
 
-    project.option.set_remote(False)    # compile locally (the default)
+    project.option.scheduler.set_name(None)       # use native tools (the default)
 
 Nothing else in the script changes between the two.
 

--- a/docs/user_guide/quickstart.rst
+++ b/docs/user_guide/quickstart.rst
@@ -3,7 +3,7 @@
 Quickstart guide
 ================
 
-If you've completed the :ref:`Installation <installation>` section and were able to run the :ref:`ASIC Demo <asic_demo>`, you will have completed a simple remote run through an :term:`ASIC` design flow!
+If you've completed the :ref:`Installation <installation>` section and were able to run the :ref:`ASIC Demo <asic_demo>`, you will have completed a simple containerized run through an :term:`ASIC` design flow!
 
 In the following sections, you will find more details about :ref:`the design <start_the_design>`, :ref:`the flow <start_the_flow>` and :ref:`the results <start_the_results>` of the run.
 
@@ -12,43 +12,41 @@ In the following sections, you will find more details about :ref:`the design <st
 Where the compilation runs
 --------------------------
 
-The same script runs either in the cloud or entirely on your own machine.
-One line decides which, and it is worth choosing deliberately before you start:
+The same script runs either against containerized tools or against tools
+installed natively. One line decides which, and it is worth choosing
+deliberately before you start:
 
 .. list-table::
    :header-rows: 1
    :widths: 12 44 44
 
    * -
-     - Remote
-     - Local
+     - Docker
+     - Native
    * - Setup
-     - Nothing beyond ``pip install siliconcompiler``.
+     - :ref:`Docker <docker>` installed and running; nothing else beyond
+       ``pip install siliconcompiler``.
      - Four EDA tools: :ref:`Yosys <tool-yosys>`, :ref:`OpenROAD <tool-openroad>`,
        :ref:`OpenSTA <tool-opensta>` and :ref:`KLayout <tool-klayout>`. See
-       :ref:`external tools <external_tools>`, or skip the install entirely with
-       the :ref:`Docker image <docker>`.
+       :ref:`external tools <external_tools>`.
+   * - Where the tools come from
+     - The ``sc_runner`` image -- one container per :term:`flowgraph node`,
+       started and stopped by SiliconCompiler.
+     - Your own machine.
    * - Needs
-     - A network connection for the whole run.
+     - A network connection the first time, to pull the image.
      - Nothing; runs offline once the :term:`PDK` is cached.
-   * - Your design
-     - Uploaded to a server. The public server is
-       `not intended for proprietary IP <https://www.siliconcompiler.com/terms>`_
-       -- run a :ref:`private server <private-server>` if that matters.
-     - Never leaves your machine.
    * - Enable with
-     - ``project.option.set_remote(True)``
-     - Nothing -- local is the default.
+     - ``project.option.scheduler.set_name("docker")``, or ``-scheduler docker``.
+     - Nothing -- native is the default.
 
-Remote is the quickest way to a first result, which is why the
-:ref:`ASIC Demo <asic_demo>` uses it. Local is the better default once you are
-iterating on a design, and it is the only option for work you cannot upload.
+Either way your design never leaves your machine: both modes read and write your
+working directory and nothing else.
 
-.. note::
-   A remote run depends on the public server being available. If it is busy or
-   down, the run fails -- please
-   :ref:`report it <faq>`, and use the :ref:`Docker image <docker>` to
-   keep working in the meantime.
+Docker is the quickest way to a first result, which is why the
+:ref:`ASIC Demo <asic_demo>` uses it. Native tools are the better default once
+you are iterating on a design, and avoid the container startup cost on every
+node.
 
 
 .. _start_the_design:
@@ -234,10 +232,11 @@ Other Ways to Run
 
 Beyond the two modes :ref:`compared above <choose_run_mode>`, there are two more:
 
-* :ref:`Docker <docker>` -- run the tools locally without installing or
-  maintaining any of them.
-* :ref:`Private server <remote_processing>` -- remote execution against a server
-  you control, for designs you cannot send to the public one.
+* :ref:`Remote <remote_processing>` -- send the job to a server you or your
+  organization operates, for pre-configured tool installations, elastic compute
+  or NDA-protected :term:`PDKs <PDK>`.
+* :ref:`Cluster schedulers <cluster_tutorial>` -- dispatch
+  each node through Slurm, LSF or SGE.
 
 Local Run Results
 ^^^^^^^^^^^^^^^^^

--- a/docs/user_guide/remote_processing.rst
+++ b/docs/user_guide/remote_processing.rst
@@ -3,13 +3,11 @@
 Guide to Remote Compilation
 ===========================
 
-SiliconCompiler supports a remote compilation model, allowing you to leverage cloud resources for access to pre-configured tool installations, elastic compute, and potentially NDA-protected :term:`PDKs <PDK>` or :term:`IPs <IP>` on private servers.
+SiliconCompiler supports a remote compilation model, allowing you to leverage cloud resources for access to pre-configured tool installations, elastic compute, and potentially NDA-protected :term:`PDKs <PDK>` or :term:`IPs <IP>`.
 
-.. note::
-
-    Our public server only supports open-source tools and PDKs.
-    During periods of high traffic, your job may be queued, which could result in processing delays.
-    When you run a remote job, SiliconCompiler will remind you that your design is being uploaded to a public service.
+Remote execution runs against a server you or your organization operates.
+SiliconCompiler does not host a server for you -- see
+:ref:`For Developers: Custom Servers <custom-servers>` for how to stand one up.
 
 .. _private-server:
 
@@ -47,7 +45,7 @@ Open your terminal and run the following command:
 
 You will be prompted to enter your server's details. Follow the prompts based on the type of server you are connecting to:
 
-* **Private/Authenticated Server:** Provide the server address, your username, and your password/API key when prompted.
+* **Authenticated Server:** Provide the server address, your username, and your password/API key when prompted.
 
 .. code-block:: bash
 
@@ -56,11 +54,11 @@ You will be prompted to enter your server's details. Follow the prompts based on
   Remote password: your-key
   Remote configuration saved to: /home/user/.sc/credentials
 
-* **Public/Unauthenticated Server:** Enter the server address and press Enter to leave the username and password fields blank.
+* **Unauthenticated Server:** Enter the server address and press Enter to leave the username and password fields blank.
 
 .. code-block:: bash
 
-  Remote server address: https://server.siliconcompiler.com
+  Remote server address: https://your-server.example.com
   Remote username:
   Remote password:
   Remote configuration saved to: /home/user/.sc/credentials
@@ -79,7 +77,7 @@ The file must contain the following JSON structure:
     "password": "your-password-or-key"
   }
 
-For a public server, simply leave the username and password fields as empty strings ("").
+For an unauthenticated server, simply leave the username and password fields as empty strings ("").
 
 Step 2: Verify the Connection
 -----------------------------
@@ -116,6 +114,8 @@ Troubleshooting
 * **Local Changes Not Reflected:** Any modifications you make to local, built-in tool scripts, PDKs, or libraries will not be used in a remote job. The remote server uses its own pre-configured environment.
 * **Network and Filesystem Issues:** Jobs run in isolated environments on the server. Code that relies on specific network or local filesystem calls may not work as expected.
 * **Reporting Issues:** If you encounter problems with the remote workflow, please open an issue on the `SiliconCompiler repository's issue page <https://github.com/siliconcompiler/siliconcompiler/issues>`_.
+
+.. _custom-servers:
 
 For Developers: Custom Servers
 ------------------------------

--- a/siliconcompiler/demos/fpga_demo.py
+++ b/siliconcompiler/demos/fpga_demo.py
@@ -86,6 +86,6 @@ if __name__ == "__main__":
         "fpga_demo",
         description="\"Self-test\" target which builds a small 8-bit counter design as an FPGA, "
                     "targeting the z1000.",
-        switchlist=["-remote"])
+        switchlist=["-remote", "-scheduler"])
     proj.run()
     proj.summary()

--- a/siliconcompiler/remote/schema.py
+++ b/siliconcompiler/remote/schema.py
@@ -2,7 +2,7 @@ from siliconcompiler.schema import BaseSchema, EditableSchema, Parameter, Scope
 from siliconcompiler.schema_support.cmdlineschema import CommandLineSchema
 
 
-SCHEMA_VERSION = '0.0.4'
+SCHEMA_VERSION = '0.0.5'
 
 
 class ServerSchema(CommandLineSchema, BaseSchema):
@@ -40,15 +40,17 @@ class ServerSchema(CommandLineSchema, BaseSchema):
         schema.insert(
             'option', 'cluster',
             Parameter(
-                '<local,slurm>',
+                '<local,slurm,docker>',
                 scope=Scope.GLOBAL,
                 defvalue='local',
                 require=True,
                 shorthelp="Type of compute cluster to use.",
                 switch="-cluster <str>",
                 example=["cli: -cluster slurm",
-                         "api: server.set('option', 'clister', 'slurm')"],
-                help="""Type of compute cluster to use."""))
+                         "api: server.set('option', 'cluster', 'slurm')"],
+                help="""Type of compute cluster to use. 'local' runs every node as a
+                process on the server itself, 'slurm' submits them to a slurm
+                cluster, and 'docker' runs each node in its own container."""))
 
         schema.insert(
             'option', 'nfsmount',

--- a/siliconcompiler/remote/server.py
+++ b/siliconcompiler/remote/server.py
@@ -392,11 +392,11 @@ class Server(ServerSchema):
 
         How much can be stopped depends on where the job's nodes are running.
         Slurm nodes are cancelable: they are named after the job hash, so the
-        server can hand them to scancel. Nodes running locally are not -- they
-        are children of the thread executing the job, and this server has no
-        handle on them -- so those run to completion. Either way the job is
-        marked canceled, which is what 'check_progress' reports and what
-        releases a waiting client.
+        server can hand them to scancel. Nodes running locally, and the
+        containers a docker cluster starts, are not -- they belong to the thread
+        executing the job, and this server has no handle on them -- so those run
+        to completion. Either way the job is marked canceled, which is what
+        'check_progress' reports and what releases a waiting client.
         '''
 
         # Process input parameters
@@ -608,7 +608,8 @@ class Server(ServerSchema):
 
         Only slurm nodes can be reached, and the scheduler that submitted them
         is what knows how: the node list this server tracks is enough for
-        SlurmSchedulerNode.cancel_nodes().
+        SlurmSchedulerNode.cancel_nodes(). A local or docker cluster has nothing
+        to reach for, so those jobs are only marked.
         '''
 
         with self.sc_jobs_lock:
@@ -731,9 +732,11 @@ class Server(ServerSchema):
         project.option.set_builddir(build_dir)
         project.option.set_remote(False)
 
-        if self.get('option', 'cluster') == 'slurm':
-            # Run the job with slurm clustering.
-            project.option.scheduler.set_name('slurm')
+        cluster = self.get('option', 'cluster')
+        if cluster != 'local':
+            # 'local' is what an unset scheduler already means; any other
+            # cluster names the per-node scheduler the run dispatches through.
+            project.option.scheduler.set_name(cluster)
 
         # Run the job.
         project.run()

--- a/siliconcompiler/scheduler/docker.py
+++ b/siliconcompiler/scheduler/docker.py
@@ -337,7 +337,12 @@ class DockerSchedulerNode(SchedulerNode):
             # Ensure we clean up containers
             if container:
                 try:
-                    container.stop()
+                    # timeout=0 skips the daemon's SIGTERM grace period, which is
+                    # 10s of dead time per node here: the container's PID 1 is an
+                    # interactive shell that ignores SIGTERM, and the task itself
+                    # ran through exec and is already done, so there is nothing
+                    # left inside to shut down gracefully.
+                    container.stop(timeout=0)
                 except docker.errors.APIError:
                     self.logger.error(f'Failed to stop docker container: {container.name}')
 

--- a/tests/demos/test_demo_switches.py
+++ b/tests/demos/test_demo_switches.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize('demo', ('asic_demo', 'fpga_demo'))
+@pytest.mark.parametrize('switch', ('-remote', '-scheduler'))
+def test_demo_accepts_switch(demo, switch):
+    '''The demos' command lines are what the README and installation docs tell
+    people to run, so the switchlist they expose is part of that contract.'''
+
+    usage = subprocess.run(
+        [sys.executable, '-m', f'siliconcompiler.demos.{demo}', '-h'],
+        capture_output=True, text=True, check=True).stdout
+
+    assert switch in usage

--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -2149,16 +2149,29 @@ def test_run_job_marks_finished_nodes_uploaded(gcd_nop_project, monkeypatch):
     assert tracked['steptwo0']['status'] == NodeStatus.PENDING
 
 
-def test_run_job_uses_slurm_when_clustered(gcd_nop_project, monkeypatch):
-    '''A slurm server hands its nodes to slurm'''
-    server = _make_server(cluster='slurm')
+@pytest.mark.parametrize('cluster', ('slurm', 'docker'))
+def test_run_job_uses_cluster_scheduler(gcd_nop_project, monkeypatch, cluster):
+    '''A clustered server hands its nodes to that cluster's scheduler'''
+    server = _make_server(cluster=cluster)
     gcd_nop_project.set('record', 'remoteid', 'f' * 32)
 
     monkeypatch.setattr(gcd_nop_project, 'run', lambda: True)
 
     server.remote_sc(gcd_nop_project, None)
 
-    assert gcd_nop_project.option.scheduler.get_name() == 'slurm'
+    assert gcd_nop_project.option.scheduler.get_name() == cluster
+
+
+def test_run_job_leaves_scheduler_unset_when_local(gcd_nop_project, monkeypatch):
+    '''A local server does not name a per-node scheduler'''
+    server = _make_server(cluster='local')
+    gcd_nop_project.set('record', 'remoteid', 'f' * 32)
+
+    monkeypatch.setattr(gcd_nop_project, 'run', lambda: True)
+
+    server.remote_sc(gcd_nop_project, None)
+
+    assert gcd_nop_project.option.scheduler.get_name() is None
 
 
 @pytest.mark.asyncio

--- a/tests/scheduler/test_docker.py
+++ b/tests/scheduler/test_docker.py
@@ -5,7 +5,7 @@ import sys
 
 import os.path
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from siliconcompiler import Project, Flowgraph, Design
 from siliconcompiler.tools.builtin.nop import NOPTask
@@ -94,6 +94,30 @@ def test_docker_run(docker_image, project):
         NodeStatus.SUCCESS
     assert project.history("job0").get("record", "status", step="steptwo", index="0") == \
         NodeStatus.SUCCESS
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='posix volume mapping')
+def test_run_stops_container_without_grace_period(project):
+    """Teardown must not sit through the daemon's SIGTERM grace period.
+
+    The container's PID 1 is an interactive shell that ignores SIGTERM, so a
+    plain stop() costs the full 10s timeout on every node.
+    """
+
+    node = DockerSchedulerNode(project, "stepone", "0")
+
+    container = MagicMock()
+    client = MagicMock()
+    client.images.get.return_value = MagicMock(id="image-id")
+    client.containers.run.return_value = container
+    client.api.exec_create.return_value = {'Id': 'exec-id'}
+    client.api.exec_start.return_value = [b'running\n']
+    client.api.exec_inspect.return_value = {'ExitCode': 0}
+
+    with patch('siliconcompiler.scheduler.docker.docker.from_env', return_value=client):
+        node.run()
+
+    container.stop.assert_called_once_with(timeout=0)
 
 
 @patch('sys.platform', 'win32')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Remote execution now supports Docker-based server clusters alongside local and Slurm execution.
  - Docker can be selected for local ASIC and FPGA tool execution, with first-run image downloads noted.

- **Documentation**
  - Clarified Docker, native, and remote execution options, including Windows guidance.
  - Updated remote execution documentation to describe user- or organization-operated servers and design privacy.
  - Added guidance for systems where native ASIC tool installation is unavailable.

- **Bug Fixes**
  - Docker job cleanup now completes without an unnecessary shutdown delay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->