### PR TITLE
env bug fix

### DIFF
--- a/examples/padring/openroad/padring.tcl
+++ b/examples/padring/openroad/padring.tcl
@@ -102,9 +102,16 @@ connect_by_abutment
 ########################################################################
 # 5. Bond pads
 #
-# The opening in the passivation that a wire or bump lands on. The offsets
-# place it over the cell it belongs to, and differ between the signal pads
-# and the supply pads because the cells are not the same height.
+# The opening in the passivation that a wire or bump lands on. Each pad cell
+# already carries the plate the bond pad lands on, so the bond pad has to land
+# exactly on it -- anywhere else and it hangs off onto the cell's own keep-out,
+# which the power grid check reports as the supply net shorting to the pad.
+#
+# The offset is measured to the bond pad's LEF origin, which sits 2.7um inside
+# its own outline, so each one is the plate's lower left corner plus 2.7. The
+# two differ because the signal pads and the supply pads are not the same
+# height: the plate is at (9.8 109.05) on a wrapped gpio and at (4.8 95.665)
+# on a supply pad.
 ########################################################################
-place_bondpad -bond sky130_ef_io__bare_pad padring/*.i0/gpio -offset "12.5 115"
-place_bondpad -bond sky130_ef_io__bare_pad padring/*.i0/io* -offset "8 95"
+place_bondpad -bond sky130_ef_io__bare_pad padring/*.i0/gpio -offset "12.5 111.75"
+place_bondpad -bond sky130_ef_io__bare_pad padring/*.i0/io* -offset "7.5 98.365"

--- a/examples/padring/padring.py
+++ b/examples/padring/padring.py
@@ -97,10 +97,9 @@ def setup_project(remote: bool = False) -> ASIC:
     for task in OpenROADPSMParameter.find_task(project):
         task.add_openroad_psmskipnets("*io*")
 
-    # The ring needs about 1520um a side (fourteen cells plus two corners), but the
-    # memory needs more: sky130's SRAM macro is 1041um wide at any depth and needs
-    # a placement channel, so with a 250um margin to clear the pads the macro is
-    # what sets this die, not the ring.
+    # The ring is what sets this die: fourteen cells plus two corners need about
+    # 1520um a side. sky130's SRAM macro is 683um wide, so with a 250um margin to
+    # clear the pads it fits inside that with room for its placement channel.
     project.constraint.area.set_dieoutline(1900, 1900, coremargin=250)
 
     # Keep placement off the memory macro so its pins stay reachable.

--- a/siliconcompiler/tool.py
+++ b/siliconcompiler/tool.py
@@ -946,10 +946,13 @@ class Task(NamedSchema, PathSchema, DocsSchema):
             dict: A dictionary of environment variable names to their values.
         """
 
-        # Add global environmental vars
+        # Add global environmental vars. A key can be declared without ever being
+        # given a value, which os.environ will not accept, so those are skipped.
         envvars: Dict[str, str] = {}
         for env in self.__schema_full.option.getkeys('env'):
-            envvars[env] = self.__schema_full.option.get_env(env)
+            value = self.__schema_full.option.get_env(env)
+            if value is not None:
+                envvars[env] = value
 
         # Add tool-specific license server vars
         for lic_env in self.getkeys('licenseserver'):
@@ -973,7 +976,9 @@ class Task(NamedSchema, PathSchema, DocsSchema):
 
         # Add task-specific vars
         for env in self.getkeys("env"):
-            envvars[env] = self.get("env", env)
+            value = self.get("env", env)
+            if value is not None:
+                envvars[env] = value
 
         return envvars
 

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1184,7 +1184,7 @@ def test_get_runtime_environmental_variables_envs(running_node, monkeypatch):
         }
 
 
-def test_get_runtime_environmental_variables_unset(running_node):
+def test_get_runtime_environmental_variables_unset(running_node, monkeypatch):
     """Env keys that exist without a value must be dropped, not passed through.
 
     The scheduler hands this dict straight to os.environ.update() before it
@@ -1204,10 +1204,14 @@ def test_get_runtime_environmental_variables_unset(running_node):
     with running_node.task.runtime(running_node) as runtool:
         envvars = runtool.get_runtime_environmental_variables(include_path=False)
 
-    assert envvars == {'GLOBAL_SET': 'here', 'TASK_SET': 'here'}
+    # os.environ is what raised the TypeError that took the node down before the
+    # tool started, so put the values through the same check. setitem assigns
+    # exactly as the scheduler does and is undone at teardown, where setenv would
+    # coerce a None to the string "None" and hide the regression.
+    for name, value in envvars.items():
+        monkeypatch.setitem(os.environ, name, value)
 
-    # The values have to survive the same check that broke the scheduler.
-    os.environ.update(envvars)
+    assert envvars == {'GLOBAL_SET': 'here', 'TASK_SET': 'here'}
 
 
 def test_get_runtime_environmental_variables_tool_path(running_node, monkeypatch):

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1184,6 +1184,32 @@ def test_get_runtime_environmental_variables_envs(running_node, monkeypatch):
         }
 
 
+def test_get_runtime_environmental_variables_unset(running_node):
+    """Env keys that exist without a value must be dropped, not passed through.
+
+    The scheduler hands this dict straight to os.environ.update() before it
+    launches the tool, and os.environ rejects None with a TypeError, so a None
+    here takes the node down before the tool ever starts. A key can reach that
+    state by being declared and then cleared, which is how a testcase built by
+    utils.issue records QT_QPA_PLATFORM when the run behind it was headless.
+    """
+    running_node.project.set('option', 'env', 'GLOBAL_SET', 'here')
+    running_node.project.set('option', 'env', 'GLOBAL_UNSET', 'gone')
+    running_node.project.unset('option', 'env', 'GLOBAL_UNSET')
+
+    assert running_node.project.set("tool", "builtin", 'task', "nop", 'env', 'TASK_SET', 'here')
+    assert running_node.project.set("tool", "builtin", 'task', "nop", 'env', 'TASK_UNSET', 'gone')
+    running_node.project.unset("tool", "builtin", 'task', "nop", 'env', 'TASK_UNSET')
+
+    with running_node.task.runtime(running_node) as runtool:
+        envvars = runtool.get_runtime_environmental_variables(include_path=False)
+
+    assert envvars == {'GLOBAL_SET': 'here', 'TASK_SET': 'here'}
+
+    # The values have to survive the same check that broke the scheduler.
+    os.environ.update(envvars)
+
+
 def test_get_runtime_environmental_variables_tool_path(running_node, monkeypatch):
     os.makedirs('./testpath', exist_ok=True)
     assert running_node.project.set("tool", "builtin", 'task', 'nop', 'path', './testpath')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime environments now omit variables configured as unset, preventing errors when applying environment settings.
  * Updated GPIO and supply-pad placement offsets for more accurate bond-pad positioning.

* **Documentation**
  * Clarified pad-ring sizing, passivation openings, plate alignment, and offset calculations.

* **Tests**
  * Updated test coverage to verify unset variables are excluded while configured variables remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->