### PR TITLE
use models.sim for stdcell verilog models

### DIFF
--- a/siliconcompiler/tools/slang/utils/macro.py
+++ b/siliconcompiler/tools/slang/utils/macro.py
@@ -535,9 +535,10 @@ def build_macro(project: ASIC, name: str) -> StdCellLibrary:
       dependency-free (STA resolves cells from Liberty).
     * ``sdc`` -- the implementation-generated constraints (propagated clocks).
 
-    The ``rtl`` view depends on the ``models.sim`` fileset of each logic library in
-    :keypath:`ASIC,asic,asiclib` that has one, since the netlist can instantiate
-    cells from any of them. These dependencies are serialized into the
+    The ``rtl`` view depends on the ``models.sim`` fileset of every logic
+    library the netlist can instantiate cells from: :keypath:`ASIC,asic,mainlib`
+    and each of :keypath:`ASIC,asic,asiclib`, for those that have one.
+    These dependencies are serialized into the
     macro's manifest (see :class:`DependencySchema`), so they are recovered when
     the macro is reloaded: a consumer can simulate the ``rtl`` view without
     re-registering the PDK libraries. The ``rtl``/``netlist``/``sdc``
@@ -582,8 +583,17 @@ def build_macro(project: ASIC, name: str) -> StdCellLibrary:
             library.set_topmodule(name)
             library.add_file(netlist)
 
+            # mainlib first, then the asiclibs, which complement it rather
+            # than include it -- iterating only asiclib misses the primary
+            # library's cells, and misses every cell where a target sets a
+            # mainlib and no asiclibs.
             loaded = project.getkeys("library")
-            for libname in project.get("asic", "asiclib"):
+            mainlib = project.get("asic", "mainlib")
+            celllibs = [mainlib] if mainlib else []
+            celllibs += [lib for lib in project.get("asic", "asiclib")
+                         if lib != mainlib]
+
+            for libname in celllibs:
                 if libname in loaded:
                     celllib = project.get_library(libname)
                     if celllib.has_fileset("models.sim"):

--- a/siliconcompiler/tools/slang/utils/macro.py
+++ b/siliconcompiler/tools/slang/utils/macro.py
@@ -535,7 +535,7 @@ def build_macro(project: ASIC, name: str) -> StdCellLibrary:
       dependency-free (STA resolves cells from Liberty).
     * ``sdc`` -- the implementation-generated constraints (propagated clocks).
 
-    The ``rtl`` view depends on the ``rtl`` fileset of each logic library in
+    The ``rtl`` view depends on the ``models.sim`` fileset of each logic library in
     :keypath:`ASIC,asic,asiclib` that has one, since the netlist can instantiate
     cells from any of them. These dependencies are serialized into the
     macro's manifest (see :class:`DependencySchema`), so they are recovered when
@@ -586,11 +586,11 @@ def build_macro(project: ASIC, name: str) -> StdCellLibrary:
             for libname in project.get("asic", "asiclib"):
                 if libname in loaded:
                     celllib = project.get_library(libname)
-                    if celllib.has_fileset("rtl"):
-                        library.add_depfileset(celllib, "rtl")
+                    if celllib.has_fileset("models.sim"):
+                        library.add_depfileset(celllib, "models.sim")
                     else:
                         project.logger.warning(
-                            f"{libname} has no rtl fileset; "
+                            f"{libname} has no models.sim fileset; "
                             f"{name} rtl view will not simulate standalone")
 
         # 'netlist' (structural, for STA): dependency-free -- STA resolves cells

--- a/tests/tools/test_slang.py
+++ b/tests/tools/test_slang.py
@@ -1439,3 +1439,51 @@ def test_macro_corners_from_project_scenarios(asic_heartbeat):
     """
     corners = asic_heartbeat.getkeys("constraint", "timing", "scenario")
     assert list(corners) == ["typical"]
+
+
+def _fake_results(project, monkeypatch):
+    """Let build_macro package a project without an actual run behind it.
+
+    build_macro only needs find_result to name the views; add_file records a
+    path without opening it, so faking them keeps this a unit test.
+    """
+    def find_result(self, filetype=None, step=None, index="0",
+                    directory="outputs", filename=None):
+        return f"/fake/{filetype}"
+
+    monkeypatch.setattr(type(project), "find_result", find_result)
+
+
+def test_macro_rtl_view_bundles_models_sim(asic_heartbeat, monkeypatch):
+    """The rtl view depends on each logic library's models.sim fileset."""
+    _fake_results(asic_heartbeat, monkeypatch)
+
+    mainlib = asic_heartbeat.get_library(asic_heartbeat.get("asic", "mainlib"))
+    with mainlib.active_fileset("models.sim"):
+        mainlib.add_file("/fake/cells.v")
+
+    library = macro.build_macro(asic_heartbeat, "heartbeat")
+
+    deps = library.get("fileset", "rtl", "depfileset")
+    assert (mainlib.name, "models.sim") in deps
+
+
+def test_macro_warns_when_library_has_no_models_sim(asic_heartbeat, monkeypatch,
+                                                    caplog):
+    """A logic library with no cell models cannot make the rtl view simulate.
+
+    nangate45 ships no cell verilog, so freepdk45 is the case this warns on. It
+    is a warning and not an error because the netlist, the liberty and the
+    physical views are all still good -- only standalone simulation of the rtl
+    view is lost.
+    """
+    asic_heartbeat.logger.propagate = True
+    _fake_results(asic_heartbeat, monkeypatch)
+
+    mainlib = asic_heartbeat.get_library(asic_heartbeat.get("asic", "mainlib"))
+    assert not mainlib.has_fileset("models.sim")
+
+    library = macro.build_macro(asic_heartbeat, "heartbeat")
+
+    assert f"{mainlib.name} has no models.sim fileset" in caplog.text
+    assert not library.get("fileset", "rtl", "depfileset")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standard-cell simulation models are now packaged from the appropriate simulation model fileset.
  - Warnings for missing model filesets now identify the correct fileset.
  - RTL views now include dependencies from the main library and applicable ASIC libraries, improving macro packaging consistency.
  - Macro packaging now handles unavailable simulation model filesets more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->