### PR TITLE
handle cancel in sc-server and task scheduler

### DIFF
--- a/siliconcompiler/project.py
+++ b/siliconcompiler/project.py
@@ -125,6 +125,10 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         # Init fields
         self.__cwd = os.getcwd()
 
+        # The scheduler executing this project, while one is. Only run() sets
+        # it; it is read through the _scheduler property.
+        self.__scheduler = None
+
         # Init options callbacks
         self.__init_option_callbacks()
 
@@ -639,6 +643,9 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
                 scheduler = ClientScheduler(self)
             else:
                 scheduler = Scheduler(self)
+            # Published before the run starts and dropped when it ends, so
+            # _scheduler holds a run exactly as long as there is one to reach.
+            self.__scheduler = scheduler
             scheduler.run()
         except SCRuntimeError as e:
             # Tear the dashboard down first: this restores (un-suppresses) the
@@ -672,10 +679,23 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
                     self.logger.debug(f"Failed to update dashboard at end of run: {e}")
                 finally:
                     self.__dashboard.stop()
+            self.__scheduler = None
 
         self.__reset_job_params()
 
         return self.history(self.option.get_jobname())
+
+    @property
+    def _scheduler(self) -> Optional[Scheduler]:
+        '''
+        Scheduler: The scheduler executing this project, or None when no run is
+        in progress.
+
+        Held for the duration of :meth:`run`, so that a caller on another
+        thread can reach the run in flight -- to cancel it, which is the one
+        thing :meth:`run` cannot be asked from the thread inside it.
+        '''
+        return self.__scheduler
 
     def __reset_job_params(self):
         """
@@ -752,6 +772,11 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         # Remove dashboard
         del state["_Project__dashboard"]
 
+        # Remove the running scheduler. It belongs to the run happening here,
+        # holds locks and log handlers that do not serialize, and means nothing
+        # to a node process or a copy taken for the history.
+        del state["_Project__scheduler"]
+
         # Pass along manager address
         state["__manager__"] = MPManager._get_manager_address()
 
@@ -779,6 +804,9 @@ class Project(PathSchemaBase, CommandLineSchema, BaseSchema):
         del state["__manager__"]
 
         self.__dict__ = state
+
+        # Whatever this copy is for, it is not the run that was in progress.
+        self.__scheduler = None
 
         # Reinitialize logger on restore
         self.__init_logger()

--- a/siliconcompiler/remote/server.py
+++ b/siliconcompiler/remote/server.py
@@ -27,7 +27,6 @@ from siliconcompiler.schema import __version__ as sc_schema_version
 
 from siliconcompiler.flowgraph import RuntimeFlowgraph
 from siliconcompiler.scheduler import SchedulerNode
-from siliconcompiler.scheduler import SlurmSchedulerNode
 from siliconcompiler.scheduler import TaskScheduler
 
 from siliconcompiler.remote import JobStatus, NodeStatus
@@ -337,7 +336,12 @@ class Server(ServerSchema):
         with self.sc_jobs_lock:
             self.sc_job_threads[sc_job_name] = {
                 "thread": job_proc,
-                "jobhash": job_hash
+                "jobhash": job_hash,
+                # Recorded before the thread starts, so a cancel arriving while
+                # the run is still in setup has something to name. remote_sc()
+                # does not reach its own bookkeeping until later, and a cancel
+                # that beat it there used to find nothing and do nothing.
+                "project": project
             }
             # Claim the job before the thread runs: remote_sc() fills in the
             # node list, and until it does a 'check_progress' call that beat it
@@ -390,13 +394,10 @@ class Server(ServerSchema):
         API handler for 'cancel_job' requests. Stop a job that is currently
         running.
 
-        How much can be stopped depends on where the job's nodes are running.
-        Slurm nodes are cancelable: they are named after the job hash, so the
-        server can hand them to scancel. Nodes running locally, and the
-        containers a docker cluster starts, are not -- they belong to the thread
-        executing the job, and this server has no handle on them -- so those run
-        to completion. Either way the job is marked canceled, which is what
-        'check_progress' reports and what releases a waiting client.
+        The run is stopped wherever its work is: the scheduler on the job's own
+        thread stops scheduling and ends each node, and each node releases
+        whatever it dispatched elsewhere. The job is also marked canceled, which
+        is what 'check_progress' reports and what releases a waiting client.
         '''
 
         # Process input parameters
@@ -420,18 +421,13 @@ class Server(ServerSchema):
                                           'success': False},
                                          status=404)
 
-        cluster = self.get('option', 'cluster')
-        # Off the event loop: cancelling shells out to scancel, and a request
-        # handler that blocks stalls every other client too.
-        await asyncio.to_thread(self.__cancel_job, job_name, job_hash)
+        # Off the event loop: cancelling shells out to scancel and waits on
+        # node processes ending, and a request handler that blocks stalls every
+        # other client too.
+        await asyncio.to_thread(self.__cancel_job, job_name)
 
-        if cluster == 'slurm':
-            message = f'Canceling job: {job_hash}.'
-        else:
-            message = f'Job {job_hash} marked as canceled. Nodes already ' \
-                      'running on this server will finish on their own.'
-
-        return web.json_response({'message': message, 'success': True})
+        return web.json_response({'message': f'Canceling job: {job_hash}.',
+                                  'success': True})
 
     ####################
     async def handle_delete_job(self, request):
@@ -602,14 +598,14 @@ class Server(ServerSchema):
             return job_hash
 
     ####################
-    def __cancel_job(self, job_name, job_hash):
+    def __cancel_job(self, job_name):
         '''
-        Mark a job canceled and stop what can be stopped.
+        Mark a job canceled and stop it.
 
-        Only slurm nodes can be reached, and the scheduler that submitted them
-        is what knows how: the node list this server tracks is enough for
-        SlurmSchedulerNode.cancel_nodes(). A local or docker cluster has nothing
-        to reach for, so those jobs are only marked.
+        Where the job's work is running is the job's business, not this
+        server's: the project publishes the scheduler executing it, that
+        scheduler stops scheduling and ends its nodes, and a node that
+        dispatched elsewhere cancels that as it goes.
         '''
 
         with self.sc_jobs_lock:
@@ -619,15 +615,13 @@ class Server(ServerSchema):
                 # own teardown has already run.
                 return
             self.sc_canceled_jobs.add(job_name)
-            nodes = [(info['step'], info['index'])
-                     for info in self.sc_jobs[job_name].values()
-                     if 'step' in info and not SCNodeStatus.is_done(info['status'])]
+            project = self.sc_job_threads.get(job_name, {}).get('project')
 
-        if self.get('option', 'cluster') != 'slurm':
-            return
-
-        if not SlurmSchedulerNode.cancel_nodes(job_hash, nodes) and nodes:
-            self.logger.warning(f'Unable to cancel nodes for job: {job_hash}')
+        # Read once: the run can end between the check and the call, and then
+        # there is nothing left to cancel anyway.
+        scheduler = project._scheduler if project is not None else None
+        if scheduler:
+            scheduler.cancel()
 
     ####################
     async def __shutdown(self, app):
@@ -648,12 +642,13 @@ class Server(ServerSchema):
 
         for job_name, info in running.items():
             self.logger.warning(f"Shutting down with job still running: {info['jobhash']}")
-            await asyncio.to_thread(self.__cancel_job, job_name, info['jobhash'])
+            await asyncio.to_thread(self.__cancel_job, job_name)
 
-        # Canceling reaches the slurm nodes; the ones running here are processes
-        # this server's job threads started, and only their scheduler can end
-        # them. Left alone they are joined at interpreter exit, which is what
-        # used to keep an sc-server alive long after it was told to stop.
+        # Cancelling above reaches every job this server is tracking. halt_all()
+        # is the backstop for anything else still holding a node process: they
+        # are not daemons, so left alone they are joined at interpreter exit,
+        # which is what used to keep an sc-server alive long after it was told
+        # to stop.
         await asyncio.to_thread(TaskScheduler.halt_all)
 
         # One deadline for the shutdown rather than one per job, and the joins
@@ -679,6 +674,15 @@ class Server(ServerSchema):
 
         try:
             self.__run_job(project, job_hash, sc_job_name)
+        except RuntimeError:
+            with self.sc_jobs_lock:
+                canceled = sc_job_name in self.sc_canceled_jobs
+            if not canceled:
+                raise
+            # A canceled run ends by raising, the same as any run that did not
+            # reach its exit nodes. Here that is the outcome that was asked for,
+            # not a failure to report as one.
+            self.logger.info(f'Canceled job: {job_hash}')
         finally:
             # Whatever happened, the job is over: a job left in sc_jobs is one
             # that 'check_progress' reports as running forever, and handle_

--- a/siliconcompiler/remote/server.py
+++ b/siliconcompiler/remote/server.py
@@ -130,6 +130,20 @@ class Server(ServerSchema):
                 self.sc_jobs[job_name][name]["status"] = \
                     project.get('record', 'status', step=step, index=index)
 
+            canceled = job_name in self.sc_canceled_jobs
+
+        if canceled:
+            # Canceled before this run had a scheduler to hand the request to.
+            # A job is claimed for a client the moment its thread is started,
+            # but the run does not publish the scheduler executing it until it
+            # is inside Project.run(), and a cancel arriving in between found
+            # nothing to stop. It is recorded rather than lost, and this is the
+            # first point past that window: the scheduler exists, and no node
+            # has been launched yet.
+            scheduler = project._scheduler
+            if scheduler:
+                scheduler.cancel()
+
     def __node_start(self, project, step, index):
         with self.sc_jobs_lock:
             job_name = self.sc_project_lookup[project]["name"]
@@ -606,6 +620,10 @@ class Server(ServerSchema):
         server's: the project publishes the scheduler executing it, that
         scheduler stops scheduling and ends its nodes, and a node that
         dispatched elsewhere cancels that as it goes.
+
+        A job whose thread has not reached Project.run() yet has no scheduler to
+        publish, so the request is only recorded here; the run picks it up from
+        sc_canceled_jobs at pre_run, before it launches anything.
         '''
 
         with self.sc_jobs_lock:

--- a/siliconcompiler/scheduler/docker.py
+++ b/siliconcompiler/scheduler/docker.py
@@ -196,6 +196,11 @@ class DockerSchedulerNode(SchedulerNode):
         6. Executes the `sc-node` command inside the container.
         7. Streams the container's log output to the console.
         8. Halts on error and ensures the container is stopped upon completion.
+
+        Step 8 also covers a canceled run, which reaches this node as an
+        interrupt raised out of whatever it was doing: a container is not this
+        process's to leave behind, and nothing outside knows to go looking for
+        one.
         """
         self._init_run_logger()
 

--- a/siliconcompiler/scheduler/run_node.py
+++ b/siliconcompiler/scheduler/run_node.py
@@ -134,8 +134,10 @@ def main():
         args.index,
         replay=args.replay)
     try:
-        # Execute the node's run() method.
-        node.run()
+        # This process is the node, so it is entered the way a scheduler enters
+        # one: run_process() adds the interrupt handling that lets a cancel --
+        # scancel, or the daemon stopping the container -- reach the tool.
+        node.run_process()
         error = False
     finally:
         # Archive results upon completion, regardless of success or failure.

--- a/siliconcompiler/scheduler/scheduler.py
+++ b/siliconcompiler/scheduler/scheduler.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import sys
 import tempfile
+import threading
 
 import os.path
 
@@ -112,6 +113,15 @@ class Scheduler:
         self.__org_job_name = self.__project.option.get_jobname()
         self.__logfile = None
 
+        # Cancel state. This scheduler exists for the whole run, while the
+        # TaskScheduler that actually executes nodes is not built until setup
+        # has finished, so a cancel arriving during setup has to be held here
+        # and handed on. Guarded because it arrives on another thread -- a
+        # server answering a request -- while this one is mid-run.
+        self.__cancel_lock = threading.Lock()
+        self.__canceled = False
+        self.__task_scheduler: Optional[TaskScheduler] = None
+
         # Create tasks
         for step, index in self.__flow.get_nodes():
             node_cls = SchedulerNode
@@ -182,6 +192,24 @@ class Scheduler:
         # instead of resolving a copy again.
         return self.__project._check_manifest()
 
+    def cancel(self) -> None:
+        """Stops this run.
+
+        Reached through :attr:`Project._scheduler`. Setup is a long stretch of the run
+        -- configuring nodes, checking tool versions, collecting sources -- and
+        the TaskScheduler is not built until the end of it, so a cancel landing
+        in that window is remembered and applied to that scheduler as soon as
+        there is one. Called from a thread other than the one running.
+        """
+        with self.__cancel_lock:
+            self.__canceled = True
+            task_scheduler = self.__task_scheduler
+
+        # Outside the lock: cancelling ends node processes, and run_core() takes
+        # the same lock to hand its scheduler over.
+        if task_scheduler:
+            task_scheduler.cancel()
+
     def run_core(self) -> None:
         """
         Executes the core task scheduling loop.
@@ -192,6 +220,15 @@ class Scheduler:
         self.__record.record_python_packages()
 
         task_scheduler = TaskScheduler(self.__project, self.__tasks)
+
+        with self.__cancel_lock:
+            self.__task_scheduler = task_scheduler
+            canceled = self.__canceled
+        if canceled:
+            # Canceled while this run was still in setup. The scheduler it was
+            # meant for exists now, so it is where the request lands.
+            task_scheduler.cancel()
+
         task_scheduler.run(self.__joblog_handler)
         task_scheduler.check()
 

--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -406,12 +406,16 @@ class SchedulerNode:
     def cancel(self) -> None:
         """Releases whatever this node is holding outside its own process.
 
-        Called by the scheduler that launched the node, from the scheduler's
-        process, when a run is canceled or interrupted -- never by the node
-        itself, which is about to be ended. Ending that process is the
-        scheduler's half and needs no help from here; this is for work the node
-        placed somewhere the process teardown cannot reach, such as a job handed
-        to a workload manager.
+        For work the node placed somewhere its process teardown cannot reach,
+        such as a job handed to a workload manager. Ending the process itself is
+        the scheduler's half and needs no help from here.
+
+        Called twice, from either side of the signal that ends the node: by the
+        scheduler that launched it, before signalling, so the work stops while
+        its waiter is still there to notice; and by the node itself in
+        :meth:`run_process`, once the interrupt has unwound whatever the first
+        call was too early to see. It must therefore be safe to repeat, and safe
+        to call for work that was never dispatched.
 
         A node that runs on this machine has nothing of the sort, so this does
         nothing. Nodes that dispatch elsewhere override it.
@@ -889,7 +893,19 @@ class SchedulerNode:
                 # Only an interrupt outside execute() reaches here -- that one
                 # is handled where the tool is, which is the only place that
                 # can take the tool down with it.
-                self.halt(errmsg=f"Execution interrupted for {self.__step}/{self.__index}")
+                try:
+                    # Cancel again, from in here. The scheduler cancels before
+                    # it signals, which can land while this node was still
+                    # handing its work over -- a cancel that finds nothing, and
+                    # a submission that completes just after it. By now that
+                    # submission has unwound, so whatever it managed to create
+                    # is there to be found. Cancelling twice costs nothing.
+                    self.cancel()
+                finally:
+                    # In a finally: a cancel that fails is not a reason to leave
+                    # the node unrecorded, and halt() is what ends this process.
+                    self.halt(
+                        errmsg=f"Execution interrupted for {self.__step}/{self.__index}")
 
     def run(self) -> None:
         """

--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -3,8 +3,10 @@ import glob
 import logging
 import os
 import shutil
+import signal
 import sys
 import tarfile
+import threading
 import time
 
 import os.path
@@ -400,6 +402,21 @@ class SchedulerNode:
             # Catch everything to avoid generating additional errors during error handling
             pass
         sys.exit(1)
+
+    def cancel(self) -> None:
+        """Releases whatever this node is holding outside its own process.
+
+        Called by the scheduler that launched the node, from the scheduler's
+        process, when a run is canceled or interrupted -- never by the node
+        itself, which is about to be ended. Ending that process is the
+        scheduler's half and needs no help from here; this is for work the node
+        placed somewhere the process teardown cannot reach, such as a job handed
+        to a workload manager.
+
+        A node that runs on this machine has nothing of the sort, so this does
+        nothing. Nodes that dispatch elsewhere override it.
+        """
+        pass
 
     def setup(self) -> bool:
         """
@@ -811,6 +828,69 @@ class SchedulerNode:
         walltime = self.__metrics.get("tasktime", step=self.__step, index=self.__index)
         self.logger.info(f"Finished task in {walltime:.2f}s")
 
+    @staticmethod
+    @contextlib.contextmanager
+    def _interruptible():
+        """Turns the terminate of a canceled run into an interrupt this node can handle.
+
+        SIGTERM's default action ends the process where it stands. That leaves
+        the tool this node started running with nobody to reap it -- a cancel
+        whose whole point was to give the machine back -- and skips the cleanup
+        the node does on its way out. Python's own interrupt is what every one
+        of those paths is already written against: Task.run_task() terminates
+        the tool's process tree on it, and run_process() below halts the node
+        and records what it got to. So raise that rather than growing a second
+        shutdown path beside it.
+
+        The previous handler is restored on the way out, since a node is not
+        always a process of its own -- a replay runs one in the caller's -- and
+        a handler left installed there would outlive the node that wanted it.
+        Only the main thread may install one at all, which a node process's is;
+        anywhere else this yields without changing anything.
+        """
+        def interrupt(signum, frame):
+            raise KeyboardInterrupt
+
+        if threading.current_thread() is not threading.main_thread():
+            yield
+            return
+
+        try:
+            previous = signal.signal(signal.SIGTERM, interrupt)
+        except ValueError:
+            # Not the main thread of the process after all (or a platform
+            # without SIGTERM). Nothing to install, and nothing to restore.
+            yield
+            return
+
+        try:
+            yield
+        finally:
+            signal.signal(signal.SIGTERM, previous)
+
+    def run_process(self) -> None:
+        """Runs this node as the whole of a process of its own.
+
+        The entry point a scheduler hands a node's process, rather than
+        something :meth:`run` does for itself. run() is made to be replaced --
+        DockerSchedulerNode and SlurmSchedulerNode both override it outright,
+        and so can anything outside this package -- and setup that lives inside
+        it is setup every one of those has to remember to reproduce.
+
+        What it adds is the interrupt handling: a canceled run ends this node
+        with SIGTERM, which arrives here as an interrupt, and the node is halted
+        and recorded like any other failure rather than the process simply
+        vanishing with its tool still running.
+        """
+        with SchedulerNode._interruptible():
+            try:
+                self.run()
+            except KeyboardInterrupt:
+                # Only an interrupt outside execute() reaches here -- that one
+                # is handled where the tool is, which is the only place that
+                # can take the tool down with it.
+                self.halt(errmsg=f"Execution interrupted for {self.__step}/{self.__index}")
+
     def run(self) -> None:
         """
         Executes the full lifecycle for this node.
@@ -826,7 +906,9 @@ class SchedulerNode:
 
         Note: Since this method may run in its own process with a separate
         address space, any changes made to the schema are communicated through
-        reading/writing the project manifest to the filesystem.
+        reading/writing the project manifest to the filesystem. A node given a
+        process of its own is entered through :meth:`run_process`, which is
+        where anything that process needs as a whole belongs.
         """
 
         # Setup logger

--- a/siliconcompiler/scheduler/slurm.py
+++ b/siliconcompiler/scheduler/slurm.py
@@ -181,8 +181,8 @@ class SlurmSchedulerNode(SchedulerNode):
 
         Returns:
             list of tuple: The nodes scancel accepted. Empty if scancel is not
-                available on this machine, and a node whose scancel did not
-                return in time is left out.
+                available on this machine, and a node whose scancel failed or
+                did not return in time is left out.
         """
 
         if shutil.which('scancel') is None:
@@ -192,13 +192,18 @@ class SlurmSchedulerNode(SchedulerNode):
         for step, index in nodes:
             job_name = SlurmSchedulerNode.get_job_name(jobhash, step, index)
             try:
-                subprocess.run(['scancel', '--name', job_name],
-                               stdout=subprocess.DEVNULL,
-                               stderr=subprocess.DEVNULL,
-                               timeout=SlurmSchedulerNode._CANCEL_TIMEOUT)
+                result = subprocess.run(['scancel', '--name', job_name],
+                                        stdout=subprocess.DEVNULL,
+                                        stderr=subprocess.DEVNULL,
+                                        timeout=SlurmSchedulerNode._CANCEL_TIMEOUT)
             except subprocess.TimeoutExpired:
                 # Nothing is known about this node's job now, so do not claim it
                 # was canceled -- but the remaining nodes still deserve a try.
+                continue
+            if result.returncode != 0:
+                # scancel said no. Reporting that as canceled would have the
+                # caller end this node's local waiter for a job that is still
+                # running on the cluster, with nothing left watching it.
                 continue
             canceled.append((step, index))
 

--- a/siliconcompiler/scheduler/slurm.py
+++ b/siliconcompiler/scheduler/slurm.py
@@ -204,6 +204,23 @@ class SlurmSchedulerNode(SchedulerNode):
 
         return canceled
 
+    def cancel(self) -> None:
+        """Cancels the slurm job submitted for this node.
+
+        The node's process is about to be ended, but the work is not in it: the
+        task is on a compute node, and the process being ended is only waiting
+        for it. Killing the waiter is also what makes the job unreachable, so
+        this runs first.
+
+        A node whose job has already finished has nothing left to cancel, which
+        scancel reports as success.
+        """
+        if not SlurmSchedulerNode.cancel_nodes(self.jobhash, [(self.step, self.index)]):
+            # Either scancel is not on this machine or it did not come back in
+            # time. Both leave a job running that was asked to stop, and neither
+            # is something this process can do anything further about.
+            self.logger.warning(f"Unable to cancel slurm job for {self.step}/{self.index}")
+
     def mark_copy(self) -> bool:
         sharedprefix: List[str] = MPManager.get_settings().get(
             SlurmSchedulerNode.__OPTIONS, "sharedpaths", default=[])

--- a/siliconcompiler/scheduler/taskscheduler.py
+++ b/siliconcompiler/scheduler/taskscheduler.py
@@ -41,8 +41,10 @@ class TaskScheduler:
     """
 
     # How long __halt_running_nodes() waits for a node to go away, first after
-    # terminate() and then after kill().
-    __HALT_TIMEOUT = 5.0
+    # terminate() and then after kill(). A node handles the terminate itself --
+    # it tears down the tool's process tree and records what it got to -- so the
+    # wait has to cover that work, not just the signal.
+    __HALT_TIMEOUT = 10.0
 
     # Every scheduler built in this process, so a caller that does not hold one
     # -- a server shutting down while a job is in flight -- can still end the
@@ -125,6 +127,11 @@ class TaskScheduler:
         # while this run's own cleanup is ending the same processes.
         self.__halt_lock = threading.Lock()
 
+        # Set once this run has been told to stop. Read by the run loop, which
+        # runs on this thread while cancel() arrives on another, so an Event
+        # rather than a plain bool.
+        self.__canceled = threading.Event()
+
         self.__create_nodes(tasks)
 
         with TaskScheduler.__instances_lock:
@@ -170,7 +177,10 @@ class TaskScheduler:
                 threads = self.__max_threads
             task["threads"] = max(1, min(threads, self.__max_threads))
 
-            task["proc"] = get_process_context().Process(target=task["node"].run)
+            # run_process(), not run(): the interrupt handling a node needs in
+            # order to be cancelable belongs to having a process, and run() is
+            # overridden by every scheduler that dispatches elsewhere.
+            task["proc"] = get_process_context().Process(target=task["node"].run_process)
             self.__nodes[(step, index)] = task
 
         # Create ordered list of nodes
@@ -279,6 +289,20 @@ class TaskScheduler:
         self.__startTimes = {None: time.time()}
 
         while len(self.get_nodes_waiting_to_run()) > 0 or len(self.get_running_nodes()) > 0:
+            if self.__canceled.is_set():
+                # Checked before anything is launched: ending the running nodes
+                # is only half of a cancel, and without this the loop would
+                # start the next ready ones straight over the top of it.
+                #
+                # cancel() has already ended those processes -- which is what
+                # released the join at the bottom of this loop -- so the work
+                # left here is to reap them: __process_completed_nodes() records
+                # each one's status and fires post_node before the loop stops.
+                self.__halt_running_nodes()
+                if self.__process_completed_nodes() and self.__dashboard:
+                    self.__dashboard.update_manifest(payload={"starttimes": self.__startTimes})
+                break
+
             changed = self.__process_completed_nodes()
             changed |= self.__launch_nodes()
 
@@ -326,6 +350,36 @@ class TaskScheduler:
         """
         return self.__halt_running_nodes()
 
+    def cancel(self) -> bool:
+        """Stops this run: nothing further is launched, and what is running ends.
+
+        This is the pair :meth:`halt` was missing. Halting ends the node
+        processes, but the run loop it left behind simply launches the next
+        ready nodes; the flag is what tells the loop the run is over. Setting it
+        first means the loop, woken by the very processes it was joining on
+        going away, sees a canceled run rather than an idle machine to fill.
+
+        Nodes that were running are recorded as errors -- they were killed
+        partway and did not produce their outputs -- and nodes that never
+        started stay pending.
+
+        Reached through :attr:`Project._scheduler`, which is what a caller
+        holding the project but not the run it started has to work with.
+
+        Returns:
+            bool: True if a node process was still running.
+        """
+        self.__canceled.set()
+        return self.__halt_running_nodes()
+
+    def is_canceled(self) -> bool:
+        """Reports whether this run has been told to stop.
+
+        Returns:
+            bool: True if the run was canceled.
+        """
+        return self.__canceled.is_set()
+
     def __halt_running_nodes(self) -> bool:
         """Ends any node process still running, so teardown cannot block on one.
 
@@ -344,10 +398,29 @@ class TaskScheduler:
         # on waitpid, and one of them loses with ChildProcessError. Whoever
         # arrives second finds nothing running and returns.
         with self.__halt_lock:
-            running = [info["proc"] for info in self.__nodes.values()
+            running = [info for info in self.__nodes.values()
                        if info.get("proc") is not None and info["proc"].is_alive()]
             if not running:
                 return False
+
+            # Each node's own half first. A node that dispatched its work
+            # elsewhere is not holding it in the process about to be killed --
+            # it is only waiting on it -- and killing the waiter is exactly what
+            # puts that work out of reach.
+            for info in running:
+                node = info.get("node")
+                if node is None:
+                    continue
+                try:
+                    node.cancel()
+                except Exception as e:  # noqa: BLE001
+                    # cancel() is overridden per scheduler and can shell out to
+                    # a cluster controller. Whatever it does wrong, the
+                    # processes below still have to be ended: leaving them
+                    # running is the deadlock this method exists to prevent.
+                    self.__logger.warning(f'Failed to cancel {info["name"]}: {e}')
+
+            running = [info["proc"] for info in running]
 
             for proc in running:
                 proc.terminate()
@@ -554,6 +627,13 @@ class TaskScheduler:
         Returns:
             bool: True if any new node was launched, False otherwise.
         """
+        if self.__canceled.is_set():
+            # The run loop breaks on the same flag, but only at the top of the
+            # next pass: a cancel arriving part way through one -- from another
+            # thread while nodes were being reaped, or from a post_node callback
+            # -- would otherwise get one full round of launches in first.
+            return False
+
         changed = False
 
         running_nodes = self.get_running_nodes()
@@ -637,8 +717,15 @@ class TaskScheduler:
         flowgraph have been successfully completed.
 
         Raises:
-            SCRuntimeError: If any final steps in the flow were not reached.
+            SCRuntimeError: If the run was canceled, or if any final steps in
+                the flow were not reached.
         """
+        if self.__canceled.is_set():
+            # Said plainly rather than through the unreached exit steps below:
+            # those are the symptom, and reporting a canceled run as a broken
+            # flow sends the reader looking for a failure that never happened.
+            raise SCRuntimeError("run was canceled before completing")
+
         exit_steps = set([step for step, _ in self.__runtime_flow.get_exit_nodes()])
         completed_steps = set([step for step, _ in
                                self.__runtime_flow.get_completed_nodes(record=self.__record)])

--- a/siliconcompiler/scheduler/taskscheduler.py
+++ b/siliconcompiler/scheduler/taskscheduler.py
@@ -1,6 +1,7 @@
 import logging
 import multiprocessing
 import pickle
+import psutil
 import sys
 import threading
 import time
@@ -401,6 +402,13 @@ class TaskScheduler:
         completion leaves __run_loop() having joined every process, so this is a
         no-op and the run's results are untouched.
 
+        A node is asked to end itself first, since only the node can do it
+        tidily -- stop its container rather than just the client talking to it,
+        record what it got to. What that leaves behind is then taken care of
+        here, because asking is not something this can depend on: the fallback
+        for a node that does not go is SIGKILL, which no node can handle, and
+        a node's tool is not its own child to reap once it has been killed.
+
         The joins are bounded on purpose. An unbounded join would trade the
         deadlock this avoids for another one, against a node that ignores
         SIGTERM.
@@ -436,6 +444,14 @@ class TaskScheduler:
 
             running = [info["proc"] for info in running]
 
+            # Taken while the nodes are still alive to be asked. A node's tool
+            # is its child, not this process's, so once the node is gone the
+            # tool is reparented and nothing ties it to this run any more --
+            # there would be nothing left to look it up by.
+            leftovers = []
+            for proc in running:
+                leftovers.extend(TaskScheduler.__descendants_of(proc))
+
             for proc in running:
                 proc.terminate()
 
@@ -445,7 +461,56 @@ class TaskScheduler:
                     proc.kill()
                     proc.join(timeout=TaskScheduler.__HALT_TIMEOUT)
 
+            # Whatever the nodes did not take with them. A node that handled the
+            # terminate has already ended its tool, and these calls find nothing;
+            # one that was killed, ignored the signal, or never got the chance --
+            # a platform where the signal does not arrive as an interrupt at all
+            # -- leaves its tool holding the cores this halt was called to give
+            # back.
+            TaskScheduler.__end_processes(leftovers)
+
             return True
+
+    @staticmethod
+    def __descendants_of(proc) -> List[psutil.Process]:
+        """Everything a node process has started, at the moment of asking.
+
+        Args:
+            proc: The node's process.
+
+        Returns:
+            list of psutil.Process: Its descendants, empty if they cannot be
+                looked up. psutil identifies each by pid *and* creation time, so
+                a pid reused after this snapshot is not mistaken for the process
+                that held it.
+        """
+        try:
+            return psutil.Process(proc.pid).children(recursive=True)
+        except (psutil.Error, AttributeError, TypeError, ValueError, OSError):
+            # Gone already, or never a real process to begin with (a stand-in in
+            # a test). Either way there is nothing here to end.
+            return []
+
+    @staticmethod
+    def __end_processes(procs: List[psutil.Process]) -> None:
+        """Ends processes left over from a node, politely and then not.
+
+        Args:
+            procs (list of psutil.Process): The processes to end. Ones that have
+                already exited are skipped.
+        """
+        for proc in procs:
+            try:
+                proc.terminate()
+            except psutil.Error:
+                pass
+
+        _, alive = psutil.wait_procs(procs, timeout=TaskScheduler.__HALT_TIMEOUT)
+        for proc in alive:
+            try:
+                proc.kill()
+            except psutil.Error:
+                pass
 
     def get_nodes(self) -> List[Tuple[str, str]]:
         """Gets an ordered list of all nodes managed by this scheduler.

--- a/siliconcompiler/scheduler/taskscheduler.py
+++ b/siliconcompiler/scheduler/taskscheduler.py
@@ -132,6 +132,14 @@ class TaskScheduler:
         # rather than a plain bool.
         self.__canceled = threading.Event()
 
+        # Serializes setting that flag against starting a node. Without it a
+        # cancel can land between the check and proc.start(), and then halt's
+        # scan for live processes runs just before the process it was meant to
+        # end exists -- leaving a node running, and the loop about to join it.
+        # Reentrant because a pre_node callback runs inside a launch and is
+        # entitled to cancel the run it is being called from.
+        self.__launch_lock = threading.RLock()
+
         self.__create_nodes(tasks)
 
         with TaskScheduler.__instances_lock:
@@ -369,7 +377,13 @@ class TaskScheduler:
         Returns:
             bool: True if a node process was still running.
         """
-        self.__canceled.set()
+        with self.__launch_lock:
+            self.__canceled.set()
+
+        # Outside the lock: whoever holds it is mid-launch, and the process they
+        # are starting is one this halt has to see. Setting the flag first is
+        # what guarantees it does -- a launch either completes before the flag
+        # is set, and is found running here, or sees the flag and never starts.
         return self.__halt_running_nodes()
 
     def is_canceled(self) -> bool:
@@ -631,7 +645,9 @@ class TaskScheduler:
             # The run loop breaks on the same flag, but only at the top of the
             # next pass: a cancel arriving part way through one -- from another
             # thread while nodes were being reaped, or from a post_node callback
-            # -- would otherwise get one full round of launches in first.
+            # -- would otherwise get one full round of launches in first. This
+            # is the cheap check; __try_start_node() is the one that cannot be
+            # raced.
             return False
 
         changed = False
@@ -695,19 +711,35 @@ class TaskScheduler:
                 return changed
             # ready_nodes preserves execution order, so breakpoint_nodes[0] is
             # the earliest pending breakpoint.
-            node = breakpoint_nodes[0]
-            if self.__allow_start(node):
-                self.__start_node(node)
-                changed = True
+            changed |= self.__try_start_node(breakpoint_nodes[0])
             return changed
 
         # Normal scheduling: launch as many ready nodes as resources allow.
         for node in ready_nodes:
-            if self.__allow_start(node):
-                self.__start_node(node)
-                changed = True
+            changed |= self.__try_start_node(node)
 
         return changed
+
+    def __try_start_node(self, node: Tuple[str, str]) -> bool:
+        """
+        Private helper to start a node unless the run has been canceled.
+
+        The cancel check and the launch are one step on purpose: apart, a cancel
+        landing between them starts a node that nothing is left to stop.
+
+        Args:
+            node (tuple): The (step, index) of the node to start.
+
+        Returns:
+            bool: True if the node was started.
+        """
+        with self.__launch_lock:
+            if self.__canceled.is_set():
+                return False
+            if not self.__allow_start(node):
+                return False
+            self.__start_node(node)
+            return True
 
     def check(self) -> None:
         """

--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -2037,6 +2037,40 @@ def test_run_start_publishes_node_statuses():
     assert server.sc_jobs[job_hash]['stepone0']['status'] == NodeStatus.SUCCESS
 
 
+def test_run_start_applies_a_cancel_that_beat_the_run():
+    '''A cancel can land after the job is claimed but before its thread reaches
+       Project.run(), where there is no scheduler yet to hand it to.
+
+    It is recorded rather than lost, and pre_run is the first point past that
+    window: the scheduler exists and no node has been launched.
+    '''
+    server = _make_server()
+    job_hash = 'd' * 32
+    project, _ = _callback_project(server, job_hash)
+
+    scheduler = Mock()
+    project._Project__scheduler = scheduler
+    server.sc_canceled_jobs.add(job_hash)
+
+    server._Server__run_start(project)
+
+    scheduler.cancel.assert_called_once_with()
+
+
+def test_run_start_leaves_an_uncanceled_run_alone():
+    '''The common path does not go looking for a scheduler to stop'''
+    server = _make_server()
+    job_hash = 'e' * 32
+    project, _ = _callback_project(server, job_hash)
+
+    scheduler = Mock()
+    project._Project__scheduler = scheduler
+
+    server._Server__run_start(project)
+
+    assert not scheduler.cancel.called
+
+
 def test_run_start_ignores_untracked_nodes():
     '''A node the job is not reporting on is skipped rather than invented'''
     server = _make_server()

--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -1202,13 +1202,19 @@ def _make_server(cluster='local', auth=False):
     return server
 
 
-def _register_job(server, job_hash, nodes=None, username=None):
+def _register_job(server, job_hash, nodes=None, username=None, project=None):
     '''Register a running job the way remote_sc() does.'''
     if nodes is None:
         nodes = {'stepone0': {'status': NodeStatus.RUNNING,
                               'step': 'stepone', 'index': '0'}}
     job_name = server.job_name(username, job_hash)
     server.sc_jobs[job_name] = {None: {'status': NodeStatus.SUCCESS}, **nodes}
+    if project is not None:
+        # What handle_remote_run() records alongside the thread, and what a
+        # cancel needs in order to name the run it is stopping.
+        server.sc_job_threads[job_name] = {'thread': Mock(),
+                                           'jobhash': job_hash,
+                                           'project': project}
     return job_name
 
 
@@ -1420,24 +1426,19 @@ async def test_handle_cancel_job_not_running():
 
 
 @pytest.mark.asyncio
-async def test_handle_cancel_job_local():
-    '''Canceling a locally-running job marks it, and says what that means'''
+async def test_handle_cancel_job_without_a_project():
+    '''A job registered before its project was recorded is still marked'''
     server = _make_server(cluster='local')
-    job_hash = 'a' * 32
+    job_hash = 'c' * 32
     job_name = _register_job(server, job_hash)
 
     mock_request = Mock()
     mock_request.json = AsyncMock(return_value={'job_hash': job_hash})
 
-    with patch('siliconcompiler.remote.server.SlurmSchedulerNode.cancel_nodes') as mock_cancel:
-        response = await server.handle_cancel_job(mock_request)
+    response = await server.handle_cancel_job(mock_request)
 
     assert response.status == 200
-    body = json.loads(response.body)
-    assert body['success'] is True
-    assert 'finish on their own' in body['message']
     assert server.sc_canceled_jobs == {job_name}
-    assert not mock_cancel.called
 
 
 @pytest.mark.asyncio
@@ -1496,46 +1497,31 @@ async def test_handle_cancel_job_invalid_params(params):
 
 
 @pytest.mark.asyncio
-async def test_handle_cancel_job_slurm():
-    '''Slurm nodes are handed to scancel by name; finished ones are left alone'''
-    server = _make_server(cluster='slurm')
+@pytest.mark.parametrize('cluster', ['local', 'slurm', 'docker'])
+async def test_handle_cancel_job_asks_the_job(cluster, gcd_nop_project):
+    '''Every cluster is canceled the same way.
+
+    Where a job's nodes run is the job's own business: the project reaches its
+    scheduler, the scheduler ends its nodes, and a node that dispatched
+    elsewhere releases that itself. The server used to branch on the cluster
+    here and reach past all of it.
+    '''
+    server = _make_server(cluster=cluster)
     job_hash = 'd' * 32
-    _register_job(server, job_hash, nodes={
-        'stepone0': {'status': NodeStatus.SUCCESS, 'step': 'stepone', 'index': '0'},
-        'steptwo0': {'status': NodeStatus.RUNNING, 'step': 'steptwo', 'index': '0'},
-        'stepthree0': {'status': NodeStatus.PENDING, 'step': 'stepthree', 'index': '0'},
-    })
+    job_name = _register_job(server, job_hash, project=gcd_nop_project)
 
     mock_request = Mock()
     mock_request.json = AsyncMock(return_value={'job_hash': job_hash})
 
-    with patch('siliconcompiler.remote.server.SlurmSchedulerNode.cancel_nodes') as mock_cancel:
-        response = await server.handle_cancel_job(mock_request)
+    scheduler = Mock()
+    gcd_nop_project._Project__scheduler = scheduler
+
+    response = await server.handle_cancel_job(mock_request)
 
     assert response.status == 200
     assert json.loads(response.body)['message'] == f'Canceling job: {job_hash}.'
-
-    # Finished nodes have nothing left to cancel, so they are not sent on.
-    mock_cancel.assert_called_once_with(job_hash, [('steptwo', '0'), ('stepthree', '0')])
-
-
-@pytest.mark.asyncio
-async def test_handle_cancel_job_no_scancel(caplog):
-    '''A host that cannot cancel slurm nodes says so, and still marks the job'''
-    server = _make_server(cluster='slurm')
-    job_hash = 'e' * 32
-    _register_job(server, job_hash)
-
-    mock_request = Mock()
-    mock_request.json = AsyncMock(return_value={'job_hash': job_hash})
-
-    with patch('siliconcompiler.remote.server.SlurmSchedulerNode.cancel_nodes',
-               return_value=[]):
-        response = await server.handle_cancel_job(mock_request)
-
-    assert response.status == 200
-    assert server.sc_canceled_jobs == {server.job_name(None, job_hash)}
-    assert f'Unable to cancel nodes for job: {job_hash}' in caplog.text
+    assert server.sc_canceled_jobs == {job_name}
+    scheduler.cancel.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -1788,6 +1774,32 @@ def test_remote_sc_tracks_and_clears_nodes(gcd_nop_project, monkeypatch):
     assert server.sc_project_lookup == {}
 
 
+def test_remote_sc_reports_a_cancel_as_a_cancel(gcd_nop_project, monkeypatch):
+    '''A canceled run raises like any incomplete flow, but it is not a failure
+
+    The run stops by raising -- it never reached its exit nodes -- and that
+    exception would otherwise come out of the job thread as a traceback, for an
+    outcome the client asked for.
+    '''
+    server = _make_server()
+    job_hash = 'd' * 32
+    gcd_nop_project.set('record', 'remoteid', job_hash)
+    sc_job_name = server.job_name(None, job_hash)
+
+    def canceled():
+        raise RuntimeError('Run failed: run was canceled before completing')
+    monkeypatch.setattr(gcd_nop_project, 'run', canceled)
+
+    server.sc_canceled_jobs.add(sc_job_name)
+    server.sc_job_threads[sc_job_name] = {'thread': Mock(), 'jobhash': job_hash}
+
+    server.remote_sc(gcd_nop_project, None)
+
+    assert server.sc_jobs == {}
+    assert server.sc_job_threads == {}
+    assert server.sc_canceled_jobs == set()
+
+
 def test_remote_sc_clears_tracking_on_failure(gcd_nop_project, monkeypatch):
     '''A job whose run raises is over, and must not be reported as running'''
     server = _make_server()
@@ -1809,27 +1821,28 @@ def test_remote_sc_clears_tracking_on_failure(gcd_nop_project, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_shutdown_cancels_running_jobs():
+async def test_shutdown_cancels_running_jobs(gcd_nop_project):
     '''Shutting down with a job in flight cancels it rather than abandoning
        whatever it submitted'''
     server = _make_server(cluster='slurm')
     job_hash = '6' * 32
-    job_name = _register_job(server, job_hash)
+    job_name = _register_job(server, job_hash, project=gcd_nop_project)
 
-    thread = Mock()
+    scheduler = Mock()
+    gcd_nop_project._Project__scheduler = scheduler
+
+    thread = server.sc_job_threads[job_name]['thread']
     thread.is_alive.return_value = False
-    server.sc_job_threads[job_name] = {'thread': thread, 'jobhash': job_hash}
 
     with patch("aiohttp.web.run_app"):
         server.run()
 
     server.app.freeze()
-    with patch('siliconcompiler.remote.server.SlurmSchedulerNode.cancel_nodes') as mock_cancel, \
-            patch('siliconcompiler.remote.server.TaskScheduler.halt_all') as mock_halt:
+    with patch('siliconcompiler.remote.server.TaskScheduler.halt_all') as mock_halt:
         await server.app.cleanup()
 
     assert job_name in server.sc_canceled_jobs
-    mock_cancel.assert_called_once_with(job_hash, [('stepone', '0')])
+    scheduler.cancel.assert_called_once_with()
     # Node processes are not the scheduler's to leave behind either: they are
     # joined at interpreter exit, so shutting down has to end them.
     mock_halt.assert_called_once()
@@ -1845,11 +1858,9 @@ async def test_shutdown_with_no_jobs():
         server.run()
 
     server.app.freeze()
-    with patch('siliconcompiler.remote.server.SlurmSchedulerNode.cancel_nodes') as mock_cancel, \
-            patch('siliconcompiler.remote.server.TaskScheduler.halt_all') as mock_halt:
+    with patch('siliconcompiler.remote.server.TaskScheduler.halt_all') as mock_halt:
         await server.app.cleanup()
 
-    assert not mock_cancel.called
     assert not mock_halt.called
 
 
@@ -2204,18 +2215,19 @@ async def test_shutdown_tolerates_job_finishing_first():
 
     thread = Mock()
     thread.is_alive.return_value = False
+    project = Mock()
     # Registered as running, but already gone from sc_jobs.
-    server.sc_job_threads[job_name] = {'thread': thread, 'jobhash': job_hash}
+    server.sc_job_threads[job_name] = {'thread': thread, 'jobhash': job_hash,
+                                       'project': project}
 
     with patch("aiohttp.web.run_app"):
         server.run()
 
     server.app.freeze()
-    with patch('siliconcompiler.remote.server.SlurmSchedulerNode.cancel_nodes') as mock_cancel, \
-            patch('siliconcompiler.remote.server.TaskScheduler.halt_all'):
+    with patch('siliconcompiler.remote.server.TaskScheduler.halt_all'):
         await server.app.cleanup()
 
-    assert not mock_cancel.called
+    assert not project._scheduler.cancel.called
     assert server.sc_canceled_jobs == set()
 
 

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -1796,3 +1796,86 @@ def test_unguarded_run_with_non_fork_default():
         assert "SC_RUN_OK" in proc.stdout, f"[{run}] missing success marker:\n{combined}"
         assert "bootstrapping phase" not in combined, \
             f"[{run}] hit the multiprocessing guard error:\n{combined}"
+
+
+###########################
+# cancel
+###########################
+
+def test_cancel_reaches_the_task_scheduler(gcd_nop_project):
+    '''A cancel arriving mid-run is handed straight down'''
+    scheduler = Scheduler(gcd_nop_project)
+
+    task_scheduler = MagicMock()
+    scheduler._Scheduler__task_scheduler = task_scheduler
+
+    scheduler.cancel()
+
+    task_scheduler.cancel.assert_called_once_with()
+
+
+def test_cancel_during_setup_is_held_for_the_task_scheduler(gcd_nop_project):
+    '''Setup is the long part of a run, and the scheduler that executes nodes
+       does not exist until the end of it.
+
+    A cancel landing in that window has nothing to hand the request to, so this
+    scheduler keeps it and applies it the moment there is one -- before any node
+    is launched.
+    '''
+    scheduler = Scheduler(gcd_nop_project)
+    scheduler.cancel()
+
+    canceled = []
+    with patch("siliconcompiler.scheduler.scheduler.TaskScheduler") as task_scheduler_cls:
+        task_scheduler_cls.return_value.cancel.side_effect = \
+            lambda: canceled.append("cancel")
+        task_scheduler_cls.return_value.run.side_effect = \
+            lambda *_: canceled.append("run")
+        scheduler.run_core()
+
+    # Canceled before it was ever asked to run, so the run loop starts on a
+    # scheduler that already knows the run is over.
+    assert canceled == ["cancel", "run"]
+
+
+def test_cancel_with_no_task_scheduler(gcd_nop_project):
+    '''A cancel before run_core() has nothing to forward to, and says so by
+       doing nothing rather than failing'''
+    Scheduler(gcd_nop_project).cancel()
+
+
+def test_project_publishes_its_scheduler(gcd_nop_project):
+    '''What a caller holding the project has to work with, since the run it
+       started keeps its scheduler on the stack'''
+    scheduler = MagicMock()
+    gcd_nop_project._Project__scheduler = scheduler
+
+    assert gcd_nop_project._scheduler is scheduler
+
+
+def test_project_scheduler_without_a_run():
+    '''No run in progress is not an error, it is None'''
+    design = Design("designtop")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("designtop")
+
+    assert Project(design)._scheduler is None
+
+
+def test_project_drops_its_scheduler_when_the_run_ends(gcd_nop_project):
+    '''The handle lives exactly as long as there is a run to stop'''
+    # history() is stubbed as well: run() returns the completed job's record,
+    # and a stubbed run never produced one.
+    with patch.object(Scheduler, "run"), patch.object(Project, "history"):
+        gcd_nop_project.run()
+
+    assert gcd_nop_project._scheduler is None
+
+
+def test_project_scheduler_is_not_serialized(gcd_nop_project):
+    '''A live scheduler holds locks and log handlers that do not pickle, and
+       means nothing to the node process or history copy being made'''
+    gcd_nop_project._Project__scheduler = Scheduler(gcd_nop_project)
+
+    assert "_Project__scheduler" not in gcd_nop_project.__getstate__()
+    assert gcd_nop_project.copy()._scheduler is None

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -363,16 +363,20 @@ def _find_sleeper():
     return None
 
 
-@pytest.mark.skipif(sys.platform == "win32",
-                    reason="Windows ends a process outright, with no signal to handle")
+@pytest.mark.skipif(sys.platform != "linux",
+                    reason="a terminated node only unwinds where the signal arrives as one: "
+                           "Windows ends a process outright, and on macOS the node was observed "
+                           "running on past the signal (3.13/3.14). The guarantee that a canceled "
+                           "run gives the machine back does not rest on this -- the scheduler ends "
+                           "what a node leaves behind -- but the tidy path it takes here does")
 @pytest.mark.timeout(120)
 def test_a_terminated_node_takes_its_tool_with_it(sleep_project):
-    '''Ending a node has to end what the node started.
+    '''A node that gets the chance ends its own tool.
 
-    This is how a canceled run reaches a node, and without a handler it is the
-    end of the node process and nothing else: the tool it launched is reparented
-    and carries on holding the cores it was given, which is the one thing the
-    cancel was for.
+    The tidy path, and the only one that can stop a container rather than just
+    the client talking to it. What a node does not manage is ended by the
+    scheduler instead, which is where the guarantee actually lives; this is
+    about the node doing it first, and doing it properly.
     '''
     node = SchedulerNode(sleep_project, "stepone", "0")
     proc = get_process_context().Process(target=node.run_process)

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -430,6 +430,41 @@ def test_run_process_records_an_interrupted_node(project, monkeypatch):
     assert project.get("record", "status", step="steptwo", index="0") == NodeStatus.ERROR
 
 
+def test_run_process_cancels_again_on_its_way_out(project, monkeypatch):
+    '''The scheduler cancels before it signals, which can be before this node
+       had finished handing its work over -- so the node cancels again once the
+       interrupt has unwound whatever that first call was too early to see'''
+    node = SchedulerNode(project, "steptwo", "0")
+    node.task.setup_work_directory(node.workdir)
+
+    order = []
+    monkeypatch.setattr(node, "run", lambda: (_ for _ in ()).throw(KeyboardInterrupt))
+    monkeypatch.setattr(node, "cancel", lambda: order.append("cancel"))
+
+    with pytest.raises(SystemExit):
+        node.run_process()
+
+    assert order == ["cancel"]
+    assert project.get("record", "status", step="steptwo", index="0") == NodeStatus.ERROR
+
+
+def test_run_process_records_a_node_whose_cancel_failed(project, monkeypatch):
+    '''A cancel that raises is not a reason to leave the node unrecorded'''
+    node = SchedulerNode(project, "steptwo", "0")
+    node.task.setup_work_directory(node.workdir)
+
+    monkeypatch.setattr(node, "run", lambda: (_ for _ in ()).throw(KeyboardInterrupt))
+    monkeypatch.setattr(node, "cancel",
+                        lambda: (_ for _ in ()).throw(RuntimeError("scancel exploded")))
+
+    # halt() ends the process, so it has to run even when the cancel above did
+    # not: SystemExit rather than the RuntimeError reaching the caller.
+    with pytest.raises(SystemExit):
+        node.run_process()
+
+    assert project.get("record", "status", step="steptwo", index="0") == NodeStatus.ERROR
+
+
 @pytest.mark.skipif(sys.platform == "win32",
                     reason="Windows ends a process outright, with no signal to handle")
 def test_run_process_covers_an_overridden_run(project):

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -390,10 +390,17 @@ def test_a_terminated_node_takes_its_tool_with_it(sleep_project):
 
         proc.terminate()
         proc.join(timeout=30)
-        assert not proc.is_alive()
 
+        # The tool, not the node process. Killing that tool is something only
+        # the node's interrupt handling does, so its death is the whole claim
+        # here -- while whether the node's own exit has been observed yet is
+        # bookkeeping between two processes, and says nothing about the machine
+        # being given back. The scheduler has its own SIGKILL backstop for a
+        # node that will not go.
         _, alive = psutil.wait_procs([sleeper], timeout=30)
-        assert not alive, "the node was ended but its tool was left running"
+        assert not alive, \
+            "the node was ended but its tool was left running " \
+            f"(node exitcode: {proc.exitcode})"
     finally:
         # Never leave the sleeper behind, whichever assertion above failed.
         if proc.is_alive():

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -2,10 +2,13 @@ import io
 import logging
 import logging.handlers
 import os
+import signal
 import sys
 import pytest
 import re
+import psutil
 import shutil
+import threading
 import time
 
 import os.path
@@ -22,8 +25,9 @@ from siliconcompiler import TaskSkip
 from siliconcompiler.tools.builtin.nop import NOPTask
 from siliconcompiler.tools.builtin.join import JoinTask
 from scheduler.tools.echo import EchoTask
+from scheduler.tools.sleeper import SleepTask, SLEEP_SECONDS
 
-from siliconcompiler.utils.multiprocessing import MPManager
+from siliconcompiler.utils.multiprocessing import MPManager, get_process_context
 from siliconcompiler.scheduler import SchedulerNode
 from siliconcompiler.scheduler.schedulernode import SchedulerFlowReset, \
     SchedulerNodeReset, SchedulerNodeResetSilent
@@ -63,6 +67,24 @@ def echo_project():
     proj = Project(design)
     proj.add_fileset("rtl")
     proj.set_flow(flow)
+
+    return proj
+
+
+@pytest.fixture
+def sleep_project():
+    flow = Flowgraph("testflow")
+    flow.node("stepone", SleepTask())
+
+    design = Design("testdesign")
+    with design.active_fileset("rtl"):
+        design.set_topmodule("top")
+
+    proj = Project(design)
+    proj.add_fileset("rtl")
+    proj.set_flow(flow)
+
+    SchedulerNode(proj, "stepone", "0").setup()
 
     return proj
 
@@ -289,6 +311,139 @@ def test_halt(project):
         node.halt()
     assert project.get("record", "status", step="steptwo", index="0") == NodeStatus.ERROR
     assert os.path.exists("build/testdesign/job0/steptwo/0/outputs/testdesign.pkg.json")
+
+
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="Windows ends a process outright, with no signal to handle")
+def test_interruptible_turns_a_terminate_into_an_interrupt():
+    '''A canceled run ends its nodes with SIGTERM, whose default action would
+       take the process out from under the tool it started'''
+    with pytest.raises(KeyboardInterrupt):
+        with SchedulerNode._interruptible():
+            os.kill(os.getpid(), signal.SIGTERM)
+
+
+def test_interruptible_restores_the_previous_handler():
+    '''A node is not always a process of its own -- a replay runs one in the
+       caller's -- and a handler left installed there outlives the node'''
+    original = signal.getsignal(signal.SIGTERM)
+
+    with SchedulerNode._interruptible():
+        assert signal.getsignal(signal.SIGTERM) is not original
+
+    assert signal.getsignal(signal.SIGTERM) is original
+
+
+def test_interruptible_off_the_main_thread():
+    '''Only the main thread may install a handler at all, so anywhere else this
+       has to yield rather than raise'''
+    original = signal.getsignal(signal.SIGTERM)
+    ran = []
+
+    def body():
+        with SchedulerNode._interruptible():
+            ran.append(signal.getsignal(signal.SIGTERM))
+
+    thread = threading.Thread(target=body)
+    thread.start()
+    thread.join(timeout=10)
+
+    assert ran == [original], "a handler was installed off the main thread"
+    assert signal.getsignal(signal.SIGTERM) is original
+
+
+def _find_sleeper():
+    """The task's executable, if it is running. None once it is gone."""
+    for proc in psutil.process_iter(["cmdline"]):
+        try:
+            if SLEEP_SECONDS in (proc.info["cmdline"] or []):
+                return proc
+        except psutil.Error:
+            continue
+    return None
+
+
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="Windows ends a process outright, with no signal to handle")
+@pytest.mark.timeout(120)
+def test_a_terminated_node_takes_its_tool_with_it(sleep_project):
+    '''Ending a node has to end what the node started.
+
+    This is how a canceled run reaches a node, and without a handler it is the
+    end of the node process and nothing else: the tool it launched is reparented
+    and carries on holding the cores it was given, which is the one thing the
+    cancel was for.
+    '''
+    node = SchedulerNode(sleep_project, "stepone", "0")
+    proc = get_process_context().Process(target=node.run_process)
+    proc.start()
+
+    sleeper = None
+    try:
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            sleeper = _find_sleeper()
+            if sleeper:
+                break
+            time.sleep(0.1)
+        assert sleeper is not None, "the task's executable never started"
+
+        proc.terminate()
+        proc.join(timeout=30)
+        assert not proc.is_alive()
+
+        _, alive = psutil.wait_procs([sleeper], timeout=30)
+        assert not alive, "the node was ended but its tool was left running"
+    finally:
+        # Never leave the sleeper behind, whichever assertion above failed.
+        if proc.is_alive():
+            proc.kill()
+            proc.join(timeout=10)
+        leftover = _find_sleeper()
+        if leftover:
+            leftover.kill()
+
+
+def test_run_process_records_an_interrupted_node(project, monkeypatch):
+    '''An interrupt outside execute() still leaves the node recorded.
+
+    Without this the process simply goes away: nothing is written, and the
+    scheduler is left inferring the outcome from an exit code.
+    '''
+    node = SchedulerNode(project, "steptwo", "0")
+    node.task.setup_work_directory(node.workdir)
+
+    def interrupted():
+        raise KeyboardInterrupt
+    monkeypatch.setattr(node, "run", interrupted)
+
+    with pytest.raises(SystemExit):
+        node.run_process()
+
+    assert project.get("record", "status", step="steptwo", index="0") == NodeStatus.ERROR
+
+
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="Windows ends a process outright, with no signal to handle")
+def test_run_process_covers_an_overridden_run(project):
+    '''The handling has to survive run() being replaced.
+
+    Every scheduler that dispatches elsewhere overrides run(), and so can
+    anything outside this package. Interrupt handling written inside run() is
+    handling each of those has to remember to reproduce, which is why it lives
+    around the call instead.
+    '''
+    class OverridingNode(SchedulerNode):
+        def run(self):
+            os.kill(os.getpid(), signal.SIGTERM)
+
+    node = OverridingNode(project, "steptwo", "0")
+    node.task.setup_work_directory(node.workdir)
+
+    with pytest.raises(SystemExit):
+        node.run_process()
+
+    assert project.get("record", "status", step="steptwo", index="0") == NodeStatus.ERROR
 
 
 def test_halt_sends_pathcache(project):

--- a/tests/scheduler/test_slurm.py
+++ b/tests/scheduler/test_slurm.py
@@ -1,11 +1,10 @@
 import json
-import logging
 import pytest
 import re
 
 import os.path
 
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from siliconcompiler import Project, Flowgraph, Design, NodeStatus
 from siliconcompiler.tools.builtin.nop import NOPTask
@@ -329,7 +328,7 @@ def test_cancel(project):
     node = SlurmSchedulerNode(project, "steptwo", "0")
 
     with patch("shutil.which", return_value="/usr/bin/scancel"), \
-            patch("subprocess.run") as run:
+            patch("subprocess.run", return_value=_scancel_ok()) as run:
         node.cancel()
 
     assert [call.args[0] for call in run.call_args_list] == [
@@ -337,10 +336,10 @@ def test_cancel(project):
     ]
 
 
-def test_cancel_without_scancel(project, caplog):
+def test_cancel_without_scancel(project, project_logger, caplog):
     '''A job that was asked to stop and could not be is worth saying out loud'''
     project.set('record', 'remoteid', 'thisisahash')
-    project.logger.setLevel(logging.INFO)
+    project_logger(project)
     node = SlurmSchedulerNode(project, "steptwo", "0")
 
     with patch("shutil.which", return_value=None):
@@ -349,9 +348,34 @@ def test_cancel_without_scancel(project, caplog):
     assert "Unable to cancel slurm job for steptwo/0" in caplog.text
 
 
+def test_cancel_reports_a_refused_scancel(project, project_logger, caplog):
+    '''A scancel that returned nonzero left the job running, and the caller is
+       about to kill the only thing waiting on it'''
+    project.set('record', 'remoteid', 'thisisahash')
+    project_logger(project)
+    node = SlurmSchedulerNode(project, "steptwo", "0")
+
+    with patch("shutil.which", return_value="/usr/bin/scancel"), \
+            patch("subprocess.run", return_value=_scancel_result(1)):
+        node.cancel()
+
+    assert "Unable to cancel slurm job for steptwo/0" in caplog.text
+
+
+def _scancel_result(returncode):
+    """What subprocess.run() hands back, with only what cancel_nodes reads."""
+    result = MagicMock()
+    result.returncode = returncode
+    return result
+
+
+def _scancel_ok():
+    return _scancel_result(0)
+
+
 def test_cancel_nodes():
     with patch("shutil.which", return_value="/usr/bin/scancel"), \
-            patch("subprocess.run") as run:
+            patch("subprocess.run", return_value=_scancel_ok()) as run:
         assert SlurmSchedulerNode.cancel_nodes(
             "thisisahash", [("stepone", "0"), ("steptwo", "1")]) == \
             [("stepone", "0"), ("steptwo", "1")]
@@ -378,6 +402,20 @@ def test_cancel_nodes_without_scancel():
     run.assert_not_called()
 
 
+def test_cancel_nodes_refused():
+    '''A scancel that returned nonzero did not cancel anything, and saying it
+       did would have the caller kill the job's only waiter'''
+    def refuse(cmd, **kwargs):
+        return _scancel_result(1 if 'steptwo_1' in cmd[-1] else 0)
+
+    with patch("shutil.which", return_value="/usr/bin/scancel"), \
+            patch("subprocess.run", side_effect=refuse):
+        assert SlurmSchedulerNode.cancel_nodes(
+            "thisisahash",
+            [("stepone", "0"), ("steptwo", "1"), ("stepthree", "2")]) == \
+            [("stepone", "0"), ("stepthree", "2")]
+
+
 def test_cancel_nodes_timeout():
     '''A scancel that does not return leaves its node unclaimed'''
     import subprocess
@@ -385,6 +423,7 @@ def test_cancel_nodes_timeout():
     def hang(cmd, **kwargs):
         if 'steptwo_1' in cmd[-1]:
             raise subprocess.TimeoutExpired(cmd, kwargs['timeout'])
+        return _scancel_ok()
 
     with patch("shutil.which", return_value="/usr/bin/scancel"), \
             patch("subprocess.run", side_effect=hang) as run:

--- a/tests/scheduler/test_slurm.py
+++ b/tests/scheduler/test_slurm.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import pytest
 import re
 
@@ -319,6 +320,33 @@ def test_check_required_paths(project):
                 step="steptwo", index="0")
 
     assert SlurmSchedulerNode(project, "steptwo", "0").check_required_paths() is True
+
+
+def test_cancel(project):
+    '''A slurm node cancels its own job, so nothing above it has to know that
+       the work is not where the node process is'''
+    project.set('record', 'remoteid', 'thisisahash')
+    node = SlurmSchedulerNode(project, "steptwo", "0")
+
+    with patch("shutil.which", return_value="/usr/bin/scancel"), \
+            patch("subprocess.run") as run:
+        node.cancel()
+
+    assert [call.args[0] for call in run.call_args_list] == [
+        ["scancel", "--name", "thisisahash_steptwo_0"]
+    ]
+
+
+def test_cancel_without_scancel(project, caplog):
+    '''A job that was asked to stop and could not be is worth saying out loud'''
+    project.set('record', 'remoteid', 'thisisahash')
+    project.logger.setLevel(logging.INFO)
+    node = SlurmSchedulerNode(project, "steptwo", "0")
+
+    with patch("shutil.which", return_value=None):
+        node.cancel()
+
+    assert "Unable to cancel slurm job for steptwo/0" in caplog.text
 
 
 def test_cancel_nodes():

--- a/tests/scheduler/test_taskscheduler.py
+++ b/tests/scheduler/test_taskscheduler.py
@@ -884,6 +884,152 @@ def test_halt_all_ends_node_processes(large_flow, make_tasks):
         proc.join(timeout=10)
 
 
+@pytest.mark.timeout(60)
+def test_cancel_stops_the_run_from_scheduling(large_flow, make_tasks):
+    '''A canceled run launches nothing further.
+
+    Ending the node processes is only half of a cancel: the loop that started
+    them is untouched by that, and left alone it fills the machine straight back
+    up with whatever became ready. Cancelling from post_node is the version that
+    tells the two halves apart -- the run's first level has just succeeded, so
+    there is a whole next level ready to go and nothing left running to stop.
+    '''
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+
+    def cancel_run(project, step, index):
+        scheduler.cancel()
+
+    TaskScheduler.register_callback("post_node", cancel_run)
+
+    scheduler.run(logging.NullHandler())
+
+    assert scheduler.is_canceled()
+
+    # Nothing downstream of the level that was already running was started:
+    # 'stepone' is excluded because those are the nodes the cancel landed among,
+    # and which of them completed before it arrived is a race.
+    flow = large_flow.get("flowgraph", "testflow", field="schema")
+    for step, index in flow.get_nodes():
+        if step == "stepone":
+            continue
+        assert large_flow.get("record", "status", step=step, index=index) == \
+            NodeStatus.PENDING, f"{step}/{index} was launched after the cancel"
+
+
+@pytest.mark.timeout(60)
+def test_cancel_ends_running_nodes(large_flow, make_tasks):
+    '''Cancelling ends what is running, not just what has yet to start'''
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+
+    proc = get_process_context().Process(target=_sleep_forever)
+    proc.start()
+    # Present it the way a launched node appears to the cancel path.
+    scheduler._TaskScheduler__nodes[("sleeper", "0")] = {"proc": proc}
+
+    try:
+        assert scheduler.cancel() is True
+        assert not proc.is_alive()
+        assert scheduler.is_canceled()
+    finally:
+        if proc.is_alive():
+            proc.kill()
+        proc.join(timeout=10)
+
+
+def test_cancel_with_nothing_running(large_flow, make_tasks):
+    '''A run with no live nodes is still canceled, it just has none to end'''
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+
+    assert scheduler.cancel() is False
+    assert scheduler.is_canceled()
+
+
+@pytest.mark.timeout(60)
+def test_canceled_scheduler_runs_nothing(large_flow, make_tasks):
+    '''A run canceled before its loop starts launches nothing at all.
+
+    This is what a cancel landing during setup becomes: Scheduler holds the
+    request until it has a TaskScheduler to give it to, which is after every
+    node is configured but before any has run.
+    '''
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+    scheduler.cancel()
+
+    scheduler.run(logging.NullHandler())
+
+    flow = large_flow.get("flowgraph", "testflow", field="schema")
+    for step, index in flow.get_nodes():
+        assert large_flow.get("record", "status", step=step, index=index) == \
+            NodeStatus.PENDING, f"{step}/{index} ran despite the cancel"
+
+
+def test_halt_asks_each_node_to_cancel_first(large_flow, make_tasks):
+    '''A node dispatched elsewhere is not holding its work in the process about
+       to be killed, and killing that process is what puts it out of reach'''
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+
+    order = []
+
+    class Node:
+        def cancel(self):
+            order.append("node")
+
+    class Proc:
+        def __init__(self):
+            self.__alive = True
+
+        def is_alive(self):
+            return self.__alive
+
+        def terminate(self):
+            order.append("terminate")
+            self.__alive = False
+
+        def kill(self):
+            pass
+
+        def join(self, timeout=None):
+            pass
+
+    scheduler._TaskScheduler__nodes[("elsewhere", "0")] = {
+        "name": "elsewhere/0", "node": Node(), "proc": Proc()}
+
+    assert scheduler.cancel() is True
+    assert order == ["node", "terminate"]
+
+
+def test_halt_ends_nodes_even_when_a_cancel_fails(large_flow, make_tasks, caplog):
+    '''A node's cancel is overridden per scheduler and can shell out. Whatever
+       it does wrong, the processes still have to be ended -- leaving them alive
+       is the deadlock the halt exists to prevent'''
+    large_flow.logger.setLevel(logging.INFO)
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+
+    class Node:
+        def cancel(self):
+            raise RuntimeError("scancel exploded")
+
+    proc = MagicMock()
+    proc.is_alive.side_effect = [True, False]
+
+    scheduler._TaskScheduler__nodes[("elsewhere", "0")] = {
+        "name": "elsewhere/0", "node": Node(), "proc": proc}
+
+    assert scheduler.cancel() is True
+    proc.terminate.assert_called_once()
+    assert "Failed to cancel elsewhere/0: scancel exploded" in caplog.text
+
+
+def test_check_reports_a_cancel_rather_than_a_broken_flow(large_flow, make_tasks):
+    '''A canceled run did not reach its exit nodes, but reporting that as
+       unreachable steps sends the reader hunting a failure that never happened'''
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+    scheduler.cancel()
+
+    with pytest.raises(SCRuntimeError, match="run was canceled before completing"):
+        scheduler.check()
+
+
 def test_halt_all_with_nothing_running(large_flow, make_tasks):
     '''A run with no live nodes reports nothing to halt'''
     TaskScheduler(large_flow, make_tasks(large_flow))

--- a/tests/scheduler/test_taskscheduler.py
+++ b/tests/scheduler/test_taskscheduler.py
@@ -1,5 +1,7 @@
 import logging
 import multiprocessing
+import os
+import sys
 import time
 import weakref
 
@@ -1079,6 +1081,76 @@ def test_check_reports_a_cancel_rather_than_a_broken_flow(large_flow, make_tasks
 
     with pytest.raises(SCRuntimeError, match="run was canceled before completing"):
         scheduler.check()
+
+
+def _deaf_node_with_a_tool(marker):
+    """A node that ignores the terminate, holding a tool the way a task does.
+
+    Stands in for every way a node fails to clean up after itself: killed
+    outright by the SIGKILL fallback, wedged in a call that never returns, or
+    on a platform where the signal does not arrive as an interrupt at all. In
+    each case the tool is left for the scheduler to find.
+    """
+    import signal as signal_module
+    import subprocess
+
+    signal_module.signal(signal_module.SIGTERM, signal_module.SIG_IGN)
+    subprocess.Popen(["sleep", marker])
+    time.sleep(120)
+
+
+def _find_marked(marker):
+    """The stand-in tool, if it is running."""
+    import psutil
+
+    for proc in psutil.process_iter(["cmdline"]):
+        try:
+            if marker in (proc.info["cmdline"] or []):
+                return proc
+        except psutil.Error:
+            continue
+    return None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="posix process tree")
+@pytest.mark.timeout(120)
+def test_halt_ends_a_tool_its_node_did_not(large_flow, make_tasks):
+    '''Asking a node to clean up cannot be depended on.
+
+    The fallback for a node that will not go is SIGKILL, which no node can
+    handle, and by then its tool is reparented with nothing tying it to this
+    run. So the scheduler notes what each node started while it can still be
+    asked, and ends whatever the node did not take with it.
+    '''
+    marker = f"{os.getpid()}42"
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+
+    proc = get_process_context().Process(target=_deaf_node_with_a_tool, args=(marker,))
+    proc.start()
+    scheduler._TaskScheduler__nodes[("deaf", "0")] = {"name": "deaf/0", "proc": proc}
+
+    tool = None
+    try:
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            tool = _find_marked(marker)
+            if tool:
+                break
+            time.sleep(0.1)
+        assert tool is not None, "the stand-in tool never started"
+
+        assert scheduler.cancel() is True
+
+        assert not proc.is_alive(), "a node that ignores SIGTERM was not killed"
+        assert _find_marked(marker) is None, \
+            "the node was ended but the tool it started was left running"
+    finally:
+        if proc.is_alive():
+            proc.kill()
+            proc.join(timeout=10)
+        leftover = _find_marked(marker)
+        if leftover:
+            leftover.kill()
 
 
 def test_halt_all_with_nothing_running(large_flow, make_tasks):

--- a/tests/scheduler/test_taskscheduler.py
+++ b/tests/scheduler/test_taskscheduler.py
@@ -998,11 +998,12 @@ def test_halt_asks_each_node_to_cancel_first(large_flow, make_tasks):
     assert order == ["node", "terminate"]
 
 
-def test_halt_ends_nodes_even_when_a_cancel_fails(large_flow, make_tasks, caplog):
+def test_halt_ends_nodes_even_when_a_cancel_fails(large_flow, make_tasks, project_logger,
+                                                  caplog):
     '''A node's cancel is overridden per scheduler and can shell out. Whatever
        it does wrong, the processes still have to be ended -- leaving them alive
        is the deadlock the halt exists to prevent'''
-    large_flow.logger.setLevel(logging.INFO)
+    project_logger(large_flow)
     scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
 
     class Node:
@@ -1018,6 +1019,56 @@ def test_halt_ends_nodes_even_when_a_cancel_fails(large_flow, make_tasks, caplog
     assert scheduler.cancel() is True
     proc.terminate.assert_called_once()
     assert "Failed to cancel elsewhere/0: scancel exploded" in caplog.text
+
+
+def test_a_canceled_run_refuses_to_start_a_node(large_flow, make_tasks):
+    '''The check that guards a launch, on its own'''
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+    scheduler.cancel()
+
+    started = []
+    scheduler._TaskScheduler__start_node = started.append
+
+    assert scheduler._TaskScheduler__try_start_node(("stepone", "0")) is False
+    assert started == []
+
+
+def test_a_launch_holds_the_cancel_lock(large_flow, make_tasks):
+    '''Checking the flag and starting the node have to be one step.
+
+    Apart, a cancel lands between them and its halt scans for live processes
+    just before the one it was meant to end exists: nothing stops that node,
+    and the run loop goes on to join it -- with a single node running, that
+    join has no timeout, so a canceled run sits through a whole task.
+
+    Holding the lock across both is what makes the two orderings the only ones:
+    the launch finishes first and halt finds it running, or the cancel gets
+    there first and the launch never happens.
+    '''
+    scheduler = TaskScheduler(large_flow, make_tasks(large_flow))
+
+    held = []
+
+    def start_node(node):
+        # From another thread: the lock is reentrant, so probing it from this
+        # one would succeed whether or not it is held.
+        def probe():
+            lock = scheduler._TaskScheduler__launch_lock
+            acquired = lock.acquire(blocking=False)
+            held.append(not acquired)
+            if acquired:
+                lock.release()
+
+        thread = Thread(target=probe)
+        thread.start()
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+
+    scheduler._TaskScheduler__start_node = start_node
+    scheduler._TaskScheduler__allow_start = lambda node: True
+
+    assert scheduler._TaskScheduler__try_start_node(("stepone", "0")) is True
+    assert held == [True], "a node was started without the cancel lock held"
 
 
 def test_check_reports_a_cancel_rather_than_a_broken_flow(large_flow, make_tasks):

--- a/tests/scheduler/tools/sleeper.py
+++ b/tests/scheduler/tools/sleeper.py
@@ -1,0 +1,27 @@
+from siliconcompiler import Task
+
+
+# Long enough that the process is certainly still there when the test looks for
+# it, and distinctive enough to pick out of the process table by command line.
+SLEEP_SECONDS = "424242"
+
+
+class SleepTask(Task):
+    """A task whose executable outlives the node running it.
+
+    For tests about what happens to a tool when its node is ended: a task that
+    finishes on its own has nothing left to orphan.
+    """
+    def __init__(self):
+        super().__init__()
+
+    def tool(self):
+        return "sleep"
+
+    def task(self):
+        return "sleep"
+
+    def setup(self):
+        super().setup()
+        self.set_exe("sleep")
+        self.add_commandline_option(SLEEP_SECONDS)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added run cancellation support across local, remote, container, and Slurm-based executions.
  - Cancellations can interrupt active tools, stop future task launches, and clean up associated resources.
  - Remote cancellation works consistently across cluster types, including requests received during setup.
  - Canceled runs now report a clear cancellation error instead of continuing to schedule work.

- **Documentation**
  - Clarified that canceled container runs clean up their containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->