### PR TITLE
bump lambdapdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "PyGithub >= 2.8.0, < 2.11.0",
     "urllib3 >= 1.26.0", # Required for PyGithub
 
-    "lambdapdk >= 0.2.19",
+    "lambdapdk >= 0.2.21",
 
     "fasteners >= 0.20",
     "tomli >= 2.0.0; python_version < '3.11'",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported `lambdapdk` runtime version to 0.2.21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->