### PR TITLE
fix docker handling

### DIFF
--- a/siliconcompiler/scheduler/docker.py
+++ b/siliconcompiler/scheduler/docker.py
@@ -226,6 +226,11 @@ class DockerSchedulerNode(SchedulerNode):
                                   f"please use 'docker logout {image_src}'")
                 self.halt()
 
+        # One manifest per node. A single shared sc_docker.json is written by
+        # every node in the job, and write_manifest() truncates in place, so a
+        # node reading it while a sibling rewrites it sees torn JSON.
+        cfg_relpath = f'sc_docker/{self.step}{self.index}.json'
+
         email_file = default_email_credentials_file()
         if is_windows:
             # Hack to get around manifest merging
@@ -234,10 +239,11 @@ class DockerSchedulerNode(SchedulerNode):
             cwd = '/sc_docker'
             builddir = f'{cwd}/build'
 
-            local_cfg = os.path.join(start_cwd, 'sc_docker.json')
-            cfg = f'{builddir}/{self.name}/{self.jobname}/{self.step}/{self.index}/sc_docker.json'
+            local_cfg = os.path.abspath(cfg_relpath)
+            cfg = f'{builddir}/{self.name}/{self.jobname}/{cfg_relpath}'
 
             user = None
+            group_add = None
 
             volumes = [
                 f"{self.project_cwd}:{cwd}:rw",
@@ -256,10 +262,20 @@ class DockerSchedulerNode(SchedulerNode):
             cwd = self.project_cwd
             builddir = self.project.find_files('option', 'builddir')
 
-            local_cfg = os.path.abspath('sc_docker.json')
+            local_cfg = os.path.abspath(cfg_relpath)
             cfg = local_cfg
 
-            user = os.getuid()
+            # Both halves are needed: given a bare uid, docker takes the group
+            # from the image's /etc/passwd, falling back to gid 0. Files the node
+            # writes into the bind-mounted build directory would then land on the
+            # host owned by root, and access granted through group membership --
+            # a shared project or cache directory -- would be lost.
+            user = f"{os.getuid()}:{os.getgid()}"
+
+            # An explicit user also drops the caller's supplementary groups, so
+            # hand them back: access to a shared project or cache directory
+            # often comes from a secondary group rather than from ownership.
+            group_add = os.getgroups()
 
             rw_volumes, ro_volumes = get_volumes_directories(
                 self.project, cache_dir, workdir, self.step, self.index)
@@ -290,12 +306,14 @@ class DockerSchedulerNode(SchedulerNode):
                     f"sc_node:{self.name}:{self.step}:{self.index}"
                 ],
                 user=user,
+                group_add=group_add,
                 detach=True,
                 tty=True,
                 auto_remove=True,
                 environment=env)
 
             # Write manifest to make it available to the docker runner
+            os.makedirs(os.path.dirname(local_cfg), exist_ok=True)
             self.project.write_manifest(local_cfg)
 
             cachemap = []

--- a/siliconcompiler/scheduler/docker.py
+++ b/siliconcompiler/scheduler/docker.py
@@ -1,7 +1,9 @@
 import docker
+import io
 import os
 import shlex
 import sys
+import tarfile
 
 import docker.errors
 
@@ -226,10 +228,11 @@ class DockerSchedulerNode(SchedulerNode):
                                   f"please use 'docker logout {image_src}'")
                 self.halt()
 
-        # One manifest per node. A single shared sc_docker.json is written by
-        # every node in the job, and write_manifest() truncates in place, so a
-        # node reading it while a sibling rewrites it sees torn JSON.
-        cfg_relpath = f'sc_docker/{self.step}{self.index}.json'
+        # The manifest is streamed straight into the container rather than
+        # staged on the host, so its path is container-local and needs no
+        # translation between the two namespaces -- and two nodes can never
+        # collide over it, since each has its own filesystem.
+        cfg = '/tmp/sc_manifest.json'
 
         email_file = default_email_credentials_file()
         if is_windows:
@@ -238,9 +241,6 @@ class DockerSchedulerNode(SchedulerNode):
             cache_dir = '/sc_cache'
             cwd = '/sc_docker'
             builddir = f'{cwd}/build'
-
-            local_cfg = os.path.abspath(cfg_relpath)
-            cfg = f'{builddir}/{self.name}/{self.jobname}/{cfg_relpath}'
 
             user = None
             group_add = None
@@ -261,9 +261,6 @@ class DockerSchedulerNode(SchedulerNode):
             cache_dir = RemoteResolver.determine_cache_dir(self.project)
             cwd = self.project_cwd
             builddir = self.project.find_files('option', 'builddir')
-
-            local_cfg = os.path.abspath(cfg_relpath)
-            cfg = local_cfg
 
             # Both halves are needed: given a bare uid, docker takes the group
             # from the image's /etc/passwd, falling back to gid 0. Files the node
@@ -312,9 +309,12 @@ class DockerSchedulerNode(SchedulerNode):
                 auto_remove=True,
                 environment=env)
 
-            # Write manifest to make it available to the docker runner
-            os.makedirs(os.path.dirname(local_cfg), exist_ok=True)
-            self.project.write_manifest(local_cfg)
+            # Hand the manifest to the runner without staging it on the host:
+            # write_manifest() takes the stream directly, and put_archive lands
+            # the bytes in the container's own filesystem.
+            manifest = io.StringIO()
+            self.project.write_manifest(manifest)
+            self.__put_manifest(container, cfg, manifest.getvalue())
 
             cachemap = []
             # for package, resolver in self.project.get(
@@ -366,6 +366,31 @@ class DockerSchedulerNode(SchedulerNode):
 
         # Restore working directory
         os.chdir(start_cwd)
+
+    @staticmethod
+    def __put_manifest(container, path, manifest):
+        """Copies the manifest into a running container as a one-entry tar.
+
+        Args:
+            container: The running container to copy into.
+            path (str): Absolute destination path inside the container.
+            manifest (str): The serialized manifest.
+        """
+
+        payload = manifest.encode()
+
+        info = tarfile.TarInfo(os.path.basename(path))
+        info.size = len(payload)
+        # Readable by the exec'd user, which runs as the caller's uid/gid.
+        info.mode = 0o444
+        if sys.platform != 'win32':
+            info.uid, info.gid = os.getuid(), os.getgid()
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode='w') as tar:
+            tar.addfile(info, io.BytesIO(payload))
+
+        container.put_archive(os.path.dirname(path), buf.getvalue())
 
     def check_required_paths(self) -> bool:
         return True

--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -481,9 +481,11 @@ class BaseSchema:
 
     @staticmethod
     @contextlib.contextmanager
-    def __open_file(filepath: Union[str, pathlib.Path],
+    def __open_file(filepath: Union[str, bytes, pathlib.Path],
                     is_read: bool = True) -> Iterator[TextIO]:
-        _, ext = os.path.splitext(filepath)
+        # fsdecode so the extension test is str-vs-str for every path flavour:
+        # splitext on a bytes path yields b".gz", which never equals ".gz".
+        _, ext = os.path.splitext(os.fsdecode(filepath))
         if ext.lower() == ".gz":
             if not _has_gzip:
                 raise RuntimeError("gzip is not available")
@@ -525,7 +527,7 @@ class BaseSchema:
 
         self._from_dict(BaseSchema._read_manifest(filepath), [])
 
-    def write_manifest(self, filepath: Union[str, pathlib.Path, TextIO]) -> None:
+    def write_manifest(self, filepath: Union[str, bytes, pathlib.Path, TextIO]) -> None:
         '''
         Writes the manifest to a file or an open text stream.
 
@@ -581,7 +583,8 @@ class BaseSchema:
         # The caller's stream: borrowed, so write to it and leave it open. Keyed
         # off the path types because those are the closed set -- "has a .write()"
         # is open-ended, and a pathlib.Path has no .write() to be caught by it.
-        if not isinstance(filepath, (str, os.PathLike)):
+        # (str, bytes, os.PathLike) is what os.fspath itself accepts as a path.
+        if not isinstance(filepath, (str, bytes, os.PathLike)):
             filepath.write(manifest_str)
             return
 

--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -31,7 +31,7 @@ import os.path
 from enum import Enum, auto
 from functools import cache, lru_cache
 from typing import Dict, Type, Tuple, TypeVar, Union, Set, Callable, List, Optional, \
-    TextIO, Iterable, Any
+    TextIO, Iterable, Iterator, Any
 
 from .parameter import Parameter, NodeValue
 from .journal import Journal
@@ -480,13 +480,21 @@ class BaseSchema:
         return schema
 
     @staticmethod
-    def __open_file(filepath: str, is_read: bool = True) -> TextIO:
+    @contextlib.contextmanager
+    def __open_file(filepath: Union[str, pathlib.Path],
+                    is_read: bool = True) -> Iterator[TextIO]:
         _, ext = os.path.splitext(filepath)
         if ext.lower() == ".gz":
             if not _has_gzip:
                 raise RuntimeError("gzip is not available")
-            return gzip.open(filepath, mode="rt" if is_read else "wt", encoding="utf-8")
-        return open(filepath, mode="r" if is_read else "w", encoding="utf-8")
+            fileobj = gzip.open(filepath, mode="rt" if is_read else "wt", encoding="utf-8")
+        else:
+            fileobj = open(filepath, mode="r" if is_read else "w", encoding="utf-8")
+
+        try:
+            yield fileobj
+        finally:
+            fileobj.close()
 
     def __format_key(self, *key: str):
         return f"[{','.join([*self._keypath, *key])}]"
@@ -500,13 +508,8 @@ class BaseSchema:
             filename (path): Path to a manifest file to be loaded.
         """
 
-        fin = BaseSchema.__open_file(filepath)
-        try:
-            manifest = json.loads(fin.read())
-        finally:
-            fin.close()
-
-        return manifest
+        with BaseSchema.__open_file(filepath) as fin:
+            return json.loads(fin.read())
 
     def read_manifest(self, filepath: str) -> None:
         """
@@ -522,57 +525,65 @@ class BaseSchema:
 
         self._from_dict(BaseSchema._read_manifest(filepath), [])
 
-    def write_manifest(self, filepath: str) -> None:
+    def write_manifest(self, filepath: Union[str, pathlib.Path, TextIO]) -> None:
         '''
-        Writes the manifest to a file.
+        Writes the manifest to a file or an open text stream.
 
         Args:
-            filename (filepath): Output filepath.
+            filepath (path or stream): Output filepath, or an already-open text
+                stream. A stream is written to directly -- nothing touches the
+                filesystem -- and is left open for its owner to close.
 
         Examples:
             >>> schema.write_manifest('mydump.json')
             Dumps the current manifest into mydump.json
+            >>> buf = io.StringIO()
+            >>> schema.write_manifest(buf)
+            Dumps the current manifest into buf
         '''
 
-        fout = BaseSchema.__open_file(filepath, is_read=False)
+        # Serialized before the destination is touched: opening first meant a
+        # failure part way through getdict() had already truncated the file.
+        def default(obj: Any) -> Any:
+            if isinstance(obj, pathlib.PurePath):
+                # Cast everything to a windows path and convert to posix.
+                # https://stackoverflow.com/questions/73682260
+                return pathlib.PureWindowsPath(obj).as_posix()
+            raise TypeError
 
-        try:
-            def default(obj: Any) -> Any:
-                if isinstance(obj, pathlib.PurePath):
-                    # Cast everything to a windows path and convert to posix.
-                    # https://stackoverflow.com/questions/73682260
-                    return pathlib.PureWindowsPath(obj).as_posix()
-                raise TypeError
+        manifest = self.getdict()
+        if _has_orjson:
+            manifest_str = json.dumps(manifest, option=json.OPT_INDENT_2,
+                                      default=default).decode()
+            # orjson emits UTF-8 and has no ensure_ascii; the stdlib escapes
+            # non-ASCII by default. Without this the manifest's encoding
+            # depends on which JSON library happened to be installed, and an
+            # ASCII manifest is the thing that lets any reader decode it
+            # whatever the host locale claims -- a server running under
+            # LANG=C failed a whole job on one Greek letter in a journal.
+            #
+            # Escape in place rather than re-serializing with the stdlib:
+            # json.dumps skips its C encoder whenever indent is set, so the
+            # fallback would push the whole manifest -- megabytes of it --
+            # through the pure-Python encoder. One Greek letter in a help
+            # string made the manifest non-ASCII and cost 45% of a test
+            # suite's runtime. Only \uXXXX is a legal JSON escape, so this
+            # cannot use backslashreplace, which works per byte and yields
+            # \xNN. isascii() is a C-level scan, so ASCII manifests (the
+            # overwhelming majority) pay nothing.
+            if not manifest_str.isascii():
+                manifest_str = manifest_str \
+                    .encode("ascii", _JSON_ASCII_ERRORS) \
+                    .decode("ascii")
+        else:
+            manifest_str = json.dumps(manifest, indent=2, default=default)
 
-            manifest = self.getdict()
-            if _has_orjson:
-                manifest_str = json.dumps(manifest, option=json.OPT_INDENT_2,
-                                          default=default).decode()
-                # orjson emits UTF-8 and has no ensure_ascii; the stdlib escapes
-                # non-ASCII by default. Without this the manifest's encoding
-                # depends on which JSON library happened to be installed, and an
-                # ASCII manifest is the thing that lets any reader decode it
-                # whatever the host locale claims -- a server running under
-                # LANG=C failed a whole job on one Greek letter in a journal.
-                #
-                # Escape in place rather than re-serializing with the stdlib:
-                # json.dumps skips its C encoder whenever indent is set, so the
-                # fallback would push the whole manifest -- megabytes of it --
-                # through the pure-Python encoder. One Greek letter in a help
-                # string made the manifest non-ASCII and cost 45% of a test
-                # suite's runtime. Only \uXXXX is a legal JSON escape, so this
-                # cannot use backslashreplace, which works per byte and yields
-                # \xNN. isascii() is a C-level scan, so ASCII manifests (the
-                # overwhelming majority) pay nothing.
-                if not manifest_str.isascii():
-                    manifest_str = manifest_str \
-                        .encode("ascii", _JSON_ASCII_ERRORS) \
-                        .decode("ascii")
-            else:
-                manifest_str = json.dumps(manifest, indent=2, default=default)
+        if hasattr(filepath, "write"):
+            filepath.write(manifest_str)
+            return
+
+        with BaseSchema.__open_file(filepath, is_read=False) as fout:
             fout.write(manifest_str)
-        finally:
-            fout.close()
 
     # Accessor methods
     def __search(self,

--- a/siliconcompiler/schema/baseschema.py
+++ b/siliconcompiler/schema/baseschema.py
@@ -578,7 +578,10 @@ class BaseSchema:
         else:
             manifest_str = json.dumps(manifest, indent=2, default=default)
 
-        if hasattr(filepath, "write"):
+        # The caller's stream: borrowed, so write to it and leave it open. Keyed
+        # off the path types because those are the closed set -- "has a .write()"
+        # is open-ended, and a pathlib.Path has no .write() to be caught by it.
+        if not isinstance(filepath, (str, os.PathLike)):
             filepath.write(manifest_str)
             return
 

--- a/siliconcompiler/schema_support/dependencyschema.py
+++ b/siliconcompiler/schema_support/dependencyschema.py
@@ -110,7 +110,7 @@ class DependencySchema(BaseSchema):
 
         return meta
 
-    def write_manifest(self, filename: Union[str, pathlib.Path, TextIO]) -> None:
+    def write_manifest(self, filename: Union[str, bytes, pathlib.Path, TextIO]) -> None:
         # Detach a copy from any parent project so the dependency graph is
         # embedded (as a flat map, see _getdict_meta) rather than deferred to
         # the project. The original object is left untouched.

--- a/siliconcompiler/schema_support/dependencyschema.py
+++ b/siliconcompiler/schema_support/dependencyschema.py
@@ -1,6 +1,7 @@
 import os.path
+import pathlib
 
-from typing import Dict, Union, Tuple, List, Optional, Set
+from typing import Dict, Union, Tuple, List, Optional, Set, TextIO
 
 from siliconcompiler.schema.baseschema import BaseSchema, LazyLoad
 from siliconcompiler.schema.editableschema import EditableSchema
@@ -109,7 +110,7 @@ class DependencySchema(BaseSchema):
 
         return meta
 
-    def write_manifest(self, filename: str) -> None:
+    def write_manifest(self, filename: Union[str, pathlib.Path, TextIO]) -> None:
         # Detach a copy from any parent project so the dependency graph is
         # embedded (as a flat map, see _getdict_meta) rather than deferred to
         # the project. The original object is left untouched.

--- a/tests/scheduler/test_docker.py
+++ b/tests/scheduler/test_docker.py
@@ -96,6 +96,63 @@ def test_docker_run(docker_image, project):
         NodeStatus.SUCCESS
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='posix path handling')
+def test_run_writes_per_node_manifest(project):
+    """Each node needs its own manifest file.
+
+    One shared sc_docker.json is rewritten by every node, and write_manifest()
+    truncates in place, so parallel siblings can read torn JSON.
+    """
+
+    seen = {}
+    for step in ("stepone", "steptwo"):
+        node = DockerSchedulerNode(project, step, "0")
+
+        client = MagicMock()
+        client.images.get.return_value = MagicMock(id="image-id")
+        client.api.exec_create.return_value = {'Id': 'exec-id'}
+        client.api.exec_start.return_value = [b'running\n']
+        client.api.exec_inspect.return_value = {'ExitCode': 0}
+
+        with patch('siliconcompiler.scheduler.docker.docker.from_env', return_value=client):
+            node.run()
+
+        cmd = client.api.exec_create.call_args.args[1]
+        seen[step] = cmd.split('-cfg ')[1].split()[0]
+
+    assert seen["stepone"].endswith('sc_docker/stepone0.json')
+    assert seen["steptwo"].endswith('sc_docker/steptwo0.json')
+    assert seen["stepone"] != seen["steptwo"]
+    # Both were actually written, not just named.
+    for path in seen.values():
+        assert os.path.isfile(path)
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='posix uid/gid mapping')
+def test_run_passes_uid_and_gid(project):
+    """The container must run as the host's uid, gid and supplementary groups.
+
+    A bare uid leaves docker to pick the group from the image's /etc/passwd,
+    falling back to gid 0, so build artifacts land on the host owned by root.
+    """
+
+    node = DockerSchedulerNode(project, "stepone", "0")
+
+    client = MagicMock()
+    client.images.get.return_value = MagicMock(id="image-id")
+    client.api.exec_create.return_value = {'Id': 'exec-id'}
+    client.api.exec_start.return_value = [b'running\n']
+    client.api.exec_inspect.return_value = {'ExitCode': 0}
+
+    with patch('siliconcompiler.scheduler.docker.docker.from_env', return_value=client):
+        node.run()
+
+    kwargs = client.containers.run.call_args.kwargs
+    assert kwargs['user'] == f"{os.getuid()}:{os.getgid()}"
+    # An explicit user drops supplementary groups unless they are handed back.
+    assert kwargs['group_add'] == os.getgroups()
+
+
 @pytest.mark.skipif(sys.platform == 'win32', reason='posix volume mapping')
 def test_run_stops_container_without_grace_period(project):
     """Teardown must not sit through the daemon's SIGTERM grace period.

--- a/tests/scheduler/test_docker.py
+++ b/tests/scheduler/test_docker.py
@@ -1,7 +1,11 @@
 import docker
+import glob
+import io
+import json
 import os
 import pytest
 import sys
+import tarfile
 
 import os.path
 
@@ -96,36 +100,42 @@ def test_docker_run(docker_image, project):
         NodeStatus.SUCCESS
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='posix path handling')
-def test_run_writes_per_node_manifest(project):
-    """Each node needs its own manifest file.
+def test_run_streams_manifest_into_container(project):
+    """The manifest is handed over in memory, never staged on the host.
 
-    One shared sc_docker.json is rewritten by every node, and write_manifest()
-    truncates in place, so parallel siblings can read torn JSON.
+    A file staged in the job directory is shared by every node, and
+    write_manifest() truncates in place, so parallel siblings could read torn
+    JSON. Each container has its own filesystem, so the collision cannot arise.
     """
 
-    seen = {}
-    for step in ("stepone", "steptwo"):
-        node = DockerSchedulerNode(project, step, "0")
+    node = DockerSchedulerNode(project, "stepone", "0")
 
-        client = MagicMock()
-        client.images.get.return_value = MagicMock(id="image-id")
-        client.api.exec_create.return_value = {'Id': 'exec-id'}
-        client.api.exec_start.return_value = [b'running\n']
-        client.api.exec_inspect.return_value = {'ExitCode': 0}
+    container = MagicMock()
+    client = MagicMock()
+    client.images.get.return_value = MagicMock(id="image-id")
+    client.containers.run.return_value = container
+    client.api.exec_create.return_value = {'Id': 'exec-id'}
+    client.api.exec_start.return_value = [b'running\n']
+    client.api.exec_inspect.return_value = {'ExitCode': 0}
 
-        with patch('siliconcompiler.scheduler.docker.docker.from_env', return_value=client):
-            node.run()
+    with patch('siliconcompiler.scheduler.docker.docker.from_env', return_value=client):
+        node.run()
 
-        cmd = client.api.exec_create.call_args.args[1]
-        seen[step] = cmd.split('-cfg ')[1].split()[0]
+    # Nothing was staged on the host.
+    assert not glob.glob(os.path.join(jobdir(project), '**', 'sc_docker*'), recursive=True)
 
-    assert seen["stepone"].endswith('sc_docker/stepone0.json')
-    assert seen["steptwo"].endswith('sc_docker/steptwo0.json')
-    assert seen["stepone"] != seen["steptwo"]
-    # Both were actually written, not just named.
-    for path in seen.values():
-        assert os.path.isfile(path)
+    # The runner is pointed at the container-local path...
+    cmd = client.api.exec_create.call_args.args[1]
+    assert '-cfg /tmp/sc_manifest.json' in cmd
+
+    # ...and the manifest actually got there, as a readable one-entry tar.
+    dest, blob = container.put_archive.call_args.args
+    assert dest == '/tmp'
+    with tarfile.open(fileobj=io.BytesIO(blob)) as tar:
+        members = tar.getmembers()
+        assert [m.name for m in members] == ['sc_manifest.json']
+        assert members[0].mode & 0o444
+        assert json.loads(tar.extractfile(members[0]).read())
 
 
 @pytest.mark.skipif(sys.platform == 'win32', reason='posix uid/gid mapping')

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -1,4 +1,6 @@
 import io
+import gzip
+import json
 import logging
 import pytest
 
@@ -858,6 +860,228 @@ def test_write_manifest():
     assert not os.path.isfile("test.json")
     schema.write_manifest("test.json")
     assert os.path.isfile("test.json")
+
+
+def _simple_schema(value=None):
+    schema = BaseSchema()
+    edit = EditableSchema(schema)
+    edit.insert("test0", "test1", Parameter("str"))
+    if value is not None:
+        schema.set("test0", "test1", value)
+    return schema
+
+
+# ---------------------------------------------------------------- stream target
+
+def test_write_manifest_stream_matches_file():
+    """A stream target produces exactly what the path target would."""
+    schema = _simple_schema()
+
+    buf = io.StringIO()
+    schema.write_manifest(buf)
+    schema.write_manifest("test.json")
+
+    with open("test.json") as f:
+        assert f.read() == buf.getvalue()
+    assert json.loads(buf.getvalue())["test0"]["test1"]
+
+
+def test_write_manifest_stream_is_not_closed():
+    """The caller owns the stream, so write_manifest must leave it open."""
+    schema = _simple_schema()
+
+    buf = io.StringIO()
+    schema.write_manifest(buf)
+
+    assert not buf.closed
+    # Still usable: appending after the call must work.
+    buf.write("trailing")
+    assert buf.getvalue().endswith("trailing")
+
+
+def test_write_manifest_stream_writes_nothing_to_disk(monkeypatch):
+    """A stream target must not touch the filesystem at all."""
+    schema = _simple_schema()
+
+    def no_open(*args, **kwargs):
+        raise AssertionError("write_manifest opened a file for a stream target")
+
+    monkeypatch.setattr("builtins.open", no_open)
+    buf = io.StringIO()
+    schema.write_manifest(buf)
+    assert buf.getvalue()
+
+
+def test_write_manifest_stream_real_file_handle():
+    """An already-open file object works and is left open."""
+    schema = _simple_schema()
+
+    with open("test.json", "w") as f:
+        schema.write_manifest(f)
+        assert not f.closed
+
+    schema.write_manifest("ref.json")
+    with open("test.json") as a, open("ref.json") as b:
+        assert a.read() == b.read()
+
+
+def test_write_manifest_stream_gzip():
+    """Compression is the stream owner's business, and it still works."""
+    schema = _simple_schema()
+
+    with gzip.open("test.json.gz", "wt", encoding="utf-8") as f:
+        schema.write_manifest(f)
+
+    with gzip.open("test.json.gz", "rt", encoding="utf-8") as f:
+        streamed = f.read()
+
+    schema.write_manifest("ref.json")
+    with open("ref.json") as f:
+        assert streamed == f.read()
+
+
+def test_write_manifest_stream_not_closed_when_write_fails():
+    """A failing write propagates without the stream being closed behind it."""
+    schema = _simple_schema()
+
+    class Failing(io.StringIO):
+        def write(self, data):
+            raise OSError("disk on fire")
+
+    buf = Failing()
+    with pytest.raises(OSError, match="disk on fire"):
+        schema.write_manifest(buf)
+    assert not buf.closed
+
+
+@pytest.mark.parametrize("stdjson", (False, True))
+def test_write_manifest_stream_non_ascii(monkeypatch, stdjson):
+    """The ASCII-escaping guarantee applies to stream targets too."""
+    if stdjson:
+        from siliconcompiler.schema import baseschema
+        monkeypatch.setattr(baseschema, 'json', json)
+        monkeypatch.setattr(baseschema, '_has_orjson', False)
+
+    schema = _simple_schema("µm_Ω")
+
+    buf = io.StringIO()
+    schema.write_manifest(buf)
+
+    assert buf.getvalue().isascii()
+    assert "\\u03a9" in buf.getvalue()
+    assert json.loads(buf.getvalue())["test0"]["test1"]["node"]["*"]["*"]["value"] == "µm_Ω"
+
+
+def test_write_manifest_stream_is_readable_manifest():
+    """What a stream receives parses back through the real read path."""
+    schema = _simple_schema("roundtrip")
+
+    buf = io.StringIO()
+    schema.write_manifest(buf)
+    Path("test.json").write_text(buf.getvalue())
+
+    manifest = BaseSchema._read_manifest("test.json")
+    assert manifest["test0"]["test1"]["node"]["*"]["*"]["value"] == "roundtrip"
+
+
+# ------------------------------------------------------------- pathlib target
+
+def test_write_manifest_pathlib():
+    """A pathlib.Path target matches the str target byte for byte."""
+    schema = _simple_schema()
+
+    schema.write_manifest("test.json")
+    schema.write_manifest(Path("test_path.json"))
+
+    with open("test.json") as a, open("test_path.json") as b:
+        assert a.read() == b.read()
+
+
+def test_write_manifest_pathlib_gz():
+    """Extension sniffing still works when given a Path rather than a str."""
+    schema = _simple_schema()
+
+    schema.write_manifest(Path("test.json.gz"))
+
+    with gzip.open("test.json.gz", "rt", encoding="utf-8") as f:
+        assert json.loads(f.read())["test0"]["test1"]
+
+
+# ------------------------------------------------- serialize-before-open order
+
+def test_write_manifest_leaves_file_intact_on_failure():
+    """Serialization happens before the destination is opened.
+
+    Opening first meant a failure part way through getdict() had already
+    truncated whatever was at that path.
+    """
+
+    class Boom(BaseSchema):
+        def getdict(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    Path("test.json").write_text("PREEXISTING")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        Boom().write_manifest("test.json")
+
+    assert Path("test.json").read_text() == "PREEXISTING"
+
+
+def test_write_manifest_creates_no_file_on_failure():
+    """A failed serialization must not leave an empty file behind either."""
+
+    class Boom(BaseSchema):
+        def getdict(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    assert not os.path.isfile("test.json")
+    with pytest.raises(RuntimeError, match="boom"):
+        Boom().write_manifest("test.json")
+    assert not os.path.isfile("test.json")
+
+
+# ------------------------------------------------------- __open_file contextmanager
+
+def _open_file(*args, **kwargs):
+    return BaseSchema._BaseSchema__open_file(*args, **kwargs)
+
+
+@pytest.mark.parametrize("name", ("test.json", "test.json.gz"))
+def test_open_file_closes_handle(name):
+    """The contextmanager owns the handle and closes it on the way out."""
+    Path("seed.json").write_text("{}")
+    if name.endswith(".gz"):
+        with gzip.open(name, "wt", encoding="utf-8") as f:
+            f.write("{}")
+    else:
+        Path(name).write_text("{}")
+
+    with _open_file(name) as fin:
+        assert not fin.closed
+        assert fin.read() == "{}"
+    assert fin.closed
+
+
+@pytest.mark.parametrize("name", ("test.json", "test.json.gz"))
+def test_open_file_closes_handle_on_exception(name):
+    """An exception in the body must not leak the handle."""
+    with pytest.raises(ValueError, match="kaboom"):
+        with _open_file(name, is_read=False) as fout:
+            handle = fout
+            raise ValueError("kaboom")
+    assert handle.closed
+
+
+def test_open_file_gz_unavailable_opens_nothing(monkeypatch):
+    """The gzip guard fires before anything is opened."""
+    from siliconcompiler.schema import baseschema
+    monkeypatch.setattr(baseschema, '_has_gzip', False)
+
+    with pytest.raises(RuntimeError, match=r"^gzip is not available$"):
+        with _open_file("test.json.gz", is_read=False):
+            pass
+    assert not os.path.isfile("test.json.gz")
 
 
 def test_write_manifest_stdjson(monkeypatch):

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -997,6 +997,48 @@ def test_write_manifest_pathlib():
         assert a.read() == b.read()
 
 
+def test_write_manifest_bytes_path():
+    """A bytes path is a path, not a stream.
+
+    ``open()`` and ``os.path.splitext()`` both take bytes, so this worked before
+    the target check existed; a path test that omits bytes turns it into a
+    confusing "'bytes' object has no attribute 'write'".
+    """
+    schema = _simple_schema("bytes_path")
+
+    schema.write_manifest(b"test.json")
+
+    assert os.path.isfile("test.json")
+    assert json.loads(Path("test.json").read_text())[
+        "test0"]["test1"]["node"]["*"]["*"]["value"] == "bytes_path"
+
+
+def test_write_manifest_bytes_path_gz():
+    """Extension sniffing must work for bytes paths too.
+
+    ``os.path.splitext(b"x.gz")`` yields ``b".gz"``, which never compares equal
+    to ``".gz"``, so without normalising the path the file would be written
+    uncompressed under a .gz name.
+    """
+    schema = _simple_schema("bytes_gz")
+
+    schema.write_manifest(b"test.json.gz")
+
+    with gzip.open("test.json.gz", "rt", encoding="utf-8") as f:
+        assert json.loads(f.read())[
+            "test0"]["test1"]["node"]["*"]["*"]["value"] == "bytes_gz"
+
+
+def test_write_manifest_bytes_matches_str():
+    """A bytes path and the equivalent str path produce the same bytes."""
+    schema = _simple_schema()
+
+    schema.write_manifest(b"test_bytes.json")
+    schema.write_manifest("test_str.json")
+
+    assert Path("test_bytes.json").read_bytes() == Path("test_str.json").read_bytes()
+
+
 def test_write_manifest_pathlib_is_never_written_to_directly():
     """A Path is a destination to open, not a stream to write into.
 

--- a/tests/schema/test_baseschema.py
+++ b/tests/schema/test_baseschema.py
@@ -997,6 +997,25 @@ def test_write_manifest_pathlib():
         assert a.read() == b.read()
 
 
+def test_write_manifest_pathlib_is_never_written_to_directly():
+    """A Path is a destination to open, not a stream to write into.
+
+    The check has to key off the path types, not off whether the target has a
+    ``write`` attribute: that is an open-ended test, and it is the paths that
+    are the closed set.
+    """
+
+    class LoudPath(type(Path("x"))):
+        def write(self, *args, **kwargs):
+            raise AssertionError("write_manifest called .write() on a Path")
+
+    schema = _simple_schema()
+    schema.write_manifest(LoudPath("test.json"))
+
+    assert os.path.isfile("test.json")
+    assert json.loads(Path("test.json").read_text())["test0"]["test1"]
+
+
 def test_write_manifest_pathlib_gz():
     """Extension sniffing still works when given a Path rather than a str."""
     schema = _simple_schema()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker jobs now stream manifests directly into containers without creating temporary host-side manifest files.
  * Containers on supported platforms run with the caller’s UID, GID, and supplementary groups.
  * Manifest writing supports string paths, byte paths, `pathlib.Path` objects, open text streams, and gzip-compressed files.

* **Bug Fixes**
  * Existing manifest files are protected from truncation when serialization fails.
  * File handles remain safely managed during successful and failed writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->