### PR TITLE
fix _prereqs.sh to avoid hard coded lists

### DIFF
--- a/setup/docker/builder.py
+++ b/setup/docker/builder.py
@@ -154,6 +154,40 @@ def make_base_tool_docker(output_dir):
     assemble_docker_file(name, tag, docker_file, {}, output_dir)
 
 
+# The per-image exceptions to the build-only sweep, declared by the tool that
+# knows them. A tool built FROM another tool's image prunes and sweeps that
+# tool's files as well as its own, so the base's exceptions have to travel with
+# it -- the whole chain is unioned here rather than repeated by hand in every
+# dependent's entry.
+_SWEEP_FIELDS = ('docker-keep-pkgs', 'docker-drop-pkgs', 'docker-prune-dirs')
+
+
+def _get_sweep_field(tool, field):
+    values = []
+    for name in [tool] + _get_docker_depends(tool):
+        entries = _tools.get_field(name, field)
+        if entries:
+            values.extend(entries)
+
+    # Deduplicated, order preserved: the same package can be named by a tool and
+    # by the tool it is built on.
+    return list(dict.fromkeys(values))
+
+
+def _get_docker_depends(tool):
+    depends = _tools.get_field(tool, 'docker-depends')
+    if not depends:
+        return []
+    if isinstance(depends, str):
+        depends = [depends]
+
+    chain = []
+    for depend in depends:
+        chain.append(depend)
+        chain.extend(_get_docker_depends(depend))
+    return chain
+
+
 def make_tool_docker(tool, output_dir, reference_tool=None):
     '''
     Generate the tool builder dockerfile
@@ -179,7 +213,10 @@ def make_tool_docker(tool, output_dir, reference_tool=None):
         # Another tool builds against this prefix, so leave its symbols alone.
         # The dependent copies this prefix in and strips it there, which is what
         # reaches sc_tools, so nothing ships unstripped either way.
-        'strip_symbols': not _is_build_input(tool)
+        'strip_symbols': not _is_build_input(tool),
+        'keep_pkgs': ' '.join(_get_sweep_field(tool, 'docker-keep-pkgs')),
+        'drop_pkgs': ' '.join(_get_sweep_field(tool, 'docker-drop-pkgs')),
+        'prune_dirs': ' '.join(_get_sweep_field(tool, 'docker-prune-dirs'))
     }
 
     if reference_tool:
@@ -394,6 +431,15 @@ def _get_tool_image_check_tag(tool):
     if cmds:
         for cmd in cmds:
             hash.update(cmd.encode('utf-8'))
+
+    # Only this tool's own entries: the dependency chain's are folded in by the
+    # depends_hash at the end, which already covers everything a base tool
+    # contributes to this image.
+    for field in _SWEEP_FIELDS:
+        entries = _tools.get_field(tool, field)
+        if entries:
+            for entry in entries:
+                hash.update(f'{field}:{entry}'.encode('utf-8'))
 
     # Whether this image gets stripped depends on the tool graph around it, not
     # only on this tool's own inputs, so a tool gaining or losing a dependent

--- a/setup/docker/tool.docker
+++ b/setup/docker/tool.docker
@@ -47,10 +47,17 @@ RUN apt-get update && \
 # _prereqs.sh is copied to $SC_BUILD/.. above, which is / only because SC_BUILD
 # defaults to /sc_build. Resolve it the same way the install scripts do, so an
 # overridden SC_BUILD still finds it.
+#
+# What this image prunes, keeps and drops is entirely the tools' own
+# declarations -- docker-prune-dirs, docker-keep-pkgs and docker-drop-pkgs in
+# _tools.json -- unioned with those of the tools this one is
+# built on top of, whose files are in this prefix too. _prereqs.sh names no
+# package and no directory of its own: it feeds every tool image's check tag, so
+# anything listed there rebuilds all 30 images to record one tool's exception.
 RUN . $SC_BUILD/../_prereqs.sh && \
     sc_strip_prefix_managed $SC_PREFIX && \
-    sc_prune_build_artifacts $SC_PREFIX && \
-    sc_remove_build_only && \
+    sc_prune_build_artifacts $SC_PREFIX{% if prune_dirs %} --dirs "{{ prune_dirs }}"{% endif %} && \
+    sc_remove_build_only{% if keep_pkgs %} --keep "{{ keep_pkgs }}"{% endif %}{% if drop_pkgs %} --drop "{{ drop_pkgs }}"{% endif %} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 {% else %}

--- a/siliconcompiler/toolscripts/_prereqs.sh
+++ b/siliconcompiler/toolscripts/_prereqs.sh
@@ -200,11 +200,29 @@ install_prereqs() {
     esac
 }
 
-# Mandatory members of the "Development Tools" group, which is the only group
-# these scripts install. Verified identical on RHEL 8 and RHEL 9.
-_SC_GROUP_DEVELOPMENT_TOOLS="autoconf automake binutils bison flex gcc gcc-c++
-gdb glibc-devel libtool make pkgconf pkgconf-m4 pkgconf-pkg-config
-redhat-rpm-config rpm-build rpm-sign strace"
+# Echo the mandatory members of a package group, as the package manager reports
+# them. Empty when it cannot say -- an unknown group, an older dnf that words
+# the heading differently, or no group support at all.
+_sc_group_payload() {
+    set +x
+
+    if [ "$_sc_backend" != "rpm" ]; then
+        return 0
+    fi
+
+    # "Mandatory Packages:" only. Default and optional members can legitimately
+    # be absent from a fully installed group, so probing them would report the
+    # group as missing forever and install it on every run.
+    $_sc_yum group info "$1" 2>/dev/null | awk '
+        /^ *Mandatory Packages:/ { in_block = 1; next }
+        /^ *[A-Za-z][A-Za-z ]*:/ { in_block = 0 }
+        in_block {
+            gsub(/^[ \t]+/, ""); gsub(/[ \t]+$/, "")
+            # dnf marks installed members with a leading "+" or "-"
+            sub(/^[+-]/, "")
+            if ($0 != "") print
+        }'
+}
 
 # Install a package group unless its payload is already present.
 #
@@ -217,10 +235,12 @@ redhat-rpm-config rpm-build rpm-sign strace"
 install_prereq_group() {
     _sc_group=$1
 
-    case "$_sc_group" in
-        "Development Tools") _sc_payload="$_SC_GROUP_DEVELOPMENT_TOOLS" ;;
-        *) _sc_payload="" ;;
-    esac
+    # What the group contains is the package manager's answer to give, not a
+    # copy of it kept here: a list would go stale against the distribution and
+    # would have to be written out per release. A query that fails or returns
+    # nothing leaves the payload empty, which installs -- the same answer this
+    # gave for a group it did not recognise.
+    _sc_payload=$(_sc_group_payload "$_sc_group")
 
     # shellcheck disable=SC2086
     if [ -n "$_sc_payload" ] && ! prereqs_missing $_sc_payload; then
@@ -326,30 +346,55 @@ sc_remove_prereqs() {
     esac
 }
 
-# Packages that look build-only by name but are needed at RUN time. Each entry
-# is here because something invokes or links it after the build, which no
-# dependency graph records:
+# Per-image exceptions to the classification below, set by sc_remove_build_only
+# from its own arguments. They are per image and not a list here on purpose: a
+# package is build-only or not according to the tool that installed it, and a
+# global list of tool facts in this file makes every tool image depend on every
+# other tool's exceptions. _prereqs.sh feeds the check tag of all 30 tool
+# images, so one tool's exception would rebuild all of them.
 #
-#   zlib1g-dev   verilator compiles the generated model, and --trace-fst needs
-#                zlib's headers; "ghdl -e" links -lz into every design
-#   ccache       verilated.mk sets "OBJCACHE ?= ccache" and invokes it
-#                unconditionally, so removing it breaks every model build
-#   graphviz     yosys' "show" shells out to dot
-#   xdot         the viewer "show" opens
-#   libc6-dev    bambu compiles its 32-bit MDPI runtime at run time
-#   libllvm18    ghdl1-llvm links libLLVM.so.18.1. Nothing records it: ghdl is
-#                built from source, so the link never becomes a package
-#                dependency, and once clang-18 and doxygen are classed as
-#                removable below, libllvm18 looks free. It is not -- dropping it
-#                breaks every "ghdl -e".
-_SC_KEEP_BUILD_PKGS="zlib1g-dev ccache graphviz xdot libc6-dev libc-dev libllvm18"
+# The tool declares them in _tools.json instead -- "docker-keep-pkgs" for a
+# package it needs at run time, "docker-drop-pkgs" for one only its build needs
+# -- and setup/docker/tool.docker passes them here.
+_sc_keep_pkgs=""
+_sc_drop_pkgs=""
 
 # True when a package name is build-only material: headers and static libraries,
 # the build tools, and documentation generators.
+#
+# This is the definition of the class, and the only naming left in this file:
+# the conventions every deb image shares, which class the same way whatever
+# built the image. A package that is build-only in one image and load-bearing
+# in another is not a rule, it is a fact about a tool, and it belongs in that
+# tool's _tools.json entry -- "docker-keep-pkgs" to hold one back,
+# "docker-drop-pkgs" to add one. Putting such a name here instead makes every
+# one of the 30 tool images depend on it: _prereqs.sh feeds all of their check
+# tags, so one tool's exception rebuilds all of them.
+#
+# dpkg's own Section field is the obvious way to have no names here at all, and
+# it does not work: measured on ubuntu 24.04, section "devel" holds gcc, g++,
+# make, ccache and binutils along with cmake and autoconf, so classing by it
+# sweeps the toolchain verilator invokes to compile the model it generates and
+# the clang bambu shells out to. It also misses pandoc, groff and texinfo,
+# which sit in "text" and "perl". Keeping the patterns costs one rebuild of
+# everything on the rare occasion they change, which is honest: a change here
+# does change every image.
 _sc_is_build_only() {
-    case " $_SC_KEEP_BUILD_PKGS " in
-        *" $1 "*) return 1 ;;
-    esac
+    # Word splitting of the pattern lists is intended: each entry is a case
+    # pattern, so "libllvm17*" matches the family without naming every member.
+    # shellcheck disable=SC2086
+    for _sc_bo_pat in $_sc_keep_pkgs; do
+        case "$1" in
+            $_sc_bo_pat) return 1 ;;
+        esac
+    done
+
+    # shellcheck disable=SC2086
+    for _sc_bo_pat in $_sc_drop_pkgs; do
+        case "$1" in
+            $_sc_bo_pat) return 0 ;;
+        esac
+    done
 
     case "$1" in
         *-dev) return 0 ;;
@@ -359,48 +404,21 @@ _sc_is_build_only() {
         doxygen|pandoc|groff|texinfo|perl-doc|icu-devtools) return 0 ;;
     esac
 
-    # Distribution toolchain runtimes that arrive under a build dependency and
-    # that no tool in the image links. Checked one at a time against every ELF
-    # object in the prefix, because a shared library nothing links is dead
-    # weight however much it looks like a runtime package:
-    #
-    #   libllvm17t64   orphaned outright -- no package depends on it and no
-    #                  binary links libLLVM.so.17
-    #   the clang-18   held up only by doxygen and by ghdl's "clang", both of
-    #   stack          which are removed. ghdl links libllvm18 directly and
-    #                  shells out to no compiler, so the front end is unused.
-    #
-    # libllvm18 is deliberately NOT here -- see _SC_KEEP_BUILD_PKGS.
-    case "$1" in
-        libllvm17*|llvm-17|llvm-17-*) return 0 ;;
-        clang-18|clang|clang-format-18|libclang-cpp18|libclang1-18) return 0 ;;
-        llvm-18-linker-tools|llvm-18-runtime|llvm-runtime) return 0 ;;
-    esac
-
-    # The MPI and ROCm stack that install-xyce.sh drags in through
-    # libopenmpi-dev. SC builds Xyce serially -- "ldd Xyce" links no libmpi at
-    # all -- so none of this is reachable, and it is a lot: libamd-comgr2 alone
-    # is 59MB and it pulls libllvm17 behind it.
-    #
-    # Named rather than left to the dependency test because these are runtime
-    # packages that legitimately depend on each other, so the test only sees a
-    # self-consistent island and leaves all of it in place.
-    # The head of the chain is boost's MPI runtime, which arrives with
-    # libboost-all-dev and which nothing links either: Xyce and libxyce.so
-    # resolve zero libmpi/libucx libraries. Leave these out and the fixpoint
-    # below correctly refuses the whole chain, because they pin it.
-    case "$1" in
-        mpi-default-bin|libboost-mpi1.*|libboost-mpi-python1.*) return 0 ;;
-        libboost-graph-parallel1.*) return 0 ;;
-        libamd-comgr2|libamdhip64-*|libucx0|libopenmpi3*|openmpi-bin) return 0 ;;
-    esac
-
     return 1
 }
 
 # Remove every build-only package that nothing outside that class depends on.
 #
-#     sc_remove_build_only
+#     sc_remove_build_only [--keep "PATTERN..."] [--drop "PATTERN..."]
+#
+# --keep protects packages this image needs at run time that the rules above
+# would otherwise class as build-only: verilator's zlib1g-dev, which it needs to
+# compile the model it generates. --drop adds packages those rules do not
+# recognise but this image has no use for: the distribution clang stack that
+# arrives under ghdl's "llvm-dev", or the ROCm and MPI libraries that arrive
+# under xyce's libboost-all-dev and that nothing links. Both take shell case
+# patterns ("libllvm17*"), and both are per image: the tool declares them in its
+# _tools.json entry and tool.docker passes them.
 #
 # A criterion rather than a list, because a list of package names goes stale the
 # moment a tool changes its prerequisites, and because the names differ per
@@ -418,6 +436,19 @@ _sc_is_build_only() {
 # the name patterns above describe, so a build-only package like ghc, gnat-13 or
 # a distribution's llvm-18 still has to be named by the tool that installs it.
 sc_remove_build_only() {
+    _sc_keep_pkgs=""
+    _sc_drop_pkgs=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --keep) _sc_keep_pkgs="$_sc_keep_pkgs $2"; shift 2 ;;
+            --drop) _sc_drop_pkgs="$_sc_drop_pkgs $2"; shift 2 ;;
+            *)
+                echo "sc_remove_build_only: unknown argument $1" >&2
+                return 1
+                ;;
+        esac
+    done
+
     if [ "$_sc_backend" != "deb" ]; then
         echo "sc_remove_build_only: deb only, skipping"
         return 0
@@ -514,25 +545,44 @@ sc_remove_build_only() {
     sc_remove_prereqs $_sc_bo_drop
 }
 
-# Directories whose static archives are linked at RUN time, not build time, and
-# so are not build artifacts however much they look like them:
+# Delete what a tool says its prefix holds that is build-only.
 #
-#   lib/ghdl      libgrt.a, linked into every design by "ghdl -e"
-#   lib/panda     bambu's softfloat and libm, linked into generated designs
-#   lib/Bluesim   Bluespec's simulation kernel, linked by "bsc -sim"
-_SC_RUNTIME_ARCHIVE_DIRS="ghdl panda Bluesim"
-
-# Delete the build-only half of an install prefix: static archives, headers,
-# and the build-system and documentation trees.
+#     sc_prune_build_artifacts [DIR] [--dirs "PATH..."]
 #
-#     sc_prune_build_artifacts [DIR]
+# Each PATH is relative to the prefix and may be a glob: "include",
+# "lib/pkgconfig", "lib/*.a", "trilinos/lib/*.a". Nothing else goes. There is no
+# blanket rule and no exception list to go with it -- an earlier version deleted
+# every *.a in the prefix and then had to be told, by name, about the three
+# directories whose archives are linked at RUN time (ghdl's lib/ghdl/libgrt.a
+# for "ghdl -e", lib/panda for bambu's generated designs, lib/Bluesim for
+# "bsc -sim"). A tool that lists "lib/*.a" says the same thing without the
+# exception, because the glob does not reach into lib/ghdl.
 #
-# $PREFIX/include and $PREFIX/lib/cmake are dev material by convention and no
-# flow reads them. Note that the headers tools genuinely need at run time do not
-# live there -- verilator's are under share/verilator/include and bambu's under
-# share/panda -- so both survive.
+# Two things are reported rather than enforced, because a wrong list here costs
+# image size and a build failure costs a tool:
+#
+#   - an entry that matches nothing is called out, so a path that upstream
+#     stopped shipping shows up in the build log instead of rotting
+#   - archives left in the prefix are listed, so a tool that has never declared
+#     them is one grep of a build log away from a correct list
+#
+# Note that the headers a tool needs at run time do not live in the prefix's own
+# include/ -- verilator's are under share/verilator/include and bambu's under
+# share/panda -- which is why "include" is safe for a tool to list.
 sc_prune_build_artifacts() {
-    _sc_prune_dir="${1:-${PREFIX:-}}"
+    _sc_prune_dir=""
+    _sc_prune_dirs=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --dirs) _sc_prune_dirs="$_sc_prune_dirs $2"; shift 2 ;;
+            -*)
+                echo "sc_prune_build_artifacts: unknown argument $1" >&2
+                return 1
+                ;;
+            *) _sc_prune_dir="$1"; shift ;;
+        esac
+    done
+    _sc_prune_dir="${_sc_prune_dir:-${PREFIX:-}}"
 
     if [ -z "$_sc_prune_dir" ] || [ ! -d "$_sc_prune_dir" ]; then
         echo "sc_prune_build_artifacts: no prefix to prune" >&2
@@ -541,40 +591,43 @@ sc_prune_build_artifacts() {
 
     echo "Pruning build artifacts from $_sc_prune_dir"
 
-    _sc_prune_args=""
-    for _sc_prune_keep in $_SC_RUNTIME_ARCHIVE_DIRS; do
-        _sc_prune_args="$_sc_prune_args ! -path */$_sc_prune_keep/*"
+    for _sc_prune_entry in $_sc_prune_dirs; do
+        _sc_prune_hit=""
+        # Unquoted on purpose: the entry is a glob and this is where it expands.
+        # The prefix stays quoted, so a path with a space in it still works.
+        for _sc_prune_path in "$_sc_prune_dir"/$_sc_prune_entry; do
+            [ -e "$_sc_prune_path" ] || continue
+            rm -rf "$_sc_prune_path"
+            _sc_prune_hit="yes"
+        done
+
+        if [ -z "$_sc_prune_hit" ]; then
+            echo "  nothing matched, drop it from docker-prune-dirs: $_sc_prune_entry"
+        fi
     done
 
-    # Pathname expansion off for the unquoted expansion below: the patterns
-    # contain */ and the shell would expand them against the current directory.
-    # A "deps/ghdl/..." tree in the working directory -- which is exactly what
-    # ghdl's builder has -- turns */ghdl/* into a literal path, the exclusion
-    # stops matching, and libgrt.a is deleted. Word splitting is still wanted,
-    # to keep the find predicates separate.
-    set -f
-    # shellcheck disable=SC2086
-    find "$_sc_prune_dir" -name '*.a' $_sc_prune_args -delete 2>/dev/null
-    set +f
-
-    rm -rf "$_sc_prune_dir/include" \
-           "$_sc_prune_dir/lib/cmake" \
-           "$_sc_prune_dir/lib/pkgconfig" \
-           "$_sc_prune_dir/share/doc" \
-           "$_sc_prune_dir/share/man"
+    # Static archives are link-time material in every prefix that has them, so
+    # one left behind is either a tool that links it at run time or a list that
+    # has not caught up. Reported, never guessed at.
+    _sc_prune_left=$(find "$_sc_prune_dir" -name '*.a' 2>/dev/null)
+    if [ -n "$_sc_prune_left" ]; then
+        echo "  static archives left in the prefix, declare the build-only ones:"
+        echo "$_sc_prune_left" | sed "s|^$_sc_prune_dir/|    |"
+    fi
 }
 
-# The binutils family on deb, including what binutils drags in transitively.
-# sc_strip_prefix_managed installs binutils and then removes exactly the subset
-# that was not there before, so everything the install can add has to be
-# nameable -- without libctf0, libctf-nobfd0 and libsframe1 the removal leaves
-# them orphaned and they land in apt.txt.
-#
-# Names absent on a distribution (rpm ships only "binutils") fall out on their
-# own: they probe as missing, and sc_remove_prereqs re-probes and skips whatever
-# the install did not actually add.
-_SC_STRIP_PKGS="binutils binutils-common libbinutils binutils-x86-64-linux-gnu
-    libctf0 libctf-nobfd0 libsframe1"
+# Echo every installed package name, one per line, sorted. Empty when there is
+# no probe to ask, which makes the caller's before/after diff empty too -- the
+# safe direction, since the cost is a package left installed.
+_sc_installed_names() {
+    set +x
+
+    if command -v dpkg-query > /dev/null 2>&1; then
+        dpkg-query -W -f='${Package}\n' 2>/dev/null | sort
+    elif command -v rpm > /dev/null 2>&1; then
+        rpm -qa --qf '%{NAME}\n' 2>/dev/null | sort
+    fi
+}
 
 # Strip a prefix even on an image that has no "strip", borrowing binutils for
 # the duration.
@@ -597,17 +650,25 @@ sc_strip_prefix_managed() {
         return 0
     fi
 
-    # Take back out exactly what this adds. On an image where part of the family
-    # was already present, removing all of it would be a change this function
-    # has no business making.
-    # Word splitting of the package list is intended.
-    # shellcheck disable=SC2086
-    _sc_strip_added=$(_sc_missing_pkgs $_SC_STRIP_PKGS)
+    # Take back out exactly what this adds, by comparing the installed set
+    # before and after rather than by naming the binutils family: what
+    # "apt-get install binutils" pulls in differs by distribution and moves
+    # between releases -- libsframe1 and libctf-nobfd0 both appeared in one --
+    # and a list that misses one leaves it installed and shipping. On an image
+    # where part of the family was already present, the diff leaves it alone.
+    _sc_strip_before=$(mktemp)
+    _sc_strip_after=$(mktemp)
 
+    _sc_installed_names > "$_sc_strip_before"
     install_prereqs binutils
+    _sc_installed_names > "$_sc_strip_after"
+
+    _sc_strip_added=$(comm -13 "$_sc_strip_before" "$_sc_strip_after" | tr '\n' ' ')
+    rm -f "$_sc_strip_before" "$_sc_strip_after"
 
     sc_strip_prefix "$@"
 
+    # Word splitting of the package list is intended.
     # shellcheck disable=SC2086
     sc_remove_prereqs $_sc_strip_added
 }

--- a/siliconcompiler/toolscripts/_tools.json
+++ b/siliconcompiler/toolscripts/_tools.json
@@ -3,13 +3,6 @@
     "git-url": "https://github.com/The-OpenROAD-Project/OpenROAD.git",
     "git-commit": "372189ed6554794bc47473259b5e6edfdecd6f1a",
     "auto-update": true,
-    "docker-prune-dirs": [
-      "include",
-      "lib/cmake",
-      "lib/pkgconfig",
-      "share/doc",
-      "share/man"
-    ],
     "_comment-drop-pkgs": [
       "The documentation toolchain and the -dev half of the GUI libraries. pandoc,",
       "groff and every libxcb*-dev are build-only by the generic rules already, so",
@@ -18,20 +11,19 @@
     ],
     "docker-drop-pkgs": [
       "bsdmainutils"
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
     ]
   },
   "surelog": {
     "git-url": "https://github.com/chipsalliance/Surelog.git",
     "git-commit": "v1.87",
     "auto-update": true,
-    "docker-prune-dirs": [
-      "include",
-      "lib/cmake",
-      "lib/pkgconfig",
-      "share/doc",
-      "share/man",
-      "lib/*.a"
-    ],
     "_comment-drop-pkgs": [
       "The JRE here runs ANTLR's parser generator at build time only --",
       "install-chisel.sh declares its own JRE, so removing this one does not leave",
@@ -42,6 +34,20 @@
     "docker-drop-pkgs": [
       "default-jre",
       "default-jre-headless"
+    ],
+    "_comment-prune-dirs": [
+      "The archive globs are measured against a build of this image. They",
+      "are one level above the directories that hold the archives linked at",
+      "The archive globs are measured against a build of this image: what",
+      "the blanket \"delete every *.a\" used to catch here."
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man",
+      "lib/*.a"
     ]
   },
   "opensta": {
@@ -49,13 +55,17 @@
     "git-commit": "2996e37a3aa7fdfd197b84842df719e70757657f",
     "auto-update": true,
     "_comment-prune-dirs": [
-      "Measured against a build of this image: every entry matched something and",
-      "nothing build-only was left behind. sc_prune_build_artifacts reports both",
-      "halves of that -- an entry that matches nothing, and any archive still in",
-      "the prefix -- so a list that goes stale says so in the build log."
+      "The archive globs are measured against a build of this image. They",
+      "are one level above the directories that hold the archives linked at",
+      "The archive globs are measured against a build of this image: what",
+      "the blanket \"delete every *.a\" used to catch here."
     ],
     "docker-prune-dirs": [
       "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man",
       "lib/*.a"
     ]
   },
@@ -113,13 +123,17 @@
       "gnat-13-x86-64-linux-gnu"
     ],
     "_comment-prune-dirs": [
-      "Measured against a build of this image: every entry matched something and",
-      "nothing build-only was left behind. sc_prune_build_artifacts reports both",
-      "halves of that -- an entry that matches nothing, and any archive still in",
-      "the prefix -- so a list that goes stale says so in the build log."
+      "The archive globs are measured against a build of this image. They",
+      "are one level above the directories that hold the archives linked at",
+      "RUN time, so no exception list is needed: lib/ghdl/libgrt.a, linked into every design by \"ghdl -e\"",
+      "the blanket \"delete every *.a\" used to catch here."
     ],
     "docker-prune-dirs": [
       "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man",
       "lib/*.a"
     ]
   },
@@ -140,17 +154,6 @@
     "git-commit": "2026.07",
     "version-prefix": "",
     "auto-update": true,
-    "docker-prune-dirs": [
-      "include",
-      "lib/cmake",
-      "lib/pkgconfig",
-      "share/doc",
-      "share/man"
-    ],
-    "_comment-prune-dirs": [
-      "No archive glob: lib/Bluesim holds the simulation kernel that \"bsc -sim\"",
-      "links into the simulations it builds."
-    ],
     "_comment-drop-pkgs": [
       "The Haskell toolchain bsc is built with. Its libghc-*-dev packages and",
       "tcl-dev are build-only by the generic rules, so only ghc has to be named --",
@@ -162,6 +165,13 @@
     ],
     "docker-drop-pkgs": [
       "ghc"
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
     ]
   },
   "klayout": {
@@ -225,13 +235,11 @@
       "# help2man, autoconf -- the sweep classes build-only on its own.",
       "RUN rm $SC_PREFIX/bin/*_dbg $SC_PREFIX/share/verilator/bin/*_dbg"
     ],
-    "_comment-prune-dirs": [
-      "Measured against a build of this image: every entry matched something and",
-      "nothing build-only was left behind. sc_prune_build_artifacts reports both",
-      "halves of that -- an entry that matches nothing, and any archive still in",
-      "the prefix -- so a list that goes stale says so in the build log."
-    ],
     "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
       "share/man"
     ]
   },
@@ -253,13 +261,6 @@
       "RUN rm -r $SC_PREFIX/share/panda/asap7",
       "RUN rm -r $SC_PREFIX/share/panda/nangate45",
       "RUN rm -r $SC_PREFIX/share/panda/scripts"
-    ],
-    "docker-prune-dirs": [
-      "include",
-      "lib/cmake",
-      "lib/pkgconfig",
-      "share/doc",
-      "share/man"
     ],
     "_comment-drop-pkgs": [
       "The clang and boost build APIs are -dev packages the generic rules catch;",
@@ -294,32 +295,54 @@
       "openmpi-bin",
       "graphviz",
       "autoconf-archive"
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
     ]
   },
   "vpr": {
     "git-url": "https://github.com/verilog-to-routing/vtr-verilog-to-routing.git",
     "git-commit": "fe77ace273b3f0558763e0e91d409b2d13344eff",
     "auto-update": false,
+    "_comment-drop-pkgs": [
+      "vpr's build pulls the distribution clang stack, and nothing in the image",
+      "links it: 65MB of libclang-cpp.so and 35MB of libclang-18.so reach sc_tools",
+      "through this image's apt.txt if it is not named here."
+    ],
+    "docker-drop-pkgs": [
+      "clang",
+      "clang-18",
+      "clang-format-18",
+      "libclang-cpp18",
+      "libclang1-18",
+      "llvm-18-linker-tools",
+      "llvm-18-runtime",
+      "llvm-runtime"
+    ],
+    "_comment-prune-dirs": [
+      "The archive globs are measured against a build of this image. They",
+      "are one level above the directories that hold the archives linked at",
+      "The archive globs are measured against a build of this image: what",
+      "the blanket \"delete every *.a\" used to catch here."
+    ],
     "docker-prune-dirs": [
       "include",
       "lib/cmake",
       "lib/pkgconfig",
       "share/doc",
       "share/man",
-      "bin/*.a"
+      "bin/*.a",
+      "lib/*.a"
     ]
   },
   "icepack": {
     "git-url": "https://github.com/YosysHQ/icestorm.git",
     "git-commit": "v1.1",
     "auto-update": false,
-    "docker-prune-dirs": [
-      "include",
-      "lib/cmake",
-      "lib/pkgconfig",
-      "share/doc",
-      "share/man"
-    ],
     "docker-drop-pkgs": [
       "clang",
       "clang-18",
@@ -341,19 +364,19 @@
       "libucx0",
       "libopenmpi3*",
       "openmpi-bin"
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
     ]
   },
   "nextpnr": {
     "git-url": "https://github.com/YosysHQ/nextpnr.git",
     "git-commit": "nextpnr-0.9",
     "docker-depends": "icepack",
-    "docker-prune-dirs": [
-      "include",
-      "lib/cmake",
-      "lib/pkgconfig",
-      "share/doc",
-      "share/man"
-    ],
     "docker-drop-pkgs": [
       "clang",
       "clang-18",
@@ -375,6 +398,13 @@
       "libucx0",
       "libopenmpi3*",
       "openmpi-bin"
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
     ]
   },
   "chisel": {
@@ -393,12 +423,19 @@
     "git-url": "https://github.com/steveicarus/iverilog.git",
     "git-commit": "v13_0",
     "auto-update": true,
+    "_comment-prune-dirs": [
+      "The archive globs are measured against a build of this image. They",
+      "are one level above the directories that hold the archives linked at",
+      "The archive globs are measured against a build of this image: what",
+      "the blanket \"delete every *.a\" used to catch here."
+    ],
     "docker-prune-dirs": [
       "include",
       "lib/cmake",
       "lib/pkgconfig",
       "share/doc",
-      "share/man"
+      "share/man",
+      "lib/*.a"
     ]
   },
   "yosys": {
@@ -415,13 +452,6 @@
     "git-commit": "v0.68",
     "version-prefix": "",
     "auto-update": true,
-    "docker-prune-dirs": [
-      "include",
-      "lib/cmake",
-      "lib/pkgconfig",
-      "share/doc",
-      "share/man"
-    ],
     "docker-drop-pkgs": [
       "clang",
       "clang-18",
@@ -431,6 +461,13 @@
       "llvm-18-linker-tools",
       "llvm-18-runtime",
       "llvm-runtime"
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
     ]
   },
   "xyce": {
@@ -438,14 +475,6 @@
     "git-commit": "Release-7.10.0",
     "version-prefix": "Release-",
     "auto-update": true,
-    "docker-prune-dirs": [
-      "include",
-      "lib/cmake",
-      "lib/pkgconfig",
-      "share/doc",
-      "share/man",
-      "trilinos/lib/*.a"
-    ],
     "docker-drop-pkgs": [
       "libllvm17*",
       "llvm-17",
@@ -459,6 +488,20 @@
       "libucx0",
       "libopenmpi3*",
       "openmpi-bin"
+    ],
+    "_comment-prune-dirs": [
+      "The archive globs are measured against a build of this image. They",
+      "are one level above the directories that hold the archives linked at",
+      "The archive globs are measured against a build of this image: what",
+      "the blanket \"delete every *.a\" used to catch here."
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man",
+      "trilinos/lib/*.a"
     ]
   },
   "xdm": {
@@ -483,6 +526,12 @@
       "COPY slurm $SC_PREFIX/slurm_cfg",
       "RUN mv $SC_PREFIX/slurm_cfg/install-slurm.sh $SC_PREFIX/",
       "RUN chmod +x $SC_PREFIX/install-slurm.sh"
+    ],
+    "_comment-prune-dirs": [
+      "The archive globs are measured against a build of this image. They",
+      "are one level above the directories that hold the archives linked at",
+      "The archive globs are measured against a build of this image: what",
+      "the blanket \"delete every *.a\" used to catch here."
     ],
     "docker-prune-dirs": [
       "include",
@@ -539,12 +588,19 @@
       "boolector"
     ],
     "auto-update": true,
+    "_comment-prune-dirs": [
+      "The archive globs are measured against a build of this image. They",
+      "are one level above the directories that hold the archives linked at",
+      "The archive globs are measured against a build of this image: what",
+      "the blanket \"delete every *.a\" used to catch here."
+    ],
     "docker-prune-dirs": [
       "include",
       "lib/cmake",
       "lib/pkgconfig",
       "share/doc",
-      "share/man"
+      "share/man",
+      "lib/*.a"
     ]
   },
   "bitwuzla": {
@@ -601,13 +657,6 @@
     "git-url": "https://github.com/keplertech/kepler-formal.git",
     "git-commit": "fcb3d23b362768ba9d04d351b628fe0290421838",
     "auto-update": true,
-    "docker-prune-dirs": [
-      "include",
-      "lib/cmake",
-      "lib/pkgconfig",
-      "share/doc",
-      "share/man"
-    ],
     "docker-drop-pkgs": [
       "clang",
       "clang-18",
@@ -617,6 +666,20 @@
       "llvm-18-linker-tools",
       "llvm-18-runtime",
       "llvm-runtime"
+    ],
+    "_comment-prune-dirs": [
+      "The archive globs are measured against a build of this image. They",
+      "are one level above the directories that hold the archives linked at",
+      "The archive globs are measured against a build of this image: what",
+      "the blanket \"delete every *.a\" used to catch here."
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man",
+      "lib/*.a"
     ]
   },
   "vcd2fst": {
@@ -656,6 +719,12 @@
       "# is not declared.",
       "RUN rm $SC_PREFIX/lib/libclang-cpp.so* $SC_PREFIX/lib/libclang.so* \\",
       "    $SC_PREFIX/lib/libLTO.so* $SC_PREFIX/lib/libRemarks.so*"
+    ],
+    "_comment-prune-dirs": [
+      "The archive globs are measured against a build of this image. They",
+      "are one level above the directories that hold the archives linked at",
+      "The archive globs are measured against a build of this image: what",
+      "the blanket \"delete every *.a\" used to catch here."
     ],
     "docker-prune-dirs": [
       "include",

--- a/siliconcompiler/toolscripts/_tools.json
+++ b/siliconcompiler/toolscripts/_tools.json
@@ -4,82 +4,170 @@
     "git-commit": "372189ed6554794bc47473259b5e6edfdecd6f1a",
     "docker-cmds": [
       "# Remove OR-Tools files",
-      "RUN rm -f $SC_PREFIX/Makefile $SC_PREFIX/README.md",
+      "RUN rm $SC_PREFIX/Makefile $SC_PREFIX/README.md",
       "# Remove OpenROAD Env file",
-      "RUN rm -f $SC_PREFIX/env.sh",
-      "# Drop the documentation toolchain and the -dev half of the GUI libraries.",
-      "# The matching runtime xcb libraries stay: they are separate packages, and",
-      "# sc_remove_prereqs does no autoremove, so they are not swept up.",
-      "RUN . $SC_BUILD/../_prereqs.sh && sc_remove_prereqs pandoc groff bsdmainutils \\",
-      "    libxcb1-dev libxcb-util-dev libxcb-icccm4-dev libxcb-image0-dev \\",
-      "    libxcb-keysyms1-dev libxcb-randr0-dev libxcb-render-util0-dev \\",
-      "    libxcb-xinerama0-dev libxcb-xkb-dev"
+      "RUN rm $SC_PREFIX/env.sh"
     ],
-    "auto-update": true
+    "auto-update": true,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ],
+    "_comment-drop-pkgs": [
+      "The documentation toolchain and the -dev half of the GUI libraries. pandoc,",
+      "groff and every libxcb*-dev are build-only by the generic rules already, so",
+      "only bsdmainutils has to be named. The matching runtime xcb libraries stay:",
+      "they are separate packages and the sweep does no autoremove."
+    ],
+    "docker-drop-pkgs": [
+      "bsdmainutils"
+    ]
   },
   "surelog": {
     "git-url": "https://github.com/chipsalliance/Surelog.git",
     "git-commit": "v1.87",
     "auto-update": true,
-    "docker-cmds": [
-      "# Link-time only: surelog and the uhdm tools are what run.",
-      "RUN rm -f $SC_PREFIX/lib/libsurelog.a $SC_PREFIX/lib/libuhdm*.a \\",
-      "    $SC_PREFIX/lib/libantlr*.a",
-      "# Drop the build toolchain. The JRE here runs ANTLR's parser generator at",
-      "# build time only -- install-chisel.sh declares its own JRE, so removing",
-      "# this one no longer leaves sbt without a java to run.",
-      "RUN . $SC_BUILD/../_prereqs.sh && sc_remove_prereqs default-jre default-jre-headless \\",
-      "    cmake swig uuid-dev libgoogle-perftools-dev python3-dev lcov \\",
-      "    pkg-config"
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man",
+      "lib/*.a"
+    ],
+    "_comment-drop-pkgs": [
+      "The JRE here runs ANTLR's parser generator at build time only --",
+      "install-chisel.sh declares its own JRE, so removing this one does not leave",
+      "sbt without a java to run. The rest of what this image builds with (cmake,",
+      "swig, uuid-dev, python3-dev, lcov, pkg-config) is build-only by the generic",
+      "rules already."
+    ],
+    "docker-drop-pkgs": [
+      "default-jre",
+      "default-jre-headless"
     ]
   },
   "opensta": {
     "git-url": "https://github.com/parallaxsw/OpenSTA.git",
     "git-commit": "2996e37a3aa7fdfd197b84842df719e70757657f",
     "auto-update": true,
-    "docker-cmds": [
-      "# libOpenSTA.a is link-time only: the sta binary is what runs. 86MB.",
-      "RUN rm -f $SC_PREFIX/lib/libOpenSTA.a"
+    "_comment-prune-dirs": [
+      "Measured against a build of this image: every entry matched something and",
+      "nothing build-only was left behind. sc_prune_build_artifacts reports both",
+      "halves of that -- an entry that matches nothing, and any archive still in",
+      "the prefix -- so a list that goes stale says so in the build log."
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/*.a"
     ]
   },
   "netgen": {
     "git-url": "https://github.com/RTimothyEdwards/netgen.git",
     "git-commit": "fb7876c7a6f9d58a3d88a49e302e682c1d12e00d",
-    "auto-update": false
+    "auto-update": false,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "ghdl": {
     "git-url": "https://github.com/ghdl/ghdl.git",
+    "_comment-keep-pkgs": [
+      "zlib1g-dev: \"ghdl -e\" links -lz into every elaborated design, and",
+      "lib/ghdl/libgrt.a with it -- which is why docker-prune-dirs below lists no",
+      "archives. libllvm18: ghdl1-llvm links libLLVM.so.18.1 and nothing records",
+      "it, because ghdl is built from source and the link never becomes a package",
+      "dependency."
+    ],
+    "docker-keep-pkgs": [
+      "zlib1g-dev",
+      "libllvm18"
+    ],
     "git-commit": "v6.0.0",
     "auto-update": true,
-    "docker-cmds": [
-      "# Drop the LLVM headers and the Ada compiler. libllvm18 and libgnat-13",
-      "# stay: ghdl1-llvm links both at runtime (ldd confirms) and ghdl shells out",
-      "# to no compiler of its own.",
-      "#",
-      "# libz-dev and lib/ghdl/libgrt.a both stay: every \"ghdl -e\" links -lz and",
-      "# libgrt.a into the elaborated design.",
-      "RUN . $SC_BUILD/../_prereqs.sh && sc_remove_prereqs llvm-18-dev llvm-18 llvm-18-tools \\",
-      "    libclang-18-dev clang clang-18 libclang-cpp18 libclang1-18 gnat \\",
-      "    gnat-13 gnat-13-x86-64-linux-gnu"
+    "_comment-drop-pkgs": [
+      "The distribution clang stack that arrives under ghdl's \"llvm-dev\", the",
+      "LLVM tools and the Ada compiler. libllvm18 and libgnat-13 stay -- ghdl1-llvm",
+      "links both at run time (ldd confirms) and ghdl shells out to no compiler of",
+      "its own -- which is why libllvm18 is in docker-keep-pkgs.",
+      "",
+      "\"llvm\" is the unversioned metapackage. Without it the sweep keeps llvm-18:",
+      "nothing classes llvm as build-only, so it counts as a runtime dependent and",
+      "pins the version it points at."
+    ],
+    "docker-drop-pkgs": [
+      "clang",
+      "clang-18",
+      "clang-format-18",
+      "libclang-cpp18",
+      "libclang1-18",
+      "llvm-18-linker-tools",
+      "llvm-18-runtime",
+      "llvm-runtime",
+      "llvm",
+      "llvm-18",
+      "llvm-18-tools",
+      "gnat",
+      "gnat-13",
+      "gnat-13-x86-64-linux-gnu"
+    ],
+    "_comment-prune-dirs": [
+      "Measured against a build of this image: every entry matched something and",
+      "nothing build-only was left behind. sc_prune_build_artifacts reports both",
+      "halves of that -- an entry that matches nothing, and any archive still in",
+      "the prefix -- so a list that goes stale says so in the build log."
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/*.a"
     ]
   },
   "magic": {
     "git-url": "https://github.com/RTimothyEdwards/magic.git",
     "git-commit": "c7f11d2169f6af8751ae22b5d70250b331e1a667",
-    "auto-update": false
+    "auto-update": false,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "bluespec": {
     "git-url": "https://github.com/B-Lang-org/bsc.git",
     "git-commit": "2026.07",
     "version-prefix": "",
     "auto-update": true,
-    "docker-cmds": [
-      "# Drop the Haskell toolchain. bsc and bluetcl are compiled binaries whose",
-      "# runtime needs are libgmp10, libffi8 and libtcl8.6 -- separate packages,",
-      "# and no autoremove means they stay. lib/Bluesim/*.a stays too: \"bsc -sim\"",
-      "# links it.",
-      "RUN . $SC_BUILD/../_prereqs.sh && sc_remove_prereqs ghc libghc-regex-compat-dev \\",
-      "    libghc-syb-dev libghc-old-time-dev libghc-split-dev tcl-dev pkg-config"
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ],
+    "_comment-prune-dirs": [
+      "No archive glob: lib/Bluesim holds the simulation kernel that \"bsc -sim\"",
+      "links into the simulations it builds."
+    ],
+    "_comment-drop-pkgs": [
+      "The Haskell toolchain bsc is built with. Its libghc-*-dev packages and",
+      "tcl-dev are build-only by the generic rules, so only ghc has to be named --",
+      "and naming it during the sweep rather than after it is what lets the",
+      "libbsd-dev, libffi-dev, libgmp-dev, libmd-dev and libncurses-dev it holds go",
+      "with it. bsc and bluetcl are compiled binaries whose runtime needs are",
+      "libgmp10, libffi8 and libtcl8.6 -- separate packages, and no autoremove",
+      "means they stay."
+    ],
+    "docker-drop-pkgs": [
+      "ghc"
     ]
   },
   "klayout": {
@@ -93,6 +181,13 @@
       "RUN echo \"sudo apt-get install -y $SC_PREFIX/klayout.deb\" >> $SC_PREFIX/install-klayout.sh",
       "RUN echo \"sudo rm $SC_PREFIX/klayout.deb\" >> $SC_PREFIX/install-klayout.sh",
       "RUN chmod +x $SC_PREFIX/install-klayout.sh"
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
     ]
   },
   "sv2v": {
@@ -103,11 +198,27 @@
       "# The Haskell Stack build tool, a statically linked 90MB binary that",
       "# install-sv2v.sh drops in the prefix to compile sv2v with. sv2v is a",
       "# standalone binary once built and never invokes it again.",
-      "RUN rm -f $SC_PREFIX/stack"
+      "RUN rm $SC_PREFIX/stack"
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
     ]
   },
   "verilator": {
     "git-url": "https://github.com/verilator/verilator.git",
+    "_comment-keep-pkgs": [
+      "zlib1g-dev: verilator compiles the generated model after the build, and",
+      "--trace-fst links -lz into it. ccache: verilated.mk sets",
+      "OBJCACHE ?= ccache and invokes it unconditionally."
+    ],
+    "docker-keep-pkgs": [
+      "zlib1g-dev",
+      "ccache"
+    ],
     "git-commit": "v5.038",
     "auto-update": true,
     "docker-cmds": [
@@ -115,85 +226,257 @@
       "# verilator_bin's 17MB and nothing in the flows selects it.",
       "#",
       "# g++, make, perl and zlib1g-dev all stay: they are what compiles the",
-      "# generated model at run time, and --trace-fst links -lz into it.",
-      "RUN rm -f $SC_PREFIX/bin/*_dbg $SC_PREFIX/share/verilator/bin/*_dbg",
-      "RUN . $SC_BUILD/../_prereqs.sh && sc_remove_prereqs libfl-dev libgoogle-perftools-dev \\",
-      "    perl-doc help2man autoconf"
+      "# generated model at run time, and --trace-fst links -lz into it. What this",
+      "# used to remove by name -- libfl-dev, libgoogle-perftools-dev, perl-doc,",
+      "# help2man, autoconf -- the sweep classes build-only on its own.",
+      "RUN rm $SC_PREFIX/bin/*_dbg $SC_PREFIX/share/verilator/bin/*_dbg"
+    ],
+    "_comment-prune-dirs": [
+      "Measured against a build of this image: every entry matched something and",
+      "nothing build-only was left behind. sc_prune_build_artifacts reports both",
+      "halves of that -- an entry that matches nothing, and any archive still in",
+      "the prefix -- so a list that goes stale says so in the build log."
+    ],
+    "docker-prune-dirs": [
+      "share/man"
     ]
   },
   "bambu": {
     "git-url": "https://github.com/ferrandi/PandA-bambu.git",
+    "_comment-keep-pkgs": [
+      "bambu compiles its 32-bit MDPI simulation runtime at run time, which needs",
+      "libc6-dev (libc-dev is the virtual name), and links lib/panda/*.a into the",
+      "designs it generates -- so docker-prune-dirs below lists no archives."
+    ],
+    "docker-keep-pkgs": [
+      "libc6-dev",
+      "libc-dev"
+    ],
     "git-commit": "2024.10",
     "auto-update": false,
     "docker-cmds": [
       "# Remove ORFS Stuff",
-      "RUN rm -rf $SC_PREFIX/share/panda/asap7",
-      "RUN rm -rf $SC_PREFIX/share/panda/nangate45",
-      "RUN rm -rf $SC_PREFIX/share/panda/scripts",
-      "# Drop the clang and boost build APIs. bambu shells out to clang-16,",
-      "# clang++-16 and llvm-link-16 at runtime, so the clang *runtime* packages",
-      "# stay; only the headers and static libraries go. libboost-all-dev is a",
-      "# metapackage, so removing it takes its whole -dev set with it.",
-      "#",
-      "# gcc-multilib, g++-multilib and libc6-dev are NOT removable: bambu",
-      "# compiles its 32-bit MDPI simulation runtime at run time. Neither is",
-      "# lib/panda/*.a, which it links into generated designs.",
-      "RUN . $SC_BUILD/../_prereqs.sh && sc_remove_prereqs llvm-16-dev libclang-16-dev \\",
-      "    libboost-all-dev doxygen graphviz libsuitesparse-dev libglpk-dev \\",
-      "    libbdd-dev libmpfi-dev libmpc-dev libmpfr-dev libxml2-dev liblzma-dev \\",
-      "    libicu-dev autoconf-archive libfl-dev"
+      "RUN rm -r $SC_PREFIX/share/panda/asap7",
+      "RUN rm -r $SC_PREFIX/share/panda/nangate45",
+      "RUN rm -r $SC_PREFIX/share/panda/scripts"
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ],
+    "_comment-drop-pkgs": [
+      "The clang and boost build APIs are -dev packages the generic rules catch;",
+      "only graphviz (doxygen's renderer) and autoconf-archive have to be named.",
+      "bambu shells out to clang-16, clang++-16 and llvm-link-16 at run time, so",
+      "the clang *runtime* packages are not listed here.",
+      "",
+      "gcc-multilib, g++-multilib and libc6-dev are NOT droppable: bambu compiles",
+      "its 32-bit MDPI simulation runtime at run time. Neither is lib/panda/*.a,",
+      "which it links into the designs it generates."
+    ],
+    "docker-drop-pkgs": [
+      "clang",
+      "clang-18",
+      "clang-format-18",
+      "libclang-cpp18",
+      "libclang1-18",
+      "llvm-18-linker-tools",
+      "llvm-18-runtime",
+      "llvm-runtime",
+      "libllvm17*",
+      "llvm-17",
+      "llvm-17-*",
+      "mpi-default-bin",
+      "libboost-mpi1.*",
+      "libboost-mpi-python1.*",
+      "libboost-graph-parallel1.*",
+      "libamd-comgr2",
+      "libamdhip64-*",
+      "libucx0",
+      "libopenmpi3*",
+      "openmpi-bin",
+      "graphviz",
+      "autoconf-archive"
     ]
   },
   "vpr": {
     "git-url": "https://github.com/verilog-to-routing/vtr-verilog-to-routing.git",
     "git-commit": "fe77ace273b3f0558763e0e91d409b2d13344eff",
     "auto-update": false,
-    "docker-cmds": [
-      "# vpr's build installs its intermediate archives into bin/ alongside the",
-      "# executables. Link-time only. 168MB.",
-      "RUN rm -f $SC_PREFIX/bin/*.a"
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man",
+      "bin/*.a"
     ]
   },
   "icepack": {
     "git-url": "https://github.com/YosysHQ/icestorm.git",
     "git-commit": "v1.1",
-    "auto-update": false
+    "auto-update": false,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ],
+    "docker-drop-pkgs": [
+      "clang",
+      "clang-18",
+      "clang-format-18",
+      "libclang-cpp18",
+      "libclang1-18",
+      "llvm-18-linker-tools",
+      "llvm-18-runtime",
+      "llvm-runtime",
+      "libllvm17*",
+      "llvm-17",
+      "llvm-17-*",
+      "mpi-default-bin",
+      "libboost-mpi1.*",
+      "libboost-mpi-python1.*",
+      "libboost-graph-parallel1.*",
+      "libamd-comgr2",
+      "libamdhip64-*",
+      "libucx0",
+      "libopenmpi3*",
+      "openmpi-bin"
+    ]
   },
   "nextpnr": {
     "git-url": "https://github.com/YosysHQ/nextpnr.git",
     "git-commit": "nextpnr-0.9",
-    "docker-depends": "icepack"
+    "docker-depends": "icepack",
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ],
+    "docker-drop-pkgs": [
+      "clang",
+      "clang-18",
+      "clang-format-18",
+      "libclang-cpp18",
+      "libclang1-18",
+      "llvm-18-linker-tools",
+      "llvm-18-runtime",
+      "llvm-runtime",
+      "libllvm17*",
+      "llvm-17",
+      "llvm-17-*",
+      "mpi-default-bin",
+      "libboost-mpi1.*",
+      "libboost-mpi-python1.*",
+      "libboost-graph-parallel1.*",
+      "libamd-comgr2",
+      "libamdhip64-*",
+      "libucx0",
+      "libopenmpi3*",
+      "openmpi-bin"
+    ]
   },
   "chisel": {
     "version": "2.0.8",
     "git-url": "https://github.com/sbt/sbt.git",
-    "auto-update": true
+    "auto-update": true,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "icarus": {
     "git-url": "https://github.com/steveicarus/iverilog.git",
     "git-commit": "v13_0",
-    "auto-update": true
+    "auto-update": true,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "yosys": {
     "git-url": "https://github.com/YosysHQ/yosys.git",
+    "_comment-keep-pkgs": [
+      "yosys' \"show\" shells out to dot and opens the result in xdot. The images",
+      "built on top of this one (sby, wildebeest, yosys-moosic) inherit this:",
+      "builder.py unions a tool's lists with those of the tools it is built on."
+    ],
+    "docker-keep-pkgs": [
+      "graphviz",
+      "xdot"
+    ],
     "git-commit": "v0.68",
     "version-prefix": "",
-    "auto-update": true
+    "auto-update": true,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ],
+    "docker-drop-pkgs": [
+      "clang",
+      "clang-18",
+      "clang-format-18",
+      "libclang-cpp18",
+      "libclang1-18",
+      "llvm-18-linker-tools",
+      "llvm-18-runtime",
+      "llvm-runtime"
+    ]
   },
   "xyce": {
     "git-url": "https://github.com/Xyce/Xyce.git",
     "git-commit": "Release-7.10.0",
     "version-prefix": "Release-",
     "auto-update": true,
-    "docker-cmds": [
-      "# Trilinos is linked into the Xyce binary and libxyce.so; the archives it",
-      "# was linked from are not needed to run either. 299MB.",
-      "RUN rm -f $SC_PREFIX/trilinos/lib/*.a"
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man",
+      "trilinos/lib/*.a"
+    ],
+    "docker-drop-pkgs": [
+      "libllvm17*",
+      "llvm-17",
+      "llvm-17-*",
+      "mpi-default-bin",
+      "libboost-mpi1.*",
+      "libboost-mpi-python1.*",
+      "libboost-graph-parallel1.*",
+      "libamd-comgr2",
+      "libamdhip64-*",
+      "libucx0",
+      "libopenmpi3*",
+      "openmpi-bin"
     ]
   },
   "xdm": {
     "version": "2.7.0",
-    "auto-update": false
+    "auto-update": false,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "slurm": {
     "version": "22.05.7",
@@ -205,25 +488,53 @@
     "docker-cmds": [
       "COPY slurm $SC_PREFIX/slurm_cfg",
       "RUN mv $SC_PREFIX/slurm_cfg/install-slurm.sh $SC_PREFIX/",
-      "RUN chmod +x $SC_PREFIX/install-slurm.sh",
-      "# Slurm loads its plugins as .so; these are the static variants. 298MB.",
-      "RUN rm -f $SC_PREFIX/lib/libslurm.a $SC_PREFIX/lib/slurm/*.a"
+      "RUN chmod +x $SC_PREFIX/install-slurm.sh"
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man",
+      "lib/*.a",
+      "lib/slurm/*.a"
     ]
   },
   "montage": {
     "version": "6.9.11",
     "auto-update": false,
-    "docker-skip": true
+    "docker-skip": true,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "verible": {
     "version": "v0.0-4051-g9fdb4057",
     "git-url": "https://github.com/chipsalliance/verible.git",
-    "auto-update": false
+    "auto-update": false,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "gtkwave": {
     "git-commit": "v3.3.116",
     "git-url": "https://github.com/gtkwave/gtkwave.git",
-    "auto-update": true
+    "auto-update": true,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "sby": {
     "git-url": "https://github.com/YosysHQ/sby.git",
@@ -233,7 +544,14 @@
       "bitwuzla",
       "boolector"
     ],
-    "auto-update": true
+    "auto-update": true,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "bitwuzla": {
     "git-url": "https://github.com/bitwuzla/bitwuzla.git",
@@ -251,33 +569,85 @@
     "git-url": "https://github.com/gadfort/moosic-yosys-plugin.git",
     "git-commit": "fbe57eaae507f50e2504777b2438fa9eb451dab9",
     "docker-depends": "yosys",
-    "auto-update": true
+    "auto-update": true,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "wildebeest": {
     "git-url": "https://github.com/zeroasiccorp/wildebeest.git",
     "git-commit": "7d376b59814404f68f800e49c9400501840ef9f0",
     "docker-depends": "yosys",
-    "auto-update": true
+    "auto-update": true,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "surfer": {
     "git-url": "https://gitlab.com/surfer-project/surfer.git",
     "git-commit": "v0.7.0",
-    "auto-update": true
+    "auto-update": true,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "keplerformal": {
     "git-url": "https://github.com/keplertech/kepler-formal.git",
     "git-commit": "fcb3d23b362768ba9d04d351b628fe0290421838",
-    "auto-update": true
+    "auto-update": true,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ],
+    "docker-drop-pkgs": [
+      "clang",
+      "clang-18",
+      "clang-format-18",
+      "libclang-cpp18",
+      "libclang1-18",
+      "llvm-18-linker-tools",
+      "llvm-18-runtime",
+      "llvm-runtime"
+    ]
   },
   "vcd2fst": {
     "git-url": "https://github.com/Silimate/vcd2fst.git",
     "git-commit": "5b00c4f9ae7d07987082992774a5e6a1b8adc8d7",
-    "auto-update": true
+    "auto-update": true,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "mlir": {
     "git-url": "https://github.com/llvm/llvm-project.git",
     "git-commit": "llvmorg-19.1.5",
-    "auto-update": false
+    "auto-update": false,
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man"
+    ]
   },
   "soda": {
     "git-url": "https://github.com/pnnl/soda-opt.git",
@@ -285,25 +655,21 @@
     "auto-update": false,
     "docker-depends": "mlir",
     "docker-cmds": [
-      "# Drop the LLVM/MLIR dev tree now that soda-opt is linked. \"ldd soda-opt\"",
-      "# reports libstdc++, libm, libgcc_s and libc and nothing else -- it is",
-      "# statically linked, so none of this has a runtime consumer.",
-      "#",
-      "# Named by prefix rather than a blanket \"find -name '*.a' -delete\". This",
-      "# image's prefix holds only mlir and soda, but three tools elsewhere ship",
-      "# static archives their runtime links against -- lib/ghdl/libgrt.a for",
-      "# \"ghdl -e\", lib/panda/*.a for bambu's generated designs, lib/Bluesim/*.a",
-      "# for \"bsc -sim\" -- so a blanket delete is the wrong habit to establish in",
-      "# a prefix that is shared whenever PREFIX is set.",
-      "RUN rm -f $SC_PREFIX/lib/libLLVM*.a $SC_PREFIX/lib/libMLIR*.a \\",
-      "    $SC_PREFIX/lib/libclang*.a $SC_PREFIX/lib/libLTO*.a \\",
-      "    $SC_PREFIX/lib/libRemarks*.a $SC_PREFIX/lib/libPolly*.a \\",
-      "    $SC_PREFIX/lib/libbenchmark*.a $SC_PREFIX/lib/libgtest*.a",
-      "RUN rm -rf $SC_PREFIX/include $SC_PREFIX/lib/cmake $SC_PREFIX/lib/pkgconfig",
       "# libclang-cpp.so and libclang.so are only loaded by c-index-test, which",
-      "# install-mlir.sh no longer installs.",
-      "RUN rm -f $SC_PREFIX/lib/libclang-cpp.so* $SC_PREFIX/lib/libclang.so* \\",
+      "# install-mlir.sh no longer installs. The static half of the LLVM/MLIR dev",
+      "# tree needs no line here: soda-opt is statically linked, this image",
+      "# declares no docker-keep-archives, and the prune takes every archive that",
+      "# is not declared.",
+      "RUN rm $SC_PREFIX/lib/libclang-cpp.so* $SC_PREFIX/lib/libclang.so* \\",
       "    $SC_PREFIX/lib/libLTO.so* $SC_PREFIX/lib/libRemarks.so*"
+    ],
+    "docker-prune-dirs": [
+      "include",
+      "lib/cmake",
+      "lib/pkgconfig",
+      "share/doc",
+      "share/man",
+      "lib/*.a"
     ]
   }
 }

--- a/siliconcompiler/toolscripts/_tools.json
+++ b/siliconcompiler/toolscripts/_tools.json
@@ -2,12 +2,6 @@
   "openroad": {
     "git-url": "https://github.com/The-OpenROAD-Project/OpenROAD.git",
     "git-commit": "372189ed6554794bc47473259b5e6edfdecd6f1a",
-    "docker-cmds": [
-      "# Remove OR-Tools files",
-      "RUN rm $SC_PREFIX/Makefile $SC_PREFIX/README.md",
-      "# Remove OpenROAD Env file",
-      "RUN rm $SC_PREFIX/env.sh"
-    ],
     "auto-update": true,
     "docker-prune-dirs": [
       "include",

--- a/tests/toolscripts/test_prereqs.py
+++ b/tests/toolscripts/test_prereqs.py
@@ -108,14 +108,24 @@ DEB_STUBS = {
 # With no package argument this is the "list the whole database" form that
 # sc_remove_build_only walks. SC_TEST_DB holds "name|depends" lines.
 if [ -z "$3" ]; then
-    [ -f "$SC_TEST_DB" ] || exit 0
     case "$2" in
         # The combined form sc_remove_build_only walks: package, provides,
         # depends. The database file stores name|depends|provides, so the last
         # two columns come out swapped.
-        *Provides*Depends*) awk -F'|' -v OFS='\t' '{print $1, $3, $2}' "$SC_TEST_DB" ;;
-        *Depends*) awk -F'|' -v OFS='\t' '{print $1, $2}' "$SC_TEST_DB" ;;
-        *) awk -F'|' '{print $1}' "$SC_TEST_DB" ;;
+        *Provides*Depends*)
+            [ -f "$SC_TEST_DB" ] &&
+                awk -F'|' -v OFS='\t' '{print $1, $3, $2}' "$SC_TEST_DB" ;;
+        *Depends*)
+            [ -f "$SC_TEST_DB" ] &&
+                awk -F'|' -v OFS='\t' '{print $1, $2}' "$SC_TEST_DB" ;;
+        # Plain name listing. Anything this run installed belongs in it too:
+        # without that the stub cannot represent "was missing, now present" to
+        # a caller that diffs the whole installed set, which is how
+        # sc_strip_prefix_managed decides what to give back.
+        *)
+            [ -f "$SC_TEST_DB" ] && awk -F'|' '{print $1}' "$SC_TEST_DB"
+            [ -f "$SC_TEST_STATE" ] && cat "$SC_TEST_STATE"
+            ;;
     esac
     exit 0
 fi
@@ -166,7 +176,20 @@ esac
 
 
 def _manager_stub(name):
-    return f'#!/bin/sh\necho "{name} $*" >> "$SC_TEST_LOG"\n'
+    """yum/dnf stub. "group info" answers with a payload, because the helper
+    asks the package manager what a group contains instead of keeping a copy of
+    the list. SC_TEST_GROUP_PAYLOAD is what it answers with; unset means the
+    query comes back empty, which stands in for an unknown group."""
+    return f"""#!/bin/sh
+if [ "$1" = group ] && [ "$2" = info ]; then
+    shift 2
+    [ "$*" = "$SC_TEST_GROUP_NAME" ] || exit 1
+    echo " Mandatory Packages:"
+    for pkg in $SC_TEST_GROUP_PAYLOAD; do echo "   $pkg"; done
+    exit 0
+fi
+echo "{name} $*" >> "$SC_TEST_LOG"
+"""
 
 
 RPM_STUBS = {"rpm": RPM_QUERY_STUB, "yum": _manager_stub("yum")}
@@ -183,8 +206,10 @@ BACKEND_STUBS = {"deb": DEB_STUBS, "rpm": RPM_STUBS, "dnf": DNF_STUBS}
 # helper shells out to.
 # sc_strip_prefix walks the prefix and reads each file's ELF magic, so it needs a
 # few more real tools than install_prereqs does.
+# comm and cat are here for sc_strip_prefix_managed, which diffs the installed
+# package set around its binutils borrow instead of naming the family.
 REAL_TOOLS = ("grep", "find", "dd", "od", "tr", "basename", "rm",
-              "mktemp", "sed", "awk", "sort")
+              "mktemp", "sed", "awk", "sort", "comm", "cat")
 
 
 @pytest.fixture
@@ -192,7 +217,8 @@ def run_prereqs():
     """Run shell against _prereqs.sh with a stubbed package manager."""
     log = os.path.abspath("prereqs.log")
 
-    def run(body, backend="deb", root=False):
+    def run(body, backend="deb", root=False,
+            group_name="Development Tools", group_payload="gcc make"):
         bindir = os.path.abspath(f"stubbin-{backend}")
         os.makedirs(bindir, exist_ok=True)
 
@@ -222,8 +248,15 @@ def run_prereqs():
             ["/bin/sh", script], capture_output=True, text=True,
             env={"PATH": bindir, "SC_TEST_LOG": log, "SC_TEST_STATE": state,
                  "SC_TEST_DB": db,
+                 "SC_TEST_GROUP_NAME": group_name,
+                 "SC_TEST_GROUP_PAYLOAD": group_payload,
                  "SC_TEST_UID": "0" if root else "1000"})
         assert proc.returncode == 0, proc.stderr
+
+        # What the helper printed, for the handful of assertions about what it
+        # reports rather than what it ran. The stub package manager's log is
+        # the return value, so this rides along on the fixture.
+        run.stdout = proc.stdout
 
         if not os.path.exists(log):
             return []
@@ -339,20 +372,36 @@ def test_group_skips_when_payload_is_present(run_prereqs):
     a group as installed even after its packages are gone, so the group itself
     cannot be asked. With every mandatory member present the install is a no-op.
     """
-    log = run_prereqs(
-        '_SC_GROUP_DEVELOPMENT_TOOLS="present-gcc present-make"\n'
-        'install_prereq_group "Development Tools"',
-        backend="rpm")
+    log = run_prereqs('install_prereq_group "Development Tools"',
+                      backend="rpm", group_payload="present-gcc present-make")
 
     assert log == []
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
 def test_unknown_group_is_installed_unconditionally(run_prereqs):
-    """No payload to probe means no confident skip, so it installs."""
+    """A group the package manager cannot describe has no payload to probe, so
+    there is no confident skip and it installs."""
     log = run_prereqs('install_prereq_group "Some Other Group"', backend="rpm")
 
     assert "yum group install -y Some Other Group" in log
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_group_payload_comes_from_the_package_manager(run_prereqs):
+    """The payload is queried, not listed here: a group whose members the
+    package manager reports as present is skipped, and the same group is
+    installed when it reports one that is missing. Nothing in _prereqs.sh names
+    a member of any group."""
+    skipped = run_prereqs('install_prereq_group "Development Tools"',
+                          backend="rpm",
+                          group_payload="present-gcc present-binutils")
+    installed = run_prereqs('install_prereq_group "Development Tools"',
+                            backend="rpm",
+                            group_payload="present-gcc missing-strace")
+
+    assert skipped == []
+    assert "yum group install -y Development Tools" in installed
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
@@ -703,19 +752,22 @@ def test_managed_strip_borrows_binutils_and_gives_it_back(run_prereqs, tmp_path)
 def test_managed_strip_gives_back_only_what_it_took(run_prereqs, tmp_path):
     """A family member that was already installed stays installed.
 
-    The stub reports "present-*" packages as installed, so naming one of the
-    binutils family that way stands in for an image that already had it.
+    The image already has libbinutils, so the before/after diff sees only
+    binutils arrive and only binutils is handed back. Which packages the family
+    has is never named -- that is the point: the diff catches whatever the
+    distribution's binutils happens to pull in.
     """
     prefix = _make_prefix(str(tmp_path / "m3"), {"bin/sta": True})
+    pre = _db(tmp_path, {"libbinutils": ""})
 
     log = run_prereqs(
-        'rm -f "$(command -v strip)"\n'
-        "_SC_STRIP_PKGS='present-libbinutils binutils'\n"
+        pre + 'rm -f "$(command -v strip)"\n'
         f"sc_strip_prefix_managed {prefix}")
 
-    removes = " ".join(line for line in log if "apt-get remove" in line)
-    assert "binutils" in removes, f"what it installed was not removed: {log}"
-    assert "present-libbinutils" not in removes, \
+    removed = set(" ".join(
+        line for line in log if "apt-get remove" in line).split())
+    assert "binutils" in removed, f"what it installed was not removed: {log}"
+    assert "libbinutils" not in removed, \
         "removed a family member the image already had"
 
 # ---------------------------------------------------------------------------
@@ -787,17 +839,68 @@ def test_build_only_still_removes_a_dev_needed_only_by_another_dev(run_prereqs, 
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
-@pytest.mark.parametrize("pkg", ["zlib1g-dev", "ccache", "graphviz", "libc6-dev"])
-def test_build_only_never_touches_the_keep_list(run_prereqs, tmp_path, pkg):
-    """Each of these is invoked or linked after the build, which no dependency
-    graph records, so only an explicit exception protects them."""
+@pytest.mark.parametrize("pkg", ["zlib1g-dev", "libc6-dev"])
+def test_build_only_never_touches_a_kept_package(run_prereqs, tmp_path, pkg):
+    """--keep is what protects a package the rules would otherwise class as
+    build-only: it is invoked or linked after the build, which no dependency
+    graph records. The tool that needs it names it in its _tools.json entry."""
     pre = _db(tmp_path, {pkg: "", "libdrop-dev": ""})
 
-    log = run_prereqs(pre + "sc_remove_build_only")
+    log = run_prereqs(pre + f'sc_remove_build_only --keep "{pkg}"')
 
     removes = " ".join(line for line in log if "apt-get remove" in line)
     assert "libdrop-dev" in removes, "nothing was removed at all"
     assert pkg not in removes
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_build_only_keep_takes_a_pattern(run_prereqs, tmp_path):
+    """A tool names a family without listing every member of it."""
+    pre = _db(tmp_path, {"libfoo1.83-dev": "", "libdrop-dev": ""})
+
+    log = run_prereqs(pre + 'sc_remove_build_only --keep "libfoo1.*"')
+
+    removes = " ".join(line for line in log if "apt-get remove" in line)
+    assert "libdrop-dev" in removes, "nothing was removed at all"
+    assert "libfoo1.83-dev" not in removes
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_build_only_drops_what_a_tool_declares_build_only(run_prereqs, tmp_path):
+    """--drop is the other half: a package the generic rules do not recognise
+    that this image has no runtime use for. It goes even though a runtime
+    package depends on it, because that dependent is itself dropped."""
+    pre = _db(tmp_path, {"toolcruft": "", "libdrop-dev": ""})
+
+    log = run_prereqs(pre + 'sc_remove_build_only --drop "toolcruft"')
+
+    removes = " ".join(line for line in log if "apt-get remove" in line)
+    assert "toolcruft" in removes
+    assert "libdrop-dev" in removes
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_build_only_keep_wins_over_drop(run_prereqs, tmp_path):
+    """A dependent's keep beats a base tool's drop when the lists are unioned
+    down a docker-depends chain, so the order the two are tested in matters."""
+    pre = _db(tmp_path, {"libboth": "", "libdrop-dev": ""})
+
+    log = run_prereqs(pre + 'sc_remove_build_only --keep "libboth" --drop "libboth"')
+
+    removes = " ".join(line for line in log if "apt-get remove" in line)
+    assert "libdrop-dev" in removes, "nothing was removed at all"
+    assert "libboth" not in removes
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_build_only_rejects_an_unknown_argument(run_prereqs, tmp_path):
+    """A typo in a generated sweep line has to fail the build, not silently
+    sweep with no exceptions at all."""
+    pre = _db(tmp_path, {"libdrop-dev": ""})
+
+    log = run_prereqs(pre + 'sc_remove_build_only --keeps "libdrop-dev" || true')
+
+    assert not any("apt-get remove" in line for line in log), log
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
@@ -822,7 +925,9 @@ def test_prune_removes_archives_headers_and_build_trees(run_prereqs, tmp_path):
         "bin/sta": True,
     })
 
-    run_prereqs(f"sc_prune_build_artifacts {prefix}")
+    run_prereqs(f'sc_prune_build_artifacts {prefix} '
+                f'--dirs "include lib/cmake lib/pkgconfig share/doc share/man '
+                f'lib/*.a"')
 
     for gone in ("lib/libOpenSTA.a", "include", "lib/cmake", "lib/pkgconfig",
                  "share/doc", "share/man"):
@@ -835,7 +940,9 @@ def test_prune_keeps_the_archives_that_are_runtime_dependencies(run_prereqs, tmp
     """The three that are linked after the build, not during it.
 
     Deleting any of them breaks the tool well after the image is built, which is
-    how the first version of this work broke bambu and ghdl.
+    how the first version of this work broke bambu and ghdl. No exception list
+    protects them any more: "lib/*.a" is one level up from lib/ghdl, so a tool
+    that declares it says exactly what it means.
     """
     prefix = _make_prefix(str(tmp_path / "pk"), {
         "lib/ghdl/libgrt.a": True,
@@ -844,12 +951,87 @@ def test_prune_keeps_the_archives_that_are_runtime_dependencies(run_prereqs, tmp
         "lib/libMLIRTestDialect.a": True,
     })
 
-    run_prereqs(f"sc_prune_build_artifacts {prefix}")
+    run_prereqs(f'sc_prune_build_artifacts {prefix} --dirs "lib/*.a"')
 
     for kept in ("lib/ghdl/libgrt.a", "lib/panda/libbambu_clang16.a",
                  "lib/Bluesim/libbskernel.a"):
         assert os.path.exists(os.path.join(prefix, kept)), f"{kept} was deleted"
     assert not os.path.exists(os.path.join(prefix, "lib/libMLIRTestDialect.a"))
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_prune_keeps_every_archive_a_tool_does_not_declare(run_prereqs, tmp_path):
+    """No blanket archive rule. A prefix whose tool lists only dev material
+    keeps its archives, which costs image size -- the direction that does not
+    break a tool at run time -- and the report below is how it gets noticed."""
+    prefix = _make_prefix(str(tmp_path / "pn"), {
+        "lib/ghdl/libgrt.a": True,
+        "bin/sta": True,
+    })
+
+    run_prereqs(f'sc_prune_build_artifacts {prefix} --dirs "include"')
+
+    assert os.path.exists(os.path.join(prefix, "lib/ghdl/libgrt.a"))
+    assert os.path.exists(os.path.join(prefix, "bin/sta"))
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_prune_reports_an_entry_that_matched_nothing(run_prereqs, tmp_path):
+    """A path upstream stopped shipping shows up in the build log rather than
+    sitting in the list doing nothing."""
+    prefix = _make_prefix(str(tmp_path / "pm"), {"bin/sta": True})
+
+    run_prereqs(f'sc_prune_build_artifacts {prefix} --dirs "lib/cmake"')
+
+    assert "drop it from docker-prune-dirs: lib/cmake" in run_prereqs.stdout
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_prune_reports_archives_it_left_behind(run_prereqs, tmp_path):
+    """The inventory a tool needs to write a correct list: every archive still
+    in the prefix, named, so an undeclared one is a grep away rather than a
+    silently larger image."""
+    prefix = _make_prefix(str(tmp_path / "pl"), {
+        "lib/ghdl/libgrt.a": True,
+        "lib/libOpenSTA.a": True,
+    })
+
+    run_prereqs(f'sc_prune_build_artifacts {prefix} --dirs "lib/*.a"')
+
+    out = run_prereqs.stdout
+    assert "static archives left in the prefix" in out
+    assert "lib/ghdl/libgrt.a" in out
+    assert "lib/libOpenSTA.a" not in out, "reported an archive it deleted"
+    assert not os.path.exists(os.path.join(prefix, "lib/libOpenSTA.a"))
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_prune_deletes_only_the_directories_the_tool_names(run_prereqs, tmp_path):
+    """No list, no deletion. The directories are the tool's declaration
+    ("docker-prune-dirs"), not a convention this file knows, so a prefix whose
+    tool names none of them keeps its include/ and share/doc."""
+    prefix = _make_prefix(str(tmp_path / "pd"), {
+        "include/sta/Sta.hh": False,
+        "share/doc/sta/index.html": False,
+        "share/man/man1/sta.1": False,
+    })
+
+    run_prereqs(f'sc_prune_build_artifacts {prefix} --dirs "share/man"')
+
+    assert not os.path.exists(os.path.join(prefix, "share/man"))
+    assert os.path.exists(os.path.join(prefix, "include/sta/Sta.hh"))
+    assert os.path.exists(os.path.join(prefix, "share/doc/sta/index.html"))
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
+def test_prune_rejects_an_unknown_argument(run_prereqs, tmp_path):
+    """A typo in a generated prune line has to fail the build rather than
+    delete the prefix's dev material by falling back to some default."""
+    prefix = _make_prefix(str(tmp_path / "pr2"), {"include/foo.h": False})
+
+    run_prereqs(f'sc_prune_build_artifacts {prefix} --dir "include" || true')
+
+    assert os.path.exists(os.path.join(prefix, "include/foo.h"))
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="only works on linux")
@@ -885,8 +1067,8 @@ def test_build_only_follows_provides(run_prereqs, tmp_path):
 def test_build_only_protects_a_kept_package_transitively(run_prereqs, tmp_path):
     """A one-level check is not enough.
 
-    zlib1g-dev is on the keep-list and depends on a build-only package,
-    which in turn depends on another. Holding back only the first is no use:
+    zlib1g-dev is kept by verilator and depends on a build-only package, which
+    in turn depends on another. Holding back only the first is no use:
     "apt-get remove" on the second takes the first, and zlib1g-dev with it.
     """
     pre = _db(tmp_path, {
@@ -896,7 +1078,7 @@ def test_build_only_protects_a_kept_package_transitively(run_prereqs, tmp_path):
         "libfree-dev": "",
     })
 
-    log = run_prereqs(pre + "sc_remove_build_only")
+    log = run_prereqs(pre + 'sc_remove_build_only --keep "zlib1g-dev"')
 
     removes = " ".join(line for line in log if "apt-get remove" in line)
     assert "libfree-dev" in removes, "nothing was removed at all"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Docker image cleanup can now be customized per tool and its dependencies, including packages to keep or remove and directories to prune.
  - Package-group contents are detected dynamically during prerequisite installation.

- **Bug Fixes**
  - Docker images are refreshed when cleanup configuration changes.
  - Prerequisite cleanup now removes only packages installed by the cleanup step.
  - Build artifact cleanup reports unmatched paths and leftover archives instead of removing them automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->