### PR TITLE
update CI to use permissions instead of TOKENs

### DIFF
--- a/.github/workflows/cache_maintenance.yml
+++ b/.github/workflows/cache_maintenance.yml
@@ -4,6 +4,13 @@ on:
     types:
       - closed
 
+# Deleting caches is the Actions cache API, hence actions: write. GITHUB_TOKEN
+# covers it; note that a pull_request event from a fork gets a read-only token
+# regardless, so those PRs leave their caches to expire on their own.
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -28,6 +28,12 @@ concurrency:
   group: daily-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least privilege; also the ceiling for the reusable workflows called below,
+# which have no way to ask for more than the caller was granted.
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   docker_image:
     uses: ./.github/workflows/docker_image.yml
@@ -308,7 +314,7 @@ jobs:
           PY
 
   gallery:
-    if: ${{ github.event_name	!= 'workflow_dispatch' || inputs.rungallery }}
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.rungallery }}
     uses: siliconcompiler/scgallery/.github/workflows/run-designs.yml@main
     with:
       sc-ref: ${{ github.ref }}

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -26,8 +26,11 @@ jobs:
     name: 'Get docker image'
     runs-on: ubuntu-latest
 
+    # Reusable, and called from scgallery as well as from daily_ci. A
+    # reusable workflow cannot be granted more than its caller holds, so this
+    # only ever reads.
     permissions:
-      contents: write
+      contents: read
       packages: read
 
     outputs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# The repository's default workflow token is write-all; nothing here writes.
+permissions:
+  contents: read
+
 jobs:
   lint_python:
     name: Lint Python Code

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -15,11 +15,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# The repository's default workflow token is write-all, so the scopes have to
+# be named here to drop the rest.
+permissions:
+  contents: read
+
 jobs:
   python_test_job:
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     name: 'Pure Python tests'
+
+    permissions:
+      contents: read
+      # Codecov uploads with OIDC rather than an upload token
+      id-token: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -106,7 +117,7 @@ jobs:
         continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: coverage.xml
           name: codecov-${{ matrix.python }}-${{ matrix.os }}
           verbose: true
@@ -115,6 +126,11 @@ jobs:
     timeout-minutes: 30
     runs-on: "ubuntu-latest"
     name: 'Pure Python tests with docs'
+
+    permissions:
+      contents: read
+      # Codecov uploads with OIDC rather than an upload token
+      id-token: write
 
     steps:
       - uses: actions/checkout@v7
@@ -149,7 +165,7 @@ jobs:
         continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: coverage.xml
           name: codecov-python-with-docs
           verbose: true

--- a/.github/workflows/tool_updater.yml
+++ b/.github/workflows/tool_updater.yml
@@ -5,15 +5,14 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   get_tools:
     name: 'Get updatable tools'
 
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-      packages: write
 
     outputs:
       tools: ${{ steps.tools.outputs.tools }}
@@ -35,6 +34,12 @@ jobs:
 
     name: 'Update tool'
     runs-on: ubuntu-latest
+
+    # GITHUB_TOKEN only reads here: the draft-PR check below is its only use.
+    # The App token minted further down does the push and the PR.
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - name: Check if draft exists
@@ -62,22 +67,39 @@ jobs:
           python3 -m venv .venv
           source .venv/bin/activate
           python3 -m pip install GitPython
-          git config --global user.name "SiliconCompiler Bot"
-          git config --global user.email "bot@siliconcompiler.com"
+          # Leaves the bump uncommitted in the working tree; create-pull-request
+          # below does the committing, with the author and message it is given.
           msg=$(python3 siliconcompiler/toolscripts/_tools.py --bump_commit --tool ${{ matrix.tool }})
-          echo $msg
+          echo "$msg"
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "msg<<$EOF" >> $GITHUB_OUTPUT
           echo "$msg" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
-          git add siliconcompiler/toolscripts/_tools.py
-          git commit -m "$msg" || true
+
+      # A GitHub App installation token rather than a PAT on a machine user:
+      # minted per job, scoped to this repository, an hour to live, revoked
+      # when the job ends. Minted here, next to its only use, so the clone in
+      # the step above does not eat into that hour.
+      #
+      # It is also deliberately not GITHUB_TOKEN, which cannot trigger further
+      # workflow runs: a PR opened with it would carry no checks at all, and
+      # 'Tool-based tests' is required to merge, so it could never land.
+      - name: Mint an App token
+        id: app-token
+        if: steps.update.outputs.msg != '' && steps.check.outputs.skip != 'true'
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.SC_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SC_BOT_APP_PRIVATE_KEY }}
+          # Narrower than the installation, should the App ever be granted more
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Create Pull Request
         if: steps.update.outputs.msg != '' && steps.check.outputs.skip != 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           title: "[SC-BOT] Update ${{ matrix.tool }}"
           author: "SiliconCompiler Bot <bot@siliconcompiler.com>"
           committer: "SiliconCompiler Bot <bot@siliconcompiler.com>"
@@ -85,6 +107,9 @@ jobs:
             ${{ steps.update.outputs.msg }}
           commit-message: |
             Update ${{ matrix.tool }}
+          # --bump_commit writes only this file; naming it keeps anything else
+          # that lands in the tree out of the PR.
+          add-paths: siliconcompiler/toolscripts/_tools.json
           branch: bot/${{ matrix.tool }}-update
           base: main
           delete-branch: true

--- a/.github/workflows/tools_ci.yml
+++ b/.github/workflows/tools_ci.yml
@@ -31,6 +31,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least privilege by default. The repository's default workflow token is
+# write-all, so the scopes have to be named here to drop the rest. The jobs
+# that push to ghcr.io raise themselves to packages: write; every sc_* package
+# is linked to this repository, so GITHUB_TOKEN covers it and no PAT is needed.
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build_tool_builder:
     name: 'Build base tool builder image'
@@ -38,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
       packages: write
 
     outputs:
@@ -55,7 +63,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Read-only credentials, can be accessed by external contributors
+      # GITHUB_TOKEN, scoped by this job's packages: write. On a pull request
+      # from a fork the token is read-only, so a run that has to build a new
+      # image fails at the push and a repo member has to run it; pulls, and any
+      # run whose images already exist, work for external contributors.
       - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
@@ -93,15 +104,6 @@ jobs:
           path: docker/
           retention-days: 1
 
-      # Read/write credentials, can only be accessed by repo members
-      - name: Log in to the Container registry
-        if: steps.docker.outputs.has_builder != 'true'
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.PACKAGES_ACTOR }}
-          password: ${{ secrets.PACKAGES_TOKEN }}
-
       - name: Build and Push SiliconCompiler Builder Docker image
         if: steps.docker.outputs.has_builder != 'true'
         uses: docker/build-push-action@v7.3.0
@@ -136,8 +138,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.PACKAGES_ACTOR }}
-          password: ${{ secrets.PACKAGES_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Build and Push Tool Docker image
         uses: docker/build-push-action@v7.3.0
@@ -174,8 +176,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.PACKAGES_ACTOR }}
-          password: ${{ secrets.PACKAGES_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Build and Push Tool Docker image
         uses: docker/build-push-action@v7.3.0
@@ -218,8 +220,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.PACKAGES_ACTOR }}
-          password: ${{ secrets.PACKAGES_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -250,8 +252,8 @@ jobs:
       uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
-        username: ${{ secrets.PACKAGES_ACTOR }}
-        password: ${{ secrets.PACKAGES_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
@@ -307,8 +309,8 @@ jobs:
       uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
-        username: ${{ secrets.PACKAGES_ACTOR }}
-        password: ${{ secrets.PACKAGES_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
 
     - name: Determine runner latest tag
       run: |
@@ -361,6 +363,12 @@ jobs:
 
     if: always() && !cancelled()
 
+    permissions:
+      contents: read
+      packages: read
+      # Codecov uploads with OIDC rather than an upload token
+      id-token: write
+
     container:
       image: ${{ needs.build_tool_builder.outputs.sc_tools }}
 
@@ -408,7 +416,7 @@ jobs:
         continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: coverage.xml
           name: codecov-tools
           verbose: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,6 +16,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least privilege by default; the publish job raises itself to what
+# trusted publishing and the release upload need.
+permissions:
+  contents: read
+
 jobs:
   klayout_cache:
     name: Cache kLayout


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Tightened automation permissions across CI, release, maintenance, and tooling workflows using least-privilege access.
  - Updated container registry authentication to use GitHub-provided credentials.
  - Code coverage uploads now authenticate through OpenID Connect instead of repository secrets.
  - Automated pull requests use scoped GitHub App credentials and limit changed files.
- **Maintenance**
  - Preserved required permissions for cache cleanup, package publishing, and release operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->