### PR TITLE
add digest to task

### DIFF
--- a/docs/user_guide/directories.rst
+++ b/docs/user_guide/directories.rst
@@ -233,8 +233,41 @@ than sharing one, because two tools rarely compile the same thing with the same
 flags. Set the variable yourself, in the environment or on the task, and your
 setting is left alone.
 
+Sharing across designs is what a compiler cache wants, but not every cache can:
+a cache whose contents are only valid for one task configuration has to be kept
+apart from the others. A driver in that position names a subdirectory after the
+task's :ref:`digest <task_digest>` instead of sharing ``tools/<tool>/``
+directly.
+
 Nothing collects this area. A tool that keeps a cache is expected to cap it
 itself -- ccache does, at 5GB by default -- so if you want it gone, delete it.
+
+.. _task_digest:
+
+Naming things after a task
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:meth:`.Task.get_digest` returns a hex digest of everything that configures a
+task -- its command line, threads, scripts, environment, tool version
+requirement, and every keypath its driver declared with
+:meth:`.Task.add_required_key`. Two tasks configured the same way get the same
+digest; two that differ anywhere, including in a single boolean, do not:
+
+.. code-block:: python
+
+   class MyTask(Task):
+       @property
+       def cachedir(self):
+           return os.path.join(super().cachedir, self.get_digest(length=16))
+
+The digest is computed from the configuration as written. It reads no files,
+resolves no :term:`dataroot`, runs no executable and does not depend on
+:keypath:`option,hash`, so it costs nothing and comes out the same on every
+machine -- a cache directory named after it can be shared across a cluster. What
+that leaves out is worth knowing before you rely on it: the contents of the input
+files, and the version of the tool actually installed. A driver that needs either
+composes it -- :meth:`.Task.get_exe_version` for the second -- or requires the
+keys that stand in for them, such as a dataroot's ``tag``.
 
 Settings and credentials
 ------------------------

--- a/docs/user_guide/directories.rst
+++ b/docs/user_guide/directories.rst
@@ -248,7 +248,7 @@ Naming things after a task
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :meth:`.Task.get_digest` returns a hex digest of everything that configures a
-task -- its command line, threads, scripts, environment, tool version
+task -- its command line, threads, scripts, environment, executable and version
 requirement, and every keypath its driver declared with
 :meth:`.Task.add_required_key`. Two tasks configured the same way get the same
 digest; two that differ anywhere, including in a single boolean, do not:
@@ -267,7 +267,9 @@ machine -- a cache directory named after it can be shared across a cluster. What
 that leaves out is worth knowing before you rely on it: the contents of the input
 files, and the version of the tool actually installed. A driver that needs either
 composes it -- :meth:`.Task.get_exe_version` for the second -- or requires the
-keys that stand in for them, such as a dataroot's ``tag``.
+keys that stand in for them, such as a dataroot's ``tag``. The *directory* the
+executable was found in is left out on purpose: it differs per machine, and a
+digest that moved with it would partition the shared cache rather than share it.
 
 Settings and credentials
 ------------------------

--- a/siliconcompiler/scheduler/schedulernode.py
+++ b/siliconcompiler/scheduler/schedulernode.py
@@ -617,8 +617,10 @@ class SchedulerNode:
         """
         Gathers all schema keys that could trigger a re-run if changed.
 
-        This includes tool options, scripts, and required inputs specified
-        in the task's schema.
+        The keys are :meth:`.Task.get_digest_keys` -- the task's own settings
+        plus everything its driver required -- split by whether they hold a
+        path, since a value is compared directly while a path is compared by
+        hash or timestamp.
 
         Returns:
             tuple: A tuple containing two sets: (value_keys, path_keys).
@@ -628,21 +630,9 @@ class SchedulerNode:
         Raises:
             KeyError: If a required keypath is not found in the schema.
         """
-        all_keys = set()
-
-        all_keys.update(self.__task.get('require'))
-
-        tool_task_prefix = ('tool', self.__task.tool(), 'task', self.__task.task())
-        for key in ('option', 'threads', 'prescript', 'postscript', 'refdir', 'script',):
-            all_keys.add(",".join([*tool_task_prefix, key]))
-
-        for env_key in self.__project.getkeys(*tool_task_prefix, 'env'):
-            all_keys.add(",".join([*tool_task_prefix, 'env', env_key]))
-
         value_keys = set()
         path_keys = set()
-        for key in all_keys:
-            keypath = tuple(key.split(","))
+        for keypath in self.__task.get_digest_keys():
             if not self.__project.valid(*keypath, default_valid=True):
                 raise KeyError(f"[{','.join(keypath)}] not found")
             if self.__project.get(*keypath, field=None).is_path:

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -1908,8 +1908,9 @@ class Task(NamedSchema, PathSchema, DocsSchema):
 
         The digest answers *what configuration is this?* -- a value computed from
         this task alone, which is what it takes to name a directory. It covers
-        the tool and task names, every keypath in :meth:`get_digest_keys` and the
-        tool version requirement, and it changes when any of their values change.
+        the tool and task names, every keypath in :meth:`get_digest_keys`, and
+        the executable and version requirement, and it changes when any of their
+        values change.
         Two tasks that differ only in a threshold, an effort level or a boolean
         get different digests, which is the whole point: a cache key that ignored
         scalars would hand one configuration's results to another.
@@ -1931,9 +1932,11 @@ class Task(NamedSchema, PathSchema, DocsSchema):
           :keypath:`option,hash` is set, so the digest would change with a flag
           rather than with the configuration.
         * The tool **version found on the system** is not included either, since
-          reading it means running the executable. Only the requirement is. A
-          driver that wants its cache keyed by the installed version has
-          :meth:`get_exe_version`, and can compose the two.
+          reading it means running the executable. Only the requirement, and the
+          executable's name. A driver that wants its cache keyed by the
+          installed version has :meth:`get_exe_version`, and can compose the
+          two. The **directory** the executable was found in is left out for the
+          same reason a resolved path is: it differs per machine.
 
         Values are read at this task's step and index, so two nodes running the
         same task share a digest exactly when nothing was set per-node to tell
@@ -1970,15 +1973,26 @@ class Task(NamedSchema, PathSchema, DocsSchema):
             raise RuntimeError("get_digest() requires a runtime, "
                                "call it on the task yielded by Task.runtime()")
 
-        # A cache named for a task pinned to >=v2.0 must not be handed to the
-        # same task pinned to <v2.0, so the version requirement is part of the
-        # digest. It is not part of get_digest_keys(), because that set is also
-        # what decides whether a node has to run again and a tightened
-        # specifier does not make an existing result wrong: the version
-        # actually found is checked before every execution and recorded in
+        # Which binary this is, and which versions of it are acceptable, are
+        # part of what a cache belongs to: a cache named for a task pinned to
+        # >=v2.0 must not be handed to the same task pinned to <v2.0.
+        #
+        # Neither is added to get_digest_keys(), because that set also decides
+        # whether a node has to run again, and neither makes an existing result
+        # wrong: the executable is resolved and its version checked before every
+        # execution, and both are recorded in [record,toolpath] and
         # [record,toolversion].
+        #
+        # [tool,<t>,task,<t>,path] is deliberately absent. It is the directory
+        # the executable was found in -- klayout sets it to
+        # ~/AppData/Roaming/KLayout or /Applications/klayout.app/... -- so
+        # hashing it would give the same task a different digest on every
+        # machine, partitioning the shared cache this digest exists to name. It
+        # is also a 'dir', so putting it in the key set would have the rerun
+        # check hash or mtime-walk an entire tool installation per node.
         keys = set(self.get_digest_keys())
-        keys.add(("tool", self.tool(), "task", self.task(), "version"))
+        prefix = ("tool", self.tool(), "task", self.task())
+        keys.update((*prefix, key) for key in ("exe", "version"))
 
         keys = sorted(keys)
         # Add keys

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -1,6 +1,7 @@
 import contextlib
 import copy
 import csv
+import hashlib
 import json
 import logging
 import os
@@ -30,7 +31,8 @@ import os.path
 from packaging.version import Version, InvalidVersion
 from packaging.specifiers import SpecifierSet, InvalidSpecifier
 
-from typing import List, Dict, Tuple, Union, Optional, Set, TextIO, Type, TypeVar, TYPE_CHECKING
+from typing import Any, List, Dict, Tuple, Union, Optional, Set, TextIO, Type, TypeVar, \
+    TYPE_CHECKING
 from pathlib import Path
 
 from siliconcompiler.schema import BaseSchema, NamedSchema, DocsSchema, LazyLoad
@@ -699,7 +701,15 @@ class Task(NamedSchema, PathSchema, DocsSchema):
         It lives under :keypath:`option,cachedir`, so a container running the
         task has it mounted and a cluster sharing that option shares the cache.
         Override this to key the directory by something other than the tool
-        name -- by tool and version, say.
+        name -- by tool and version, say, or by :meth:`get_digest` where a
+        cached result is only valid for the configuration that produced it::
+
+            @property
+            def cachedir(self):
+                return os.path.join(super().cachedir, self.get_digest(length=16))
+
+        Sharing across designs is the default because that is what a compiler
+        cache wants; a digest is for the caches that cannot.
         """
         return os.path.join(paths.toolcachedir(self.project), self.tool())
 
@@ -1855,6 +1865,150 @@ class Task(NamedSchema, PathSchema, DocsSchema):
             raise ValueError("key can only contain strings")
 
         return self.add("require", ",".join(key), step=step, index=index)
+
+    def get_digest_keys(self) -> Set[Tuple[str, ...]]:
+        '''
+        Returns every keypath that configures this task.
+
+        That is the task's own settings -- the command line, the thread count,
+        the scripts and the environment -- together with everything the driver
+        declared through :meth:`add_required_key`. Keypaths are complete: they
+        address the project, not the task, and are returned whether or not they
+        hold a value.
+
+        This is the one definition of what a task consists of:
+        :meth:`get_digest` hashes it, and
+        :meth:`.SchedulerNode.get_check_changed_keys` decides from it whether a
+        node has to run again. A driver that overrides this is answered by both.
+
+        Returns:
+            set of tuple of str: keypaths that configure this task.
+        '''
+
+        keys: Set[Tuple[str, ...]] = set()
+
+        for require in self.get("require"):
+            keys.add(tuple(require.split(",")))
+
+        # Built from tool()/task() rather than from _keypath, the way cachedir
+        # is, so that a task object standing in for the one attached to the
+        # project still names the keys the attached one would.
+        prefix = ("tool", self.tool(), "task", self.task())
+        for key in ("option", "threads", "prescript", "postscript", "refdir", "script"):
+            keys.add((*prefix, key))
+
+        for env_key in self.getkeys("env"):
+            keys.add((*prefix, "env", env_key))
+
+        return keys
+
+    def get_digest(self, length: Optional[int] = None) -> str:
+        '''
+        Returns a digest of this task's configuration, for naming things after it.
+
+        The digest answers *what configuration is this?* -- a value computed from
+        this task alone, which is what it takes to name a directory. It covers
+        the tool and task names, every keypath in :meth:`get_digest_keys` and the
+        tool version requirement, and it changes when any of their values change.
+        Two tasks that differ only in a threshold, an effort level or a boolean
+        get different digests, which is the whole point: a cache key that ignored
+        scalars would hand one configuration's results to another.
+
+        It is deliberately cheap and total. Nothing is resolved, downloaded,
+        read or executed, and nothing depends on :keypath:`option,hash`:
+
+        * A path contributes the value **as written** plus its
+          :term:`dataroot` name, never a resolved absolute path -- so the digest
+          is the same on every machine, and a shared cache directory is shared
+          rather than partitioned by where each user keeps their files. The name
+          is all of the dataroot that is portable, so re-pointing or re-tagging
+          one leaves the digest alone; a driver that cannot live with that
+          requires ``dataroot,<name>,tag`` like any other key and gets it
+          counted.
+        * File **contents** are not hashed. That would be a provenance record,
+          not a cache key: it costs minutes of I/O on a real PDK, and the
+          ``filehash`` field it would read is only populated when
+          :keypath:`option,hash` is set, so the digest would change with a flag
+          rather than with the configuration.
+        * The tool **version found on the system** is not included either, since
+          reading it means running the executable. Only the requirement is. A
+          driver that wants its cache keyed by the installed version has
+          :meth:`get_exe_version`, and can compose the two.
+
+        Values are read at this task's step and index, so two nodes running the
+        same task share a digest exactly when nothing was set per-node to tell
+        them apart.
+
+        The digest is a name, not a checksum: it says that two tasks are
+        configured the same way, not that a directory holds valid contents.
+
+        Args:
+            length (int): if given, truncate the digest to this many characters.
+                A directory name rarely wants all 64.
+
+        Raises:
+            RuntimeError: if the task has no runtime, since the required
+                keypaths cannot be read without a project to read them from.
+            KeyError: if a required keypath is not in the schema.
+            ValueError: if `length` is not between 1 and the digest's length.
+
+        Returns:
+            str: hex digest.
+
+        Examples:
+            >>> os.path.join(task.cachedir, task.get_digest(length=16))
+            A cache directory for this tool, private to this configuration.
+        '''
+
+        hashobj = hashlib.sha256()
+
+        if length is not None and not 0 < length <= hashobj.digest_size * 2:
+            raise ValueError(f"length must be between 1 and {hashobj.digest_size * 2}")
+
+        project = self.project
+        if project is None:
+            raise RuntimeError("get_digest() requires a runtime, "
+                               "call it on the task yielded by Task.runtime()")
+
+        # A cache named for a task pinned to >=v2.0 must not be handed to the
+        # same task pinned to <v2.0, so the version requirement is part of the
+        # digest. It is not part of get_digest_keys(), because that set is also
+        # what decides whether a node has to run again and a tightened
+        # specifier does not make an existing result wrong: the version
+        # actually found is checked before every execution and recorded in
+        # [record,toolversion].
+        keys = set(self.get_digest_keys())
+        keys.add(("tool", self.tool(), "task", self.task(), "version"))
+
+        keys = sorted(keys)
+        # Add keys
+        hashobj.update(json.dumps(keys, default=repr).encode("utf-8"))
+
+        # The keypath travels with the value so that moving a setting from one
+        # key to another is a change, and sorting makes the digest independent
+        # of the order the driver happened to require things in.
+        material: List[Any] = [self.tool(), self.task()]
+        for keypath in keys:
+            if not project.valid(*keypath, default_valid=True):
+                raise KeyError(f"[{','.join(keypath)}] not found")
+
+            param = project.get(*keypath, field=None)
+            step, index = self.__step, self.__index
+            if param.get(field="pernode").is_never():
+                step, index = None, None
+
+            entry: List[Any] = [",".join(keypath), param.get(step=step, index=index)]
+            if param.is_path:
+                # Which dataroot a path is relative to is part of the path.
+                entry.append(param.get(field="dataroot", step=step, index=index))
+            material.append(entry)
+
+        # default=repr rather than an error: a driver's own parameter type is
+        # not worth refusing to name a directory over, and repr is stable and
+        # tells two types apart.
+        hashobj.update(json.dumps(material, default=repr).encode("utf-8"))
+
+        return hashobj.hexdigest()[:length]
 
     def set_threads(self, max_threads: Optional[int] = None,
                     step: Optional[str] = None, index: Optional[Union[str, int]] = None,

--- a/tests/scheduler/test_schedulernode.py
+++ b/tests/scheduler/test_schedulernode.py
@@ -35,6 +35,18 @@ from siliconcompiler.utils.logging import SC_CONSOLE_QUIET_ATTR
 from siliconcompiler.utils.paths import jobdir, workdir
 
 
+class OwnKeysTask(NOPTask):
+    """A driver that decides for itself what configures it."""
+    def tool(self):
+        return "ownkeys"
+
+    def task(self):
+        return "ownkeys"
+
+    def get_digest_keys(self):
+        return {("option", "novercheck"), ("option", "builddir")}
+
+
 @pytest.fixture
 def project():
     flow = Flowgraph("testflow")
@@ -715,6 +727,19 @@ def test_get_check_changed_keys(project):
         ('tool', 'builtin', 'task', 'nop', 'postscript'),
         ('tool', 'builtin', 'task', 'nop', 'prescript'),
         ('tool', 'builtin', 'task', 'nop', 'script')}
+
+
+def test_get_check_changed_keys_follows_the_task(project):
+    """The task owns the definition; the node only sorts it into values and paths."""
+    flow = Flowgraph("ownkeys")
+    flow.node("stepone", OwnKeysTask())
+    project.set_flow(flow)
+
+    node = SchedulerNode(project, "stepone", "0")
+    with node.runtime():
+        values, paths = node.get_check_changed_keys()
+    assert values == {("option", "novercheck")}
+    assert paths == {("option", "builddir")}
 
 
 def test_get_check_changed_keys_with_invalid_require(project):

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -3,6 +3,7 @@ import copy
 import csv
 import gc
 import hashlib
+import json
 import logging
 import pathlib
 import re
@@ -241,6 +242,336 @@ def test_task_cachedir_override(running_node):
     with task.runtime(running_node) as runtool:
         assert pathlib.Path(runtool.cachedir) == \
             pathlib.Path(os.path.abspath("thiscache")) / "tools" / "builtin" / "1.2.3"
+
+
+@pytest.fixture
+def configured_node(running_node):
+    """A node whose task sets one of everything the digest has to encode.
+
+    A string, a bool, a float, a tuple list, a string list, an int, a path with
+    a dataroot, an environment variable, a version specifier, and a required key
+    outside the task.
+    """
+    nop = running_node.project.get_nop()
+
+    nop.add_parameter("effort", "str", "effort", defvalue="high")
+    nop.add_parameter("aggressive", "bool", "aggressive", defvalue=False)
+    nop.add_parameter("margin", "float", "margin")
+    nop.add_parameter("plusargs", "[(str,str)]", "plusargs")
+    nop.set("var", "aggressive", True)
+    nop.set("var", "margin", 0.25)
+    nop.set("var", "plusargs", [("seed", "7"), ("trace", None)])
+    for var in ("effort", "aggressive", "margin", "plusargs"):
+        nop.add_required_key("var", var)
+
+    nop.add_required_key("library", "testdesign", "fileset", "rtl", "topmodule")
+
+    nop.set("option", ["-fast", "-x"])
+    nop.set("threads", 4)
+    nop.set("version", ">=2.0")
+    nop.set("env", "BUILD", "here")
+
+    nop.set_dataroot("mydata", "git+https://example.invalid/x", tag="v1")
+    nop.set_script("sc_nop.tcl", dataroot="mydata")
+
+    return running_node
+
+
+def test_task_get_digest_exact(configured_node):
+    """The cache-key contract: this configuration has this digest.
+
+    A directory named after a digest is findable only for as long as the digest
+    is the same value. Changing the key set, the ordering, the encoding or the
+    hash function orphans every cache directory a released SiliconCompiler ever
+    named, and nothing collects them. So this number changing is a decision to
+    take deliberately, with a release note -- never a test updated to match a
+    diff.
+    """
+    with configured_node.task.runtime(configured_node) as task:
+        assert task.get_digest() == \
+            "f759039b73148bce5dec4f161e22f5b337447464aa59a6ec3ad15216e40ba4a3"
+        assert task.get_digest(length=16) == "f759039b73148bce"
+
+
+def test_task_get_digest_exact_material(configured_node):
+    """Which values are hashed, and in what shape.
+
+    The keys are hashed first, so that a key carrying no value still moves the
+    digest by being there at all; then each value in the same order. Note the
+    shapes: a path carries a second element for its dataroot, an unset one
+    carries both, and a tuple keeps its interior None rather than closing the
+    gap the way the Tcl writer does.
+
+    Built independently of the digest above so that a break names the entry that
+    moved rather than only the number.
+    """
+    keys = [
+        ["library", "testdesign", "fileset", "rtl", "topmodule"],
+        ["tool", "builtin", "task", "nop", "env", "BUILD"],
+        ["tool", "builtin", "task", "nop", "option"],
+        ["tool", "builtin", "task", "nop", "postscript"],
+        ["tool", "builtin", "task", "nop", "prescript"],
+        ["tool", "builtin", "task", "nop", "refdir"],
+        ["tool", "builtin", "task", "nop", "script"],
+        ["tool", "builtin", "task", "nop", "threads"],
+        ["tool", "builtin", "task", "nop", "var", "aggressive"],
+        ["tool", "builtin", "task", "nop", "var", "effort"],
+        ["tool", "builtin", "task", "nop", "var", "margin"],
+        ["tool", "builtin", "task", "nop", "var", "plusargs"],
+        ["tool", "builtin", "task", "nop", "version"]]
+    material = [
+        "builtin", "nop",
+        ["library,testdesign,fileset,rtl,topmodule", "designtop"],
+        ["tool,builtin,task,nop,env,BUILD", "here"],
+        ["tool,builtin,task,nop,option", ["-fast", "-x"]],
+        ["tool,builtin,task,nop,postscript", [], []],
+        ["tool,builtin,task,nop,prescript", [], []],
+        ["tool,builtin,task,nop,refdir", [], []],
+        ["tool,builtin,task,nop,script", ["sc_nop.tcl"], ["mydata"]],
+        ["tool,builtin,task,nop,threads", 4],
+        ["tool,builtin,task,nop,var,aggressive", True],
+        ["tool,builtin,task,nop,var,effort", "high"],
+        ["tool,builtin,task,nop,var,margin", 0.25],
+        ["tool,builtin,task,nop,var,plusargs", [["seed", "7"], ["trace", None]]],
+        ["tool,builtin,task,nop,version", [">=2.0"]]]
+
+    expect = hashlib.sha256()
+    expect.update(json.dumps(keys, default=repr).encode("utf-8"))
+    expect.update(json.dumps(material, default=repr).encode("utf-8"))
+
+    with configured_node.task.runtime(configured_node) as task:
+        assert task.get_digest() == expect.hexdigest()
+
+
+def test_task_get_digest_keys(running_node):
+    """The task's own configuration, with nothing required yet."""
+    with running_node.task.runtime(running_node) as runtool:
+        assert runtool.get_digest_keys() == {
+            ("tool", "builtin", "task", "nop", "option"),
+            ("tool", "builtin", "task", "nop", "threads"),
+            ("tool", "builtin", "task", "nop", "refdir"),
+            ("tool", "builtin", "task", "nop", "script"),
+            ("tool", "builtin", "task", "nop", "prescript"),
+            ("tool", "builtin", "task", "nop", "postscript")}
+
+
+def test_task_get_digest_keys_require_and_env(running_node):
+    """Required keypaths and task environment variables join the set."""
+    nop = running_node.project.get_nop()
+    nop.add_required_key("library", "testdesign", "fileset", "rtl", "topmodule")
+    nop.set("env", "BUILD", "here")
+
+    with running_node.task.runtime(running_node) as runtool:
+        keys = runtool.get_digest_keys()
+    assert ("library", "testdesign", "fileset", "rtl", "topmodule") in keys
+    assert ("tool", "builtin", "task", "nop", "env", "BUILD") in keys
+
+
+def test_task_get_digest(running_node):
+    with running_node.task.runtime(running_node) as runtool:
+        digest = runtool.get_digest()
+    assert re.match(r"^[0-9a-f]{64}$", digest)
+
+
+def test_task_get_digest_stable(running_node):
+    """The same configuration digests the same, every time."""
+    with running_node.task.runtime(running_node) as runtool:
+        assert runtool.get_digest() == runtool.get_digest()
+
+    other = SchedulerNode(running_node.project, "running", "0")
+    with other.task.runtime(other) as runtool:
+        repeat = runtool.get_digest()
+    with running_node.task.runtime(running_node) as runtool:
+        assert runtool.get_digest() == repeat
+
+
+def test_task_get_digest_survives_a_manifest(running_node):
+    """A cache key is read on the far side of a scheduler, from the manifest."""
+    nop = running_node.project.get_nop()
+    nop.add_parameter("effort", "str", "how hard to try", defvalue="high")
+    nop.add_required_key("var", "effort")
+    nop.set("env", "BUILD", "here")
+
+    with running_node.task.runtime(running_node) as task:
+        before = task.get_digest()
+
+    running_node.project.write_manifest("digest.json")
+    reloaded = Project.from_manifest(filepath="digest.json")
+    node = SchedulerNode(reloaded, "running", "0")
+    with node.task.runtime(node) as task:
+        assert task.get_digest() == before
+
+
+def test_task_get_digest_length(running_node):
+    with running_node.task.runtime(running_node) as runtool:
+        assert runtool.get_digest()[:16] == runtool.get_digest(length=16)
+        assert len(runtool.get_digest(length=16)) == 16
+
+
+@pytest.mark.parametrize("length", (0, -1, 65))
+def test_task_get_digest_length_invalid(running_node, length):
+    with running_node.task.runtime(running_node) as runtool:
+        with pytest.raises(ValueError, match=r"^length must be between 1 and 64$"):
+            runtool.get_digest(length=length)
+
+
+def test_task_get_digest_no_runtime():
+    """A digest needs a project to read the required keypaths from."""
+    with pytest.raises(RuntimeError,
+                       match=r"^get_digest\(\) requires a runtime, "
+                             r"call it on the task yielded by Task.runtime\(\)$"):
+        NOPTask().get_digest()
+
+
+def test_task_get_digest_invalid_require(running_node):
+    running_node.project.get_nop().add("require", "this,key")
+
+    with running_node.task.runtime(running_node) as runtool:
+        with pytest.raises(KeyError, match=r"^'\[this,key\] not found'$"):
+            runtool.get_digest()
+
+
+def test_task_get_digest_tracks_task_option(running_node):
+    with running_node.task.runtime(running_node) as task:
+        before = task.get_digest()
+
+    running_node.project.get_nop().add("option", "-fast")
+    with running_node.task.runtime(running_node) as task:
+        assert task.get_digest() != before
+
+
+def test_task_get_digest_tracks_scalar_require(running_node):
+    """The point of the digest: a required non-path value counts.
+
+    Drivers put booleans and thresholds in [require] -- openroad's
+    repair_timing requires five of them -- and a cache key that only looked at
+    paths would hand one configuration's results to another.
+    """
+    nop = running_node.project.get_nop()
+    nop.add_parameter("aggressive", "bool", "run aggressively", defvalue=False)
+    nop.add_required_key("var", "aggressive")
+
+    with running_node.task.runtime(running_node) as task:
+        before = task.get_digest()
+
+    nop.set("var", "aggressive", True)
+    with running_node.task.runtime(running_node) as task:
+        assert task.get_digest() != before
+
+
+def test_task_get_digest_tracks_version_requirement(running_node):
+    with running_node.task.runtime(running_node) as task:
+        before = task.get_digest()
+
+    running_node.project.get_nop().set("version", ">=2.0")
+    with running_node.task.runtime(running_node) as task:
+        assert task.get_digest() != before
+
+
+def test_task_get_digest_tracks_env(running_node):
+    nop = running_node.project.get_nop()
+    nop.set("env", "BUILD", "here")
+    with running_node.task.runtime(running_node) as task:
+        before = task.get_digest()
+
+    nop.set("env", "BUILD", "there")
+    with running_node.task.runtime(running_node) as task:
+        assert task.get_digest() != before
+
+
+def test_task_get_digest_tracks_dataroot(running_node):
+    """A path and its dataroot are both part of what the path is."""
+    design = running_node.project.get_library("testdesign")
+    design.set_dataroot("one", os.path.abspath("one"))
+    design.set_dataroot("two", os.path.abspath("two"))
+    with design.active_fileset("rtl"):
+        with design.active_dataroot("one"):
+            design.add_file("top.v")
+
+    nop = running_node.project.get_nop()
+    nop.add_required_key(design, "fileset", "rtl", "file", "verilog")
+
+    with running_node.task.runtime(running_node) as task:
+        before = task.get_digest()
+
+    design.unset("fileset", "rtl", "file", "verilog")
+    with design.active_fileset("rtl"):
+        with design.active_dataroot("two"):
+            design.add_file("top.v")
+    with running_node.task.runtime(running_node) as task:
+        assert task.get_digest() != before
+
+
+def test_task_get_digest_ignores_where_the_build_is(running_node):
+    """A digest a shared cache can be named after cannot depend on the machine."""
+    with running_node.task.runtime(running_node) as task:
+        before = task.get_digest()
+
+    running_node.project.option.set_builddir(os.path.abspath("somewhere_else"))
+    running_node.project.option.set_cachedir(os.path.abspath("some_cache"))
+    with running_node.task.runtime(running_node) as task:
+        assert task.get_digest() == before
+
+
+def test_task_get_digest_ignores_option_hash(running_node):
+    """Unlike every other hash in the schema, this one is not optional."""
+    with running_node.task.runtime(running_node) as task:
+        before = task.get_digest()
+
+    running_node.project.option.set_hash(True)
+    with running_node.task.runtime(running_node) as task:
+        assert task.get_digest() == before
+
+
+def test_task_get_digest_pernode(running_node):
+    """Two nodes of one task diverge only when their configuration does."""
+    notrunning = SchedulerNode(running_node.project, "notrunning", "0")
+
+    with running_node.task.runtime(running_node) as task:
+        running = task.get_digest()
+    with notrunning.task.runtime(notrunning) as task:
+        assert task.get_digest() == running
+
+    running_node.project.get_nop().set("threads", 3, step="notrunning", index="0")
+    with running_node.task.runtime(running_node) as task:
+        running = task.get_digest()
+    with notrunning.task.runtime(notrunning) as task:
+        assert task.get_digest() != running
+
+
+def test_task_get_digest_keys_override(running_node):
+    """A driver can add a key it reads without requiring."""
+    class ExtraKeyTask(NOPTask):
+        def get_digest_keys(self):
+            keys = super().get_digest_keys()
+            keys.add(("option", "novercheck"))
+            return keys
+
+    task = ExtraKeyTask()
+    with task.runtime(running_node) as runtool:
+        before = runtool.get_digest()
+    running_node.project.option.set_novercheck(True)
+    with task.runtime(running_node) as runtool:
+        assert runtool.get_digest() != before
+
+
+def test_task_cachedir_keyed_by_digest(running_node):
+    """The consumer the digest exists for: a cache private to a configuration."""
+    class DigestCacheTask(NOPTask):
+        @property
+        def cachedir(self):
+            return os.path.join(super().cachedir, self.get_digest(length=16))
+
+    task = DigestCacheTask()
+    running_node.project.option.set_cachedir("thiscache")
+    with task.runtime(running_node) as runtool:
+        before = runtool.cachedir
+        assert pathlib.Path(before).parent == \
+            pathlib.Path(os.path.abspath("thiscache")) / "tools" / "builtin"
+
+    running_node.project.get_nop().add("option", "-fast")
+    with task.runtime(running_node) as runtool:
+        assert runtool.cachedir != before
 
 
 def test_runtime_invalid_type():

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -289,8 +289,8 @@ def test_task_get_digest_exact(configured_node):
     """
     with configured_node.task.runtime(configured_node) as task:
         assert task.get_digest() == \
-            "f759039b73148bce5dec4f161e22f5b337447464aa59a6ec3ad15216e40ba4a3"
-        assert task.get_digest(length=16) == "f759039b73148bce"
+            "d8709b2465656a75b8f88f7adfeabdf0d669f441aff6e0ea10e169f57de00c38"
+        assert task.get_digest(length=16) == "d8709b2465656a75"
 
 
 def test_task_get_digest_exact_material(configured_node):
@@ -308,6 +308,7 @@ def test_task_get_digest_exact_material(configured_node):
     keys = [
         ["library", "testdesign", "fileset", "rtl", "topmodule"],
         ["tool", "builtin", "task", "nop", "env", "BUILD"],
+        ["tool", "builtin", "task", "nop", "exe"],
         ["tool", "builtin", "task", "nop", "option"],
         ["tool", "builtin", "task", "nop", "postscript"],
         ["tool", "builtin", "task", "nop", "prescript"],
@@ -323,6 +324,7 @@ def test_task_get_digest_exact_material(configured_node):
         "builtin", "nop",
         ["library,testdesign,fileset,rtl,topmodule", "designtop"],
         ["tool,builtin,task,nop,env,BUILD", "here"],
+        ["tool,builtin,task,nop,exe", None],
         ["tool,builtin,task,nop,option", ["-fast", "-x"]],
         ["tool,builtin,task,nop,postscript", [], []],
         ["tool,builtin,task,nop,prescript", [], []],
@@ -466,6 +468,31 @@ def test_task_get_digest_tracks_version_requirement(running_node):
     running_node.project.get_nop().set("version", ">=2.0")
     with running_node.task.runtime(running_node) as task:
         assert task.get_digest() != before
+
+
+def test_task_get_digest_tracks_exe(running_node):
+    """Which binary runs is part of what a cache belongs to."""
+    with running_node.task.runtime(running_node) as task:
+        before = task.get_digest()
+
+    running_node.project.get_nop().set("exe", "nop-ng")
+    with running_node.task.runtime(running_node) as task:
+        assert task.get_digest() != before
+
+
+def test_task_get_digest_ignores_the_tool_install_path(running_node):
+    """Where the executable was found is a property of the machine, not the task.
+
+    klayout sets [path] to ~/AppData/Roaming/KLayout or
+    /Applications/klayout.app/..., so hashing it would give one task a different
+    digest per machine and partition the shared cache the digest exists to name.
+    """
+    with running_node.task.runtime(running_node) as task:
+        before = task.get_digest()
+
+    running_node.project.get_nop().set("path", os.path.abspath("some_install"))
+    with running_node.task.runtime(running_node) as task:
+        assert task.get_digest() == before
 
 
 def test_task_get_digest_tracks_env(running_node):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks can generate deterministic configuration digests for naming task-specific cache directories.
  * Cache digests include task configuration, required settings, environment variables, executable details, and version requirements while remaining consistent across machines.
  * Digest length can be customized for shorter cache directory names.
  * Scheduler change checks now follow each task’s declared configuration keys.

* **Documentation**
  * Added guidance on digest-based cache directories and clarified included and excluded configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->