### PR TITLE
add cleanup to run

### DIFF
--- a/docs/development_guide/options.rst
+++ b/docs/development_guide/options.rst
@@ -212,6 +212,53 @@ In this example:
 
 If the preferred tool is not found or not registered, SiliconCompiler will fall back to its default discovery mechanism.
 
+Cache Cleanup Settings (The 'cache' Category)
+---------------------------------------------
+
+The data source cache in ``~/.sc/cache`` grows every time a project asks for a
+version of a PDK, library, or design that is not already there, and nothing in a
+normal run removes what an older project needed.
+At the start of every run SiliconCompiler sweeps the cache and deletes entries
+that have gone unused, along with the lock files of entries that are already
+gone.
+
+The sweep is deliberately conservative, because nothing asked for it: it runs at
+most once a week per cache directory and only collects entries that have not been
+resolved in 90 days. Orphaned lock files are collected whatever their age -- an
+empty file guarding a directory that no longer exists is residue, and a lock
+costs nothing to recreate -- except one taken in the last hour, which may belong
+to a download that has yet to create its directory.
+Deleting a cache entry costs a download, not data -- it is fetched again the next
+time something resolves it.
+The ``cache`` category tunes both numbers:
+
+.. code-block:: json
+
+    {
+        "cache": {
+            "cleanupdays": 30,
+            "cleanupinterval": 1
+        }
+    }
+
+* ``cleanupdays`` -- days an entry must go unused before it is collected
+  (default 90); orphaned lock files ignore it. Set it to ``0`` to turn the
+  automatic sweep off entirely.
+* ``cleanupinterval`` -- minimum days between two sweeps of the same cache
+  directory (default 7).
+
+Each cache directory records when it was last swept in a ``.sc_cleanup`` file,
+which is how the interval is enforced across independent runs.
+An entry's last-use time is the modification time of its ``.lock`` file, which
+every resolve stamps -- including one that hits the cache and downloads nothing.
+
+To sweep on demand, or with a different threshold, run the ``cleanup`` support
+app:
+
+.. code-block:: bash
+
+    python3 -m siliconcompiler.apps.utils.cleanup -days 30 -dryrun
+
 Record Settings (The 'record' Category)
 ---------------------------------------
 

--- a/docs/user_guide/directories.rst
+++ b/docs/user_guide/directories.rst
@@ -180,10 +180,11 @@ run. Deleting it while a run is in progress is not.
 
 Because nothing in a normal run removes the version an older project needed, the
 cache only grows. Every run therefore starts with a sweep of it: entries that
-have not been resolved in 90 days are deleted, as is any lock file whose entry is
-already gone, whatever its age. The sweep runs at most once a week per cache
-directory, records when it last ran in ``.sc_cleanup``, and never interrupts a
-run. Both the age and the
+have not been resolved in 90 days are deleted, as is any ``.lock`` or
+``.sc_lock`` file whose entry is already gone, whatever its age -- except one
+taken in the last hour, which is kept in case a resolve is holding it and has yet
+to create its directory. The sweep runs at most once a week per cache directory,
+records when it last ran in ``.sc_cleanup``, and never interrupts a run. Both the age and the
 interval are configurable, and the sweep can be switched off entirely -- see
 :ref:`User Settings <user_settings>`. To collect the cache on demand instead,
 with a threshold of your own:

--- a/docs/user_guide/directories.rst
+++ b/docs/user_guide/directories.rst
@@ -164,7 +164,8 @@ version and the hash distinguishes sources that resolve differently:
    └── ...
 
 The ``.lock`` files coordinate concurrent runs so that two processes do not
-download the same package at once; they are not data and can be ignored.
+download the same package at once; they are not data and can be ignored. Their
+modification time doubles as the entry's last-use time, stamped by every resolve.
 
 Set :keypath:`option,cachedir` to move the cache -- to shared storage on a
 cluster, for instance, so that every user and every compute node resolves
@@ -176,6 +177,20 @@ packages from one place:
 
 The cache is safe to delete; anything missing is downloaded again on the next
 run. Deleting it while a run is in progress is not.
+
+Because nothing in a normal run removes the version an older project needed, the
+cache only grows. Every run therefore starts with a sweep of it: entries that
+have not been resolved in 90 days are deleted, as is any lock file whose entry is
+already gone, whatever its age. The sweep runs at most once a week per cache
+directory, records when it last ran in ``.sc_cleanup``, and never interrupts a
+run. Both the age and the
+interval are configurable, and the sweep can be switched off entirely -- see
+:ref:`User Settings <user_settings>`. To collect the cache on demand instead,
+with a threshold of your own:
+
+.. code-block:: bash
+
+   python3 -m siliconcompiler.apps.utils.cleanup -days 30 -dryrun
 
 Settings and credentials
 ------------------------

--- a/siliconcompiler/apps/utils/cleanup.py
+++ b/siliconcompiler/apps/utils/cleanup.py
@@ -1,11 +1,10 @@
 # Copyright 2026 Silicon Compiler Authors. All Rights Reserved.
 import sys
-import shutil
-from datetime import datetime, timedelta
 from pathlib import Path
 
 from siliconcompiler import Project
 from siliconcompiler.package import RemoteResolver
+from siliconcompiler.package.cleanup import cleanup_cache, format_size, DEFAULT_DAYS
 
 
 ###########################
@@ -16,8 +15,9 @@ def main():
     Utility script to clean up old cache entries.
 
     Scans the cache directory and removes entries that haven't been
-    accessed in the specified number of days. Uses lock file modification
-    times to determine access times.
+    accessed in the specified number of days, using lock file modification
+    times to determine access times. Lock files left behind by entries that
+    are already gone are removed whatever their age.
     ------------------------------------------------------------
     """
 
@@ -27,7 +27,7 @@ def main():
             self._add_commandline_argument(
                 "days", "int",
                 "Remove cache entries older than this many days.",
-                defvalue=90)
+                defvalue=DEFAULT_DAYS)
             self._add_commandline_argument(
                 "dryrun", "bool",
                 "Show what would be deleted without actually deleting.",
@@ -71,105 +71,23 @@ def main():
     if dryrun:
         proj.logger.info("DRY RUN MODE - no files will be deleted")
 
-    # Calculate cutoff time
-    cutoff_time = datetime.now() - timedelta(days=days)
-    cutoff_timestamp = cutoff_time.timestamp()
-
-    deleted_count = 0
-    deleted_size = 0
-    error_count = 0
-
-    # Scan cache directory for subdirectories with lock files
     try:
-        for entry in cachedir.iterdir():
-            if not entry.is_dir():
-                continue
-
-            # Look for associated lock file
-            lock_file = cachedir / f"{entry.name}.lock"
-
-            if not lock_file.exists():
-                # Also try _make_readonly reference format with sc_lock
-                sc_lock_file = cachedir / f"{entry.name}.sc_lock"
-                if sc_lock_file.exists():
-                    lock_file = sc_lock_file
-                else:
-                    # No lock file found, skip this directory
-                    proj.logger.debug(f"No lock file found for {entry.name}, skipping")
-                    continue
-
-            # Get lock file modification time
-            try:
-                lock_mtime = lock_file.stat().st_mtime
-            except OSError as e:
-                proj.logger.warning(f"Could not stat lock file {lock_file}: {e}")
-                error_count += 1
-                continue
-
-            # Check if entry is old enough to delete
-            if lock_mtime < cutoff_timestamp:
-                last_accessed = datetime.fromtimestamp(lock_mtime)
-
-                # Calculate directory size
-                try:
-                    dir_size = sum(
-                        f.stat().st_size for f in entry.rglob('*') if f.is_file()
-                    )
-                except OSError as e:
-                    proj.logger.warning(f"Could not calculate size for {entry.name}: {e}")
-                    dir_size = 0
-
-                proj.logger.info(
-                    f"Removing {entry.name} "
-                    f"(last accessed: {last_accessed.isoformat()}, "
-                    f"size: {_format_size(dir_size)})"
-                )
-
-                if not dryrun:
-                    try:
-                        # Make writable first (cache entries are read-only by default)
-                        resolver = RemoteResolver("cleanup", proj, "", "")
-                        resolver._make_writable(entry)
-
-                        # Remove directory
-                        shutil.rmtree(entry)
-
-                        # Remove lock files
-                        lock_file.unlink(missing_ok=True)
-                        (cachedir / f"{entry.name}.sc_lock").unlink(missing_ok=True)
-
-                        deleted_count += 1
-                        deleted_size += dir_size
-                    except Exception as e:
-                        proj.logger.error(f"Failed to delete {entry.name}: {e}")
-                        error_count += 1
-                else:
-                    deleted_count += 1
-                    deleted_size += dir_size
-
+        stats = cleanup_cache(cachedir, days, dryrun=dryrun, logger=proj.logger)
     except Exception as e:
         proj.logger.error(f"Error scanning cache directory: {e}")
         return 1
 
     # Summary
     proj.logger.info(
-        f"Cleanup complete: {deleted_count} entries removed "
-        f"({_format_size(deleted_size)})"
+        f"Cleanup complete: {stats.entries} entries removed "
+        f"({format_size(stats.size)}), "
+        f"{stats.locks} orphaned lock files removed"
     )
 
-    if error_count > 0:
-        proj.logger.warning(f"{error_count} errors occurred during cleanup")
+    if stats.errors > 0:
+        proj.logger.warning(f"{stats.errors} errors occurred during cleanup")
 
     return 0
-
-
-def _format_size(size_bytes):
-    """Format bytes into human-readable size string."""
-    for unit in ['B', 'KB', 'MB', 'GB']:
-        if size_bytes < 1024:
-            return f"{size_bytes:.1f}{unit}"
-        size_bytes /= 1024
-    return f"{size_bytes:.1f}TB"
 
 
 #########################

--- a/siliconcompiler/apps/utils/cleanup.py
+++ b/siliconcompiler/apps/utils/cleanup.py
@@ -16,8 +16,9 @@ def main():
 
     Scans the cache directory and removes entries that haven't been
     accessed in the specified number of days, using lock file modification
-    times to determine access times. Lock files left behind by entries that
-    are already gone are removed whatever their age.
+    times to determine access times. A .lock or .sc_lock file whose entry
+    is already gone is removed whatever its age, unless it was taken in the
+    last hour, which may mean another process is holding it.
     ------------------------------------------------------------
     """
 

--- a/siliconcompiler/package/__init__.py
+++ b/siliconcompiler/package/__init__.py
@@ -684,6 +684,7 @@ class RemoteResolver(Resolver):
 
         with self.lock():
             if self.check_cache():
+                self._touch_lock()
                 return self.cache_path
 
             try:
@@ -708,10 +709,32 @@ class RemoteResolver(Resolver):
             except OSError as e:
                 self.logger.warning(f"Could not make cache read-only: {e}")
 
+            self._touch_lock()
             self.set_changed()
             return self.cache_path
 
-    def _make_readonly(self, path: Union[str, Path]) -> None:
+    def _touch_lock(self) -> None:
+        """
+        Records now as the time this cache entry was last accessed.
+
+        Nothing else in the cache carries that information: a hit returns the
+        path and reads nothing, and the cached tree is made read-only after the
+        download, so every mtime inside it stays frozen at the fetch. The lock
+        file is the one writable thing beside an entry, which is why
+        :mod:`siliconcompiler.package.cleanup` reads its mtime as the access
+        time -- and it only means that because a resolve stamps it here.
+
+        Called with the entry's lock held, so no other process is mid-download.
+        Failure is not worth interrupting a resolve over; it only costs the
+        entry its place in the access record.
+        """
+        try:
+            self.lock_file.touch()
+        except OSError as e:
+            self.logger.debug(f"Could not update access time of {self.lock_file}: {e}")
+
+    @staticmethod
+    def _make_readonly(path: Union[str, Path]) -> None:
         """
         Recursively makes all files and directories in the given path read-only.
 
@@ -743,13 +766,14 @@ class RemoteResolver(Resolver):
         elif path.is_dir():
             # Process all contents recursively
             for item in path.iterdir():
-                self._make_readonly(item)
+                RemoteResolver._make_readonly(item)
             # Remove write permissions from the directory itself
             current_mode = os.stat(path).st_mode
             new_mode = current_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
             os.chmod(path, new_mode)
 
-    def _make_writable(self, path: Union[str, Path]) -> None:
+    @staticmethod
+    def _make_writable(path: Union[str, Path]) -> None:
         """
         Recursively makes all files and directories in the given path writable.
 
@@ -771,7 +795,7 @@ class RemoteResolver(Resolver):
         elif path.is_dir():
             # Process all contents recursively
             for item in path.iterdir():
-                self._make_writable(item)
+                RemoteResolver._make_writable(item)
             # Add owner write permission to the directory itself
             current_mode = os.stat(path).st_mode
             new_mode = current_mode | stat.S_IWUSR

--- a/siliconcompiler/package/cleanup.py
+++ b/siliconcompiler/package/cleanup.py
@@ -1,0 +1,477 @@
+# Copyright 2026 Silicon Compiler Authors. All Rights Reserved.
+"""
+Collection of stale entries from the on-disk data source cache.
+
+The cache in ``~/.sc/cache`` (or ``[option,cachedir]``) only ever grows: every
+new version of a data source lands beside the old ones, and nothing removes an
+entry once the design that needed it has moved on. This module is the garbage
+collector for that directory, used both by the ``cleanup`` support app and by
+the automatic sweep at the start of every run (:func:`auto_cleanup`).
+
+Two kinds of residue are collected:
+
+* **Entries** -- a cached directory plus its lock files, judged by the lock
+  file's modification time, which :meth:`RemoteResolver._touch_lock` stamps on
+  every resolve.
+* **Orphaned lock files** -- a ``.lock`` or ``.sc_lock`` whose directory is
+  already gone. They are empty, but nothing else can ever collect them, so they
+  accumulate for the life of the install. These are collected on sight rather
+  than on the age threshold: a lock with nothing to guard is residue, and one is
+  free to recreate. Only a lock new enough to belong to a download still
+  creating its directory is spared.
+"""
+
+import contextlib
+import logging
+import shutil
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional, Union
+
+from fasteners import InterProcessLock
+
+from siliconcompiler.package import RemoteResolver
+from siliconcompiler.utils.multiprocessing import MPManager
+
+
+#: Settings category (in ``~/.sc/settings.json``) holding the automatic sweep's knobs.
+SETTINGS_CATEGORY = "cache"
+
+#: Days an entry must go unused before it is collected, by the automatic sweep and
+#: by the ``cleanup`` app alike.
+DEFAULT_DAYS = 90
+
+#: Minimum days between two automatic sweeps of the same cache directory. The
+#: automatic sweep is unasked-for housekeeping, so it stays out of the way.
+DEFAULT_INTERVAL = 7
+
+#: Records when a cache directory was last swept automatically.
+STAMP_FILE = ".sc_cleanup"
+
+#: Suffixes of the lock files that sit beside a cache entry.
+LOCK_SUFFIXES = (".lock", ".sc_lock")
+
+#: How recently a lock must have been taken to belong, plausibly, to a running
+#: process -- one still downloading behind the fallback lock, or one that has not
+#: created its cache directory yet. RemoteResolver gives up waiting on a lock
+#: after 10 minutes, so one older than this is residue.
+LOCK_ACTIVE_SECONDS = 60 * 60
+
+
+@dataclass
+class CleanupStats:
+    """
+    Tally of what a sweep removed.
+
+    Attributes:
+        entries (int): Cache entry directories removed.
+        locks (int): Orphaned lock files removed.
+        size (int): Total bytes freed by the removed entries.
+        errors (int): Failures encountered; the sweep continues past all of them.
+    """
+    entries: int = 0
+    locks: int = 0
+    size: int = 0
+    errors: int = 0
+
+
+def format_size(size_bytes: float) -> str:
+    """
+    Formats a byte count into a human-readable size string.
+
+    Args:
+        size_bytes (float): The number of bytes.
+
+    Returns:
+        str: The size with a unit suffix, e.g. ``"1.5MB"``.
+    """
+    for unit in ['B', 'KB', 'MB', 'GB']:
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f}{unit}"
+        size_bytes /= 1024
+    return f"{size_bytes:.1f}TB"
+
+
+def _entry_lock_file(cachedir: Path, name: str) -> Optional[Path]:
+    """
+    Finds the lock file guarding a cache entry.
+
+    Args:
+        cachedir (Path): The cache directory holding the entry.
+        name (str): The entry's directory name.
+
+    Returns:
+        Path: The lock file, or None if the entry has none.
+    """
+    for suffix in LOCK_SUFFIXES:
+        lock_file = cachedir / f"{name}{suffix}"
+        if lock_file.exists():
+            return lock_file
+    return None
+
+
+@contextlib.contextmanager
+def _exclusive(cachedir: Path, name: str):
+    """
+    Holds a cache entry's download lock for the duration of its removal.
+
+    A sweep can run while other SiliconCompiler processes are resolving data
+    sources, so an entry must not be deleted out from under a reader. This takes
+    the same lock :meth:`RemoteResolver.resolve` holds while downloading, without
+    waiting: a busy entry is left for the next sweep rather than blocking the run.
+
+    Args:
+        cachedir (Path): The cache directory holding the entry.
+        name (str): The entry's directory name.
+
+    Yields:
+        bool: True if the caller now holds the lock and may delete, False if
+            another process is working on the entry.
+    """
+    # The fallback lock exists only while it is held -- RemoteResolver unlinks it
+    # on release -- so a recent one means a live download on a filesystem where
+    # flock is unavailable, which is also the case the file lock below cannot
+    # detect. An old one is residue from a process that was killed.
+    fallback = cachedir / f"{name}.sc_lock"
+    try:
+        if fallback.exists() and \
+                datetime.now().timestamp() - fallback.stat().st_mtime < LOCK_ACTIVE_SECONDS:
+            yield False
+            return
+    except OSError:
+        yield False
+        return
+
+    primary = cachedir / f"{name}.lock"
+    if not primary.exists():
+        # Nothing to take a lock on, and creating one here would leave behind the
+        # very orphan this module collects.
+        yield True
+        return
+
+    lock = InterProcessLock(str(primary))
+    try:
+        acquired = lock.acquire(blocking=False)
+    except (OSError, RuntimeError):
+        # Filesystem does not support locking; resolve() falls back to the
+        # existence check already made above.
+        yield True
+        return
+
+    try:
+        yield acquired
+    finally:
+        if acquired:
+            # Bookkeeping on an open descriptor; failing at it must not abort
+            # the rest of the sweep.
+            with contextlib.suppress(Exception):
+                lock.release()
+
+
+def _remove_locks(cachedir: Path, name: str, logger: logging.Logger) -> None:
+    """
+    Deletes both of a cache entry's lock files, if they exist.
+
+    Args:
+        cachedir (Path): The cache directory holding the entry.
+        name (str): The entry's directory name.
+        logger (logging.Logger): Logger for reporting what could not be removed.
+    """
+    for suffix in LOCK_SUFFIXES:
+        lock_file = cachedir / f"{name}{suffix}"
+        try:
+            lock_file.unlink(missing_ok=True)
+        except OSError as e:
+            # The entry itself is gone, so this is now an orphan and a later
+            # sweep will try again.
+            logger.warning(f"Could not remove {lock_file.name}: {e}")
+
+
+def _directory_size(path: Path, logger: logging.Logger) -> int:
+    """
+    Sums the size of every file under a directory.
+
+    Args:
+        path (Path): The directory to measure.
+        logger (logging.Logger): Logger for reporting unreadable entries.
+
+    Returns:
+        int: The total size in bytes, 0 if the directory could not be walked.
+    """
+    try:
+        return sum(f.stat().st_size for f in path.rglob('*') if f.is_file())
+    except OSError as e:
+        logger.warning(f"Could not calculate size for {path.name}: {e}")
+        return 0
+
+
+def _collect_entries(cachedir: Path,
+                     cutoff: float,
+                     dryrun: bool,
+                     logger: logging.Logger,
+                     stats: CleanupStats) -> None:
+    """
+    Removes cache entry directories that have gone unused, and their lock files.
+
+    An entry with no lock file at all is left alone: there is no access record
+    for it, so there is nothing to judge it by.
+
+    Args:
+        cachedir (Path): The cache directory to sweep.
+        cutoff (float): Timestamp before which an entry counts as unused.
+        dryrun (bool): Report what would be removed without removing it.
+        logger (logging.Logger): Logger for progress and errors.
+        stats (CleanupStats): Tally to add this pass's removals to.
+    """
+    for entry in sorted(cachedir.iterdir()):
+        if not entry.is_dir():
+            continue
+
+        lock_file = _entry_lock_file(cachedir, entry.name)
+        if lock_file is None:
+            logger.debug(f"No lock file found for {entry.name}, skipping")
+            continue
+
+        try:
+            lock_mtime = lock_file.stat().st_mtime
+        except OSError as e:
+            logger.warning(f"Could not stat lock file {lock_file}: {e}")
+            stats.errors += 1
+            continue
+
+        if lock_mtime >= cutoff:
+            continue
+
+        size = _directory_size(entry, logger)
+        last_accessed = datetime.fromtimestamp(lock_mtime)
+        message = (f"Removing {entry.name} "
+                   f"(last accessed: {last_accessed.isoformat()}, "
+                   f"size: {format_size(size)})")
+
+        if dryrun:
+            logger.info(message)
+            stats.entries += 1
+            stats.size += size
+            continue
+
+        removed = False
+        with _exclusive(cachedir, entry.name) as exclusive:
+            if not exclusive:
+                logger.info(f"Skipping {entry.name}, it is in use by another process")
+                continue
+
+            logger.info(message)
+            try:
+                # Cache entries are made read-only after download
+                RemoteResolver._make_writable(entry)
+                shutil.rmtree(entry)
+                removed = True
+            except Exception as e:
+                logger.error(f"Failed to delete {entry.name}: {e}")
+                stats.errors += 1
+
+        if not removed:
+            continue
+
+        # Outside the lock: Windows refuses to unlink a file another handle
+        # still holds open, and the handle in question is the one just released.
+        _remove_locks(cachedir, entry.name, logger)
+
+        stats.entries += 1
+        stats.size += size
+
+
+def _collect_orphan_locks(cachedir: Path,
+                          dryrun: bool,
+                          logger: logging.Logger,
+                          stats: CleanupStats) -> None:
+    """
+    Removes lock files whose cache entry is already gone.
+
+    :func:`_collect_entries` only visits directories, so these are invisible to
+    it and nothing else in SiliconCompiler ever removes one. They are not judged
+    on age: an empty file guarding a directory that does not exist is residue
+    whenever it was written, and a lock costs nothing to recreate. The one
+    exception is a lock taken within :data:`LOCK_ACTIVE_SECONDS`, which may
+    belong to a download that has not created its directory yet.
+
+    Args:
+        cachedir (Path): The cache directory to sweep.
+        dryrun (bool): Report what would be removed without removing it.
+        logger (logging.Logger): Logger for progress and errors.
+        stats (CleanupStats): Tally to add this pass's removals to.
+    """
+    cutoff = datetime.now().timestamp() - LOCK_ACTIVE_SECONDS
+
+    for lock_file in sorted(cachedir.iterdir()):
+        suffix = lock_file.suffix
+        if suffix not in LOCK_SUFFIXES or not lock_file.is_file():
+            continue
+
+        name = lock_file.name[:-len(suffix)]
+        if (cachedir / name).exists():
+            continue
+
+        try:
+            lock_mtime = lock_file.stat().st_mtime
+        except OSError as e:
+            logger.warning(f"Could not stat lock file {lock_file}: {e}")
+            stats.errors += 1
+            continue
+
+        if lock_mtime >= cutoff:
+            logger.debug(f"{lock_file.name} was taken too recently to be residue, skipping")
+            continue
+
+        last_taken = datetime.fromtimestamp(lock_mtime)
+        message = (f"Removing orphaned lock {lock_file.name} "
+                   f"(last taken: {last_taken.isoformat()})")
+
+        if dryrun:
+            logger.info(message)
+            stats.locks += 1
+            continue
+
+        with _exclusive(cachedir, name) as exclusive:
+            if not exclusive:
+                logger.info(f"Skipping {lock_file.name}, it is in use by another process")
+                continue
+
+        # Taking the lock proved nobody else is using it; unlinking happens once
+        # it is released, so Windows still has no open handle to refuse.
+        logger.info(message)
+        try:
+            lock_file.unlink(missing_ok=True)
+            stats.locks += 1
+        except OSError as e:
+            logger.error(f"Failed to delete {lock_file.name}: {e}")
+            stats.errors += 1
+
+
+def cleanup_cache(cachedir: Union[str, Path],
+                  days: int,
+                  dryrun: bool = False,
+                  logger: Optional[logging.Logger] = None,
+                  collect_entries: bool = True) -> CleanupStats:
+    """
+    Removes cache entries and orphaned lock files that have gone unused.
+
+    An entry is collected when the modification time of its lock file -- stamped
+    on every resolve by :meth:`RemoteResolver._touch_lock` -- is older than
+    ``days``. Orphaned lock files are collected regardless of ``days``; see
+    :func:`_collect_orphan_locks`.
+
+    Deleting a cache entry is not destructive; it is re-downloaded the next time
+    it is resolved.
+
+    Args:
+        cachedir (Path): The cache directory to sweep.
+        days (int): Remove entries not accessed in this many days.
+        dryrun (bool): Report what would be removed without removing it.
+        logger (logging.Logger): Logger for progress and errors.
+        collect_entries (bool): Whether to collect entry directories at all. Pass
+            False to sweep only the orphaned lock files, which need no access
+            history to judge.
+
+    Returns:
+        CleanupStats: What was removed.
+    """
+    if logger is None:
+        logger = logging.getLogger("siliconcompiler")
+
+    cachedir = Path(cachedir)
+    stats = CleanupStats()
+
+    if collect_entries:
+        cutoff = (datetime.now() - timedelta(days=days)).timestamp()
+        _collect_entries(cachedir, cutoff, dryrun, logger, stats)
+
+    _collect_orphan_locks(cachedir, dryrun, logger, stats)
+
+    return stats
+
+
+def auto_cleanup(project) -> None:
+    """
+    Sweeps the data source cache at the start of a run.
+
+    This is the only thing that runs :func:`cleanup_cache` without being asked,
+    so it is deliberately timid. It is throttled to one sweep per cache directory
+    per ``cleanupinterval`` days (weekly by default), it only collects what has
+    gone unused for ``cleanupdays`` (90 by default), and every failure is
+    swallowed -- a housekeeping pass must never be the reason a run does not
+    start.
+
+    Both knobs live in the ``cache`` category of ``~/.sc/settings.json``, so a
+    user or a site administrator can tune or disable the sweep:
+
+    .. code-block:: json
+
+        {"cache": {"cleanupdays": 30, "cleanupinterval": 1}}
+
+    Setting ``cleanupdays`` to 0 turns the automatic sweep off entirely.
+
+    Args:
+        project (Project): The project whose cache directory should be swept.
+    """
+    logger = project.logger.getChild("cache")
+
+    try:
+        settings = MPManager.get_settings()
+        try:
+            days = int(settings.get(SETTINGS_CATEGORY, "cleanupdays",
+                                    default=DEFAULT_DAYS))
+            interval = int(settings.get(SETTINGS_CATEGORY, "cleanupinterval",
+                                        default=DEFAULT_INTERVAL))
+        except (TypeError, ValueError):
+            logger.warning("Invalid cache cleanup settings, using defaults")
+            days, interval = DEFAULT_DAYS, DEFAULT_INTERVAL
+
+        if days <= 0:
+            return
+
+        cachedir = RemoteResolver.determine_cache_dir(project)
+        if not cachedir.is_dir():
+            # Nothing has been cached yet
+            return
+
+        stamp = cachedir / STAMP_FILE
+        first_sweep = not stamp.exists()
+        if not first_sweep:
+            age = datetime.now().timestamp() - stamp.stat().st_mtime
+            if age < timedelta(days=max(interval, 0)).total_seconds():
+                return
+
+        try:
+            stamp.touch()
+        except OSError as e:
+            # A cache directory that cannot be stamped cannot be throttled, and
+            # sweeping it on every single run is worse than not sweeping it.
+            logger.debug(f"Could not record cache cleanup time in {stamp}: {e}")
+            return
+
+        if first_sweep:
+            # Until this release the lock file's mtime was the download time, not
+            # the access time, so every entry on an existing install looks as old
+            # as the day it was fetched -- including the ones in use every day.
+            # Spare them all: this run's own resolves stamp everything it still
+            # needs, and the next sweep sees real access times. The orphaned
+            # locks are collected now regardless; judging those needs no history.
+            logger.debug(f"Recording baseline cache access times in {cachedir}")
+
+        stats = cleanup_cache(cachedir, days, logger=logger,
+                              collect_entries=not first_sweep)
+
+        if stats.entries:
+            logger.info(f"Cleaned up {stats.entries} cache "
+                        f"{'entry' if stats.entries == 1 else 'entries'} "
+                        f"({format_size(stats.size)}) "
+                        f"not used in {days} days")
+        if stats.locks:
+            logger.info(f"Cleaned up {stats.locks} orphaned lock "
+                        f"{'file' if stats.locks == 1 else 'files'}")
+    except Exception as e:
+        # Housekeeping is never worth failing a run over.
+        logger.debug(f"Cache cleanup skipped: {e} ({e.__class__.__name__})")

--- a/siliconcompiler/package/cleanup.py
+++ b/siliconcompiler/package/cleanup.py
@@ -23,7 +23,11 @@ Two kinds of residue are collected:
 
 import contextlib
 import logging
+import os
 import shutil
+import stat
+
+import os.path
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -94,21 +98,26 @@ def format_size(size_bytes: float) -> str:
     return f"{size_bytes:.1f}TB"
 
 
-def _entry_lock_file(cachedir: Path, name: str) -> Optional[Path]:
+def _entry_lock_mtime(cachedir: Path, name: str) -> Optional[float]:
     """
-    Finds the lock file guarding a cache entry.
+    Reads when a cache entry's lock was last stamped.
 
     Args:
         cachedir (Path): The cache directory holding the entry.
         name (str): The entry's directory name.
 
     Returns:
-        Path: The lock file, or None if the entry has none.
+        float: The lock file's modification time, or None if the entry has no
+            lock file and so no access record at all.
+
+    Raises:
+        OSError: If a lock file is there but cannot be read.
     """
     for suffix in LOCK_SUFFIXES:
-        lock_file = cachedir / f"{name}{suffix}"
-        if lock_file.exists():
-            return lock_file
+        try:
+            return (cachedir / f"{name}{suffix}").stat().st_mtime
+        except FileNotFoundError:
+            continue
     return None
 
 
@@ -136,7 +145,7 @@ def _exclusive(cachedir: Path, name: str):
     # detect. An old one is residue from a process that was killed.
     fallback = cachedir / f"{name}.sc_lock"
     try:
-        if fallback.exists() and \
+        if os.path.exists(fallback) and \
                 datetime.now().timestamp() - fallback.stat().st_mtime < LOCK_ACTIVE_SECONDS:
             yield False
             return
@@ -145,7 +154,7 @@ def _exclusive(cachedir: Path, name: str):
         return
 
     primary = cachedir / f"{name}.lock"
-    if not primary.exists():
+    if not os.path.exists(primary):
         # Nothing to take a lock on, and creating one here would leave behind the
         # very orphan this module collects.
         yield True
@@ -226,19 +235,18 @@ def _collect_entries(cachedir: Path,
         stats (CleanupStats): Tally to add this pass's removals to.
     """
     for entry in sorted(cachedir.iterdir()):
-        if not entry.is_dir():
-            continue
-
-        lock_file = _entry_lock_file(cachedir, entry.name)
-        if lock_file is None:
-            logger.debug(f"No lock file found for {entry.name}, skipping")
+        if not os.path.isdir(entry):
             continue
 
         try:
-            lock_mtime = lock_file.stat().st_mtime
+            lock_mtime = _entry_lock_mtime(cachedir, entry.name)
         except OSError as e:
-            logger.warning(f"Could not stat lock file {lock_file}: {e}")
+            logger.warning(f"Could not stat lock file for {entry.name}: {e}")
             stats.errors += 1
+            continue
+
+        if lock_mtime is None:
+            logger.debug(f"No lock file found for {entry.name}, skipping")
             continue
 
         if lock_mtime >= cutoff:
@@ -307,20 +315,28 @@ def _collect_orphan_locks(cachedir: Path,
 
     for lock_file in sorted(cachedir.iterdir()):
         suffix = lock_file.suffix
-        if suffix not in LOCK_SUFFIXES or not lock_file.is_file():
+        if suffix not in LOCK_SUFFIXES:
             continue
 
         name = lock_file.name[:-len(suffix)]
-        if (cachedir / name).exists():
+        if os.path.exists(cachedir / name):
             continue
 
         try:
-            lock_mtime = lock_file.stat().st_mtime
+            info = lock_file.stat()
+        except FileNotFoundError:
+            # Removed under us, which is the outcome this pass wanted anyway
+            continue
         except OSError as e:
             logger.warning(f"Could not stat lock file {lock_file}: {e}")
             stats.errors += 1
             continue
 
+        if not stat.S_ISREG(info.st_mode):
+            # Something that merely ends in .lock
+            continue
+
+        lock_mtime = info.st_mtime
         if lock_mtime >= cutoff:
             logger.debug(f"{lock_file.name} was taken too recently to be residue, skipping")
             continue
@@ -360,7 +376,10 @@ def cleanup_cache(cachedir: Union[str, Path],
 
     An entry is collected when the modification time of its lock file -- stamped
     on every resolve by :meth:`RemoteResolver._touch_lock` -- is older than
-    ``days``. Orphaned lock files are collected regardless of ``days``; see
+    ``days``. A ``.lock`` or ``.sc_lock`` whose entry directory is already gone
+    is collected regardless of ``days``, unless it was stamped within the last
+    :data:`LOCK_ACTIVE_SECONDS`, which may mean a resolve is holding it and has
+    not created its directory yet. See :func:`_collect_entries` and
     :func:`_collect_orphan_locks`.
 
     Deleting a cache entry is not destructive; it is re-downloaded the next time
@@ -433,12 +452,12 @@ def auto_cleanup(project) -> None:
             return
 
         cachedir = RemoteResolver.determine_cache_dir(project)
-        if not cachedir.is_dir():
+        if not os.path.isdir(cachedir):
             # Nothing has been cached yet
             return
 
         stamp = cachedir / STAMP_FILE
-        first_sweep = not stamp.exists()
+        first_sweep = not os.path.exists(stamp)
         if not first_sweep:
             age = datetime.now().timestamp() - stamp.stat().st_mtime
             if age < timedelta(days=max(interval, 0)).total_seconds():

--- a/siliconcompiler/scheduler/scheduler.py
+++ b/siliconcompiler/scheduler/scheduler.py
@@ -27,6 +27,7 @@ from siliconcompiler import utils
 from siliconcompiler.utils.logging import SCLoggerFormatter
 from siliconcompiler.utils.multiprocessing import MPManager, get_process_context, forking
 from siliconcompiler.scheduler import send_messages, SCRuntimeError
+from siliconcompiler.package.cleanup import auto_cleanup
 from siliconcompiler.utils.paths import collectiondir, jobdir
 from siliconcompiler.utils.curation import collect
 
@@ -265,6 +266,11 @@ class Scheduler:
             # Informational check: warn if an editable install's environment is
             # out of sync with its declared pyproject.toml dependencies.
             utils.check_python_dependencies(self.__logger)
+
+            # Collect data sources that have gone unused, before this run's own
+            # resolves mark everything it needs as fresh. Throttled and very
+            # forgiving by default, and it never raises -- see auto_cleanup().
+            auto_cleanup(self.__project)
 
             # Check validity of setup
             if not self.check_manifest():

--- a/tests/apps/test_cleanup.py
+++ b/tests/apps/test_cleanup.py
@@ -265,6 +265,7 @@ def test_cleanup_removes_both_lock_types(monkeypatch, temp_cache_dir):
 
     old_time = (datetime.now() - timedelta(days=91)).timestamp()
     os.utime(lock_file, (old_time, old_time))
+    os.utime(sc_lock_file, (old_time, old_time))
 
     monkeypatch.setattr('sys.argv', [
         'cleanup',
@@ -324,29 +325,30 @@ def test_cleanup_calculates_size(monkeypatch, cache_with_old_entries, capsys):
     assert "-entry-1234567890ab" in output
 
 
-def test_format_size_bytes():
-    '''Test _format_size with bytes.'''
-    assert cleanup._format_size(512) == "512.0B"
+def test_cleanup_removes_orphaned_locks(monkeypatch, temp_cache_dir, capsys):
+    '''Test cleanup collects lock files whose cache entry is already gone.'''
+    orphan = temp_cache_dir / "gone-entry-0123456789ab.lock"
+    orphan.touch()
+    old_time = (datetime.now() - timedelta(days=91)).timestamp()
+    os.utime(orphan, (old_time, old_time))
 
+    recent_orphan = temp_cache_dir / "recent-entry-abcdef123456.lock"
+    recent_orphan.touch()
 
-def test_format_size_kilobytes():
-    '''Test _format_size with kilobytes.'''
-    assert cleanup._format_size(1024) == "1.0KB"
+    monkeypatch.setattr('sys.argv', [
+        'cleanup',
+        '-days', '90',
+        '-cachedir', str(temp_cache_dir)
+    ])
 
+    assert cleanup.main() == 0
 
-def test_format_size_megabytes():
-    '''Test _format_size with megabytes.'''
-    assert cleanup._format_size(1024 * 1024) == "1.0MB"
+    assert not orphan.exists()
+    assert recent_orphan.exists()
 
-
-def test_format_size_gigabytes():
-    '''Test _format_size with gigabytes.'''
-    assert cleanup._format_size(1024 * 1024 * 1024) == "1.0GB"
-
-
-def test_format_size_terabytes():
-    '''Test _format_size with terabytes.'''
-    assert cleanup._format_size(1024 * 1024 * 1024 * 1024) == "1.0TB"
+    output = capsys.readouterr().out
+    assert "Removing orphaned lock gone-entry-0123456789ab.lock" in output
+    assert "1 orphaned lock files removed" in output
 
 
 def test_cleanup_summary_shows_total_size(monkeypatch, cache_with_old_entries, capsys):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,20 @@ def test_wrapper(tmp_path, request, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def no_cache_cleanup(monkeypatch):
+    '''Keep the automatic cache sweep out of the test suite's way.
+
+    Scheduler.run() sweeps the data source cache at the start of every run, and
+    with SCTESTCACHE set that is the shared cache the whole suite resolves
+    against -- not somewhere a test should be planting stamp files or deleting
+    downloads. Only the scheduler's own reference to it is stubbed, so tests of
+    the sweep itself still get the real function.
+    '''
+    monkeypatch.setattr("siliconcompiler.scheduler.scheduler.auto_cleanup",
+                        lambda *args, **kwargs: None)
+
+
+@pytest.fixture(autouse=True)
 def use_cache(monkeypatch, request):
     '''Set [option, cachedir]
     '''

--- a/tests/package/test_cache_cleanup.py
+++ b/tests/package/test_cache_cleanup.py
@@ -1,0 +1,564 @@
+# Copyright 2026 Silicon Compiler Authors. All Rights Reserved.
+import logging
+import os
+import pytest
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from siliconcompiler import Project
+from siliconcompiler.package import cleanup
+from siliconcompiler.utils.multiprocessing import MPManager
+
+
+@pytest.fixture
+def cachedir():
+    '''An empty cache directory in the test's own working directory.'''
+    path = Path("cache")
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def project(project_logger):
+    proj = Project("testproj")
+    project_logger(proj)
+    proj.logger.setLevel(logging.INFO)
+    proj.option.set_cachedir("cache")
+    return proj
+
+
+def make_entry(cachedir, name, age_days=None, lock=".lock", contents=b"data"):
+    '''Create a cache entry directory and its lock file, aged by age_days.'''
+    entry = cachedir / name
+    entry.mkdir()
+    (entry / "data.txt").write_bytes(contents)
+
+    if lock is None:
+        return entry
+
+    lock_file = cachedir / f"{name}{lock}"
+    lock_file.touch()
+    if age_days is not None:
+        age_lock(lock_file, age_days)
+
+    return entry
+
+
+def age_lock(lock_file, age_days):
+    '''Backdate a lock file by age_days days.'''
+    when = (datetime.now() - timedelta(days=age_days)).timestamp()
+    os.utime(lock_file, (when, when))
+
+
+# ============================================================================
+# format_size
+# ============================================================================
+
+def test_format_size_bytes():
+    assert cleanup.format_size(512) == "512.0B"
+
+
+def test_format_size_kilobytes():
+    assert cleanup.format_size(1024) == "1.0KB"
+
+
+def test_format_size_megabytes():
+    assert cleanup.format_size(1024 * 1024) == "1.0MB"
+
+
+def test_format_size_gigabytes():
+    assert cleanup.format_size(1024 * 1024 * 1024) == "1.0GB"
+
+
+def test_format_size_terabytes():
+    assert cleanup.format_size(1024 * 1024 * 1024 * 1024) == "1.0TB"
+
+
+# ============================================================================
+# cleanup_cache: entries
+# ============================================================================
+
+def test_cleanup_cache_removes_old_entry(cachedir):
+    entry = make_entry(cachedir, "old", age_days=91)
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert not entry.exists()
+    assert not (cachedir / "old.lock").exists()
+    assert stats.entries == 1
+    assert stats.size == 4
+    assert stats.locks == 0
+    assert stats.errors == 0
+
+
+def test_cleanup_cache_keeps_recent_entry(cachedir):
+    entry = make_entry(cachedir, "recent", age_days=89)
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert entry.exists()
+    assert (cachedir / "recent.lock").exists()
+    assert stats.entries == 0
+
+
+def test_cleanup_cache_dryrun(cachedir):
+    entry = make_entry(cachedir, "old", age_days=91)
+
+    stats = cleanup.cleanup_cache(cachedir, 90, dryrun=True)
+
+    assert entry.exists()
+    assert (cachedir / "old.lock").exists()
+    assert stats.entries == 1
+    assert stats.size == 4
+
+
+def test_cleanup_cache_keeps_entry_without_lock(cachedir):
+    '''An entry with no lock file has no access record, so it is never judged.'''
+    entry = make_entry(cachedir, "nolock", lock=None)
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert entry.exists()
+    assert stats.entries == 0
+    assert stats.locks == 0
+
+
+def test_cleanup_cache_accepts_string_path(cachedir):
+    entry = make_entry(cachedir, "old", age_days=91)
+
+    assert cleanup.cleanup_cache(str(cachedir), 90).entries == 1
+    assert not entry.exists()
+
+
+def test_cleanup_cache_removes_readonly_entry(cachedir):
+    '''Cache entries are read-only on disk; the sweep still has to remove them.'''
+    entry = make_entry(cachedir, "old", age_days=91)
+    (entry / "data.txt").chmod(0o444)
+    entry.chmod(0o555)
+
+    assert cleanup.cleanup_cache(cachedir, 90).entries == 1
+    assert not entry.exists()
+
+
+def test_cleanup_cache_reports_stat_error(cachedir, caplog):
+    make_entry(cachedir, "old", age_days=91)
+
+    with patch("pathlib.Path.stat", side_effect=OSError("boom")):
+        stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert stats.entries == 0
+    assert stats.errors == 1
+    assert "Could not stat lock file" in caplog.text
+
+
+def test_cleanup_cache_reports_delete_error(cachedir, caplog):
+    make_entry(cachedir, "old", age_days=91)
+
+    with patch("shutil.rmtree", side_effect=OSError("boom")):
+        stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert stats.entries == 0
+    assert stats.errors == 1
+    assert "Failed to delete old" in caplog.text
+
+
+def test_cleanup_cache_warns_when_lock_survives_entry(cachedir, caplog):
+    '''The directory is gone either way; the lock becomes an orphan to retry.'''
+    entry = make_entry(cachedir, "old", age_days=91)
+
+    real_unlink = Path.unlink
+
+    def fail_on_lock(self, *args, **kwargs):
+        if self.suffix in cleanup.LOCK_SUFFIXES:
+            raise OSError("held open")
+        return real_unlink(self, *args, **kwargs)
+
+    with patch("pathlib.Path.unlink", fail_on_lock):
+        stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert not entry.exists()
+    assert (cachedir / "old.lock").exists()
+    assert stats.entries == 1
+    assert "Could not remove old.lock" in caplog.text
+
+
+def test_cleanup_cache_logs_access_time(cachedir, caplog):
+    make_entry(cachedir, "old", age_days=91)
+    caplog.set_level(logging.INFO)
+
+    cleanup.cleanup_cache(cachedir, 90)
+
+    assert "Removing old (last accessed:" in caplog.text
+
+
+# ============================================================================
+# cleanup_cache: orphaned lock files (nothing else can ever collect these)
+# ============================================================================
+
+def test_cleanup_cache_removes_orphaned_lock(cachedir):
+    lock_file = cachedir / "gone.lock"
+    lock_file.touch()
+    age_lock(lock_file, 91)
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert not lock_file.exists()
+    assert stats.locks == 1
+    assert stats.entries == 0
+
+
+def test_cleanup_cache_removes_orphaned_sc_lock(cachedir):
+    lock_file = cachedir / "gone.sc_lock"
+    lock_file.touch()
+    age_lock(lock_file, 91)
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert not lock_file.exists()
+    assert stats.locks == 1
+
+
+def test_cleanup_cache_removes_orphaned_lock_regardless_of_age(cachedir):
+    '''A lock guarding a directory that does not exist is residue at any age.'''
+    lock_file = cachedir / "gone.lock"
+    lock_file.touch()
+    age_lock(lock_file, 1)
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert not lock_file.exists()
+    assert stats.locks == 1
+
+
+def test_cleanup_cache_spares_brand_new_orphaned_lock(cachedir):
+    '''A lock this new may belong to a download that has yet to create its
+    directory, which is the one case an orphan is not residue.'''
+    lock_file = cachedir / "downloading.lock"
+    lock_file.touch()
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert lock_file.exists()
+    assert stats.locks == 0
+
+
+def test_cleanup_cache_collects_orphan_locks_just_past_the_window(cachedir):
+    lock_file = cachedir / "gone.lock"
+    lock_file.touch()
+    when = datetime.now().timestamp() - cleanup.LOCK_ACTIVE_SECONDS - 60
+    os.utime(lock_file, (when, when))
+
+    assert cleanup.cleanup_cache(cachedir, 90).locks == 1
+    assert not lock_file.exists()
+
+
+def test_cleanup_cache_entries_only_pass(cachedir):
+    '''collect_entries=False sweeps the locks and leaves every directory alone.'''
+    entry = make_entry(cachedir, "old", age_days=91)
+    orphan = cachedir / "gone.lock"
+    orphan.touch()
+    age_lock(orphan, 1)
+
+    stats = cleanup.cleanup_cache(cachedir, 90, collect_entries=False)
+
+    assert entry.exists()
+    assert not orphan.exists()
+    assert stats.entries == 0
+    assert stats.locks == 1
+
+
+def test_cleanup_cache_keeps_lock_with_live_entry(cachedir):
+    '''A lock guarding a directory that is still there is the first pass's business.'''
+    make_entry(cachedir, "recent", age_days=89)
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert (cachedir / "recent.lock").exists()
+    assert stats.locks == 0
+
+
+def test_cleanup_cache_orphan_lock_dryrun(cachedir):
+    lock_file = cachedir / "gone.lock"
+    lock_file.touch()
+    age_lock(lock_file, 1)
+
+    stats = cleanup.cleanup_cache(cachedir, 90, dryrun=True)
+
+    assert lock_file.exists()
+    assert stats.locks == 1
+
+
+def test_cleanup_cache_removes_entry_lock_pair_once(cachedir):
+    '''Removing an entry removes its lock, so the second pass must not double count.'''
+    make_entry(cachedir, "old", age_days=91)
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert stats.entries == 1
+    assert stats.locks == 0
+    assert not list(cachedir.iterdir())
+
+
+def test_cleanup_cache_ignores_other_files(cachedir):
+    '''Anything that is not a lock file or an entry is left alone.'''
+    stamp = cachedir / cleanup.STAMP_FILE
+    stamp.touch()
+    age_lock(stamp, 400)
+
+    other = cachedir / "notes.txt"
+    other.write_text("keep me")
+    age_lock(other, 400)
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert stamp.exists()
+    assert other.exists()
+    assert stats.entries == 0
+    assert stats.locks == 0
+
+
+def test_cleanup_cache_orphan_lock_stat_error(cachedir, caplog):
+    lock_file = cachedir / "gone.lock"
+    lock_file.touch()
+    age_lock(lock_file, 91)
+
+    real_stat = Path.stat
+
+    def fail_on_lock(self, *args, **kwargs):
+        if self.name == "gone.lock":
+            raise OSError("boom")
+        return real_stat(self, *args, **kwargs)
+
+    with patch("pathlib.Path.stat", fail_on_lock):
+        stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert stats.locks == 0
+    assert stats.errors == 1
+    assert "Could not stat lock file" in caplog.text
+
+
+def test_cleanup_cache_orphan_lock_delete_error(cachedir, caplog):
+    lock_file = cachedir / "gone.lock"
+    lock_file.touch()
+    age_lock(lock_file, 91)
+
+    with patch("pathlib.Path.unlink", side_effect=OSError("boom")):
+        stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert stats.locks == 0
+    assert stats.errors == 1
+    assert "Failed to delete gone.lock" in caplog.text
+
+
+# ============================================================================
+# cleanup_cache: an entry another process is working on must survive
+# ============================================================================
+
+def test_cleanup_cache_skips_locked_entry(cachedir, caplog):
+    entry = make_entry(cachedir, "old", age_days=91)
+    caplog.set_level(logging.INFO)
+
+    with patch("fasteners.InterProcessLock.acquire", return_value=False):
+        stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert entry.exists()
+    assert stats.entries == 0
+    assert "Skipping old, it is in use" in caplog.text
+
+
+def test_cleanup_cache_skips_entry_with_live_fallback_lock(cachedir):
+    '''A .sc_lock exists only while it is held, so a fresh one means a live download.'''
+    entry = make_entry(cachedir, "old", age_days=91)
+    (cachedir / "old.sc_lock").touch()
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert entry.exists()
+    assert stats.entries == 0
+
+
+def test_cleanup_cache_removes_entry_with_stale_fallback_lock(cachedir):
+    '''An old .sc_lock is residue from a killed process, not a live download.'''
+    entry = make_entry(cachedir, "old", age_days=91)
+    fallback = cachedir / "old.sc_lock"
+    fallback.touch()
+    age_lock(fallback, 91)
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert not entry.exists()
+    assert not fallback.exists()
+    assert stats.entries == 1
+
+
+def test_cleanup_cache_removes_entry_when_locking_unsupported(cachedir):
+    '''Where flock does not work, resolve() falls back to the .sc_lock check.'''
+    entry = make_entry(cachedir, "old", age_days=91)
+
+    with patch("fasteners.InterProcessLock.acquire", side_effect=OSError("no flock")):
+        stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert not entry.exists()
+    assert stats.entries == 1
+
+
+def test_cleanup_cache_does_not_create_lock_to_delete_entry(cachedir):
+    '''An entry guarded only by a .sc_lock must not leave a fresh .lock behind.'''
+    entry = make_entry(cachedir, "old", age_days=91, lock=".sc_lock")
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert not entry.exists()
+    assert stats.entries == 1
+    assert not list(cachedir.iterdir())
+
+
+# ============================================================================
+# auto_cleanup: the unattended sweep at the start of a local run
+# ============================================================================
+
+@pytest.fixture
+def swept_cache(cachedir):
+    '''A cache directory swept before, long enough ago to be swept again.'''
+    stamp = cachedir / cleanup.STAMP_FILE
+    stamp.touch()
+    age_lock(stamp, cleanup.DEFAULT_INTERVAL + 1)
+    return cachedir
+
+
+def test_auto_cleanup_first_call_spares_entries(project, cachedir, caplog):
+    '''An install upgrading into access tracking must not lose a cache it uses.
+
+    Before the resolver stamped lock files, their mtime was the download time,
+    so every entry looks as old as the day it was fetched. The orphaned locks
+    have no such excuse and go on the first sweep.
+    '''
+    entry = make_entry(cachedir, "old", age_days=cleanup.DEFAULT_DAYS + 1)
+    orphan = cachedir / "gone.lock"
+    orphan.touch()
+    age_lock(orphan, 1)
+    caplog.set_level(logging.INFO)
+
+    cleanup.auto_cleanup(project)
+
+    assert entry.exists()
+    assert not orphan.exists()
+    assert (cachedir / cleanup.STAMP_FILE).exists()
+    assert "Cleaned up 1 orphaned lock file" in caplog.text
+
+
+def test_auto_cleanup_sweeps_after_baseline(project, swept_cache, caplog):
+    entry = make_entry(swept_cache, "old", age_days=cleanup.DEFAULT_DAYS + 1)
+    caplog.set_level(logging.INFO)
+
+    cleanup.auto_cleanup(project)
+
+    assert not entry.exists()
+    assert "Cleaned up 1 cache entry (4.0B) not used in 90 days" in caplog.text
+
+
+def test_auto_cleanup_default_is_forgiving(project, swept_cache):
+    '''The unattended default spares anything used inside the default window.'''
+    entry = make_entry(swept_cache, "old", age_days=cleanup.DEFAULT_DAYS - 1)
+
+    cleanup.auto_cleanup(project)
+
+    assert entry.exists()
+
+
+def test_auto_cleanup_throttled_by_stamp(project, cachedir):
+    stamp = cachedir / cleanup.STAMP_FILE
+    stamp.touch()
+    entry = make_entry(cachedir, "old", age_days=cleanup.DEFAULT_DAYS + 1)
+
+    with patch.object(cleanup, "cleanup_cache") as sweep:
+        cleanup.auto_cleanup(project)
+
+    sweep.assert_not_called()
+    assert entry.exists()
+
+
+def test_auto_cleanup_refreshes_stamp(project, swept_cache):
+    cleanup.auto_cleanup(project)
+
+    age = datetime.now().timestamp() - (swept_cache / cleanup.STAMP_FILE).stat().st_mtime
+    assert age < 60
+
+
+def test_auto_cleanup_disabled_by_settings(project, swept_cache):
+    MPManager.get_settings().set(cleanup.SETTINGS_CATEGORY, "cleanupdays", 0)
+    entry = make_entry(swept_cache, "old", age_days=cleanup.DEFAULT_DAYS + 1)
+
+    cleanup.auto_cleanup(project)
+
+    assert entry.exists()
+    # Disabled means untouched: no stamp refresh either
+    assert datetime.now().timestamp() - \
+        (swept_cache / cleanup.STAMP_FILE).stat().st_mtime > 60
+
+
+def test_auto_cleanup_honors_settings_days(project, swept_cache):
+    MPManager.get_settings().set(cleanup.SETTINGS_CATEGORY, "cleanupdays", 30)
+    entry = make_entry(swept_cache, "old", age_days=31)
+    assert 31 < cleanup.DEFAULT_DAYS, "must be a threshold the default would spare"
+
+    cleanup.auto_cleanup(project)
+
+    assert not entry.exists()
+
+
+def test_auto_cleanup_honors_settings_interval(project, cachedir):
+    MPManager.get_settings().set(cleanup.SETTINGS_CATEGORY, "cleanupinterval", 30)
+    stamp = cachedir / cleanup.STAMP_FILE
+    stamp.touch()
+    age_lock(stamp, cleanup.DEFAULT_INTERVAL + 1)
+
+    with patch.object(cleanup, "cleanup_cache") as sweep:
+        cleanup.auto_cleanup(project)
+
+    sweep.assert_not_called()
+
+
+def test_auto_cleanup_bad_settings_fall_back_to_defaults(project, swept_cache, caplog):
+    MPManager.get_settings().set(cleanup.SETTINGS_CATEGORY, "cleanupdays", "soon")
+    entry = make_entry(swept_cache, "old", age_days=cleanup.DEFAULT_DAYS + 1)
+
+    cleanup.auto_cleanup(project)
+
+    assert not entry.exists()
+    assert "Invalid cache cleanup settings" in caplog.text
+
+
+def test_auto_cleanup_no_cache_dir(project):
+    '''Nothing has been cached yet, so there is nothing to sweep or to stamp.'''
+    with patch.object(cleanup, "cleanup_cache") as sweep:
+        cleanup.auto_cleanup(project)
+
+    sweep.assert_not_called()
+    assert not Path("cache").exists()
+
+
+def test_auto_cleanup_unstampable_cache_dir(project, cachedir, caplog):
+    '''A sweep that cannot be throttled is worse than no sweep at all.'''
+    project.logger.setLevel(logging.DEBUG)
+    caplog.set_level(logging.DEBUG)
+
+    with patch("pathlib.Path.touch", side_effect=OSError("read-only")), \
+            patch.object(cleanup, "cleanup_cache") as sweep:
+        cleanup.auto_cleanup(project)
+
+    sweep.assert_not_called()
+    assert "Could not record cache cleanup time" in caplog.text
+
+
+def test_auto_cleanup_never_raises(project, swept_cache, caplog):
+    '''Housekeeping must never be the reason a run does not start.'''
+    project.logger.setLevel(logging.DEBUG)
+    caplog.set_level(logging.DEBUG)
+
+    with patch.object(cleanup, "cleanup_cache", side_effect=RuntimeError("boom")):
+        cleanup.auto_cleanup(project)
+
+    assert "Cache cleanup skipped: boom (RuntimeError)" in caplog.text

--- a/tests/package/test_cache_cleanup.py
+++ b/tests/package/test_cache_cleanup.py
@@ -142,15 +142,34 @@ def test_cleanup_cache_removes_readonly_entry(cachedir):
     assert not entry.exists()
 
 
-def test_cleanup_cache_reports_stat_error(cachedir, caplog):
-    make_entry(cachedir, "old", age_days=91)
+def unreadable(*names):
+    '''Patch Path.stat to fail for these names only.
 
-    with patch("pathlib.Path.stat", side_effect=OSError("boom")):
+    Scoping it matters: pathlib implements exists() and is_file() on top of
+    Path.stat on Python 3.12 and earlier, and an OSError carrying no errno is
+    re-raised rather than read as "absent" -- so an unscoped patch fails
+    somewhere different on every interpreter in the support matrix.
+    '''
+    real_stat = Path.stat
+
+    def stat(self, *args, **kwargs):
+        if self.name in names:
+            raise OSError("boom")
+        return real_stat(self, *args, **kwargs)
+
+    return patch("pathlib.Path.stat", stat)
+
+
+def test_cleanup_cache_reports_stat_error(cachedir, caplog):
+    entry = make_entry(cachedir, "old", age_days=91)
+
+    with unreadable("old.lock", "old.sc_lock"):
         stats = cleanup.cleanup_cache(cachedir, 90)
 
+    assert entry.exists()
     assert stats.entries == 0
     assert stats.errors == 1
-    assert "Could not stat lock file" in caplog.text
+    assert "Could not stat lock file for old" in caplog.text
 
 
 def test_cleanup_cache_reports_delete_error(cachedir, caplog):
@@ -269,6 +288,38 @@ def test_cleanup_cache_entries_only_pass(cachedir):
     assert stats.locks == 1
 
 
+def test_cleanup_cache_orphan_lock_vanishes_mid_sweep(cachedir):
+    '''Another sweep, or a user, got there first.'''
+    lock_file = cachedir / "gone.lock"
+    lock_file.touch()
+    age_lock(lock_file, 91)
+
+    real_stat = Path.stat
+
+    def vanish(self, *args, **kwargs):
+        if self.name == "gone.lock":
+            real_stat(self, *args, **kwargs)
+            raise FileNotFoundError("gone")
+        return real_stat(self, *args, **kwargs)
+
+    with patch("pathlib.Path.stat", vanish):
+        stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert stats.locks == 0
+    assert stats.errors == 0
+
+
+def test_cleanup_cache_ignores_directory_named_like_a_lock(cachedir):
+    trap = cachedir / "notreally.lock"
+    trap.mkdir()
+
+    stats = cleanup.cleanup_cache(cachedir, 90)
+
+    assert trap.exists()
+    assert stats.locks == 0
+    assert stats.errors == 0
+
+
 def test_cleanup_cache_keeps_lock_with_live_entry(cachedir):
     '''A lock guarding a directory that is still there is the first pass's business.'''
     make_entry(cachedir, "recent", age_days=89)
@@ -324,16 +375,10 @@ def test_cleanup_cache_orphan_lock_stat_error(cachedir, caplog):
     lock_file.touch()
     age_lock(lock_file, 91)
 
-    real_stat = Path.stat
-
-    def fail_on_lock(self, *args, **kwargs):
-        if self.name == "gone.lock":
-            raise OSError("boom")
-        return real_stat(self, *args, **kwargs)
-
-    with patch("pathlib.Path.stat", fail_on_lock):
+    with unreadable("gone.lock"):
         stats = cleanup.cleanup_cache(cachedir, 90)
 
+    assert lock_file.exists()
     assert stats.locks == 0
     assert stats.errors == 1
     assert "Could not stat lock file" in caplog.text

--- a/tests/package/test_package.py
+++ b/tests/package/test_package.py
@@ -12,6 +12,7 @@ import zipfile
 
 import os.path
 
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1791,6 +1792,80 @@ def test_indirect_resolver_does_not_repeat_the_log():
 
     # Exactly one announcement, from the dataroot the indirection points at
     assert len([msg for msg in messages if "data at" in msg]) == 1
+
+
+# ============================================================================
+# Tests for _touch_lock(): the cache's only record of when an entry was used
+# ============================================================================
+
+def test_resolve_touches_lock_on_cache_hit():
+    """A hit stamps the lock file, which is the access time cleanup reads.
+
+    Without this the mtime never moves off the download, so an entry resolved
+    every day looks as stale as one nothing has asked for since it landed.
+    """
+    class AlwaysCached(RemoteResolver):
+        def check_cache(self):
+            return True
+
+        def resolve_remote(self):
+            raise AssertionError("cache hit must not download")
+
+    os.makedirs("cache", exist_ok=True)
+    proj = Project("testproj")
+    proj.option.set_cachedir("cache")
+
+    resolver = AlwaysCached("cached", proj, "notused", "notused")
+    resolver.lock_file.touch()
+    stale = (datetime.now() - timedelta(days=100)).timestamp()
+    os.utime(resolver.lock_file, (stale, stale))
+
+    resolver.resolve()
+
+    assert resolver.lock_file.stat().st_mtime > stale
+
+
+def test_resolve_touches_lock_after_download():
+    class AlwaysNew(RemoteResolver):
+        def check_cache(self):
+            return False
+
+        def resolve_remote(self):
+            os.makedirs(self.cache_path, exist_ok=True)
+
+    os.makedirs("cache", exist_ok=True)
+    proj = Project("testproj")
+    proj.option.set_cachedir("cache")
+
+    resolver = AlwaysNew("fresh", proj, "notused", "notused")
+
+    resolver.resolve()
+
+    assert resolver.lock_file.exists()
+    assert datetime.now().timestamp() - resolver.lock_file.stat().st_mtime < 60
+
+
+def test_touch_lock_failure_is_not_fatal(project_logger, caplog):
+    class AlwaysCached(RemoteResolver):
+        def check_cache(self):
+            return True
+
+        def resolve_remote(self):
+            raise AssertionError("cache hit must not download")
+
+    os.makedirs("cache", exist_ok=True)
+    proj = Project("testproj")
+    project_logger(proj)
+    proj.logger.setLevel(logging.DEBUG)
+    caplog.set_level(logging.DEBUG)
+    proj.option.set_cachedir("cache")
+
+    resolver = AlwaysCached("cached", proj, "notused", "notused")
+
+    with patch("pathlib.Path.touch", side_effect=OSError("read-only")):
+        assert resolver.resolve() == resolver.cache_path
+
+    assert "Could not update access time of" in caplog.text
 
 
 # ============================================================================

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -1502,6 +1502,18 @@ def test_scruntime_error_init_invalid_flow(basic_project):
         Scheduler(basic_project)
 
 
+def test_run_sweeps_data_source_cache(basic_project):
+    """The run collects stale cache entries before resolving anything itself."""
+    scheduler = Scheduler(basic_project)
+
+    with patch("siliconcompiler.scheduler.scheduler.auto_cleanup") as sweep, \
+            patch.object(scheduler, "check_manifest", return_value=False):
+        with pytest.raises(SCRuntimeError, match="check_manifest"):
+            scheduler.run()
+
+    sweep.assert_called_once_with(basic_project)
+
+
 def test_scruntime_error_run_manifest_check(basic_project):
     """Verify check_manifest failure raises SCRuntimeError during run"""
     scheduler = Scheduler(basic_project)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of unused data source cache entries and orphaned lock files.
  * Cache usage is tracked to safely identify stale entries.
  * Cleanup runs periodically without interrupting normal runs and supports configurable retention and intervals.
  * Added an on-demand cleanup command with dry-run support.
* **Documentation**
  * Added user guidance covering cache cleanup settings, behavior, and manual cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->