### PR TITLE
fix server handling of cache

### DIFF
--- a/siliconcompiler/remote/server.py
+++ b/siliconcompiler/remote/server.py
@@ -112,11 +112,12 @@ class Server(ServerSchema):
         with self.sc_jobs_lock:
             job_hash = self.sc_project_lookup[project]["jobhash"]
 
-        start_tar = os.path.join(self.nfs_mount, job_hash, f'{job_hash}_None.tar.gz')
+        start_tar = os.path.join(self.build_root, job_hash, f'{job_hash}_None.tar.gz')
         start_status = NodeStatus.SUCCESS
         with tarfile.open(start_tar, "w:gz") as tf:
             start_manifest = os.path.join(jobdir(project), f"{project.name}.pkg.json")
-            tf.add(start_manifest, arcname=os.path.relpath(start_manifest, self.nfs_mount))
+            tf.add(start_manifest,
+                   arcname=os.path.relpath(start_manifest, self.build_root))
 
         with self.sc_jobs_lock:
             job_name = self.sc_project_lookup[project]["name"]
@@ -158,7 +159,7 @@ class Server(ServerSchema):
 
         project = project.copy()
         project._Project__cwd = os.path.join(project.option.get_builddir(), '..')
-        with tarfile.open(os.path.join(self.nfs_mount,
+        with tarfile.open(os.path.join(self.build_root,
                                        job_hash,
                                        f'{job_hash}_{step}{index}.tar.gz'),
                           mode='w:gz') as tf:
@@ -173,6 +174,8 @@ class Server(ServerSchema):
         # makedirs() raises if it cannot deliver the directory, so there is
         # nothing left to test for afterwards.
         os.makedirs(self.nfs_mount, exist_ok=True)
+        os.makedirs(self.build_root, exist_ok=True)
+        os.makedirs(self.cache_dir, exist_ok=True)
         os.makedirs(self.staging_mount, exist_ok=True)
         with open(os.path.join(self.nfs_mount, ".gitignore"), "w") as f:
             f.write("*")
@@ -300,7 +303,7 @@ class Server(ServerSchema):
         project.set('record', 'remoteid', job_hash)
 
         # Ensure that the job's root directory exists.
-        job_root = os.path.join(self.nfs_mount, job_hash)
+        job_root = os.path.join(self.build_root, job_hash)
         job_dir = os.path.join(job_root, design, job_name)
         os.makedirs(job_dir, exist_ok=True)
 
@@ -324,6 +327,13 @@ class Server(ServerSchema):
 
         # Create the working directory for the given 'job hash' if necessary.
         project.option.set_builddir(job_root)
+
+        # Downloaded PDKs and data packages belong on the shared filesystem
+        # beside the jobs, not in the home directory of whoever happens to run
+        # the node: a compute node need not share a home with the server, and
+        # left unset this defaults to ~/.sc/cache. Cluster-wide rather than
+        # per-job -- under job_root every job would re-download the PDK.
+        project.option.set_cachedir(self.cache_dir)
 
         # Remove 'remote' JSON config value to run locally on compute node.
         project.option.set_remote(False)
@@ -394,7 +404,7 @@ class Server(ServerSchema):
         if not self.__job_belongs_to(job_hash, job_params['username']):
             return self.__not_owner_response()
 
-        zipfn = os.path.join(self.nfs_mount, job_hash, f'{job_hash}_{node}.tar.gz')
+        zipfn = os.path.join(self.build_root, job_hash, f'{job_hash}_{node}.tar.gz')
         if not os.path.exists(zipfn):
             return web.json_response(
                 {'message': 'Could not find results for the requested job/node.'},
@@ -473,10 +483,10 @@ class Server(ServerSchema):
         # has matched '^[0-9a-f]{32}$' in delete_job.json, so it cannot carry a
         # path separator; the check below is what keeps that guarantee load
         # bearing if the schema is ever loosened.
-        build_dir = os.path.join(self.nfs_mount, job_hash)
+        build_dir = os.path.join(self.build_root, job_hash)
         check_dir = os.path.dirname(build_dir)
         deleted = False
-        if check_dir == self.nfs_mount:
+        if check_dir == self.build_root:
             # suppress() rather than an exists() check first: nothing here holds
             # a lock on the job's data, so a file can go away between the two.
             with contextlib.suppress(FileNotFoundError):
@@ -750,8 +760,9 @@ class Server(ServerSchema):
             }
             self.sc_jobs[sc_job_name] = nodes
 
-        build_dir = os.path.join(self.nfs_mount, job_hash)
+        build_dir = os.path.join(self.build_root, job_hash)
         project.option.set_builddir(build_dir)
+        project.option.set_cachedir(self.cache_dir)
         project.option.set_remote(False)
 
         cluster = self.get('option', 'cluster')
@@ -822,7 +833,7 @@ class Server(ServerSchema):
 
     ###################
     def __job_owner_file(self, job_hash):
-        return os.path.join(self.nfs_mount, job_hash, '.owner')
+        return os.path.join(self.build_root, job_hash, '.owner')
 
     ###################
     def __record_job_owner(self, job_hash, username):
@@ -877,6 +888,29 @@ class Server(ServerSchema):
     def nfs_mount(self):
         # Ensure that NFS mounting path is absolute.
         return os.path.abspath(self.get('option', 'nfsmount'))
+
+    ###################
+    @property
+    def build_root(self):
+        """Where job directories live, one per job hash.
+
+        A level below the mount rather than at its root, so that job data and
+        the shared cache do not share a namespace -- and so a job hash can
+        never collide with something the server keeps beside it.
+        """
+        return os.path.join(self.nfs_mount, 'builds')
+
+    ###################
+    @property
+    def cache_dir(self):
+        """Where downloaded packages are cached for the whole cluster.
+
+        On the shared mount rather than in a home directory, so that every
+        compute node resolves the same files as the server: the scheduler hands
+        this path to the node, so it is the server's value that decides where
+        the node looks.
+        """
+        return os.path.join(self.nfs_mount, 'cache')
 
     ###################
     @property

--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -17,10 +17,15 @@ from siliconcompiler.remote import JobStatus, NodeStatus as RemoteNodeStatus
 
 
 def _job_owner(nfs_path):
-    '''Reads the owner record off the one job in a server's mount.'''
-    jobs = [entry for entry in os.listdir(nfs_path) if len(entry) == 32]
-    assert len(jobs) == 1, f"expected one job in {nfs_path}, found {jobs}"
-    with open(os.path.join(nfs_path, jobs[0], '.owner')) as f:
+    '''Reads the owner record off the one job in a server's mount.
+
+    Job directories live under "builds/", beside the shared "cache/", rather
+    than at the root of the mount.
+    '''
+    build_root = os.path.join(nfs_path, 'builds')
+    jobs = [entry for entry in os.listdir(build_root) if len(entry) == 32]
+    assert len(jobs) == 1, f"expected one job in {build_root}, found {jobs}"
+    with open(os.path.join(build_root, jobs[0], '.owner')) as f:
         return json.load(f)
 
 
@@ -445,7 +450,7 @@ async def test_handle_get_results_with_node():
     # Use valid 32-char hex job_hash
     job_hash = 'fedcba98765432100123456789abcdef'
     node = 'step0'
-    job_dir = os.path.join(tmpdir, job_hash)
+    job_dir = os.path.join(tmpdir, 'builds', job_hash)
     os.makedirs(job_dir, exist_ok=True)
 
     # Create a dummy tar.gz file
@@ -508,7 +513,7 @@ async def test_handle_delete_job_success():
 
     # Use valid 32-char hex job_hash
     job_hash = 'abcdef01234567890abcdef012345678'
-    job_dir = os.path.join(tmpdir, job_hash)
+    job_dir = os.path.join(tmpdir, 'builds', job_hash)
     os.makedirs(job_dir, exist_ok=True)
 
     # Create a dummy file
@@ -546,7 +551,7 @@ async def test_handle_delete_job_success():
 
 def _owned_job(server, job_hash, username):
     """Lays down a job directory carrying the owner record the server writes."""
-    job_dir = os.path.join(server.nfs_mount, job_hash)
+    job_dir = os.path.join(server.build_root, job_hash)
     os.makedirs(job_dir, exist_ok=True)
     with open(os.path.join(job_dir, '.owner'), 'w') as f:
         json.dump({'username': username}, f)
@@ -635,7 +640,7 @@ async def test_handle_delete_job_malformed_owner_record():
     server.sc_jobs = {}
 
     job_hash = 'abcdef01234567890abcdef012345678'
-    job_dir = os.path.join(server.nfs_mount, job_hash)
+    job_dir = os.path.join(server.build_root, job_hash)
     os.makedirs(job_dir, exist_ok=True)
     with open(os.path.join(job_dir, '.owner'), 'w') as f:
         json.dump({}, f)
@@ -655,7 +660,7 @@ async def test_handle_delete_job_without_owner_record():
     server.sc_jobs = {}
 
     job_hash = 'abcdef01234567890abcdef012345678'
-    job_dir = os.path.join(server.nfs_mount, job_hash)
+    job_dir = os.path.join(server.build_root, job_hash)
     os.makedirs(job_dir, exist_ok=True)
 
     response = await _delete(server, job_hash)
@@ -804,7 +809,7 @@ def test_handle_get_results_none_node():
 
         # Use valid 32-char hex job_hash
         job_hash = 'fedcba98765432100123456789abcdef'
-        job_dir = os.path.join(tmpdir, job_hash)
+        job_dir = os.path.join(tmpdir, 'builds', job_hash)
         os.makedirs(job_dir, exist_ok=True)
 
         # Create a dummy tar.gz file for None node
@@ -1226,7 +1231,7 @@ def _authed_server_with_job(job_hash, owner):
     """A server with one job owned by `owner`, and two users who can authenticate."""
     server = _make_server(auth=True)
     server.user_keys = {'owner': {'password': 'pass'}, 'stranger': {'password': 'pass'}}
-    job_dir = os.path.join(server.nfs_mount, job_hash)
+    job_dir = os.path.join(server.build_root, job_hash)
     os.makedirs(job_dir, exist_ok=True)
     with open(os.path.join(job_dir, '.owner'), 'w') as f:
         json.dump({'username': owner}, f)
@@ -1341,7 +1346,7 @@ def _server_holding_job(job_hash, owner, auth, node='step0'):
         server.user_keys = {'owner': {'password': 'pass'},
                             'stranger': {'password': 'pass'}}
 
-    job_dir = os.path.join(server.nfs_mount, job_hash)
+    job_dir = os.path.join(server.build_root, job_hash)
     os.makedirs(job_dir, exist_ok=True)
     if owner is not _NO_RECORD:
         with open(os.path.join(job_dir, '.owner'), 'w') as f:
@@ -1727,7 +1732,10 @@ async def test_handle_remote_run_stages_upload(gcd_nop_project):
 
     assert os.listdir(server.staging_mount) == []
     # The extracted job directory is what remains under the mount.
-    assert sorted(os.listdir(server.nfs_mount)) == ['.staging', job_hash]
+    # Job data lands under builds/, leaving the mount root to the server's own
+    # entries -- the staging area here, and cache/ once it is created.
+    assert sorted(os.listdir(server.nfs_mount)) == ['.staging', 'builds']
+    assert os.listdir(server.build_root) == [job_hash]
 
 
 @pytest.mark.asyncio
@@ -1905,7 +1913,8 @@ async def test_handle_delete_job_archive_only():
     server = _make_server()
 
     job_hash = '7' * 32
-    tar_file = os.path.join(server.nfs_mount, f'{job_hash}.tar.gz')
+    os.makedirs(server.build_root, exist_ok=True)
+    tar_file = os.path.join(server.build_root, f'{job_hash}.tar.gz')
     with tarfile.open(tar_file, 'w:gz') as tar:
         info = tarfile.TarInfo(name='test.txt')
         info.size = 0
@@ -2007,7 +2016,7 @@ def _callback_project(server, job_hash):
     project.set_flow(flow)
     project.set('record', 'remoteid', job_hash)
 
-    job_root = os.path.join(server.nfs_mount, job_hash)
+    job_root = os.path.join(server.build_root, job_hash)
     project.set('option', 'builddir', job_root)
     os.makedirs(jobdir(project), exist_ok=True)
     project.write_manifest(os.path.join(jobdir(project), f'{project.name}.pkg.json'))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Job data is now organized under a dedicated `builds` directory on the server storage.
  - Compute nodes now share a common package download cache, reducing repeated downloads and improving build efficiency.
  - Server startup automatically prepares the required build and cache directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->