### PR TITLE
fix bluespec build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -313,6 +313,15 @@ linkcheck_allowed_redirects = {
     r"https://[^/]+\.readthedocs\.io/?$": r"https://[^/]+\.readthedocs\.io/en/[^/]+/$",
     # In the historical package changelog, which is a record and not edited.
     r"https://psutil\.readthedocs\.io/en/latest/$": r"https://psutil\.io/$",
+    # PNNL's GitLab bounces an unauthenticated client to its sign-in page, so
+    # soda-opt's documentation link reports as redirected on every run. The
+    # link is correct and there is no public replacement: soda-opt's own docs
+    # live on that server, and pnnl.github.io/soda-opt does not exist.
+    # Keyed on the host but constrained by the target: a project that actually
+    # moved redirects to its new location, not to the login page, and so is
+    # still reported. Left unanchored because GitLab may append a
+    # ?redirect_to= query to the sign-in URL.
+    r"https://gitlab\.pnnl\.gov/.*": r"https://gitlab\.pnnl\.gov/users/sign_in",
 }
 
 # Being rate-limited by a host is not a broken link; back off and retry rather

--- a/siliconcompiler/toolscripts/ubuntu20/install-bluespec.sh
+++ b/siliconcompiler/toolscripts/ubuntu20/install-bluespec.sh
@@ -15,57 +15,41 @@ else
     SUDO_INSTALL=""
 fi
 
-install_prereqs ghc libghc-regex-compat-dev libghc-syb-dev \
-    libghc-old-time-dev libghc-split-dev tcl-dev build-essential pkg-config \
+install_prereqs tcl-dev build-essential pkg-config \
     autoconf gperf flex bison
 
-install_prereqs git wget
+install_prereqs git curl
 
 mkdir -p deps
 cd deps
 
-# bsc 2026.01 swapped its vendored strict MVar for Hackage's
-# strict-concurrency, and src/Makefile gates the build on
-# "ghc-pkg list strict-concurrency". Nothing packages it: there is
-# no libghc-strict-concurrency-dev, and Ubuntu 24.04's cabal 3.8 can
-# no longer reach Hackage at all, its built-in root keys having
-# stopped verifying. So build it from a pinned release, with the
-# Cabal library that ghc already bundles.
+# Ubuntu's ghc is too old to build bsc. It bundles bytestring 0.10, and
+# BinData.hs calls Data.ByteString.indexMaybe, which arrived in bytestring
+# 0.11; bytestring is a GHC boot library, so its version is the compiler's and
+# cannot be raised from Hackage. Upstream INSTALL.md recommends installing GHC
+# through ghcup for exactly this reason, and calls every version older than the
+# 9.6.7 it tests untested.
 #
-# --user keeps it in $HOME: it is a dependency of the Haskell
-# compile only, and has no place in an install prefix, which is
-# often shared and which is what ships in the container image.
-hs_pkg=strict-concurrency-0.2.4.3
-hs_url=https://hackage.haskell.org/package/${hs_pkg}
-# Hackage revises .cabal files in place to widen version bounds after a
-# release, and the tarball keeps the original: 0.2.4.3 as shipped caps
-# deepseq below 1.5, which is the version Ubuntu 26.04's ghc provides,
-# and revision 1 is what lifts the cap to 1.6.
-#
-# Take that revision by number and check what arrives. A numbered
-# revision is immutable, where the unnumbered .cabal always serves
-# whatever the newest revision has become, so pinning the version alone
-# would have left the bounds this builds against free to move.
-hs_cabal_rev=1
-hs_cabal_sha256=fede3d515b877b56623ac1ccacbf17c326baded87640af0f10c27c66dd742f49
-hs_tar_sha256=02d934ec5053d3d42031798e5a3cd25547ccde5973d562f9fc943d635d9956c0
-if [ -z "$(ghc-pkg list --simple-output strict-concurrency)" ]; then
-    # Both downloads land in a file and are checked before anything reads
-    # them. Piping the archive straight into tar would unpack whatever
-    # arrived, and a short read would leave a half-extracted tree behind.
-    wget -q -O ${hs_pkg}.tar.gz ${hs_url}/${hs_pkg}.tar.gz
-    echo "${hs_tar_sha256}  ${hs_pkg}.tar.gz" | sha256sum --quiet -c -
-    tar xzf ${hs_pkg}.tar.gz
-    cd ${hs_pkg}
-    wget -q -O strict-concurrency.cabal ${hs_url}/revision/${hs_cabal_rev}.cabal
-    echo "${hs_cabal_sha256}  strict-concurrency.cabal" | sha256sum --quiet -c -
-    # Build-type: Simple, so the stock Setup is the whole build system.
-    printf 'import Distribution.Simple\nmain = defaultMain\n' > Setup.hs
-    runghc Setup.hs configure --user
-    runghc Setup.hs build
-    runghc Setup.hs install
-    cd -
+# ghcup also brings its own strict-concurrency, so the pinned Hackage build
+# that the distro-ghc path needed is gone with it.
+install_prereqs build-essential curl libffi7 libffi-dev libgmp-dev \
+    libgmp10 libncurses-dev libncurses5 libtinfo5 pkg-config
+if [ ! -z ${PREFIX} ]; then
+    export PATH="$PREFIX/bin:$PATH"
+    export GHCUP_INSTALL_BASE_PREFIX=$PREFIX
 fi
+
+export BOOTSTRAP_HASKELL_NONINTERACTIVE=yes
+
+curl -sSL https://get-ghcup.haskell.org | sh -s
+
+if [ ! -z ${PREFIX} ]; then
+    . ${PREFIX}/.ghcup/env
+else
+    . ${HOME}/.ghcup/env
+fi
+
+cabal v1-install regex-compat syb old-time split strict-concurrency
 
 git clone $(python3 ${src_path}/_tools.py --tool bluespec --field git-url) bluespec
 cd bluespec

--- a/siliconcompiler/toolscripts/ubuntu22/install-bluespec.sh
+++ b/siliconcompiler/toolscripts/ubuntu22/install-bluespec.sh
@@ -18,77 +18,38 @@ fi
 install_prereqs tcl-dev build-essential pkg-config \
     autoconf gperf flex bison
 
-install_prereqs git curl wget
+install_prereqs git curl
 
 mkdir -p deps
 cd deps
 
-if [ "$(uname -m)" = "x86_64" ]; then
-    install_prereqs ghc libghc-regex-compat-dev libghc-syb-dev \
-        libghc-old-time-dev libghc-split-dev
-
-    # bsc 2026.01 swapped its vendored strict MVar for Hackage's
-    # strict-concurrency, and src/Makefile gates the build on
-    # "ghc-pkg list strict-concurrency". Nothing packages it: there is
-    # no libghc-strict-concurrency-dev, and Ubuntu 24.04's cabal 3.8 can
-    # no longer reach Hackage at all, its built-in root keys having
-    # stopped verifying. So build it from a pinned release, with the
-    # Cabal library that ghc already bundles.
-    #
-    # --user keeps it in $HOME: it is a dependency of the Haskell
-    # compile only, and has no place in an install prefix, which is
-    # often shared and which is what ships in the container image.
-    hs_pkg=strict-concurrency-0.2.4.3
-    hs_url=https://hackage.haskell.org/package/${hs_pkg}
-    # Hackage revises .cabal files in place to widen version bounds after a
-    # release, and the tarball keeps the original: 0.2.4.3 as shipped caps
-    # deepseq below 1.5, which is the version Ubuntu 26.04's ghc provides,
-    # and revision 1 is what lifts the cap to 1.6.
-    #
-    # Take that revision by number and check what arrives. A numbered
-    # revision is immutable, where the unnumbered .cabal always serves
-    # whatever the newest revision has become, so pinning the version alone
-    # would have left the bounds this builds against free to move.
-    hs_cabal_rev=1
-    hs_cabal_sha256=fede3d515b877b56623ac1ccacbf17c326baded87640af0f10c27c66dd742f49
-    hs_tar_sha256=02d934ec5053d3d42031798e5a3cd25547ccde5973d562f9fc943d635d9956c0
-    if [ -z "$(ghc-pkg list --simple-output strict-concurrency)" ]; then
-        # Both downloads land in a file and are checked before anything reads
-        # them. Piping the archive straight into tar would unpack whatever
-        # arrived, and a short read would leave a half-extracted tree behind.
-        wget -q -O ${hs_pkg}.tar.gz ${hs_url}/${hs_pkg}.tar.gz
-        echo "${hs_tar_sha256}  ${hs_pkg}.tar.gz" | sha256sum --quiet -c -
-        tar xzf ${hs_pkg}.tar.gz
-        cd ${hs_pkg}
-        wget -q -O strict-concurrency.cabal ${hs_url}/revision/${hs_cabal_rev}.cabal
-        echo "${hs_cabal_sha256}  strict-concurrency.cabal" | sha256sum --quiet -c -
-        # Build-type: Simple, so the stock Setup is the whole build system.
-        printf 'import Distribution.Simple\nmain = defaultMain\n' > Setup.hs
-        runghc Setup.hs configure --user
-        runghc Setup.hs build
-        runghc Setup.hs install
-        cd -
-    fi
-else
-    install_prereqs build-essential curl libffi-dev libffi8 libgmp-dev \
-        libgmp10 libncurses-dev libncurses5 libtinfo5 pkg-config
-    if [ ! -z ${PREFIX} ]; then
-        export PATH="$PREFIX/bin:$PATH"
-        export GHCUP_INSTALL_BASE_PREFIX=$PREFIX
-    fi
-
-    export BOOTSTRAP_HASKELL_NONINTERACTIVE=yes
-
-    curl -sSL https://get-ghcup.haskell.org | sh -s
-
-    if [ ! -z ${PREFIX} ]; then
-        . ${PREFIX}/.ghcup/env
-    else
-        . ${HOME}/.ghcup/env
-    fi
-
-    cabal v1-install regex-compat syb old-time split strict-concurrency
+# Ubuntu's ghc is too old to build bsc. It bundles bytestring 0.10, and
+# BinData.hs calls Data.ByteString.indexMaybe, which arrived in bytestring
+# 0.11; bytestring is a GHC boot library, so its version is the compiler's and
+# cannot be raised from Hackage. Upstream INSTALL.md recommends installing GHC
+# through ghcup for exactly this reason, and calls every version older than the
+# 9.6.7 it tests untested.
+#
+# ghcup also brings its own strict-concurrency, so the pinned Hackage build
+# that the distro-ghc path needed is gone with it.
+install_prereqs build-essential curl libffi8 libffi-dev libgmp-dev \
+    libgmp10 libncurses-dev libncurses5 libtinfo5 pkg-config
+if [ ! -z ${PREFIX} ]; then
+    export PATH="$PREFIX/bin:$PATH"
+    export GHCUP_INSTALL_BASE_PREFIX=$PREFIX
 fi
+
+export BOOTSTRAP_HASKELL_NONINTERACTIVE=yes
+
+curl -sSL https://get-ghcup.haskell.org | sh -s
+
+if [ ! -z ${PREFIX} ]; then
+    . ${PREFIX}/.ghcup/env
+else
+    . ${HOME}/.ghcup/env
+fi
+
+cabal v1-install regex-compat syb old-time split strict-concurrency
 
 git clone $(python3 ${src_path}/_tools.py --tool bluespec --field git-url) bluespec
 cd bluespec


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation link validation now handles redirects to the PNNL GitLab sign-in page, reducing false-positive redirect reports.

* **Improvements**
  * Updated Bluespec installation on Ubuntu 20.04 and 22.04 to use a consistent Haskell toolchain setup.
  * Improved installation support across system architectures.
  * Simplified installation of required Haskell packages and build prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->