### PR TITLE
only read in docker_image flow

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
       packages: read
 
     outputs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the permissions requested by the Docker image workflow, improving security while preserving its existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->